### PR TITLE
Added drivers_path config to Multibackend

### DIFF
--- a/config/vufind/MultiBackend.ini
+++ b/config/vufind/MultiBackend.ini
@@ -7,7 +7,7 @@
 ; (Optional) the path to the drivers configurations relative to vufind config 
 ; dir -- omit to locate those in vufind config dir -- it also could be an
 ; absolute path
-;drivers_path            = private
+;drivers_config_path            = private
 
 ; This section is for declaring which driver to use for each institution.
 ; The key should be the Source ID of a specific institution, and the value

--- a/config/vufind/MultiBackend.ini
+++ b/config/vufind/MultiBackend.ini
@@ -4,6 +4,11 @@
 ; from the [Drivers] section below if set -- omit to have no default driver)
 ;default_driver = "instance1"
 
+; (Optional) the path to the drivers configurations relative to vufind config 
+; dir -- omit to locate those in vufind config dir -- it also could be an
+; absolute path
+;drivers_path            = private
+
 ; This section is for declaring which driver to use for each institution.
 ; The key should be the Source ID of a specific institution, and the value
 ; should be the name of an ILS driver.

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -145,7 +145,8 @@ class MultiBackend extends AbstractBase
             ? $this->config['General']['default_driver']
             : null;
         
-        $this->driversConfigPath = isset($this->config['General']['drivers_config_path'])
+        $this->driversConfigPath = 
+            isset($this->config['General']['drivers_config_path'])
             ? $this->config['General']['drivers_config_path']
             : null;
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -71,7 +71,7 @@ class MultiBackend extends AbstractBase
      * 
      * @var string
      */
-    protected $driversPath;
+    protected $driversConfigPath;
 
     /**
      * The array of cached drivers
@@ -145,8 +145,8 @@ class MultiBackend extends AbstractBase
             ? $this->config['General']['default_driver']
             : null;
         
-        $this->driversPath = isset($this->config['General']['drivers_path'])
-            ? $this->config['General']['drivers_path']
+        $this->driversConfigPath = isset($this->config['General']['drivers_config_path'])
+            ? $this->config['General']['drivers_config_path']
             : null;
     }
 
@@ -1365,9 +1365,9 @@ class MultiBackend extends AbstractBase
     {
         // Determine config file name based on class name:
         try {
-            $path = empty($this->driversPath)
+            $path = empty($this->driversConfigPath)
                 ? $source
-                : $this->driversPath . '/' . $source;
+                : $this->driversConfigPath . '/' . $source;
 
             $config = $this->configLoader->get($path);
         } catch (\Zend\Config\Exception\RuntimeException $e) {

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1365,7 +1365,7 @@ class MultiBackend extends AbstractBase
     {
         // Determine config file name based on class name:
         try {
-            $path = ($this->driversPath === null)
+            $path = empty($this->driversPath)
                 ? $source
                 : $this->driversPath . '/' . $source;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -65,6 +65,13 @@ class MultiBackend extends AbstractBase
      * @var string
      */
     protected $defaultDriver;
+    
+    /**
+     * The path to the drivers relative to the config path
+     * 
+     * @var string
+     */
+    protected $driversPath;
 
     /**
      * The array of cached drivers
@@ -136,6 +143,10 @@ class MultiBackend extends AbstractBase
         $this->drivers = $this->config['Drivers'];
         $this->defaultDriver = isset($this->config['General']['default_driver'])
             ? $this->config['General']['default_driver']
+            : null;
+        
+        $this->driversPath = isset($this->config['General']['drivers_path'])
+            ? $this->config['General']['drivers_path']
             : null;
     }
 
@@ -1354,7 +1365,11 @@ class MultiBackend extends AbstractBase
     {
         // Determine config file name based on class name:
         try {
-            $config = $this->configLoader->get($source);
+            $path = ($this->driversPath === null) 
+                ? $source 
+                : $this->driversPath . '/' . $source;
+
+            $config = $this->configLoader->get($path);
         } catch (\Zend\Config\Exception\RuntimeException $e) {
             // Configuration loading failed; probably means file does not
             // exist -- just return an empty array in that case:

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1365,8 +1365,8 @@ class MultiBackend extends AbstractBase
     {
         // Determine config file name based on class name:
         try {
-            $path = ($this->driversPath === null) 
-                ? $source 
+            $path = ($this->driversPath === null)
+                ? $source
                 : $this->driversPath . '/' . $source;
 
             $config = $this->configLoader->get($path);

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -145,8 +145,8 @@ class MultiBackend extends AbstractBase
             ? $this->config['General']['default_driver']
             : null;
         
-        $this->driversConfigPath = 
-            isset($this->config['General']['drivers_config_path'])
+        $this->driversConfigPath
+            = isset($this->config['General']['drivers_config_path'])
             ? $this->config['General']['drivers_config_path']
             : null;
     }


### PR DESCRIPTION
We need to have institutions configs in a different directory in order to version them in our private repository, so here I came up with drivers_path solution which points to a directory where the configuration of the institutions can be found.