### PR TITLE
Symphony: check both unseen, total renewals left

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1241,8 +1241,10 @@ class Symphony extends AbstractBase
                     $transactions;
 
                 foreach ($transactions as $transaction) {
-                    if (!empty($transaction->unseenRenewalsRemaining)
-                        || !empty($transaction->unseenRenewalsRemainingUnlimited)
+                    if ((!empty($transaction->unseenRenewalsRemaining)
+                        || !empty($transaction->unseenRenewalsRemainingUnlimited)) &&
+                       (!empty($transaction->renewalsRemaining)
+                        || !empty($transaction->renewalsRemainingUnlimited))
                     ) {
                         $renewable = true;
                     } else {


### PR DESCRIPTION
Add a check for total number of renewals remaining when checking whether an
item can be renewed.

The total number of renewals remaining (the values renewalsRemaining and
renewalsRemainingUnlimited) govern, even if unseen renewals remain, or are
unlmited. That is, Symphony treats unseen renewals as limiting the conditions
in which a renewal can take place, not a separate type of renewal that can be
performed without the item in hand.

Refer to SirsiDynix KB #131608 for additional details.
