### PR TITLE
Display text for Linking Entry Fields

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -771,22 +771,31 @@ class SolrMarc extends SolrDefault
             $relationshipIndicator = '0';
         }
 
-        // Assign notes based on the relationship type
-        $value = $field->getTag();
-        switch ($value) {
-        case '780':
-            if (in_array($relationshipIndicator, range('0', '7'))) {
-                $value .= '_' . $relationshipIndicator;
-            }
-            break;
-        case '785':
-            if (in_array($relationshipIndicator, range('0', '8'))) {
-                $value .= '_' . $relationshipIndicator;
-            }
-            break;
+        // If set, display relationship information in i subfield
+        if ($value = $field->getSubfield('i')) {
+            $value = $value->getData();
+
+            return $value;
         }
 
-        return 'note_' . $value;
+        // Assign notes based on the relationship type
+        else {
+            $value = $field->getTag();
+            switch ($value) {
+            case '780':
+                if (in_array($relationshipIndicator, range('0', '7'))) {
+                    $value .= '_' . $relationshipIndicator;
+                }
+                break;
+            case '785':
+                if (in_array($relationshipIndicator, range('0', '8'))) {
+                    $value .= '_' . $relationshipIndicator;
+                }
+                break;
+            }
+
+            return 'note_' . $value;
+        }
     }
 
     /**


### PR DESCRIPTION
In MARC Linking Entry Fields (76x/77x/78x) subfield $i contains relationship information. If present in a record this text should be used for display.
This PR adds the use of text from $i if present instead of using a standardized text based on the field number.