### PR TITLE
Added a Coalesce of the location value

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -651,7 +651,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         $loc = $shelf = '';
         $reserves = "N";
 
-        $sql = "select i.itemnumber as ITEMNO, i.location, av.lib_opac AS LOCATION,
+        $sql = "select i.itemnumber as ITEMNO, i.location, 
+            COALESCE(av.lib_opac,av.lib, av.authorised_value) AS LOCATION,
             i.holdingbranch as HLDBRNCH, i.homebranch as HOMEBRANCH,
             i.reserves as RESERVES, i.itemcallnumber as CALLNO, i.barcode as BARCODE,
             i.copynumber as COPYNO, i.notforloan as NOTFORLOAN,


### PR DESCRIPTION
Added a coalesce of the location value, so it first checks for the OPAC Description, the general description, and if that doesn't exist it falls back to the Location's internal code.