### PR TITLE
Removing duplicate URLs generated in getLinkDetails()

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -562,6 +562,9 @@ class Record extends AbstractHelper
         if (empty($urls)) {
             return [];
         }
+        
+        //removes duplicates that have the same url and desc (would be better to remove a duplicate based on url only, but that does not seem to be very efficient)
+        $urls = array_map('unserialize', array_unique(array_map('serialize', $urls)));
 
         // If we found links, we may need to convert from the "route" format
         // to the "full URL" format.


### PR DESCRIPTION
Unserialization of mult-dimensional array to remove duplicates to then serialize the array again. Drawback here is that in cases in which the url is the same, but the desc value is different, these duplicates will remain, example:
array(5) { 
[0]=> array(2) { ["url"]=> string(59) "http://elib.tiho-hannover.de/dissertations/leidelf_ws14.pdf" ["desc"]=> string(59) "http://elib.tiho-hannover.de/dissertations/leidelf_ws14.pdf" }
[1]… 
[2]… 
[3]=> array(2) { ["url"]=> string(59) "http://elib.tiho-hannover.de/dissertations/leidelf_ws14.pdf" ["desc"]=> string(9) "full text" } 
[4]… 
} }
