### PR TITLE
Make sure string is a string in the constructor of TranslatableString…

### DIFF
--- a/module/VuFind/src/VuFind/I18n/TranslatableString.php
+++ b/module/VuFind/src/VuFind/I18n/TranslatableString.php
@@ -60,7 +60,7 @@ class TranslatableString implements TranslatableStringInterface
      */
     public function __construct($string, $displayString)
     {
-        $this->string = $string;
+        $this->string = (string)$string;
         $this->displayString = $displayString;
     }
 


### PR DESCRIPTION
… since it could also be a TranslatableString object and that would break __toString().