### PR TITLE
Improve YAML test coverage and add @parent_yaml support

### DIFF
--- a/config/vufind/searchspecs.yaml
+++ b/config/vufind/searchspecs.yaml
@@ -148,6 +148,19 @@
 # [uppercase] - Convert string to uppercase
 #
 # See the CallNumber search below for an example of custom munging in action.
+#
+#-----------------------------------------------------------------------------------
+#
+# Note that you may create a "@parent_yaml" entry at the very top of the file to
+# inherit sections from another file. For example:
+#
+# @parent_yaml: "/path/to/my/file.yaml"
+#
+# Only sections not found in this file will be loaded in from the parent file.
+# In some complex scenarios, this can be a useful way of sharing settings
+# between multiple configured VuFind instances. You can create a chain of parent
+# files if necessary.
+#
 #-----------------------------------------------------------------------------------
 
 # These searches use Dismax when possible:

--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -74,39 +74,75 @@ class SearchSpecsReader
     {
         // Load data if it is not already in the object's cache:
         if (!isset($this->searchSpecs[$filename])) {
-            // Connect to searchspecs cache:
-            $cache = (null !== $this->cacheManager)
-                ? $this->cacheManager->getCache('searchspecs') : false;
-
-            // Determine full configuration file path:
-            $fullpath = Locator::getBaseConfigPath($filename);
-            $local = Locator::getLocalConfigPath($filename);
-
-            // Generate cache key:
-            $cacheKey = $filename . '-'
-                . (file_exists($fullpath) ? filemtime($fullpath) : 0);
-            if (!empty($local)) {
-                $cacheKey .= '-local-' . filemtime($local);
-            }
-            $cacheKey = md5($cacheKey);
-
-            // Generate data if not found in cache:
-            if ($cache === false || !($results = $cache->getItem($cacheKey))) {
-                $results = file_exists($fullpath)
-                    ? Yaml::parse(file_get_contents($fullpath)) : [];
-                if (!empty($local)) {
-                    $localResults = Yaml::parse(file_get_contents($local));
-                    foreach ($localResults as $key => $value) {
-                        $results[$key] = $value;
-                    }
-                }
-                if ($cache !== false) {
-                    $cache->setItem($cacheKey, $results);
-                }
-            }
-            $this->searchSpecs[$filename] = $results;
+            $this->searchSpecs[$filename] = $this->getFromPaths(
+                Locator::getBaseConfigPath($filename),
+                Locator::getLocalConfigPath($filename)
+            );
         }
 
         return $this->searchSpecs[$filename];
+    }
+
+    /**
+     * Given core and local filenames, retrieve the searchspecs data.
+     *
+     * @param string $defaultFile Full path to file containing default YAML
+     * @param string $customFile  Full path to file containing local customizations
+     * (may be null if no local file exists).
+     *
+     * @return array
+     */
+    protected function getFromPaths($defaultFile, $customFile = null)
+    {
+        // Connect to searchspecs cache:
+        $cache = (null !== $this->cacheManager)
+            ? $this->cacheManager->getCache('searchspecs') : false;
+
+        // Generate cache key:
+        $cacheKey = basename($defaultFile) . '-'
+            . (file_exists($defaultFile) ? filemtime($defaultFile) : 0);
+        if (!empty($customFile)) {
+            $cacheKey .= '-local-' . filemtime($customFile);
+        }
+        $cacheKey = md5($cacheKey);
+
+        // Generate data if not found in cache:
+        if ($cache === false || !($results = $cache->getItem($cacheKey))) {
+            $results = $this->parseYaml($customFile, $defaultFile);
+            if ($cache !== false) {
+                $cache->setItem($cacheKey, $results);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Process a YAML file (and its parent, if necessary).
+     *
+     * @param string $file          YAML file to load (will evaluate to empty array
+     * if file does not exist).
+     * @param string $defaultParent Parent YAML file from which $file should
+     * inherit (unless overridden by a specific directive in $file). None by
+     * default.
+     *
+     * @return array
+     */
+    protected function parseYaml($file, $defaultParent = null)
+    {
+        // First load current file:
+        $results = (!empty($file) && file_exists($file))
+            ? Yaml::parse(file_get_contents($file)) : [];
+
+        // Now load in missing sections from parent, if applicable:
+        if (null !== $defaultParent) {
+            foreach ($this->parseYaml($defaultParent) as $section => $contents) {
+                if (!isset($results[$section])) {
+                    $results[$section] = $contents;
+                }
+            }
+        }
+
+        return $results;
     }
 }

--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -134,6 +134,13 @@ class SearchSpecsReader
         $results = (!empty($file) && file_exists($file))
             ? Yaml::parse(file_get_contents($file)) : [];
 
+        // Override default parent with explicitly-defined parent, if present:
+        if (isset($results['@parent_yaml'])) {
+            $defaultParent = $results['@parent_yaml'];
+            // Swallow the directive after processing it:
+            unset($results['@parent_yaml']);
+        }
+
         // Now load in missing sections from parent, if applicable:
         if (null !== $defaultParent) {
             foreach ($this->parseYaml($defaultParent) as $section => $contents) {

--- a/module/VuFind/tests/fixtures/configs/yaml/core.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/core.yaml
@@ -1,0 +1,4 @@
+top:
+  foo: "bar"
+bottom:
+  goo: "gar"

--- a/module/VuFind/tests/fixtures/configs/yaml/local.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/local.yaml
@@ -1,0 +1,4 @@
+top:
+  foo: "xyzzy"
+middle:
+  moo: "cow"

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/SearchSpecsReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/SearchSpecsReaderTest.php
@@ -26,7 +26,7 @@
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
 namespace VuFindTest\Config;
-use VuFind\Config\SearchSpecsReader;
+use VuFind\Config\Locator, VuFind\Config\SearchSpecsReader;
 
 /**
  * Config SearchSpecsReader Test Class
@@ -40,6 +40,49 @@ use VuFind\Config\SearchSpecsReader;
  */
 class SearchSpecsReaderTest extends \VuFindTest\Unit\TestCase
 {
+    /**
+     * Flag -- did writing config files fail?
+     *
+     * @var bool
+     */
+    protected static $writeFailed = false;
+
+    /**
+     * Array of files to clean up after test.
+     *
+     * @var array
+     */
+    protected static $filesToDelete = [];
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // Create test files:
+        $parentPath = Locator::getLocalConfigPath('top.yaml', null, true);
+        $parent = "top: foo";
+        $childPath = Locator::getLocalConfigPath('middle.yaml', null, true);
+        $child = "@parent_yaml: $parentPath\nmiddle: bar";
+        $grandchildPath = Locator::getLocalConfigPath('bottom.yaml', null, true);
+        $grandchild = "@parent_yaml: $childPath\nbottom: baz";
+
+        // Fail if we are unable to write files:
+        if (null === $parentPath || null === $childPath || null === $grandchildPath
+            || !file_put_contents($parentPath, $parent)
+            || !file_put_contents($childPath, $child)
+            || !file_put_contents($grandchildPath, $grandchild)
+        ) {
+            self::$writeFailed = true;
+            return;
+        }
+
+        // Mark for cleanup:
+        self::$filesToDelete = [$parentPath, $childPath, $grandchildPath];
+    }
+
     /**
      * Test loading of a YAML file.
      *
@@ -113,5 +156,39 @@ class SearchSpecsReaderTest extends \VuFindTest\Unit\TestCase
             ],
             $this->callMethod($reader, 'getFromPaths', [$core, $local])
         );
+    }
+
+    /**
+     * Test @parent_yaml directive.
+     *
+     * @return void
+     */
+    public function testParentYaml()
+    {
+        if (self::$writeFailed) {
+            $this->markTestSkipped('Could not write test configurations.');
+        }
+        $reader = new SearchSpecsReader();
+        $core = Locator::getLocalConfigPath('middle.yaml', null, true);
+        $local = Locator::getLocalConfigPath('bottom.yaml', null, true);
+        $this->assertEquals(
+            [
+                'top' => 'foo',
+                'middle' => 'bar',
+                'bottom' => 'baz',
+            ],
+            $this->callMethod($reader, 'getFromPaths', [$core, $local])
+        );
+    }
+
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        // Clean up test files:
+        array_map('unlink', self::$filesToDelete);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/SearchSpecsReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/SearchSpecsReaderTest.php
@@ -68,4 +68,50 @@ class SearchSpecsReaderTest extends \VuFindTest\Unit\TestCase
         $specs = $reader->get('notreallyasearchspecs.yaml');
         $this->assertEquals([], $specs);
     }
+
+    /**
+     * Test direct loading of two single files.
+     *
+     * @return void
+     */
+    public function testYamlLoad()
+    {
+        $reader = new SearchSpecsReader();
+        $core = __DIR__ . '/../../../../fixtures/configs/yaml/core.yaml';
+        $local = __DIR__ . '/../../../../fixtures/configs/yaml/local.yaml';
+        $this->assertEquals(
+            [
+                'top' => ['foo' => 'bar'],
+                'bottom' => ['goo' => 'gar'],
+            ],
+            $this->callMethod($reader, 'getFromPaths', [$core])
+        );
+        $this->assertEquals(
+            [
+                'top' => ['foo' => 'xyzzy'],
+                'middle' => ['moo' => 'cow'],
+            ],
+            $this->callMethod($reader, 'getFromPaths', [$local])
+        );
+    }
+
+    /**
+     * Test merging of two files.
+     *
+     * @return void
+     */
+    public function testYamlMerge()
+    {
+        $reader = new SearchSpecsReader();
+        $core = __DIR__ . '/../../../../fixtures/configs/yaml/core.yaml';
+        $local = __DIR__ . '/../../../../fixtures/configs/yaml/local.yaml';
+        $this->assertEquals(
+            [
+                'top' => ['foo' => 'xyzzy'],
+                'middle' => ['moo' => 'cow'],
+                'bottom' => ['goo' => 'gar'],
+            ],
+            $this->callMethod($reader, 'getFromPaths', [$core, $local])
+        );
+    }
 }


### PR DESCRIPTION
This PR supersedes (and takes significant inspiration from) #786. YAML loading has been refactored to allow better test coverage, and a new feature has been added to allow an explicit parent file to be specified in order to chain files together.