### PR TITLE
Added support for loading all record tabs, including the initial one,…

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -77,9 +77,11 @@ defaultLoggedInModule = MyResearch
 ; or omit to attempt to retain the user's current context after log out.
 ;logOutRoute = home
 ; This tab will show by default when a record is viewed:
-defaultRecordTab= Holdings
+defaultRecordTab = Holdings
 ; Hide the holdings tab if no holdings are available from the ILS
 hideHoldingsTabWhenEmpty = false
+; Whether to load all tabs (including default tab) via ajax (default is false):
+;ajaxTabs = true
 ; This page will show by default when a user accesses the MyResearch module:
 defaultAccountPage = Favorites
 ; Allow access to the Admin module? (See the access.AdminModule setting in

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -666,10 +666,14 @@ class AbstractRecord extends AbstractBase
             return $patron;
         }
 
+        $config = $this->getConfig();
+
         $view = $this->createViewModel();
         $view->tabs = $this->getAllTabs();
         $view->activeTab = strtolower($tab);
         $view->defaultTab = strtolower($this->getDefaultTab());
+        $view->ajaxTabs = isset($config->Site->ajaxTabs)
+            ? $config->Site->ajaxTabs : false;
 
         // Set up next/previous record links (if appropriate)
         if ($this->resultScrollerActive()) {

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -167,15 +167,17 @@ function ajaxLoadTab(tabid, setHash) {
     var urlroot = '/' + chunks[0] + '/' + chunks[1];
   }
 
+  $('#record-tabs .tab-pane.active').removeClass('active');
+  $('#'+tabid+'-tab').addClass('active');
+  $('#'+tabid).tab('show');
+  
   // Request the tab via AJAX:
   $.ajax({
     url: path + urlroot + '/AjaxTab',
     type: 'POST',
     data: {tab: tabid},
     success: function(data) {
-      $('#record-tabs .tab-pane.active').removeClass('active');
-      $('#'+tabid+'-tab').html(data).addClass('active');
-      $('#'+tabid).tab('show');
+      $('#'+tabid+'-tab').html(data);
       registerTabEvents();
       if(typeof syn_get_widget === "function") {
         syn_get_widget();
@@ -265,10 +267,11 @@ $(document).ready(function(){
       window.location.hash = tabid;
       return false;
     } else {
+      var initialTab = $('#record-tabs .tab-pane.active').length == 0;
       $('#record-tabs').append('<div class="tab-pane" id="'+tabid+'-tab"><i class="fa fa-spinner fa-spin"></i> '+vufindString['loading']+'...</div>');
       $('#record-tabs .tab-pane.active').removeClass('active');
       $('#'+tabid+'-tab').addClass('active');
-      return ajaxLoadTab(tabid);
+      return ajaxLoadTab(tabid, !initialTab);
     }
   });
   applyRecordTabHash();

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -57,7 +57,9 @@
           $desc = $obj->getDescription();
           $tab_classes = array();
           if (0 === strcasecmp($this->activeTab, $tab)) {
-            $tab_classes[] = 'active';
+            if (!$this->ajaxTabs || !$obj->supportsAjax()) {
+              $tab_classes[] = 'active';
+            }
             $tab_classes[] = 'initiallyActive';
             $this->layout()->breadcrumbs .= '<li class="active">' . $this->transEsc($desc) . '</li>';
             $activeTabObj = $obj;
@@ -73,9 +75,11 @@
     <? endif; ?>
 
     <div class="tab-content" id="record-tabs">
-      <div class="tab-pane active" id="<?=$this->activeTab ?>-tab">
-        <?=isset($activeTabObj) ? $this->record($this->driver)->getTab($activeTabObj) : '' ?>
-      </div>
+      <? if (!$this->ajaxTabs || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
+        <div class="tab-pane active" id="<?=$this->activeTab ?>-tab">
+          <?=isset($activeTabObj) ? $this->record($this->driver)->getTab($activeTabObj) : '' ?>
+        </div>
+      <? endif; ?>
     </div>
 
     <?=$this->driver->supportsCoinsOpenURL()?'<span class="Z3988" title="'.$this->escapeHtmlAttr($this->driver->getCoinsOpenURL()).'"></span>':''?>


### PR DESCRIPTION
… via ajax.

I've tried to make sure that:

1.) The hash is not updated on initial load of the record page 
2.) The hash is updated on moving to other tabs 
3.) The hash is also updated when moving back to the initial tab

Moving some of the code out of the success handler in record.js helps update the tab state faster when loading the tab takes time.