### PR TITLE
enables conditional filters for Solr

### DIFF
--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -92,3 +92,10 @@ permission = access.StaffViewTab
 ;[shibboleth.StaffView]
 ;shibboleth = "affiliation staff@example.org"
 ;permission = access.StaffViewTab
+
+; Example for conditional filters
+;[conditionalFilter.MyUniversity]
+;require = ANY
+;ipRange[] = 1.2.3.1-1.2.3.254
+;role = loggedin
+;permission = conditionalFilter.MyUniversity

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -554,3 +554,24 @@ container_title = "Journal Title"
 ; Priority order (descending) for record sources (record ID prefixes separated
 ; from the actual record by period, e.g. testsrc.12345)
 ;sources = alli,testsrc
+
+; This section can get used to define conditional filters, i.e. filters,
+; that are applied under certain conditions.
+; You can use a permission set as condition, which has to be defined in 
+; permissions.ini.
+; Keys are ignored, but increasing numeric values (1, 2, 3...) are recommended.
+; Values need to be formatted using this schema:
+; [-]permission|filter-query
+; Prefixing the condition with a minus (-) means, that the filter is applied,
+; when the condition does not match (the permission is not granted).
+; The filter may be any filter query valid for Solr.
+; Examples:
+; -conditionalFilter.MyUniversity|format:Book
+; apply filter "format:Book" if permission conditionalFilter.MyUniversity
+; (from permissions.ini) is not granted
+; conditionalFilter.MyUniversity|format:Article
+; apply filter "format:Article" if permission conditionalFilter.MyUniversity
+; (from permissions.ini) is granted
+[ConditionalHiddenFilters]
+;0 = "-conditionalFilter.MyUniversity|format:Book"
+;1 = "conditionalFilter.MyUniversity|format:Article"

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -413,7 +413,9 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      */
     protected function getInjectConditionalFilterListener(Config $search)
     {
-        $listener = new InjectConditionalFilterListener($search->ConditionalHiddenFilters);
+        $listener = new InjectConditionalFilterListener(
+            $search->ConditionalHiddenFilters
+        );
         $listener->setAuthorizationService(
             $this->serviceLocator->get('ZfcRbac\Service\AuthorizationService')
         );

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -29,6 +29,7 @@
 namespace VuFind\Search\Factory;
 
 use VuFind\Search\Solr\InjectHighlightingListener;
+use VuFind\Search\Solr\InjectConditionalFilterListener;
 use VuFind\Search\Solr\InjectSpellingListener;
 use VuFind\Search\Solr\MultiIndexListener;
 use VuFind\Search\Solr\V3\ErrorListener as LegacyErrorListener;
@@ -176,6 +177,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
 
         // Highlighting
         $this->getInjectHighlightingListener($backend, $search)->attach($events);
+        $this->getInjectConditionalFilterListener($search)->attach($events);
 
         // Spellcheck
         if (isset($config->Spelling->enabled) && $config->Spelling->enabled) {
@@ -394,5 +396,19 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
         $fl = isset($search->General->highlighting_fields)
             ? $search->General->highlighting_fields : '*';
         return new InjectHighlightingListener($backend, $fl);
+    }
+
+    /**
+     * Get a hierarchical facet listener for the backend
+     *
+     * @param BackendInterface $backend Search backend
+     *
+     * @return HierarchicalFacetListener
+     */
+    protected function getInjectConditionalFilterListener(Config $search)
+    {
+        $chf = isset($search->ConditionalHiddenFilters)
+            ? $search->ConditionalHiddenFilters : array();
+        return new InjectConditionalFilterListener($chf, $this->serviceLocator);
     }
 }

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -403,7 +403,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
     /**
      * Get a Conditional Filter Listener
      *
-     * @param Config           $search  Search configuration
+     * @param Config $search Search configuration
      *
      * @return InjectConditionalFilterListener
      */

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -177,6 +177,8 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
 
         // Highlighting
         $this->getInjectHighlightingListener($backend, $search)->attach($events);
