### PR TITLE
Fix invalid yaml escape sequences

### DIFF
--- a/config/vufind/searchspecs.yaml
+++ b/config/vufind/searchspecs.yaml
@@ -487,20 +487,20 @@ CallNumber:
   CustomMunge:
     callnumber_exact:
       # Strip whitespace and quotes:
-      - [preg_replace, '/[ "]/', ""]
+      - [preg_replace, '/[ "]/', '']
       # Escape colons (unescape first to avoid double-escapes):
-      - [preg_replace, "/(\\\:)/", ':']
+      - [preg_replace, '/(\\:)/', ':']
       - [preg_replace, '/:/', '\:']
       # Strip pre-existing trailing asterisks:
-      - [preg_replace, "/\*+$/", ""]
+      - [preg_replace, '/\*+$/', '']
     callnumber_fuzzy:
       # Strip whitespace and quotes:
-      - [preg_replace, '/[ "]/', ""]
+      - [preg_replace, '/[ "]/', '']
       # Escape colons (unescape first to avoid double-escapes):
-      - [preg_replace, "/(\\\:)/", ':']
+      - [preg_replace, '/(\\:)/', ':']
       - [preg_replace, '/:/', '\:']
       # Strip pre-existing trailing asterisks, then add a new one:
-      - [preg_replace, "/\*+$/", ""]
+      - [preg_replace, '/\*+$/', '']
       - [append, "*"]
   QueryFields:
     callnumber-search:


### PR DESCRIPTION
As a result of using double quotes, some of the escape sequences in the searchspecs.yaml file were invalid. While symfony/yaml 2.* is more lenient towards invalid escape sequences (assuming the invalid sequence simply meant `\\` instead of the invalid escape sequence), the newer 3.0 package no longer accepts invalid sequences, which would cause the current version of the file to cause a parse error. This fix produces identical php array compared to the previous version and also makes the file parsable on symfony/yaml 3.0.