### PR TITLE
Implemented default ZendHttpClient's adapter to be Curl instead of null

### DIFF
--- a/vendor/vufind-org/vufindhttp/src/VuFindHttp/HttpService.php
+++ b/vendor/vufind-org/vufindhttp/src/VuFindHttp/HttpService.php
@@ -230,6 +230,8 @@ class HttpService implements HttpServiceInterface
         }
         if (null !== $this->defaultAdapter) {
             $client->setAdapter($this->defaultAdapter);
+        } else {
+            $client->setAdapter(new \Zend\Http\Client\Adapter\Curl());
         }
         if (null !== $url) {
             $client->setUri($url);


### PR DESCRIPTION
We have encountered an error when sending an POST request to Aleph REST API. It returns "400 Bad Request" & results in a crash. I've found out it was caused by the latest upstream merge we have made. Also setting the client's adapter to Curl resolved the error & now is the VuFind capable of communicating with Aleph using POST requests again :) But there's one catch - you have to aquire the "php5-curl" package. On debian just perform "sudo apt-get install php5-curl", but it is by default installed on many systems along with php5.