### PR TITLE
Fix for config-based enabling/disabling ajaxTabs

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -686,7 +686,7 @@ class AbstractRecord extends AbstractBase
         $view->activeTab = strtolower($tab);
         $view->defaultTab = strtolower($this->getDefaultTab());
         $view->ajaxTabs = isset($config->Site->ajaxTabs)
-            ? $config->Site->ajaxTabs : false;
+            ? (boolean) $config->Site->ajaxTabs : false;
 
         // Set up next/previous record links (if appropriate)
         if ($this->resultScrollerActive()) {

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -72,7 +72,7 @@
                 $activeTabObj = $obj;
               }
               if (!$obj->isVisible()) { $tab_classes[] = 'hidden'; }
-              if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
+              if (!$this->ajaxTabs || !$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
             ?>
             <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
               <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"><?=$this->transEsc($desc)?></a>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -66,7 +66,7 @@
                 $activeTabObj = $obj;
               }
               if (!$obj->isVisible()) { $tab_classes[] = 'hidden'; }
-              if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
+              if (!$this->ajaxTabs || !$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
             ?>
             <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
               <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"><?=$this->transEsc($desc)?></a>


### PR DESCRIPTION
This fix allows disabling ajaxTabs via config.ini setting `Site->ajaxTabs` as in the templates the class `noajax` was not assigned to the tabs if ajaxTabs was set to false. The config setting `Site->ajaxTabs` handed down to the view was an empty string if set to `false` - casting it to boolean makes the value of the setting more explicit (PHP does handle an empty string as "false" though...).