### PR TITLE
Fixes piwik limitation to track custom variables 4 and 5 together with trackSiteSearch

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -330,8 +330,11 @@ EOT;
         foreach ($customVars as $key => $value) {
             ++$i;
 
-            //workaround to prevent that custom variables 4 and 5 get overwritten by trackSiteSearch, see http://forum.piwik.org/read.php?2,115537,115538
-            if ($i === 4) $i = 6;
+            //workaround to prevent that custom variables 4 and 5 get overwritten by
+            //trackSiteSearch, see http://forum.piwik.org/read.php?2,115537,115538
+            if ($i === 4) {
+                $i = 6;
+            }
 
             $value = $escape($value);
             $code .= <<<EOT

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -329,6 +329,10 @@ EOT;
         $i = 0;
         foreach ($customVars as $key => $value) {
             ++$i;
+
+            //workaround to prevent that custom variables 4 and 5 get overwritten by trackSiteSearch, see http://forum.piwik.org/read.php?2,115537,115538
+            if ($i === 4) $i = 6;
+
             $value = $escape($value);
             $code .= <<<EOT
 _paq.push(['setCustomVariable', $i, '$key', '$value', 'page']);


### PR DESCRIPTION
Today I encountered an issue when tracking more than 3 custom variables together with a trackSiteSearch call in Piwik. If you enable custom variables in VuFind ([Piwik] custom_variables = true) automatically 8 custom variables get tracked for a search.
The variables in slot 4 and 5 get overwritten by the search category and result count. This is a well known issue in piwik and the suggestion of piwik founder Matt is to only use the slots from 6-?. (see http://forum.piwik.org/read.php?2,115537,115538)

My workaround does simply skip the custom variable numbers 4 and 5. With this approach users that track up to 3 variables do not have to increase the default piwik custom variables amount. (see http://piwik.org/faq/how-to/faq_17931/)

The generated code before the workaround (in this case the variables SearchBackend and Sort get overwritten by basic and 60381 and thus are not tracked):
```Javascript
_paq.push(['setCustomVariable', 1, 'Facets', '', 'page']);
_paq.push(['setCustomVariable', 2, 'FacetTypes', '', 'page']);
_paq.push(['setCustomVariable', 3, 'SearchType', 'basic', 'page']);
_paq.push(['setCustomVariable', 4, 'SearchBackend', 'Solr', 'page']);
_paq.push(['setCustomVariable', 5, 'Sort', 'relevance', 'page']);
_paq.push(['setCustomVariable', 6, 'Page', '1', 'page']);
_paq.push(['setCustomVariable', 7, 'Limit', '20', 'page']);
_paq.push(['setCustomVariable', 8, 'View', 'list', 'page']);
_paq.push(['trackSiteSearch', 'test', 'basic', 60381]);
```

The generated code after the workaround:
```Javascript
_paq.push(['setCustomVariable', 1, 'Facets', '', 'page']);
_paq.push(['setCustomVariable', 2, 'FacetTypes', '', 'page']);
_paq.push(['setCustomVariable', 3, 'SearchType', 'basic', 'page']);
_paq.push(['setCustomVariable', 6, 'SearchBackend', 'Solr', 'page']);
_paq.push(['setCustomVariable', 7, 'Sort', 'relevance', 'page']);
_paq.push(['setCustomVariable', 8, 'Page', '1', 'page']);
_paq.push(['setCustomVariable', 9, 'Limit', '20', 'page']);
_paq.push(['setCustomVariable', 10, 'View', 'list', 'page']);
_paq.push(['trackSiteSearch', 'test', 'basic', 60381]);
```

Do you know this issue and do you probably have another workaround?