### PR TITLE
Retrieve optimization

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat.php
@@ -148,7 +148,7 @@ class WorldCat extends SolrMarc
      */
     public function getUniqueID()
     {
-        return (string)$this->marcRecord->getField('001')->getData();
+        return (string)$this->getMarcRecord()->getField('001')->getData();
     }
 
     /**
@@ -200,7 +200,7 @@ class WorldCat extends SolrMarc
     public function getLanguages()
     {
         $retVal = [];
-        $field = $this->marcRecord->getField('008');
+        $field = $this->getMarcRecord()->getField('008');
         if ($field) {
             $content = $field->getData();
             if (strlen($content) >= 38) {
@@ -227,7 +227,7 @@ class WorldCat extends SolrMarc
      */
     public function getSortTitle()
     {
-        $field = $this->marcRecord->getField('245');
+        $field = $this->getMarcRecord()->getField('245');
         if ($field) {
             $title = $field->getSubfield('a');
             if ($title) {

--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -101,6 +101,9 @@ class InjectHighlightingListener
      */
     public function onSearchPre(EventInterface $event)
     {
+        if ($event->getParam('context') != 'search') {
+            return $event;
+        }
         $backend = $event->getTarget();
         if ($backend === $this->backend) {
             $params = $event->getParam('params');
@@ -132,8 +135,8 @@ class InjectHighlightingListener
      */
     public function onSearchPost(EventInterface $event)
     {
-        // Do nothing if highlighting is disabled....
-        if (!$this->active) {
+        // Do nothing if highlighting is disabled or context is wrong
+        if (!$this->active || $event->getParam('context') != 'search') {
             return $event;
         }
 

--- a/module/VuFind/src/VuFind/Search/Solr/InjectSpellingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectSpellingListener.php
@@ -109,6 +109,9 @@ class InjectSpellingListener
      */
     public function onSearchPre(EventInterface $event)
     {
+        if ($event->getParam('context') != 'search') {
+            return $event;
+        }
         $backend = $event->getTarget();
         if ($backend === $this->backend) {
             $params = $event->getParam('params');
@@ -148,8 +151,8 @@ class InjectSpellingListener
      */
     public function onSearchPost(EventInterface $event)
     {
-        // Do nothing if spelling is disabled....
-        if (!$this->active) {
+        // Do nothing if spelling is disabled or context is wrong
+        if (!$this->active || $event->getParam('context') != 'search') {
             return $event;
         }
 


### PR DESCRIPTION
For Solr 4 this can make retrieval of a record about an order of magnitude faster. For Solr 5.1 it's even more dramatic (in my tests it takes 0-1 ms without highlighting and 68-250ms with highlighting). I've asked about this on the Solr mailing list since the slowness seriously affects normal searches too, but I believe this optimization makes sense nevertheless. Only thing I'm not sure is if there are other contexts where highlighting or spelling would be appropriate.

Second part is initializing the File_MARC record lazily in SolrMarc. File_MARC is fairly slow, so this also makes a noticeable difference e.g. when the record is only needed for RecordLink view helper. One downside of this change is that any derived classes would need to be changed to use the accessor too.