### PR TITLE
Advances in W3C validation with Bootstrap3

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -135,7 +135,7 @@ var Lightbox = {
     if(this.XHR) { this.XHR.abort(); }
     // Reset content so we start fresh when we open a lightbox
     $('#modal').removeData('modal');
-    $('#modal').find('.modal-title').html('');
+    $('#modal').find('.modal-title').html('&nbsp;');
     $('#modal').find('.modal-body').html(vufindString.loading + "...");
   },
   /**
@@ -416,7 +416,7 @@ $(document).ready(function() {
   $('#modal').on('hidden.bs.modal', Lightbox.closeActions);
   /**
    * If a link with the class .modal-link triggers the lightbox,
-   * look for a title="" to use as our lightbox title.
+   * look for a title="&nbsp;" to use as our lightbox title.
    */
   $('.modal-link,.help-link').click(function() {
     var title = $(this).attr('title');

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -416,7 +416,7 @@ $(document).ready(function() {
   $('#modal').on('hidden.bs.modal', Lightbox.closeActions);
   /**
    * If a link with the class .modal-link triggers the lightbox,
-   * look for a title="&nbsp;" to use as our lightbox title.
+   * look for a title attribute to use as our lightbox title.
    */
   $('.modal-link,.help-link').click(function() {
     var title = $(this).attr('title');

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -4,7 +4,7 @@
     <span class="sr-only">Toggle navigation</span>
     <i class="fa fa-bars"></i>
   </button>
-  <a role="logo" class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="<?=$this->url('home')?>">VuFind</a>
+  <a class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="<?=$this->url('home')?>">VuFind</a>
 </div>
 <? if ($this->layout()->searchbox !== false): ?>
   <section class="visible-lg">

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -13,7 +13,8 @@
 <? endif; ?>
 <? if (!isset($this->layout()->renderingError)): ?>
   <div class="collapse navbar-collapse" id="header-collapse">
-    <ul role="navigation" class="nav navbar-nav navbar-right flip">
+    <nav>
+    <ul class="nav navbar-nav navbar-right flip">
       <? if ($this->feedback()->tabEnabled()): ?>
         <li>
           <a id="feedbackLink" class="modal-link" href="<?=$this->url('feedback-home') ?>"><i class="fa fa-envelope"></i> <?=$this->transEsc("Feedback")?></a>
@@ -68,5 +69,6 @@
         </li>
       <? endif; ?>
     </ul>
+    </nav>
   </div>
 <? endif; ?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -137,7 +137,7 @@
         <?=$this->layout()->content ?>
       </div>
     </div>
-    <footer role="contentinfo" class="hidden-print">
+    <footer class="hidden-print">
       <div class="container">
         <?=$this->render('footer.phtml')?>
         <?=$this->layout()->poweredBy ?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -149,7 +149,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-            <h4 id="modalTitle" class="modal-title"></h4>
+            <h4 id="modalTitle" class="modal-title">&nbsp;</h4>
           </div>
           <div class="modal-body"><?=$this->transEsc('Loading') ?>...</div>
         </div>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -98,7 +98,7 @@
         $this->layout()->searchbox = $this->render('search/searchbox.phtml');
       }
     ?>
-    <header role="banner" class="hidden-print">
+    <header class="hidden-print">
       <div class="container navbar">
         <a class="sr-only" href="#content"><?=$this->transEsc('Skip to content') ?></a>
         <?=$this->render('header.phtml')?>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -60,7 +60,8 @@
 ?>
 
 <?=$this->flashmessages()?>
-<form role="search" name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
+<div role="search">
+<form name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
   <div class="row">
     <div class="<?=$this->layoutClass('mainbody')?>">
       <input type="hidden" name="sort" value="relevance">
@@ -183,3 +184,4 @@
     </div>
   </div>
 </form>
+</div>

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -28,7 +28,7 @@
       <p><a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a></p>
     </div>
   <? endif; ?>
-  <div class="well well-lg clearfix">
+  <div class="well well-lg clearfix" role="search">
     <?=$this->render("search/searchbox.phtml")?>
   </div>
 </div>


### PR DESCRIPTION
Following this PR are a few changes in Vufind that make it validate without errors or warnings on the W3C validator (https://validator.w3.org/).

This PR is a continuation of https://github.com/vufind-org/vufind/pull/454

The homepage and advanced search are already being validated nicely:

BEFORE: (not really before, this print is with a few fixes already committed)
![screenshot from 2015-08-25 17-31-20](https://cloud.githubusercontent.com/assets/2778482/9559679/ddd9989e-4dcd-11e5-8e26-4dfc3a91630c.png)

AFTER:
![screenshot from 2015-08-28 21-27-10](https://cloud.githubusercontent.com/assets/2778482/9559687/f4c99e14-4dcd-11e5-9366-298ecce360d9.png)

The fixes are basic things, they include changing some ARIA's role positions or even deleting them (when don't needed).