### PR TITLE
Added linkPreviewsToCovers configuration setting.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -694,6 +694,12 @@ authors         = Wikipedia
 ; http://code.google.com/apis/books/branding.html before using Google Book Search.
 ;previews       = Google,OpenLibrary,HathiTrust
 
+; This setting controls whether or not cover images are linked to previews when
+; available. Legal settings are false (never link), * (always link; default), or
+; a comma-separated list of templates in which linking should occur (see coversize
+; above for a list of legal values).
+;linkPreviewsToCovers = *
+
 ; Possible HathiRights options = pd,ic,op,orph,und,umall,ic-world,nobody,pdus,cc-by,cc-by-nd,
 ; cc-by-nc-nd,cc-by-nc,cc-by-nc-sa,cc-by-sa,orphcand,cc-zero,und-world,icus
 ; Default is "pd,ic-world" if unset here.

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -442,6 +442,28 @@ class Record extends AbstractHelper
     }
 
     /**
+     * Should cover images be linked to previews (when applicable) in the provided
+     * template context?
+     *
+     * @param string $context Context of code being generated
+     *
+     * @return bool
+     */
+    protected function getPreviewCoverLinkSetting($context)
+    {
+        static $previewContexts = false;
+        if (false === $previewContexts) {
+            $previewContexts = isset($this->config->Content->linkPreviewsToCovers)
+                ? array_map(
+                    'trim',
+                    explode(',', $this->config->Content->linkPreviewsToCovers)
+                ) : ['*'];
+        }
+        return in_array('*', $previewContexts)
+            || in_array($context, $previewContexts);
+    }
+
+    /**
      * Get the rendered cover plus some useful parameters.
      *
      * @param string $context Context of code being generated
@@ -453,7 +475,8 @@ class Record extends AbstractHelper
     public function getCoverDetails($context, $default, $link = false)
     {
         $details = compact('link', 'context') + [
-            'driver' => $this->driver, 'cover' => false, 'size' => false
+            'driver' => $this->driver, 'cover' => false, 'size' => false,
+            'linkPreview' => $this->getPreviewCoverLinkSetting($context),
         ];
         $preferredSize = $this->getCoverSize($context, $default);
         if (empty($preferredSize)) {    // covers disabled entirely

--- a/themes/bootstrap3/js/preview.js
+++ b/themes/bootstrap3/js/preview.js
@@ -43,7 +43,7 @@ function applyPreviewUrl($link, url) {
 
     // Update associated record thumbnail, if any:
   $link.parents('.result,.record')
-        .find('.recordcover').parents('a').attr('href', url);
+        .find('.recordcover[data-linkpreview="true"]').parents('a').attr('href', url);
 }
 
 function processBookInfo(booksInfo, previewClass, viewOptions) {

--- a/themes/bootstrap3/templates/record/cover.phtml
+++ b/themes/bootstrap3/templates/record/cover.phtml
@@ -1,8 +1,8 @@
 <? /* Display thumbnail if appropriate: */ ?>
 <? if ($cover): ?>
   <? if ($this->link): ?><a href="<?=$this->escapeHtmlAttr($this->link)?>"><? endif; ?>
-  <img alt="<?=$this->transEsc('Cover Image')?>" class="recordcover" src="<?=$this->escapeHtmlAttr($cover); ?>"/>
+  <img alt="<?=$this->transEsc('Cover Image')?>" <? if ($linkPreview): ?>data-linkpreview="true" <? endif; ?>class="recordcover" src="<?=$this->escapeHtmlAttr($cover); ?>"/>
   <? if ($this->link): ?></a><? endif; ?>
 <? else: ?>
-  <img src="<?=$this->url('cover-unavailable')?>" class="recordcover" alt="<?=$this->transEsc('No Cover Image')?>"/>
+  <img src="<?=$this->url('cover-unavailable')?>" <? if ($linkPreview): ?>data-linkpreview="true" <? endif; ?>class="recordcover" alt="<?=$this->transEsc('No Cover Image')?>"/>
 <? endif; ?>


### PR DESCRIPTION
Currently, when the preview setting is turned on, all thumbnail links are replaced with links to third-party book previews. This is not always desirable. This pull request adds a config setting which allows preview linking to be either completely disabled, or else configured on a page-by-page basis.