### PR TITLE
Move cover URL generation to its own class.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -140,6 +140,7 @@ $config = [
             'VuFind\ContentExcerptsPluginManager' => 'VuFind\Service\Factory::getContentExcerptsPluginManager',
             'VuFind\ContentReviewsPluginManager' => 'VuFind\Service\Factory::getContentReviewsPluginManager',
             'VuFind\CookieManager' => 'VuFind\Service\Factory::getCookieManager',
+            'VuFind\Cover\Router' => 'VuFind\Service\Factory::getCoverRouter',
             'VuFind\DateConverter' => 'VuFind\Service\Factory::getDateConverter',
             'VuFind\DbAdapter' => 'VuFind\Service\Factory::getDbAdapter',
             'VuFind\DbAdapterFactory' => 'VuFind\Service\Factory::getDbAdapterFactory',

--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Cover image router
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2016.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind
+ * @package  Cover_Generator
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/configuration:external_content Wiki
+ */
+namespace VuFind\Cover;
+use VuFind\RecordDriver\AbstractBase as RecordDriver;
+
+/**
+ * Cover image router
+ *
+ * @category VuFind
+ * @package  Cover_Generator
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/configuration:external_content Wiki
+ */
+class Router
+{
+    /**
+     * Base URL for dynamic cover images.
+     *
+     * @var string
+     */
+    protected $dynamicUrl;
+
+    /**
+     * Constructor
+     *
+     * @param string $url Base URL for dynamic cover images.
+     */
+    public function __construct($url)
+    {
+        $this->dynamicUrl = $url;
+    }
+
+    /**
+     * Generate a thumbnail URL (return false if unsupported).
+     *
+     * @param RecordDriver $driver Record driver
+     * @param string       $size   Size of thumbnail (small, medium or large --
+     * small is default).
+     *
+     * @return string|bool
+     */
+    public function getUrl(RecordDriver $driver, $size = 'small')
+    {
+        // Try to build thumbnail:
+        $thumb = $driver->tryMethod('getThumbnail', [$size]);
+
+        // No thumbnail?  Return false:
+        if (empty($thumb)) {
+            return false;
+        }
+
+        // Array?  It's parameters to send to the cover generator:
+        if (is_array($thumb)) {
+            return $this->dynamicUrl . '?' . http_build_query($thumb);
+        }
+
+        // Default case -- return fixed string:
+        return $thumb;
+    }
+}

--- a/module/VuFind/src/VuFind/Service/Factory.php
+++ b/module/VuFind/src/VuFind/Service/Factory.php
@@ -216,6 +216,20 @@ class Factory
     }
 
     /**
+     * Construct the cover router.
+     *
+     * @param ServiceManager $sm Service manager.
+     *
+     * @return \VuFind\Cover\Router
+     */
+    public static function getCoverRouter(ServiceManager $sm)
+    {
+        $base = $sm->get('ControllerPluginManager')->get('url')
+            ->fromRoute('cover-show');
+        return new \VuFind\Cover\Router($base);
+    }
+
+    /**
      * Construct the date converter.
      *
      * @param ServiceManager $sm Service manager.

--- a/module/VuFind/src/VuFind/View/Helper/Root/Factory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Factory.php
@@ -367,9 +367,13 @@ class Factory
      */
     public static function getRecord(ServiceManager $sm)
     {
-        return new Record(
+        $helper = new Record(
             $sm->getServiceLocator()->get('VuFind\Config')->get('config')
         );
+        $helper->setCoverRouter(
+            $sm->getServiceLocator()->get('VuFind\Cover\Router')
+        );
+        return $helper;
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -26,6 +26,7 @@
  * @link     https://vufind.org/wiki/development Wiki
  */
 namespace VuFind\View\Helper\Root;
+use VuFind\Cover\Router as CoverRouter;
 use Zend\View\Exception\RuntimeException, Zend\View\Helper\AbstractHelper;
 
 /**
@@ -45,6 +46,13 @@ class Record extends AbstractHelper
      * @var \VuFind\View\Helper\Root\Context
      */
     protected $contextHelper;
+
+    /**
+     * Cover router
+     *
+     * @var CoverRouter
+     */
+    protected $coverRouter = null;
 
     /**
      * Record driver
@@ -70,6 +78,19 @@ class Record extends AbstractHelper
         $this->config = $config;
     }
 
+    /**
+     * Inject the cover router
+     *
+     * @param CoverRouter $router Cover router
+     *
+     * @return void
+     */
+    public function setCoverRouter($router)
+    {
+        $this->coverRouter = $router;
+    }
+
+    
     /**
      * Render a template within a record driver folder.
      *
@@ -552,22 +573,9 @@ class Record extends AbstractHelper
      */
     public function getThumbnail($size = 'small')
     {
-        // Try to build thumbnail:
-        $thumb = $this->driver->tryMethod('getThumbnail', [$size]);
-
-        // No thumbnail?  Return false:
-        if (empty($thumb)) {
-            return false;
-        }
-
-        // Array?  It's parameters to send to the cover generator:
-        if (is_array($thumb)) {
-            $urlHelper = $this->getView()->plugin('url');
-            return $urlHelper('cover-show') . '?' . http_build_query($thumb);
-        }
-
-        // Default case -- return fixed string:
-        return $thumb;
+        return $this->coverRouter
+            ? $this->coverRouter->getUrl($this->driver, $size)
+            : false;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Cover/RouterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Cover/RouterTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Cover Router Test Class
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2016.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Cover;
+use VuFind\Cover\Router, VuFindTest\RecordDriver\TestHarness;
+
+/**
+ * Cover Router Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RouterTest extends \VuFindTest\Unit\TestCase
+{
+    /**
+     * Get a fake record driver
+     *
+     * @param array $data Test data
+     *
+     * @return TestHarness
+     */
+    protected function getDriver($data)
+    {
+        $driver = new TestHarness();
+        $driver->setRawData($data);
+        return $driver;
+    }
+
+    /**
+     * Get a router to test
+     *
+     * @return Router
+     */
+    protected function getRouter()
+    {
+        return new Router('https://vufind.org/cover');
+    }
+
+    /**
+     * Test a record driver with no thumbnail data.
+     *
+     * @return void
+     */
+    public function testUnsupportedThumbnail()
+    {
+        $this->assertFalse(
+            $this->getRouter()->getUrl($this->getDriver([]))
+        );
+    }
+
+    /**
+     * Test a record driver with static thumbnail data.
+     *
+     * @return void
+     */
+    public function testStaticUrl()
+    {
+        $url = 'http://foo/bar';
+        $this->assertEquals(
+            $url, $this->getRouter()->getUrl($this->getDriver(['Thumbnail' => $url]))
+        );
+    }
+
+    /**
+     * Test a record driver with dynamic thumbnail data.
+     *
+     * @return void
+     */
+    public function testDynamicUrl()
+    {
+        $params = ['foo' => 'bar'];
+        $this->assertEquals(
+            'https://vufind.org/cover?foo=bar',
+            $this->getRouter()->getUrl($this->getDriver(['Thumbnail' => $params]))
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -384,7 +384,7 @@ class RecordTest extends \PHPUnit_Framework_TestCase
         // Hard-coded thumbnail:
         $driver = new \VuFindTest\RecordDriver\TestHarness();
         $driver->setRawData(['Thumbnail' => ['bar' => 'baz']]);
-        $record = $this->getRecord($driver, [], null, 'cover-show');
+        $record = $this->getRecord($driver);
         $this->assertEquals('http://foo/bar?bar=baz', $record->getThumbnail());
     }
 
@@ -518,6 +518,7 @@ class RecordTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->getMockResolver()));
         $config = is_array($config) ? new \Zend\Config\Config($config) : $config;
         $record = new Record($config);
+        $record->setCoverRouter(new \VuFind\Cover\Router('http://foo/bar'));
         $record->setView($view);
         return $record->__invoke($driver);
     }


### PR DESCRIPTION
- Allows easier code reuse.
- Eliminates redundant route calculation.