### PR TITLE
New mechanism in SwitchQuery Recommend module to truncate single char

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -316,12 +316,14 @@ CallNumber = callnumber
 ;
 ; Available modules recommended for use in the "no results" area:
 ;
-; SwitchQuery:[backend]:[checks to skip]
+; SwitchQuery:[backend]:[checks to skip]:[transforms to add]
 ;       This module analyzes the user's query and offers suggestions for ways to
 ;       improve it. [backend] is the name of the search backend currently in use,
 ;       which will help with accurate analysis (default = Solr). [checks to skip]
 ;       is a comma-separated list of checks to disable; see the check*() methods
 ;       in the module's code for a complete list of available checks.
+;       [transforms to add] is a comma-separated list of transforms to enable;
+;       currently there is only one: truncatechar
 ; SwitchType:[field]:[field description]
 ;       If the current search type is not the same as [field], display a link
 ;       suggesting that the user try switching to [field].  [field description]
@@ -343,6 +345,7 @@ Author[]            = AuthorFacets
 ;Subject[]          = WorldCatTerms
 
 [NoResultsRecommendations]
+CallNumber[] = SwitchQuery::wildcard:truncatechar
 
 ; These settings control the top and side recommendations within the special Author
 ; module (the page accessed by clicking on an author's name within the search

--- a/languages/en.ini
+++ b/languages/en.ini
@@ -869,6 +869,7 @@ switchquery_lowercasebools = "If you are trying to use Boolean operators, they m
 switchquery_unwantedbools = "The words AND, OR and NOT may confuse the search; try adding quotes"
 switchquery_unwantedquotes = "Removing quotes may allow a broader search"
 switchquery_wildcard = "Adding a wildcard symbol may retrieve word variants"
+switchquery_truncatechar = "Shorten your search to broaden it"
 System Unavailable = "System Unavailable"
 Table of Contents = "Table of Contents"
 Table of Contents unavailable = "Table of Contents unavailable"

--- a/module/VuFind/src/VuFind/Recommend/SwitchQuery.php
+++ b/module/VuFind/src/VuFind/Recommend/SwitchQuery.php
@@ -74,6 +74,15 @@ class SwitchQuery implements RecommendInterface
     protected $skipChecks = array();
 
     /**
+     * Names of transforms to apply. These should correspond
+     * with transform method names -- e.g. to apply the transform found in the
+     * transformTruncateChar() method, you would put 'truncatechar' into this array.
+     *
+     * @var array
+     */
+    protected $transforms = array();
+
+    /**
      * Constructor
      *
      * @param BackendManager $backendManager Search backend plugin manager
@@ -101,6 +110,8 @@ class SwitchQuery implements RecommendInterface
         };
         $this->skipChecks = !empty($params[1])
             ? array_map($callback, explode(',', $params[1])) : array();
+        $this->transforms = !empty($params[2])
+            ? explode(',', $params[2]) : array();
     }
 
     /**
@@ -158,6 +169,20 @@ class SwitchQuery implements RecommendInterface
                     $result = $this->$method($query);
                     if ($result) {
                         $this->suggestions['switchquery_' . $currentCheck] = $result;
+                    }
+                }
+            }
+        }
+
+        // Perform all transforms (based on naming convention):
+        $methods = get_class_methods($this);
+        foreach ($methods as $method) {
+            if (substr($method, 0, 9) == 'transform') {
+                $currentTransform = strtolower(substr($method, 9));
+                if (in_array($currentTransform, $this->transforms)) {
+                    $result = $this->$method($query);
+                    if ($result) {
+                        $this->suggestions['switchquery_' . $currentTransform] = $result;
                     }
                 }
             }
@@ -251,6 +276,23 @@ class SwitchQuery implements RecommendInterface
         }
         $query = trim($query, ' ?');
         return (substr($query, -1) != '*') ? $query . '*' : false;
+    }
+
+    /**
+     * Broaden search by truncating one character (e.g. call number)
+     *
+     * @param string $query Query to transform
+     *
+     * @return string|bool
+     */
+    protected function transformTruncatechar($query)
+    {
+        // Don't truncate phrases:
+        if (substr($query, -1) == '"') {
+            return false;
+        }
+        $query = trim($query);
+        return (strlen($query) > 1) ? substr($query, 0, -1) : false;
     }
 
     /**


### PR DESCRIPTION
Currently this module accepts 'checks to skip' but since this is pretty
specialized to callnumber searches (although potentially useful
elsewhere) I created a new config category called 'transforms to apply'
