### PR TITLE
- fixed missing title in hierarchyTree if "title_in_hierarchy" is empty ...

### DIFF
--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
@@ -165,13 +165,14 @@ class Solr extends AbstractBase
             ++$count;
             if ($sorting) {
                 $positions = $current->getHierarchyPositionsInParents();
-                $titles = $current->getTitlesInHierarchy();
                 if (isset($positions[$parentID])) {
                     $sequence = $positions[$parentID];
                 }
-                $title = isset($titles[$parentID])
-                    ? $titles[$parentID] : $current->getTitle();
             }
+
+            $titles = $current->getTitlesInHierarchy();
+            $title = isset($titles[$parentID])
+                ? $titles[$parentID] : $current->getTitle();
 
             $this->debug("$parentID: " . $current->getUniqueID());
             $xmlNode = '';


### PR DESCRIPTION
...(optional index field, was introduced in https://github.com/vufind-org/vufind/commit/39582484ac0f7699f739e47cf2a794f559e19841)
