### PR TITLE
Fixed a comparison to make default pickup location selection work pro…

### DIFF
--- a/themes/bootstrap3/js/hold.js
+++ b/themes/bootstrap3/js/hold.js
@@ -24,7 +24,7 @@ function setUpHoldRequestForm(recordId) {
       var defaultValue = $('#pickUpLocation').data('default');
       $.each(response.data.locations, function holdPickupLocationEach() {
         var option = $('<option></option>').attr('value', this.locationID).text(this.locationDisplay);
-        if (this.locationID === defaultValue || (defaultValue === '' && this.isDefault && $emptyOption.length === 0)) {
+        if (this.locationID == defaultValue || (defaultValue === '' && this.isDefault && $emptyOption.length === 0)) {
           option.attr('selected', 'selected');
         }
         $('#pickUpLocation').append(option);

--- a/themes/bootstrap3/js/hold.js
+++ b/themes/bootstrap3/js/hold.js
@@ -24,6 +24,7 @@ function setUpHoldRequestForm(recordId) {
       var defaultValue = $('#pickUpLocation').data('default');
       $.each(response.data.locations, function holdPickupLocationEach() {
         var option = $('<option></option>').attr('value', this.locationID).text(this.locationDisplay);
+        // Weak comparison between locationID and defaultValue since locationID may be an integer 
         if (this.locationID == defaultValue || (defaultValue === '' && this.isDefault && $emptyOption.length === 0)) {
           option.attr('selected', 'selected');
         }


### PR DESCRIPTION
…perly when request groups are in use.

The data attribute always contains a string while the value in the AJAX response may be integer too, so use "==" instead of "===".