### PR TITLE
Adds success namespace to flash messages

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -131,7 +131,7 @@ class AbstractRecord extends AbstractBase
                 $driver->getUniqueId(), $driver->getResourceSource(), true, $driver
             );
             $resource->addComment($comment, $user);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('add_comment_success');
         } else {
             $this->flashMessenger()->setNamespace('error')
@@ -155,7 +155,7 @@ class AbstractRecord extends AbstractBase
         $id = $this->params()->fromQuery('delete');
         $table = $this->getTable('Comments');
         if (!is_null($id) && $table->deleteIfOwnedByUser($id, $user)) {
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('delete_comment_success');
         } else {
             $this->flashMessenger()->setNamespace('error')
@@ -188,7 +188,7 @@ class AbstractRecord extends AbstractBase
         if ($tags = $this->params()->fromPost('tag')) {
             $tagParser = $this->getServiceLocator()->get('VuFind\Tags');
             $driver->addTags($user, $tagParser->parse($tags));
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage(['msg' => 'add_tag_success']);
             return $this->redirectToRecord();
         }
@@ -222,7 +222,7 @@ class AbstractRecord extends AbstractBase
         // Save tags, if any:
         if ($tag = $this->params()->fromPost('tag')) {
             $driver->deleteTags($user, [$tag]);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage(
                     [
                         'msg' => 'tags_deleted',
@@ -286,7 +286,7 @@ class AbstractRecord extends AbstractBase
         $driver->saveToFavorites($post, $user);
 
         // Display a success status message:
-        $this->flashMessenger()->setNamespace('info')
+        $this->flashMessenger()->setNamespace('success')
             ->addMessage('bulk_save_success');
 
         // redirect to followup url saved in saveAction
@@ -412,7 +412,7 @@ class AbstractRecord extends AbstractBase
                     $view->to, $view->from, $view->message, $driver,
                     $this->getViewRenderer(), $view->subject, $cc
                 );
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('email_success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
@@ -456,7 +456,7 @@ class AbstractRecord extends AbstractBase
                     ['driver' => $driver, 'to' => $view->to]
                 );
                 $sms->text($view->provider, $view->to, null, $body);
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('sms_success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -227,7 +227,7 @@ class CartController extends AbstractBase
                     $view->to, $view->from, $view->message,
                     $url, $this->getViewRenderer(), $view->subject, $cc
                 );
-                return $this->redirectToSource('info', 'email_success');
+                return $this->redirectToSource('success', 'email_success');
             } catch (MailException $e) {
                 $this->flashMessenger()->setNamespace('error')
                     ->addMessage($e->getMessage());
@@ -299,7 +299,7 @@ class CartController extends AbstractBase
                     'cart/export-success.phtml', ['url' => $url]
                 )
             ];
-            return $this->redirectToSource('info', $msg);
+            return $this->redirectToSource('success', $msg);
         }
 
         // Load the records:
@@ -387,7 +387,7 @@ class CartController extends AbstractBase
         if ($this->formWasSubmitted('submit')) {
             $this->favorites()
                 ->saveBulk($this->getRequest()->getPost()->toArray(), $user);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('bulk_save_success');
             $list = $this->params()->fromPost('list');
             if (!empty($list)) {

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -134,7 +134,7 @@ trait HoldsTrait
                             '%%url%%' => $this->url()->fromRoute('myresearch-holds')
                         ],
                     ];
-                    $this->flashMessenger()->setNamespace('info')->addMessage($msg);
+                    $this->flashMessenger()->setNamespace('success')->addMessage($msg);
                     return $this->redirectToRecord('#top');
                 } else {
                     // Failure: use flash messenger to display messages, stay on

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -134,7 +134,8 @@ trait HoldsTrait
                             '%%url%%' => $this->url()->fromRoute('myresearch-holds')
                         ],
                     ];
