### PR TITLE
Fixes strict standards error on function SummonrecordController->preDispatch

### DIFF
--- a/module/VuFind/src/VuFind/Controller/SummonrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/SummonrecordController.php
@@ -67,9 +67,13 @@ class SummonrecordController extends AbstractRecord
     /**
      * Use preDispatch event to add Summon message.
      *
+     * @param MvcEvent $e Event object
+     *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function preDispatch()
+    public function preDispatch(MvcEvent $e)
     {
         $this->layout()->poweredBy
             = 'Powered by Summon™ from Serials Solutions, a division of ProQuest.';


### PR DESCRIPTION
There is the same strict standards error on the SummonrecordController as there was on the SummonController.

Thanks for having a look at it!