### PR TITLE
Proper parsing with Dspace even without hdl.handle

### DIFF
--- a/import/xsl/dspace.xsl
+++ b/import/xsl/dspace.xsl
@@ -151,7 +151,7 @@
 
                 <!-- URL -->
                <xsl:for-each select="//dc:identifier">
-                   <xsl:if test="substring(., 1, 21) = &quot;http://hdl.handle.net&quot;">
+                   <xsl:if test="substring(., 1, 4) = &quot;http&quot;">
                        <field name="url">
                            <xsl:value-of select="." />
                        </field>


### PR DESCRIPTION
Since I don't know how the development of Vufind goes, this commit perhaps will be dropped because I didn't proposed the best solution.

But We're having trouble at my university because Vufind only gets the article's links if it starts with hdl.handle.net (I don't really know why this worked this way) and we have our own handle system (we still use dx.doi thou).

I changed the parser to get anything inside the dc:identifier that starts with "http" (could it be "http://" but it would miss the https cases).

I know I could make a variant to dspace.xsl for our use, but I think the general case should be this one, not the hdl.handle's.