### PR TITLE
AJAX skipping for RecordTab drivers

### DIFF
--- a/module/VuFind/src/VuFind/RecordTab/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordTab/AbstractBase.php
@@ -75,6 +75,17 @@ abstract class AbstractBase implements TabInterface
     }
 
     /**
+     * Can this tab be loaded via AJAX?
+     *
+     * @return bool
+     */
+    public function supportsAjax()
+    {
+        // Assume we can load by AJAX; subclasses may add rules.
+        return true;
+    }
+
+    /**
      * Set the record driver
      *
      * @param \VuFind\RecordDriver\AbstractBase $driver Record driver

--- a/module/VuFind/src/VuFind/RecordTab/Map.php
+++ b/module/VuFind/src/VuFind/RecordTab/Map.php
@@ -56,6 +56,17 @@ class Map extends AbstractBase
     }
 
     /**
+     * Can this tab be loaded via AJAX?
+     *
+     * @return bool
+     */
+    public function supportsAjax()
+    {
+        // No, Google script magic required
+        return false;
+    }
+
+    /**
      * Get the on-screen description for this tab.
      *
      * @return string

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -150,9 +150,11 @@ function registerTabEvents() {
 
 function ajaxLoadTab(tabid) {
   var id = $('.hiddenId')[0].value;
-  // Grab the part of the url that is the Controller and Record ID
+  // Try to parse out the controller portion of the URL. If this fails, or if
+  // we're flagged to skip AJAX for this tab, just return true and let the
+  // browser handle it.
   var urlroot = document.URL.match(new RegExp('/[^/]+/'+id));
-  if(!urlroot) {
+  if(!urlroot || document.getElementById(tabid).parentNode.className.indexOf('noajax') > -1) {
     return true;
   }
   $.ajax({

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -61,13 +61,16 @@
         <? foreach ($this->tabs as $tab => $obj): ?>
         <? // add current tab to breadcrumbs if applicable:
           $desc = $obj->getDescription();
-          $isCurrent = (strtolower($this->activeTab) == strtolower($tab));
-          if ($isCurrent) {
+          $tab_classes = array();
+          if (0 === strcasecmp($this->activeTab, $tab)) {
+            $tab_classes[] = 'active';
             $this->layout()->breadcrumbs .= ' <li class="active">' . $this->transEsc($desc) . '</li>';
             $activeTabObj = $obj;
           }
+          if (!$obj->isVisible()) { $tab_classes = 'hidden'; }
+          if (!$obj->supportsAjax()) { $tab_classes = 'noajax'; }
         ?>
-        <li<?=$isCurrent ? ' class="active"' : ''?>>
+        <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
           <a id="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"><?=$this->transEsc($desc)?></a>
         </li>
         <? endforeach; ?>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -55,14 +55,14 @@
         <? foreach ($this->tabs as $tab => $obj): ?>
         <? // add current tab to breadcrumbs if applicable:
           $desc = $obj->getDescription();
-          $isCurrent = (strtolower($this->activeTab) == strtolower($tab));
-          if ($isCurrent) {
+          $tab_classes = array();
+          if (0 === strcasecmp($this->activeTab, $tab)) {
+            $tab_classes[] = 'active';
             $this->layout()->breadcrumbs .= '<li class="active">' . $this->transEsc($desc) . '</li>';
             $activeTabObj = $obj;
           }
-          $tab_classes = array();
-          if ($isCurrent) $tab_classes[] = 'active';
-          if (!$obj->isVisible()) $tab_classes[] = 'hidden';
+          if (!$obj->isVisible()) { $tab_classes[] = 'hidden'; }
+          if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
         ?>
         <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
           <a id="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"><?=$this->transEsc($desc)?></a>


### PR DESCRIPTION
Adds a supportsAjax boolean method to RecordTabs. Setting to false will prevent subclass tab from loading through AJAX.

Applied to Maps tab.