### PR TITLE
Lazily load QR code images when clicked instead of loading them all at once

### DIFF
--- a/themes/blueprint/js/common.js
+++ b/themes/blueprint/js/common.js
@@ -364,7 +364,17 @@ $(document).ready(function(){
         } else {
             $(this).html(vufindString.qrcode_hide).addClass("active");
         }
-        $(this).next('.qrcodeHolder').toggle();
+
+        var holder = $(this).next('.qrcodeHolder');
+
+        if (holder.find('img').length == 0) {
+            // We need to insert the QRCode image
+            var template = holder.find('.qrCodeImgTag').html();
+            holder.html(template);
+        }
+
+        holder.toggle();
+
         return false;
     });
 

--- a/themes/blueprint/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/blueprint/templates/RecordDriver/EDS/result-list.phtml
@@ -89,7 +89,9 @@
       ?>
       <a href="<?=$this->escapeHtmlAttr($QRCode);?>" class="qrcodeLink"><?=$this->transEsc('qrcode_show')?></a>
       <div class="qrcodeHolder">
-        <img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+        <script type="text/template" class="qrCodeImgTag">
+          <img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+        </script>
       </div>
     <? endif; ?>
 

--- a/themes/blueprint/templates/RecordDriver/SolrDefault/result-list.phtml
+++ b/themes/blueprint/templates/RecordDriver/SolrDefault/result-list.phtml
@@ -153,7 +153,9 @@
       ?>
       <a href="<?=$this->escapeHtmlAttr($QRCode);?>" class="qrcodeLink"><?=$this->transEsc('qrcode_show')?></a>
       <div class="qrcodeHolder">
-        <img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+        <script type="text/template" class="qrCodeImgTag">
+          <img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+        </script>
       </div>
     <? endif; ?>
 

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -360,7 +360,17 @@ $(document).ready(function() {
     } else {
       $(this).html(vufindString.qrcode_hide).addClass("active");
     }
-    $(this).next('.qrcode').toggleClass('hidden');
+
+    var holder = $(this).next('.qrcode');
+
+    if (holder.find('img').length == 0) {
+      // We need to insert the QRCode image
+      var template = holder.find('.qrCodeImgTag').html();
+      holder.html(template);
+    }
+
+    holder.toggleClass('hidden');
+
     return false;
   });
 

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -85,7 +85,9 @@
         <span class="hidden-xs">
           <i class="fa fa-qrcode"></i> <a href="<?=$this->escapeHtmlAttr($QRCode);?>" class="qrcodeLink"><?=$this->transEsc('qrcode_show')?></a>
           <div class="qrcode hidden">
-            <img alt="<?=$this->transEsc('QR Code')?>" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+            <script type="text/template" class="qrCodeImgTag">
+              <img alt="<?=$this->transEsc('QR Code')?>" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+            </script>
           </div><br/>
         </span>
       <? endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-list.phtml
@@ -161,7 +161,9 @@
         <span class="hidden-xs">
           <i class="fa fa-qrcode"></i> <a href="<?=$this->escapeHtmlAttr($QRCode);?>" class="qrcodeLink"><?=$this->transEsc('qrcode_show')?></a>
           <div class="qrcode hidden">
-            <img alt="<?=$this->transEsc('QR Code')?>" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+            <script type="text/template" class="qrCodeImgTag">
+              <img alt="<?=$this->transEsc('QR Code')?>" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+            </script>
           </div><br/>
         </span>
       <? endif; ?>


### PR DESCRIPTION
Fetching QR codes for a page of 20 search results can tie up quite a few
Apache workers.  Instead, use JavaScript to load in QR code images on
demand.

The motivation for this came from Luke Osullivan's report on the vufind-tech list:

  http://vufind.2307425.n4.nabble.com/Apache-Woes-Again-td4667140.html

I've tested this patch with all three default themes, and in Chrome, Firefox, IE 10 and Safari and it seems to do the job, but let me know if anything seems wrong.  I think the JavaScript should be more-or-less backwards compatible, since it won't do anything new if the QR code image was already inserted by the theme's template.

Cheers,
Mark