### PR TITLE
Set proper headers on Cover Images so they can be cached by the browser

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -109,6 +109,22 @@ class CoverController extends AbstractBase
         $headers->addHeaderLine(
             'Content-type', $this->getLoader()->getContentType()
         );
+
+        // Send proper caching headers so that the user's browser
+        // is able to cache the cover images and not have to re-request
+        // then on each page load. Default TTL set at 14 days
+
+        $coverImageTtl = (60*60*24*14); // 14 days
+        $headers->addHeaderLine(
+            'Cache-Control', "maxage=".$coverImageTtl
+        );
+        $headers->addHeaderLine(
+            'Pragma', 'public'
+        );
+        $headers->addHeaderLine(
+            'Expires', gmdate('D, d M Y H:i:s', time()+$coverImageTtl) . ' GMT'
+        );
+
         $response->setContent($this->getLoader()->getImage());
         return $response;
     }


### PR DESCRIPTION
Before this commit cover images were requested on each page load, even if they have already been sent to the user's browser. Since the cover images will not change between requests it would be better to send proper headers with them so that the user's browser can cache them. This will also reduce the number of HTTP requests the server needs to respond to which can reduce load and improve performance.