-                    $this->flashMessenger()->setNamespace('success')->addMessage($msg);
+                    $this->flashMessenger()->setNamespace('success')
+                        ->addMessage($msg);
                     return $this->redirectToRecord('#top');
                 } else {
                     // Failure: use flash messenger to display messages, stay on

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -112,7 +112,7 @@ trait ILLRequestsTrait
 
             // Success: Go to Display ILL Requests
             if (isset($results['success']) && $results['success'] == true) {
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('ill_request_place_success');
                 if ($this->inLightbox()) {
                     return false;

--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -163,7 +163,7 @@ class LibraryCardsController extends AbstractBase
             $user->deleteLibraryCard($cardID);
 
             // Success Message
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('Library Card Deleted');
             // Redirect to MyResearch library cards
             return $this->redirect()->toRoute('librarycards-home');

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -285,11 +285,11 @@ class MyResearchController extends AbstractBase
         $search = $this->getTable('Search');
         if (($id = $this->params()->fromQuery('save', false)) !== false) {
             $search->setSavedFlag($id, true, $user->id);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('search_save_success');
         } else if (($id = $this->params()->fromQuery('delete', false)) !== false) {
             $search->setSavedFlag($id, false);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('search_unsave_success');
         } else {
             throw new \Exception('Missing save and delete parameters.');
@@ -326,7 +326,7 @@ class MyResearchController extends AbstractBase
         if (!empty($homeLibrary)) {
             $user->changeHomeLibrary($homeLibrary);
             $this->getAuthManager()->updateSession($user);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('profile_update');
         }
 
@@ -409,7 +409,7 @@ class MyResearchController extends AbstractBase
         // Process the deletes if necessary:
         if ($this->formWasSubmitted('submit')) {
             $this->favorites()->delete($ids, $listID, $user);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('fav_delete_success');
             return $this->redirect()->toUrl($newUrl);
         }
@@ -460,12 +460,12 @@ class MyResearchController extends AbstractBase
             $table = $this->getTable('UserList');
             $list = $table->getExisting($listID);
             $list->removeResourcesById($user, [$id], $source);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('Item removed from list');
         } else {
             // ...My Favorites
             $user->removeResourcesById([$id], $source);
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('Item removed from favorites');
         }
 
@@ -503,7 +503,7 @@ class MyResearchController extends AbstractBase
         if ($addToList > -1) {
             $driver->saveToFavorites(['list' => $addToList], $user);
         }
-        $this->flashMessenger()->setNamespace('info')
+        $this->flashMessenger()->setNamespace('success')
             ->addMessage('edit_list_success');
 
         $newUrl = is_null($listID)
@@ -801,7 +801,7 @@ class MyResearchController extends AbstractBase
                 $list->delete($this->getUser());
 
                 // Success Message
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('fav_list_delete');
             } catch (\Exception $e) {
                 switch(get_class($e)) {
@@ -1245,7 +1245,7 @@ class MyResearchController extends AbstractBase
                         $this->translate('recovery_email_subject'),
                         $message
                     );
-                    $this->flashMessenger()->setNamespace('info')
+                    $this->flashMessenger()->setNamespace('success')
                         ->addMessage('recovery_email_sent');
                 } catch (MailException $e) {
                     $this->flashMessenger()->setNamespace('error')
@@ -1370,7 +1370,7 @@ class MyResearchController extends AbstractBase
         // Login
         $this->getAuthManager()->login($this->request);
         // Go to favorites
-        $this->flashMessenger()->setNamespace('info')
+        $this->flashMessenger()->setNamespace('success')
             ->addMessage('new_password_success');
         return $this->redirect()->toRoute('myresearch-home');
     }

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -147,7 +147,7 @@ class Holds extends AbstractRequestBase
                     // messages so we can avoid a double translation here.
                     $msg = $this->getController()
                         ->translate('hold_cancel_success_items');
-                    $flashMsg->setNamespace('info')->addMessage(
+                    $flashMsg->setNamespace('success')->addMessage(
                         $cancelResults['count'] . ' ' . $msg
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/ILLRequests.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ILLRequests.php
@@ -164,7 +164,7 @@ class ILLRequests extends AbstractRequestBase
                     $msg = $this->getController()->translate(
                         'ill_request_cancel_success_items'
                     );
-                    $flashMsg->setNamespace('info')->addMessage(
+                    $flashMsg->setNamespace('success')->addMessage(
                         $cancelResults['count'] . ' ' . $msg
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/StorageRetrievalRequests.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/StorageRetrievalRequests.php
@@ -164,7 +164,7 @@ class StorageRetrievalRequests extends AbstractRequestBase
                     $msg = $this->getController()->translate(
                         'storage_retrieval_request_cancel_success_items'
                     );
-                    $flashMsg->setNamespace('info')->addMessage(
+                    $flashMsg->setNamespace('success')->addMessage(
                         $cancelResults['count'] . ' ' . $msg
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -123,7 +123,7 @@ class SearchController extends AbstractSearch
                     $view->to, $view->from, $view->message,
                     $view->url, $this->getViewRenderer(), $view->subject, $cc
                 );
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('email_success');
                 return $this->redirect()->toUrl($view->url);
             } catch (MailException $e) {

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -112,7 +112,7 @@ trait StorageRetrievalRequestsTrait
 
             // Success: Go to Display Storage Retrieval Requests
             if (isset($results['success']) && $results['success'] == true) {
-                $this->flashMessenger()->setNamespace('info')
+                $this->flashMessenger()->setNamespace('success')
                     ->addMessage('storage_retrieval_request_place_success');
                 if ($this->inLightbox()) {
                     return false;

--- a/module/VuFind/src/VuFind/View/Helper/Root/Flashmessages.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Flashmessages.php
@@ -76,7 +76,7 @@ class Flashmessages extends AbstractHelper
     public function __invoke()
     {
         $html = '';
-        $namespaces = ['error', 'info'];
+        $namespaces = ['error', 'info', 'success'];
         foreach ($namespaces as $ns) {
             $this->fm->setNamespace($ns);
             $messages = array_merge(

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
@@ -65,7 +65,7 @@ class ConfigController extends AbstractAdmin
         $writer = new \VuFind\Config\Writer($configFile);
         $writer->set('System', 'autoConfigure', 1);
         if ($writer->save()) {
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('Auto-configuration enabled.');
 
             // Reload config now that it has been edited (otherwise, old setting

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
@@ -66,7 +66,7 @@ class MaintenanceController extends AbstractAdmin
         // If cache is unset, we didn't go through the loop above, so no message
         // needs to be displayed.
         if (isset($cache)) {
-            $this->flashMessenger()->setNamespace('info')
+            $this->flashMessenger()->setNamespace('success')
                 ->addMessage('Cache(s) cleared.');
         }
         return $this->forwardTo('AdminMaintenance', 'Home');
@@ -139,7 +139,7 @@ class MaintenanceController extends AbstractAdmin
                 $search->delete($query);
                 $msg = str_replace('%%count%%', $count, $successString);
             }
-            $this->flashMessenger()->setNamespace('info')->addMessage($msg);
+            $this->flashMessenger()->setNamespace('success')->addMessage($msg);
         }
         return $this->forwardTo('AdminMaintenance', 'Home');
     }

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
@@ -180,7 +180,7 @@ class TagsController extends AbstractAdmin
             return $this->redirect()->toUrl($originUrl);
         }
 
-        $this->flashMessenger()->setNamespace('info')
+        $this->flashMessenger()->setNamespace('success')
             ->addMessage(
                 [
                     'msg' => 'tags_deleted',

--- a/themes/jquerymobile/css/styles.css
+++ b/themes/jquerymobile/css/styles.css
@@ -209,7 +209,7 @@ div.footer-text {
     padding:0 .5em .5em 20px;
 }
 
-.error, .alert, .info {
+.error, .alert, .info, .success {
   text-align:center;
   padding:10px 0;
   box-shadow:0 1px 0 #AAA,0 -1px 0 #FFF;
@@ -220,7 +220,11 @@ div.footer-text {
   border:1px solid #811;
 }
 .notice {color:#514721;}
-.success {color:#264409;}
+.success {
+  color:#264409;
+  background:#e6efc2;
+  border:1px solid #c6d880;
+}
 .info {
   color:#205791;
   background:#DEF;

--- a/themes/jquerymobile/templates/myresearch/checkedout.phtml
+++ b/themes/jquerymobile/templates/myresearch/checkedout.phtml
@@ -34,7 +34,7 @@
           <? $renewDetails = $this->renewResult[$ilsDetails['item_id']]; ?>
           <? $prefix = isset($ilsDetails['title']) ? $ilsDetails['title'] : $ilsDetails['item_id']; ?>
           <? if (isset($renewDetails['success']) && $renewDetails['success']): ?>
-            <div class="info"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_success')?></div>
+            <div class="success"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_success')?></div>
           <? else: ?>
             <div class="error"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_fail')?><? if (isset($renewDetails['sysMessage'])): ?>: <?=$this->escapeHtml($renewDetails['sysMessage'])?><? endif; ?></div>
           <? endif; ?>


### PR DESCRIPTION
Dear Demian

I updated the flash messages namespaces. Turns out a lot of "info" messages are actually "success" messages.
This implementation already works for bootstrap themes since bootstrap adds styling for alert-success.
I am not very familiar with the other themes, I would like to ask for your assistance / guidance there.

Kind regards
Markus