### PR TITLE
Fixed cache member variable name conflict with base class in MultiBac…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -4,7 +4,7 @@
  *
  * PHP version 5
  *
- * Copyright (C) The National Library of Finland 2012.
+ * Copyright (C) The National Library of Finland 2012-2016.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -67,19 +67,11 @@ class MultiBackend extends AbstractBase
     protected $defaultDriver;
 
     /**
-     * The array of cached pre-instantiated drivers
+     * The array of cached drivers
      *
      * @var object[]
      */
-    protected $cache = [];
-
-    /**
-     * The array of booleans letting us know if a
-     * driver in the cache has been initialized.
-     *
-     * @var boolean[]
-     */
-    protected $isInitialized = [];
+    protected $driverCache = [];
 
     /**
      * The array of driver configuration options.
@@ -1312,83 +1304,40 @@ class MultiBackend extends AbstractBase
             }
         }
 
-        if (!isset($this->isInitialized[$source])
-            || !$this->isInitialized[$source]
-        ) {
-            $driverInst = null;
-
-            // And we don't have a copy in our cache...
-            if (!isset($this->cache[$source])) {
-                // Get an uninitialized copy
-                $driverInst = $this->getUninitializedDriver($source);
-            } else {
-                // Otherwise, use the uninitialized cached copy
-                $driverInst = $this->cache[$source];
-            }
-
-            // If we have a driver, initialize it.  That version has already
-            // been cached.
-            if ($driverInst) {
-                $this->initializeDriver($driverInst, $source);
-            } else {
+        // Check for a cached driver
+        if (!array_key_exists($source, $this->driverCache)) {
+            // Create the driver
+            $this->driverCache[$source] = $this->createDriver($source);
+            if (null === $this->driverCache[$source]) {
                 $this->debug("Could not initialize driver for source '$source'");
                 return null;
             }
         }
-        return $this->cache[$source];
+        return $this->driverCache[$source];
     }
 
     /**
-     * Find the correct driver for the correct configuration file
-     * for the given source.  For performance reasons, we do not
-     * want to initialize the driver yet if it hasn't been already.
+     * Create a driver for the given source.
      *
-     * @param string $source the source title for the driver.
+     * @param string $source Source id for the driver.
      *
-     * @return mixed On success an uninitialized driver object, otherwise null.
+     * @return mixed On success a driver object, otherwise null.
      */
