### PR TITLE
Bugfixing for sharded Solr-Setup

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
@@ -124,8 +124,11 @@ class MultiIndexListener
             } else {
                 // In any other context, we should make sure our field values are
                 // all legal.
-                $params->set('shards', implode(',', $this->shards));
-                $shards = $params->get('shards');
+
+                // Check if $params->get('shards') returns an array to prevent
+                // invalid argument warnings.
+                $shards = explode(',', implode(',',
+                    (is_array($params->get('shards')) ? $params->get('shards') : array())));
                 $fields = $this->getFields($shards);
                 $specs  = $this->getSearchSpecs($fields);
                 $backend->getQueryBuilder()->setSpecs($specs);

--- a/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
@@ -124,7 +124,8 @@ class MultiIndexListener
             } else {
                 // In any other context, we should make sure our field values are
                 // all legal.
-                $shards = explode(',', implode(',', $params->get('shards')));
+                $params->set('shards', implode(',', $this->shards));
+                $shards = $params->get('shards');
                 $fields = $this->getFields($shards);
                 $specs  = $this->getSearchSpecs($fields);
                 $backend->getQueryBuilder()->setSpecs($specs);

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -459,7 +459,7 @@ class Params extends \VuFind\Search\Base\Params
         // Shards
         $allShards = $this->getOptions()->getShards();
         $shards = $this->getSelectedShards();
-        if (is_null($shards)) {
+        if (empty($shards)) {
             $shards = array_keys($allShards);
         }
 


### PR DESCRIPTION
On testing a sharded setup with Vufind2.3.1 I came upon some errors in the recommendation sidebar in record-view. After further investigation I found some bugs in the code (it's identical in Vufind2.3.1 and latest github-commit):

1.) replaced not_null check of initialized array in VuFind\Search\Solr\Params
2.) removed redundant call of explode(implode) in VuFind\Search\Solr\MultiIndexListener
3.) added params->set(shards) for other contexts than retrieval in VuFind\Search\Solr\MultiIndexListener (I'm not entirely sure if this fix is correct - identical params->set(shards...) calls in the if- and the else-block should be moved out of the if-else-block but I wanted to make the fix as inobstrusive as possible in case I'm getting something wrong how the different event-contexts work)

Similiar items/recommendation-sidebar do work fine after this fix with a sharded index.