### PR TITLE
Aleph's getMyFines custom lang error fixed

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1143,6 +1143,8 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
                 $mult = -100;
             } elseif ($transactiontype == "Credit") {
                 $mult = 100;
+            } else {
+                $mult = -100;
             }
             $amount
                 = (float)(preg_replace("/[\(\)]/", "", (string) $z31->{'z31-sum'}))

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1139,13 +1139,8 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
             $barcode = (string) $z30->{'z30-barcode'};
             $checkout = (string) $z31->{'z31-date'};
             $id = $this->barcodeToID($barcode);
-            if ($transactiontype == "Debit") {
-                $mult = -100;
-            } elseif ($transactiontype == "Credit") {
-                $mult = 100;
-            } else {
-                $mult = -100;
-            }
+            $mult = ($transactiontype == "Credit") ? 100 : -100;
+            
             $amount
                 = (float)(preg_replace("/[\(\)]/", "", (string) $z31->{'z31-sum'}))
                 * $mult;


### PR DESCRIPTION
There is an error parsing $amount in case of having the 'z31-credit-debit' field in custom language, because the z-31-sum is multiplied by $mult, which is undefined as it didn't have any default value yet