### PR TITLE
RDFa - more granular publication details

### DIFF
--- a/themes/blueprint/templates/RecordDriver/SolrDefault/core.phtml
+++ b/themes/blueprint/templates/RecordDriver/SolrDefault/core.phtml
@@ -87,7 +87,18 @@
       <th><?=$this->transEsc('Published')?>: </th>
       <td>
         <? foreach ($publications as $field): ?>
-          <?=$this->escapeHtml($field)?><br/>
+          <span property="publisher" typeof="Organization">
+          <? $pubPlace = $field->getPlace(); if (!empty($pubPlace)): ?>
+            <span property="location"><?=$this->escapeHtml($pubPlace)?></span>
+          <? endif; ?>
+          <? $pubName = $field->getName(); if (!empty($pubName)): ?>
+            <span property="name"><?=$this->escapeHtml($pubName)?></span>
+          <? endif; ?>
+          </span>
+          <? $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
+            <span property="publicationDate"><?=$this->escapeHtml($pubDate)?></span>
+          <? endif; ?>
+          <br/>
         <? endforeach; ?>
       </td>
     </tr>

--- a/themes/bootstrap/templates/RecordDriver/SolrDefault/core.phtml
+++ b/themes/bootstrap/templates/RecordDriver/SolrDefault/core.phtml
@@ -116,7 +116,18 @@
         <th><?=$this->transEsc('Published')?>: </th>
         <td>
           <? foreach ($publications as $field): ?>
-            <?=$this->escapeHtml($field)?><br/>
+            <span property="publisher" typeof="Organization">
+            <? $pubPlace = $field->getPlace(); if (!empty($pubPlace)): ?>
+              <span property="location"><?=$this->escapeHtml($pubPlace)?></span>
+            <? endif; ?>
+            <? $pubName = $field->getName(); if (!empty($pubName)): ?>
+              <span property="name"><?=$this->escapeHtml($pubName)?></span>
+            <? endif; ?>
+            </span>
+            <? $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
+              <span property="publicationDate"><?=$this->escapeHtml($pubDate)?></span>
+            <? endif; ?>
+            <br/>
           <? endforeach; ?>
         </td>
       </tr>


### PR DESCRIPTION
Take advantage of the fine-grained PublicationDetails object to break
out the publisher name, location, and publication date as separate RDFa
properties.

Signed-off-by: Dan Scott dan@coffeecode.net
