### PR TITLE
Fixed storage retrieval requests in VoyagerRestful to use correct config...

### DIFF
--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -170,8 +170,8 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ;helpText[en-gb] = "Help text for English language."
 
 
-; This section controls call slip behavior. To enable, uncomment (at minimum) the
-; HMACKeys and extraFields settings below.
+; This section controls call slip behavior (storage retrieval requests in VuFind). 
+; To enable, uncomment (at minimum) the HMACKeys and extraFields settings below.
 [StorageRetrievalRequests]
 ; Colon-separated list of item types where call slip is allowed
 ;valid_item_types = 1:2:3

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -255,8 +255,8 @@ class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInte
             = isset($this->config['Holds']['holdCheckLimit'])
             ? $this->config['Holds']['holdCheckLimit'] : "15";
         $this->callSlipCheckLimit
-            = isset($this->config['CallSlips']['callSlipCheckLimit'])
-            ? $this->config['CallSlips']['callSlipCheckLimit'] : "15";
+            = isset($this->config['StorageRetrievalRequests']['checkLimit'])
+            ? $this->config['StorageRetrievalRequests']['checkLimit'] : "15";
 
         $this->recallsEnabled
             = isset($this->config['Holds']['enableRecalls'])
@@ -432,9 +432,9 @@ class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInte
     protected function isStorageRetrievalRequestAllowed($holdingsRow)
     {
         $holdingsRow = $holdingsRow['_fullRow'];
-        if (isset($this->config['CallSlips']['valid_item_types'])) {
+        if (isset($this->config['StorageRetrievalRequests']['valid_item_types'])) {
             $validTypes = explode(
-                ':', $this->config['CallSlips']['valid_item_types']
+                ':', $this->config['StorageRetrievalRequests']['valid_item_types']
             );
 
             $type = $holdingsRow['TEMP_ITEM_TYPE_ID']
@@ -638,7 +638,7 @@ class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInte
             return false;
         }
         if ($this->checkAccountBlocks($patron['id'])) {
-            return 'block';
+            return false;
         }
 
         $level = isset($data['level']) ? $data['level'] : "copy";

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -431,6 +431,13 @@ class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInte
      */
     protected function isStorageRetrievalRequestAllowed($holdingsRow)
     {
+        if (!isset($holdingsRow['TEMP_ITEM_TYPE_ID'])
+            || !isset($holdingsRow['ITEM_TYPE_ID'])
+        ) {
+            // Not a real item
+            return false;
+        }
+
         $holdingsRow = $holdingsRow['_fullRow'];
         if (isset($this->config['StorageRetrievalRequests']['valid_item_types'])) {
             $validTypes = explode(


### PR DESCRIPTION
... section and checkStorageRetrievalRequestIsValid() to always return bool instead of a string for patron blocks.