### PR TITLE
Allow APPLICATION_PATH to be defined in Apache as an environment vari…

### DIFF
--- a/config/vufind/httpd-vufind.conf
+++ b/config/vufind/httpd-vufind.conf
@@ -61,4 +61,9 @@ Alias /vufind /usr/local/vufind/public
   # Multiple modules may be specified separated by commas.  This mechanism can be used to override
   # core VuFind functionality without modifying core code.
   #SetEnv VUFIND_LOCAL_MODULES VuFindLocalTemplate
+
+  # This line overrides the detection of VuFind base directory. By default it is determined from
+  # the location of the index.php file, but in case it is e.g. symlinked or there is another reason
+  # to define the path manually, you can uncomment and modify this line.
+  #SetEnv VUFIND_APPLICATION_PATH /usr/local/vufind
 </Directory>

--- a/module/VuFindTheme/Module.php
+++ b/module/VuFindTheme/Module.php
@@ -100,6 +100,6 @@ class Module
      */
     public static function getThemeInfo()
     {
-        return new ThemeInfo(realpath(__DIR__ . '/../../themes'), 'bootprint3');
+        return new ThemeInfo(realpath(APPLICATION_PATH . '/themes'), 'bootprint3');
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -13,15 +13,25 @@ if (!empty($xhprof) && extension_loaded('xhprof')) {
 
 // Define path to application directory
 defined('APPLICATION_PATH')
-    || define('APPLICATION_PATH', (getenv('VUFIND_APPLICATION_PATH') ? getenv('VUFIND_APPLICATION_PATH') : dirname(__DIR__)));
+    || define(
+        'APPLICATION_PATH',
+        (getenv('VUFIND_APPLICATION_PATH') ? getenv('VUFIND_APPLICATION_PATH')
+            : dirname(__DIR__))
+    );
 
 // Define application environment
 defined('APPLICATION_ENV')
-    || define('APPLICATION_ENV', (getenv('VUFIND_ENV') ? getenv('VUFIND_ENV') : 'production'));
+    || define(
+        'APPLICATION_ENV',
+        (getenv('VUFIND_ENV') ? getenv('VUFIND_ENV') : 'production')
+    );
 
 // Define path to local override directory
 defined('LOCAL_OVERRIDE_DIR')
-    || define('LOCAL_OVERRIDE_DIR', (getenv('VUFIND_LOCAL_DIR') ? getenv('VUFIND_LOCAL_DIR') : ''));
+    || define(
+        'LOCAL_OVERRIDE_DIR',
+        (getenv('VUFIND_LOCAL_DIR') ? getenv('VUFIND_LOCAL_DIR') : '')
+    );
 
 // Save original working directory in case we need to remember our context, then
 // switch to the application directory for convenience:

--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,7 @@ if (!empty($xhprof) && extension_loaded('xhprof')) {
 
 // Define path to application directory
 defined('APPLICATION_PATH')
-    || define('APPLICATION_PATH', dirname(__DIR__));
+    || define('APPLICATION_PATH', (getenv('VUFIND_APPLICATION_PATH') ? getenv('VUFIND_APPLICATION_PATH') : dirname(__DIR__)));
 
 // Define application environment
 defined('APPLICATION_ENV')


### PR DESCRIPTION
…able so that __DIR__ is not used (doesn't work properly with symlinked files). Also use APPLICATION_PATH in theme base directory.

At least the index.php change is needed for us to be able to use a mostly symlinked (apart from a custom theme and maybe a module) VuFind installation for all institutions. The theme change would be nice so we wouldn't need to override it locally.