### PR TITLE
CLI-Tool to synchronize language files

### DIFF
--- a/util/synclangfiles.php
+++ b/util/synclangfiles.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Create all the hierarchy files which are used for looking up hierarchichal trees.
+ * This script will search the Solr index and create the files needed so they don't
+ * need to be built at runtime. If this script is run after every index, the caching
+ * time for hierarchy trees can be set to -1 so that trees are always assumed to be
+ * up to date.
+ *
+ * -!!!!-This script is specifically for trees built for JSTree from Solr.-!!!!-
+ *
+ * PHP version 5
+ *
+ * Copyright (C) National Library of Ireland 2012.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Utilities
+ * @author   Lutz Biedinger <lutz.biedinger@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki Wiki
+ */
+
+// Load the Zend framework -- this will automatically trigger the appropriate
+// controller action based on directory and file names
+define('CLI_DIR', __DIR__);     // save directory name of current script
+require_once __DIR__ . '/../public/index.php';

--- a/util/synclangfiles.php
+++ b/util/synclangfiles.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Create all the hierarchy files which are used for looking up hierarchichal trees.
- * This script will search the Solr index and create the files needed so they don't
- * need to be built at runtime. If this script is run after every index, the caching
- * time for hierarchy trees can be set to -1 so that trees are always assumed to be
- * up to date.
+ * This tool allows to compare and synchronize language files for VuFind2.
+ * You can either run it as CLI-tool with output on STDOUT to check whether
+ * language files are out of sync (default) or synchronize language files
+ * automatically by writing the missing lines into the .ini files.
  *
- * -!!!!-This script is specifically for trees built for JSTree from Solr.-!!!!-
+ * For more available options see run php synclangfiles.php --help
  *
  * PHP version 5
  *
- * Copyright (C) National Library of Ireland 2012.
+ * Copyright (C) Leipzig University Library 2015.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -27,7 +26,7 @@
  *
  * @category VuFind2
  * @package  Utilities
- * @author   Lutz Biedinger <lutz.biedinger@gmail.com>
+ * @author   André Lahmann <lahmann@ub.uni-leipzig.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://vufind.org/wiki Wiki
  */


### PR DESCRIPTION
During our ongoing migration from VuFind1.x to VuFind2.x we faced some translation issues having strings translated into German although English was selected. It turned out that the fallback logic apparently wasn't in place in VuFind1.x and therefore we did not update the en.ini with our custom strings using the logic that the to-be-translated-phrase gets printed if no translation was found.
So, our language files where badly out of sync.
Instead of a manual comparison, which would mean also to compare the customized language files from several other libraries, I decided to write a small CLI-tool which reads the language files using VuFind\I18n\Translator\Loader\ExtendedIni and compares the keys of each language, reporting missing keys and optionally writing those into the language .ini file in question.
The tool has several options:

    $ php synclangfiles.php --help
    Synchronize language files.
    
    Options:
    --help             this output.
    --enable-comments  write output as ini comments (disabled by default).
    --enable-fallback  fallback languages are enabled (by default, fallback logic is overriden).
    --ignore-local-dir ignore VUFIND_LOCAL_DIR if set and only sync language files in VUFIND_HOME/languages.
    --write-keys       write language file keys as translation (write translation by default).
    --write-to-ini     write missing lines directly into .ini files (writes to stdout by default).

Maybe this is useful for others, especially if one wants to complete localization for VuFind: you can see all missing translations for the language files in /languages by running:

    $ synclangfiles.php --ignore-local-dirs
