### PR TITLE
Never set followup to lightbox. Otherwise e.g. Shibboleth login with …

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -261,16 +261,13 @@ class AbstractBase extends AbstractActionController
             $msg = 'You must be logged in first';
         }
 
-        // If we're doing off-site login requests,
-        // we don't want to return to the lightbox
+        // We don't want to return to the lightbox
         $serverUrl = $this->getServerUrl();
-        if ($this->getAuthManager()->getSessionInitiator($serverUrl)) {
-            $serverUrl = str_replace(
-                ['?layout=lightbox', '&layout=lightbox'],
-                ['?', '&'],
-                $serverUrl
-            );
-        }
+        $serverUrl = str_replace(
+            ['?layout=lightbox', '&layout=lightbox'],
+            ['?', '&'],
+            $serverUrl
+        );
 
         // Store the current URL as a login followup action
         $this->followup()->store($extras, $serverUrl);


### PR DESCRIPTION
…ChoiceAuth will return to a lightbox page. 

I'm not sure there ever is a way to safely return to the lightbox if you visit another page in between.