### PR TITLE
Change the publicNotes to item_notes

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -801,7 +801,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 'item_id'      => $rowItem['ITEMNO'],
                 'status'       => $status,
                 'location'     => $loc,
-                'publicNotes'  => $rowItem['PUBLICNOTES'],
+                'item_notes'  => (null == $rowItem['PUBLICNOTES']
+                    ? null : [ $rowItem['PUBLICNOTES'] ]),
                 'notes'        => $notes["MFHD"],
                 //'reserve'      => (null == $rowItem['RESERVES'])
                 //    ? 'N' : $rowItem['RESERVES'],


### PR DESCRIPTION
Changing publicNotes to item_notes. This change will allow item notes to be display on the holdings page.

Also has to be sent as an array, since the value comes from Koha's Item record (952$z) which only allows for one note per record.