### PR TITLE
Revert "Searches initiated from advanced search now remain advanced f…

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -449,13 +449,9 @@ class Params implements ServiceLocatorAwareInterface
 
         $this->searchType = $this->query instanceof Query ? 'basic' : 'advanced';
 
-        // If we ended up with a basic search, set the default handler if necessary
-        // and convert it to an advanced search:
-        if ($this->searchType == 'basic') {
-            if ($this->query->getHandler() === null) {
-                $this->query->setHandler($this->getOptions()->getDefaultHandler());
-            }
-            $this->convertToAdvancedSearch();
+        // If we ended up with a basic search, set the default handler if necessary:
+        if ($this->searchType == 'basic' && $this->query->getHandler() === null) {
+            $this->query->setHandler($this->getOptions()->getDefaultHandler());
         }
     }
 

--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -56,8 +56,7 @@ abstract class QueryAdapter
      */
     public static function deminify(array $search)
     {
-        // Use array_key_exists since null is also valid
-        if (array_key_exists('l', $search)) {
+        if (isset($search['l'])) {
             $handler = isset($search['i']) ? $search['i'] : $search['f'];
             return new Query(
                 $search['l'], $handler, isset($search['o']) ? $search['o'] : null

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -309,17 +309,9 @@ class QueryBuilder implements QueryBuilderInterface
                 [$this, 'reduceQueryGroupComponents'], $component->getQueries()
             );
             $searchString = $component->isNegated() ? 'NOT ' : '';
-            $reduced = array_filter(
-                $reduced,
-                function ($s) {
-                    return '' !== $s;
-                }
+            $searchString .= sprintf(
+                '(%s)', implode(" {$component->getOperator()} ", $reduced)
             );
-            if ($reduced) {
-                $searchString .= sprintf(
-                    '(%s)', implode(" {$component->getOperator()} ", $reduced)
-                );
-            }
         } else {
             $searchString  = $this->getLuceneHelper()
                 ->normalizeSearchString($component->getString());
@@ -327,7 +319,7 @@ class QueryBuilder implements QueryBuilderInterface
                 $component->getHandler(),
                 $searchString
             );
-            if ($searchHandler && '' !== $searchString) {
+            if ($searchHandler) {
                 $searchString
                     = $this->createSearchString($searchString, $searchHandler);
             }
@@ -347,9 +339,6 @@ class QueryBuilder implements QueryBuilderInterface
     {
         $advanced = $this->getLuceneHelper()->containsAdvancedLuceneSyntax($string);
 
-        if (null === $string) {
-            return '';
-        }
         if ($advanced && $handler) {
             return $handler->createAdvancedQueryString($string);
         } else if ($handler) {


### PR DESCRIPTION
…or user experience consistency."

This reverts commit 063ee52ec2cf92d58013ab055191864bd0e89bf6 from PR #625.

This change ended up causing trouble with empty searches where the lookfor parameter is dropped when e.g. a facet is clicked causing the search to be converted to an advanced search for no real reason. Need to come up with a better solution.