### PR TITLE
add method to correctly encode/escape urls before passing them to Tik…

### DIFF
--- a/import/index_scripts/getFulltext.bsh
+++ b/import/index_scripts/getFulltext.bsh
@@ -15,6 +15,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import java.net.URI;
+import java.net.URL;
+
 
 // define the base level indexer so that its methods can be called from the script.
 // note that the SolrIndexer code will set this value before the script methods are called.
@@ -251,10 +254,24 @@ public String harvestWithTika(url, scraperPath) {
  * @return String The full-text
  */
 public String harvestWithParser(url, settings) {
+    url = urlEncode(url);
     if (settings[0].equals("aperture")) {
         return harvestWithAperture(url, settings[1]);
     } else if (settings[0].equals("tika")) {
         return harvestWithTika(url, settings[1]);
     }
     return null;
+}
+
+/**
+ * Ensure the url is correctly encoded
+ *
+ * @param String The url extracted from the MARC tag.
+ * @return String The correctly encoded url
+ */
+public String urlEncode(url) {
+    String decodedUrl = URLDecoder.decode(url, "UTF-8");
+    URL url= new URL(decodedUrl);
+    URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+    return uri.toASCIIString();
 }

--- a/import/index_scripts/getFulltext.bsh
+++ b/import/index_scripts/getFulltext.bsh
@@ -15,8 +15,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import java.net.URI;
-import java.net.URL;
 
 
 // define the base level indexer so that its methods can be called from the script.
@@ -89,7 +87,7 @@ public String getFulltext(Record record, String fieldSpec, String extension) {
     if (fields != null) {
         while(fieldsIter.hasNext()) {
             // Get the current string to work on:
-            String current = fieldsIter.next();
+            String current = fieldsIter.next().replaceAll(" ", "%20");
             // Filter by file extension
             if (extension == null || current.endsWith(extension)) {
                 // Load the parser output for each tag into a string
@@ -254,24 +252,10 @@ public String harvestWithTika(url, scraperPath) {
  * @return String The full-text
  */
 public String harvestWithParser(url, settings) {
-    url = urlEncode(url);
     if (settings[0].equals("aperture")) {
         return harvestWithAperture(url, settings[1]);
     } else if (settings[0].equals("tika")) {
         return harvestWithTika(url, settings[1]);
     }
     return null;
-}
-
-/**
- * Ensure the url is correctly encoded
- *
- * @param String The url extracted from the MARC tag.
- * @return String The correctly encoded url
- */
-public String urlEncode(url) {
-    String decodedUrl = URLDecoder.decode(url, "UTF-8");
-    URL url= new URL(decodedUrl);
-    URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
-    return uri.toASCIIString();
 }


### PR DESCRIPTION
…a/Aperture during fulltext indexing

Our MARC 856s have some urls that already escape characters (e.g. %20 for spaces) and some that don't escape characters. The current code breaks when spaces aren't escaped. I assume this should be a pull-request against SolrMarc too, but thought I'd do it here first for comment/review. An alternative approach might be to quote the url when passing to tika or aperture, but I haven't tried that.

Cheers

Some refs:
http://stackoverflow.com/a/25735202
http://stackoverflow.com/a/18900433
