### PR TITLE
adding functionality for parent yaml

### DIFF
--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -111,9 +111,9 @@ class SearchSpecsReader
     }
 
     /**
-     * Returns content of yaml as an array, considers import of other a parent-yaml-file using "@parent_yaml="
+     * Returns content of yaml as an array, considers import of other a parent-yaml-file using the key "@parent_yaml"
      *
-     * @param string $file_contents yaml as a string
+     * @param string $filepath path of the yaml file
      *
      * @return array
      */
@@ -123,16 +123,20 @@ class SearchSpecsReader
         $parent_yaml_array = null;
         $yaml_array = Yaml::parse($file_contents);
 
-        if (array_key_exists("parent_yaml", $yaml_array)) {
-            $parent_yaml_filepath = $yaml_array["parent_yaml"];
+        if (array_key_exists("@parent_yaml", $yaml_array)) {
+            $parent_yaml_filepath = $yaml_array["@parent_yaml"];
             $parent_yaml_filepath = pathinfo($filepath)[dirname] . "/" . $parent_yaml_filepath;
             $parent_yaml_array = Yaml::parse(file_get_contents($parent_yaml_filepath));
         }
 
-        if ($parent_yaml_array !== null) {
-            $yaml_array = array_replace_recursive($parent_yaml_array, $yaml_array);
+        $combined_yaml_array = $parent_yaml_array;
+        if ($combined_yaml_array !== null) {
+            foreach ($yaml_array as $key => $value) {
+                $combined_yaml_array[$key] = $value;
+            }
         }
-        return $yaml_array;
+        else $combined_yaml_array = $yaml_array;
+        return $combined_yaml_array;
     }
 
 }

--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -120,32 +120,16 @@ class SearchSpecsReader
     private function parseYaml($filepath)
     {
         $file_contents = file_get_contents($filepath);
-        $parentYamlDirectiveString = '@parent_yaml=';
-        $parent_directive_startpos = strpos($file_contents, $parentYamlDirectiveString);
         $parent_yaml_array = null;
+        $yaml_array = Yaml::parse($file_contents);
 
-        if ($parent_directive_startpos !== false) {
-            // read parent yaml:
-            $parent_directive_endpos = strpos($file_contents, PHP_EOL, $parent_directive_startpos + 1);
-            $parent_yaml_filepath =
-                substr(
-                    $file_contents, $parent_directive_startpos + strlen($parentYamlDirectiveString),
-                    $parent_directive_endpos - $parent_directive_startpos - strlen($parentYamlDirectiveString)
-                );
-            $parent_yaml_filepath = pathinfo($filepath)[dirname] . "/" .  $parent_yaml_filepath;
+        if (array_key_exists("parent_yaml", $yaml_array)) {
+            $parent_yaml_filepath = $yaml_array["parent_yaml"];
+            $parent_yaml_filepath = pathinfo($filepath)[dirname] . "/" . $parent_yaml_filepath;
             $parent_yaml_array = Yaml::parse(file_get_contents($parent_yaml_filepath));
-
-            //remove include-directive from yaml:
-            $file_contents =
-                substr($file_contents, 0, $parent_directive_startpos) . substr(
-                    $file_contents,
-                    $parent_directive_endpos + 1
-                );
         }
 
-        $yaml_array = Yaml::parse($file_contents);
         if ($parent_yaml_array !== null) {
-            // overwrite parent_yaml_array with yaml_array
             $yaml_array = array_replace_recursive($parent_yaml_array, $yaml_array);
         }
         return $yaml_array;


### PR DESCRIPTION
First draft of adding functionality to have parent file of the searchspec-yaml. Looks for "@parent_yaml=" (anywhere in the file) and merges the content of this file with the current one (=adding values from the parent file, if no corresponding value exists in the current file).

It takes the first occurrence of the "parent_yaml" directive. If there are more later in the file, they will be ignored completely.

 - [ ] Should we remove multiple "parent_yaml" directives unprocessed?

Not tested with nested "parent_yaml" directives.

 - [ ] Should we allow nested "parent_yaml" directives?

The part where the filename is extracted is quite verbose, we can reduce it, if needed.