### PR TITLE
Aleph-Driver, comments in placehold()

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1496,6 +1496,13 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
             $pickupLocation = $this->getDefaultPickUpLocation($patron, $details);
         }
         $comment = $details['comment'];
+        if (strlen($comment) <= 50) {
+            $comment1 = $comment;
+        }
+        else {
+            $comment1 = substr($comment, 0, 50);
+            $comment2 = substr($comment, 50, 50);
+        }
         try {
             $requiredBy = $this->dateConverter
                 ->convertFromDisplayDate('Ymd', $details['requiredBy']);
@@ -1512,7 +1519,8 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
         );
         $body->addChild('pickup-location', $pickupLocation);
         $body->addChild('last-interest-date', $requiredBy);
-        $body->addChild('note-l', $comment);
+        $body->addChild('note-1', $comment1);
+        $body->addChild('note-2', $comment2);
         $body = 'post_xml=' . $body->asXML();
         try {
             $result = $this->doRestDLFRequest(


### PR DESCRIPTION
- fix typo in element name (happened here: 8f62add)
- break comment message into two notefields of aleph (Z37_NOTE_1/2)
- both hold 50 characters each, VARCHAR2(50)
- post comment message into two fields
- comments longer than 100 characters will be lost (before, more than 50 were lost)
- see Issue swissbib/sbvf2#372 for more (in German)
