### PR TITLE
Add two new parameters to the OAI harvester: timeout, combineRecords

### DIFF
--- a/harvest/oai.ini
+++ b/harvest/oai.ini
@@ -8,8 +8,7 @@
 ; metadataPrefix = oai_dc
 ; timeout = 60
 ; combineRecords = false
-; combineRecordsBeginTag = <collection>
-; combineRecordsEndTag = </collection>
+; combineRecordsTag = <collection>
 ; idSearch[] = "/oai:myuniversity.edu:/"
 ; idReplace[] = "myprefix-"
 ; injectDate = false
@@ -47,9 +46,11 @@
 ; response chunk size). The default setting (false) will result in a new file being
 ; created for each record.
 ;
-; combineRecordsBeginTag and combineRecordsEndTag may be used to supply a beginning and
-; ending XML tag (if combinedRecords is set to true) which will be used to wrap the set of
-; combined records. The default values are <collection> and </collection> respectively.
+; combineRecordsTag may be used to supply a beginning and ending XML tag (if
+; combinedRecords is set to true) which will be used to wrap the set of
+; combined records. The default value is <collection>. Note: you may also add
+; attributes to this tag, e.g., <collection attr="value"> will correctly
+; wrap the records in <collection attr="value"></collection> tags.
 ;
 ; idPrefix is the OAI-specific prefix attached to ID values.  If you provide the
 ; value here, it will be automatically stripped for you when generating filenames,

--- a/module/VuFind/src/VuFind/Harvester/OAI.php
+++ b/module/VuFind/src/VuFind/Harvester/OAI.php
@@ -63,18 +63,11 @@ class OAI
     protected $combineRecords = false;
 
     /**
-     * The wrapping XML begin tag to be used if combinedRecords is set to true
+     * The wrapping XML tag to be used if combinedRecords is set to true
      *
      * @var string
      */
-    protected $combineRecordsBeginTag = '<collection>';
-
-    /**
-     * The wrapping XML end tag to be used if combinedRecords is set to true
-     *
-     * @var string
-     */
-    protected $combineRecordsEndTag = '</collection>';
+    protected $combineRecordsTag = '<collection>';
 
     /**
      * URL to harvest from
@@ -277,9 +270,8 @@ class OAI
         }
 
         // User-defined collection tags:
-        if (isset($settings['combineRecordsBeginTag']) && isset($settings['combineRecordsEndTag'])) {
-            $this->combineRecordsBeginTag = $settings['combineRecordsBeginTag'];
-            $this->combineRecordsEndTag = $settings['combineRecordsEndTag'];
+        if (isset($settings['combineRecordsTag'])) {
+            $this->combineRecordsTag = $settings['combineRecordsTag'];
         }
 
         // Don't time out during harvest!!
@@ -790,7 +782,7 @@ class OAI
     protected function processRecords($records)
     {
         $this->writeLine('Processing ' . count($records) . " records...");
-        $xml = $this->combineRecordsBeginTag;
+        $xml = $this->combineRecordsTag;
 
         // Array for tracking successfully harvested IDs:
         $harvestedIds = array();
@@ -835,7 +827,9 @@ class OAI
 
         if ($this->combineRecords) {
             if(!empty($harvestedIds)) {
-                $xml .= $this->combineRecordsEndTag;
+                $parts = explode(' ', $this->combineRecordsTag);
+                $combineRecordsEndTag = '</' . str_replace(array('<', '>'), '', $parts[0]) . '>';
+                $xml .= $combineRecordsEndTag;
                 file_put_contents($this->getFilename($harvestedIds[0], 'xml'), $xml);
             }
 


### PR DESCRIPTION
The former is obvious.

The latter parameter allows administrators to tell the harvester to combine harvested records into
one collection file instead of one file per record. The harvester will combine these records after
every chunk (i.e., for every resumptionToken), therefore if a server's chunk size is set to 1000, then
instead of harvesting 3,123 record files, the harvester will create only 4 record files.
The default value is false.
