### PR TITLE
Add support for showing the 856$3

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -698,7 +698,7 @@ class SolrMarc extends SolrDefault
 
         // Which fields/subfields should we check for URLs?
         $fieldsToCheck = [
-            '856' => ['y', 'z'],   // Standard URL
+            '856' => ['y', 'z', '3'],   // Standard URL
             '555' => ['a']         // Cumulative index/finding aids
         ];
 


### PR DESCRIPTION
The 856$3 is the Materials specified field. Which includes items such as the Table of Contents.