### PR TITLE
Inverted language file inheritance

### DIFF
--- a/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIni.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIni.php
@@ -177,8 +177,8 @@ class ExtendedIni implements FileLoaderInterface
             return $data;
         }
         $parent = $this->loadLanguageFile($data['@parent_ini']);
-        $parent->merge($data);
-        return $parent;
+        $data->merge($parent);
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Parent language files referenced by @parent_ini will be merged with their children overwriting the children's values. Inheritance should work the other way round - children's values overwriting parent's values.
This small fix inverts the merge and produces the same behaviour for language files as for config files (child beats parent).