### PR TITLE
Activate a library card when it is saved if necessary.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -585,6 +585,13 @@ class User extends RowGateway implements \VuFind\Db\Table\DbTableAwareInterface,
         }
 
         $row->save();
+
+        // If this is the first library card or no credentials are currently set,
+        // activate the card now
+        if ($this->getLibraryCards()->count() == 1 || empty($this->cat_username)) {
+            $this->activateLibraryCard($row->id);
+        }
+
         return $row->id;
     }
 


### PR DESCRIPTION
When logging in with auth method other than ILS or MultiILS, the user doesn't have an initial library card. If one is added, it also needs to be activated so that user isn't prompted for credentials when trying to display loans etc.