### PR TITLE
changes isset function to empty function for expected date

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -772,7 +772,7 @@ class DAIA extends AbstractBase implements
                     }
                 }
                 // attribute expected is mandatory for unavailable element
-                if (isset($unavailable['expected'])) {
+                if (!empty($unavailable['expected'])) {
                     try {
                         $duedate = $this->dateConverter
                             ->convertToDisplayDate(


### PR DESCRIPTION
This mini-PR fixes a small failure in the DAIA driver.

Our DAIA server sets in some cases an empty expected element (this is not very nice, but I guess it might happen). This confuses the DAIA driver and lets it assume, that the item is due at this day. A !empty-check instead of isset on the expected element avoids this and does not set a duedate for an empty expected element.
