### PR TITLE
trim 034 subfield values when extracing latitude & longitude coordinates

### DIFF
--- a/import/index_scripts/location.bsh
+++ b/import/index_scripts/location.bsh
@@ -29,7 +29,7 @@ public String getLongLat(Record record) {
             Iterator subfieldsIter_d = subfields_d.iterator();
             if (subfields_d != null) {
                 while (subfieldsIter_d.hasNext()) {
-                    val = subfieldsIter_d.next().getData();
+                    val = subfieldsIter_d.next().getData().trim();
                     if (!val.matches("-?\\d+(.\\d+)?")) {
                         return null;
                     }
@@ -39,7 +39,7 @@ public String getLongLat(Record record) {
             Iterator subfieldsIter_f = subfields_f.iterator();
             if (subfields_f != null) {
                 while (subfieldsIter_f.hasNext()) {
-                    String val2 = subfieldsIter_f.next().getData();
+                    String val2 = subfieldsIter_f.next().getData().trim();
                     if (!val2.matches("-?\\d+(.\\d+)?")) {
                         return null;
                     }


### PR DESCRIPTION
Trivial change - some co-ordinates weren't getting indexed when there were trailing spaces in 034 subfield values.