-    protected function getUninitializedDriver($source)
+    protected function createDriver($source)
     {
-        // We don't really care if it's initialized here.  If it is, then there's
-        // still no added overhead of returning an initialized driver.
-        if (isset($this->cache[$source])) {
-            return $this->cache[$source];
+        if (!isset($this->drivers[$source])) {
+            return null;
         }
-
-        if (isset($this->drivers[$source])) {
-            $driver = $this->drivers[$source];
-            $config = $this->getDriverConfig($source);
-            if (!$config) {
-                $this->error("No configuration found for source '$source'");
-                return null;
-            }
-            $driverInst = clone($this->getServiceLocator()->get($driver));
-            $driverInst->setConfig($config);
-            $this->cache[$source] = $driverInst;
-            $this->isInitialized[$source] = false;
-            return $driverInst;
+        $driver = $this->drivers[$source];
+        $config = $this->getDriverConfig($source);
+        if (!$config) {
+            $this->error("No configuration found for source '$source'");
+            return null;
         }
-
-        return null;
-    }
-
-    /**
-     * Initialize an uninitialized driver.
-     *
-     * @param object $driver The driver object to be initialized
-     * @param string $source The source related to the driver for caching purposes.
-     *
-     * @return void
-     */
-    protected function initializeDriver($driver, $source)
-    {
-        if (!isset($this->isInitialized[$source])
-            || !$this->isInitialized[$source]
-        ) {
-            $driver->init();
-            $this->isInitialized[$source] = true;
-            $this->cache[$source] = $driver;
-        }
+        $driverInst = clone($this->getServiceLocator()->get($driver));
+        $driverInst->setConfig($config);
+        $driverInst->init();
+        return $driverInst;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -5,7 +5,7 @@
  * PHP version 5
  *
  * Copyright (C) Villanova University 2011.
- * Copyright (C) The National Library of Finland 2014.
+ * Copyright (C) The National Library of Finland 2014-2016.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -152,9 +152,7 @@ class MultiBackendTest extends \VuFindTest\Unit\TestCase
     }
 
     /**
-     * Test that MultiBackend can properly retrieve a new driver
-     * Almost the same as testing the Uninitialized driver, we just
-     * have to expect it to get initialized.
+     * Test that MultiBackend can properly retrieve a new driver.
      *
      * @return void
      */
@@ -163,7 +161,7 @@ class MultiBackendTest extends \VuFindTest\Unit\TestCase
         $driver = $this->getDriver();
         //Set up the mock driver to be retrieved
         $ILS = $this->getMockILS('Voyager', ['init', 'setConfig']);
-        $ILS->expects($this->exactly(2))
+        $ILS->expects($this->once())
             ->method('init');
         $ILS->expects($this->once())
             ->method('setConfig')
@@ -180,115 +178,9 @@ class MultiBackendTest extends \VuFindTest\Unit\TestCase
         $returnDriver = $this->callMethod($driver, 'getDriver', ['testing2']);
         $this->assertEquals($ILS, $returnDriver);
 
-        $this->setProperty($driver, 'isInitialized', []);
-        $returnDriver = $this->callMethod($driver, 'getDriver', ['testing2']);
-        $this->assertEquals($ILS, $returnDriver);
-
         $returnDriver
             = $this->callMethod($driver, 'getDriver', ['nonexistent']);
         $this->assertNull($returnDriver);
-    }
-
-    /**
-     * Test that MultiBackend can properly retrieve an uninitialized
-     * driver.
-     *
-     * @return void
-     */
-    public function testGetUninitializedDriver()
-    {
-        $driver = $this->getDriver();
-        //Set up the mock driver to be retrieved
-        $ILS = $this->getMockILS('Voyager', ['setConfig']);
-        $ILS->expects($this->once())
-            ->method('setConfig')
-            ->with(['config' => 'values']);
-
-        //Set up the ServiceLocator so it returns our mock driver
-        $sm = $this->getMockSM($this->once(), 'Voyager', $ILS);
-        $driver->setServiceLocator($sm);
-        //Add an entry for our test driver to the array of drivers
-        $drivers = ['testing' => 'Voyager'];
-        $this->setProperty($driver, 'drivers', $drivers);
-
-        //Case: A driver is associated with the given name
-            //Result: Return that driver. Cached, but not initialized.
-        $unInitDriver = $this->callMethod(
-            $driver,
-            'getUninitializedDriver',
-            ['testing']
-        );
-        $this->assertEquals($ILS, $unInitDriver);
-
-        //Check the cache arrays to make sure they get set correctly
-        $isInit = $this->getProperty($driver, 'isInitialized');
-        $cache = $this->getproperty($driver, 'cache');
-        $this->assertEquals($ILS, $cache['testing']);
-        $this->assertFalse($isInit['testing']);
-
-        //Verify that the cached driver is returned properly
-        $unInitDriver = $this->callMethod(
-            $driver,
-            'getUninitializedDriver',
-            ['testing']
-        );
-        $this->assertEquals($ILS, $unInitDriver);
-
-        //Case: No driver associated with that name exists
-            //Result: Return of null
-        $unInitDriver = $this->callMethod(
-            $driver,
-            'getUninitializedDriver',
-            ['noDriverWithThisName']
-        );
-        $this->assertNull($unInitDriver);
-
-        //Case: No configuration for the driver
-            //Result: Return of null
-        $mockPM = $this->getMock('\VuFind\Config\PluginManager');
-        $mockPM->expects($this->any())
-            ->method('get')
-            ->will(
-                $this->throwException(new \Zend\Config\Exception\RuntimeException())
-            );
-        $driver = new MultiBackend($mockPM, $this->getMockILSAuthenticator());
-        $driver->setConfig(['Drivers' => ['d1' => 'Voyager']]);
-        $driver->init();
-        $unInitDriver = $this->callMethod(
-            $driver,
-            'getUninitializedDriver',
-            ['d1']
-        );
-        $this->assertNull($unInitDriver);
-    }
-
-    /**
-     * Test that MultiBackend can properly initialize a driver it
-     * is given, and cache it.
-     *
-     * @return void
-     */
-    public function testInitializeDriver()
-    {
-        $driver = $this->getDriver();
-        //Set up the mock driver to be initialized.
-        $ILS = $this->getMockILS('Voyager', ['init']);
-        $ILS->expects($this->once())
-            ->method('init');
-
-        //Run the test method
-        $this->callMethod($driver, 'initializeDriver', [$ILS, 'test']);
-
-        //Check the cache arrays
-        $isInit = $this->getProperty($driver, 'isInitialized');
-        $cache = $this->getproperty($driver, 'cache');
-        $this->assertSame($ILS, $cache['test']);
-        $this->assertTrue($isInit['test']);
-
-        $this->setProperty($driver, 'isInitialized', []);
-        $d = new \VuFind\ILS\Driver\Voyager(new \VuFind\Date\Converter());
-        $this->setExpectedException('VuFind\Exception\ILS');
-        $this->callMethod($driver, 'initializeDriver', [$d, 'fail']);
     }
 
     /**
@@ -990,13 +882,11 @@ class MultiBackendTest extends \VuFindTest\Unit\TestCase
             ->with('username', 'password')
             ->will($this->returnValue($patronReturn));
 
-        //Prep MultiBackend with values it will need
+        // Prep MultiBackend with values it will need
         $drivers = [$instance => 'Voyager'];
-        $isInit = [$instance => true];
         $cache = [$instance => $ILS];
         $this->setProperty($driver, 'drivers', $drivers);
-        $this->setProperty($driver, 'isInitialized', $isInit);
-        $this->setProperty($driver, 'cache', $cache);
+        $this->setProperty($driver, 'driverCache', $cache);
 
         //Call the method
         $patron = $driver->patronLogin("$instance.username", 'password');


### PR DESCRIPTION
…kend driver and simplified the driver instantiation.

There was no point in having uninitialized drivers in the cache since they were initialized anyway right after, and an uninitialized driver isn't really useful.