### PR TITLE
Added back support for specifying lightbox title

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -13,6 +13,15 @@ VuFind.lightbox = (function() {
   };
   var _html = function(html) {
     _modalBody.html(html);
+    // Set or update title if we have one
+    if (_lightboxTitle != '') {
+      var h2 = _modalBody.find('h2:first-child');
+      if (h2.length == 0) {
+        h2 = $('<h2/>').prependTo(_modalBody);
+      }
+      h2.text(_lightboxTitle);
+      _lightboxTitle = '';
+    }
     _modal.modal('handleUpdate');
   };
   var _emit = function(msg, details) {
@@ -94,14 +103,6 @@ VuFind.lightbox = (function() {
     // information about which button was clicked here as checking focused button
     // doesn't work on all browsers and platforms.
     _modalBody.find('[type=submit]').click(_storeClickedStatus);
-    // Set or update title if we have one
-    if (_lightboxTitle != '') {
-      var h2 = _modalBody.find('h2:first-child');
-      if (h2.length == 0) {
-        h2 = $('<h2/>').prependTo(_modalBody);
-      }
-      h2.text(_lightboxTitle);
-    }
 
     var forms = _modalBody.find('form:not([data-lightbox-ignore])');
     for (var i=0;i<forms.length;i++) {
@@ -216,6 +217,7 @@ VuFind.lightbox = (function() {
    *
    * data-lightbox-onsubmit = on submit, run named function
    * data-lightbox-onclose  = on close, run named function
+   * data-lightbox-title = Lightbox title (overrides any title the page provides)
    *
    * Submit button data options:
    *
@@ -260,6 +262,8 @@ VuFind.lightbox = (function() {
     if (submit.closest(_modal).length > 0) {
       submit.attr('disabled', 'disabled');
     }
+    // Store custom title
+    _lightboxTitle = $(form).data('lightboxTitle');
     // Get Lightbox content
     ajax({
       url: form.action || _currentUrl,

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -3,6 +3,7 @@ VuFind.lightbox = (function() {
   // State
   var _originalUrl = false;
   var _currentUrl = false;
+  var _lightboxTitle = '';
   var refreshOnClose = false;
   // Elements
   var _modal, _modalBody, _clickedButton = null;
@@ -93,6 +94,14 @@ VuFind.lightbox = (function() {
     // information about which button was clicked here as checking focused button
     // doesn't work on all browsers and platforms.
     _modalBody.find('[type=submit]').click(_storeClickedStatus);
+    // Set or update title if we have one
+    if (_lightboxTitle != '') {
+      var h2 = _modalBody.find('h2:first-child');
+      if (h2.length == 0) {
+        h2 = $('<h2/>').prependTo(_modalBody);
+      }
+      h2.text(_lightboxTitle);
+    }
 
     var forms = _modalBody.find('form:not([data-lightbox-ignore])');
     for (var i=0;i<forms.length;i++) {
@@ -179,6 +188,7 @@ VuFind.lightbox = (function() {
    * data-lightbox-href = go to this url instead
    * data-lightbox-ignore = do not open this link in lightbox
    * data-lightbox-post = post data
+   * data-lightbox-title = Lightbox title (overrides any title the page provides)
    */
   var _constrainLink = function(event) {
     if (typeof $(this).data('lightboxIgnore') != 'undefined') {
@@ -191,6 +201,7 @@ VuFind.lightbox = (function() {
         obj.type = 'POST';
         obj.data = $(this).data('lightboxPost');
       }
+      _lightboxTitle = $(this).data('lightboxTitle');
       ajax(obj);
       _currentUrl = this.href;
       VuFind.modal('show');


### PR DESCRIPTION
The previous lightbox implementation used the title attribute of a link for the lightbox title. This PR adds the equivalent functionality but with a data-lightbox-title attribute so that it doesn't get mixed with the link title.

We are currently missing this e.g. in holds where we used to include in the title a bit more information on which item is being requested, and this data is not immediately available in the hold action. 