### PR TITLE
Enable highlighting only for searches.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -101,6 +101,9 @@ class InjectHighlightingListener
      */
     public function onSearchPre(EventInterface $event)
     {
+        if ($event->getParam('context') !== 'search') {
+            return $event;
+        }
         $backend = $event->getTarget();
         if ($backend === $this->backend) {
             $params = $event->getParam('params');


### PR DESCRIPTION
For Solr 4 this can make retrieval of a record about an order of magnitude faster. For Solr 5.1 it's even more dramatic (in my tests it takes 0-1 ms without highlighting and 68-250ms with highlighting).

Only thing I'm not sure is if there are other contexts where highlighting would be appropriate.