### PR TITLE
Extended maximum record_id length to 255.

### DIFF
--- a/module/VuFind/sql/migrations/pgsql/3.0/002-modify-resource-columns.sql
+++ b/module/VuFind/sql/migrations/pgsql/3.0/002-modify-resource-columns.sql
@@ -3,4 +3,6 @@
 --
 
 ALTER TABLE "resource"
-  ALTER COLUMN source SET DEFAULT 'Solr';
+  ALTER COLUMN source SET DEFAULT 'Solr',
+  ALTER COLUMN record_id TYPE varchar(255);
+  

--- a/module/VuFind/sql/migrations/pgsql/3.0/003-add-record-table.sql
+++ b/module/VuFind/sql/migrations/pgsql/3.0/003-add-record-table.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE `record` (
   id serial NOT NULL,
-  record_id varchar(120),
+  record_id varchar(255),
   source varchar(50),
   version varchar(20) NOT NULL,
   data text,

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -69,7 +69,7 @@ CREATE TABLE `oai_resumption` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `resource` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `record_id` varchar(120) NOT NULL DEFAULT '',
+  `record_id` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(200) NOT NULL DEFAULT '',
   `author` varchar(200) DEFAULT NULL,
   `year` mediumint(6) DEFAULT NULL,
@@ -300,7 +300,7 @@ CREATE TABLE `user_card` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `record` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `record_id` varchar(120) DEFAULT NULL,
+  `record_id` varchar(255) DEFAULT NULL,
   `source` varchar(50) DEFAULT NULL,
   `version` varchar(20) NOT NULL,
   `data` longtext DEFAULT NULL,

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -24,7 +24,7 @@ CREATE INDEX comments_resource_id_idx ON comments (resource_id);
 
 CREATE TABLE resource (
 id SERIAL,
-record_id varchar(120) NOT NULL DEFAULT '',
+record_id varchar(255) NOT NULL DEFAULT '',
 title varchar(200) NOT NULL DEFAULT '',
 author varchar(200) DEFAULT NULL,
 year int DEFAULT NULL,
@@ -252,7 +252,7 @@ DROP TABLE IF EXISTS "record";
 
 CREATE TABLE `record` (
   id serial NOT NULL,
-  record_id varchar(120),
+  record_id varchar(255),
   source varchar(50),
   version varchar(20) NOT NULL,
   data text,


### PR DESCRIPTION
We have unfortunately stumbled on the 120 character limit with some record id's in urn form (currently the longest one encountered is 152 characters). And it doesn't really cost anything to up the limit.