### PR TITLE
Improved ILS availability system

### DIFF
--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -62,6 +62,7 @@ cancelStorageRetrievalRequests = 50
 changePassword = 33
 checkILLRequestBlock = 10
 checkILLRequestIsValid = 10
+checkIntermittentFailure = 0  ; chance of simulating low-level system failure
 checkRenewBlock = 25
 checkRequestBlock = 10
 checkRequestIsValid = 10

--- a/module/VuFind/src/VuFind/Controller/AjaxController.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxController.php
@@ -1500,4 +1500,32 @@ class AjaxController extends AbstractBase
     {
         return $this->getServiceLocator()->get('VuFind\SearchResultsPluginManager');
     }
+
+    /**
+     * Get Ils Status
+     *
+     * This will check the ILS for being online and will return the ils-offline
+     * template upon failure.
+     *
+     * @return \Zend\Http\Response
+     * @author André Lahmann <lahmann@ub.uni-leipzig.de>
+     */
+    protected function getIlsStatusAjax()
+    {
+        $this->disableSessionWrites();  // avoid session write timing bug
+        if ($this->getILS()->getOfflineMode(true) == 'ils-offline') {
+            $offlineModeMsg = $this->params()->fromPost(
+                'offlineModeMsg',
+                $this->params()->fromQuery('offlineModeMsg')
+            );
+            return $this->output(
+                $this->getViewRenderer()->render(
+                    'Helpers/ils-offline.phtml',
+                    compact('offlineModeMsg')
+                ),
+                self::STATUS_OK
+            );
+        }
+        return $this->output('', self::STATUS_OK);
+    }
 }

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -509,13 +509,7 @@ class InstallController extends AbstractBase
         if (in_array($config->Catalog->driver, ['Sample', 'Demo'])) {
             $status = false;
         } else {
-            try {
-                $catalog = $this->getILS();
-                $catalog->getStatus('1');
-                $status = true;
-            } catch (\Exception $e) {
-                $status = false;
-            }
+            $status = 'ils-offline' !== $this->getILS()->getOfflineMode(true);
         }
         return ['title' => 'ILS', 'status' => $status, 'fix' => 'fixils'];
     }

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -65,7 +65,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      *
      * @var object
      */
-    protected $driver;
+    protected $driver = null;
 
     /**
      * ILS configuration
@@ -89,11 +89,25 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     protected $titleHoldsMode = 'disabled';
 
     /**
+     * Driver plugin manager
+     *
+     * @var \VuFind\ILS\Driver\PluginManager
+     */
+    protected $driverManager;
+
+    /**
      * Configuration loader
      *
      * @var \VuFind\Config\PluginManager
      */
     protected $configReader;
