### PR TITLE
Fixed issue causing all items on Holds & Recalls page to be cancelled re...

### DIFF
--- a/themes/blueprint/js/common.js
+++ b/themes/blueprint/js/common.js
@@ -376,7 +376,7 @@ $(document).ready(function(){
     // Support holds cancel list buttons:
     function cancelHolds(type) {
       var typeIDS = type+'IDS';
-      var ids = $('[name="'+typeIDS+'[]"]');
+      var ids = $('[name="'+typeIDS+'[]"]:checked');
       var cancelIDS = [];
       for(var i=0;i<ids.length;i++) {
         cancelIDS.push(ids[i].value);


### PR DESCRIPTION
...gardless of selection.

On the "Holds and Recalls" page at  MyResearch/Holds, when attempting to cancel specific holds using "Cancel Selected Holds", all Holds are cancelled regardless of what is selected because the cancelHolds function in common.js sends the values of all checkboxes instead of just the ones that are checked.  This change adds a jquery selector to select only the checkboxes that are checked.
