### PR TITLE
Fixes form submission on error

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -118,7 +118,8 @@ function bulkActionSubmit($form) {
   var submit = $form.find('[type="submit"][clicked=true]').attr('name');
   var checks = $form.find('input.checkbox-select-item:checked');
   if(checks.length == 0 && submit != 'empty') {
-    return Lightbox.displayError(vufindString['bulk_noitems_advice']);
+    Lightbox.displayError(vufindString['bulk_noitems_advice']);
+    return false;
   }
   if (submit == 'print') {
     //redirect page


### PR DESCRIPTION
If a user does not select a book in /MyResearch/Favorites but hits the button "Email", "Delete", etc. an error gets displayed in the lightbox and the page reloads itself. Then the same error is displayed again above the title "Your Favorites". This is quite confusing and I guess not intended.

I was not sure whether Lightbox.displayError should always return false so I implemented it in a way that only the bulkActionSubmit method is concerned. Like this the form submission is suppressed. 