### PR TITLE
fixed case sensitive locale names for unix locales

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormat.php
@@ -92,7 +92,7 @@ class SafeMoneyFormat extends AbstractHelper
         // fail if locale has comma as a decimal separator.
         // (see https://bugs.php.net/bug.php?id=54538)
         $locale = setlocale(LC_NUMERIC, 0);
-        setlocale(LC_NUMERIC, ['en_us.UTF-8', 'en_us.UTF8', 'en_us']);
+        setlocale(LC_NUMERIC, ['en_us.UTF-8', 'en_us.UTF8', 'en_us', 'en_US.UTF-8', 'en_US.UTF8', 'en_US']);
         $result = $escaper(
             $this->formatter->formatCurrency((float)$number, $currency)
         );


### PR DESCRIPTION
on linux systems its mandatory to preserve the case sensitive naming of locales. otherwise the default locale is taken which can lead to confusing results.

see the issue finc/docker-vufind2#1