### PR TITLE
Extended Dismax

### DIFF
--- a/config/vufind/searchspecs.yaml
+++ b/config/vufind/searchspecs.yaml
@@ -22,13 +22,20 @@
 #      - field3^boost
 #    # DismaxParams is optional and allows you to override default Dismax settings
 #    #     (i.e. mm / bf) on a search-by-search basis.  If you want global default
-#    #     values for these settings, you can edit the "dismax" search handler in
+#    #     values for these settings, you can edit the appropriate search handler in
 #    #     solr/biblio/conf/solrconfig.xml.
 #    DismaxParams:
 #      - [param1_name, param1_value]
 #      - [param2_name, param2_value]
 #      - [param3_name, param3_value]
-#    # QueryFields define the fields we are searching when not using Dismax
+#    # This optional setting may be set to true to use traditional Dismax instead of
+#    #     Extended Dismax. It defaults to false. It is not recommended that you use
+#    #     this unless you have a compelling reason to (e.g. connecting to an old
+#    #     version of Solr).
+#    DisableExtendedDismax: true|false
+#    # QueryFields define the fields we are searching when not using Dismax; VuFind
+#    #     detects queries that will not work with Dismax/Extended Dismax and
+#    #     switches to QueryFields as needed.
 #    QueryFields:
 #      SolrField:
 #        - [howToMungeSearchstring, weight]
@@ -133,7 +140,7 @@
 # See the CallNumber search below for an example of custom munging in action.
 #-----------------------------------------------------------------------------------
 
-# These searches use Dismax when possible:
+# These searches use Extended Dismax when possible:
 Author:
   DismaxFields:
     - author^100

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -142,7 +142,9 @@ class QueryBuilder implements QueryBuilderInterface
         $string  = $query->getString() ?: '*:*';
         $handler = $this->getSearchHandler($query->getHandler());
 
