### PR TITLE
Translation for language names

### DIFF
--- a/import/index_scripts/format.bsh
+++ b/import/index_scripts/format.bsh
@@ -259,6 +259,10 @@ public Set getFormat(Record record){
                 result.add("Book");
             }
             break;
+		// Analytics
+        case 'A':
+                result.add("Analytic");
+            break;
         // Serial
         case 'S':
             // Look in 008 to determine what type of Continuing Resource

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/core.phtml
@@ -115,7 +115,7 @@
       <? $langs = $this->driver->getLanguages(); if (!empty($langs)): ?>
         <tr>
           <th><?=$this->transEsc('Language')?>: </th>
-          <td><? foreach ($langs as $lang): ?><?= $this->escapeHtml($lang)?><br/><? endforeach; ?></td>
+          <td><? foreach ($langs as $lang): ?><?= $this->transEsc($lang)?><br/><? endforeach; ?></td>
         </tr>
       <? endif; ?>
 


### PR DESCRIPTION
In RecordDrive/SolrDefault/core.phtml record names are not translated.
See at https://vufind.org/jira/browse/VUFIND-1044