### PR TITLE
Don't try to add ID prefixes if source is empty in MultiBackend driver.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1429,7 +1429,7 @@ class MultiBackend extends AbstractBase
     protected function addIdPrefixes($data, $source,
         $modifyFields = ['id', 'cat_username']
     ) {
-        if (!isset($data) || empty($data) || !is_array($data)) {
+        if (empty($source) || empty($data) || !is_array($data)) {
             return $data;
         }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -342,6 +342,14 @@ class MultiBackendTest extends \VuFindTest\Unit\TestCase
         $result = $this->callMethod($driver, 'addIdPrefixes', [$data, $source]);
         $this->assertEquals($expected, $result);
 
+        // Empty source must not add prefixes
+        $expected = [
+            'id' => "record1",
+            'cat_username' => "record2"
+        ];
+        $result = $this->callMethod($driver, 'addIdPrefixes', [$data, '']);
+        $this->assertEquals($expected, $result);
+
         $data = [
             'id' => 'record1',
             'cat_username' => [


### PR DESCRIPTION
From [VuFind-Tech] MultiBackend in result-list.