### PR TITLE
XSS vulnerability fixed in presentation layer

### DIFF
--- a/themes/bootstrap3/templates/error/index.phtml
+++ b/themes/bootstrap3/templates/error/index.phtml
@@ -25,7 +25,7 @@
 <? if (isset($this->display_exceptions) && $this->display_exceptions): ?>
   <h2><?=$this->transEsc('Exception')?>:</h2>
   <p>
-    <b><?=$this->transEsc('Message')?>:</b> <?=$this->exception->getMessage()?>
+    <b><?=$this->transEsc('Message')?>:</b> <?=$this->escapeHtml($this->exception->getMessage())?>
   </p>
 
   <h2><?=$this->transEsc('Backtrace')?>:</h2>


### PR DESCRIPTION
Possible vulnerability in `/Search/Results?saved=999999999999</p><img src="http://tinyurl.com/n9cs3q4"/>`
Reproducable in Firefox, not in Opera.