### PR TITLE
Slack Log Writer

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1070,6 +1070,10 @@ skip_numeric = true
 ;file           = /var/log/vufind.log:alert,error,notice,debug
 ;email          = alerts@myuniversity.edu:alert-5,error-5
 
+; Get URL from https://YOURSLACK.slack.com/apps/manage/custom-integrations
+;slack = #channel_name:alert,error
+;slackurl = https://hooks.slack.com/services/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
+
 ; This section can be used to specify a "parent configuration" from which
 ; the current configuration file will inherit.  You can chain multiple
 ; configurations together if you wish.
@@ -1232,7 +1236,7 @@ callnumber_handler = false
 next_prev_navigation = false
 
 ; Set this to true in order to enable "first" and "last" links to navigate
-; through the content result set from within the record view. Note, this 
+; through the content result set from within the record view. Note, this
 ; may cause slow behavior with some installations. The option will only work
 ; when next_prev_navigation is also set to true.
 first_last_navigation = false

--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -131,8 +131,8 @@ class Logger extends BaseLogger implements ServiceLocatorAwareInterface
             // Make Writers
             $writer = new Writer\Slack(
                 $config->Logging->slackurl,
-                $channel,
-                $this->getServiceLocator()->get('VuFind\Http')->createClient()
+                $this->getServiceLocator()->get('VuFind\Http')->createClient(),
+                $channel
             );
             $writer->setContentType('application/json');
             $formatter = new \Zend\Log\Formatter\Simple("%priorityName%: %message%");

--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -119,6 +119,27 @@ class Logger extends BaseLogger implements ServiceLocatorAwareInterface
             $this->addWriters($writer, $filters);
         }
 
