### PR TITLE
Replaced empty() checks in pickup location AJAX calls with null check…

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AjaxController.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxController.php
@@ -1252,7 +1252,7 @@ class AjaxController extends AbstractBase
         $this->disableSessionWrites();  // avoid session write timing bug
         $id = $this->params()->fromQuery('id');
         $pickupLib = $this->params()->fromQuery('pickupLib');
-        if (empty($id) || empty($pickupLib)) {
+        if (null === $id || null === $pickupLib) {
             return $this->output(
                 $this->translate('bulk_error_missing'),
                 self::STATUS_ERROR,
@@ -1304,7 +1304,7 @@ class AjaxController extends AbstractBase
         $this->disableSessionWrites();  // avoid session write timing bug
         $id = $this->params()->fromQuery('id');
         $requestGroupId = $this->params()->fromQuery('requestGroupId');
-        if (empty($id) || empty($requestGroupId)) {
+        if (null === $id || null === $requestGroupId) {
             return $this->output(
                 $this->translate('bulk_error_missing'),
                 self::STATUS_ERROR,


### PR DESCRIPTION
…s so that zero and other values that empty() treat as empty are considered valid.