### PR TITLE
Fixed favorite deletion to not handle the form submission as a login …

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -41,6 +41,22 @@ var VuFind = (function VuFind() {
     return _translations[op] || op;
   };
 
+  /**
+   * Reload the page without causing trouble with POST parameters while keeping hash
+   */
+  var refreshPage = function refreshPage() {
+    var parts = window.location.href.split('#');
+    if (typeof parts[1] === 'undefined') {
+      window.location.href = window.location.href;
+    } else {
+      var href = parts[0];
+      // Force reload with a timestamp
+      href += href.indexOf('?') === -1 ? '?_=' : '&_=';
+      href += new Date().getTime() + '#' + parts[1];
+      window.location.href = href;
+    }
+  }
+  
   //Reveal
   return {
     defaultSearchBackend: defaultSearchBackend,
@@ -48,6 +64,7 @@ var VuFind = (function VuFind() {
 
     addTranslations: addTranslations,
     init: init,
+    refreshPage: refreshPage,
     register: register,
     translate: translate
   };

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -41,21 +41,6 @@ VuFind.register('lightbox', function Lightbox() {
     return document.dispatchEvent(event);
   }
 
-  /**
-   * Reload the page without causing trouble with POST parameters while keeping hash
-   */
-  function _refreshPage() {
-    var parts = window.location.href.split('#');
-    if (typeof parts[1] === 'undefined') {
-      window.location.href = window.location.href;
-    } else {
-      var href = parts[0];
-      // Force reload with a timestamp
-      href += href.indexOf('?') === -1 ? '?_=' : '&_=';
-      href += new Date().getTime() + '#' + parts[1];
-      window.location.href = href;
-    }
-  }
   // Public: Present an alert
   function showAlert(message, _type) {
     var type = _type || 'info';
@@ -140,7 +125,7 @@ VuFind.register('lightbox', function Lightbox() {
     _xhr.always(function lbAjaxAlways() { _xhr = false; })
       .done(function lbAjaxDone(content, status, jq_xhr) {
         if (jq_xhr.status === 205) {
-          _refreshPage();
+          VuFind.refreshPage();
           return;
         }
         // Place Hold error isolation
@@ -154,7 +139,7 @@ VuFind.register('lightbox', function Lightbox() {
         }
         if ( // Close the lightbox after deliberate login
           obj.method                                                                 // is a form
-          && ((obj.url.match(/MyResearch/) && !obj.url.match(/Bulk/))                // that matches login/create account
+          && ((obj.url.match(/MyResearch/) && !obj.url.match(/Bulk/) && !obj.url.match(/Delete/)) // that matches login/create account
             || obj.url.match(/catalogLogin/))                                        // or catalog login for holds
           && $('<div/>').html(content).find('.flash-message.alert-danger').length === 0 // skip failed logins
         ) {
@@ -164,7 +149,7 @@ VuFind.register('lightbox', function Lightbox() {
           });
           if (_originalUrl.match(/UserLogin/) || obj.url.match(/catalogLogin/)) {
             if (eventResult) {
-              _refreshPage();
+              VuFind.refreshPage();
             }
             return false;
           } else {
@@ -313,7 +298,7 @@ VuFind.register('lightbox', function Lightbox() {
     _modalBody = _modal.find('.modal-body');
     _modal.on('hide.bs.modal', function lightboxHide() {
       if (VuFind.lightbox.refreshOnClose) {
-        _refreshPage();
+        VuFind.refreshPage();
       }
       _emit('VuFind.lightbox.closing');
     });

--- a/themes/bootstrap3/templates/myresearch/delete.phtml
+++ b/themes/bootstrap3/templates/myresearch/delete.phtml
@@ -1,7 +1,7 @@
-<form action="<?=$this->url('myresearch-delete')?>" method="post" name="bulkDelete">
+<h2><?=$this->transEsc('delete_selected_favorites')?></h2>
+ <form action="<?=$this->url('myresearch-delete')?>" method="post" name="bulkDelete" data-lightbox-onclose="VuFind.refreshPage();">
   <div id="popupMessages"><?=$this->flashmessages()?></div>
   <div id="popupDetails">
-    <h2><?=$this->transEsc('delete_selected_favorites')?></h2>
     <? if (!$this->list): ?>
       <div class="alert alert-info"><?=$this->transEsc("fav_delete_warn") ?></div>
     <? else: ?>


### PR DESCRIPTION
…event.

Deleting favorites refreshed the page only because the lightbox thought it was a login event. While I'd like to have a more robust mechanism for detecting login form submission, this change prevents MyResearch/Delete action from being handled as a login event. Subsequently a page refresh is required after deletion, so I moved the refreshPage method to VuFind common, used it in the deletion form and made the lightbox also use it.

I also moved the h2 of the delete screen to a more proper place before the form. While this doesn't make a difference in bootstrap3 or bootprint3, it's in line with other pages and makes it easier to customize in CSS how headings are displayed in the lightbox.