### PR TITLE
* fixed missing closing div in RandomRecommend.phtml

### DIFF
--- a/themes/bootstrap3/templates/Recommend/RandomRecommend.phtml
+++ b/themes/bootstrap3/templates/Recommend/RandomRecommend.phtml
@@ -54,5 +54,6 @@
         <? endif; ?>
       </li>
     <? endforeach; ?>
+    </div>
   </ul>
 <?endif;?>


### PR DESCRIPTION
Found that while porting bootstrap3-templates to foundation5.