### PR TITLE
Fixed OpenURL click handling when loading Combined results with ajax.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
@@ -120,9 +120,6 @@ class OpenUrl extends \Zend\View\Helper\AbstractHelper
         }
 
         $embed = (isset($this->config->embed) && !empty($this->config->embed));
-        if ($embed) {
-            $counter++;
-        }
 
         $embedAutoLoad = isset($this->config->embed_auto_load)
             ? $this->config->embed_auto_load : false;

--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
@@ -111,9 +111,6 @@ class OpenUrl extends \Zend\View\Helper\AbstractHelper
      */
     public function renderTemplate()
     {
-        // Static counter to ensure that each OpenURL gets a unique ID.
-        static $counter = 0;
-
         if (null !== $this->config && isset($this->config->url)) {
             // Trim off any parameters (for legacy compatibility -- default config
             // used to include extraneous parameters):
@@ -161,8 +158,7 @@ class OpenUrl extends \Zend\View\Helper\AbstractHelper
             'openUrlGraphicHeight' => empty($this->config->graphic_height)
                 ? false : $this->config->graphic_height,
             'openUrlEmbed' => $embed,
-            'openUrlEmbedAutoLoad' => $embedAutoLoad,
-            'openUrlId' => $counter
+            'openUrlEmbedAutoLoad' => $embedAutoLoad
         ];
 
         // Render the subtemplate:

--- a/themes/bootstrap3/js/openurl.js
+++ b/themes/bootstrap3/js/openurl.js
@@ -18,6 +18,12 @@ function loadResolverLinks($target, openUrl) {
     });
 }
 
+function embedOpenUrlLinks(element) {
+    var openUrl = element.children('span.openUrl:first').attr('title');
+    element.removeClass('openUrlEmbed').hide();
+    loadResolverLinks(element.next('div.resolver').removeClass('hidden'), openUrl);
+}
+
 $(document).ready(function() {
     // assign action to the openUrlWindow link class
     $('a.openUrlWindow').click(function(){
@@ -28,11 +34,8 @@ $(document).ready(function() {
     });
 
     // assign action to the openUrlEmbed link class
-    $('a.openUrlEmbed').click(function(){
-        var params = extractClassParams(this);
-        var openUrl = $(this).children('span.openUrl:first').attr('title');
-        $(this).hide();
-        loadResolverLinks($('#openUrlEmbed'+params.openurl_id).removeClass('hidden'), openUrl);
+    $('a.openUrlEmbed').click(function() {
+        embedOpenUrlLinks($(this));
         return false;
     });
 

--- a/themes/bootstrap3/templates/Helpers/openurl.phtml
+++ b/themes/bootstrap3/templates/Helpers/openurl.phtml
@@ -1,7 +1,7 @@
 <?
   $this->headScript()->appendFile("openurl.js");
   if ($this->openUrlEmbed) {
-    $classes = "fulltext openUrlEmbed openurl_id:{$this->openUrlId}"
+    $classes = "fulltext openUrlEmbed"
       . ($this->openUrlEmbedAutoLoad ? ' openUrlEmbedAutoLoad' : '');
     $class = ' class="' . $classes . '"';
   } elseif ($this->openUrlWindow) {
@@ -29,5 +29,5 @@
   <? endif; ?>
 </a>
 <? if ($this->openUrlEmbed): ?>
-  <div id="openUrlEmbed<?=$this->openUrlId?>" class="resolver hidden"><?=$this->transEsc('Loading')?>...</div>
+  <div class="resolver hidden"><?=$this->transEsc('Loading')?>...</div>
 <? endif; ?>

--- a/themes/bootstrap3/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap3/templates/combined/results-ajax.phtml
@@ -12,14 +12,16 @@
     $searchClassIdHtmlEscaped = $this->escapeHtml($searchClassId);
     $lookforEncoded = urlencode($lookfor);
     $loadJs = <<<JS
-var url = path + '/Combined/Result?id=$searchClassIdEncoded&lookfor=$lookforEncoded';
-$('#combined_$searchClassIdHtmlEscaped').load(url, '', function(responseText) {
-    if (responseText.length == 0) {
-        $('#combined_$searchClassIdHtmlEscaped').hide();
-    }
-    $('a.openUrlEmbed').click(function() {
-        embedOpenUrlLinks($(this));
-        return false;
+$(document).ready(function(){
+    var url = path + '/Combined/Result?id=$searchClassIdEncoded&lookfor=$lookforEncoded';
+    $('#combined_$searchClassIdHtmlEscaped').load(url, '', function(responseText) {
+        if (responseText.length == 0) {
+            $('#combined_$searchClassIdHtmlEscaped').hide();
+        }
+        $('a.openUrlEmbed').click(function() {
+            embedOpenUrlLinks($(this));
+            return false;
+        });
     });
 });
 JS;
@@ -27,5 +29,5 @@ JS;
 ?>
 <h2><?=$this->transEsc($currentSearch['label'])?></h2>
 <p><i class="fa fa-spinner fa-spin"></i> <?=$this->transEsc("Loading")?>...</p>
-<?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '$(document).ready(function(){' . $loadJs . '});', 'SET')?>
+<?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $loadJs, 'SET')?>
 <noscript><?=$this->transEsc('Please enable JavaScript.')?></noscript>

--- a/themes/bootstrap3/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap3/templates/combined/results-ajax.phtml
@@ -1,13 +1,29 @@
 <?
+    // Make sure OpenURL support is loaded
+    $this->headScript()->appendFile("openurl.js");
+
     $view = $currentSearch['view'];
     $results = $view->results;
     $params = $results->getParams();
     $lookfor = $params->getDisplayQuery();
 
     // Set up Javascript for use below:
-    $loadJs = 'var url = path + "/Combined/Result?id=' . urlencode($searchClassId)
-        . '&lookfor=' . urlencode($lookfor) . '";'
-        . "\$('#combined_" . $this->escapeHtml($searchClassId) . "').load(url, '', function(responseText) { if (responseText.length == 0) $('#combined_" . $this->escapeHtml($searchClassId) . "').hide(); });";
+    $searchClassIdEncoded = urlencode($searchClassId);
+    $searchClassIdHtmlEscaped = $this->escapeHtml($searchClassId);
+    $lookforEncoded = urlencode($lookfor);
+    $loadJs = <<<JS
+var url = path + '/Combined/Result?id=$searchClassIdEncoded&lookfor=$lookforEncoded';
+$('#combined_$searchClassIdHtmlEscaped').load(url, '', function(responseText) {
+    if (responseText.length == 0) {
+        $('#combined_$searchClassIdHtmlEscaped').hide();
+    }
+    $('a.openUrlEmbed').click(function() {
+        embedOpenUrlLinks($(this));
+        return false;
+    });
+});
+JS;
+
 ?>
 <h2><?=$this->transEsc($currentSearch['label'])?></h2>
 <p><i class="fa fa-spinner fa-spin"></i> <?=$this->transEsc("Loading")?>...</p>


### PR DESCRIPTION
I tried to make this backwards-compatible so that it works with customized openurl.phtml files too, but of course if would be cleaner to get rid of the counter completely.