### PR TITLE
Filter for empty lines in toc tab

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -617,7 +617,7 @@ class SolrMarc extends SolrDefault
                 // and merge them into return array:
                 $toc = array_merge(
                     $toc,
-                    array_filter(explode('--', $subfield->getData()),'trim')
+                    array_filter(explode('--', $subfield->getData()), 'trim')
                 );
             }
         }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -617,11 +617,7 @@ class SolrMarc extends SolrDefault
                 // and merge them into return array:
                 $toc = array_merge(
                     $toc,
-                    array_filter(
-                        array_filter(
-                            explode('--', $subfield->getData()),
-                            'trim'),
-                        'strlen')
+                    array_filter(explode('--', $subfield->getData()),'trim')
                 );
             }
         }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -613,9 +613,16 @@ class SolrMarc extends SolrDefault
         foreach ($fields as $field) {
             $subfields = $field->getSubfields();
             foreach ($subfields as $subfield) {
-                // Break the string into appropriate chunks,  and merge them into
-                // return array:
-                $toc = array_merge($toc, explode('--', $subfield->getData()));
+                // Break the string into appropriate chunks, filtering empty strings,
+                // and merge them into return array:
+                $toc = array_merge(
+                    $toc,
+                    array_filter(
+                        array_filter(
+                            explode('--', $subfield->getData()),
+                            'trim'),
+                        'strlen')
+                );
             }
         }
         return $toc;


### PR DESCRIPTION
Referring to http://www.loc.gov/marc/bibliographic/bd505.html subfield $t can contain the explode delimiter `--` which resulted for some of our records in empty lines in the TOC-tab. The added trim filters those empty array-elements.