### PR TITLE
Added a pure PHP OCI8 wrapper for Voyager Oracle connections to elimi…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "vufind-org/vufindcode": "1.0.3",
         "vufind-org/vufindharvest": "2.1.0",
         "vufind-org/vufindhttp": "2.1.0",
-        "yajra/laravel-pdo-via-oci8": "1.*",
+        "yajra/laravel-pdo-via-oci8": "1.1.1",
         "zendframework/zendframework": "2.4.6",
         "zendframework/zendrest": "2.0.2",
         "zendframework/zendservice-amazon": "2.0.4",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "vufind-org/vufindcode": "1.0.3",
         "vufind-org/vufindharvest": "2.1.0",
         "vufind-org/vufindhttp": "2.1.0",
+        "yajra/laravel-pdo-via-oci8": "1.*",
         "zendframework/zendframework": "2.4.6",
         "zendframework/zendrest": "2.0.2",
         "zendframework/zendservice-amazon": "2.0.4",

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -5,7 +5,7 @@
  * PHP version 5
  *
  * Copyright (C) Villanova University 2007.
- * Copyright (C) The National Library of Finland 2014.
+ * Copyright (C) The National Library of Finland 2014-2016.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -29,7 +29,7 @@
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
 namespace VuFind\ILS\Driver;
-use File_MARC, PDO, PDOException,
+use File_MARC, Yajra\Pdo\Oci8, PDO, PDOException,
     VuFind\Exception\Date as DateException,
     VuFind\Exception\ILS as ILSException,
     VuFind\I18n\Translator\TranslatorAwareInterface,
@@ -57,7 +57,7 @@ class Voyager extends AbstractBase
     /**
      * Database connection
      *
-     * @var PDO
+     * @var Oci8
      */
     protected $db;
 
@@ -157,8 +157,8 @@ class Voyager extends AbstractBase
                  ')' .
                ')';
         try {
-            $this->db = new PDO(
-                "oci:dbname=$tns",
+            $this->db = new Oci8(
+                "oci:dbname=$tns;charset=US_ACII",
                 $this->config['Catalog']['user'],
                 $this->config['Catalog']['password']
             );

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -158,7 +158,7 @@ class Voyager extends AbstractBase
                ')';
         try {
             $this->db = new Oci8(
-                "oci:dbname=$tns;charset=US_ACII",
+                "oci:dbname=$tns;charset=US_ASCII",
                 $this->config['Catalog']['user'],
                 $this->config['Catalog']['password']
             );


### PR DESCRIPTION
…nate the need to install the troublesome PDO_OCI module.

While the package name in composer.json hints at laravel, it's just a generic module.

This eliminates the need for https://vufind.org/wiki/installation:php_oci#set_up_pdo_oci and avoids trouble that the PDO_OCI module causes with Apache 2.4 and PHP 7 if "apachectl graceful" is executed (see e.g. http://serverfault.com/questions/763631/php-zlib-version-change-because-of-pdo-oci-after-an-apache-graceful-reload that we've experienced too).