### PR TITLE
introduces showMore parameter to control, how many facet values should be displayed in list

### DIFF
--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -76,7 +76,9 @@ facet_limit = 30
 ;facet_limit_by_field[format] = 50
 ; By default, the side facets will only show 6 facets and then the "show more" button.
 ; This can get configured with the showMore settings.
-; Format these settings like this: showMore['<facetName>'] = value
+; You can use the * to set a new default setting.
+showMore[*] = 6
+; Or you can set a facet specific value by using the facet name as index.
 ;showMore['format'] = 10
 ; Rows and columns for table used by top facets
 top_rows = 2

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -74,6 +74,10 @@ dateRange[] = publishDate
 facet_limit = 30
 ; Override facet_limit on a per-field basis using this array:
 ;facet_limit_by_field[format] = 50
+; By default, the side facets will only show 6 facets and then the "show more" button.
+; This can get configured with the showMore settings.
+; Format these settings like this: showMore['<facetName>'] = value
+;showMore['format'] = 10
 ; Rows and columns for table used by top facets
 top_rows = 2
 top_cols = 3

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -356,8 +356,8 @@ class SideFacets extends AbstractFacets
         if ($this->showMoreSettings[$facetName]) {
             return $this->showMoreSettings[$facetName];
         }
-        // If the facet name is not configured, try to get the default value
         elseif ($facetName != '*' && $this->showMoreSettings['*']) {
+            // If the facet name is not configured, try to get the default value
             return $this->showMoreSettings['*'];
         }
 

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -355,8 +355,7 @@ class SideFacets extends AbstractFacets
 
         if ($this->showMoreSettings[$facetName]) {
             return $this->showMoreSettings[$facetName];
-        }
-        elseif ($facetName != '*' && $this->showMoreSettings['*']) {
+        } elseif ($facetName != '*' && $this->showMoreSettings['*']) {
             // If the facet name is not configured, try to get the default value
             return $this->showMoreSettings['*'];
         }

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -192,6 +192,12 @@ class SideFacets extends AbstractFacets
                 = $config->SpecialFacets->hierarchical->toArray();
         }
 
+        // Ahow more in frontend:
+        if (isset($config->Results_Settings->showMore)) {
+            $this->showMoreSettings
+                = $config->Results_Settings->showMore->toArray();
+        }
+
         // Hierarchical facet sort options:
         if (isset($config->SpecialFacets->hierarchicalFacetSortOptions)) {
             $this->hierarchicalFacetSortOptions
@@ -393,6 +399,16 @@ class SideFacets extends AbstractFacets
             }
         }
         return $result;
+    }
+
+    /**
+     * Return the list of facets configured to be hierarchical
+     *
+     * @return array
+     */
+    public function getShowMoreSettings()
+    {
+        return $this->showMoreSettings;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -181,6 +181,12 @@ class SideFacets extends AbstractFacets
             $this->checkboxFacets = array_flip($this->checkboxFacets);
         }
 
