### PR TITLE
Made AND the default operator for advanced search queries so that any…

### DIFF
--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -184,16 +184,14 @@ abstract class QueryAdapter
                 if ($lookfor[$i] != '') {
                     // Use default fields if not set
                     $typeArr = $request->get('type' . $groupCount);
-                    $handler = (isset($typeArr[$i]) && !empty($typeArr[$i]))
-                        ? $typeArr[$i] : $defaultHandler;
+                    $handler = !empty($typeArr[$i]) ? $typeArr[$i] : $defaultHandler;
 
                     $opArr = $request->get('op' . $groupCount);
-                    $operator = (isset($opArr[$i]) && !empty($opArr[$i]))
-                        ? $opArr[$i] : null;
+                    $operator = !empty($opArr[$i]) ? $opArr[$i] : null;
 
                     // Add term to this group
                     $boolArr = $request->get('bool' . $groupCount);
-                    $lastBool = isset($boolArr[0]) ? $boolArr[0] : null;
+                    $lastBool = isset($boolArr[0]) ? $boolArr[0] : 'AND';
                     $group[] = new Query($lookfor[$i], $handler, $operator);
                 }
             }
@@ -209,7 +207,7 @@ abstract class QueryAdapter
         }
 
         return (count($groups) > 0)
-            ? new QueryGroup($request->get('join'), $groups)
+            ? new QueryGroup($request->get('join', 'AND'), $groups)
             : new Query();
     }
 


### PR DESCRIPTION
… missing parameters don't make the search fail.