### PR TITLE
[deb] Support for php7 and mariadb

### DIFF
--- a/packages/DEBIAN/control
+++ b/packages/DEBIAN/control
@@ -1,10 +1,11 @@
 Package: vufind
-Version: 3.0 
-Section: World Wide Web 
+Version: 3.0
+Section: World Wide Web
 Priority: Optional
 Architecture: all 
 Depends: apache2,
          default-jdk,
+         libapache2-mod-php5 | libapache2-mod-php,
          mysql-server | virtual-mysql-server-core,
          php-pear,
          php5 | php,

--- a/packages/DEBIAN/control
+++ b/packages/DEBIAN/control
@@ -1,9 +1,21 @@
 Package: vufind
-Version: 3.0
-Section: World Wide Web
+Version: 3.0 
+Section: World Wide Web 
 Priority: Optional
-Architecture: all
-Depends: default-jdk, apache2, php5, php5-dev, php-pear, php5-intl, php5-json, php5-ldap, php5-mcrypt, php5-mysql, php5-xsl, php5-gd, mysql-server
+Architecture: all 
+Depends: apache2,
+         default-jdk,
+         mysql-server | virtual-mysql-server-core,
+         php-pear,
+         php5 | php,
+         php5-dev | php-dev,
+         php5-gd | php-gd,
+         php5-intl | php-intl,
+         php5-json | php-json,
+         php5-ldap | php-ldap,
+         php5-mcrypt | php-mcrypt,
+         php5-mysql | php-mysql,
+         php5-xsl | php-xml
 Maintainer: VuFind Project Administration Team <vufind-admins@lists.sourceforge.net>
 Homepage: http://vufind.org/
 Description: A library resource discovery portal
@@ -11,4 +23,3 @@ Description: A library resource discovery portal
  libraries. The goal of VuFind is to enable your users to search and browse
  through all of your library's resources by replacing the traditional OPAC.
  You can find more information at http://vufind.org.
-


### PR DESCRIPTION
# TO-DO
- [x] Confirm php7 support using debian sid.

As discussed on https://sourceforge.net/p/vufind/mailman/message/35002108/

This is the main change i would like to make in time to 3.0 release. The packaging process needs other changes that i'm planning to discuss and make (if you're willing) but they're not so much important as this one. This will make vufind compatible with php7 and mariadb de facto, because as long as vufind itself already support them its deb package don't.

I would like to point out that this changes won't break the previous behaviour, it will just introduce new alternative dependencies based on virtual packages that can either provide php5 or php7, i did not test them yet, i'm planning to virtualize a debian sid to do so but it's very unlikelly that something is wrong and if it is, it would just break the php7 use case.

How are you guys on the release schedule? I'm planning to make the test at about this friday, but i understand that i may be pushing you guys to close to the deadline and if that's the case i can hurry up and test it tomorrow or wednesday.

PS.: If i'm not wrong, only members of the project can label PRs, so i'm leaving this one without it.