### PR TITLE
Directory-Based Multisite and VUFIND_CACHE_DIR in httpd-vufind.conf

### DIFF
--- a/config/vufind/httpd-vufind.conf
+++ b/config/vufind/httpd-vufind.conf
@@ -29,11 +29,19 @@ Alias /vufind /usr/local/vufind/public
   # AND comment out the "Require all granted" line above. There must not be any other
   # "Require" lines in this configuration section for the "Require shibboleth"
   # directive to be effective.
+  php_value short_open_tag On
+  
+  # If you wish to use the Shibboleth authentication, uncomment the following lines
+  # AND comment out the "Require all granted" line above. There must not be any other
+  # "Require" lines in this configuration section for the "Require shibboleth"
+  # directive to be effective.
   #AuthType shibboleth
   #Require shibboleth
+</Directory>
 
+<Location /vufind>
   RewriteEngine On
-  RewriteBase /vufind
+  #RewriteBase /vufind
 
   # If using VuDL, uncomment the following line, fill in your appropriate Fedora
   # server and port, and make sure that Apache mod_proxy and mod_proxy_http are
@@ -45,8 +53,6 @@ Alias /vufind /usr/local/vufind/public
   RewriteCond %{REQUEST_FILENAME} -d
   RewriteRule ^.*$ - [NC,L]
   RewriteRule ^.*$ index.php [NC,L]
-
-  php_value short_open_tag On
 
   # Uncomment this line to put VuFind into development mode in order to see more detailed messages:
   #SetEnv VUFIND_ENV development
@@ -66,7 +72,7 @@ Alias /vufind /usr/local/vufind/public
   # encounter unexpected side effects -- while this directory may be outside of the
   # local settings directory, there should be exactly one separate cache location per
   # local settings directory.
-  #SetEnv VUFIND_CACHE_DIR /usr/local/vufind/cache
+  #SetEnv VUFIND_CACHE_DIR /usr/local/vufind/local/cache
 
   # This line specifies additional Zend Framework 2 modules to load after the standard VuFind module.
   # Multiple modules may be specified separated by commas.  This mechanism can be used to override
@@ -77,4 +83,4 @@ Alias /vufind /usr/local/vufind/public
   # the location of the index.php file, but in case it is e.g. symlinked or there is another reason
   # to define the path manually, you can uncomment and modify this line.
   #SetEnv VUFIND_APPLICATION_PATH /usr/local/vufind
-</Directory>
+</Location>


### PR DESCRIPTION
Set VUFIND_CACHE_DIR to the local cache directory.

Using directory directive fixes Apache Configuration for Directory-Based Multisite. Multiple config files of vufind can be configured in httpd.conf of Apache for multisite mode without symlinking the public directory.