### PR TITLE
Fix for the ajaxLoadTab method in record.js

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -151,14 +151,12 @@ function registerTabEvents() {
 function ajaxLoadTab(tabid) {
   var id = $('.hiddenId')[0].value;
   // Grab the part of the url that is the Controller and Record ID
+  //var urlroot = document.URL.match(new RegExp('/[^/]+/'+id+'\\b')) + "/";
+  var urlroot = document.URL.match(new RegExp('/[^/]+/'+id)) + "/";
 
-  var urlroot = document.URL.match(new RegExp('/[^/]+/'+id+'(/|\\b)'));
-  var regexPath = Array.isArray(urlroot) ? urlroot[0] : urlroot;
-  if (regexPath[regexPath.length -1] != '/') {
-    regexPath += '/';
-  }
+
   $.ajax({
-    url: path + regexPath + 'AjaxTab' ,
+    url: path + urlroot + 'AjaxTab',
     type: 'POST',
     data: {tab: tabid},
     success: function(data) {

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -151,13 +151,14 @@ function registerTabEvents() {
 function ajaxLoadTab(tabid) {
   var id = $('.hiddenId')[0].value;
   // Grab the part of the url that is the Controller and Record ID
+
   var urlroot = document.URL.match(new RegExp('/[^/]+/'+id+'(/|\\b)'));
-  urlroot = urlroot.slice(-1);
-  if(urlroot.substring(-1) != '/') {
-    urlroot += '/';
+  var regexPath = Array.isArray(urlroot) ? urlroot[0] : urlroot;
+  if (regexPath[regexPath.length -1] != '/') {
+    regexPath += '/';
   }
   $.ajax({
-    url: path + urlroot + 'AjaxTab',
+    url: path + regexPath + 'AjaxTab' ,
     type: 'POST',
     data: {tab: tabid},
     success: function(data) {


### PR DESCRIPTION
Hi Chris
I took a look into your fix for the method you have done yesterday.
Please don't use the substring method with one parameter as it produces error messages. Not only in relation to the Tab mechanism but also using the login dialog on the Record-Controller page (which leads to a popup dialog box still open after successful login). I'm not a specialist in JavaScript programming but looking into  http://www.w3schools.com/jsref/jsref_obj_string.asp it is defined with only two parameters (which produces the error in the application)

I tried to make the method a little bit more stable as I'm not pretty sure if the   match method in 
document.URL.match always returns an array. Therefore the additional Array type operation.

The propsoed implementation in this pull request fit's for  all the cases I have seen - so far - in our use case.

Please give it a try!

Günter