### PR TITLE
Made the Records section not commented-out in searches.ini by default si...

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -536,7 +536,7 @@ container_title = "Journal Title"
 ;1 = "language:\"English\" OR language:\"French\""
 
 ; This section defines how records are handled when being fetched from Solr.
-;[Records]
+[Records]
 ; Boolean value indicating if deduplication is enabled. Defaults to false.
 ;deduplication = true
 ; Priority order (descending) for record sources (record ID prefixes separated


### PR DESCRIPTION
...nce it's very easy to miss.

Since I'm not the only one who has missed this, here's a tiny change to make the section friendlier.