### PR TITLE
Don't include Parent_Config section in the returned configuration to …

### DIFF
--- a/module/VuFind/src/VuFind/Config/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginFactory.php
@@ -113,6 +113,11 @@ class PluginFactory implements AbstractFactoryInterface
                 )
                 : [];
             foreach ($child as $section => $contents) {
+                // Ignore Parent_Config since it could cause trouble e.g. in
+                // permissions handling where each section is iterated.
+                if ($section === 'Parent_Config') {
+                    continue;
+                }
                 if (in_array($section, $overrideSections)
                     || !isset($config->$section)
                 ) {


### PR DESCRIPTION
…avoid problems with e.g. permissions handling.