### PR TITLE
Outsourced tab rendering into separate template

### DIFF
--- a/themes/bootstrap3/templates/search/searchTabs.phtml
+++ b/themes/bootstrap3/templates/search/searchTabs.phtml
@@ -1,0 +1,9 @@
+<? if (count($searchTabs) > 0): ?>
+  <ul class="nav nav-tabs">
+    <? foreach ($searchTabs as $tab): ?>
+      <li<?=$tab['selected'] ? ' class="active"' : ''?>>
+        <a <?=$tab['selected'] ? '' : 'href="' . $this->escapeHtmlAttr($tab['url']) . '"' ?>><?=$this->transEsc($tab['label']); ?></a>
+      </li>
+    <? endforeach; ?>
+  </ul>
+<? endif; ?>

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -20,16 +20,8 @@
 <? if ($this->searchType == 'advanced'): ?>
   <div id="searchForm">
     <? $searchTabs = $this->searchtabs($this->searchClassId, $this->lookfor, $this->searchIndex, $this->searchType); ?>
-    <? if (count($searchTabs) > 0): ?>
-      <ul class="nav nav-tabs">
-      <? foreach ($searchTabs as $tab): ?>
-        <li<?=$tab['selected'] ? ' class="active"' : ''?>>
-          <a href="<?=$tab['selected'] ? '' : $this->escapeHtmlAttr($tab['url'])?>"><?=$this->transEsc($tab['label']); ?></a>
-        </li>
-      <? endforeach; ?>
-      </ul>
-      <div class="tab-content clearfix">
-    <? endif; ?>
+    <?= $this->render('search/searchTabs', array('searchTabs' => $searchTabs)); ?>
+    <div class="tab-content clearfix">
     <p class="navbar-text"><?=$this->transEsc("Your search terms")?> : "<strong><?=$this->escapeHtml($this->lookfor)?>"</strong></p>
     <a class="navbar-text" href="<?=$this->url($advSearch)?>?edit=<?=$this->escapeHtmlAttr($this->searchId)?>"><?=$this->transEsc("Edit this Advanced Search")?></a>
     <a class="navbar-text" href="<?=$this->url($advSearch)?>"><?=$this->transEsc("Start a new Advanced Search")?></a>
@@ -41,15 +33,7 @@
 <? else: ?>
   <form role="search" class="navbar-form navbar-left" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" id="searchForm" autocomplete="off">
     <? $searchTabs = $this->searchtabs($this->searchClassId, $this->lookfor, $this->searchIndex, $this->searchType); ?>
-    <? if (count($searchTabs) > 0): ?>
-      <ul class="nav nav-tabs">
-      <? foreach ($searchTabs as $tab): ?>
-        <li<?=$tab['selected'] ? ' class="active"' : ''?>>
-          <a href="<?=$tab['selected'] ? '' : $this->escapeHtmlAttr($tab['url'])?>"><?=$this->transEsc($tab['label']); ?></a>
-        </li>
-      <? endforeach; ?>
-      </ul>
-    <? endif; ?>
+    <?= $this->render('search/searchTabs', array('searchTabs' => $searchTabs)); ?>
     <input class="form-control search-query<? if($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><? endif ?>" id="searchForm_lookfor" type="text" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"/>
     <? if ($handlerCount > 1): ?>
       <select class="form-control" id="searchForm_type" name="type" data-native-menu="false">


### PR DESCRIPTION
I have two small suggestions:

First: Outsourcing the rendering of the tabs into a separate template since you are using it twice and we are even using it in three different places.

Second: Not render the "href" attribute if the tab is not selected. If the "href" attribute gets rendered empty, then the browser reloads the page on click. If the "href" attribute does not get rendered at all, then the browser does not reload the page. An a-tag without "href" attribute is even valid HTML5. 
