### PR TITLE
Voyager: Implemented support for sorting holdings according to Voyager's...

### DIFF
--- a/config/vufind/Voyager.ini
+++ b/config/vufind/Voyager.ini
@@ -58,3 +58,6 @@ login_field = LAST_NAME
 ;supplements = "867az"
 ; Fields to include in indexes. Default is none.
 ;indexes = "867az"
+; By default holdings are sorted by Voyager's Holdings Sort Groups. Uncomment this
+; line to disable sorting.
+;use_sort_groups = false

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -241,3 +241,6 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ;supplements = "867az"
 ; Fields to include in indexes. Default is none.
 ;indexes = "867az"
+; By default holdings are sorted by Voyager's Holdings Sort Groups. Uncomment this
+; line to disable sorting.
+;use_sort_groups = false


### PR DESCRIPTION
... Holdings Sort Groups.

Since Voyager's Holdings Sort Groups can be used to define the order of locations in WebVoyage, it makes sense to follow the same ordering in VuFind. I don't see any reason for not doing this, but I included a setting that allows to disable the sorting if necessary.

With this change it became necessary to do both SQL queries for getStatus too (as discussed when implementing the same for getHolding...), as a location without items (such as "Online") may have a higher priority than a location with items. 
