### PR TITLE
 Updated install.php to allow for CLI Arguments

### DIFF
--- a/install.php
+++ b/install.php
@@ -69,7 +69,7 @@ try {
 }
 
 // Load user settings if we are not forcing defaults:
-if (!$opts->getOption('use-defaults') && !opts->getOption('non-interactive')) {
+if (!$opts->getOption('use-defaults') && !$opts->getOption('non-interactive')) {
     if ($opts->getOption('overridedir')) {
         $overrideDir = $opts->getOption('overridedir');
         initializeOverrideDir($overrideDir, true);


### PR DESCRIPTION
Added the ability to use the following arguments when install VuFind.
'use-defaults' => 'Use VuFind Defaults to Configure', (Already there)
'overridedir=s' => "Where would you like to store your local settings? [{$baseDir}/local]",
'module-name=w' => 'What module name would you like to use?',
'basepath=s' => 'What base path should be used in VuFind\'s URL? [/vufind]',
'multisite-w' => 'Specify we are going to setup a multisite. Options are: directory and host', (Already there, added options)
'hostname=s' => 'Specify the hostname for the VuFind Site, this is used when multisite=2',