+        // Show more settings:
+        if (isset($config->Results_Settings->showMore)) {
+            $this->showMoreSettings
+                = $config->Results_Settings->showMore->toArray();
+        }
+
         // Collapsed facets:
         if (isset($config->Results_Settings->collapsedFacets)) {
             $this->collapsedFacets = $config->Results_Settings->collapsedFacets;
@@ -190,12 +196,6 @@ class SideFacets extends AbstractFacets
         if (isset($config->SpecialFacets->hierarchical)) {
             $this->hierarchicalFacets
                 = $config->SpecialFacets->hierarchical->toArray();
-        }
-
-        // Ahow more in frontend:
-        if (isset($config->Results_Settings->showMore)) {
-            $this->showMoreSettings
-                = $config->Results_Settings->showMore->toArray();
         }
 
         // Hierarchical facet sort options:
@@ -340,6 +340,33 @@ class SideFacets extends AbstractFacets
     }
 
     /**
+     * Return the list of facets configured to be collapsed
+     *
+     * @param string $facetName Name of the facet to get
+     *
+     * @return int
+     */
+    public function getShowMoreSetting($facetName = '*')
+    {
+        // If we do not have any showMore settings, return 6 as default value
+        if (empty($this->showMoreSettings)) {
+            return 6;
+        }
+
+        if ($this->showMoreSettings[$facetName]) {
+            return $this->showMoreSettings[$facetName];
+        }
+        // If the facet name is not configured, try to get the default value
+        elseif ($facetName != '*' && $this->showMoreSettings['*']) {
+            return $this->showMoreSettings['*'];
+        }
+
+        // If the facet name is not configured and also no default value
+        // has been set, return 6 as default value
+        return 6;
+    }
+
+    /**
      * Get the list of filters to display
      *
      * @param array $extraFilters Extra filters to add to the list.
@@ -399,16 +426,6 @@ class SideFacets extends AbstractFacets
             }
         }
         return $result;
-    }
-
-    /**
-     * Return the list of facets configured to be hierarchical
-     *
-     * @return array
-     */
-    public function getShowMoreSettings()
-    {
-        return $this->showMoreSettings;
     }
 
     /**

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -1,5 +1,4 @@
 <? $results = $this->recommend->getResults(); ?>
-<? $showMoreSettings = $this->recommend->getShowMoreSettings(); ?>
 <? if ($results->getResultTotal() > 0): ?>
   <h4><?=$this->transEsc(isset($this->overrideSideFacetCaption) ? $this->overrideSideFacetCaption : 'Narrow Search')?></h4>
 <? endif; ?>
@@ -57,7 +56,7 @@
 <? if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
   <? foreach ($sideFacetSet as $title => $cluster): ?>
     <? $allowExclude = $this->recommend->excludeAllowed($title); ?>
-    <? isset($showMoreSettings[$title]) ? $facets_before_more = $showMoreSettings[$title] : $facets_before_more = 6; ?>
+    <? $facets_before_more = $this->recommend->getShowMoreSetting($title); ?>
     <div class="list-group facet" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>">
       <div class="list-group-item title<? if(in_array($title, $collapsedFacets)): ?> collapsed<? endif ?>" data-toggle="collapse" href="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
         <?=$this->transEsc($cluster['label'])?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -1,4 +1,5 @@
 <? $results = $this->recommend->getResults(); ?>
+<? $showMoreSettings = $this->recommend->getShowMoreSettings(); ?>
 <? if ($results->getResultTotal() > 0): ?>
   <h4><?=$this->transEsc(isset($this->overrideSideFacetCaption) ? $this->overrideSideFacetCaption : 'Narrow Search')?></h4>
 <? endif; ?>
@@ -56,6 +57,7 @@
 <? if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
   <? foreach ($sideFacetSet as $title => $cluster): ?>
     <? $allowExclude = $this->recommend->excludeAllowed($title); ?>
+    <? isset($showMoreSettings[$title]) ? $facets_before_more = $showMoreSettings[$title] : $facets_before_more = 6; ?>
     <div class="list-group facet" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>">
       <div class="list-group-item title<? if(in_array($title, $collapsedFacets)): ?> collapsed<? endif ?>" data-toggle="collapse" href="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
         <?=$this->transEsc($cluster['label'])?>
@@ -160,11 +162,11 @@ JS;
                 }
               ?>
               <? $moreClass = 'narrowGroupHidden-'.$this->escapeHtmlAttr($title).' hidden'; ?>
-            <? if ($i == 6): ?>
+            <? if ($i == $facets_before_more): ?>
               <a id="more-narrowGroupHidden-<?=$this->escapeHtmlAttr($title)?>" class="list-group-item narrow-toggle" href="javascript:moreFacets('narrowGroupHidden-<?=$title ?>')"><?=$this->transEsc('more')?> ...</a>
             <? endif; ?>
             <? if ($thisFacet['isApplied']): ?>
-              <a class="list-group-item active<? if ($i>5): ?><?=$moreClass ?><?endif ?><? if ($thisFacet['operator'] == 'OR'): ?> facetOR applied<? endif ?>" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>">
+              <a class="list-group-item active<? if ($i>($facets_before_more-1)): ?><?=$moreClass ?><?endif ?><? if ($thisFacet['operator'] == 'OR'): ?> facetOR applied<? endif ?>" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], true, $thisFacet['operator']) ?>">
                 <? if ($thisFacet['operator'] == 'OR'): ?>
                   <i class="fa fa-check-square-o"></i>
                 <? else: ?>
@@ -175,9 +177,9 @@ JS;
             <? else: ?>
               <? $addURL = $this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator']); ?>
               <? if ($allowExclude): ?>
-                <div class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i>5): ?> <?=$moreClass ?><?endif ?>">
+                <div class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i>($facets_before_more-1)): ?> <?=$moreClass ?><?endif ?>">
               <? else: ?>
-                <a href="<?=$addURL ?>" class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i>5): ?> <?=$moreClass ?><?endif ?>">
+                <a href="<?=$addURL ?>" class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i>($facets_before_more-1)): ?> <?=$moreClass ?><?endif ?>">
               <? endif; ?>
               <span class="badge">
                 <?=$this->localizedNumber($thisFacet['count'])?>


### PR DESCRIPTION
This PR introduces a new parameter for facet configuration, that allows the administrator to easily modify the number of facet values, that should be displayed after someone collapsed a facet. For values beyond that number the user needs to click the "show more" button.

This value had been hardcoded before. However, this could be a nice simplification for frontend modifications, that does not hurt.