### PR TITLE
Fix next/prev scrolling for author facet searches

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AuthorController.php
+++ b/module/VuFind/src/VuFind/Controller/AuthorController.php
@@ -46,7 +46,20 @@ class AuthorController extends AbstractSearch
     public function resultsAction()
     {
         $this->searchClassId = 'SolrAuthor';
-        $this->saveToHistory = false;
+
+        /*
+         * save author searches if next_prev_navigation is enabled -
+         * otherwise there are wacky results when trying to page
+         * through results (the next/prev links only appear for
+         * records which were included in the results for the previous
+         * keyword search, and the next/prev links will iterate you
+         * through that search
+         */
+
+        $config = $this->getServiceLocator()->get('VuFind\Config')->get('config');
+        $this->saveToHistory = (isset($config->Record->next_prev_navigation)
+          && $config->Record->next_prev_navigation);
+
         return parent::resultsAction();
     }
 
@@ -77,6 +90,18 @@ class AuthorController extends AbstractSearch
             return $this->forwardTo('Author', 'Results');
         }
         return $this->createViewModel();
+    }
+
+    /**
+     * Is the result scroller active?
+     * 
+     * @return bool
+     */
+    protected function resultScrollerActive()
+    {
+        $config = $this->getServiceLocator()->get('VuFind\Config')->get('config');
+        return (isset($config->Record->next_prev_navigation)
+            && $config->Record->next_prev_navigation);
     }
 }
 

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
@@ -82,6 +82,25 @@ class ResultScroller extends AbstractPlugin
         if (!$this->enabled) {
             return false;
         }
+        
+        /*
+         * The AuthorController handles both SolrAuthor and SolrAuthorFacets
+         * searches. Because individual SolrAuthorFacets results are arrays
+         * (not objects that are subclassed from VuFind\RecordDriver\AbstractBase),
+         * we can't scroll through them, so we don't initiate a scroller here.
+         *
+         * But we only need to do this if author searches are saved in the session,
+         * which only happens if next/previous navigation is enabled.
+         */
+
+        $config = $this->getController()->getServiceLocator()
+            ->get('VuFind\Config')->get('config');
+
+        if (isset($config->Record->next_prev_navigation) &&
+            $config->Record->next_prev_navigation &&
+            is_a($searchObject, 'VuFind\Search\SolrAuthorFacets\Results')) {
+            return;
+        }
 
         // Save the details of this search in the session
         $this->data->searchId = $searchObject->getSearchId();

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
@@ -82,25 +82,6 @@ class ResultScroller extends AbstractPlugin
         if (!$this->enabled) {
             return false;
         }
-        
-        /*
-         * The AuthorController handles both SolrAuthor and SolrAuthorFacets
-         * searches. Because individual SolrAuthorFacets results are arrays
-         * (not objects that are subclassed from VuFind\RecordDriver\AbstractBase),
-         * we can't scroll through them, so we don't initiate a scroller here.
-         *
-         * But we only need to do this if author searches are saved in the session,
-         * which only happens if next/previous navigation is enabled.
-         */
-
-        $config = $this->getController()->getServiceLocator()
-            ->get('VuFind\Config')->get('config');
-
-        if (isset($config->Record->next_prev_navigation) &&
-            $config->Record->next_prev_navigation &&
-            is_a($searchObject, 'VuFind\Search\SolrAuthorFacets\Results')) {
-            return;
-        }
 
         // Save the details of this search in the session
         $this->data->searchId = $searchObject->getSearchId();
@@ -117,7 +98,7 @@ class ResultScroller extends AbstractPlugin
         unset($this->data->prevIds);
         unset($this->data->nextIds);
 
-        return true;
+        return (bool)$this->data->currIds;
     }
 
     /**
@@ -412,6 +393,9 @@ class ResultScroller extends AbstractPlugin
 
         $retVal = [];
         foreach ($searchObject->getResults() as $record) {
+            if(!is_a($record, 'VuFind\RecordDriver\AbstractBase')) {
+                return false;
+            }
             $retVal[] = $record->getResourceSource() . '|' . $record->getUniqueId();
         }
         return $retVal;


### PR DESCRIPTION
When running a keyword search, then choosing an author hyperlink from
the results to run an author facet search, the next/previous links in the
individual results would be based on the initial keyword search, not the facet
search.

This was for two reasons:
- the ResultScroller was not active in the AuthorController, which
handles author facet searches
- the ResultScroller retrieves the current search from the session to
create the scrolling links, and author facet searches were configured to not
be saved in the session

Correct these two issues in AuthorController, but only if
next_prev_navigation is enabled. Because AuthorController also handles
SolrAuthorFacet searches (searches that produce a list of authors, not a
list of titles by a specific author) and those results cannot be iterated
through by a ResultScroller, we also have to make an additional fix in
the ResultScroller plugin to handle the case where SolrAuthorFacet
result is passed to create the ResultScroller, and prevent it from
being instantiated.