### PR TITLE
Updated getTagList for mySQL 5.7.5+ compatibility

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Table/Tags.php
@@ -227,7 +227,7 @@ class Tags extends Gateway
             if (is_callable($extra_where)) {
                 $extra_where($select);
             }
-            $select->group('tags.tag');
+            $select->group('tags.id','tags.tag');
             switch ($sort) {
             case 'alphabetical':
                 $select->order(['tags.tag', 'cnt DESC']);


### PR DESCRIPTION
Updated GROUP BY clause to include both tags.id and tags.tag. Fixes bug that prevents tag autocomplete when using mySQL 5.7.5+
