### PR TITLE
fixed inclusion of less and sass file

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/ResourceContainer.php
+++ b/module/VuFindTheme/src/VuFindTheme/ResourceContainer.php
@@ -100,8 +100,8 @@ class ResourceContainer
             $less = array($less);
         }
         unset($less['active']);
-        foreach ($less as $index=>$current) {
-            $this->less[$index] = $current;
+        foreach ($less as $current) {
+            $this->less[] = $current;
             $this->removeCSS($current);
         }
     }
@@ -119,8 +119,8 @@ class ResourceContainer
             $scss = array($scss);
         }
         unset($scss['active']);
-        foreach ($scss as $index=>$current) {
-            $this->scss[$index] = $current;
+        foreach ($scss as $current) {
+            $this->scss[] = $current;
             $this->removeCSS($current);
         }
     }


### PR DESCRIPTION
The problem is, that less or sass files which are defined in the theme-config of an extending theme overwrite the ones which are defined in the base theme. 

Due to the fact that in the foreach loop a local index is taken.

Example

_theme.config.php in the base theme._

``` php
'less' => array (
   'base.less' // index is 0
)
```

results in 

``` php
$this->less[0] = 'base.less'
```

_theme.config.php in the extending theme_

``` php
'less' => array(
 'extending.less' // index is 0 too
)
```

results in 

``` php
$this->less[0] = 'extending.less' // instead of $this->less[1] = 'extending.less'
```

Or am I missing a point?
