### PR TITLE
Add trailing question mark handling for eDismax.

### DIFF
--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -130,6 +130,34 @@ class QueryBuilderTest extends \VuFindTest\Unit\TestCase
     }
 
     /**
+     * Test generation with a query handler with edismax
+     *
+     * @return void
+     */
+    public function testQueryHandlerWithEdismax()
+    {
+        // Set up an array of expected inputs and outputs:
+        // @codingStandardsIgnoreStart
+        $tests = [
+            ['this?', '(this?) OR (this\?)'],// trailing question mark
+        ];
+        // @codingStandardsIgnoreEnd
+
+        $qb = new QueryBuilder(
+            [
+                'test' => ['DismaxHandler' => 'edismax', 'DismaxFields' => ['foo']]
+            ]
+        );
+        foreach ($tests as $test) {
+            list($input, $output) = $test;
+            $q = new Query($input, 'test');
+            $response = $qb->build($q);
+            $processedQ = $response->get('q');
+            $this->assertEquals($output, $processedQ[0]);
+        }
+    }
+
+    /**
      * Test that the appropriate handler gets called for a quoted search when exact
      * settings are enabled.
      *


### PR DESCRIPTION
This addresses a problem noticed by @EreMaijala: trailing question marks were not getting handled gracefully when using edismax instead of dismax.