### PR TITLE
Return value from session handler save callback

### DIFF
--- a/module/VuFind/src/VuFind/Session/Database.php
+++ b/module/VuFind/src/VuFind/Session/Database.php
@@ -65,11 +65,12 @@ class Database extends AbstractBase
      * @param string $sess_id The current session ID
      * @param string $data    The session data to write
      *
-     * @return void
+     * @return bool
      */
     public function write($sess_id, $data)
     {
         $this->getTable('Session')->writeSession($sess_id, $data);
+        return true;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Session/File.php
+++ b/module/VuFind/src/VuFind/Session/File.php
@@ -106,7 +106,7 @@ class File extends AbstractBase
      * @param string $sess_id The current session ID
      * @param string $data    The session data to write
      *
-     * @return void
+     * @return bool
      */
     public function write($sess_id, $data)
     {
@@ -115,7 +115,7 @@ class File extends AbstractBase
             $return = fwrite($fp, $data);
             fclose($fp);
             if ($return !== false) {
-                return;
+                return true;
             }
         }
         // If we got this far, something went wrong with the file output...
@@ -123,6 +123,7 @@ class File extends AbstractBase
         // outside of the context of exception handling, so all we can do is
         // echo a message.
         echo 'Cannot write session to ' . $sess_file . "\n";
+        return false;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Session/Memcache.php
+++ b/module/VuFind/src/VuFind/Session/Memcache.php
@@ -95,7 +95,7 @@ class Memcache extends AbstractBase
      * @param string $sess_id The current session ID
      * @param string $data    The session data to write
      *
-     * @return void
+     * @return bool
      */
     public function write($sess_id, $data)
     {


### PR DESCRIPTION
PHP 7 expects that session save callbacks return either a `true` or `false` value to indicate success. If a boolean value is not returned, the following error is produced:

    Warning: session_write_close(): Session callback expects true/false return value

This pull request simply adds boolean return values to the session save handlers, which fixes the warning.