### PR TITLE
Proxy type can now be specified in config.ini

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -835,6 +835,9 @@ url             = https://www.myendnoteweb.com/EndNoteWeb.html
 ;host = your.proxy.server
 ;port = 8000
 
+; Uncomment following line to set proxy type to SOCKS 5
+;type = socks5
+
 ; Default HTTP settings can be loaded here. These values will be passed to
 ; the \Zend\Http\Client's setOptions method.
 [Http]

--- a/module/VuFind/src/VuFind/Service/Factory.php
+++ b/module/VuFind/src/VuFind/Service/Factory.php
@@ -353,6 +353,10 @@ class Factory
             if (isset($config->Proxy->port)) {
                 $options['proxy_port'] = $config->Proxy->port;
             }
+            
+            if (isset($config->Proxy->type)) {
+                $options['proxy_type'] = $config->Proxy->type;
+            }
         }
         $defaults = isset($config->Http)
             ? $config->Http->toArray() : [];


### PR DESCRIPTION
Can be used for example to force using SOCKS 5 proxy.

The config would look like:

[Proxy]
host = localhost
port = 5000
type = socks5

Note that turning an SOCKS 5 proxy on is as easy as executing "ssh -D 5000 username@hostname"