### PR TITLE
Implementation of cover driver for Buchhandel.de

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -560,7 +560,7 @@ database          = mysql://root@localhost/vufind
 ; coversize setting to false:
 ;coversize = false
 
-; You can select Syndetics, LibraryThing, Summon, Amazon, Booksite, OpenLibrary,
+; You can select Syndetics, LibraryThing, Summon, Amazon, Booksite, OpenLibrary, Buchhandel.de
 ; Contentcafe and/or Google Books.
 ;   Note: Summon service takes a Serials Solutions client key, NOT Summon API key!
 ;coverimages     = Syndetics:MySyndeticsId,Amazon:MyAccessKeyId,Booksite,LibraryThing:MyLibraryThingId,Google,OpenLibrary,Summon:MySerialsSolutionsClientKey,Contentcafe:MyContentCafeID
@@ -623,6 +623,12 @@ authors         = Wikipedia
 ; You can select from Google, OpenLibrary, HathiTrust.  You should consult
 ; http://code.google.com/apis/books/branding.html before using Google Book Search.
 ; previews       = Google,OpenLibrary,HathiTrust
+ 
+; You can select from Buchhandel.de. For the access you need an authentication token.
+[Buchhandel]
+url = "https://api.vlb.de/api/v1/cover/"
+; token = "XXXXXX-XXXX-XXXXX-XXXXXXXXXXXX" 
+link = 'http://www.buchhandel.de/default.aspx?strframe=titelsuche&caller=vlbPublic&func=DirectIsbnSearch&nSiteId=11&isbn='
 
 ; Possible HathiRights options = pd,ic,op,orph,und,umall,ic-world,nobody,pdus,cc-by,cc-by-nd,
 ; cc-by-nc-nd,cc-by-nc,cc-by-nc-sa,cc-by-sa,orphcand,cc-zero,und-world,icus

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -625,6 +625,7 @@ authors         = Wikipedia
 ; previews       = Google,OpenLibrary,HathiTrust
  
 ; You can select from Buchhandel.de. For the access you need an authentication token.
+; Please look at http://info.buchhandel.de/handbuch_links for detail informations.
 [Buchhandel]
 url = "https://api.vlb.de/api/v1/cover/"
 ; token = "XXXXXX-XXXX-XXXXX-XXXXXXXXXXXX" 

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -305,6 +305,7 @@ $config = [
                 'factories' => [
                     'amazon' => 'VuFind\Content\Covers\Factory::getAmazon',
                     'booksite' => 'VuFind\Content\Covers\Factory::getBooksite',
+                    'buchhandel' => 'VuFind\Content\Covers\Factory::getBuchhandel',
                     'contentcafe' => 'VuFind\Content\Covers\Factory::getContentCafe',
                     'syndetics' => 'VuFind\Content\Covers\Factory::getSyndetics',
                 ],

--- a/module/VuFind/src/VuFind/Content/Covers/Buchhandel.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Buchhandel.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Buchhandel cover content loader.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Content
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Jochen Lienhard <lienhard@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
+ */
+namespace VuFind\Content\Covers;
+
+/**
+ * Buchhandel cover content loader.
+ *
+ * @category VuFind2
+ * @package  Content
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Jochen Lienhard <lienhard@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
+ */
+class Buchhandel extends \VuFind\Content\AbstractCover
+{
+    /**
+     * Base URL for Buchhandel
+     *
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * API token for Buchhandel 
+     *
+     * @var string
+     */
+    protected $apiToken;
+
+    /**
+     * Constructor
+     *
+     * @param string $url      Base URL for Buchhandel 
+     * @param string $apiToken API token for Buchhandel 
+     */
+    public function __construct($url, $apiToken)
+    {
+        $this->url = $url;
+        $this->apiToken = $apiToken;
+        $this->supportsIsbn = true;
+        $this->cacheAllowed = false;
+    }
+
+    /**
+     * Get image URL for a particular API token and set of IDs (or false if invalid).
+     *
+     * @param string $key  API key
+     * @param string $size Size of image to load (small/medium/large)
+     * @param array  $ids  Associative array of identifiers (keys may include 'isbn'
+     * pointing to an ISBN object and 'issn' pointing to a string)
+     *
+     * @return string|bool
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function getUrl($key, $size, $ids)
+    {
+        if (!isset($ids['isbn'])) {
+            return false;
+        }
+        $isbn = $ids['isbn']->get13();
+        switch ($size) {
+        case 'small': $lsize = "s"; break;
+        case 'medium': $lsize = "m"; break;
+        case 'large': $lsize = "l"; break;
+        default:
+            $lsize = "s";
+            break;
+        }
+
+        return $this->url . $isbn ."/" . $lsize . "?access_token=" . $this->apiToken;
+    }
+}

--- a/module/VuFind/src/VuFind/Content/Covers/Buchhandel.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Buchhandel.php
@@ -48,7 +48,7 @@ class Buchhandel extends \VuFind\Content\AbstractCover
     protected $url;
 
     /**
-     * API token for Buchhandel 
+     * API token for Buchhandel
      *
      * @var string
      */
@@ -57,8 +57,8 @@ class Buchhandel extends \VuFind\Content\AbstractCover
     /**
      * Constructor
      *
-     * @param string $url      Base URL for Buchhandel 
-     * @param string $apiToken API token for Buchhandel 
+     * @param string $url      Base URL for Buchhandel
+     * @param string $apiToken API token for Buchhandel
      */
     public function __construct($url, $apiToken)
     {
@@ -87,14 +87,16 @@ class Buchhandel extends \VuFind\Content\AbstractCover
         }
         $isbn = $ids['isbn']->get13();
         switch ($size) {
-        case 'small': $lsize = "s"; break;
-        case 'medium': $lsize = "m"; break;
-        case 'large': $lsize = "l"; break;
+        case 'small':
+        case 'medium':
+        case 'large':
+            $lsize = substr($size, 0, 1);
+            break;
         default:
             $lsize = "s";
             break;
         }
 
-        return $this->url . $isbn ."/" . $lsize . "?access_token=" . $this->apiToken;
+        return "{$this->url}{$isbn}/{$lsize}?access_token={$this->apiToken}";
     }
 }

