### PR TITLE
Define directory for caching in environment variable

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -22,7 +22,7 @@ if ($localModules = getenv('VUFIND_LOCAL_MODULES')) {
 // Set up cache directory (be sure to keep separate cache for CLI vs. web and
 // to account for potentially variant environment settings):
 $baseDir = ($local = getenv('VUFIND_LOCAL_DIR')) ? $local : 'data';
-$cacheDir = $baseDir . '/cache';
+$cacheDir = ($cache = getenv('VUFIND_CACHE_DIR')) ? $cache : $baseDir . '/cache';
 if (!is_dir($cacheDir)) {
     mkdir($cacheDir);
 }

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1139,16 +1139,12 @@ dewey = title
 HMACkey = mySuperSecretValue
 
 ; This section sets global defaults for caches; file caching is used by default.
+; A custom directory for caching can be defined by the environment variable
+; VUFIND_CACHE_DIR (s. httpd-vufind.conf). The default location is inside the
+; local settings directory.
 ;[Cache]
 ; Set time to live value for Zend caches (in seconds), 0 means maximum possible.
 ;ttl = 0
-; This setting can be used to force caching in a specific location other than the
-; default location inside the local settings directory. This directory must exist
-; and be writable by the web server. Do not share this directory between multiple
-; instances of VuFind or you may encounter unexpected side effects -- while this
-; directory may be outside of the local settings directory, there should be exactly
-; one separate cache location per local settings directory.
-;cache_dir = "local/cache/"
 ; Override umask for cache directories and files.
 ;umask = 022
 ; Permissions for Zend-created cache directories and files, subject to umask

--- a/config/vufind/httpd-vufind.conf
+++ b/config/vufind/httpd-vufind.conf
@@ -57,6 +57,14 @@ Alias /vufind /usr/local/vufind/public
   # to override VuFind core features/settings.  Set to blank string ("") to disable.
   SetEnv VUFIND_LOCAL_DIR /usr/local/vufind/local
 
+  # This line can be used to force caching in a specific location other than the
+  # default location inside the local settings directory.
+  # Do not share this directory between multiple instances of VuFind or you may
+  # encounter unexpected side effects -- while this directory may be outside of the
+  # local settings directory, there should be exactly one separate cache location per
+  # local settings directory.
+  #SetEnv VUFIND_CACHE_DIR /usr/local/vufind/cache
+
   # This line specifies additional Zend Framework 2 modules to load after the standard VuFind module.
   # Multiple modules may be specified separated by commas.  This mechanism can be used to override
   # core VuFind functionality without modifying core code.

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -148,11 +148,16 @@ class Manager
     public function getCacheDir($allowCliOverride = true)
     {
         if ($this->defaults && isset($this->defaults['cache_dir'])) {
-            $dir = $this->defaults['cache_dir'];
-            // ensure trailing slash:
-            if (substr($dir, -1) != '/') {
-                $dir .= '/';
-            }
+            // cache_dir setting in config.ini is deprecated
+            throw new \Exception(
+                'cache_dir setting found in config.ini - as of VuFind 2.6 folder ' .
+                'for caching must be defined in environment variable ' .
+                'VUFIND_CACHE_DIR'
+            );
+        }
+
+        if (strlen(LOCAL_CACHE_DIR) > 0) {
+            $dir = LOCAL_CACHE_DIR . '/';
         } else if (strlen(LOCAL_OVERRIDE_DIR) > 0) {
             $dir = LOCAL_OVERRIDE_DIR . '/cache/';
         } else {

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -150,9 +150,9 @@ class Manager
         if ($this->defaults && isset($this->defaults['cache_dir'])) {
             // cache_dir setting in config.ini is deprecated
             throw new \Exception(
-                'cache_dir setting found in config.ini - as of VuFind 2.6 folder ' .
-                'for caching must be defined in environment variable ' .
-                'VUFIND_CACHE_DIR'
+                'Deprecated cache_dir setting found in config.ini - please use '
+                . 'Apache environment variable VUFIND_CACHE_DIR in '
+                . 'httpd-vufind.conf instead.'
             );
         }
 

--- a/public/index.php
+++ b/public/index.php
@@ -35,7 +35,11 @@ defined('LOCAL_OVERRIDE_DIR')
 
 // Define path to cache directory
 defined('LOCAL_CACHE_DIR')
-|| define('LOCAL_CACHE_DIR', (getenv('VUFIND_CACHE_DIR') ? getenv('VUFIND_CACHE_DIR') : LOCAL_OVERRIDE_DIR . '/cache'));
+    || define(
+        'LOCAL_CACHE_DIR',
+        (getenv('VUFIND_CACHE_DIR')
+            ? getenv('VUFIND_CACHE_DIR') : LOCAL_OVERRIDE_DIR . '/cache')
+    );
 
 // Save original working directory in case we need to remember our context, then
 // switch to the application directory for convenience:

--- a/public/index.php
+++ b/public/index.php
@@ -33,6 +33,10 @@ defined('LOCAL_OVERRIDE_DIR')
         (getenv('VUFIND_LOCAL_DIR') ? getenv('VUFIND_LOCAL_DIR') : '')
     );
 
+// Define path to cache directory
+defined('LOCAL_CACHE_DIR')
+|| define('LOCAL_CACHE_DIR', (getenv('VUFIND_CACHE_DIR') ? getenv('VUFIND_CACHE_DIR') : LOCAL_OVERRIDE_DIR . '/cache'));
+
 // Save original working directory in case we need to remember our context, then
 // switch to the application directory for convenience:
 define('ORIGINAL_WORKING_DIRECTORY', getcwd());


### PR DESCRIPTION
As discussed in #488 this pull request has the cache_dir setting removed from config.ini and adds the environment variable `VUFIND_CACHE_DIR` to http-vufind.conf. CacheManager will throw an exception if cache_dir is set in config.ini.
Depending on the VuFind version this code goes into the exception message might need some adjustment (as for now it says "starting with VuFind 2.6").