### PR TITLE
Fix lightbox submit form action handling on Microsoft Edge.

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -266,8 +266,8 @@ VuFind.register('lightbox', function() {
     _lightboxTitle = submit.data('lightboxTitle') || $(form).data('lightboxTitle') || '';
     // Get Lightbox content
     ajax({
-      url: form.action || _currentUrl,
-      method: form.method || 'GET',
+      url: $(form).attr('action') || _currentUrl,
+      method: $(form).attr('method') || 'GET',
       data: data
     });
 


### PR DESCRIPTION
Microsoft Edge returns the URL of the current page in form.action if there is no action attribute in the form element. This resulted in the current page URL being used instead of the correct address where the lightbox was loaded from e.g. when submitting a hold form.