### PR TITLE
[VUFIND-1157] Include request in the call to getSessionInitiator in a…

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
@@ -238,13 +238,17 @@ class ChoiceAuth extends AbstractBase
      * Get the URL to establish a session (needed when the internal VuFind login
      * form is inadequate).  Returns false when no session initiator is needed.
      *
-     * @param string $target Full URL where external authentication strategy should
+     * @param string  $target  Full URL where external authentication strategy should
      * send user after login (some drivers may override this).
+     * @param Request $request Optional request object.
      *
      * @return bool|string
      */
-    public function getSessionInitiator($target)
+    public function getSessionInitiator($target, $request = null)
     {
+        if (null !== $request) {
+            $this->setStrategyFromRequest($request);
+        }
         return $this->proxyAuthMethod('getSessionInitiator', func_get_args());
     }
 

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -550,7 +550,7 @@ class Manager implements \ZfcRbac\Identity\IdentityProviderInterface
     public function login($request)
     {
         // Validate CSRF for form-based authentication methods:
-        if (!$this->getAuth()->getSessionInitiator(null)
+        if (!$this->getAuth()->getSessionInitiator(null, $request)
             && !$this->csrf->isValid($request->getPost()->get('csrf'))
         ) {
             throw new AuthException('authentication_error_technical');


### PR DESCRIPTION
…uth manager so that ChoiceAuth can proxy the request to the correct method.

This is my attempt at fixing https://vufind.org/jira/browse/VUFIND-1157. If there's a better way, please disregard this.