### PR TITLE
Ignore any record ID that comes from a source that is not in the sour…

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -329,6 +329,9 @@ class DeduplicationListener
      */
     protected function determineSourcePriority($recordSources)
     {
+        if (empty($recordSources)) {
+            return [];
+        }
         return array_flip(explode(',', $recordSources));
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -211,6 +211,10 @@ class DeduplicationListener
             foreach ($localIds as $localId) {
                 $localPriority = null;
                 list($source) = explode('.', $localId, 2);
+                // Ignore ID if source is not in the list of allowed record sources:
+                if (!empty($sourcePriority) && !isset($sourcePriority[$source])) {
+                    continue;
+                }
                 if (!empty($buildingPriority)) {
                     if (isset($buildingPriority[$source])) {
                         $localPriority = -$buildingPriority[$source];


### PR DESCRIPTION
…ce list (if defined) when fetching local records for dedup records.

In practice this can happen when "sources" setting is defined in seaches.ini, there is in the merge record a record ID that doesn't belong to them, and a building filter that is associated to the record is used.