### PR TITLE
Updated install.php to allow for CLI Arguments

### DIFF
--- a/install.php
+++ b/install.php
@@ -73,7 +73,7 @@ if (!$opts->getOption('use-defaults') ) {
        $module = getModule();
     }
 
-    if ($opts->getOption('module-name')) {
+    if ($opts->getOption('basepath')) {
        $basePath = $opts->getOption('basepath');
     } else {
        $basePath = getBasePath($basePath);


### PR DESCRIPTION
Added the ability to use the following arguments when install VuFind.
'use-defaults' => 'Use VuFind Defaults to Configure', (Already there)
'overridedir=s' => "Where would you like to store your local settings? [{$baseDir}/local]",
'module-name=w' => 'What module name would you like to use?',
'basepath=s' => 'What base path should be used in VuFind\'s URL? [vufind]',
'multisite-w' => 'Specify we are going to setup a multisite. Options are: directory and host', (Already there, added options)
'hostname=s' => 'Specify the hostname for the VuFind Site, this is used when multisite=2',
