### PR TITLE
Fix ajaxTabLoad to work when there are query parameters in the URL.

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -154,7 +154,7 @@ function ajaxLoadTab(tabid) {
   }
 
   // Parse out the base URL for the current record:
-  var urlParts = document.URL.split('#');
+  var urlParts = document.URL.split(/[?#]/);
   var urlWithoutFragment = urlParts[0];
   var pathInUrl = urlWithoutFragment.indexOf(path);
   var chunks = urlWithoutFragment.substring(pathInUrl + path.length + 1).split('/');


### PR DESCRIPTION
The UI got confused when using URL like /Record/123?lng=fi#usercomments.