### PR TITLE
opening of hierarchical facets

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -244,7 +244,7 @@ class HierarchicalFacetHelper
      *
      * @param array $list Facet list
      *
-     * @return boolean Whether any items are applied (for recursive calls)
+     * @return boolean Whether any items are applied or any items in subtrees are applied (for recursive calls)
      */
     protected function updateAppliedChildrenStatus($list)
     {
@@ -252,7 +252,7 @@ class HierarchicalFacetHelper
         foreach ($list as &$item) {
             $item['hasAppliedChildren'] = !empty($item['children'])
                 && $this->updateAppliedChildrenStatus($item['children']);
-            if ($item['isApplied']) {
+            if ($item['isApplied'] || $item['hasAppliedChildren']) {
                 $result = true;
             }
         }


### PR DESCRIPTION
When we have applied facet on level 3 or higher, we should open not just parent, but all ancestors, so the facet is visible.