### PR TITLE
fixes the warning if a cache folder does not exist

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -22,14 +22,18 @@ if ($localModules = getenv('VUFIND_LOCAL_MODULES')) {
 // Set up cache directory (be sure to keep separate cache for CLI vs. web and
 // to account for potentially variant environment settings):
 $baseDir = ($local = getenv('VUFIND_LOCAL_DIR')) ? $local : 'data';
+$cacheDir = $baseDir . '/cache';
+if (!is_dir($cacheDir)) {
+    mkdir($cacheDir);
+}
 if (PHP_SAPI == 'cli') {
-    $cacheDir = $baseDir . '/cache/cli';
+    $cacheDir .= '/cli';
     if (!is_dir($cacheDir)) {
         mkdir($cacheDir);
     }
     $cacheDir .= '/configs';
 } else {
-    $cacheDir = $baseDir . '/cache/configs';
+    $cacheDir .= '/configs';
 }
 if (!is_dir($cacheDir)) {
     mkdir($cacheDir);


### PR DESCRIPTION
If `VUFIND_LOCAL_DIR/cache` does not exist, a PHP-warning is issued as the `mkdir()` calls in `application.config.php` are called on subfolders of `VUFIND_LOCAL_DIR/cache`.
The added extra check of the cache folder solves this.