### PR TITLE
Map multi valued ldap field to column in user table

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -464,10 +464,7 @@ database          = mysql://root@localhost/vufind
 
 ; LDAP is optional.  This section only needs to exist if the
 ; Authentication Method is set to LDAP.  When LDAP is active,
-; host, port, basedn and username are required.  The remaining
-; settings are optional, mapping fields in your LDAP schema
-; to fields in VuFind's database -- the more you fill in, the more
-; data will be imported from LDAP into VuFind.
+; host, port, basedn and username are required.
 ;[LDAP]
 ; Prefix the host with ldaps:// to use LDAPS; omit the prefix for standard
 ; LDAP with TLS.
@@ -475,6 +472,12 @@ database          = mysql://root@localhost/vufind
 ;port            = 389       ; LDAPS usually uses port 636 instead
 ;basedn          = "o=myuniversity.edu"
 ;username        = uid
+; separator string for mapping multi-valued ldap-fields to a user attribute
+; if no separator is given, only the first value is mapped to the given attribute
+;separator = ';'
+; Optional settings to map fields in your LDAP schema to fields in the user table
+; in VuFind's database -- the more you fill in, the more data will be imported
+; from LDAP into VuFind:
 ;firstname       = givenname
 ;lastname        = sn
 ;email           = mail
@@ -482,9 +485,6 @@ database          = mysql://root@localhost/vufind
 ;cat_password    =
 ;college         = studentcollege
 ;major           = studentmajor
-; separator string for mapping multi-valued ldap-fields to a user attribute
-; if no separator is given, only the first value is mapped to the given attribute
-separator = ';'
 ; If you need to bind to LDAP with a particular account before
 ; it can be searched, you can enter the necessary credentials
 ; here.  If this extra security measure is not needed, leave

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -482,6 +482,9 @@ database          = mysql://root@localhost/vufind
 ;cat_password    =
 ;college         = studentcollege
 ;major           = studentmajor
+; separator string for mapping multi-valued ldap-fields to a user attribute
+; if no separator is given, only the first value is mapped to the given attribute
+separator = ';'
 ; If you need to bind to LDAP with a particular account before
 ; it can be searched, you can enter the necessary credentials
 ; here.  If this extra security measure is not needed, leave

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -278,7 +278,7 @@ class LDAP extends AbstractBase
                     $configValue = $this->getSetting($field);
                     if ($data[$i][$j] == $configValue && !empty($configValue)) {
                         $value = $data[$i][$configValue];
-						// check if $configValue is a multi-valued field in LDAP
+                        // check if $configValue is a multi-valued field in LDAP
                         if (is_array($value)) {
                         	$value = serialize($value);
                         	$this->debug("found multi-valued field: $field = serialized value = $value");

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -277,14 +277,19 @@ class LDAP extends AbstractBase
                 foreach ($fields as $field) {
                     $configValue = $this->getSetting($field);
                     if ($data[$i][$j] == $configValue && !empty($configValue)) {
+                        
                         $value = $data[$i][$configValue];
-                        // check if $configValue is a multi-valued field in LDAP
-                        if (is_array($value)) {
-                        	$value = serialize($value);
-                        	$this->debug("found multi-valued field: $field = serialized value = $value");
+                        $seperator = $this->config->LDAP->separator;
+                        // if no separator is given map only the first value
+                        if (isset($separator)) {
+                            unset($value["count"]);
+                            $value = implode($seperator, $value);
                         } else {
-                        	$this->debug("found $field = $value");
+                            $value = $value[0];
                         }
+                        
+                        
+                        
                         if ($field != "cat_password") {
                             $user->$field = $value;
                         } else {

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -279,16 +279,17 @@ class LDAP extends AbstractBase
                     if ($data[$i][$j] == $configValue && !empty($configValue)) {
                         
                         $value = $data[$i][$configValue];
-                        $seperator = $this->config->LDAP->separator;
+                        $separator = $this->config->LDAP->separator;
                         // if no separator is given map only the first value
                         if (isset($separator)) {
-                            unset($value["count"]);
-                            $value = implode($seperator, $value);
+                            $tmp = [];
+                            for ($k = 0; $k < $value["count"]; $k++) {
+                                $tmp[] = $value[$k];
+                            }
+                            $value = implode($separator, $tmp);
                         } else {
                             $value = $value[0];
                         }
-                        
-                        
                         
                         if ($field != "cat_password") {
                             $user->$field = $value;

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -277,8 +277,14 @@ class LDAP extends AbstractBase
                 foreach ($fields as $field) {
                     $configValue = $this->getSetting($field);
                     if ($data[$i][$j] == $configValue && !empty($configValue)) {
-                        $value = $data[$i][$configValue][0];
-                        $this->debug("found $field = $value");
+                        $value = $data[$i][$configValue];
+						// check if $configValue is a multi-valued field in LDAP
+                        if (is_array($value)) {
+                        	$value = serialize($value);
+                        	$this->debug("found multi-valued field: $field = serialized value = $value");
+                        } else {
+                        	$this->debug("found $field = $value");
+                        }
                         if ($field != "cat_password") {
                             $user->$field = $value;
                         } else {

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -277,7 +277,6 @@ class LDAP extends AbstractBase
                 foreach ($fields as $field) {
                     $configValue = $this->getSetting($field);
                     if ($data[$i][$j] == $configValue && !empty($configValue)) {
-                        
                         $value = $data[$i][$configValue];
                         $separator = $this->config->LDAP->separator;
                         // if no separator is given map only the first value


### PR DESCRIPTION
Hi,

if using an LDAP for authentication config.ini allows to map fields from LDAP-Schema to fields in the user-Table. At the moment only single-valued fields are supported. This little code snippet checks if the ldap-field is multi-valued and serializes the data if necessary.
Are you interested in such an extension?

