### PR TITLE
Fix for PostgreSQL bytea write bug.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/Gateway.php
+++ b/module/VuFind/src/VuFind/Db/Table/Gateway.php
@@ -93,7 +93,9 @@ class Gateway extends AbstractTableGateway implements ServiceLocatorAwareInterfa
             $maps = isset($cfg['vufind']['pgsql_seq_mapping'])
                 ? $cfg['vufind']['pgsql_seq_mapping'] : null;
             if (isset($maps[$this->table])) {
-                $this->featureSet = new Feature\FeatureSet();
+                if (!is_object($this->featureSet)) {
+                    $this->featureSet = new Feature\FeatureSet();
+                }
                 $this->featureSet->addFeature(
                     new Feature\SequenceFeature(
                         $maps[$this->table][0], $maps[$this->table][1]


### PR DESCRIPTION
This enables PDO to properly escape data sent to the bytea search_object field.

Supersedes #594.