### PR TITLE
Defaults OJSs harvest type to "article"

### DIFF
--- a/import/xsl/ojs.xsl
+++ b/import/xsl/ojs.xsl
@@ -53,7 +53,7 @@
                 </xsl:if>
 
                 <!-- FORMAT -->
-                <field name="format">Online</field>
+                <field name="format">article</field>
 
                 <!-- AUTHOR -->
                 <xsl:if test="//dc:creator">


### PR DESCRIPTION
Instead of using "Online", which does not look like a good approach.

There could be a small chance that somebody used OJS to host things like tcc, tcce or thesis, but in any way "Online" would not work.

Setting it to article at least makes the most common usecase of OJS correctly harvested.