+        // Activate slack logging, if applicable:
+        if (isset($config->Logging->slack) && isset($config->Logging->slackurl)) {
+            // Get config
+            list($channel, $error_types) = explode(':', $config->Logging->slack);
+            if ($error_types == null) {
+                $error_types = $channel;
+                $channel = null;
+            }
+            $filters = explode(',', $error_types);
+            // Make Writers
+            $writer = new Writer\Slack(
+                $config->Logging->slackurl,
+                $channel,
+                $this->getServiceLocator()->get('VuFind\Http')->createClient()
+            );
+            $writer->setContentType('application/json');
+            $formatter = new \Zend\Log\Formatter\Simple("%priorityName%: %message%");
+            $writer->setFormatter($formatter);
+            $this->addWriters($writer, $filters);
+        }
+
         // Null (no-op) writer to avoid errors
         if (count($this->writers) == 0) {
             $nullWriter = 'Zend\Log\Writer\Noop';

--- a/module/VuFind/src/VuFind/Log/Writer/Post.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Post.php
@@ -26,6 +26,7 @@
  * @link     https://vufind.org Main Site
  */
 namespace VuFind\Log\Writer;
+use Zend\Http\Client;
 
 /**
  * This class extends the Zend Logging to sent POST messages over HTTP
@@ -69,10 +70,10 @@ class Post extends \Zend\Log\Writer\AbstractWriter
     /**
      * Constructor
      *
-     * @param string            $url    URL to open as a stream
-     * @param \Zend\Http\Client $client Pre-configured http client
+     * @param string $url    URL to open as a stream
+     * @param Client $client Pre-configured http client
      */
-    public function __construct($url, $client)
+    public function __construct($url, Client $client)
     {
         $this->url = $url;
         $this->client = $client;

--- a/module/VuFind/src/VuFind/Log/Writer/Post.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Post.php
@@ -93,7 +93,7 @@ class Post extends \Zend\Log\Writer\AbstractWriter
     /**
      * Set verbosity
      *
-     * @param integer $verb verbosity setting
+     * @param integer $type content type string
      *
      * @return void
      */

--- a/module/VuFind/src/VuFind/Log/Writer/Post.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Post.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * HTTP POST log writer
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Error_Logging
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\Log\Writer;
+
+/**
+ * This class extends the Zend Logging to sent POST messages over HTTP
+ *
+ * @category VuFind
+ * @package  Error_Logging
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class Post extends \Zend\Log\Writer\AbstractWriter
+{
+    /**
+     * Holds the verbosity level
+     *
+     * @var int
+     */
+    protected $url = null;
+
+    /**
+     * Pre-configured http client
+     *
+     * @var \Zend\Http\Client
+     */
+    protected $client = null;
+
+    /**
+     * Holds the verbosity level
+     *
+     * @var int
+     */
+    protected $verbosity = 1;
+
+    /**
+     * Content type
+     *
+     * @var string
+     */
+    protected $contentType = 'application/x-www-form-urlencoded';
+
+    /**
+     * Constructor
+     *
+     * @param string            $url    URL to open as a stream
+     * @param \Zend\Http\Client $client Pre-configured http client
+     */
+    public function __construct($url, $client)
+    {
+        $this->url = $url;
+        $this->client = $client;
+    }
+
+    /**
+     * Set verbosity
+     *
+     * @param integer $verb verbosity setting
+     *
+     * @return void
+     */
+    public function setVerbosity($verb)
+    {
+        $this->verbosity = $verb;
+    }
+
+    /**
+     * Set verbosity
+     *
+     * @param integer $verb verbosity setting
+     *
+     * @return void
+     */
+    public function setContentType($type)
+    {
+        $this->contentType = $type;
+    }
+
+    /**
+     * Get data for raw body
+     *
+     * @param array $event event data
+     *
+     * @return string
+     */
+    protected function getBody($event)
+    {
+        return ['message' => $this->formatter->format($event) . PHP_EOL];
+    }
+
+    /**
+     * Write a message to the log.
+     *
+     * @param array $event event data
+     *
+     * @return void
+     * @throws \Zend\Log\Exception\RuntimeException
+     */
+    protected function doWrite(array $event)
+    {
+        // Apply verbosity filter:
+        if (is_array($event['message'])) {
+            $event['message'] = $event['message'][$this->verbosity];
+        }
+
+        // Create request
+        $this->client->setUri($this->url);
+        $this->client->setMethod('POST');
+        $this->client->setEncType($this->contentType);
+        $this->client->setRawBody($this->getBody($event));
+        // Send
+        $response = $this->client->send();
+    }
+}

--- a/module/VuFind/src/VuFind/Log/Writer/Slack.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Slack.php
@@ -26,6 +26,7 @@
  * @link     https://vufind.org Main Site
  */
 namespace VuFind\Log\Writer;
+use Zend\Http\Client;
 
 /**
  * This class extends the Zend Logging to send errors to Slack
@@ -48,11 +49,11 @@ class Slack extends Post
     /**
      * Constructor
      *
-     * @param string            $url     URL to open as a stream
-     * @param string            $channel Slack channel
-     * @param \Zend\Http\Client $client  Pre-configured http client
+     * @param string $url     URL to open as a stream
+     * @param Client $client  Pre-configured http client
+     * @param string $channel Slack channel
      */
-    public function __construct($url, $channel, $client)
+    public function __construct($url, Client $client, $channel = '#vufind_log')
     {
         $this->channel = $channel;
         parent::__construct($url, $client);

--- a/module/VuFind/src/VuFind/Log/Writer/Slack.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Slack.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * HTTP POST log writer for Slack
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Error_Logging
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\Log\Writer;
+
+/**
+ * This class extends the Zend Logging to send errors to Slack
+ *
+ * @category VuFind
+ * @package  Error_Logging
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class Slack extends Post
+{
+    protected $channel = null;
+
+    /**
+     * Constructor
+     *
+     * @param string            $url     URL to open as a stream
+     * @param string            $channel Slack channel
+     * @param \Zend\Http\Client $client  Pre-configured http client
+     */
+    public function __construct($url, $channel, $client)
+    {
+        $this->channel = $channel;
+        parent::__construct($url, $client);
+    }
+
+    /**
+     * Get data for raw body
+     *
+     * @param array $event event data
+     *
+     * @return string
+     */
+    protected function getBody($event)
+    {
+        $data = ['text' => $this->formatter->format($event) . PHP_EOL];
+        if ($this->channel) {
+            $data['channel'] = $this->channel;
+        }
+        return json_encode($data);
+    }
+}

--- a/module/VuFind/src/VuFind/Log/Writer/Slack.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Slack.php
@@ -38,7 +38,12 @@ namespace VuFind\Log\Writer;
  */
 class Slack extends Post
 {
-    protected $channel = null;
+    /**
+     * The slack channel that should receive messages.
+     *
+     * @var string
+     */
+    protected $channel;
 
     /**
      * Constructor


### PR DESCRIPTION
Allows you to configure VuFind to send log messages to Slack.
- Same message type and verbosity config
- Choice and easy change of room
- Send messages directly to a user