### PR TITLE
Use a more specific selector when checking for flash messages in ligh…

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/Flashmessages.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/Flashmessages.php
@@ -50,6 +50,6 @@ class Flashmessages extends \VuFind\View\Helper\Root\Flashmessages
         if ($ns == 'error') {
             $ns = 'danger';
         }
-        return 'alert alert-' . $ns;
+        return 'flash-message alert alert-' . $ns;
     }
 }

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -68,8 +68,8 @@ VuFind.lightbox = (function() {
       return;
     }
     // Isolate successes
-    var htmlDiv = $('<div>'+html+'</div>');
-    var alerts = htmlDiv.find('.alert-success');
+    var htmlDiv = $('<div/>').html(html);
+    var alerts = htmlDiv.find('.flash-message.alert-success');
     if (alerts.length > 0) {
       showAlert(alerts[0].innerHTML, 'success');
       return;
@@ -127,10 +127,10 @@ VuFind.lightbox = (function() {
           return;
         }
         if ( // Close the lightbox after deliberate login
-          obj.method                                                  // is a form
-          && !html.match(/alert alert-danger/)                        // skip failed logins
-          && ((obj.url.match(/MyResearch/) && !obj.url.match(/Bulk/)) // that matches login/create account
-            || obj.url.match(/catalogLogin/))                         // or catalog login for holds
+          obj.method                                                                // is a form
+          && ((obj.url.match(/MyResearch/) && !obj.url.match(/Bulk/))               // that matches login/create account
+            || obj.url.match(/catalogLogin/))                                       // or catalog login for holds
+          && $('<div/>').html(html).find('.flash-message.alert-danger').length == 0 // skip failed logins
         ) {
           if (_originalUrl.match(/UserLogin/) || obj.url.match(/catalogLogin/)) {
             _refreshPage();


### PR DESCRIPTION
…tbox so that other markup using the classes doesn't confuse lightbox. Also always use jQuery selectors to find the flash messages to be more tolerant of markup changes (e.g. whitespace, class ordering etc.).

This is based on a real-life issue where the page after lightbox login contains a hidden 
`<div class="alert alert-danger">...</div> `
and this caused the lightbox login to display that div instead of finishing the login properly, so I believe it's better to have a flash message specific selector to avoid false matches. 