### PR TITLE
While it doesn't make sense to display a request group for an item ho…

### DIFF
--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -16,7 +16,7 @@
   <form class="form-horizontal" method="post" name="placeHold">
     <?=$this->flashmessages()?>
     <? if (in_array("comments", $this->extraHoldFields)): ?>
-      <div class="form-group">
+      <div class="form-group hold-comment">
         <label class="col-sm-3 control-label"><?=$this->transEsc("Comments")?>:</label>
         <div class="col-sm-9">
           <textarea rows="3" cols="20" name="gatheredDetails[comment]" class="form-control"><?=isset($this->gatheredDetails['comment']) ? $this->escapeHtml($this->gatheredDetails['comment']) : ''?></textarea>
@@ -25,7 +25,7 @@
     <? endif; ?>
 
     <? if (in_array("requiredByDate", $this->extraHoldFields)): ?>
-      <div class="form-group">
+      <div class="form-group hold-required-by">
         <label class="col-sm-3 control-label"><?=$this->transEsc("hold_required_by")?>:</label>
         <div class="col-sm-9">
           <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="8" class="form-control"/>
@@ -34,12 +34,8 @@
       </div>
     <? endif; ?>
 
-    <? $showRequestGroups = in_array("requestGroup", $this->extraHoldFields)
-        && (empty($this->gatheredDetails['level'])
-            || $this->gatheredDetails['level'] != 'copy');
-    ?>
     <? if ($this->requestGroupNeeded): ?>
-      <div class="form-group">
+      <div class="form-group hold-request-group">
         <?
           if (isset($this->gatheredDetails['requestGroupId']) && $this->gatheredDetails['requestGroupId'] !== "") {
               $selected = $this->gatheredDetails['requestGroupId'];
@@ -57,7 +53,7 @@
           <? endif; ?>
           <? foreach ($this->requestGroups as $group): ?>
             <option value="<?=$this->escapeHtmlAttr($group['id'])?>"<?=($selected == $group['id']) ? ' selected="selected"' : ''?>>
-              <?=$this->escapeHtml($group['name'])?>
+              <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
             </option>
           <? endforeach; ?>
           </select>
@@ -76,7 +72,7 @@
         }
       ?>
       <? if ($this->requestGroupNeeded): ?>
-        <div class="form-group">
+        <div class="form-group hold-pickup-location">
           <label id="pickUpLocationLabel" class="col-sm-3 control-label"><i></i> <?=$this->transEsc("pick_up_location")?>:
             <? if (in_array("requestGroup", $this->extraHoldFields)): ?>
               <noscript> (<?=$this->transEsc("Please enable JavaScript.")?>)</noscript>
@@ -92,8 +88,8 @@
             </select>
           </div>
         </div>
-      <? elseif (count($this->pickup) > 1): ?>
-        <div class="form-group">
+      <? elseif ($this->pickup): ?>
+        <div class="form-group hold-pickup-location">
           <label class="col-sm-3 control-label"><?=$this->transEsc("pick_up_location")?>:</label>
           <div class="col-sm-9">
             <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" class="form-control">
@@ -104,7 +100,7 @@
             <? endif; ?>
             <? foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
-                <?=$this->escapeHtml($lib['locationDisplay'])?>
+                <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
             <? endforeach; ?>
             </select>

--- a/themes/jquerymobile/templates/record/hold.phtml
+++ b/themes/jquerymobile/templates/record/hold.phtml
@@ -18,21 +18,21 @@
       <form method="post" data-ajax="false">
 
         <? if (in_array("comments", $this->extraHoldFields)): ?>
-          <div>
+          <div class="hold-comment">
           <strong><?=$this->transEsc("Comments")?>:</strong><br/>
           <textarea rows="3" cols="20" name="gatheredDetails[comment]"><?=isset($this->gatheredDetails['comment']) ? $this->escapeHtml($this->gatheredDetails['comment']) : ''?></textarea>
           </div>
         <? endif; ?>
 
         <? if (in_array("requiredByDate", $this->extraHoldFields)): ?>
-          <div>
+          <div class="hold-required-by">
           <strong><?=$this->transEsc("hold_required_by")?>: </strong>
           <div id="requiredByHolder"><input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtml($this->gatheredDetails['requiredBy']) : $this->escapeHtml($this->defaultRequiredDate)?>" size="8" /> <strong>(<?=$this->dateTime()->getDisplayDateFormat()?>)</strong></div>
           </div>
         <? endif; ?>
 
         <? if ($this->requestGroupNeeded): ?>
-          <div>
+          <div class="hold-request-group">
             <?
               if (isset($this->gatheredDetails['requestGroupId']) && $this->gatheredDetails['requestGroupId'] !== "") {
                   $selected = $this->gatheredDetails['requestGroupId'];
@@ -49,7 +49,7 @@
             <? endif; ?>
             <? foreach ($this->requestGroups as $group): ?>
               <option value="<?=$this->escapeHtmlAttr($group['id'])?>"<?=($selected == $group['id']) ? ' selected="selected"' : ''?>>
-                <?=$this->transEsc('location_' . $group['name'], array(), $group['name'])?>
+                <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
               </option>
             <? endforeach; ?>
             </select>
@@ -66,7 +66,7 @@
                 $selected = $this->defaultPickup;
             }
           ?>
-          <div>
+          <div class="hold-pickup-location">
           <? if ($this->requestGroupNeeded): ?>
             <span id="pickUpLocationLabel"><strong><?=$this->transEsc("pick_up_location")?>:
               <noscript> (<?=$this->transEsc("Please enable JavaScript.")?>)</noscript>
@@ -78,7 +78,7 @@
               </option>
               <? endif; ?>
             </select>
-          <? elseif (count($this->pickup) > 1): ?>
+          <? elseif ($this->pickup): ?>
             <strong><?=$this->transEsc("pick_up_location")?>:</strong><br/>
             <select name="gatheredDetails[pickUpLocation]">
             <? if ($selected === false): ?>
@@ -88,7 +88,7 @@
             <? endif; ?>
             <? foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
-                <?=$this->escapeHtml($lib['locationDisplay'])?>
+                <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
             <? endforeach; ?>
             </select>


### PR DESCRIPTION
…ld, take it into account in case it imposes limits to available pickup locations. Display pickup location selection in the hold form even when there's a single one and allow translation of request groups and pickup locations.

So we have sound logic to not display the request group selection for item holds, but it may still limit what pickup locations are available, so let the driver know the request group when fetching pickup locations. 

Also the pickup location is useful information for the user even if it cannot be changed, so always display it. It can still be hidden with the added css class or the displayed choices can be improved with translations.