### PR TITLE
Remove batch record loading support from Primo backend as it doesn't …

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -28,8 +28,6 @@
  */
 namespace VuFindSearch\Backend\Primo;
 
-use VuFindSearch\Feature\RetrieveBatchInterface;
-
 use VuFindSearch\Query\AbstractQuery;
 
 use VuFindSearch\ParamBag;
@@ -49,7 +47,7 @@ use VuFindSearch\Backend\Exception\BackendException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class Backend extends AbstractBackend implements RetrieveBatchInterface
+class Backend extends AbstractBackend
 {
     /**
      * Connector.
@@ -150,52 +148,6 @@ class Backend extends AbstractBackend implements RetrieveBatchInterface
         $collection = $this->createRecordCollection($response);
         $this->injectSourceIdentifier($collection);
         return $collection;
-    }
-
-    /**
-     * Retrieve a batch of documents.
-     *
-     * @param array    $ids    Array of document identifiers
-     * @param ParamBag $params Search backend parameters
-     *
-     * @return RecordCollectionInterface
-     */
-    public function retrieveBatch($ids, ParamBag $params = null)
-    {
-        $onCampus = (null !== $params) ? $params->get('onCampus') : [false];
-        $onCampus = $onCampus ? $onCampus[0] : false;
-
-        // Load 100 records at a time; this is a good number to avoid memory
-        // problems while still covering a lot of ground.
-        $pageSize = 100;
-
-        // Retrieve records a page at a time:
-        $results = false;
-        while (count($ids) > 0) {
-            $currentPage = array_splice($ids, 0, $pageSize, []);
-
-            try {
-                $response = $this->connector->getRecords(
-                    $currentPage, $this->connector->getInstitutionCode(), $onCampus
-                );
-            } catch (\Exception $e) {
-                throw new BackendException(
-                    $e->getMessage(),
-                    $e->getCode(),
-                    $e
-                );
-            }
-            $next = $this->createRecordCollection($response);
-            if (!$results) {
-                $results = $next;
-            } else {
-                foreach ($next->getRecords() as $record) {
-                    $results->add($record);
-                }
-            }
-        }
-        $this->injectSourceIdentifier($results);
-        return $results;
     }
 
     /**


### PR DESCRIPTION
…work properly (too many hits, a too long query will fail).

Sadly it seems the Primo API can't really handle a request for multiple records, so better to resort to loading them one by one. Otherwise users get locked out of their favorites as the API balks, and wrong records are loaded leading to only cached data being displayed.