### PR TITLE
Fix a problem where ajaxLoadTab fails to load a tab when the domain n…

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -164,7 +164,7 @@ function ajaxLoadTab($newTab, tabid, setHash) {
     urlroot = '/' + chunks[3] + '/' + chunks[4];
   } else {
     // standard case -- VuFind has its own path under site:
-    var pathInUrl = urlWithoutFragment.indexOf(path);
+    var pathInUrl = urlWithoutFragment.indexOf(path, urlWithoutFragment.indexOf('//') + 2);
     var parts = urlWithoutFragment.substring(pathInUrl + path.length + 1).split('/');
     urlroot = '/' + parts[0] + '/' + parts[1];
   }


### PR DESCRIPTION
…ame begins with the VuFind path (e.g. http://vufind2.local/vufind2/Record/something).