### PR TITLE
Complete W3C validation of Vufind on Bootstrap3

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -365,7 +365,7 @@ var Lightbox = {
    *
    * This function gleans all the information in a form from the function above
    * Then it uses the action="..." attribute of the form to figure out where to send the data
-   * and the method=titel attribute to send it the proper way
+   * and the method="" attribute to send it the proper way
    *
    * Forms without an action="..." are submitted to the current URL.
    * In the case where we have a form with no action in the lightbox,

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -135,7 +135,7 @@ var Lightbox = {
     if(this.XHR) { this.XHR.abort(); }
     // Reset content so we start fresh when we open a lightbox
     $('#modal').removeData('modal');
-    $('#modal').find('.modal-title').html('');
+    $('#modal').find('.modal-title').html('&nbsp;');
     $('#modal').find('.modal-body').html(vufindString.loading + "...");
   },
   /**
@@ -365,7 +365,7 @@ var Lightbox = {
    *
    * This function gleans all the information in a form from the function above
    * Then it uses the action="..." attribute of the form to figure out where to send the data
-   * and the method="" attribute to send it the proper way
+   * and the method=titel attribute to send it the proper way
    *
    * Forms without an action="..." are submitted to the current URL.
    * In the case where we have a form with no action in the lightbox,
@@ -416,7 +416,7 @@ $(document).ready(function() {
   $('#modal').on('hidden.bs.modal', Lightbox.closeActions);
   /**
    * If a link with the class .modal-link triggers the lightbox,
-   * look for a title="" to use as our lightbox title.
+   * look for a title="&nbsp;" to use as our lightbox title.
    */
   $('.modal-link,.help-link').click(function() {
     var title = $(this).attr('title');

--- a/themes/bootstrap3/templates/error/index.phtml
+++ b/themes/bootstrap3/templates/error/index.phtml
@@ -1,7 +1,10 @@
 <?
   // Set page title.
   $this->headTitle($this->translate('An error has occurred'));
-
+  
+  // Disable top search box -- this page has a special layout.
+  $this->layout()->searchbox = false;
+  
   $this->layout()->breadcrumbs = '<li class="active">Error</li>';
 ?>
 <div class="alert alert-danger">

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -13,7 +13,8 @@
 <? endif; ?>
 <? if (!isset($this->layout()->renderingError)): ?>
   <div class="collapse navbar-collapse" id="header-collapse">
-    <ul role="navigation" class="nav navbar-nav navbar-right flip">
+    <nav role="navigation">
+    <ul class="nav navbar-nav navbar-right flip">
       <? if ($this->feedback()->tabEnabled()): ?>
         <li>
           <a id="feedbackLink" class="modal-link" href="<?=$this->url('feedback-home') ?>"><i class="fa fa-envelope"></i> <?=$this->transEsc("Feedback")?></a>
@@ -68,5 +69,6 @@
         </li>
       <? endif; ?>
     </ul>
+    </nav>
   </div>
 <? endif; ?>

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -4,7 +4,7 @@
     <span class="sr-only">Toggle navigation</span>
     <i class="fa fa-bars"></i>
   </button>
-  <a role="logo" class="navbar-brand" href="<?=$this->url('home')?>">VuFind</a>
+  <a class="navbar-brand" href="<?=$this->url('home')?>">VuFind</a>
 </div>
 <? if ($this->layout()->searchbox !== false): ?>
   <section class="visible-lg">

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -13,7 +13,7 @@
 <? endif; ?>
 <? if (!isset($this->layout()->renderingError)): ?>
   <div class="collapse navbar-collapse" id="header-collapse">
-    <nav role="navigation">
+    <nav>
     <ul class="nav navbar-nav navbar-right flip">
       <? if ($this->feedback()->tabEnabled()): ?>
         <li>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -137,7 +137,7 @@
         <?=$this->layout()->content ?>
       </div>
     </div>
-    <footer role="contentinfo" class="hidden-print">
+    <footer class="hidden-print">
       <div class="container">
         <?=$this->render('footer.phtml')?>
         <?=$this->layout()->poweredBy ?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -98,7 +98,7 @@
         $this->layout()->searchbox = $this->render('search/searchbox.phtml');
       }
     ?>
-    <header role="banner" class="hidden-print">
+    <header class="hidden-print">
       <div class="container navbar">
         <a class="sr-only" href="#content"><?=$this->transEsc('Skip to content') ?></a>
         <?=$this->render('header.phtml')?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -149,7 +149,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            <h4 id="modalTitle" class="modal-title"></h4>
+            <h4 id="modalTitle" class="modal-title">void</h4>
           </div>
           <div class="modal-body"><?=$this->transEsc('Loading') ?>...</div>
         </div>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -149,7 +149,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            <h4 id="modalTitle" class="modal-title">void</h4>
+            <h4 id="modalTitle" class="modal-title">&nbsp;</h4>
           </div>
           <div class="modal-body"><?=$this->transEsc('Loading') ?>...</div>
         </div>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -60,7 +60,8 @@
 ?>
 
 <?=$this->flashmessages()?>
-<form role="search" name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
+<div role="search">
+<form name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
   <div class="row">
     <div class="<?=$this->layoutClass('mainbody')?>">
       <input type="hidden" name="sort" value="relevance">
@@ -183,3 +184,4 @@
     </div>
   </div>
 </form>
+</div>

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -28,7 +28,7 @@
       <p><a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a></p>
     </div>
   <? endif; ?>
-  <div class="well well-lg clearfix">
+  <div class="well well-lg clearfix" role="search">
     <?=$this->render("search/searchbox.phtml")?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -30,7 +30,7 @@
     <? if (!empty($tabs)): ?></div><? endif; ?>
   </div>
 <? else: ?>
-  <form role="search" class="navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" id="searchForm" autocomplete="off">
+  <form class="navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" id="searchForm" autocomplete="off">
     <?= $this->render('search/searchTabs'); ?>
     <input class="form-control search-query<? if($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><? endif ?>" id="searchForm_lookfor" type="text" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"/>
     <? if ($handlerCount > 1): ?>


### PR DESCRIPTION
Following this PR are a few changes in Vufind that make it validate without errors or warnings on the W3C validator (https://validator.w3.org/).

I'd like to receive some opinions on the changes I made, specially on https://github.com/vufind-org/vufind/commit/31388de47f18320101b114fe4410f629f6bf796a and https://github.com/vufind-org/vufind/commit/c35270b24680b30850428d5abb2b50c0ec21df88 cause I think somebody could come up with a best solution.

There are currently one problem on the page that logged users see (that one where it shows their favorites, etc), It looks like that page is calling the searchtab twice, as seen in this error:
Error: Duplicate ID searchForm_lookfor.

This was the same problem faced on https://github.com/vufind-org/vufind/commit/c35270b24680b30850428d5abb2b50c0ec21df88, and I fixed it by disabling the top search bar, the unavailable error does the same thing, so i thought it would be a nice fix in this case [vufind/themes/bootstrap3/templates/error/unavailable.phtml], don't know how to fix the user page, though.

Any views on how to solve the favorite issue or a better approach to any of the commits?

The homepage and advanced search are already being validated nicely:

BEFORE: (not really before, this print is with a few fixes already committed)
![screenshot from 2015-08-25 17-31-20](https://cloud.githubusercontent.com/assets/2778482/9559679/ddd9989e-4dcd-11e5-8e26-4dfc3a91630c.png)

AFTER:
![screenshot from 2015-08-28 21-27-10](https://cloud.githubusercontent.com/assets/2778482/9559687/f4c99e14-4dcd-11e5-9366-298ecce360d9.png)

The fixes are basic things, they include changing some ARIA's role positions or even deleting them (when don't needed).

