### PR TITLE
Try different locale variants in SafeMoneyFormatTest.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
@@ -55,7 +55,7 @@ class SafeMoneyFormatTest extends \PHPUnit_Framework_TestCase
     {
         // store current default and set a value for consistency in testing
         $this->locale = setlocale(LC_MONETARY, 0);
-        setlocale(LC_MONETARY, 'en_US.UTF8');
+        setlocale(LC_MONETARY, array('en_US.UTF8', 'en_US.UTF-8', 'en_US'));
     }
 
     /**


### PR DESCRIPTION
For instance on Mac OS X 'en_US.UTF8' doesn't work while 'en_US.UTF-8' does. This fixes the test in that case, although it might be also a good idea to check setlocale() result and do something accordingly.