### PR TITLE
* fixed 'Notice: Undefined index' fines-template for non record-rows

### DIFF
--- a/themes/bootstrap3/templates/myresearch/fines.phtml
+++ b/themes/bootstrap3/templates/myresearch/fines.phtml
@@ -28,7 +28,7 @@
         <td>
           <? if (empty($record['title'])): ?>
             <?=$this->transEsc('not_applicable')?>
-          <? elseif (!is_object($record['driver'])): ?>
+          <? elseif (!isset($record['driver']) || !is_object($record['driver'])): ?>
             <?=$this->escapeHtml(trim($record['title'], '/:'))?>
           <? else: ?>
             <a href="<?=$this->recordLink()->getUrl($record['driver'])?>"><?=$this->escapeHtml(trim($record['title'], '/:'))?></a>


### PR DESCRIPTION
This solves the PHP-Notice for non-record rows, but I'm not sure if this should rather be addressed in `MyResearchController.php` (https://github.com/vufind-org/vufind/blob/master/module/VuFind/src/VuFind/Controller/MyResearchController.php#L1109) as for non-record-rows a `RecordMissingException` is thrown in `Record\Loader` and caught in the above mentioned try-catch block in `MyResearchController.php` - therefore setting `$row['driver'] = null` in the Controller might be a better fix than just adding an `isset()`-check in the template.