### PR TITLE
Check that the missing record has an ID before trying to load it from th...

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Missing.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Missing.php
@@ -62,11 +62,14 @@ class Missing extends SolrDefault
     public function determineMissingTitle()
     {
         // If available, load title from database:
-        $table = $this->getDbTable('Resource');
-        $resource = $table
-            ->findResource($this->getUniqueId(), $this->getResourceSource(), false);
-        if (!empty($resource) && !empty($resource->title)) {
-            return $resource->title;
+        $id = $this->getUniqueId();
+        if ($id) {
+            $table = $this->getDbTable('Resource');
+            $resource = $table
+                ->findResource($id, $this->getResourceSource(), false);
+            if (!empty($resource) && !empty($resource->title)) {
+                return $resource->title;
+            }
         }
 
         // Default -- message about missing title:


### PR DESCRIPTION
...e database.

E.g. ILL request list calls $this->record($resource)->getThumbnail() which, for Voyager ILL records, creates a Missing record without an ID since the ID isn't available from Voyager. Then SolrDefault->getThumbnail('small') calls Missing->getTitle() which ends up in Missing->determineMissingTitle() and tries to load the record from database without an ID and causes an error.