### PR TITLE
Added timeout settings to DAIA and PAIA drivers

### DIFF
--- a/config/vufind/DAIA.ini
+++ b/config/vufind/DAIA.ini
@@ -24,6 +24,11 @@
 ; The base URL for the DAIA webservice.
 baseUrl = [your DAIA server base url]
 
+; Set a DAIA specific timeout in seconds to be used for DAIA http requests (defaults
+; to Zend defaults or as defined in
+; vendor/vufind-org/vufindhttp/src/VuFindHttp/HttpService.php)
+;timeout = 30
+
 ; The prefix prepended to the VuFind record Id resulting in the document URI
 ; used for the DAIA request (default = ppn:) (the prefix usually defines the
 ; field which the DAIA server uses for the loookup - e.g. ppn: or isbn:).

--- a/config/vufind/PAIA.ini
+++ b/config/vufind/PAIA.ini
@@ -9,6 +9,11 @@
 ; base URL of the PAIA server WITH trailing slash
 baseUrl = ""
 
+; Set a PAIA specific timeout in seconds to be used for PAIA http requests (defaults
+; to Zend defaults or as defined in
+; vendor/vufind-org/vufindhttp/src/VuFindHttp/HttpService.php)
+;timeout = 30
+
 ; Enable caching for PAIA items (default is false). TTL for cached data will be the
 ; same as for DAIA cache (see cacheLifetime setting in DAIA.ini).
 ;paiaCache = false

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -149,7 +149,7 @@ class DAIA extends AbstractBase implements
         } else {
             throw new ILSException('DAIA/baseUrl configuration needs to be set.');
         }
-        // use PAIA specific timeout setting for http requests if configured
+        // use DAIA specific timeout setting for http requests if configured
         if ((isset($this->config['DAIA']['timeout']))) {
             $this->daiaTimeout = $this->config['DAIA']['timeout'];
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -60,6 +60,13 @@ class DAIA extends AbstractBase implements
     protected $baseUrl;
 
     /**
+     * Timeout in seconds to be used for DAIA http requests
+     *
+     * @var string
+     */
+    protected $daiaTimeout = null;
+
+    /**
      * Flag to switch on/off caching for DAIA items
      *
      * @var bool
@@ -141,6 +148,10 @@ class DAIA extends AbstractBase implements
             );
         } else {
             throw new ILSException('DAIA/baseUrl configuration needs to be set.');
+        }
+        // use PAIA specific timeout setting for http requests if configured
+        if ((isset($this->config['DAIA']['timeout']))) {
+            $this->daiaTimeout = $this->config['DAIA']['timeout'];
         }
         if (isset($this->config['DAIA']['daiaResponseFormat'])) {
             $this->daiaResponseFormat = strtolower(
@@ -448,7 +459,7 @@ class DAIA extends AbstractBase implements
         try {
             $result = $this->httpService->get(
                 $this->baseUrl,
-                $params, null, $http_headers
+                $params, $this->daiaTimeout, $http_headers
             );
         } catch (\Exception $e) {
             throw new ILSException(

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -57,6 +57,13 @@ class PAIA extends DAIA
     protected $paiaURL;
 
     /**
+     * Timeout in seconds to be used for PAIA http requests
+     *
+     * @var
+     */
+    protected $paiaTimeout = null;
+
+    /**
      * Flag to switch on/off caching for PAIA items
      *
      * @var bool
@@ -163,6 +170,11 @@ class PAIA extends DAIA
             throw new ILSException('PAIA/baseUrl configuration needs to be set.');
         }
         $this->paiaURL = $this->config['PAIA']['baseUrl'];
+
+        // use PAIA specific timeout setting for http requests if configured
+        if ((isset($this->config['PAIA']['timeout']))) {
+            $this->paiaTimeout = $this->config['PAIA']['timeout'];
+        }
 
         // do we have caching enabled for PAIA
         if (isset($this->config['PAIA']['paiaCache'])) {
@@ -1502,7 +1514,7 @@ class PAIA extends DAIA
                 $this->paiaURL . $file,
                 $postData,
                 'application/json; charset=UTF-8',
-                null,
+                $this->paiaTimeout,
                 $http_headers
             );
         } catch (\Exception $e) {
@@ -1539,7 +1551,7 @@ class PAIA extends DAIA
         try {
             $result = $this->httpService->get(
                 $this->paiaURL . $file,
-                [], null, $http_headers
+                [], $this->paiaTimeout, $http_headers
             );
         } catch (\Exception $e) {
             throw new ILSException($e->getMessage());


### PR DESCRIPTION
A simple and backwards-compatible addition to the DAIA and PAIA drivers to allow driver specific timeout settings for the http requests being made. Both drivers talk to web services that might be slow, so being able to adjust timeout settings for each service might be helpful for some setups.