### PR TITLE
Fixed IE bug while editing advanced search

### DIFF
--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -13,7 +13,9 @@ function addSearch(group, fieldValues)
   $newSearch.attr('id', 'search'+inputID);
   $newSearch.find('input.form-control')
     .attr('id', 'search_lookfor'+inputID)
-    .attr('name', 'lookfor'+group+'[]');
+    .attr('name', 'lookfor'+group+'[]')
+    .attr('value', '');
+  $newSearch.find('select.type option:first-child').attr('selected', 1);
   $newSearch.find('select.type')
     .attr('id', 'search_type'+inputID)
     .attr('name', 'type'+group+'[]');


### PR DESCRIPTION
When in edit mode of Advanced search, you select "Add search field", the IE does copy the contents of the first row, while Mozilla nor Chrome doesn't. 
This way we can kind of unite the browser's behavior.