### PR TITLE
Fixes RSS feed not available for advanced search

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
@@ -145,7 +145,7 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
         $feed->setOpensearchTotalResults($results->getResultTotal());
         $feed->setOpensearchItemsPerPage($params->getLimit());
         $feed->setOpensearchStartIndex($results->getStartRecord() - 1);
-        $feed->setOpensearchSearchTerms($params->getQuery()->getString());
+        $feed->setOpensearchSearchTerms($params->getQuery()->getAllTerms());
 
         $records = $results->getResults();
         foreach ($records as $current) {


### PR DESCRIPTION
There is a bug that makes the RSS feed unavailable when coming from an advanced search. (The bug is also reproducible on the vufind demo page)
Simply make an advanced search with two terms and then try to get the RSS feed on the result list.

When coming from an advanced search $params->getQuery() returns a QueryGroup object. The QueryGroup does not implement the method getString and thus a Fatal Error occurs. 
I changed the method to getAllTerms which is part of the QueryInterface. 

Maybe it might be good to either add getString to the QueryInterface or replace all getString calls by getAllTerms calls since they are the same at the moment.