### PR TITLE
Include searchClassId in getResolverLinks call so that the results ca…

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AjaxController.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxController.php
@@ -1115,6 +1115,7 @@ class AjaxController extends AbstractBase
     {
         $this->writeSession();  // avoid session write timing bug
         $openUrl = $this->params()->fromQuery('openurl', '');
+        $searchClassId = $this->params()->fromQuery('searchClassId', '');
 
         $config = $this->getConfig();
         $resolverType = isset($config->OpenURL->resolver)
@@ -1169,7 +1170,8 @@ class AjaxController extends AbstractBase
         // Render the links using the view:
         $view = [
             'openUrlBase' => $base, 'openUrl' => $openUrl, 'print' => $print,
-            'electronic' => $electronic, 'services' => $services
+            'electronic' => $electronic, 'services' => $services,
+            'searchClassId' => $searchClassId
         ];
         $html = $this->getViewRenderer()->render('ajax/resolverLinks.phtml', $view);
 

--- a/themes/bootstrap3/js/openurl.js
+++ b/themes/bootstrap3/js/openurl.js
@@ -1,8 +1,8 @@
 /*global extractClassParams, VuFind */
 
-function loadResolverLinks($target, openUrl) {
+function loadResolverLinks($target, openUrl, searchClassId) {
   $target.addClass('ajax_availability');
-  var url = VuFind.getPath() + '/AJAX/JSON?' + $.param({method:'getResolverLinks',openurl:openUrl});
+  var url = VuFind.getPath() + '/AJAX/JSON?' + $.param({method:'getResolverLinks',openurl:openUrl,searchClassId:searchClassId});
   $.ajax({
     dataType: 'json',
     url: url
@@ -31,7 +31,7 @@ function embedOpenUrlLinks(element) {
   // If the target is already visible, a previous click has populated it;
   // don't waste time doing redundant work.
   if (target.hasClass('hidden')) {
-    loadResolverLinks(target.removeClass('hidden'), openUrl);
+    loadResolverLinks(target.removeClass('hidden'), openUrl, element.data('search-class-id'));
   }
 }
 

--- a/themes/bootstrap3/templates/Helpers/openurl.phtml
+++ b/themes/bootstrap3/templates/Helpers/openurl.phtml
@@ -16,7 +16,7 @@
 
 <span class="openUrlControls<? if ($this->openUrlEmbed): ?> openUrlEmbed<? if ($this->openUrlEmbedAutoLoad): ?> openUrlEmbedAutoLoad<? endif; ?><? endif; ?>">
   <? if (!$this->openUrlImageBasedSrc || $this->openUrlImageBasedMode == 'both'): ?>
-  <a href="<?=$this->escapeHtmlAttr($this->openUrlBase . '?' . $this->openUrl)?>"<?=$class?>>
+  <a href="<?=$this->escapeHtmlAttr($this->openUrlBase . '?' . $this->openUrl)?>"<?=$class?> data-search-class-id="<?=$this->escapeHtmlAttr($this->searchClassId) ?>">
     <? /* put the openUrl here in a span (COinS almost) so we can retrieve it later */ ?>
     <span title="<?=$this->escapeHtmlAttr($this->openUrl)?>" class="openUrl"></span>
     <? if ($this->openUrlGraphic): ?>


### PR DESCRIPTION
…n be tweaked for each backend.

Currently resolverLinks.phtml doesn't use this, but we need it so that we can return slightly different results for Primo records.