### PR TITLE
Bind AJAX status lookups to availability of ILS

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -1072,7 +1072,9 @@ class SolrMarc extends SolrDefault
      */
     public function supportsAjaxStatus()
     {
-        return true;
+        // as AJAX status lookups are done via the ILS AJAX status lookup support is
+        // only given if the ILS is available for this record
+        return $this->hasILS();
     }
 
     /**


### PR DESCRIPTION
AJAX status lookups are done via the ILS, therefore AJAX status lookup support is only given if the ILS is available for this record which should be the case for SolrMarc-Records only if hasILS() returns true. By hardcoding SolrMarc to support AJAX status requests the ILS is requested from the search results whereas it is not from the record details holdings tab (which indirectly checks hasILS() by calling getRealTimeHoldings()).
If I'm not overseeing some other dependencies this should make the behaviour of status requests more consistent for SolrMarc-Records.