### PR TITLE
Fix installation of CodeSniffer in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ env:
   - VUFIND_HOME=$PWD VUFIND_LOCAL_DIR=$PWD/local
 
 before_script:
-  - pyrus install pear/PHP_CodeSniffer
+  - pear install pear/PHP_CodeSniffer
   - phpenv rehash
 
 script:
   - phpunit --stderr --configuration module/VuFind/tests/phpunit.xml
   - phpcs --standard=PEAR --ignore=*/config/*,*/tests/* --extensions=php $PWD/module
+


### PR DESCRIPTION
Apparently something changed in Travis making pyrus unable to install PHP_CodeSniffer. Use pear instead (Travis' docs have both versions, so this should be valid too).