### PR TITLE
Added support for the cat_password attribute to be pulled from Shibboleth Attributes

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -335,6 +335,7 @@ database          = mysql://root@localhost/vufind
 ; Some or all of the following entries may be uncommented to map Shibboleth
 ; attributes to user database columns:
 ;cat_username = HTTP_ALEPH_ID
+;cat_password = HTTP_CAT_PASSWORD
 ;email = HTTP_MAIL
 ;firstname = HTTP_FIRST_NAME
 ;lastname = HTTP_LAST_NAME

--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -96,8 +96,8 @@ class Shibboleth extends AbstractBase
 
         // Has the user configured attributes to use for populating the user table?
         $attribsToCheck = array(
-            "cat_username", "email", "lastname", "firstname", "college", "major",
-            "home_library"
+            "cat_username", "cat_password", "email", "lastname", "firstname",
+            "college", "major", "home_library"
         );
         foreach ($attribsToCheck as $attribute) {
             if (isset($shib->$attribute)) {


### PR DESCRIPTION
Have not tested this, since I don't have Shibboleth.

Feature was requested in the CAS module I am working on (https://github.com/vufind-org/vufind/pull/13#issuecomment-22524042)
