### PR TITLE
urlencoding of query-string values

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -548,7 +548,7 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
         $sep = (strpos($url, "?") === false)?'?':'&';
         if ($params != null) {
             foreach ($params as $key => $value) {
-                $url.= $sep . $key . "=" . $value;
+                $url.= $sep . $key . "=" . urlencode($value);
                 $sep = "&";
             }
         }


### PR DESCRIPTION
- fixes issue with usernames containing a blank space
- valid for x-server and restful api calls
