### PR TITLE
Fixed a comparison operator to fix searchspecs caching.

### DIFF
--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -90,7 +90,7 @@ class SearchSpecsReader
             $cacheKey = md5($cacheKey);
 
             // Generate data if not found in cache:
-            if (!$cache || !($results = $cache->getItem($cacheKey))) {
+            if ($cache === false || !($results = $cache->getItem($cacheKey))) {
                 $results = Yaml::parse($fullpath);
                 if (!empty($local)) {
                     $localResults = Yaml::parse($local);
@@ -98,7 +98,7 @@ class SearchSpecsReader
                         $results[$key] = $value;
                     }
                 }
-                if ($cache) {
+                if ($cache !== false) {
                     $cache->setItem($cacheKey, $results);
                 }
             }


### PR DESCRIPTION
Second fix for searchspecs caching. !$object may be true even if the object is valid.
