### PR TITLE
adding support for syndetics plus over SSL

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -579,11 +579,11 @@ authors         = Wikipedia
 ; and set plus_id to your syndetics ID.  This loads the javascript file.
 ; Syndetics vs. SyndeticsPlus: SyndeticsPlus has nice formatting, but loads slower
 ; and requires javascript to be enabled in users' browsers.
-; set use_ssl to syndetics' secure url if you serve your site over ssl and you
+; set use_ssl to true if you serve your site over ssl and you
 ; use SyndeticsPlus to avoid insecure content browser warnings
 ; (or if you just prefer ssl)
 [Syndetics]
-;use_ssl = https://secure.syndetics.com
+use_ssl = false
 plus = false
 ;plus_id = "MySyndeticsId"
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/AbstractSyndetics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AbstractSyndetics.php
@@ -100,8 +100,8 @@ abstract class AbstractSyndetics extends AbstractHelper
      */
     protected function getSyndeticsUrl($id, $file = 'index.xml', $type = 'rw12,h7')
     {
-        $baseUrl = isset($this->config->use_ssl)
-            ? $this->config->use_ssl : 'http://syndetics.com';
+        $baseUrl = (isset($this->config->use_ssl) && $this->config->use_ssl)
+            ? 'https://secure.syndetics.com' : 'http://syndetics.com';
         return $baseUrl . '/index.aspx?isbn=' . $this->getIsbn10()
             . '/' . $file . '&client=' . $id . '&type=' . $type;
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlus.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlus.php
@@ -78,8 +78,8 @@ class SyndeticsPlus extends \Zend\View\Helper\AbstractHelper
     {
         // Determine whether to include script tag for SyndeticsPlus
         if (isset($this->config->plus_id)) {
-            $baseUrl = isset($this->config->use_ssl)
-                ? $this->config->use_ssl : 'http://plus.syndetics.com';
+            $baseUrl = (isset($this->config->use_ssl) && $this->config->use_ssl)
+                ? 'https://secure.syndetics.com' : 'http://plus.syndetics.com';
             return $baseUrl . "/widget.php?id="
                 . urlencode($this->config->plus_id);
         }


### PR DESCRIPTION
It may look like this commit introduces backward-incompatibility by getting rid of the [Syndetics] 'url' setting, however, the code that called on that setting got buggy in the migration to vufind2 so it would never have worked for anyone. Instead of adding another 'url' setting, and since the base ssl url is the same for regular syndetics and syndetics plus, I replaced 'url' with 'use_ssl'. If 'use_ssl' is not set then we use the non-ssl urls that were also our prior default values.
