### PR TITLE
Fixed the local check call when fetching remote holds.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2224,7 +2224,7 @@ EOT;
         if (isset($results->holds->institution)) {
             foreach ($results->holds->institution as $institution) {
                 // Only take remote holds
-                if ($this->isLocalInst($institution)) {
+                if ($this->isLocalInst((string)$institution->attributes()->id)) {
                     continue;
                 }
 


### PR DESCRIPTION
The same check is done properly in getRemoteCallSlips(), but here SimpleXMLElement was compared to string.