### PR TITLE
bibtex-export

### DIFF
--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -129,8 +129,6 @@ foreach ($this->record($this->driver)->getUrlList() as $url) {
     echo "url = {{$url}}\n";
 }
 
-echo "crossref = {" . $this->serverUrl($this->recordLink()->getUrl($this->driver)) . "},\n";
-
 // Record separator:
 echo "}\n\n";
 ?>


### PR DESCRIPTION
* removes field 'crossref' from bibtex-export
* crossref is used for links to records (host items) within the same bibtex file, not to link to the record itself
* See https://en.wikipedia.org/wiki/BibTeX#Cross-referencing for examples
* If used, the field causes trouble with literature management software who interpret it as link to host item (for instance, Citavi https://www.citavi.com/)