### PR TITLE
Pass Auth exceptions through on login so that custom error messages c…

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -113,6 +113,9 @@ class ILS extends AbstractBase
         // Connect to catalog:
         try {
             $patron = $this->getCatalog()->patronLogin($username, $password);
+        } catch (AuthException $e) {
+            // Pass Auth exceptions through
+            throw $e;
         } catch (\Exception $e) {
             throw new AuthException('authentication_error_technical');
         }

--- a/module/VuFind/src/VuFind/Auth/MultiILS.php
+++ b/module/VuFind/src/VuFind/Auth/MultiILS.php
@@ -71,6 +71,9 @@ class MultiILS extends ILS
         // Connect to catalog:
         try {
             $patron = $this->getCatalog()->patronLogin($username, $password);
+        } catch (AuthException $e) {
+            // Pass Auth exceptions through
+            throw $e;
         } catch (\Exception $e) {
             throw new AuthException('authentication_error_technical');
         }


### PR DESCRIPTION
…an be displayed. This allows e.g. the ILS authentication to report a locked account with a non-generic message.

If this doesn't fly or for additional flexibility I was thinking of adding a flag to the exceptions classes that could be used to mark exceptions user-visible so that they would be displayed also in non-debug mode. What do you think?