### PR TITLE
Ignore biblio and authority SOLR index artefacts.

### DIFF
--- a/solr/.gitignore
+++ b/solr/.gitignore
@@ -1,0 +1,4 @@
+*/index
+*/spellchecker
+*/spellShingle
+*/tlog


### PR DESCRIPTION
I believe that `solr/<indexname>/conf` is the most important part, while things like
- `solr/<indexname>/index`
- `solr/<indexname>/spellchecker`
- `solr/<indexname>/spellSingle`
- `solr/<indexname>/tlog`

could be ignored.
