### PR TITLE
Added possibility to disallow canceling of requests that are availabl…

### DIFF
--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -23,6 +23,9 @@ login_field = LAST_NAME
 ; This is the timeout value for making HTTP requests to the Voyager API.
 http_timeout = 30
 
+; Whether purchase history is enabled. Default is true.
+;purchase_history = false
+
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.
@@ -174,6 +177,9 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ;helpText = "Help text for all languages."
 ;helpText[en-gb] = "Help text for English language."
 
+; By default a request can be canceled even if the item is available for pickup.
+; Uncomment this to disable canceling of available requests.
+;allowCancelingAvailableRequests = false
 
 ; This section controls call slip behavior (storage retrieval requests in VuFind).
 ; To enable, uncomment (at minimum) the HMACKeys and extraFields settings below.
@@ -229,6 +235,16 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 [ILLRequestSources]
 ;devdb = "1@DEVDB20011102161616"
 ;otherdb = "1@OTHERDB20011030191919"
+
+; Status rankings can be used to either promote or demote certain item statuses when
+; determining the status to be displayed. The lower the rank, the higher the 
+; priority. The sample values below make "Missing" most important and drop request
+; statuses below others so that e.g. "On Hold" is displayed instead of 
+; "Hold Request".    
+;[StatusRankings]
+;Missing = 0
+;Recall Request = 99
+;Hold Request = 99
 
 ; Settings for controlling how holdings are displayed
 [Holdings]

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -60,9 +60,11 @@ class Holds extends AbstractRequestBase
                     = $catalog->getCancelHoldLink($ilsDetails);
             } else {
                 // Form Details
-                $ilsDetails['cancel_details']
-                    = $catalog->getCancelHoldDetails($ilsDetails);
-                $this->rememberValidId($ilsDetails['cancel_details']);
+                $cancelDetails = $catalog->getCancelHoldDetails($ilsDetails);
+                if ($cancelDetails !== '') {
+                    $ilsDetails['cancel_details'] = $cancelDetails;
+                    $this->rememberValidId($ilsDetails['cancel_details']);
+                }
             }
         }
 


### PR DESCRIPTION
…e for pickup and the required functionality to the VoyagerRestful driver.

Since Voyager doesn't have a (built-in) mechanism for reporting cancellation of available requests to the staff, it's useful to disallow them. 

Also fixed a mistake in SQL debug logging function call while at it. 