### PR TITLE
Tag-Search Results

### DIFF
--- a/module/VuFind/src/VuFind/Controller/TagController.php
+++ b/module/VuFind/src/VuFind/Controller/TagController.php
@@ -57,6 +57,9 @@ class TagController extends AbstractSearch
         if (!$this->tagsEnabled()) {
             throw new \Exception('Tags disabled');
         }
+        if ($this->params()->fromQuery('type') != 'tag') {
+            return $this->forwardTo('Search', 'Results');
+        }
         return $this->resultsAction();
     }
 }

--- a/module/VuFind/src/VuFind/Search/Tags/Options.php
+++ b/module/VuFind/src/VuFind/Search/Tags/Options.php
@@ -46,12 +46,42 @@ class Options extends \VuFind\Search\Base\Options
     public function __construct(\VuFind\Config\PluginManager $configLoader)
     {
         parent::__construct($configLoader);
-        $this->basicHandlers = ['tags' => 'Tag'];
-        $this->defaultSort = 'title';
-        $this->sortOptions = [
+        $searchSettings = $configLoader->get($this->searchIni);
+        if (isset($searchSettings->Basic_Searches)) {
+            foreach ($searchSettings->Basic_Searches as $key => $value) {
+                $this->basicHandlers[$key] = $value;
+            }
+        } else {
+            $this->basicHandlers = ['tags' => 'Tag'];
+        }
+        
+        if (isset($searchSettings->General->default_sort)) {
+           $this->defaultSort = $searchSettings->General->default_sort;
+        } else {
+            $this->defaultSort = 'title';
+        }
+        
+        if (isset($searchSettings->Sorting)) {
+            foreach ($searchSettings->Sorting as $key => $value) {
+                $this->sortOptions[$key] = $value;
+            }
+        } else {
+            $this->sortOptions = [
             'title' => 'sort_title', 'author' => 'sort_author',
             'year DESC' => 'sort_year', 'year' => 'sort_year asc'
-        ];
+            ];
+        }
+    }
+
+    /**
+     * Return the route name of the action used for performing advanced searches.
+     * Returns false if the feature is not supported.
+     *
+     * @return string|bool
+     */
+    public function getAdvancedSearchAction()
+    {
+        return 'search-advanced';
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Tags/Options.php
+++ b/module/VuFind/src/VuFind/Search/Tags/Options.php
@@ -71,6 +71,10 @@ class Options extends \VuFind\Search\Base\Options
             'year DESC' => 'sort_year', 'year' => 'sort_year asc'
             ];
         }
+        // Load autocomplete preference:
+        if (isset($searchSettings->Autocomplete->enabled)) {
+            $this->autocompleteEnabled = $searchSettings->Autocomplete->enabled;
+        }
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Tags/Options.php
+++ b/module/VuFind/src/VuFind/Search/Tags/Options.php
@@ -56,7 +56,7 @@ class Options extends \VuFind\Search\Base\Options
         }
         
         if (isset($searchSettings->General->default_sort)) {
-           $this->defaultSort = $searchSettings->General->default_sort;
+            $this->defaultSort = $searchSettings->General->default_sort;
         } else {
             $this->defaultSort = 'title';
         }


### PR DESCRIPTION
Updates the Search Tags results page so that the searchbox has the options of the regular Search Results searchbox, thus making the search results pages (Search/Results and Tag/Home) look similar to the end user. 

To Do: 
- need to make this configurable