### PR TITLE
Add a heading for the lightbox facet list, init lightbox_facets js on…

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -735,12 +735,15 @@ class AbstractSearch extends AbstractBase
             $this->params()->fromQuery('facetop', 'AND') == 'OR'
         );
         $list = $facets[$facet]['data']['list'];
+        $params->activateAllFacets();
+        $facetLabel = $params->getFacetLabel($facet);
 
         $view = $this->createViewModel(
             [
                 'data' => $list,
                 'exclude' => $this->params()->fromQuery('facetexclude', 0),
                 'facet' => $facet,
+                'facetLabel' => $facetLabel,
                 'operator' => $this->params()->fromQuery('facetop', 'AND'),
                 'page' => $page,
                 'results' => $results,

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -45,11 +45,11 @@
             'libphonenumber_tooshort' => 'libphonenumber_tooshort',
             'libphonenumber_tooshortidd' => 'libphonenumber_tooshortidd',
             'loading' => 'Loading',
-            'sms_success' => 'sms_success',
+            'more' => 'more',
             'number_thousands_separator' => [
                 'number_thousands_separator', null, ','
             ],
-           'more' => 'more'
+            'sms_success' => 'sms_success'
           )
         );
         // Add libphonenumber.js strings

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -46,7 +46,10 @@
             'libphonenumber_tooshortidd' => 'libphonenumber_tooshortidd',
             'loading' => 'Loading',
             'sms_success' => 'sms_success',
-            'number_thousands_separator' => ['number_thousands_separator', null, ',']
+            'number_thousands_separator' => [
+                'number_thousands_separator', null, ','
+            ],
+           'more' => 'more'
           )
         );
         // Add libphonenumber.js strings

--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -7,6 +7,7 @@
   }
   $urlBase = $this->url($facetLightbox) . $results->getUrlQuery()->getParams() . '&amp;facet=' . urlencode($this->facet) . '&amp;facetexclude=' . $this->exclude . '&amp;facetop=' . $this->operator;
 ?>
+<h2><?=$this->transEsc($this->facetLabel) ?></h2>
 <? if (count($this->sortOptions) > 1): ?>
   <label><?=$this->translate('Sort') ?></label>
   <div class="btn-group">
@@ -69,4 +70,4 @@
   <? endforeach; ?>
 </div>
 <button class="btn btn-default lightbox-only" data-dismiss="modal"><?=$this->translate('close') ?></button>
-<?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, 'VuFind.lightbox_facets.setup();', 'SET'); ?>
+<?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '(typeof VuFind.lightbox_facets !== "undefined") && VuFind.lightbox_facets.setup();', 'SET'); ?>

--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -9,14 +9,16 @@
 ?>
 <h2><?=$this->transEsc($this->facetLabel) ?></h2>
 <? if (count($this->sortOptions) > 1): ?>
-  <label><?=$this->translate('Sort') ?></label>
-  <div class="btn-group">
-    <? foreach ($this->sortOptions as $key=>$sort): ?>
-      <a href="<?=$urlBase . '&amp;facetpage=1&amp;facetsort=' . urlencode($key) ?>" class="btn btn-default js-facet-sort<? if($this->sort == $key): ?> active<? endif; ?>" data-sort="<?=$key ?>" data-lightbox-ignore><?=$this->translate($sort) ?></a>
-    <? endforeach; ?>
+  <div class="full-facet-sort-options">
+    <label><?=$this->translate('Sort') ?></label>
+    <div class="btn-group">
+      <? foreach ($this->sortOptions as $key=>$sort): ?>
+        <a href="<?=$urlBase . '&amp;facetpage=1&amp;facetsort=' . urlencode($key) ?>" class="btn btn-default js-facet-sort<? if($this->sort == $key): ?> active<? endif; ?>" data-sort="<?=$key ?>" data-lightbox-ignore><?=$this->translate($sort) ?></a>
+      <? endforeach; ?>
+    </div>
   </div>
 <? endif; ?>
-<div class="lightbox-scroll">
+<div class="lightbox-scroll full-facets">
   <? foreach ($this->sortOptions as $key=>$sort): ?>
     <? $active = $this->sort == $key; ?>
     <div class="full-facet-list list-group<? if(!$active): ?> hidden<? endif; ?>" id="facet-list-<?=$this->escapeHtmlAttr($key) ?>">


### PR DESCRIPTION
…ly if available and translate 'more' properly in JS.

The heading is for making the context more obvious especially in non-lightbox mode. I like it also in lightbox, but that might be partially because we have headings in all lightboxes (like there used to be before the new new lightbox).