### PR TITLE
Check the source from additional field

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1277,7 +1277,7 @@ class MultiBackend extends AbstractBase
                 if ($source) {
                     return $source;
                 }
-            } elseif ($key === 0 || $key === 'id' || $key === 'cat_username') {
+            } elseif ($key === 0 || $key === 'id' || $key === 'item_id' || $key === 'cat_username') {
                 $source = $this->getSource(
                     $value, $key === 'cat_username' ? 'login' : ''
                 );


### PR DESCRIPTION
- This solves a problem in connection with Aleph::getMyHolds(), where the ISBN number of holds comes in a numbered array and, as it can contain a dot, it is looked upon as source. Item_id comes simply first, so should be checked for source-code
- am not sure if this has no side effects