--- a/module/VuFind/src/VuFind/Content/Covers/Factory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Factory.php
@@ -87,7 +87,7 @@ class Factory
     {
         $config = $sm->getServiceLocator()->get('VuFind\Config')->get('config');
         $url = isset($config->Buchhandel->url)
-            ? $config->Buchhandel->url  : 'https://api.vlb.de/api/v1/cover/';
+            ? trim($config->Buchhandel->url, '/').'/'  : 'https://api.vlb.de/api/v1/cover/';
         if (!isset($config->Buchhandel->token)) {
             throw new \Exception("Buchhandel.de 'token' not set in VuFind config");
         }

--- a/module/VuFind/src/VuFind/Content/Covers/Factory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Factory.php
@@ -76,6 +76,24 @@ class Factory
         return new Booksite($url, $config->Booksite->key);
     }
 
+   /**
+     * Create Buchhandel.de loader
+     *
+     * @param ServiceManager $sm Service manager
+     *
+     * @return mixed
+     */
+    public static function getBuchhandel(ServiceManager $sm)
+    {   
+        $config = $sm->getServiceLocator()->get('VuFind\Config')->get('config');
+        $url = isset($config->Buchhandel->url)
+            ? $config->Buchhandel->url  : 'https://api.vlb.de/api/v1/cover/';
+        if (!isset($config->Buchhandel->token)) {
+            throw new \Exception("Buchhandel.de 'token' not set in VuFind config");
+        }
+        return new Buchhandel($url, $config->Buchhandel->token);
+    }
+
     /**
      * Create a ContentCafe loader
      *

--- a/module/VuFind/src/VuFind/Content/Covers/Factory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Factory.php
@@ -76,7 +76,7 @@ class Factory
         return new Booksite($url, $config->Booksite->key);
     }
 
-   /**
+    /**
      * Create Buchhandel.de loader
      *
      * @param ServiceManager $sm Service manager
@@ -84,7 +84,7 @@ class Factory
      * @return mixed
      */
     public static function getBuchhandel(ServiceManager $sm)
-    {   
+    {
         $config = $sm->getServiceLocator()->get('VuFind\Config')->get('config');
         $url = isset($config->Buchhandel->url)
             ? $config->Buchhandel->url  : 'https://api.vlb.de/api/v1/cover/';

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BuchhandelTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BuchhandelTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Unit tests for Buchhandel cover loader.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Jochen Lienhard <lienhard@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org
+ */
+namespace VuFindTest\Content\Covers;
+use VuFindCode\ISBN, VuFind\Content\Covers\Buchhandel;
+
+/**
+ * Unit tests for Booksite cover loader.
+ *
+ * @category VuFind2
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Jochen Lienhard <lienhard@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org
+ */
+class BuchhandelTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test cover loading
+     *
+     * @return void
+     */
+    public function testValidCoverLoading()
+    {
+        $loader = new Buchhandel('http://base/', 'mytoken');
+        $this->assertEquals(
+            'http://base/9780739313121/s?access_token=mytoken',
+            $loader->getUrl(
+                'mytoken', 'small', ['isbn' => new ISBN('0739313126')]
+            )
+        );
+    }
+
+    /**
+     * Test missing ISBN
+     *
+     * @return void
+     */
+    public function testMissingIsbn()
+    {
+        $loader = new Buchhandel('http://base', 'mytoken');
+        $this->assertEquals(false, $loader->getUrl('mytoken', 'small', []));
+    }
+}


### PR DESCRIPTION
Buchhandel.de supports covers, you need a token to get access to the covers.