### PR TITLE
Changed advanced search group join element to #groupJoinOptions

### DIFF
--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -48,8 +48,8 @@
       <div class="clearfix">
         <p class="lead pull-left"><?=$this->transEsc('Advanced Search')?></p>
         <div id="groupJoin" class="form-inline pull-right hidden">
-          <label for="join"><?=$this->transEsc("search_match")?>:</label>
-          <select id="search_bool0" name="join" class="form-control">
+          <label for="groupJoinOptions"><?=$this->transEsc("search_match")?>:</label>
+          <select id="groupJoinOptions" name="join" class="form-control">
             <option value="AND"<? if($searchDetails && $searchDetails->getOperator()=='ALL'):?> selected<?endif?>><?= $this->transEsc('group_AND') ?></option>
             <option value="OR"<? if($searchDetails && $searchDetails->getOperator()=='OR'):?> selected<?endif?>><?= $this->transEsc('group_OR') ?></option>
           </select>


### PR DESCRIPTION
Hello- on the advanced search form, I think the ID for the group join options may be wrong in the boostrap3 theme. In blueprint it's "groupJoinOptions". (If it's set to search_bool0 you end up with more than one element with the same id.)