### PR TITLE
Multiple subfields in 264

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -327,8 +327,7 @@ class SolrMarc extends SolrDefault
                         $sfcontent[] = $sf;
                     };
                     $currentVal = implode(', ', $sfcontent);
-                }
-                else {
+                } else {
                     $currentVal = array_values($subfields)[0];
                     $currentVal = is_object($currentVal)
                         ? $currentVal->getData() : null;
@@ -349,7 +348,7 @@ class SolrMarc extends SolrDefault
         if (count($pubResults) > 0) {
             $results = $pubResults;
         } else if (count($copyResults) > 0) {
-            $results = $pubResults;
+            $results = $copyResults;
         }
 
         return $results;

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -320,9 +320,20 @@ class SolrMarc extends SolrDefault
         $fields = $this->getMarcRecord()->getFields('264');
         if (is_array($fields)) {
             foreach ($fields as $currentField) {
-                $currentVal = $currentField->getSubfield($subfield);
-                $currentVal = is_object($currentVal)
-                    ? $currentVal->getData() : null;
+                $subfields = $currentField->getSubfields($subfield);
+                if (count($subfields) > 1) {
+                    foreach ($subfields as $sf) {
+                        $sf = is_object($sf) ? $sf->getData() : null;
+                        $sfcontent[] = $sf;
+                    };
+                    $currentVal = implode(', ', $sfcontent);
+                }
+                else {
+                    $currentVal = array_values($subfields)[0];
+                    $currentVal = is_object($currentVal)
+                        ? $currentVal->getData() : null;
+                }
+
                 if (!empty($currentVal)) {
                     switch ($currentField->getIndicator('2')) {
                     case '1':

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -347,9 +347,9 @@ class SolrMarc extends SolrDefault
             }
         }
         if (count($pubResults) > 0) {
-            $results = array_merge($results, $pubResults);
+            $results = $pubResults;
         } else if (count($copyResults) > 0) {
-            $results = array_merge($results, $copyResults);
+            $results = $pubResults;
         }
 
         return $results;


### PR DESCRIPTION
Subfields in 264 are repeatable. Currently this information is not displayed in VuFind. This PR adds support for such cases.

Additionally I removed the array merge which merges information from fields 260 and 264 if both are present in a record. This usually shouldn't be happening but if it does anyway, it's better to prefer the information from one field instead of doubling the information.