### PR TITLE
Adds removeCachedData() to ILS\Driver\AbstractBase

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
@@ -155,4 +155,20 @@ abstract class AbstractBase implements DriverInterface
         ];
         $this->cache->setItem($this->formatCacheKey($key), $item);
     }
+
+    /**
+     * Helper function for removing cached data.
+     *
+     * @param string $key Cache entry key
+     *
+     * @return void
+     */
+    protected function removeCachedData($key)
+    {
+        // Don't write to cache if we don't have a cache!
+        if (null === $this->cache) {
+            return;
+        }
+        $this->cache->removeItem($this->formatCacheKey($key));
+    }
 }


### PR DESCRIPTION
This pull request adds functionality to remove cached data to ILS\Driver\AbstractBase (cf. https://github.com/vufind-org/vufind/pull/729#issuecomment-228401382).