### PR TITLE
Reset helpers array of Results object when cloned to avoid using old …

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -148,8 +148,7 @@ abstract class Results implements ServiceLocatorAwareInterface
      */
     public function __construct(Params $params)
     {
-        // Save the parameters, then perform the search:
-        $this->setParams($params);
+        $this->params = $params;
     }
 
     /**
@@ -162,6 +161,7 @@ abstract class Results implements ServiceLocatorAwareInterface
         if (is_object($this->params)) {
             $this->params = clone($this->params);
         }
+        $this->helpers = [];
     }
 
     /**


### PR DESCRIPTION
…params in e.g. UrlQueryHelper.

Without this fix unexpected things happen when you try to clone a results object and change its params:

1.) New params are not relayed to UrlQueryHelper:

$search = clone($this->results);
$search->getParams()->addFilter('test', '1');
echo $search->getUrlQuery()->getParams(); // doesn't have the new filter

2.) UrlQueryHelper continues to modify the params of the old Results object:

$search = clone($this->results);
$search->getUrlQuery()->setDefaultParameter('test', 2);
echo $this->results->getUrlQuery()->getParams(); // has the new parameter
