### PR TITLE
Encode opensearch searchTerms in RSS feed according to RFC 3986.

### DIFF
--- a/module/VuFind/src/VuFind/Feed/Writer/Extension/OpenSearch/Renderer/Feed.php
+++ b/module/VuFind/src/VuFind/Feed/Writer/Extension/OpenSearch/Renderer/Feed.php
@@ -158,7 +158,7 @@ class Feed extends AbstractRenderer
         if (!empty($searchTerms)) {
             $elem = $dom->createElement('opensearch:Query');
             $elem->setAttribute('role', 'request');
-            $elem->setAttribute('searchTerms', $searchTerms);
+            $elem->setAttribute('searchTerms', rawurlencode($searchTerms));
             if ($startIndex !== null) {
                 $elem->setAttribute('startIndex', $startIndex);
             }


### PR DESCRIPTION
There are other issues preventing validation of the feed, but this one is non-controversial in that it doesn't affect the contents.