### PR TITLE
corrects check for existence of ilslink

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -190,7 +190,9 @@ class DAIA extends AbstractBase implements
      */
     public function getHoldLink($id, $details)
     {
-        return ($details['ilslink'] != '') ? $details['ilslink'] : null;
+        return (isset($details['ilslink']) && $details['ilslink'] != '')
+            ? $details['ilslink']
+            : null;
     }
 
     /**


### PR DESCRIPTION
This mini PR corrects a check for the index key ilslink in DAIA driver to avoid PHP warnings if the index key is not set.