### PR TITLE
Don't try to load record with empty id.

### DIFF
--- a/module/VuFind/src/VuFind/Record/Loader.php
+++ b/module/VuFind/src/VuFind/Record/Loader.php
@@ -95,21 +95,26 @@ class Loader
     public function load($id, $source = DEFAULT_SEARCH_BACKEND,
         $tolerateMissing = false
     ) {
-        $results = [];
-        if (null !== $this->recordCache && $this->recordCache->isPrimary($source)) {
-            $results = $this->recordCache->lookup($id, $source);
-        }
-        if (empty($results)) {
-            $results = $this->searchService->retrieve($source, $id)->getRecords();
-        }
-        if (empty($results) && null !== $this->recordCache
-            && $this->recordCache->isFallback($source)
-        ) {
-            $results = $this->recordCache->lookup($id, $source);
-        }
+        if (null !== $id && '' !== $id) {
+            $results = [];
+            if (null !== $this->recordCache
+                && $this->recordCache->isPrimary($source)
+            ) {
+                $results = $this->recordCache->lookup($id, $source);
+            }
+            if (empty($results)) {
+                $results = $this->searchService->retrieve($source, $id)
+                    ->getRecords();
+            }
+            if (empty($results) && null !== $this->recordCache
+                && $this->recordCache->isFallback($source)
+            ) {
+                $results = $this->recordCache->lookup($id, $source);
+            }
 
-        if (!empty($results)) {
-            return $results[0];
+            if (!empty($results)) {
+                return $results[0];
+            }
         }
         if ($tolerateMissing) {
             $record = $this->recordFactory->get('Missing');


### PR DESCRIPTION
I didn't use empty() since it returns true for 0 which is a valid id, I suppose.

This avoids stupid cache lookups or backends trying to e.g. do an empty search.