### PR TITLE
Fixed fetching similar records when deduplication is enabled and made…

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -573,7 +573,9 @@ container_title = "Journal Title"
 
 ; This section defines how records are handled when being fetched from Solr.
 [Records]
-; Boolean value indicating if deduplication is enabled. Defaults to false.
+; Boolean value indicating if deduplication is enabled. If true, deduplication is 
+; enabled. If false, dedup records are filtered out. If unspecified, deduplication 
+; support is completely disabled.
 ;deduplication = true
 ; Priority order (descending) for record sources (record ID prefixes separated
 ; from the actual record by period, e.g. testsrc.12345)

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -213,10 +213,10 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
         }
 
         // Apply deduplication if applicable:
-        if (isset($search->Records->deduplication)
-            && $search->Records->deduplication
-        ) {
-            $this->getDeduplicationListener($backend)->attach($events);
+        if (isset($search->Records->deduplication)) {
+            $this->getDeduplicationListener(
+                $backend, $search->Records->deduplication
+            )->attach($events);
         }
 
         // Attach hierarchical facet listener:
@@ -370,15 +370,18 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      * Get a deduplication listener for the backend
      *
      * @param BackendInterface $backend Search backend
+     * @param bool             $enabled Whether deduplication is enabled
      *
      * @return DeduplicationListener
      */
-    protected function getDeduplicationListener(BackendInterface $backend)
+    protected function getDeduplicationListener(BackendInterface $backend, $enabled)
     {
         return new DeduplicationListener(
             $backend,
             $this->serviceLocator,
-            $this->searchConfig
+            $this->searchConfig,
+            'datasources',
+            $enabled
         );
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -77,24 +77,34 @@ class DeduplicationListener
     protected $dataSourceConfig;
 
     /**
+     * Whether deduplication is enabled.
+     *
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
      * Constructor.
      *
      * @param BackendInterface        $backend          Search backend
      * @param ServiceLocatorInterface $serviceLocator   Service locator
      * @param string                  $searchConfig     Search config file id
      * @param string                  $dataSourceConfig Data source file id
+     * @param bool                    $enabled          Whether deduplication is
+     * enabled
      *
      * @return void
      */
     public function __construct(
         BackendInterface $backend,
         ServiceLocatorInterface $serviceLocator,
-        $searchConfig, $dataSourceConfig = 'datasources'
+        $searchConfig, $dataSourceConfig = 'datasources', $enabled = true
     ) {
         $this->backend = $backend;
         $this->serviceLocator = $serviceLocator;
         $this->searchConfig = $searchConfig;
         $this->dataSourceConfig = $dataSourceConfig;
+        $this->enabled = $enabled;
     }
 
     /**
@@ -125,7 +135,18 @@ class DeduplicationListener
             $params = $event->getParam('params');
             $context = $event->getParam('context');
             if (($context == 'search' || $context == 'similar') && $params) {
-                $params->add('fq', '-merged_child_boolean:TRUE');
+                // If deduplication is enabled, filter out merged child records,
+                // otherwise filter out dedup records.
+                if ($this->enabled) {
+                    $fq = '-merged_child_boolean:true';
+                    if ($context == 'similar' && $id = $event->getParam('id')) {
+                        $fq .= ' AND -local_ids_str_mv:"'
+                            . addcslashes($id, '"') . '"';
+                    }
+                } else {
+                    $fq = '-merged_boolean:true';
+                }
+                $params->add('fq', $fq);
             }
         }
         return $event;
@@ -147,7 +168,7 @@ class DeduplicationListener
             return $event;
         }
         $context = $event->getParam('context');
-        if ($context == 'search') {
+        if ($this->enabled && ($context == 'search' || $context == 'similar')) {
             $this->fetchLocalRecords($event);
         }
         return $event;


### PR DESCRIPTION
… it possible to also disable deduplication in a deduplicated Solr index so that dedup records are filtered out.

Similar record handling includes two fixes: filter out merged child records and the dedup record containing the original record.
There is now also the option of specifying deduplication=false in searches.ini so that dedup records can be ignored while deduplication is otherwise inactive. 
If this can be merged, I'll also update the wiki page with more information regarding the options.