### PR TITLE
Tweaked ICU workaround in SafeMoneyFormat to only touch LC_NUMERIC as th...

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
@@ -91,12 +91,12 @@ class SafeMoneyFormat extends AbstractHelper
         // Workaround for a problem in ICU library < 4.9 causing formatCurrency to
         // fail if locale has comma as a decimal separator.
         // (see https://bugs.php.net/bug.php?id=54538)
-        $locale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, ['en_us.UTF-8', 'en_us.UTF8', 'en_us']);
+        $locale = setlocale(LC_NUMERIC, 0);
+        setlocale(LC_NUMERIC, ['en_us.UTF-8', 'en_us.UTF8', 'en_us']);
         $result = $escaper(
             $this->formatter->formatCurrency((float)$number, $currency)
         );
-        setlocale(LC_ALL, $locale);
+        setlocale(LC_NUMERIC, $locale);
         return $result;
     }
 }


### PR DESCRIPTION
...e value of LC_ALL could become too long for setlocale() to handle in the end.

So I found out that the CentOS system our Jenkins runs on started to fail ("Specified locale name is too long") with the SafeMoneyFormat tweak because setlocale(LC_ALL, 0) returned a string over 255 chars long. This change should fix it while keeping the workaround working.