### PR TITLE
Fixed JS translations injection

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/JsTranslations.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/JsTranslations.php
@@ -98,7 +98,7 @@ class JsTranslations extends AbstractHelper
             $translation = is_array($v)
                 ? call_user_func_array([$this->transEsc, '__invoke'], $v)
                 : $this->transEsc->__invoke($v);
-            $parts[] = $k . ': "' . addslashes($translation) . '"';
+            $parts[] = '"' . $k . '": "' . addslashes($translation) . '"';
         }
         return '{' . implode(',', $parts) . '}';
     }


### PR DESCRIPTION
There was thrown an error when we've added translation using key having reserved chars because it rendered like { 0/BOOKS : "Books" } instead of { "0/BOOKS" : "Books" }