### PR TITLE
Fix request group handling in hold function when there are more than …

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -100,7 +100,8 @@ trait HoldsTrait
         $requestGroupNeeded = in_array('requestGroup', $extraHoldFields)
             && !empty($requestGroups)
             && (empty($gatheredDetails['level'])
-                || $gatheredDetails['level'] != 'copy');
+                || ($gatheredDetails['level'] != 'copy'
+                    || count($requestGroups) > 1));
 
         $pickupDetails = $gatheredDetails;
         if (!$requestGroupNeeded && !empty($requestGroups)


### PR DESCRIPTION
…one request group for an item level hold.

I didn't realize that there can actually be more than one request group for an item level hold, so change the previously added check to make sure the request group can be properly selected in that case. 