### PR TITLE
Change schema.org mapping from MusicRecording to MusicAlbum

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -1600,7 +1600,7 @@ class SolrDefault extends AbstractBase
                 $types['Map'] = 1;
                 break;
             case 'Audio':
-                $types['MusicRecording'] = 1;
+                $types['MusicAlbum'] = 1;
                 break;
             default:
                 $types['CreativeWork'] = 1;


### PR DESCRIPTION
http://schema.org/MusicRecording is intended for individual tracks, and
although we cannot be sure with just "Audio", most library systems seem to
catalog at the album level... so switch to MusicAlbum instead.

Signed-off-by: Dan Scott dan@coffeecode.net
