### PR TITLE
Allow deselecting a facet by clicking the facet value also in AND facets

### DIFF
--- a/themes/blueprint/templates/Recommend/SideFacets.phtml
+++ b/themes/blueprint/templates/Recommend/SideFacets.phtml
@@ -77,17 +77,17 @@
             <? $indent = $hierarchical
                 ? str_pad('', 4 * $thisFacet['level'] * 6, '&nbsp;', STR_PAD_LEFT)
                 : ''; ?>
-            <? if ($thisFacet['isApplied']): ?>
-              <dd class="facet<?=$thisFacet['operator'] ?> applied"<? if($thisFacet['operator'] == 'OR'): ?> href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>"<? endif ?>><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?> <img src="<?=$this->imageLink('silk/tick.png')?>" alt="Selected"/></dd>
-            <? else: ?>
               <dd>
+            <? if ($thisFacet['isApplied']): ?>
+                <a class="facet<?=$thisFacet['operator'] ?> applied" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>"><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?> <img src="<?=$this->imageLink('silk/tick.png')?>" alt="Selected"/></a>
+            <? else: ?>
                 <a class="facet<?=$thisFacet['operator'] ?>" href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator'])?>"><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?></a> (<?=$this->localizedNumber($thisFacet['count'])?>)
                 <? if ($allowExclude): ?>
                   <a href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>" title="<?=$this->transEsc('exclude_facet')?>"><img src="<?=$this->imageLink('fugue/cross-small.png')?>" alt="Delete"/></a>
                 <? endif; ?>
-              </dd>
             <? endif; ?>
-          <? endforeach; ?>
+              </dd>
+            <? endforeach; ?>
           <? if ($i > 5): ?><dd><a href="#" onclick="lessFacets('<?=$this->escapeHtmlAttr($title)?>'); return false;"><?=$this->transEsc('less')?> ...</a></dd><? endif; ?>
         </dl>
       <? endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -162,7 +162,7 @@ JS;
             <a id="more-narrowGroupHidden-<?=$this->escapeHtmlAttr($title)?>" class="list-group-item" href="javascript:moreFacets('narrowGroupHidden-<?=$title ?>')"><?=$this->transEsc('more')?> ...</a>
           <? endif; ?>
           <? if ($thisFacet['isApplied']): ?>
-            <a class="list-group-item active<? if ($i>5): ?><?=$moreClass ?><?endif ?><? if ($thisFacet['operator'] == 'OR'): ?> facetOR applied" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?><? endif ?>">
+            <a class="list-group-item active<? if ($i>5): ?><?=$moreClass ?><?endif ?><? if ($thisFacet['operator'] == 'OR'): ?> facetOR applied<? endif ?>" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>">
               <? if ($thisFacet['operator'] == 'OR'): ?>
                 <i class="fa fa-check-square-o"></i>
               <? else: ?>

--- a/themes/jquerymobile/templates/Recommend/SideFacets-dialog.phtml
+++ b/themes/jquerymobile/templates/Recommend/SideFacets-dialog.phtml
@@ -21,7 +21,7 @@
                     ? str_pad('', 4 * $thisFacet['level'] * 6, '&nbsp;', STR_PAD_LEFT)
                     : ''; ?>
                 <? if ($thisFacet['isApplied']): ?>
-                  <li data-icon="check" class="checked"><a href="" data-rel="back"><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?></a> <span class="ui-li-count"><?=$this->localizedNumber($thisFacet['count'])?></span></li>
+                  <li data-icon="check" class="checked"><a href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>" data-rel="external"><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?></a> <span class="ui-li-count"><?=$this->localizedNumber($thisFacet['count'])?></span></li>
                 <? else: ?>
                   <li><a rel="external" href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator'])?>"><?=$indent?><?=$this->escapeHtml($thisFacet['displayText'])?></a> <span class="ui-li-count"><?=$this->localizedNumber($thisFacet['count'])?></span></li>
                 <? endif; ?>


### PR DESCRIPTION
Our usability studies showed that users expect they can toggle a facet on and off by clicking it. This already works for OR facets, but these changes allow delection of a facet by clicking it in the facet list also for AND facets.