### PR TITLE
Get rid of action="" in forms (not valid in HTML5)-pt2

### DIFF
--- a/themes/jquerymobile/templates/myresearch/recover.phtml
+++ b/themes/jquerymobile/templates/myresearch/recover.phtml
@@ -16,7 +16,7 @@
     <? if (!$this->auth()->getManager()->supportsRecovery()): ?>
       <div class="error"><?=$this->transEsc('recovery_disabled') ?></div>
     <? else: ?>
-      <form data-ajax="false" action="" method="post">
+      <form data-ajax="false" method="post">
         <?=$this->auth()->getPasswordRecoveryForm() ?>
       </form>
     <? endif; ?>

--- a/themes/jquerymobile/templates/record/sms.phtml
+++ b/themes/jquerymobile/templates/record/sms.phtml
@@ -6,7 +6,7 @@
   <?=$this->mobileMenu()->header()?>
   <div data-role="content">
     <?=$this->flashmessages()?>
-    <form method="post" action="" name="smsRecord" data-ajax="false">
+    <form method="post" name="smsRecord" data-ajax="false">
       <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
       <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getResourceSource())?>" />
       <div data-role="fieldcontain">


### PR DESCRIPTION
There were some action="" left, now they're gone.

Removed with $grep -r -l "action=\"\"" * | xargs sed -i 's/action=\"\" //g'

Reference: https://github.com/vufind-org/vufind/pull/369