### PR TITLE
enable multiple children-titles in hierarchies

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -1350,17 +1350,24 @@ class SolrDefault extends AbstractBase
      *
      * @return Array
      */
-    public function getHierarchyTitlesInParents()
+    public function getTitlesInHierarchy()
     {
-        $retVal = array();
-        if (isset($this->fields['hierarchy_parent_id'])
-            && isset($this->fields['is_hierarchy_title'])
-        ) {
-            foreach ($this->fields['hierarchy_parent_id'] as $key => $val) {
-                $retVal[$val] = $this->fields['is_hierarchy_title'][$key];
-            }
+        if (!isset($this->fields['title_in_hierarchy'])) {
+            return false;
         }
-        return $retVal;
+        else {
+            $titles = $this->fields['title_in_hierarchy'];
+            $parentIDs = $this->fields['hierarchy_parent_id'];
+
+            if (count($titles) === count($parentIDs)) {
+                $retVal = array();
+                foreach ($parentIDs as $key => $val) {
+                    $retVal[$val] = $titles[$key];
+                }
+                return $retVal;
+            }
+            else return false;
+        }
     }
 
     /**

--- a/solr/biblio/conf/schema.xml
+++ b/solr/biblio/conf/schema.xml
@@ -195,7 +195,8 @@
    <field name="hierarchy_parent_title" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="hierarchy_sequence" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="is_hierarchy_id" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="false"/>
+   <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="hierarchy_browse" type="textFacetRaw" indexed="true" stored="false" multiValued="true"/>
    <!-- Used for loading correct record driver -->
    <field name="recordtype" type="string" indexed="false" stored="true"/>


### PR DESCRIPTION
- build cache file with title depending on parent ID
- RecordDriver-function to return array with titles and parent ID
- set field to multiValued in schema (would require reindexing)
- (this is a proposition following the techlist-discussion)
