### PR TITLE
Fix warning on the holdings pages in apache when debug is enabled or disabled

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -639,7 +639,9 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
     {
 
         $this->debug(
-            "Function getHolding($id, " . implode(",", $patron) . ") called"
+            "Function getHolding($id, "
+               . implode(",", (array)$patron)
+               . ") called"
         );
 
         $started = microtime(true);


### PR DESCRIPTION
Wrapped a Debug statement around a if(debug_enabled) statement