### PR TITLE
Set pickupLocation=holdingbranch(es) when neither defaultPickupLocation nor pickupLocation[] is set in KohaILSDI.ini

### DIFF
--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -43,6 +43,9 @@ extraHoldFields = comments:pickUpLocation:requiredByDate
 ; available. The default of 'false' will force users to pick a pickup
 ; location. By setting this to a Koha location code (e.g. '"MAIN"'),
 ; Vufind will default to that location.
+; If no defaultPickUpLocation and no pickupLocations are defined,
+; the driver will try to use the actual homebranch(es) of the item/title 
+; as a fallback.
 defaultPickUpLocation = "MAIN"
 
 ; branchcodes for libraries avalaible as pickup locations

--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -44,7 +44,7 @@ extraHoldFields = comments:pickUpLocation:requiredByDate
 ; location. By setting this to a Koha location code (e.g. '"MAIN"'),
 ; Vufind will default to that location.
 ; If no defaultPickUpLocation and no pickupLocations are defined,
-; the driver will try to use the actual homebranch(es) of the item/title 
+; the driver will try to use the actual holdingbranch(es) of the item/title 
 ; as a fallback.
 defaultPickUpLocation = "MAIN"
 

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -463,6 +463,40 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             if (!$this->db) {
                 $this->initDb();
             }
+            if (!$this->pickupEnableBranchcodes) {
+                // No defaultPickupLocation is defined in config AND no pickupLocations are defined either
+                if (isset($holdDetails['item_id']) && (empty($holdDetails['level']) || $holdDetails['level'] == 'item' )) {
+                    // We try to get the actual branchcode the item is found at
+                    $item_id = $holdDetails['item_id'];
+                    $sql = "SELECT homebranch
+                            FROM items
+                            WHERE itemnumber=($item_id)";
+                    try {
+                        $sqlSt = $this->db->prepare($sql);
+                        $sqlSt->execute();
+                        $this->pickupEnableBranchcodes = $sqlSt->fetch();
+                    } catch (PDOException $e) {
+                            $this->debug('Connection failed: ' . $e->getMessage());
+                            throw new ILSException($e->getMessage());
+                    }
+                } elseif (!empty($holdDetails['level']) && $holdDetails['level'] == 'title' ) {
+                    // We try to get the actual branchcodes the title is found at
+                    $id = $holdDetails['id'];
+                    $sql = "SELECT DISTINCT homebranch
+                            FROM items
+                            WHERE biblionumber=($id)";
+                    try {
+                        $sqlSt = $this->db->prepare($sql);
+                        $sqlSt->execute();
+                        foreach ($sqlSt->fetchAll() as $row) {
+                            $this->pickupEnableBranchcodes[] = $row['homebranch'];
+                        }
+                    } catch (PDOException $e) {
+                            $this->debug('Connection failed: ' . $e->getMessage());
+                            throw new ILSException($e->getMessage());
+                    }
+                }
+            }
             $branchcodes = "'" . implode(
                 "','", $this->pickupEnableBranchcodes
             ) . "'";

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -467,7 +467,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 // No defaultPickupLocation is defined in config 
                 // AND no pickupLocations are defined either
                 if (isset($holdDetails['item_id']) && (empty($holdDetails['level'])
-                    || $holdDetails['level'] == 'item' )
+                    || $holdDetails['level'] == 'item')
                 ) {
                     // We try to get the actual branchcode the item is found at
                     $item_id = $holdDetails['item_id'];
@@ -482,8 +482,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                             $this->debug('Connection failed: ' . $e->getMessage());
                             throw new ILSException($e->getMessage());
                     }
-                } elseif (!empty($holdDetails['level']) 
-                    && $holdDetails['level'] == 'title' 
+                } elseif (!empty($holdDetails['level'])
+                    && $holdDetails['level'] == 'title'
                 ) {
                     // We try to get the actual branchcodes the title is found at
                     $id = $holdDetails['id'];

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -467,7 +467,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 // No defaultPickupLocation is defined in config 
                 // AND no pickupLocations are defined either
                 if (isset($holdDetails['item_id']) && (empty($holdDetails['level'])
-                    || $holdDetails['level'] == 'item' )) {
+                    || $holdDetails['level'] == 'item' )
+                ) {
                     // We try to get the actual branchcode the item is found at
                     $item_id = $holdDetails['item_id'];
                     $sql = "SELECT homebranch
@@ -482,7 +483,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                             throw new ILSException($e->getMessage());
                     }
                 } elseif (!empty($holdDetails['level']) 
-                    && $holdDetails['level'] == 'title' ) {
+                    && $holdDetails['level'] == 'title' 
+                ) {
                     // We try to get the actual branchcodes the title is found at
                     $id = $holdDetails['id'];
                     $sql = "SELECT DISTINCT homebranch

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -471,7 +471,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 ) {
                     // We try to get the actual branchcode the item is found at
                     $item_id = $holdDetails['item_id'];
-                    $sql = "SELECT homebranch
+                    $sql = "SELECT holdingbranch
                             FROM items
                             WHERE itemnumber=($item_id)";
                     try {
@@ -487,14 +487,14 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 ) {
                     // We try to get the actual branchcodes the title is found at
                     $id = $holdDetails['id'];
-                    $sql = "SELECT DISTINCT homebranch
+                    $sql = "SELECT DISTINCT holdingbranch
                             FROM items
                             WHERE biblionumber=($id)";
                     try {
                         $sqlSt = $this->db->prepare($sql);
                         $sqlSt->execute();
                         foreach ($sqlSt->fetchAll() as $row) {
-                            $this->pickupEnableBranchcodes[] = $row['homebranch'];
+                            $this->pickupEnableBranchcodes[] = $row['holdingbranch'];
                         }
                     } catch (PDOException $e) {
                             $this->debug('Connection failed: ' . $e->getMessage());

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -464,8 +464,10 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 $this->initDb();
             }
             if (!$this->pickupEnableBranchcodes) {
-                // No defaultPickupLocation is defined in config AND no pickupLocations are defined either
-                if (isset($holdDetails['item_id']) && (empty($holdDetails['level']) || $holdDetails['level'] == 'item' )) {
+                // No defaultPickupLocation is defined in config 
+                // AND no pickupLocations are defined either
+                if (isset($holdDetails['item_id']) && (empty($holdDetails['level'])
+                    || $holdDetails['level'] == 'item' )) {
                     // We try to get the actual branchcode the item is found at
                     $item_id = $holdDetails['item_id'];
                     $sql = "SELECT homebranch
@@ -479,7 +481,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                             $this->debug('Connection failed: ' . $e->getMessage());
                             throw new ILSException($e->getMessage());
                     }
-                } elseif (!empty($holdDetails['level']) && $holdDetails['level'] == 'title' ) {
+                } elseif (!empty($holdDetails['level']) 
+                    && $holdDetails['level'] == 'title' ) {
                     // We try to get the actual branchcodes the title is found at
                     $id = $holdDetails['id'];
                     $sql = "SELECT DISTINCT homebranch


### PR DESCRIPTION
When defaultPickupLocation AND pickupLocationp[] is empty in KohaILSDI.ini and holds are enabled, the user would get an error.
In that case, as a last resort, it is relatively safe to use the holdingbranch location as a pickup location.

When in item level holds: get the one location the selected item is available at.
When in title level holds: get the unique locations the selected title is available at.