### PR TITLE
Fixes strict standards error on function preDispatch

### DIFF
--- a/module/VuFind/src/VuFind/Controller/SummonController.php
+++ b/module/VuFind/src/VuFind/Controller/SummonController.php
@@ -63,9 +63,11 @@ class SummonController extends AbstractSearch
     /**
      * Use preDispatch event to add Summon message.
      *
+     * @param MvcEvent $e Event object
+     *
      * @return void
      */
-    public function preDispatch()
+    public function preDispatch(MvcEvent $e)
     {
         $this->layout()->poweredBy
             = 'Powered by Summon™ from Serials Solutions, a division of ProQuest.';


### PR DESCRIPTION
The SummonController produces the following PHP strict standards error:

Strict standards: Declaration of VuFind\Controller\SummonController::preDispatch() should be compatible with VuFind\Controller\AbstractBase::preDispatch(Zend\Mvc\MvcEvent $e) in /.../vufind/module/VuFind/src/VuFind/Controller/SummonController.php on line 41

That is because VuFind\Controller\AbstractBase has an event parameter but VuFind\Controller\SummonController does not.

We would really appreciate if you could merge that pull request! 