### PR TITLE
Added support for filtering call slips based on their status in the V…

### DIFF
--- a/config/vufind/Voyager.ini
+++ b/config/vufind/Voyager.ini
@@ -42,6 +42,16 @@ login_field = LAST_NAME
 ; fund tree to filter out unwanted values.  Leave it commented out to get all funds.
 ;parent_fund = 0
 
+; This section controls call slip behavior (storage retrieval requests in VuFind).
+[StorageRetrievalRequests]
+
+; Colon-separated list of call slip statuses (see CALL_SLIP_STATUS_TYPE table in 
+; Voyager's database) that control whether a call slip is displayed. Current Voyager 
+; versions (as of May 2016) don't immediately delete a call slip from the database 
+; when it has been processed and converted to a hold, which may confuse users.  
+;display_statuses = 1:2:3:5:8:9
+
+
 ; Settings for controlling how holdings are displayed
 [Holdings]
 ; How purchase history is displayed. Supported values are:

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -218,6 +218,12 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ;helpText = "Help text for all languages."
 ;helpText[en-gb] = "Help text for English language."
 
+; Colon-separated list of call slip statuses (see CALL_SLIP_STATUS_TYPE table in 
+; Voyager's database) that control whether a call slip is displayed. Current Voyager 
+; versions (as of May 2016) don't immediately delete a call slip from the database 
+; when it has been processed and converted to a hold, which may confuse users.  
+;display_statuses = 1:2:3:5:8:9
+
 ; This section controls UB (Universal Borrowing, ILL in VuFind) behavior. To enable,
 ; uncomment (at minimum) the HMACKeys and extraFields settings below. See also
 ; section ILLRequestSources for mapping between patron ID's and UB libraries.

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -1794,6 +1794,18 @@ class Voyager extends AbstractBase
             'BIB_TEXT.BIB_ID = CALL_SLIP.BIB_ID'
         ];
 
+        if (!empty($this->config['StorageRetrievalRequests']['display_statuses'])) {
+            $statuses = preg_replace(
+                '/[^:\d]*/',
+                '',
+                $this->config['StorageRetrievalRequests']['display_statuses']
+            );
+            if ($statuses) {
+                $sqlWhere[] = 'CALL_SLIP.STATUS IN ('
+                    . str_replace(':', ',', $statuses) . ')';
+            }
+        }
+
         // Order by
         $sqlOrderBy = [
             "to_char(CALL_SLIP.DATE_REQUESTED, 'YYYY-MM-DD HH24:MI:SS')"


### PR DESCRIPTION
…oyager driver.

Voyager converts processed call slips to holds, but the call slip isn't moved to the archive table until Circjob 8 is run. Since the call slips remaining visible may confuse users, make it possible to limit which statuses are actually displayed.