### PR TITLE
Alphabetic browse custom solr folder

### DIFF
--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -10,11 +10,18 @@ else
   JAVA="java"
 fi
 
+if [ "$SOLR_HOME" ]
+then
+  SOLR_HOME="$SOLR_HOME"
+else
+  SOLR_HOME="`dirname $0`/solr"
+fi
+
 set -e
 set -x
 
 cd "`dirname $0`/import"
-CLASSPATH="browse-indexing.jar:../solr/lib/*"
+CLASSPATH="browse-indexing.jar:${SOLR_HOME}/lib/*"
 
 # make index work with replicated index
 # current index is stored in the last line of index.properties
@@ -38,9 +45,9 @@ function locate_index
     eval $targetVar="$indexDir/$subDir"
 }
 
-locate_index "bib_index" "../solr/biblio"
-locate_index "auth_index" "../solr/authority"
-index_dir="../solr/alphabetical_browse"
+locate_index "bib_index" "${SOLR_HOME}/biblio"
+locate_index "auth_index" "${SOLR_HOME}/authority"
+index_dir="${SOLR_HOME}/alphabetical_browse"
 
 mkdir -p "$index_dir"
 


### PR DESCRIPTION
Adds a SOLR_HOME variable to the index_alphabetic_browse.sh script to accommodate non-default location Solr instances