### PR TITLE
Introduces piwik tracker object to be able to have multiple piwik backends

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -97,8 +97,7 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
         }
 
         $inlineScript = $this->getView()->plugin('inlinescript');
-        return $inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $code, 'SET')
-            ->prependFile($this->url . 'piwik.js');
+        return $inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $code, 'SET');
     }
 
     /**
@@ -289,12 +288,14 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getOpeningTrackingCode()
     {
         return <<<EOT
-var VuFindPiwikTracker = Piwik.getTracker();
 
-VuFindPiwikTracker.setSiteId({$this->siteId});
-VuFindPiwikTracker.setTrackerUrl('{$this->url}piwik.php');
-VuFindPiwikTracker.setCustomUrl(location.protocol + '//'
-     + location.host + location.pathname);
+function initVuFindPiwikTracker(){
+    var VuFindPiwikTracker = Piwik.getTracker();
+
+    VuFindPiwikTracker.setSiteId({$this->siteId});
+    VuFindPiwikTracker.setTrackerUrl('{$this->url}piwik.php');
+    VuFindPiwikTracker.setCustomUrl(location.protocol + '//'
+        + location.host + location.pathname);
 
 EOT;
     }
@@ -307,8 +308,14 @@ EOT;
     protected function getClosingTrackingCode()
     {
         return <<<EOT
-VuFindPiwikTracker.enableLinkTracking();
-
+    VuFindPiwikTracker.enableLinkTracking();
+};
+(function(){
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.defer=true; g.async=true;
+    g.src='{$this->url}piwik.js';
+    g.onload=initVuFindPiwikTracker;
+s.parentNode.insertBefore(g,s); })();
 EOT;
     }
 
@@ -335,7 +342,7 @@ EOT;
 
             $value = $escape($value);
             $code .= <<<EOT
-VuFindPiwikTracker.setCustomVariable($i, '$key', '$value', 'page');
+    VuFindPiwikTracker.setCustomVariable($i, '$key', '$value', 'page');
 
 EOT;
         }
@@ -359,7 +366,7 @@ EOT;
 
         // Use trackSiteSearch *instead* of trackPageView in searches
         return <<<EOT
-VuFindPiwikTracker.trackSiteSearch('$searchTerms', '$searchType', $resultCount);
+    VuFindPiwikTracker.trackSiteSearch('$searchTerms', '$searchType', $resultCount);
 
 EOT;
     }
@@ -372,7 +379,7 @@ EOT;
     protected function getTrackPageViewCode()
     {
         return <<<EOT
-VuFindPiwikTracker.trackPageView();
+    VuFindPiwikTracker.trackPageView();
 
 EOT;
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -97,7 +97,8 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
         }
 
         $inlineScript = $this->getView()->plugin('inlinescript');
-        return $inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $code, 'SET');
+        return $inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $code, 'SET')
+            ->prependFile($this->url . 'piwik.js');
     }
 
     /**
@@ -288,12 +289,12 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getOpeningTrackingCode()
     {
         return <<<EOT
-var _paq = _paq || [];
-(function(){
-_paq.push(['setSiteId', {$this->siteId}]);
-_paq.push(['setTrackerUrl', '{$this->url}piwik.php']);
-_paq.push(['setCustomUrl', location.protocol + '//'
-     + location.host + location.pathname]);
+var VuFindPiwikTracker = Piwik.getTracker();
+
+VuFindPiwikTracker.setSiteId({$this->siteId});
+VuFindPiwikTracker.setTrackerUrl('{$this->url}piwik.php');
+VuFindPiwikTracker.setCustomUrl(location.protocol + '//'
+     + location.host + location.pathname);
 
 EOT;
     }
@@ -306,11 +307,7 @@ EOT;
     protected function getClosingTrackingCode()
     {
         return <<<EOT
-_paq.push(['enableLinkTracking']);
-var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.defer=true; g.async=true;
-    g.src='{$this->url}piwik.js';
-s.parentNode.insertBefore(g,s); })();
+VuFindPiwikTracker.enableLinkTracking();
 
 EOT;
     }
@@ -338,7 +335,7 @@ EOT;
 
             $value = $escape($value);
             $code .= <<<EOT
-_paq.push(['setCustomVariable', $i, '$key', '$value', 'page']);
+VuFindPiwikTracker.setCustomVariable($i, '$key', '$value', 'page');
 
 EOT;
         }
@@ -362,7 +359,7 @@ EOT;
 
         // Use trackSiteSearch *instead* of trackPageView in searches
         return <<<EOT
-_paq.push(['trackSiteSearch', '$searchTerms', '$searchType', $resultCount]);
+VuFindPiwikTracker.trackSiteSearch('$searchTerms', '$searchType', $resultCount);
 
 EOT;
     }
@@ -375,7 +372,7 @@ EOT;
     protected function getTrackPageViewCode()
     {
         return <<<EOT
-_paq.push(['trackPageView']);
+VuFindPiwikTracker.trackPageView();
 
 EOT;
     }


### PR DESCRIPTION
We are currently in the transition from a commercial piwik analytics provider to our own solution. At least in the transition phase we need to have multiple piwik backends. To do so one has to use the Piwik.getTracker() API rather then the global variable _paq. For each instance of the tracker there could be a different backend.

Notice that the piwik script gets prepended to the tracking code to ensure that the Piwik variable is present to get the tracker from it. (Piwik.getTracker())

I thought you might want to include this because it increases the flexibility and at the same time does no harm. Feel free whether to include it or not. If you think its better to leave it as it is we will overwrite the Piwik class.

Kind regards!