### PR TITLE
Added boolean dynamic field type to biblio schema. Fixed indentation of ...

### DIFF
--- a/solr/biblio/conf/schema.xml
+++ b/solr/biblio/conf/schema.xml
@@ -95,6 +95,7 @@
     </fieldType>
     <fieldType name="date" class="solr.TrieDateField" sortMissingLast="true" omitNorms="true" precisionStep="6"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true" />
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
   </types>
  <fields>
    <!-- Required by Solr 4.x -->
@@ -218,6 +219,7 @@
    <dynamicField name="*_txtP" type="textProper" indexed="true" stored="true"/>
    <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
    <dynamicField name="*_random" type="random" />
+   <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
  </fields>
  <uniqueKey>id</uniqueKey>
  <defaultSearchField>allfields</defaultSearchField>

--- a/solr/biblio/conf/solrconfig.xml
+++ b/solr/biblio/conf/solrconfig.xml
@@ -360,9 +360,9 @@
        <str name="fl">*</str>
        <str name="version">2.1</str>
         -->
-     <str name="spellcheck.extendedResults">true</str>
-     <str name="spellcheck.onlyMorePopular">true</str>
-     <str name="spellcheck.count">20</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>
@@ -379,12 +379,12 @@
   -->
   <requestHandler name="dismax" class="solr.SearchHandler">
     <lst name="defaults">
-     <str name="defType">dismax</str>
-     <!-- str name="fl">a*,b*,c*,d*,e*,first_indexed,format,fullrecord,g*,h*,i*,l*,o*,p*,r*,s*,t*,u*,*_date*,*_isn*,*_str*,*_txt*</str -->
-     <str name="echoParams">explicit</str>
-     <str name="spellcheck.extendedResults">true</str>
-     <str name="spellcheck.onlyMorePopular">true</str>
-     <str name="spellcheck.count">20</str>
+      <str name="defType">dismax</str>
+      <!-- str name="fl">a*,b*,c*,d*,e*,first_indexed,format,fullrecord,g*,h*,i*,l*,o*,p*,r*,s*,t*,u*,*_date*,*_isn*,*_str*,*_txt*</str -->
+      <str name="echoParams">explicit</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>
@@ -393,13 +393,13 @@
 
   <requestHandler name="edismax" class="solr.SearchHandler">
     <lst name="defaults">
-     <str name="defType">edismax</str>
-     <!-- str name="fl">a*,b*,c*,d*,e*,first_indexed,format,fullrecord,g*,h*,i*,l*,o*,p*,r*,s*,t*,u*,*_date*,*_isn*,*_str*,*_txt*</str -->
-     <str name="echoParams">explicit</str>
-     <str name="spellcheck.extendedResults">true</str>
-     <str name="spellcheck.onlyMorePopular">true</str>
-     <str name="spellcheck.count">20</str>
-     <str name="lowercaseOperators">false</str>
+      <str name="defType">edismax</str>
+      <!-- str name="fl">a*,b*,c*,d*,e*,first_indexed,format,fullrecord,g*,h*,i*,l*,o*,p*,r*,s*,t*,u*,*_date*,*_isn*,*_str*,*_txt*</str -->
+      <str name="echoParams">explicit</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
+      <str name="lowercaseOperators">false</str>
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>


### PR DESCRIPTION
...a couple of lines in biblio solrconfig.xml.

I just realized that there's no definition for boolean dynamic fields in the default Solr schema, although it's required for the built-in deduplication support. This adds it and fixes some indentation issues as a bonus.
