### PR TITLE
Workaround for a problem in ICU library < 4.9 causing formatCurrency to ...

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
@@ -88,8 +88,15 @@ class SafeMoneyFormat extends AbstractHelper
             $currency = $this->defaultCurrency;
         }
         $escaper = $this->getView()->plugin('escapeHtml');
-        return $escaper(
+        // Workaround for a problem in ICU library < 4.9 causing formatCurrency to
+        // fail if locale has comma as a decimal separator.
+        // (see https://bugs.php.net/bug.php?id=54538)
+        $locale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, 'en_us');
+        $result = $escaper(
             $this->formatter->formatCurrency((float)$number, $currency)
         );
+        setlocale(LC_ALL, $locale);
+        return $result;
     }
 }


### PR DESCRIPTION
...fail if locale has comma as a decimal separator.

See https://bugs.php.net/bug.php?id=54538, http://bugs.icu-project.org/trac/ticket/8214 and http://bugs.icu-project.org/trac/ticket/8561 for more information.