### PR TITLE
Improved record tab hash handling for the initially active tab.

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -183,6 +183,8 @@ function ajaxLoadTab($newTab, tabid, setHash) {
     }
     if (typeof setHash == 'undefined' || setHash) {
       window.location.hash = tabid;
+    } else {
+      removeHashFromLocation();
     }
   });
   return false;
@@ -264,6 +266,15 @@ function applyRecordTabHash() {
   }
 }
 
+function removeHashFromLocation() {
+  if (window.history.replaceState) {
+    var href = window.location.href.split('#');
+    window.history.replaceState({}, document.title, href[0]);  
+  } else {
+    window.location.hash = '#';  
+  }
+}
+
 $(window).on('hashchange', applyRecordTabHash);
 
 function recordDocReady() {
@@ -293,7 +304,11 @@ function recordDocReady() {
     $(this).tab('show');
     if ($top.find('.' + tabid + '-tab').length > 0) {
       $top.find('.' + tabid + '-tab').addClass('active');
-      window.location.hash = tabid;
+      if ($(this).parent().hasClass('initiallyActive')) {
+        removeHashFromLocation();
+      } else {
+        window.location.hash = tabid;
+      }
       return false;
     } else {
       var newTab = getNewRecordTab(tabid).addClass('active');


### PR DESCRIPTION
There was a problem when loadInitialTabWithAjax setting was true and a page was loaded with a hash in that clicking the default tab didn't reset the hash. This patch improves the hash handling so that when the initially active tab is activated, the hash is always removed.