### PR TITLE
Find more records in PrimoCentral

### DIFF
--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -92,7 +92,6 @@ domain  = Source
 ; pcAvailability is a special facet. It's used to show all records found in PrimoCentral
 ; without checking the local availability against a holdingsfile.
 [CheckboxFacets]
-;edition:1st* = "First Edition"     ; Contrived hypothetical example
 ;pcAvailability = "add_other_libraries"       ; pcAvailability is a special facet, see documentation above
 
 ; Facet display settings

--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -93,7 +93,7 @@ domain  = Source
 ; without checking the local availability against a holdingsfile.
 [CheckboxFacets]
 ;edition:1st* = "First Edition"     ; Contrived hypothetical example
-;pcAvailability = "Show more"       ; pcAvailability is a special facet, see documentation above
+;pcAvailability = "add_other_libraries"       ; pcAvailability is a special facet, see documentation above
 
 ; Facet display settings
 [Results_Settings]

--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -88,6 +88,13 @@ domain  = Source
 ; Top facets (not used by default)
 [FacetsTop]
 
+; Checkbox facets are facets, which are getting displayed as checkboxes
+; pcAvailability is a special facet. It's used to show all records found in PrimoCentral
+; without checking the local availability against a holdingsfile.
+[CheckboxFacets]
+;edition:1st* = "First Edition"     ; Contrived hypothetical example
+;pcAvailability = "Show more"       ; pcAvailability is a special facet, see documentation above
+
 ; Facet display settings
 [Results_Settings]
 ; Rows and columns for table used by top facets

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -225,6 +225,7 @@ class Backend extends AbstractBackend
 
         // Convert the options:
         $options = [];
+
         // Most parameters need to be flattened from array format, but a few
         // should remain as arrays:
         $arraySettings = [
@@ -232,6 +233,11 @@ class Backend extends AbstractBackend
         ];
         foreach ($params as $key => $param) {
             $options[$key] = in_array($key, $arraySettings) ? $param : $param[0];
+        }
+
+        // Use special facet pcAvailabilty if it has been set
+        if (array_key_exists('pcAvailability', $params['filterList'])) {
+            $options['pcAvailability'] = true;
         }
 
         return $options;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -232,8 +232,8 @@ class Backend extends AbstractBackend
             'query', 'facets', 'filterList', 'groupFilters', 'rangeFilters'
         ];
         foreach ($params as $key => $param) {
-            $options[$key] =
-                in_array($key, $arraySettings) ? $param : $param[0];
+            $options[$key]
+                = in_array($key, $arraySettings) ? $param : $param[0];
         }
 
         // Use special facet pcAvailabilty if it has been set

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -232,11 +232,14 @@ class Backend extends AbstractBackend
             'query', 'facets', 'filterList', 'groupFilters', 'rangeFilters'
         ];
         foreach ($params as $key => $param) {
-            $options[$key] = in_array($key, $arraySettings) ? $param : $param[0];
+            $options[$key] =
+                in_array($key, $arraySettings) ? $param : $param[0];
         }
 
         // Use special facet pcAvailabilty if it has been set
-        if (array_key_exists('pcAvailability', $params['filterList'])) {
+        if (array_key_exists('filterList', $params)
+            && array_key_exists('pcAvailability', $params['filterList'])
+        ) {
             $options['pcAvailability'] = true;
         }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -240,6 +240,7 @@ class Backend extends AbstractBackend
         if (array_key_exists('filterList', $params)
             && array_key_exists('pcAvailability', $params['filterList'])
         ) {
+            unset($options['filterList']['pcAvailability']);
             $options['pcAvailability'] = true;
         }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -237,8 +237,7 @@ class Backend extends AbstractBackend
         }
 
         // Use special facet pcAvailabilty if it has been set
-        if (array_key_exists('filterList', $params)
-            && array_key_exists('pcAvailability', $params['filterList'])
+        if (isset($params['filterList']['pcAvailability'])
         ) {
             unset($options['filterList']['pcAvailability']);
             $options['pcAvailability'] = true;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -322,7 +322,6 @@ class Connector implements \Zend\Log\LoggerAwareInterface
             // all primocentral queries need this
             $qs[] = "loc=adaptor,primo_central_multiple_fe";
 
-
             if ($this->debug) {
                 print "URL: " . implode('&', $qs);
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -134,6 +134,7 @@ class Connector implements \Zend\Log\LoggerAwareInterface
             "onCampus" => true,
             "didYouMean" => false,
             "filterList" => null,
+            "pcAvailability" => false,
             "pageNumber" => 1,
             "limit" => 20,
             "sort" => null,
@@ -286,6 +287,17 @@ class Connector implements \Zend\Log\LoggerAwareInterface
                 }
             }
 
+            // QUERYSTRING: pcAvailability
+            // by default, PrimoCentral only returns matches,
+            // which are available via Holdingsfile
+            // pcAvailability = false
+            // By setting this value to true, also matches, which
+            // are NOT available via Holdingsfile are returned
+            // (yes, right, set this to true - thats ExLibris Logic)
+            if ($args["pcAvailability"]) {
+                $qs[] = "pcAvailability=true";
+            }
+
             // QUERYSTRING: indx (start record)
             $recordStart = $args["pageNumber"];
             if ($recordStart != 1) {
@@ -309,6 +321,7 @@ class Connector implements \Zend\Log\LoggerAwareInterface
             // QUERYSTRING: loc
             // all primocentral queries need this
             $qs[] = "loc=adaptor,primo_central_multiple_fe";
+
 
             if ($this->debug) {
                 print "URL: " . implode('&', $qs);


### PR DESCRIPTION
By default a query in PrimoCentral only returns records, which are marked as "fulltext available" in the holdingsfile, which is used by PrimoCentral. This can get changed using a simple parameter in the PrimoCentral query URL.

This PR implements this parameter by adding a checkbox facet, which can be used to drop that default filter.