### PR TITLE
Remove cat_password check in Shibboleth Auth Plugin

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -122,7 +122,7 @@ class Shibboleth extends AbstractBase
         }
 
         // Save credentials if applicable:
-        if (!empty($catPassword) && !empty($user->cat_username)) {
+        if (!empty($user->cat_username)) {
             $user->saveCredentials($user->cat_username, $catPassword);
         }
 


### PR DESCRIPTION
As not every ILS requires a password for querying user data the current check on the cat_password in Shibboleth Auth Plugin prevents VuFind from directly querying the ILS after a successful Shibboleth-Authentication (which will return the cat_username, but seldomly sends cat_password - which should not be necessary anyway if ILS does not require pw as the user is already authenticated via Shibboleth).
If catalog-login fails due to missing password VuFind will ask the user to enter valid ILS-login data anyway, so lifting the requirements a little bit will not result in other behaviour but only in more flexible Shibboleth out-of-the box features in VuFind.