### PR TITLE
Update schema.xml's location

### DIFF
--- a/import/xsl/nlm_ojs.xsl
+++ b/import/xsl/nlm_ojs.xsl
@@ -62,7 +62,7 @@
                     </field>
                 </xsl:if>
 
-                <!-- Article endPage !! Only enable this part of the code if you have defined "container_end_page" in  ./solr/biblio/conf/schema.xml -> <field name="container_end_page" type="text" indexed="true" stored="true"/> !!
+                <!-- Article endPage !! Only enable this part of the code if you have defined "container_end_page" in  ./solr/vufind/biblio/conf/schema.xml -> <field name="container_end_page" type="text" indexed="true" stored="true"/> !!
 
                 <xsl:if test="//nlm:lpage[normalize-space()]">
                         <field name="container_end_page">


### PR DESCRIPTION
nlm_ojs.xsl have pre-vufind3 solr location commented, update to the new one `./solr/vufind/...`.

Also, maybe it would be nice to have the commented entry:
`<field name="container_end_page" type="text" indexed="true" stored="true"/>/'
on schema.xml, just below the start_page one.

I can open another PR if you think this would also be a valid change.