+
+        // Conditional Filters
         $this->getInjectConditionalFilterListener($search)->attach($events);
 
         // Spellcheck
@@ -399,11 +401,11 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
     }
 
     /**
-     * Get a hierarchical facet listener for the backend
+     * Get a Conditional Filter Listener
      *
-     * @param BackendInterface $backend Search backend
+     * @param Config           $search  Search configuration
      *
-     * @return HierarchicalFacetListener
+     * @return InjectConditionalFilterListener
      */
     protected function getInjectConditionalFilterListener(Config $search)
     {

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -414,7 +414,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
     protected function getInjectConditionalFilterListener(Config $search)
     {
         $listener = new InjectConditionalFilterListener(
-            $search->ConditionalHiddenFilters
+            $search->ConditionalHiddenFilters->toArray()
         );
         $listener->setAuthorizationService(
             $this->serviceLocator->get('ZfcRbac\Service\AuthorizationService')

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -71,16 +71,17 @@ class InjectConditionalFilterListener
     /**
      * Constructor.
      *
-     * @param Config           $searchConf      Search configuration parameters
-     * @param ServiceLocator   $serviceLocator  Service Locator
+     * @param Config $searchConf Search configuration parameters
+     * @param ServiceLocator $serviceLocator Service Locator
      *
      * @return void
      */
     public function __construct($searchConf, $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
-        $this->setAuthorizationService($this->serviceLocator
-            ->get('ZfcRbac\Service\AuthorizationService'));
+        $this->setAuthorizationService(
+            $this->serviceLocator->get('ZfcRbac\Service\AuthorizationService')
+        );
         $this->filters = $searchConf->toArray();
         $this->filterList = array();
     }
@@ -117,7 +118,8 @@ class InjectConditionalFilterListener
             // So we have to check existance of the filter condition first
             if ($this->_permissionExists(substr($filterCondition, 1))) {
                 if (!$this->getAuthorizationService()
-                    ->isGranted(substr($filterCondition, 1))) {
+                    ->isGranted(substr($filterCondition, 1))
+                ) {
                     $this->filterList[] = $filter;
                 }
             }

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -71,15 +71,16 @@ class InjectConditionalFilterListener
     /**
      * Constructor.
      *
-     * @param BackendInterface $backend    Backend
-     * @param Config           $searchConf Field(s) to highlight (hl.fl param)
+     * @param Config           $searchConf      Search configuration parameters
+     * @param ServiceLocator   $serviceLocator  Service Locator
      *
      * @return void
      */
     public function __construct($searchConf, $serviceLocator)
     {
         $this->serviceLocator = $serviceLocator;
-        $this->setAuthorizationService($this->serviceLocator->get('ZfcRbac\Service\AuthorizationService'));
+        $this->setAuthorizationService($this->serviceLocator
+            ->get('ZfcRbac\Service\AuthorizationService'));
         $this->filters = $searchConf->toArray();
         $this->filterList = array();
     }
@@ -103,7 +104,7 @@ class InjectConditionalFilterListener
      *
      * @return void
      */
-    private function addConditionalFilter($configOption)
+    private function _addConditionalFilter($configOption)
     {
         $filterArr = explode('|', $configOption);
         $filterCondition = $filterArr[0];
@@ -114,8 +115,9 @@ class InjectConditionalFilterListener
         if (substr($filterCondition, 0, 1) == '-') {
             // isGranted on a non existing rule will always return false
             // So we have to check existance of the filter condition first
-            if ($this->permissionExists(substr($filterCondition, 1))) {
-                if (!$this->getAuthorizationService()->isGranted(substr($filterCondition, 1))) {
+            if ($this->_permissionExists(substr($filterCondition, 1))) {
+                if (!$this->getAuthorizationService()
+                    ->isGranted(substr($filterCondition, 1))) {
                     $this->filterList[] = $filter;
                 }
             }
@@ -134,7 +136,8 @@ class InjectConditionalFilterListener
      *
      * @return bool
      */
-    private function permissionExists($name) {
+    private function _permissionExists($name)
+    {
         $configLoader = $this->serviceLocator->get('VuFind\Config');
         $permissions = $configLoader->get('permissions')->toArray();
         if (array_key_exists($name, $permissions)) {
@@ -154,7 +157,7 @@ class InjectConditionalFilterListener
     {
         // Add conditional filters
         foreach ($this->filters as $fc) {
-            $this->addConditionalFilter($fc);
+            $this->_addConditionalFilter($fc);
         }
 
         $params = $event->getParam('params');

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -100,6 +100,11 @@ class InjectConditionalFilterListener
         $filter = $filterArr[1];
         $authService = $this->getAuthorizationService();
 
+        // if no authorization service is available, don't do anything
+        if (!$authService) {
+            return;
+        }
+
         // if the filter condition starts with a minus (-), it should not match
         // to get the filter applied
         if (substr($filterCondition, 0, 1) == '-') {
@@ -130,6 +135,9 @@ class InjectConditionalFilterListener
 
         $params = $event->getParam('params');
         $fq = $params->get('fq');
+        if (!is_array($fq)) {
+            $fq = array();
+        }
         $new_fq = array_merge($fq, $this->filterList);
         $params->set('fq', $new_fq);
 

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -72,6 +72,11 @@ class InjectConditionalFilterListener
     {
         $this->filters = $searchConf;
         $this->filterList = array();
+        // Set default AuthorizationService
+        $this->setAuthorizationService(
+            $this->serviceLocator->get('ZfcRbac\Service\AuthorizationService')
+        );
+
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Conditional Filter listener.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2013.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Oliver Goldschmidt <o.goldschmidt@tuhh.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org   Main Site
+ */
+namespace VuFind\Search\Solr;
+
+use Zend\EventManager\SharedEventManagerInterface;
+use Zend\EventManager\EventInterface;
+
+use ZfcRbac\Service\AuthorizationServiceAwareInterface,
+    ZfcRbac\Service\AuthorizationServiceAwareTrait;
+
+/**
+ * Conditional Filter listener.
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Oliver Goldschmidt <o.goldschmidt@tuhh.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org   Main Site
+ */
+class InjectConditionalFilterListener
+{
+    use AuthorizationServiceAwareTrait;
+
+    /**
+     * Filters to apply.
+     *
+     * @var array
+     */
+    protected $filterList;
+
+    /**
+     * Filters from configuration.
+     *
+     * @var array
+     */
+    protected $filters;
+
+    /**
+     * Service Locator
+     *
+     * @var ServiceLocator
+     */
+    protected $serviceLocator;
+
+    /**
+     * Constructor.
+     *
+     * @param BackendInterface $backend    Backend
+     * @param Config           $searchConf Field(s) to highlight (hl.fl param)
+     *
+     * @return void
+     */
+    public function __construct($searchConf, $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        $this->setAuthorizationService($this->serviceLocator->get('ZfcRbac\Service\AuthorizationService'));
+        $this->filters = $searchConf->toArray();
+        $this->filterList = array();
+    }
+
+    /**
+     * Attach listener to shared event manager.
+     *
+     * @param SharedEventManagerInterface $manager Shared event manager
+     *
+     * @return void
+     */
+    public function attach(SharedEventManagerInterface $manager)
+    {
+        $manager->attach('VuFind\Search', 'pre', [$this, 'onSearchPre']);
+    }
+
+    /**
+     * Add a conditional filter.
+     *
+     * @param String $configOption Conditional Filter
+     *
+     * @return void
+     */
+    private function addConditionalFilter($configOption)
+    {
+        $filterArr = explode('|', $configOption);
+        $filterCondition = $filterArr[0];
+        $filter = $filterArr[1];
+
+        // if the filter condition starts with a minus (-), it should not match
+        // to get the filter applied
+        if (substr($filterCondition, 0, 1) == '-') {
+            // isGranted on a non existing rule will always return false
+            // So we have to check existance of the filter condition first
+            if ($this->permissionExists(substr($filterCondition, 1))) {
+                if (!$this->getAuthorizationService()->isGranted(substr($filterCondition, 1))) {
+                    $this->filterList[] = $filter;
+                }
+            }
+        } else {
+            // otherwise the condition should match to apply the filter
+            if ($this->getAuthorizationService()->isGranted($filterCondition)) {
+                $this->filterList[] = $filter;
+            }
+        }
+    }
+
+    /**
+     * Helper function to detect, if a permission name exists.
+     *
+     * @param String $name Name of the Permission set
+     *
+     * @return bool
+     */
+    private function permissionExists($name) {
+        $configLoader = $this->serviceLocator->get('VuFind\Config');
+        $permissions = $configLoader->get('permissions')->toArray();
+        if (array_key_exists($name, $permissions)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set up conditional hidden filters.
+     *
+     * @param EventInterface $event Event
+     *
+     * @return EventInterface
+     */
+    public function onSearchPre(EventInterface $event)
+    {
+        // Add conditional filters
+        foreach ($this->filters as $fc) {
+            $this->addConditionalFilter($fc);
+        }
+
+        $params = $event->getParam('params');
+        $fq = $params->get('fq');
+        $new_fq = array_merge($fq, $this->filterList);
+        $params->set('fq', $new_fq);
+
+        return $event;
+    }
+
+}

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -110,6 +110,7 @@ class InjectConditionalFilterListener
         $filterArr = explode('|', $configOption);
         $filterCondition = $filterArr[0];
         $filter = $filterArr[1];
+        $authService = $this->getAuthorizationService();
 
         // if the filter condition starts with a minus (-), it should not match
         // to get the filter applied
@@ -117,13 +118,13 @@ class InjectConditionalFilterListener
             // isGranted on a non existing rule will always return false
             // So we have to check existance of the filter condition first
             if ($this->_permissionExists(substr($filterCondition, 1))) {
-                if (!$this->getAuthorizationService()->isGranted(substr($filterCondition, 1))) {
+                if (!$authService->isGranted(substr($filterCondition, 1))) {
                     $this->filterList[] = $filter;
                 }
             }
         } else {
             // otherwise the condition should match to apply the filter
-            if ($this->getAuthorizationService()->isGranted($filterCondition)) {
+            if ($authService->isGranted($filterCondition)) {
                 $this->filterList[] = $filter;
             }
         }

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -64,13 +64,13 @@ class InjectConditionalFilterListener
     /**
      * Constructor.
      *
-     * @param Config $searchConf Search configuration parameters
+     * @param array $searchConf Search configuration parameters
      *
      * @return void
      */
     public function __construct($searchConf)
     {
-        $this->filters = $searchConf->toArray();
+        $this->filters = $searchConf;
         $this->filterList = array();
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -64,7 +64,7 @@ class InjectConditionalFilterListener
     /**
      * Constructor.
      *
-     * @param Config         $searchConf     Search configuration parameters
+     * @param Config $searchConf Search configuration parameters
      *
      * @return void
      */

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -71,7 +71,7 @@ class InjectConditionalFilterListener
     /**
      * Constructor.
      *
-     * @param Config $searchConf Search configuration parameters
+     * @param Config         $searchConf     Search configuration parameters
      * @param ServiceLocator $serviceLocator Service Locator
      *
      * @return void
@@ -117,7 +117,8 @@ class InjectConditionalFilterListener
             // isGranted on a non existing rule will always return false
             // So we have to check existance of the filter condition first
             if ($this->_permissionExists(substr($filterCondition, 1))) {
-                if (!$this->getAuthorizationService()
+                if (
+                    !$this->getAuthorizationService()
                     ->isGranted(substr($filterCondition, 1))
                 ) {
                     $this->filterList[] = $filter;

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -72,11 +72,6 @@ class InjectConditionalFilterListener
     {
         $this->filters = $searchConf;
         $this->filterList = array();
-        // Set default AuthorizationService
-        $this->setAuthorizationService(
-            $this->serviceLocator->get('ZfcRbac\Service\AuthorizationService')
-        );
-
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectConditionalFilterListener.php
@@ -117,10 +117,7 @@ class InjectConditionalFilterListener
             // isGranted on a non existing rule will always return false
             // So we have to check existance of the filter condition first
             if ($this->_permissionExists(substr($filterCondition, 1))) {
-                if (
-                    !$this->getAuthorizationService()
-                    ->isGranted(substr($filterCondition, 1))
-                ) {
+                if (!$this->getAuthorizationService()->isGranted(substr($filterCondition, 1))) {
                     $this->filterList[] = $filter;
                 }
             }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * Unit tests for Conditional Filter listener.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2015.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Oliver Goldschmidt <o.goldschmidt@tuhh.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org   Main Site
+ */
+namespace VuFindTest\Search\Solr;
+
+use VuFindSearch\ParamBag;
+use VuFindSearch\Backend\Solr\Backend;
+use VuFindSearch\Backend\Solr\Connector;
+use VuFindSearch\Backend\Solr\HandlerMap;
+use VuFind\Search\BackendManager;
+
+use VuFind\Search\Solr\InjectConditionalFilterListener;
+use VuFindTest\Unit\TestCase;
+use Zend\EventManager\Event;
+
+use ZfcRbac\Service\AuthorizationServiceAwareInterface,
+    ZfcRbac\Service\AuthorizationServiceAwareTrait;
+
+/**
+ * Unit tests for Conditional Filter listener.
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Oliver Goldschmidt <o.goldschmidt@tuhh.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org   Main Site
+ */
+class ConditionalFilterListenerTest extends TestCase
+{
+    /**
+     * Specs used for stripping tests.
+     *
+     * @var array
+     */
+/*
+    protected static $specs = [
+        'test' => [
+            'QueryFields' => [
+                'A' => [
+                    ['onephrase', 500],
+                    ['and', 200]
+                ],
+                'B' => [
+                    ['and', 100],
+                    ['or', 50],
+                ],
+                0 => [
+                    0 => ['AND', 50],
+                    'C' => [
+                        ['onephrase', 200],
+                    ],
+                    'D' => [
+                        ['onephrase', 300],
+                    ],
+                    '-E' => [
+                        ['or', '~']
+                    ]
+                ]
+            ],
+            'FilterQuery' => 'format:Book',
+        ]
+    ];
+*/
+    /**
+     * Available shards used for stripping tests.
+     *
+     * @var array
+     */
+
+    protected static $shards = [
+        'a' => 'example.org/a',
+        'b' => 'example.org/b',
+        'c' => 'example.org/c',
+    ];
+
+    /**
+     * Shard fields used for stripping tests.
+     *
+     * @var array
+     */
+/*
+    protected static $fields = [
+        'a' => ['field_1', 'field_3'],
+        'b' => ['field_3'],
+    ];
+*/
+
+    protected static $searchConfig = [
+        '0' => '-conditionalFilter.sample|(NOT institution:"MyInst")'
+    ];
+
+    /**
+     * Backend.
+     *
+     * @var BackendInterface
+     */
+    protected $backend;
+
+    /**
+     * Prepare listener.
+     *
+     * @var InjectConditionalFilterListener
+     */
+    protected $listener;
+
+    /**
+     * Setup.
+     *
+     * @return void
+     */
+    protected function setup()
+    {
+        $handlermap     = new HandlerMap(['select' => ['fallback' => true]]);
+        $connector      = new Connector('http://example.org/', $handlermap);
+        $this->backend  = new Backend($connector);
+        $this->listener = new InjectConditionalFilterListener(self::$searchConfig);
+
+        $mockAuth = $this->getMock('ZfcRbac\Service\AuthorizationServiceInterface');
+        $mockAuth->expects($this->once())->method('isGranted')->with($this->equalTo('myPermission'))->will($this->returnValue(true));
+        $this->listener->setAuthorizationService($mockAuth);
+        //$sm = $this->getMockForAbstractClass(
+//            'Zend\ServiceManager\ServiceLocatorInterface'
+//        );
+/*
+        $this->setupSearchService()
+        $serviceLocator = $this->getServiceManager();
+        $this->listener->setAuthorizationService(
+            $serviceLocator->get('ZfcRbac\Service\AuthorizationService')
+        );
+*/
+    }
+
+    /**
+     * Test the listener with a given configuration
+     *
+     * @return void
+     */
+    public function testConditionalFilterList()
+    {
+        $params   = new ParamBag(
+            [
+                'facet.field' => ['field_1', 'field_2', 'field_3'],
+                'shards' => [self::$shards['b'], self::$shards['c']],
+            ]
+        );
+        $event    = new Event('pre', $this->backend, ['params' => $params]);
+        $this->listener->onSearchPre($event);
+
+        $fq   = $params->get('fq');
+//        var_dump($fq);
+        $this->assertEquals(['field_1', 'field_2'], $facets);
+    }
+
+    /**
+     * Test attaching listener.
+     *
+     * @return void
+     */
+    public function testAttach()
+    {
+        $mock = $this->getMock('Zend\EventManager\SharedEventManagerInterface');
+        $mock->expects($this->once())->method('attach')->with(
+            $this->equalTo('VuFind\Search'),
+            $this->equalTo('pre'),
+            $this->equalTo([$this->listener, 'onSearchPre'])
+        );
+        $this->listener->attach($mock);
+    }
+
+    /**
+     * Apply strip to empty specs.
+     *
+     * @return void
+     */
+/*
+    public function testStripSpecsEmptySpecs()
+    {
+        $this->setProperty($this->listener, 'specs', []);
+        $specs = $this->callMethod($this->listener, 'getSearchSpecs', [['A', 'B', 'E']]);
+        $this->assertEmpty($specs);
+    }
+*/
+    /**
+     * Don't strip anything.
+     *
+     * @return void
+     */
+/*
+    public function testStripSpecsNoFieldsToStrip()
+    {
+        $specs = $this->callMethod($this->listener, 'getSearchSpecs', [['F', 'G', 'H']]);
+        $this->assertEquals($specs, self::$specs);
+    }
+*/
+    /**
+     * Strip specs.
+     *
+     * @return void
+     */
+/*
+    public function testStripSpecsStrip()
+    {
+        $specs = $this->callMethod($this->listener, 'getSearchSpecs', [['A', 'B', 'E']]);
+        $this->assertEquals(
+            ['test' => [
+                      'QueryFields' => [
+                          0 => [
+                              0 => ['AND', 50],
+                              'C' => [
+                                  ['onephrase', 200]
+                              ],
+                              'D' => [
+                                  ['onephrase', 300]
+                              ]
+                          ]
+                      ],
+                      'FilterQuery' => 'format:Book',
+                  ]
+            ],
+            $specs
+        );
+    }
+*/
+    /**
+     * Strip an entire QueryFields section.
+     *
+     * @return void
+     */
+/*
+    public function testStripSpecsAllQueryFields()
+    {
+        $specs = $this->callMethod($this->listener, 'getSearchSpecs', [['A', 'B', 'C', 'D', 'E']]);
+        $this->assertEquals(
+            ['test' => ['QueryFields' => [], 'FilterQuery' => 'format:Book']],
+            $specs
+        );
+    }
+*/
+}


### PR DESCRIPTION
This is my suggestion to enable conditional filters, which are interacting with the permission system. I guess the method permissionExists($name) should be better in another class, but I did not know, which class would be best for it. 

I have also done some documentation for the new option in searches.ini and have put an example for an appropriate permission set for conditional filters into permissions.ini.

It would be great, if you could review and comment, how this feature could be improved.

One limitation is, that its only applicable for Solr at the moment. But I think it shouldn't be too difficult to use it also in other contexts.