### PR TITLE
Proposing to change hardcoded prefix 'location_' to translatables domain 'Location::' in templates

### DIFF
--- a/languages/Location/de.ini
+++ b/languages/Location/de.ini
@@ -1,0 +1,1 @@
+; put your global location translations here

--- a/languages/Location/en.ini
+++ b/languages/Location/en.ini
@@ -1,0 +1,1 @@
+; put your global location translations here

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -55,7 +55,7 @@
 <? endif; ?>
 <? foreach ($holdings as $holding): ?>
 <h3>
-  <? $locationText = $this->transEsc('location_' . $holding['location'], array(), $holding['location']); ?>
+  <? $locationText = $this->transEsc('Location::' . $holding['location'], array(), $holding['location']); ?>
   <? if (isset($holding['locationhref']) && $holding['locationhref']): ?>
     <a href="<?=$holding['locationhref']?>" target="_blank"><?=$locationText?></a>
   <? else: ?>

--- a/themes/bootstrap3/templates/ajax/status-full.phtml
+++ b/themes/bootstrap3/templates/ajax/status-full.phtml
@@ -8,7 +8,7 @@
     <? if (++$i == 5) break; // Show no more than 5 items ?>
     <tr>
       <td class="fullLocation">
-        <? $locationText = $this->transEsc('location_' . $item['location'], array(), $item['location']); ?>
+        <? $locationText = $this->transEsc('Location::' . $item['location'], array(), $item['location']); ?>
         <? if (isset($item['locationhref']) && $item['locationhref']): ?>
           <a href="<?=$item['locationhref']?>" target="_blank"><?=$locationText?></a>
         <? else: ?>

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -115,12 +115,12 @@
             <? endif; ?>
 
             <? if (!empty($ilsDetails['institution_name']) && (empty($ilsDetails['borrowingLocation']) || $ilsDetails['institution_name'] != $ilsDetails['borrowingLocation'])): ?>
-              <strong><?=$this->transEsc('location_' . $ilsDetails['institution_name'], array(), $ilsDetails['institution_name'])?></strong>
+              <strong><?=$this->transEsc('Location::' . $ilsDetails['institution_name'], array(), $ilsDetails['institution_name'])?></strong>
               <br />
             <? endif; ?>
 
             <? if (!empty($ilsDetails['borrowingLocation'])): ?>
-              <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEsc('location_' . $ilsDetails['borrowingLocation'], array(), $ilsDetails['borrowingLocation'])?>
+              <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEsc('Location::' . $ilsDetails['borrowingLocation'], array(), $ilsDetails['borrowingLocation'])?>
               <br />
             <? endif; ?>
 

--- a/themes/bootstrap3/templates/myresearch/holds.phtml
+++ b/themes/bootstrap3/templates/myresearch/holds.phtml
@@ -98,7 +98,7 @@
             <? endif; ?>
 
             <? if (!empty($ilsDetails['requestGroup'])): ?>
-              <strong><?=$this->transEsc('hold_requested_group') ?>:</strong> <?=$this->transEsc('location_' . $ilsDetails['requestGroup'], array(), $ilsDetails['requestGroup'])?>
+              <strong><?=$this->transEsc('hold_requested_group') ?>:</strong> <?=$this->transEsc('Location::' . $ilsDetails['requestGroup'], array(), $ilsDetails['requestGroup'])?>
               <br />
             <? endif; ?>
 

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -104,7 +104,7 @@
             <? endif; ?>
             <? foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
-                <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
+                <?=$this->transEsc('Location::' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
             <? endforeach; ?>
             </select>

--- a/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
@@ -83,7 +83,7 @@
             <? endif; ?>
             <? foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
-                <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
+                <?=$this->transEsc('Location::' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
             <? endforeach; ?>
             </select>

--- a/themes/jquerymobile/templates/RecordTab/holdingsils.phtml
+++ b/themes/jquerymobile/templates/RecordTab/holdingsils.phtml
@@ -43,7 +43,7 @@
 <? endif; ?>
 <? foreach ($holdings as $holding): ?>
 <h4>
-  <? $locationText = $this->transEsc('location_' . $holding['location'], array(), $holding['location']); ?>
+  <? $locationText = $this->transEsc('Location::' . $holding['location'], array(), $holding['location']); ?>
   <? if (isset($holding['locationhref']) && $holding['locationhref']): ?>
     <a href="<?=$holding['locationhref']?>" rel="external"><?=$locationText?></a>
   <? else: ?>

--- a/themes/jquerymobile/templates/myresearch/checkedout.phtml
+++ b/themes/jquerymobile/templates/myresearch/checkedout.phtml
@@ -77,7 +77,7 @@
             <? endif; ?>
 
             <? if (!empty($ilsDetails['borrowingLocation'])): ?>
-              <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEsc('location_' . $ilsDetails['borrowingLocation'], array(), $ilsDetails['borrowingLocation'])?>
+              <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEsc('Location::' . $ilsDetails['borrowingLocation'], array(), $ilsDetails['borrowingLocation'])?>
               <br />
             <? endif; ?>
 

--- a/themes/jquerymobile/templates/myresearch/holds.phtml
+++ b/themes/jquerymobile/templates/myresearch/holds.phtml
@@ -61,7 +61,7 @@
             <? if (!empty($ilsDetails['requestGroup'])): ?>
               <p>
                 <strong><?=$this->transEsc('hold_requested_group') ?>:</strong>
-                <?=$this->transEsc('location_' . $ilsDetails['requestGroup'], array(), $ilsDetails['requestGroup'])?>
+                <?=$this->transEsc('Location::' . $ilsDetails['requestGroup'], array(), $ilsDetails['requestGroup'])?>
               </p>
             <? endif; ?>
 

--- a/themes/jquerymobile/templates/record/hold.phtml
+++ b/themes/jquerymobile/templates/record/hold.phtml
@@ -88,7 +88,7 @@
             <? endif; ?>
             <? foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
-                <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
+                <?=$this->transEsc('Location::' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
             <? endforeach; ?>
             </select>


### PR DESCRIPTION
A quick proposal for improving customization - if we change the 'location_' prefixes in the templates for translatables to the domain 'Location::' and add dummy files free for customization, those custom location strings would be properly isolated from other translatable strings in their own domain (not only by prefix) making use of the VuFind's domain feature.