### PR TITLE
Disable xdebug in Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - pear install phing/phing
   - composer global require fabpot/php-cs-fixer
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - phpenv config-rm xdebug.ini
   - phpenv rehash
 
 script:


### PR DESCRIPTION
This speeds up the build process quite a bit as hinted by the recent php-cs-fixer versions.