### PR TITLE
Fixed displaying hierarchical facet values without translations in th…

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -207,7 +207,8 @@ class HierarchicalFacetHelper
         $displayText = $item['displayText'];
         if ($displayText == $item['value']) {
             // Only show the current level part
-            $displayText = $this->formatDisplayText($displayText);
+            $displayText = $this->formatDisplayText($displayText)
+                ->getDisplayString();
         }
 
         list($level, $value) = explode('/', $item['value'], 2);


### PR DESCRIPTION
…e facet tree.

So it seems I dropped the ball and failed to check the impact of the last patch to the facet tree itself. This should make the untranslated string display properly.