### PR TITLE
RecordDriver for swapping the SolrMarc-fullrecord to external service

### DIFF
--- a/config/vufind/SolrMarcRemote.ini
+++ b/config/vufind/SolrMarcRemote.ini
@@ -1,3 +1,0 @@
-[General]
-; Set the URI-pattern of the server which serves the raw Marc-data.
-baseUrl        = http://127.0.0.1/%s

--- a/config/vufind/SolrMarcRemote.ini
+++ b/config/vufind/SolrMarcRemote.ini
@@ -1,0 +1,3 @@
+[General]
+; Set the URI-pattern of the server which serves the raw Marc-data.
+baseUrl        = http://127.0.0.1/%s

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1009,6 +1009,11 @@ next_prev_navigation = false
 ; suppressed. (Default = true)
 ;marc_links_use_visibility_indicator = false
 
+; Set the URI-pattern of the server which serves the raw Marc-data. (see
+; https://vufind.org/wiki/remote_marc_records for more information on how to set up a
+; remote service for raw Marc-data)
+;remote_marc_url = http://127.0.0.1/%s
+
 ; You can use this setting to hide holdings information for particular named locations
 ; as returned by the catalog.
 hide_holdings[] = "World Wide Web"

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -444,6 +444,7 @@ $config = [
                     'solrauth' => 'VuFind\RecordDriver\Factory::getSolrAuth',
                     'solrdefault' => 'VuFind\RecordDriver\Factory::getSolrDefault',
                     'solrmarc' => 'VuFind\RecordDriver\Factory::getSolrMarc',
+                    'solrmarcremote' => 'VuFind\RecordDriver\Factory::getSolrMarcRemote',
                     'solrreserves' => 'VuFind\RecordDriver\Factory::getSolrReserves',
                     'solrweb' => 'VuFind\RecordDriver\Factory::getSolrWeb',
                     'summon' => 'VuFind\RecordDriver\Factory::getSummon',
@@ -630,6 +631,18 @@ $config = [
                 'defaultTab' => null,
             ],
             'VuFind\RecordDriver\SolrMarc' => [
+                'tabs' => [
+                    'Holdings' => 'HoldingsILS', 'Description' => 'Description',
+                    'TOC' => 'TOC', 'UserComments' => 'UserComments',
+                    'Reviews' => 'Reviews', 'Excerpt' => 'Excerpt',
+                    'Preview' => 'preview',
+                    'HierarchyTree' => 'HierarchyTree', 'Map' => 'Map',
+                    'Similar' => 'SimilarItemsCarousel',
+                    'Details' => 'StaffViewMARC',
+                ],
+                'defaultTab' => null,
+            ],
+            'VuFind\RecordDriver\SolrMarcRemote' => [
                 'tabs' => [
                     'Holdings' => 'HoldingsILS', 'Description' => 'Description',
                     'TOC' => 'TOC', 'UserComments' => 'UserComments',

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -642,18 +642,6 @@ $config = [
                 ],
                 'defaultTab' => null,
             ],
-            'VuFind\RecordDriver\SolrMarcRemote' => [
-                'tabs' => [
-                    'Holdings' => 'HoldingsILS', 'Description' => 'Description',
-                    'TOC' => 'TOC', 'UserComments' => 'UserComments',
-                    'Reviews' => 'Reviews', 'Excerpt' => 'Excerpt',
-                    'Preview' => 'preview',
-                    'HierarchyTree' => 'HierarchyTree', 'Map' => 'Map',
-                    'Similar' => 'SimilarItemsCarousel',
-                    'Details' => 'StaffViewMARC',
-                ],
-                'defaultTab' => null,
-            ],
             'VuFind\RecordDriver\Summon' => [
                 'tabs' => [
                     'Description' => 'Description',

--- a/module/VuFind/src/VuFind/RecordDriver/Factory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Factory.php
@@ -175,6 +175,29 @@ class Factory
     }
 
     /**
+     * Factory for SolrMarcRemote record driver.
+     *
+     * @param ServiceManager $sm Service manager.
+     *
+     * @return SolrMarc
+     */
+    public static function getSolrMarcRemote(ServiceManager $sm)
+    {
+        $driver = new SolrMarcRemote(
+            $sm->getServiceLocator()->get('VuFind\Config')->get('config'),
+            $sm->getServiceLocator()->get('VuFind\Config')->get('SolrMarcRemote'),
+            $sm->getServiceLocator()->get('VuFind\Config')->get('searches')
+        );
+        $driver->attachILS(
+            $sm->getServiceLocator()->get('VuFind\ILSConnection'),
+            $sm->getServiceLocator()->get('VuFind\ILSHoldLogic'),
+            $sm->getServiceLocator()->get('VuFind\ILSTitleHoldLogic')
+        );
+        $driver->attachSearchService($sm->getServiceLocator()->get('VuFind\Search'));
+        return $driver;
+    }
+
+    /**
      * Factory for SolrReserves record driver.
      *
      * @param ServiceManager $sm Service manager.

--- a/module/VuFind/src/VuFind/RecordDriver/Factory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Factory.php
@@ -185,7 +185,7 @@ class Factory
     {
         $driver = new SolrMarcRemote(
             $sm->getServiceLocator()->get('VuFind\Config')->get('config'),
-            $sm->getServiceLocator()->get('VuFind\Config')->get('SolrMarcRemote'),
+            null,
             $sm->getServiceLocator()->get('VuFind\Config')->get('searches')
         );
         $driver->attachILS(

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Model for MARC records without a fullrecord in Solr. The fullrecord is being
+ * retrieved from an external source.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Leipzig University Library 2014.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  RecordDrivers
+ * @author   André Lahmann <lahmann@ub.uni-leipzig.de>
+ * @author   Ulf Seltmann <seltmann@ub.uni-leipzig.de>
+ * @author   Gregor Gawol <gawol@ub.uni-leipzig.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:record_drivers Wiki
+ */
+namespace VuFind\RecordDriver;
+use VuFindHttp\HttpServiceAwareInterface as HttpServiceAwareInterface,
+    Zend\Log\LoggerAwareInterface as LoggerAwareInterface;
+
+/**
+ * Model for MARC records without a fullrecord in Solr. The fullrecord is being
+ * retrieved from an external source.
+ *
+ * @category VuFind2
+ * @package  RecordDrivers
+ * @author   André Lahmann <lahmann@ub.uni-leipzig.de>
+ * @author   Ulf Seltmann <seltmann@ub.uni-leipzig.de>
+ * @author   Gregor Gawol <gawol@ub.uni-leipzig.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:record_drivers Wiki
+ */
+class SolrMarcRemote extends SolrMarc implements
+    HttpServiceAwareInterface, LoggerAwareInterface
+{
+    use \VuFindHttp\HttpServiceAwareTrait;
+    use \VuFind\Log\LoggerAwareTrait;
+
+    /**
+     * MARC record. Access only via getMarcRecord() as this is initialized lazily.
+     *
+     * @var \File_MARC_Record
+     */
+    protected $lazyMarcRecord = null;
+
+    /**
+     * holds the URI-Pattern of the service that returns the marc binary blob by id
+     *
+     * @var string
+     */
+    protected $uriPattern = '';
+
+    /**
+     * holds config.ini data
+     *
+     * @var array
+     */
+    protected $mainConfig;
+
+    /**
+     * holds searches.ini data
+     *
+     * @var array
+     */
+    protected $searchesConfig;
+
+    /**
+     * Constructor
+     *
+     * @param \Zend\Config\Config $mainConfig     VuFind main configuration (omit for
+     * built-in defaults)
+     * @param \Zend\Config\Config $recordConfig   Record-specific configuration file
+     * (omit to use $mainConfig as $recordConfig)
+     * @param \Zend\Config\Config $searchSettings Search-specific configuration file
+     *
+     * @throws \Exception
+     */
+    public function __construct($mainConfig = null, $recordConfig = null,
+                                $searchSettings = null
+    ) {
+        parent::__construct($mainConfig, $recordConfig, $searchSettings);
+
+        if (!isset($recordConfig->General)) {
+            throw new \Exception('SolrMarcRemote General settings missing.');
+        }
+
+        // get config values for remote fullrecord service
+        if (! $recordConfig->General->get('baseUrl')) {
+            throw new \Exception('SolrMarcRemote baseUrl-setting missing.');
+        } else {
+            $this->uriPattern = $recordConfig->General->get('baseUrl');
+        }
+
+        $this->mainConfig = $mainConfig;
+        $this->searchesConfig = $searchSettings;
+    }
+
+    /**
+     * Get access to the raw File_MARC object.
+     *
+     * @return \File_MARCBASE
+     * @throws \Exception
+     * @throws \File_MARC_Exception
+     */
+    public function getMarcRecord()
+    {
+        if (null === $this->lazyMarcRecord) {
+            // handle availability of fullrecord
+            if (isset($this->fields['fullrecord'])) {
+                // standard Vufind2-behaviour
+
+                // also process the MARC record:
+                $marc = trim($this->fields['fullrecord']);
+
+            } else {
+                // fallback: retrieve fullrecord from external source
+
+                if (! isset($this->fields['id'])) {
+                    throw new \Exception(
+                        'No unique id given for fullrecord retrieval'
+                    );
+                }
+
+                $marc = $this->getRemoteFullrecord($this->fields['id']);
+
+            }
+
+            if (isset($marc)) {
+                // continue with standard Vufind2-behaviour if marcrecord is present
+
+                // check if we are dealing with MARCXML
+                if (substr($marc, 0, 1) == '<') {
+                    $marc = new \File_MARCXML($marc, \File_MARCXML::SOURCE_STRING);
+                } else {
+                    // When indexing over HTTP, SolrMarc may use entities instead of
+                    // certain control characters; we should normalize these:
+                    $marc = str_replace(
+                        ['#29;', '#30;', '#31;'], ["\x1D", "\x1E", "\x1F"], $marc
+                    );
+                    $marc = new \File_MARC($marc, \File_MARC::SOURCE_STRING);
+                }
+
+                $this->lazyMarcRecord = $marc->next();
+                if (!$this->lazyMarcRecord) {
+                    throw new \File_MARC_Exception('Cannot Process MARC Record');
+                }
+
+            } else {
+                // no marcrecord was found
+
+                throw new \Exception(
+                    'no Marc was found neither on the marc server ' .
+                    'nor in the solr-record for id ' . $this->fields['id']
+                );
+            }
+        }
+
+        return $this->lazyMarcRecord;
+    }
+
+    /**
+     * Retrieves the full Marcrecord from a remote service defined by uriPattern
+     *
+     * @param String $id - this record's unique identifier
+     *
+     * @return bool|string
+     * @throws \Exception
+     */
+    protected function getRemoteFullrecord($id)
+    {
+
+        if (empty($id)) {
+            throw new \Exception('empty id given');
+        }
+
+        if (empty($this->uriPattern)) {
+            throw new \Exception('no Marc-Server configured');
+        }
+
+        $url = sprintf($this->uriPattern, $id);
+
+        try {
+            $response = $this->httpService->get($url);
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+
+        if (!$response->isSuccess()) {
+            $this->debug(
+                'HTTP status ' . $response->getStatusCode() .
+                ' received, retrieving data for record: ' . $id
+            );
+
+            return false;
+        }
+
+        return $response->getBody();
+    }
+}

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
@@ -58,21 +58,21 @@ class SolrMarcRemote extends SolrMarc implements
     protected $lazyMarcRecord = null;
 
     /**
-     * holds the URI-Pattern of the service that returns the marc binary blob by id
+     * Holds the URI-Pattern of the service that returns the marc binary blob by id
      *
      * @var string
      */
     protected $uriPattern = '';
 
     /**
-     * holds config.ini data
+     * Holds config.ini data
      *
      * @var array
      */
     protected $mainConfig;
 
     /**
-     * holds searches.ini data
+     * Holds searches.ini data
      *
      * @var array
      */
@@ -90,7 +90,7 @@ class SolrMarcRemote extends SolrMarc implements
      * @throws \Exception
      */
     public function __construct($mainConfig = null, $recordConfig = null,
-                                $searchSettings = null
+        $searchSettings = null
     ) {
         parent::__construct($mainConfig, $recordConfig, $searchSettings);
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
@@ -78,10 +78,10 @@ class SolrMarcRemote extends SolrMarc implements
         }
 
         // get config values for remote fullrecord service
-        if (! $recordConfig->General->get('baseUrl')) {
+        if (! $mainConfig->Record->get('remote_marc_url')) {
             throw new \Exception('SolrMarcRemote baseUrl-setting missing.');
         } else {
-            $this->uriPattern = $recordConfig->General->get('baseUrl');
+            $this->uriPattern = $mainConfig->Record->get('remote_marc_url');
         }
     }
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
@@ -43,6 +43,7 @@ use VuFindHttp\HttpServiceAwareInterface as HttpServiceAwareInterface,
  * @author   Gregor Gawol <gawol@ub.uni-leipzig.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://vufind.org/wiki/vufind2:record_drivers Wiki
+ * @link     https://vufind.org/wiki/remote_marc_records
  */
 class SolrMarcRemote extends SolrMarc implements
     HttpServiceAwareInterface, LoggerAwareInterface


### PR DESCRIPTION
Referring to our discussion in http://sourceforge.net/p/vufind/mailman/message/33269958/ I am happy to open the pull request on this feature today.
As discussed on the mailinglist we have been struggling with a huge index for quite a while and mitigated it by moving the index's MARC-fullrecord field to a dedicated binary-server reducing the index by ~25%. The included RecordDriver allows to pull the MARC-fullrecord if needed (already using lazyMarcRecord) from another http-service. All that's necessary is to set up the service providing the MARC-fullrecord-files and configure this service in the RecordDriver's SolrMarcRemote.ini.

We have prepared documentation on setting up such a service and would like to add it to the vufind.org wiki - I thought about including it in https://vufind.org/wiki/performance or referencing it in https://vufind.org/wiki/performance#index_optimization would be a good idea.