### PR TITLE
Fix AJAX fail handlers to not cause JS errors if responseJSON is not …

### DIFF
--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -80,9 +80,10 @@ function checkItemStatuses() {
     $(".ajax-availability").removeClass('ajax-availability');
   })
   .fail(function(response, textStatus) {
-    if (textStatus == "abort") { return; }
+    $('.ajax-availability').empty();
+    if (textStatus == 'abort' || typeof response.responseJSON === 'undefined') { return; }
     // display the error message on each of the ajax status place holder
-    $(".ajax-availability").empty().append(response.responseJSON.data).addClass('text-danger');
+    $('.ajax-availability').append(response.responseJSON.data).addClass('text-danger');
   });
 }
 

--- a/themes/bootstrap3/js/openurl.js
+++ b/themes/bootstrap3/js/openurl.js
@@ -11,9 +11,9 @@ function loadResolverLinks($target, openUrl, searchClassId) {
     $target.removeClass('ajax_availability').empty().append(response.data);
   })
   .fail(function(response, textStatus) {
-    if (textStatus == "abort") { return; }
-    $target.removeClass('ajax_availability').addClass('text-danger')
-      .empty().append(response.responseJSON.data);
+    $target.removeClass('ajax_availability').addClass('text-danger').empty();
+    if (textStatus == 'abort' || typeof response.responseJSON === 'undefined') { return; }
+    $target.append(response.responseJSON.data);
   });
 }
 

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -96,7 +96,7 @@ function registerAjaxCommentRecord() {
       $(form).find('input[type="submit"]').button('loading');
     })
     .fail(function(response, textStatus) {
-      if (textStatus == "abort") { return; }
+      if (textStatus == 'abort' || typeof response.responseJSON === 'undefined') { return; }
       Lightbox.displayError(response.responseJSON.data);
     });
     return false;


### PR DESCRIPTION
…defined.

At least with Firefox textStatus == 'error' when an AJAX call is aborted due to page refresh or navigation away from the current page, and there's no certainty that we have responseJSON in any case, so check for it before trying to use it.