### PR TITLE
SolrMarc.php getAllSubjectHeadings - now returns unique array

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -130,8 +130,8 @@ class SolrMarc extends SolrDefault
             }
         }
 
-        // Send back everything we collected:
-        return array_unique($retval, SORT_REGULAR);
+        // Remove duplicates and then send back everything we collected:
+        return array_map('unserialize', array_unique(array_map('serialize', $retval)));
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -131,7 +131,7 @@ class SolrMarc extends SolrDefault
         }
 
         // Send back everything we collected:
-        return $retval;
+        return array_unique($retval, SORT_REGULAR);
     }
 
     /**


### PR DESCRIPTION
The array returned by getAllSubjectHeadings() is not unique. The array returned by SolrDefault.php already returns unique array...Demian mentioned that array_unique() might not work properly for more complex arrays. I wonder whether this is the reason why array_unique() has not been originally implemented here. However it seems to work as supposed, i.e. duplicates are suppressed.