### PR TITLE
Daia

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -264,6 +264,8 @@ class DAIA extends AbstractBase implements \Zend\Log\LoggerAwareInterface
                     'barcode' => 'No samples',
                     'status' => '',
                     'id' => $id,
+		    'location' => '',
+                    'ilslink' => $ilslink,
                     'label' => 'No samples'
             );
             for ($c = 0; $itemlist->item($c) !== null; $c++) {


### PR DESCRIPTION
The current DAIA-driver throws an error in the full result view.
Change the notes field from notes:errno:lang to notes:lang, so it can be used by all themes.
