### PR TITLE
add sslcafile parameter to http-section in config.ini for easier ssl-configuration

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -799,7 +799,8 @@ url             = https://www.myendnoteweb.com/EndNoteWeb.html
 ; Default HTTP settings can be loaded here. These values will be passed to
 ; the \Zend\Http\Client's setOptions method.
 [Http]
-;sslcapath = "/etc/ssl/certs"
+;sslcapath = "/etc/ssl/certs" ; e.g. for Debian systems
+;sslcafile = "/etc/pki/tls/certs.pem" ; e.g. for CentOS systems
 
 ; Using a curl Adapter instead of the the defaultAdapter (Socket)
 ; adapter = 'Zend\Http\Client\Adapter\Curl'

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -800,7 +800,7 @@ url             = https://www.myendnoteweb.com/EndNoteWeb.html
 ; the \Zend\Http\Client's setOptions method.
 [Http]
 ;sslcapath = "/etc/ssl/certs" ; e.g. for Debian systems
-;sslcafile = "/etc/pki/tls/certs.pem" ; e.g. for CentOS systems
+;sslcafile = "/etc/pki/tls/cert.pem" ; e.g. for CentOS systems
 
 ; Using a curl Adapter instead of the the defaultAdapter (Socket)
 ; adapter = 'Zend\Http\Client\Adapter\Curl'


### PR DESCRIPTION
We just had some trouble setting up the VuFindHttp-Service to work with SSL but handled it by using the `sslcafile` parameter rather than the `sslcapath` parameter in the `[Http]` section.
I think including this alternative option in the config.ini will save people time researching the possible parameters for configuring the Http-Adapter (especially as we are more and more progressing in using VuFindHttp for any http-connections).