### PR TITLE
PAIA driver - removed strip_slashes on json post data as it would invalidate json…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -1502,7 +1502,7 @@ class PAIA extends DAIA
     protected function paiaPostRequest($file, $data_to_send, $access_token = null)
     {
         // json-encoding
-        $postData = stripslashes(json_encode($data_to_send));
+        $postData = json_encode($data_to_send);
 
         $http_headers = [];
         if (isset($access_token)) {


### PR DESCRIPTION
Removed strip_slashes on json post data as it would invalidate json string if it contains chars that need to be escaped - I don't know how that managed to stay under radar.