### PR TITLE
Voyager: Removed "distinct" modifier from fines SQL since it was just wr...

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -1445,9 +1445,6 @@ class Voyager extends AbstractBase
      */
     protected function getFineSQL($patron)
     {
-        // Modifier
-        $sqlSelectModifier = "distinct";
-
         // Expressions
         $sqlExpressions = array(
             "FINE_FEE_TYPE.FINE_FEE_DESC",
@@ -1478,7 +1475,6 @@ class Voyager extends AbstractBase
         $sqlBind = array(':id' => $patron['id']);
 
         $sqlArray = array(
-            'modifier' => $sqlSelectModifier,
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,


### PR DESCRIPTION
...ong.

The query worked in practice because the time stamps usually differ by some seconds. I believe the "distinct" may have been placed there originally in VuFind 1.x in the belief that Voyager had duplicate rows in the table, while they were actually valid rows, just for a couple of different ITEM_ID's of a single BIB_ID.
