### PR TITLE
Fix for Record helper's renderTemplate() to avoid masking a real error.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -94,18 +94,15 @@ class Record extends AbstractHelper
         // in case we need to use a parent class' name to find the appropriate
         // template.
         $className = get_class($this->driver);
+        $resolver = $this->view->resolver();
         while (true) {
             // Guess the template name for the current class:
             $classParts = explode('\\', $className);
             $template = 'RecordDriver/' . array_pop($classParts) . '/' . $name;
-            try {
-                // Try to render the template....
-                $html = $this->view->render($template);
-                $this->contextHelper->restore($oldContext);
-                return $html;
-            } catch (RuntimeException $e) {
-                // If the template doesn't exist, let's see if we can inherit a
-                // template from a parent class:
+
+            // If the template doesn't exist, let's see if we can inherit a
+            // template from a parent class:
+            if (!$resolver->resolve($template)) {
                 $className = get_parent_class($className);
                 if (empty($className)) {
                     // No more parent classes left to try?  Throw an exception!
@@ -114,7 +111,12 @@ class Record extends AbstractHelper
                         get_class($this->driver)
                     );
                 }
+                continue;
             }
+            // Try to render the template....
+            $html = $this->view->render($template);
+            $this->contextHelper->restore($oldContext);
+            return $html;
         }
     }
 
@@ -529,7 +531,7 @@ class Record extends AbstractHelper
             if (!isset($link['desc'])) {
                 $link['desc'] = $link['url'];
             }
-            
+
             return $link;
         };
 


### PR DESCRIPTION
For instance if rendering of result-list.phtml failed because a sub-template was missing, the old code complained it couldn't find result-list.phtml, which made finding the real culprit difficult. 