### PR TITLE
Allow INDEX_OPTIONS to be set via an environmental variable

### DIFF
--- a/import-marc.sh
+++ b/import-marc.sh
@@ -49,7 +49,12 @@ fi
 # -XX:+UseParallelGC
 # -XX:+AggressiveOpts
 ##################################################
-INDEX_OPTIONS='-Xms512m -Xmx512m -DentityExpansionLimit=0'
+if [ -z "$INDEX_OPTIONS" ]
+then
+  INDEX_OPTIONS='-Xms512m -Xmx512m -DentityExpansionLimit=0'
+fi
+
+
 
 
 ##################################################


### PR DESCRIPTION
Allow INDEX_OPTIONS to be set via an environmental variable for the import-march.sh script