+
+    /**
+     * Is the current ILS driver failing?
+     *
+     * @var bool
+     */
+    protected $failing = false;
 
     /**
      * Constructor
@@ -107,28 +121,15 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
         \VuFind\ILS\Driver\PluginManager $driverManager,
         \VuFind\Config\PluginManager $configReader
     ) {
-        $this->config = $config;
-        $this->configReader = $configReader;
-        if (!isset($this->config->driver)) {
+        if (!isset($config->driver)) {
             throw new \Exception('ILS driver setting missing.');
         }
-        $service = $this->config->driver;
-        if (!$driverManager->has($service)) {
-            throw new \Exception('ILS driver missing: ' . $service);
+        if (!$driverManager->has($config->driver)) {
+            throw new \Exception('ILS driver missing: ' . $config->driver);
         }
-        $this->setDriver($driverManager->get($service));
-
-        // If we're configured to fail over to the NoILS driver, we need
-        // to test if the main driver is working.
-        if (isset($this->config->loadNoILSOnFailure)
-            && $this->config->loadNoILSOnFailure
-        ) {
-            try {
-                $this->getDriver();
-            } catch (\Exception $e) {
-                $this->setDriver($driverManager->get('NoILS'));
-            }
-        }
+        $this->config = $config;
+        $this->configReader = $configReader;
+        $this->driverManager = $driverManager;
     }
 
     /**
@@ -152,24 +153,78 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function getDriverClass()
     {
-        return get_class($this->driver);
+        return get_class($this->getDriver(false));
+    }
+
+    /**
+     * Initialize the ILS driver.
+     *
+     * @return void
+     */
+    protected function initializeDriver()
+    {
+        $this->driver->setConfig($this->getDriverConfig());
+        $this->driver->init();
+        $this->driverInitialized = true;
+    }
+
+    /**
+     * Are we configured to fail over to the NoILS driver on error?
+     *
+     * @return bool
+     */
+    protected function hasNoILSFailover()
+    {
+        // If we're configured to fail over to the NoILS driver, do so now:
+        return isset($this->config->loadNoILSOnFailure)
+            && $this->config->loadNoILSOnFailure;
+    }
+
+    /**
+     * If configured, fail over to the NoILS driver and return true; otherwise,
+     * return false.
+     *
+     * @return bool
+     */
+    protected function failOverToNoILS()
+    {
+        $this->failing = true;
+
+        // Only fail over if we're configured to allow it and we haven't already
+        // done so!
+        if ($this->hasNoILSFailover()) {
+            $noILS = $this->driverManager->get('NoILS');
+            if (get_class($noILS) != $this->getDriverClass()) {
+                $this->setDriver($noILS);
+                $this->initializeDriver();
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
      * Get access to the driver object.
      *
+     * @param bool $init Should we initialize the driver (if necessary), or load it
+     * "as-is"?
+     *
      * @throws \Exception
      * @return object
      */
-    public function getDriver()
+    public function getDriver($init = true)
     {
-        if (!$this->driverInitialized) {
-            if (!is_object($this->driver)) {
-                throw new \Exception('ILS driver missing.');
+        if (null === $this->driver) {
+            $this->setDriver($this->driverManager->get($this->config->driver));
+        }
+        if (!$this->driverInitialized && $init) {
+            try {
+                $this->initializeDriver();
+            } catch (\Exception $e) {
+                if (!$this->failOverToNoILS()) {
+                    throw $e;
+                }
             }
-            $this->driver->setConfig($this->getDriverConfig());
-            $this->driver->init();
-            $this->driverInitialized = true;
         }
         return $this->driver;
     }
@@ -586,10 +641,17 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function checkRequestIsValid($id, $data, $patron)
     {
-        if ($this->checkCapability(
-            'checkRequestIsValid', [$id, $data, $patron]
-        )) {
-            return $this->getDriver()->checkRequestIsValid($id, $data, $patron);
+        try {
+            if ($this->checkCapability(
+                'checkRequestIsValid', [$id, $data, $patron]
+            )) {
+                return $this->getDriver()->checkRequestIsValid($id, $data, $patron);
+            }
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
         }
         // If the driver has no checkRequestIsValid method, we will assume that
         // all requests are valid - failure can be handled later after the user
@@ -611,12 +673,19 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function checkStorageRetrievalRequestIsValid($id, $data, $patron)
     {
-        if ($this->checkCapability(
-            'checkStorageRetrievalRequestIsValid', [$id, $data, $patron]
-        )) {
-            return $this->getDriver()->checkStorageRetrievalRequestIsValid(
-                $id, $data, $patron
-            );
+        try {
+            if ($this->checkCapability(
+                'checkStorageRetrievalRequestIsValid', [$id, $data, $patron]
+            )) {
+                return $this->getDriver()->checkStorageRetrievalRequestIsValid(
+                    $id, $data, $patron
+                );
+            }
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
         }
         // If the driver has no checkStorageRetrievalRequestIsValid method, we
         // will assume that the request is not valid
@@ -637,12 +706,19 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function checkILLRequestIsValid($id, $data, $patron)
     {
-        if ($this->checkCapability(
-            'checkILLRequestIsValid', [$id, $data, $patron]
-        )) {
-            return $this->getDriver()->checkILLRequestIsValid(
-                $id, $data, $patron
-            );
+        try {
+            if ($this->checkCapability(
+                'checkILLRequestIsValid', [$id, $data, $patron]
+            )) {
+                return $this->getDriver()->checkILLRequestIsValid(
+                    $id, $data, $patron
+                );
+            }
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
         }
         // If the driver has no checkILLRequestIsValid method, we
         // will assume that the request is not valid
@@ -666,14 +742,33 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      *
      * This is responsible for returning the offline mode
      *
+     * @param bool $healthCheck Perform a health check in addition to consulting
+     * the ILS status?
+     *
      * @return string|bool "ils-offline" for systems where the main ILS is offline,
      * "ils-none" for systems which do not use an ILS, false for online systems.
      */
-    public function getOfflineMode()
+    public function getOfflineMode($healthCheck = false)
     {
+        // If we have NoILS failover configured, force driver initialization so
+        // we can know we are checking the offline mode against the correct driver.
+        if ($this->hasNoILSFailover()) {
+            $this->getDriver();
+        }
+
+        // If we need to perform a health check, try to do a random item lookup
+        // before proceeding.
+        if ($healthCheck) {
+            $this->getStatus('1');
+        }
+
+        // If we're encountering failures, let's go into ils-offline mode if
+        // the ILS driver does not natively support getOfflineMode().
+        $default = $this->failing ? 'ils-offline' : false;
+
         // Graceful degradation -- return false if no method supported.
         return $this->checkCapability('getOfflineMode')
-            ? $this->getDriver()->getOfflineMode() : false;
+            ? $this->getDriver()->getOfflineMode() : $default;
     }
 
     /**
@@ -700,8 +795,15 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     public function hasHoldings($id)
     {
         // Graceful degradation -- return true if no method supported.
-        return $this->checkCapability('hasHoldings', [$id])
-            ? $this->getDriver()->hasHoldings($id) : true;
+        try {
+            return $this->checkCapability('hasHoldings', [$id])
+                ? $this->getDriver()->hasHoldings($id) : true;
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
+        }
     }
 
     /**
@@ -714,8 +816,15 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     public function loginIsHidden()
     {
         // Graceful degradation -- return false if no method supported.
-        return $this->checkCapability('loginIsHidden')
-            ? $this->getDriver()->loginIsHidden() : false;
+        try {
+            return $this->checkCapability('loginIsHidden')
+                ? $this->getDriver()->loginIsHidden() : false;
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
+        }
     }
 
     /**
@@ -732,13 +841,19 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     public function checkCapability($method, $params = [], $throw = false)
     {
         try {
-            // First check that the function is callable without the expense of
-            // initializing the driver:
-            if (is_callable([$this->getDriverClass(), $method])) {
+            // If we have NoILS failover disabled, we can check capabilities of
+            // the driver class without wasting time initializing it; if NoILS
+            // failover is enabled, we have to initialize the driver object now
+            // to be sure we are checking capabilities on the appropriate class.
+            $driverToCheck = $this->hasNoILSFailover()
+                ? $this->getDriver() : $this->getDriverClass();
+
+            // First check that the function is callable:
+            if (is_callable([$driverToCheck, $method])) {
                 // At least drivers implementing the __call() magic method must also
                 // implement supportsMethod() to verify that the method is actually
                 // usable:
-                if (method_exists($this->getDriverClass(), 'supportsMethod')) {
+                if (method_exists($driverToCheck, 'supportsMethod')) {
                     return $this->getDriver()->supportsMethod($method, $params);
                 }
                 return true;
@@ -799,10 +914,17 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function __call($methodName, $params)
     {
-        if ($this->checkCapability($methodName, $params)) {
-            return call_user_func_array(
-                [$this->getDriver(), $methodName], $params
-            );
+        try {
+            if ($this->checkCapability($methodName, $params)) {
+                return call_user_func_array(
+                    [$this->getDriver(), $methodName], $params
+                );
+            }
+        } catch (\Exception $e) {
+            if ($this->failOverToNoILS()) {
+                return call_user_func_array([$this, __METHOD__], func_get_args());
+            }
+            throw $e;
         }
         throw new ILSException(
             'Cannot call method: ' . $this->getDriverClass() . '::' . $methodName

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -163,6 +163,7 @@ class Demo extends AbstractBase
                 }
             }
         }
+        $this->checkIntermittentFailure();
     }
 
     /**
@@ -289,6 +290,19 @@ class Demo extends AbstractBase
     {
         return isset($this->config['Records']['source'])
             ? $this->config['Records']['source'] : DEFAULT_SEARCH_BACKEND;
+    }
+
+    /**
+     * Should we simulate a system failure?
+     *
+     * @return void
+     * @throws ILSException
+     */
+    protected function checkIntermittentFailure()
+    {
+        if ($this->isFailing(__METHOD__, 0)) {
+            throw new ILSException('Simulating low-level system failure');
+        }
     }
 
     /**
@@ -586,6 +600,7 @@ class Demo extends AbstractBase
      */
     public function getStatuses($ids)
     {
+        $this->checkIntermittentFailure();
         return array_map([$this, 'getStatus'], $ids);
     }
 
@@ -604,6 +619,8 @@ class Demo extends AbstractBase
      */
     public function getHolding($id, array $patron = null)
     {
+        $this->checkIntermittentFailure();
+
         // Get basic status info:
         $status = $this->getSimulatedStatus($id, $patron);
 
@@ -640,6 +657,7 @@ class Demo extends AbstractBase
      */
     public function getPurchaseHistory($id)
     {
+        $this->checkIntermittentFailure();
         $issues = rand(0, 3);
         $retval = [];
         for ($i = 0; $i < $issues; $i++) {
@@ -662,6 +680,7 @@ class Demo extends AbstractBase
      */
     public function patronLogin($barcode, $password)
     {
+        $this->checkIntermittentFailure();
         if (isset($this->config['Users'])) {
             if (!isset($this->config['Users'][$barcode])
                 || $password !== $this->config['Users'][$barcode]
@@ -694,6 +713,7 @@ class Demo extends AbstractBase
      */
     public function getMyProfile($patron)
     {
+        $this->checkIntermittentFailure();
         $patron = [
             'firstname' => 'Lib-' . $patron['cat_username'],
             'lastname'  => 'Rarian',
@@ -721,6 +741,7 @@ class Demo extends AbstractBase
      */
     public function getMyFines($patron)
     {
+        $this->checkIntermittentFailure();
         $session = $this->getSession();
         if (!isset($session->fines)) {
             // How many items are there? %20 - 2 = 10% chance of none,
@@ -777,6 +798,7 @@ class Demo extends AbstractBase
      */
     public function getMyHolds($patron)
     {
+        $this->checkIntermittentFailure();
         $session = $this->getSession();
         if (!isset($session->holds)) {
             $session->holds = $this->createRequestList('Holds');
@@ -797,6 +819,7 @@ class Demo extends AbstractBase
      */
     public function getMyStorageRetrievalRequests($patron)
     {
+        $this->checkIntermittentFailure();
         $session = $this->getSession();
         if (!isset($session->storageRetrievalRequests)) {
             $session->storageRetrievalRequests
@@ -818,6 +841,7 @@ class Demo extends AbstractBase
      */
     public function getMyILLRequests($patron)
     {
+        $this->checkIntermittentFailure();
         $session = $this->getSession();
         if (!isset($session->ILLRequests)) {
             $session->ILLRequests = $this->createRequestList('ILLRequests');
@@ -833,6 +857,7 @@ class Demo extends AbstractBase
      */
     protected function getTransactionList()
     {
+        $this->checkIntermittentFailure();
         // If Demo.ini includes a fixed set of transactions, load those; otherwise
         // build some random ones.
         return isset($this->config['Records']['transactions'])
@@ -936,6 +961,7 @@ class Demo extends AbstractBase
      */
     public function getMyTransactions($patron)
     {
+        $this->checkIntermittentFailure();
         $session = $this->getSession();
         if (!isset($session->transactions)) {
             $session->transactions = $this->getTransactionList();
@@ -964,6 +990,7 @@ class Demo extends AbstractBase
      */
     public function getPickUpLocations($patron = false, $holdDetails = null)
     {
+        $this->checkIntermittentFailure();
         return [
             [
                 'locationID' => 'A',
@@ -993,6 +1020,7 @@ class Demo extends AbstractBase
      */
     public function getHoldDefaultRequiredDate($patron, $holdInfo)
     {
+        $this->checkIntermittentFailure();
         // 5 years in the future (but similate intermittent failure):
         return !$this->isFailing(__METHOD__, 50)
             ? mktime(0, 0, 0, date('m'), date('d'), date('Y') + 5) : null;
@@ -1016,6 +1044,7 @@ class Demo extends AbstractBase
      */
     public function getDefaultPickUpLocation($patron = false, $holdDetails = null)
     {
+        $this->checkIntermittentFailure();
         $locations = $this->getPickUpLocations($patron);
         return $locations[0]['locationID'];
     }
@@ -1038,6 +1067,7 @@ class Demo extends AbstractBase
      */
     public function getDefaultRequestGroup($patron = false, $holdDetails = null)
     {
+        $this->checkIntermittentFailure();
         if ($this->isFailing(__METHOD__, 50)) {
             return false;
         }
@@ -1059,6 +1089,7 @@ class Demo extends AbstractBase
      */
     public function getRequestGroups($bibId = null, $patron = null)
     {
+        $this->checkIntermittentFailure();
         return [
             [
                 'id' => 1,
@@ -1080,6 +1111,7 @@ class Demo extends AbstractBase
      */
     public function getFunds()
     {
+        $this->checkIntermittentFailure();
         return ["Fund A", "Fund B", "Fund C"];
     }
 
@@ -1092,6 +1124,7 @@ class Demo extends AbstractBase
      */
     public function getDepartments()
     {
+        $this->checkIntermittentFailure();
         return ["Dept. A", "Dept. B", "Dept. C"];
     }
 
@@ -1104,6 +1137,7 @@ class Demo extends AbstractBase
      */
     public function getInstructors()
     {
+        $this->checkIntermittentFailure();
         return ["Instructor A", "Instructor B", "Instructor C"];
     }
 
@@ -1116,6 +1150,7 @@ class Demo extends AbstractBase
      */
     public function getCourses()
     {
+        $this->checkIntermittentFailure();
         return ["Course A", "Course B", "Course C"];
     }
 
@@ -1140,6 +1175,7 @@ class Demo extends AbstractBase
      */
     public function getNewItems($page, $limit, $daysOld, $fundId = null)
     {
+        $this->checkIntermittentFailure();
         // Pick a random number of results to return -- don't exceed limit or 30,
         // whichever is smaller (this can be pretty slow due to the random ID code).
         $count = rand(0, $limit > 30 ? 30 : $limit);
@@ -1174,6 +1210,7 @@ class Demo extends AbstractBase
      */
     public function findReserves($course, $inst, $dept)
     {
+        $this->checkIntermittentFailure();
         // Pick a random number of results to return -- don't exceed 30.
         $count = rand(0, 30);
         $results = [];
@@ -1206,6 +1243,7 @@ class Demo extends AbstractBase
      */
     public function cancelHolds($cancelDetails)
     {
+        $this->checkIntermittentFailure();
         // Rewrite the holds in the session, removing those the user wants to
         // cancel.
         $newHolds = new ArrayObject();
@@ -1269,6 +1307,7 @@ class Demo extends AbstractBase
      */
     public function cancelStorageRetrievalRequests($cancelDetails)
     {
+        $this->checkIntermittentFailure();
         // Rewrite the items in the session, removing those the user wants to
         // cancel.
         $newRequests = new ArrayObject();
@@ -1331,6 +1370,7 @@ class Demo extends AbstractBase
      */
     public function renewMyItems($renewDetails)
     {
+        $this->checkIntermittentFailure();
         // Simulate an account block at random.
         if ($this->checkRenewBlock()) {
             return [
@@ -1419,6 +1459,7 @@ class Demo extends AbstractBase
      */
     public function checkRequestIsValid($id, $data, $patron)
     {
+        $this->checkIntermittentFailure();
         return !$this->isFailing(__METHOD__, 10);
     }
 
@@ -1435,6 +1476,7 @@ class Demo extends AbstractBase
      */
     public function placeHold($holdDetails)
     {
+        $this->checkIntermittentFailure();
         // Simulate failure:
         if ($this->isFailing(__METHOD__, 50)) {
             return [
@@ -1520,6 +1562,7 @@ class Demo extends AbstractBase
      */
     public function checkStorageRetrievalRequestIsValid($id, $data, $patron)
     {
+        $this->checkIntermittentFailure();
         if (!$this->storageRetrievalRequests || $this->isFailing(__METHOD__, 10)) {
             return false;
         }
@@ -1539,6 +1582,7 @@ class Demo extends AbstractBase
      */
     public function placeStorageRetrievalRequest($details)
     {
+        $this->checkIntermittentFailure();
         if (!$this->storageRetrievalRequests) {
             return [
                 "success" => false,
@@ -1623,6 +1667,7 @@ class Demo extends AbstractBase
      */
     public function checkILLRequestIsValid($id, $data, $patron)
     {
+        $this->checkIntermittentFailure();
         if (!$this->ILLRequests || $this->isFailing(__METHOD__, 10)) {
             return false;
         }
@@ -1642,6 +1687,7 @@ class Demo extends AbstractBase
      */
     public function placeILLRequest($details)
     {
+        $this->checkIntermittentFailure();
         if (!$this->ILLRequests) {
             return [
                 'success' => false,
@@ -1746,6 +1792,7 @@ class Demo extends AbstractBase
      */
     public function getILLPickupLibraries($id, $patron)
     {
+        $this->checkIntermittentFailure();
         if (!$this->ILLRequests) {
             return false;
         }
@@ -1782,6 +1829,7 @@ class Demo extends AbstractBase
      */
     public function getILLPickupLocations($id, $pickupLib, $patron)
     {
+        $this->checkIntermittentFailure();
         switch ($pickupLib) {
         case 1:
             return [
@@ -1827,6 +1875,7 @@ class Demo extends AbstractBase
      */
     public function cancelILLRequests($cancelDetails)
     {
+        $this->checkIntermittentFailure();
         // Rewrite the items in the session, removing those the user wants to
         // cancel.
         $newRequests = new ArrayObject();
@@ -1889,6 +1938,7 @@ class Demo extends AbstractBase
      */
     public function changePassword($details)
     {
+        $this->checkIntermittentFailure();
         if (!$this->isFailing(__METHOD__, 33)) {
             return ['success' => true, 'status' => 'change_password_ok'];
         }
@@ -1912,6 +1962,7 @@ class Demo extends AbstractBase
      */
     public function getConfig($function, $params = null)
     {
+        $this->checkIntermittentFailure();
         if ($function == 'Holds') {
             return [
                 'HMACKeys' => 'id:item_id:level',

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -19,7 +19,22 @@
 ?>
 
 <div class="searchHomeContent">
-  <?=($this->ils()->getOfflineMode() == "ils-offline") ? $this->render('Helpers/ils-offline.phtml', ['offlineModeMsg' => 'ils_offline_home_message']) : ''?>
+  <?
+  $ilsStatusScript = <<<JS
+      $(document).ready(function() {
+        $.ajax({
+            dataType: 'json',
+            method: 'GET',
+            data: {'offlineModeMsg':'ils_offline_home_message'},
+            url: VuFind.path + '/AJAX/JSON?method=getIlsStatus',
+            success: function(response) {
+                $('.searchHomeContent').append(response.data);
+            }
+        });
+      });
+JS;
+  ?>
+  <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $ilsStatusScript, 'SET'); ?>
   <div class="well well-lg clearfix" role="search">
     <?=$this->context($this)->renderInContext("search/searchbox.phtml", ['ignoreHiddenFilterMemory' => true])?>
   </div>


### PR DESCRIPTION
This pull request contains work in progress on a smarter approach to detecting and dealing with ILS technical difficulties. The existing "loadNoILSOnFailure" mechanism depends upon the ILS driver throwing an exception in its init() method to detect problems. This may be too limiting.

TODO:

- [x] Refactor VuFind\ILS\Connection to perform NoILS failover "on demand" rather than in the constructor.
- [x] Discuss whether the health check in getOfflineMode needs to be made more intelligent; perhaps we should add a method to the driver spec and fail over to this default behavior when the method is undefined. (This may be worth considering in the future, but was not implemented at this time).
- [x] Discuss whether we need a configuration setting for the AJAX health check on the search/home page. (We decided this is not needed at this time).
- [x] Investigate whether we can use some kind of cache to improve ILS performance -- for example, if we have a health check, can we cache health check status for a period of time to reduce load on the ILS? (We decided not to do this, as it could magnify intermittent problems).
- [x] Investigate whether we can extend #736 so that its on-demand database initialization functionality remains compatible with the NoILS failover capabilities of VuFind.