### PR TITLE
Catches description using DC

### DIFF
--- a/import/xsl/ojs.xsl
+++ b/import/xsl/ojs.xsl
@@ -94,6 +94,13 @@
                         <xsl:value-of select="php:function('VuFind::stripArticles', string(//dc:title[normalize-space()]))"/>
                     </field>
                 </xsl:if>
+                
+                <!-- DESCRIPTION -->
+                <xsl:if test="//dc:description">
+                    <field name="description">
+                        <xsl:value-of select="//dc:description" />
+                    </field>
+                </xsl:if>
 
                 <!-- PUBLISHER -->
                 <xsl:if test="//dc:publisher[normalize-space()]">


### PR DESCRIPTION
This should make VuFind stores description of everything harvested using ojs.xsl.

Altough It looks like using nlm is better with OJS, I think it would be nice to improve this method too.