### PR TITLE
Added id Prefix to getStatus() and getHolding()

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
@@ -139,6 +139,9 @@ class NoILS extends AbstractBase implements TranslatorAwareInterface
                 ]
             ];
         } else if ($useStatus == "marc") {
+            // Add idPrefix condition
+            $idPrefix = isset($this->config['settings']['idPrefix']) ? $this->config['settings']['idPrefix'] : null;
+            $id = isset($idPrefix) ? $idPrefix . $id : $id;
             // Retrieve record from index:
             $recordDriver = $this->getSolrRecord($id);
             return $this->getFormattedMarcDetails($recordDriver, 'MarcStatus');
@@ -218,6 +221,9 @@ class NoILS extends AbstractBase implements TranslatorAwareInterface
                 ]
             ];
         } elseif ($useHoldings == "marc") {
+            // Add idPrefix condition
+            $idPrefix = isset($this->config['settings']['idPrefix']) ? $this->config['settings']['idPrefix'] : null;
+            $id = isset($idPrefix) ? $idPrefix . $id : $id;
             // Retrieve record from index:
             $recordDriver = $this->getSolrRecord($id);
             return $this->getFormattedMarcDetails($recordDriver, 'MarcHoldings');


### PR DESCRIPTION
Added idPrefix parameter as an optional parameter to get records via getHolding() and getStatus(). This applies when NoILS is used in combo with MultiBackend.