### PR TITLE
Relax check for MARCXML so that the xml prolog is not required.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -88,8 +88,7 @@ class SolrMarc extends SolrDefault
         $marc = trim($data['fullrecord']);
 
         // check if we are dealing with MARCXML
-        $xmlHead = '<?xml version';
-        if (strcasecmp(substr($marc, 0, strlen($xmlHead)), $xmlHead) === 0) {
+        if (substr($marc, 0, 1) == '<') {
             $marc = new \File_MARCXML($marc, \File_MARCXML::SOURCE_STRING);
         } else {
             // When indexing over HTTP, SolrMarc may use entities instead of certain


### PR DESCRIPTION
Since the prolog isn't required, a simple check for '<' at the beginning should be enough especially since a MARC record in ISO2709 format must start with digits. 
