### PR TITLE
Make controller available to JS in record view so that ajaxLoadTab do…

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -147,16 +147,15 @@ function registerTabEvents() {
 }
 
 function ajaxLoadTab(tabid) {
-  var id = $('.hiddenId')[0].value;
-  // Try to parse out the controller portion of the URL. If this fails, or if
-  // we're flagged to skip AJAX for this tab, just return true and let the
-  // browser handle it.
-  var urlroot = document.URL.match(new RegExp('/[^/]+/' + encodeURIComponent(id)));
-  if(!urlroot || document.getElementById(tabid).parentNode.className.indexOf('noajax') > -1) {
+  var id = $('.hiddenId').val();
+  var controller = $('.hiddenId').data('controller');
+  // If we don't know the controller, or if we're flagged to skip AJAX for this tab, 
+  // just return true and let the browser handle it.
+  if(!controller || document.getElementById(tabid).parentNode.className.indexOf('noajax') > -1) {
     return true;
   }
   $.ajax({
-    url: path + urlroot + '/AjaxTab',
+    url: path + '/' + controller + '/' + encodeURIComponent(id) + '/AjaxTab',
     type: 'POST',
     data: {tab: tabid},
     success: function(data) {

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -49,7 +49,7 @@
 <div class="row">
   <div class="<?=$tree ? 'col-sm-12' : $this->layoutClass('mainbody') ?>">
     <div class="record">
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id" />
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id"  data-controller="<?=$this->escapeHtmlAttr($this->record($this->driver)->getController())?>"/>
       <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getResourceSource())?>" class="hiddenSource" />
       <?=$this->flashmessages()?>
       <?=$this->record($this->driver)->getCollectionMetadata()?>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -43,7 +43,7 @@
 <div class="row">
   <div class="<?=$this->layoutClass('mainbody')?>">
     <div class="record recordId source<?=$this->escapeHtmlAttr($this->driver->getResourceSource())?>" id="record">
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id" />
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id" data-controller="<?=$this->escapeHtmlAttr($this->record($this->driver)->getController())?>"/>
       <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getResourceSource()) ?>" class="hiddenSource" />
       <?=$this->flashmessages()?>
       <?=$this->record($this->driver)->getCoreMetadata()?>


### PR DESCRIPTION
…esn't need to try to parse it from the URL.

This is continued from #491. This version avoids any URL parsing with regexp. Downside is that a template change is required.