### PR TITLE
Truncate varchar metadata columns on insert into resource table

### DIFF
--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -70,8 +70,8 @@ CREATE TABLE `oai_resumption` (
 CREATE TABLE `resource` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `record_id` varchar(255) NOT NULL DEFAULT '',
-  `title` varchar(200) NOT NULL DEFAULT '',
-  `author` varchar(200) DEFAULT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
+  `author` varchar(255) DEFAULT NULL,
   `year` mediumint(6) DEFAULT NULL,
   `source` varchar(50) NOT NULL DEFAULT 'Solr',
   PRIMARY KEY (`id`),

--- a/module/VuFind/src/VuFind/Db/Row/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Row/Resource.php
@@ -155,13 +155,23 @@ class Resource extends RowGateway implements \VuFind\Db\Table\DbTableAwareInterf
     public function assignMetadata($driver, \VuFind\Date\Converter $converter)
     {
         // Grab title -- we have to have something in this field!
-        $this->title = $driver->tryMethod('getSortTitle');
+        $this->title = mb_substr(
+            $driver->tryMethod('getSortTitle'),
+            0,
+            255,
+            "UTF-8"
+        );
         if (empty($this->title)) {
             $this->title = $driver->getBreadcrumb();
         }
 
         // Try to find an author; if not available, just leave the default null:
-        $author = $driver->tryMethod('getPrimaryAuthor');
+        $this->title = mb_substr(
+            $driver->tryMethod('getPrimaryAuthor'),
+            0,
+            255,
+            "UTF-8"
+        );
         if (!empty($author)) {
             $this->author = $author;
         }


### PR DESCRIPTION
If return value of RecordDriver->getSortTitle() or RecordDriver->getPrimaryAuthor() exceeds the maximum length of columns resource.title or resource.author defined both as VARCHAR(200) writing the metadata compiled in \VuFind\Db\Row\Resource::assignMetadata to the database will throw a fatal error: "Data too long for column 'title' at row 1".

This results from MySQL databases being by default in mode "STRICT_TRANS_TABLES" (see http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_strict_trans_tables) so that too long input values are not truncated automatically.

This pull request adds a default truncation of of the input values of resource.title and resource.author limiting their length to 255 chars. To avoid future confusion when extending resource.title and resource.author to the maximum length of VARCHAR, the column's datatypes where changed from VARCHAR(200) to VARCHAR(255).