### PR TITLE
Include host name in exceptions logged at levels 2 or 3.

### DIFF
--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -288,6 +288,8 @@ class Logger extends BaseLogger implements ServiceLocatorAwareInterface
             . 'Referer = ' . $referer . ', '
             . 'User Agent = '
             . $server->get('HTTP_USER_AGENT') . ', '
+            . 'Host = '
+            . $server->get('HTTP_HOST') . ', '
             . 'Request URI = '
             . $server->get('REQUEST_URI') . ')';
         $detailedServer = "\nServer Context:\n"
@@ -329,7 +331,7 @@ class Logger extends BaseLogger implements ServiceLocatorAwareInterface
 
         $this->log(BaseLogger::CRIT, $errorDetails);
     }
-    
+
     /**
      * Convert function argument to a loggable string
      *
@@ -339,7 +341,7 @@ class Logger extends BaseLogger implements ServiceLocatorAwareInterface
      */
     protected function argumentToString($arg)
     {
-        
+
         if (is_object($arg)) {
             return get_class($arg) . ' Object';
         }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Log/LoggerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Log/LoggerTest.php
@@ -53,11 +53,12 @@ Array
 (
     [REMOTE_ADDR] => 1.2.3.4
     [HTTP_USER_AGENT] => Fake browser
+    [HTTP_HOST] => localhost:80
     [REQUEST_URI] => /foo/bar
 )
 CONTEXT;
             return $a[1] === 'test'
-                && $a[2] === 'test(Server: IP = 1.2.3.4, Referer = none, User Agent = Fake browser, Request URI = /foo/bar)'
+                && $a[2] === 'test(Server: IP = 1.2.3.4, Referer = none, User Agent = Fake browser, Host = localhost:80, Request URI = /foo/bar)'
                 && false !== strpos($a[3], $a[2])
                 && false !== strpos($a[3], 'Backtrace:')
                 && false !== strpos($a[3], 'line')
@@ -85,6 +86,7 @@ CONTEXT;
                 [
                     'REMOTE_ADDR' => '1.2.3.4',
                     'HTTP_USER_AGENT' => 'Fake browser',
+                    'HTTP_HOST' => 'localhost:80',
                     'REQUEST_URI' => '/foo/bar'
                 ]
             );


### PR DESCRIPTION
This is important for multisite services to identify which instance reported the exception when name-based virtual hosts are used.