### PR TITLE
bugfix in AbstractRecordController

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -650,8 +650,9 @@ class AbstractRecord extends AbstractBase
             return $patron;
         }
 
+        $tabs = $this->getAllTabs();
         $view = $this->createViewModel();
-        $view->tabs = $this->getAllTabs();
+        $view->tabs = $tabs;
         $view->activeTab = strtolower($tab);
         $view->defaultTab = strtolower($this->getDefaultTab());
 


### PR DESCRIPTION
The view model cannot be created, unless all tabs are loaded, therefore getAllTabs must be called first.
