### PR TITLE
Jetty's work files in /tmp are purged in UNIX-y systems, crashing the Solr admin interface

### DIFF
--- a/solr/jetty/work/.gitignore
+++ b/solr/jetty/work/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
As documented in https://issues.apache.org/jira/browse/SOLR-118, Jetty's work directory in /tmp gets purged in UNIX-y systems, which kills the Solr admin interface (404 error). Creating the work directory inside the jetty directory (with a .gitignore inside to get around Git's hatred of empty directories) should resolve the issue.
