### PR TITLE
KohaILSDI Driver Update: Remove stocknumber check in getNewItems()

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -859,7 +859,6 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         $sql = "SELECT distinct biblionumber as id
                 FROM items
                 WHERE itemlost = 0
-                   and stocknumber > 1
                    and dateaccessioned > DATE_ADD(CURRENT_TIMESTAMP,
                       INTERVAL -$daysOld day)
                 ORDER BY dateaccessioned DESC";


### PR DESCRIPTION
Remove stock number check in getNewItems().

Function now performs as expected.

Recommendation from Hugo Agud