### PR TITLE
Workaround for MarkerCluster display bug

### DIFF
--- a/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
@@ -162,6 +162,8 @@ var infowindow = new google.maps.InfoWindow({maxWidth: 480, minWidth: 480});
         map.addOverlay(markers[i]);
       }
     }
+    // Workaround for library bug that causes disappearing markers -- we may be able to eliminate
+    // the next two lines at some point in the future:
     mapcenter = map.getCenter();
     map.setCenter(new google.maps.LatLng((mapcenter.lat() + 0.0000001), mapcenter.lng()));
   }

--- a/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
@@ -162,6 +162,8 @@ var infowindow = new google.maps.InfoWindow({maxWidth: 480, minWidth: 480});
         map.addOverlay(markers[i]);
       }
     }
+    mapcenter = map.getCenter();
+    map.setCenter(new google.maps.LatLng((mapcenter.lat() + 0.0000001), mapcenter.lng()));
   }
   function load_content(marker){
     var xmlhttp;


### PR DESCRIPTION
GoogleMaps bug makes cluster icons disappear when map is zoomed in/out or when the cluster checkbox is checked/unchecked, until map is panned. Workaround pans map every so slightly (not noticeable to the eye).