### PR TITLE
Comment out LDAP settings by Default

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -278,20 +278,20 @@ database          = mysql://root@localhost/vufind
 ; settings are optional, mapping fields in your LDAP schema
 ; to fields in VuFind's database -- the more you fill in, the more
 ; data will be imported from LDAP into VuFind.
-[LDAP]
+;[LDAP]
 ; Prefix the host with ldaps:// to use LDAPS; omit the prefix for standard
 ; LDAP with TLS.
-host            = ldap.myuniversity.edu
-port            = 389       ; LDAPS usually uses port 636 instead
-basedn          = "o=myuniversity.edu"
-username        = uid
-firstname       = givenname
-lastname        = sn
-email           = mail
-cat_username    =
-cat_password    =
-college         = studentcollege
-major           = studentmajor
+;host            = ldap.myuniversity.edu
+;port            = 389       ; LDAPS usually uses port 636 instead
+;basedn          = "o=myuniversity.edu"
+;username        = uid
+;firstname       = givenname
+;lastname        = sn
+;email           = mail
+;cat_username    =
+;cat_password    =
+;college         = studentcollege
+;major           = studentmajor
 ; If you need to bind to LDAP with a particular account before
 ; it can be searched, you can enter the necessary credentials
 ; here.  If this extra security measure is not needed, leave


### PR DESCRIPTION
Since all the other configuration options are commented by default, shouldn't LDAP be as well?
