### PR TITLE
first pass at browse offset and match highlighting

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -259,13 +259,13 @@ class Backend extends AbstractBackend
      * @return array
      */
     public function alphabeticBrowse($source, $from, $page, $limit = 20,
-        $params = null
+        $offset=0, $params = null
     ) {
         $params = $params ?: new ParamBag();
         $this->injectResponseWriter($params);
 
         $params->set('from', $from);
-        $params->set('offset', $page * $limit);
+        $params->set('offset', ($page * $limit) + $offset);
         $params->set('rows', $limit);
         $params->set('source', $source);
 

--- a/themes/bootstrap/css/bootstrap-custom.css
+++ b/themes/bootstrap/css/bootstrap-custom.css
@@ -11,6 +11,7 @@ h2,#modal h3 {margin-bottom:20px;font-size:21px;font-weight:200;line-height:30px
 
 .alphabrowse .lcc {width:20%;}
 .alphabrowse .titles {width:10%;text-align:center}
+.alphabrowse .browse-match {border:2px solid blue}
 
 /* --- Visualization View --- */
 .node {

--- a/themes/bootstrap/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap/templates/alphabrowse/home.phtml
@@ -51,9 +51,20 @@
       </tr>
     </thead>
     <tbody>
+      <? $row = 0; ?>
       <? foreach ($this->result['Browse']['items'] as $i => $item): ?>
-      <tr>
-        <td class="<?=$this->source ?>">
+        <? if (isset($this->highlight_row) && $row == $this->highlight_row): ?>
+          <tr class="browse-match">
+          <? if (isset($this->no_exact_match)): ?>
+            <?// this is the right row but query doesn't match value ?>
+            <td colspan="<?=count($this->extras) + 2;?>">your_match_would_be_here</td>
+            </tr>
+            <tr>
+          <? endif; ?>
+        <? else: ?>
+          <tr>
+        <? endif; ?>
+          <td class="<?=$this->source ?>">
           <? if ($item['count'] > 0): ?>
             <?/* linking using bib ids is generally more reliable than
               doing searches for headings, but headings give shorter
@@ -119,7 +130,14 @@
             <?=$item['count']; ?>
           <? endif; ?>
         </td>
+      </tr>
+      <? $row++; ?>
       <? endforeach; ?>
+      <? if (isset($this->highlight_end)): ?>
+        <tr class="browse-match">
+          <td colspan="<?=count($this->extras) + 2;?>">your_match_would_be_here</td>
+        </tr>
+      <? endif; ?>
     </tbody>
   </table>
   <?= $pageLinks ?>

--- a/themes/bootstrap3/less/bootstrap.less
+++ b/themes/bootstrap3/less/bootstrap.less
@@ -46,9 +46,21 @@ label.list-group-item {border-radius:0;font-weight:normal;margin-top:0;padding-l
 
 /* --- Alphabrowse --- */
 .alphabrowse {
+  border-collapse:separate;
   .lcc {width:20%;}
   .titles {width:10%;text-align:center}
-  .browse-match {border:2px solid @brand-primary}
+  /* highlighting the row makes ff bugs; operate on its children */
+  tr.browse-match td {
+    border-top:.2em solid @brand-primary;
+    border-bottom:.2em solid @brand-primary;
+  }
+  tr.browse-match td:first-child {
+    border-left:.2em solid @brand-primary;
+  }
+  tr.browse-match td:last-child {
+    border-right:.2em solid @brand-primary;
+  }
+
 }
 
 /* --- Autocomplete --- */

--- a/themes/bootstrap3/less/bootstrap.less
+++ b/themes/bootstrap3/less/bootstrap.less
@@ -48,6 +48,7 @@ label.list-group-item {border-radius:0;font-weight:normal;margin-top:0;padding-l
 .alphabrowse {
   .lcc {width:20%;}
   .titles {width:10%;text-align:center}
+  .browse-match {border:2px solid @brand-primary}
 }
 
 /* --- Autocomplete --- */

--- a/themes/bootstrap3/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap3/templates/alphabrowse/home.phtml
@@ -49,8 +49,19 @@
       </tr>
     </thead>
     <tbody>
+      <? $row = 0; ?>
       <? foreach ($this->result['Browse']['items'] as $item): ?>
-        <tr>
+        <? if (isset($this->highlight_row) && $row == $this->highlight_row): ?>
+          <tr class="browse-match">
+          <? if (isset($this->no_exact_match)): ?>
+            <?// this is the right row but query doesn't match value ?>
+            <td colspan="<?=count($this->extras) + 2;?>">your_match_would_be_here</td>
+            </tr>
+            <tr>
+          <? endif; ?>
+        <? else: ?>
+          <tr>
+        <? endif; ?>
           <td class="<?=$this->source ?>">
             <? if ($item['count'] > 0): ?>
               <?/* linking using bib ids is generally more reliable than
@@ -116,7 +127,13 @@
             <? endif; ?>
           </td>
         </tr>
-      <? endforeach; ?>
+        <? $row++; ?>
+        <? endforeach; ?>
+        <? if (isset($this->highlight_end)): ?>
+          <tr class="browse-match">
+            <td colspan="<?=count($this->extras) + 2;?>">your_match_would_be_here</td>
+          </tr>
+        <? endif; ?>
     </tbody>
   </table>
   <?= $pageLinks ?>


### PR DESCRIPTION
Note there are TODOs (most notably the config file piece). 

Seeking input on:
* how to deal with the method signature of alphabeticBrowse in VuFindSearch/Backend/Solr/Backend
* css styling (currently a blue box but if nothing else the color should change)
* is there a better way to figure out whether the result solr returns is an exact match? I'm actually fine with the rough comparison (uppercase, strip spaces) but if there's any easy and more precise way to tell I'd use that.