### PR TITLE
initialize $number

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Sierra.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Sierra.php
@@ -494,6 +494,7 @@ class Sierra extends AbstractBase implements TranslatorAwareInterface
             foreach ($itemIds as $item) {
                 $callnumber = null;
                 $results1 = pg_execute($this->db, "prep_query", [$item]);
+                $number = "";
                 while ($row1 = pg_fetch_row($results1)) {
                     if ($row1[4] == "b") {
                         $barcode = $row1[3];


### PR DESCRIPTION
The uninitialized variable $number was causing an error message. Additionally, if a record didn't create a value for that variable, it could end up using the previous value for the current record.