### PR TITLE
Indexing author relator-terms

### DIFF
--- a/import/index_scripts/author-modification.bsh
+++ b/import/index_scripts/author-modification.bsh
@@ -181,7 +181,8 @@ public String getFirstAuthorFilteredByRelator(Record record, String tagList,
  * @returns Set result
  */
 public Set getRelatorsFilteredByRelator(Record record, String tagList,
-    String acceptWithoutRelator, String relatorConfig, Boolean firstOnly
+    String acceptWithoutRelator, String relatorConfig, Boolean firstOnly,
+    String defaultRelator
 ) {
     Set result = new LinkedHashSet();
     String[] noRelatorAllowed = acceptWithoutRelator.split(":");
@@ -198,7 +199,7 @@ public Set getRelatorsFilteredByRelator(Record record, String tagList,
                 List subfield4 = normalizeRelatorSubfieldList(authorField.getSubfields('4'));
     
                 // get the first non-empty subfield
-                String relator = "none";
+                String relator = defaultRelator;
 
                 // try subfield E first
                 for (int j = 0; j < subfieldE.size(); j++) {
@@ -240,7 +241,7 @@ public Set getRelatorsFilteredByRelator(Record record, String tagList,
 ) {
     // default firstOnly to false!
     return getRelatorsFilteredByRelator(
-        record, tagList, acceptWithoutRelator, relatorConfig, false
+        record, tagList, acceptWithoutRelator, relatorConfig, false, "default_relator"
     );
 }
 

--- a/import/index_scripts/author-modification.bsh
+++ b/import/index_scripts/author-modification.bsh
@@ -167,6 +167,84 @@ public String getFirstAuthorFilteredByRelator(Record record, String tagList,
 }
 
 /**
+ * Filter values retrieved using tagList to include only those whose relator
+ * values are acceptable. Used for saving relators of authors separated by different
+ * types.
+ *
+ * @param record               The record (fed in automatically)
+ * @param tagList              The field specification to read
+ * @param acceptWithoutRelator Colon-delimited list of tags whose values should
+ * be accepted even if no relator subfield is defined
+ * @param relatorConfig        The setting in author-classification.ini which
+ * defines which relator terms are acceptable (or a colon-delimited list)
+ * @param firstOnly            Return first result only?
+ * @returns Set result
+ */
+public Set getRelatorsFilteredByRelator(Record record, String tagList,
+    String acceptWithoutRelator, String relatorConfig, Boolean firstOnly
+) {
+    Set result = new LinkedHashSet();
+    String[] noRelatorAllowed = acceptWithoutRelator.split(":");
+    HashMap parsedTagList = getParsedTagList(tagList);
+    List fields = indexer.getFieldSetMatchingTagList(record, tagList);
+    Iterator fieldsIter = fields.iterator();
+    if (fields != null){
+        DataField authorField;
+        while (fieldsIter.hasNext()){
+            authorField = (DataField) fieldsIter.next();
+            //add all author types to the result set
+            if (authorHasAppropriateRelator(authorField, noRelatorAllowed, relatorConfig)) {
+                List subfieldE = normalizeRelatorSubfieldList(authorField.getSubfields('e'));
+                List subfield4 = normalizeRelatorSubfieldList(authorField.getSubfields('4'));
+    
+                // get the first non-empty subfield
+                String relator = "none";
+
+                // try subfield E first
+                for (int j = 0; j < subfieldE.size(); j++) {
+                    if (!subfieldE.get(j).getData().isEmpty()) {
+                        relator = subfieldE.get(j).getData();
+                        continue;
+                    }
+                }
+                // try subfield 4 now and overwrite relator as subfield 4 is most important
+                for (int j = 0; j < subfield4.size(); j++) {
+                    if (!subfield4.get(j).getData().isEmpty()) {
+                        relator = subfield4.get(j).getData();
+                        continue;
+                    }
+                }
+
+                result.add(relator);
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Filter values retrieved using tagList to include only those whose relator
+ * values are acceptable. Used for saving relators of authors separated by different
+ * types.
+ *
+ * @param record               The record (fed in automatically)
+ * @param tagList              The field specification to read
+ * @param acceptWithoutRelator Colon-delimited list of tags whose values should
+ * be accepted even if no relator subfield is defined
+ * @param relatorConfig        The setting in author-classification.ini which
+ * defines which relator terms are acceptable (or a colon-delimited list)
+ * @returns Set result
+ */
+public Set getRelatorsFilteredByRelator(Record record, String tagList,
+    String acceptWithoutRelator, String relatorConfig
+) {
+    // default firstOnly to false!
+    return getRelatorsFilteredByRelator(
+        record, tagList, acceptWithoutRelator, relatorConfig, false
+    );
+}
+
+/**
  * This method fetches relator definitions from ini file and casts them to an
  * array. If a colon-delimited string is passed in, this will be directly parsed
  * instead of resorting to .ini loading.

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -14,9 +14,11 @@
 # (by default, the scripts have the same behavior as the built-in functions,
 # but the external scripts are easier to customize to your needs).
 #format = script(format.bsh), getFormat, format_map.properties
-author = script(author-modification.bsh), getAuthorsFilteredByRelator(100abcd:110ab:111abc:700abcd,100:110:111:700,firstAuthorRoles)
-author2 = script(author-modification.bsh), getAuthorsFilteredByRelator(700abcd:710ab:711ab,710:711,secondAuthorRoles)
-author_sort = script(author-modification.bsh), getFirstAuthorFilteredByRelator(100abcd:110ab:111abc:700abcd,100:110:111:700,firstAuthorRoles)
+author       = script(author-modification.bsh), getAuthorsFilteredByRelator(100abcd:110ab:111abc:700abcd,100:110:111:700,firstAuthorRoles)
+author_role  = script(author-modification.bsh), getRelatorsFilteredByRelator(100abcd:110ab:111abc:700abcd,100:110:111:700,firstAuthorRoles)
+author2      = script(author-modification.bsh), getAuthorsFilteredByRelator(700abcd:710ab:711ab,710:711,secondAuthorRoles)
+author2_role = script(author-modification.bsh), getRelatorsFilteredByRelator(700abcd:710ab:711ab,710:711,secondAuthorRoles)
+author_sort  = script(author-modification.bsh), getFirstAuthorFilteredByRelator(100abcd:110ab:111abc:700abcd,100:110:111:700,firstAuthorRoles)
 #callnumber-subject = script(callnumber.bsh), getCallNumberSubject(090a:050a), callnumber_subject_map.properties
 #callnumber-label = script(callnumber.bsh), getCallNumberLabel(090a:050a)
 #publishDate = script(getdate.bsh), getDate

--- a/solr/biblio/conf/schema.xml
+++ b/solr/biblio/conf/schema.xml
@@ -126,7 +126,7 @@
    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-   <field name="author_role" type="textProper" indexed="true" stored="true" multiValued="true"/>
+   <field name="author_role" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="author_facet" type="textFacet" indexed="true" stored="false" multiValued="true"/>
    <field name="author_sort" type="string" indexed="true" stored="true"/>
    <field name="title" type="text" indexed="true" stored="true"/>
@@ -167,7 +167,7 @@
    <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
    <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <field name="author2_role" type="textProper" indexed="true" stored="true" multiValued="true"/>
+   <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="author_fuller" type="textProper" indexed="true" stored="true" />
    <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
    <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>

--- a/solr/biblio/conf/schema.xml
+++ b/solr/biblio/conf/schema.xml
@@ -126,6 +126,7 @@
    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true"/>
+   <field name="author_role" type="textProper" indexed="true" stored="true" multiValued="true"/>
    <field name="author_facet" type="textFacet" indexed="true" stored="false" multiValued="true"/>
    <field name="author_sort" type="string" indexed="true" stored="true"/>
    <field name="title" type="text" indexed="true" stored="true"/>
@@ -166,6 +167,7 @@
    <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
    <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
+   <field name="author2_role" type="textProper" indexed="true" stored="true" multiValued="true"/>
    <field name="author_fuller" type="textProper" indexed="true" stored="true" />
    <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
    <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
Demian, as discussed on the mailinglist this implements the pretty much copied routines from author-indexing by filtered relator terms again but indexes the relator terms in the same order as the authors are processed. If no relator exists for the author "none" is store.

I updated the `marc_local.properties` and hope that the field declaration is alright (I just c&p'ed `author`&`author2` without termVectors-attribute). Unfortunately java properties-files do not have a very elaborate syntax therefore there's no way around copy&pasting the fields from author/author2 to author_role/author2_role - btw. should we name the suffix `_role` `_relator` instead? Just to be consistent with MARC-terminology.

I guess, next step would be to reflect these changes in VuFind-Core?