### PR TITLE
Add related config fallback

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -375,8 +375,12 @@ abstract class AbstractBase implements \VuFind\Db\Table\DbTableAwareInterface,
     public function getRelated(\VuFind\Related\PluginManager $factory, $types = null)
     {
         if (is_null($types)) {
-            $types = isset($this->recordConfig->Record->related) ?
-                $this->recordConfig->Record->related : [];
+            if (isset($this->recordConfig->Record->related)) {
+                $types = $this->recordConfig->Record->related;
+            } else {
+                $types = isset($this->mainConfig->Record->related) ?
+                    $this->mainConfig->Record->related : [];
+            }
         }
         $retVal = [];
         foreach ($types as $current) {


### PR DESCRIPTION
The current code requires any RecordDriver.ini to contain the Record->related settings - by changing the code as below the related settings from mainConfig will be used as a fallback (as it is done elsewhere in the code e.g. the RecordDriver\AbstractBase->__constructor() mapping mainConfig to recordConfig if no recordConfig is passed to the constructer. 