### PR TITLE
Added idPrefix optional parameter

### DIFF
--- a/config/vufind/NoILS.ini
+++ b/config/vufind/NoILS.ini
@@ -14,6 +14,9 @@ useHoldings = none
 ; marc = Use information in the Marc Record Mapped from [MarcStatus]
 ; custom = use the options in the [Status] section below
 useStatus = none
+;idPrefix - Optional - Prefix for the catalogue/set of records managed by this driver.
+;                      To use in combination with MultiBackend driver.
+;idPrefix = "instance1
 
 [MarcHoldings]
 ; Used if useHoldings is set to "marc"


### PR DESCRIPTION
Added inside [settings] section the idPrefix parameter, optional, to use in combination with the MultiBackend driver.