### PR TITLE
Increase length of username and email columns in user table so that e…

### DIFF
--- a/module/VuFind/sql/migrations/pgsql/2.5/002-modify-user-columns.sql
+++ b/module/VuFind/sql/migrations/pgsql/2.5/002-modify-user-columns.sql
@@ -1,0 +1,7 @@
+-- 
+-- Modifications to table `user`
+--
+
+ALTER TABLE user
+  ALTER COLUMN username TYPE varchar(255),
+  ALTER COLUMN email TYPE varchar(255);

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -165,12 +165,12 @@ CREATE TABLE `tags` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `user` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `username` varchar(50) NOT NULL DEFAULT '',
+  `username` varchar(255) NOT NULL DEFAULT '',
   `password` varchar(32) NOT NULL DEFAULT '',
   `pass_hash` varchar(60) DEFAULT NULL,
   `firstname` varchar(50) NOT NULL DEFAULT '',
   `lastname` varchar(50) NOT NULL DEFAULT '',
-  `email` varchar(250) NOT NULL DEFAULT '',
+  `email` varchar(255) NOT NULL DEFAULT '',
   `cat_username` varchar(50) DEFAULT NULL,
   `cat_password` varchar(50) DEFAULT NULL,
   `cat_pass_enc` varchar(110) DEFAULT NULL,

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -97,12 +97,12 @@ PRIMARY KEY (id)
 
 CREATE TABLE "user"(
 id SERIAL,
-username varchar(50) NOT NULL DEFAULT '',
+username varchar(255) NOT NULL DEFAULT '',
 password varchar(32) NOT NULL DEFAULT '',
 pass_hash varchar(60) DEFAULT NULL,
 firstname varchar(50) NOT NULL DEFAULT '',
 lastname varchar(50) NOT NULL DEFAULT '',
-email varchar(250) NOT NULL DEFAULT '',
+email varchar(255) NOT NULL DEFAULT '',
 cat_username varchar(50) DEFAULT NULL,
 cat_password varchar(50) DEFAULT NULL,
 cat_pass_enc varchar(110) DEFAULT NULL,


### PR DESCRIPTION
…mail addresses fit in them.

Since e.g. Shibboleth typically uses user's email address as the ID, there should be enough space in username column for it. And since email address can be 254 characters, it should be enlarged too. And since it's so close to the beautiful 255, just use it.

Note: I couldn't test the pgsql migration.