### PR TITLE
Fixed date converter to use the same timezone for conversion and display...

### DIFF
--- a/module/VuFind/src/VuFind/Date/Converter.php
+++ b/module/VuFind/src/VuFind/Date/Converter.php
@@ -123,13 +123,17 @@ class Converter
                 'warning_count' => 0, 'error_count' => 0, 'errors' => array()
             );
             try {
-                $date = new DateTime($dateString);
+                $date = new DateTime(
+                    $dateString, new \DateTimeZone($this->timezone)
+                );
             } catch (\Exception $e) {
                 $getErrors['error_count']++;
                 $getErrors['errors'][] = $e->getMessage();
             }
         } else {
-            $date = DateTime::createFromFormat($inputFormat, $dateString);
+            $date = DateTime::createFromFormat(
+                $inputFormat, $dateString, new \DateTimeZone($this->timezone)
+            );
             $getErrors = DateTime::getLastErrors();
         }
 


### PR DESCRIPTION
I'm not 100% confident about this, but to me it seems the same time zone should be used in date conversion as in display. At least this fixes a Date Converter test case when the PHP default time zone is Europe/Helsinki.
