### PR TITLE
Quote also the regular expressions delimiter when analyzing query terms.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -151,7 +151,7 @@ class Query extends AbstractQuery
     {
         // Escape characters with special meaning in regular expressions to avoid
         // errors:
-        $needle = preg_quote($needle);
+        $needle = preg_quote($needle, '/');
 
         return (bool)preg_match("/\b$needle\b/u", $this->getString());
     }
@@ -178,7 +178,7 @@ class Query extends AbstractQuery
     {
         // Escape $from so it is regular expression safe (just in case it
         // includes any weird punctuation -- unlikely but possible):
-        $from = preg_quote($from);
+        $from = preg_quote($from, '/');
 
         // If our "from" pattern contains non-word characters, we can't use word
         // boundaries for matching.  We want to try to use word boundaries when

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
@@ -49,12 +49,16 @@ class QueryTest extends PHPUnit_Framework_TestCase
      */
     public function testContainsTerm()
     {
-        $q = new Query('test query we<(ird');
+        $q = new Query('test query we<(ird and/or');
 
         // Should contain all actual terms (even those containing regex chars):
         $this->assertTrue($q->containsTerm('test'));
         $this->assertTrue($q->containsTerm('query'));
         $this->assertTrue($q->containsTerm('we<(ird'));
+        // A slash can be a word boundary but also a single term
+        $this->assertTrue($q->containsTerm('and'));
+        $this->assertTrue($q->containsTerm('or'));
+        $this->assertTrue($q->containsTerm('and/or'));
 
         // Should not contain a non-present term:
         $this->assertFalse($q->containsTerm('garbage'));
@@ -70,9 +74,14 @@ class QueryTest extends PHPUnit_Framework_TestCase
      */
     public function testReplaceTerm()
     {
-        $q = new Query('test query we<(ird');
+        $q = new Query('test query we<(ird and/or');
         $q->replaceTerm('we<(ird', 'we>(ird');
-        $this->assertEquals('test query we>(ird', $q->getString());
+        $q->replaceTerm('and/or', 'and-or');
+        $this->assertEquals('test query we>(ird and-or', $q->getString());
+
+        $q = new Query('test query we<(ird and/or');
+        $q->replaceTerm('and', 'not');
+        $this->assertEquals('test query we<(ird not/or', $q->getString());
     }
 
     /**


### PR DESCRIPTION
I forgot to include the delimiter when switching to preg_quote causing queries containing slashes to fail in preg_match.