-        if ($this->containsAdvancedLuceneSyntax($string)) {
+        if (!($handler && $handler->hasExtendedDismax())
+            && $this->containsAdvancedLuceneSyntax($string)
+        ) {
             if ($handler) {
                 $string = $this->createAdvancedInnerSearchString($string, $handler);
                 if ($handler->hasDismax()) {
@@ -159,7 +161,7 @@ class QueryBuilder implements QueryBuilderInterface
         } else {
             if ($handler && $handler->hasDismax()) {
                 $params->set('qf', implode(' ', $handler->getDismaxFields()));
-                $params->set('qt', 'dismax');
+                $params->set('qt', $handler->hasExtendedDismax() ? 'edismax' : 'dismax');
                 foreach ($handler->getDismaxParams() as $param) {
                     $params->add(reset($param), next($param));
                 }

--- a/solr/authority/conf/solrconfig.xml
+++ b/solr/authority/conf/solrconfig.xml
@@ -357,18 +357,26 @@
     </lst>
   </requestHandler>
   
-  <!-- the following handler will be used for eligible dismax searches defined
-     in web/conf/searchspecs.yaml.  Searches relying on advanced features
-     incompatible with dismax will be sent to the standard handler instead.
-     You can use this handler definition to set global Dismax settings
-     (i.e. mm / bf).  If you need different settings for different types of
-     searches (i.e. Title vs. Author), you can also configure individual
-     settings in the searchspecs.yaml file.
+  <!-- the following two handlers will be used for eligible dismax searches defined
+     in searchspecs.yaml. The edismax handler will be used most of the time, unless
+     a specific configuration tells VuFind to use traditional dismax instead. You
+     can use these handler definitions to set global Dismax settings (e.g. mm / bf).
+     If you need different settings for different types of searches (e.g. Title vs.
+     Author), you can also configure individual settings in the searchspecs.yaml
+     file.
   -->
   <requestHandler name="dismax" class="solr.SearchHandler">
     <lst name="defaults">
      <str name="defType">dismax</str>
      <str name="echoParams">explicit</str>
+    </lst>
+  </requestHandler>
+  
+  <requestHandler name="edismax" class="solr.SearchHandler">
+    <lst name="defaults">
+     <str name="defType">edismax</str>
+     <str name="echoParams">explicit</str>
+     <str name="lowercaseOperators">false</str>
     </lst>
   </requestHandler>
   

--- a/solr/biblio/conf/solrconfig.xml
+++ b/solr/biblio/conf/solrconfig.xml
@@ -365,13 +365,13 @@
     </arr>
   </requestHandler>
 
-  <!-- the following handler will be used for eligible dismax searches defined
-     in web/conf/searchspecs.yaml.  Searches relying on advanced features
-     incompatible with dismax will be sent to the standard handler instead.
-     You can use this handler definition to set global Dismax settings
-     (i.e. mm / bf).  If you need different settings for different types of
-     searches (i.e. Title vs. Author), you can also configure individual
-     settings in the searchspecs.yaml file.
+  <!-- the following two handlers will be used for eligible dismax searches defined
+     in searchspecs.yaml. The edismax handler will be used most of the time, unless
+     a specific configuration tells VuFind to use traditional dismax instead. You
+     can use these handler definitions to set global Dismax settings (e.g. mm / bf).
+     If you need different settings for different types of searches (e.g. Title vs.
+     Author), you can also configure individual settings in the searchspecs.yaml
+     file.
   -->
   <requestHandler name="dismax" class="solr.SearchHandler">
     <lst name="defaults">
@@ -381,6 +381,21 @@
      <str name="spellcheck.extendedResults">true</str>
      <str name="spellcheck.onlyMorePopular">true</str>
      <str name="spellcheck.count">20</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <requestHandler name="edismax" class="solr.SearchHandler">
+    <lst name="defaults">
+     <str name="defType">edismax</str>
+     <!-- str name="fl">a*,b*,c*,d*,e*,first_indexed,format,fullrecord,g*,h*,i*,l*,o*,p*,r*,s*,t*,u*,*_date*,*_isn*,*_str*,*_txt*</str -->
+     <str name="echoParams">explicit</str>
+     <str name="spellcheck.extendedResults">true</str>
+     <str name="spellcheck.onlyMorePopular">true</str>
+     <str name="spellcheck.count">20</str>
+     <str name="lowercaseOperators">false</str>
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>

--- a/solr/reserves/conf/solrconfig.xml
+++ b/solr/reserves/conf/solrconfig.xml
@@ -357,18 +357,26 @@
     </lst>
   </requestHandler>
   
-  <!-- the following handler will be used for eligible dismax searches defined
-     in web/conf/searchspecs.yaml.  Searches relying on advanced features
-     incompatible with dismax will be sent to the standard handler instead.
-     You can use this handler definition to set global Dismax settings
-     (i.e. mm / bf).  If you need different settings for different types of
-     searches (i.e. Title vs. Author), you can also configure individual
-     settings in the searchspecs.yaml file.
+  <!-- the following two handlers will be used for eligible dismax searches defined
+     in searchspecs.yaml. The edismax handler will be used most of the time, unless
+     a specific configuration tells VuFind to use traditional dismax instead. You
+     can use these handler definitions to set global Dismax settings (e.g. mm / bf).
+     If you need different settings for different types of searches (e.g. Title vs.
+     Author), you can also configure individual settings in the searchspecs.yaml
+     file.
   -->
   <requestHandler name="dismax" class="solr.SearchHandler">
     <lst name="defaults">
      <str name="defType">dismax</str>
      <str name="echoParams">explicit</str>
+    </lst>
+  </requestHandler>
+  
+  <requestHandler name="edismax" class="solr.SearchHandler">
+    <lst name="defaults">
+     <str name="defType">edismax</str>
+     <str name="echoParams">explicit</str>
+     <str name="lowercaseOperators">false</str>
     </lst>
   </requestHandler>
   

--- a/solr/website/conf/solrconfig.xml
+++ b/solr/website/conf/solrconfig.xml
@@ -367,13 +367,13 @@
     </arr>
   </requestHandler>
 
-  <!-- the following handler will be used for eligible dismax searches defined
-     in web/conf/searchspecs.yaml.  Searches relying on advanced features
-     incompatible with dismax will be sent to the standard handler instead.
-     You can use this handler definition to set global Dismax settings
-     (i.e. mm / bf).  If you need different settings for different types of
-     searches (i.e. Title vs. Author), you can also configure individual
-     settings in the searchspecs.yaml file.
+  <!-- the following two handlers will be used for eligible dismax searches defined
+     in searchspecs.yaml. The edismax handler will be used most of the time, unless
+     a specific configuration tells VuFind to use traditional dismax instead. You
+     can use these handler definitions to set global Dismax settings (e.g. mm / bf).
+     If you need different settings for different types of searches (e.g. Title vs.
+     Author), you can also configure individual settings in the searchspecs.yaml
+     file.
   -->
   <requestHandler name="dismax" class="solr.SearchHandler">
     <lst name="defaults">
@@ -382,6 +382,20 @@
      <str name="spellcheck.extendedResults">true</str>
      <str name="spellcheck.onlyMorePopular">true</str>
      <str name="spellcheck.count">20</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <requestHandler name="edismax" class="solr.SearchHandler">
+    <lst name="defaults">
+     <str name="defType">edismax</str>
+     <str name="echoParams">explicit</str>
+     <str name="spellcheck.extendedResults">true</str>
+     <str name="spellcheck.onlyMorePopular">true</str>
+     <str name="spellcheck.count">20</str>
+     <str name="lowercaseOperators">false</str>
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>


### PR DESCRIPTION
This branch switches VuFind to use Extended Dismax by default while still allowing the previous behavior to be turned on by request.
