### PR TITLE
Allow separate dynamic cover settings for different sizes.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -777,6 +777,11 @@ authors         = Wikipedia
 
 ; This section controls the behavior of the cover generator when makeDynamicCovers
 ; above is non-false.
+;
+; Note that any of these settings may be filtered to be size-specific by subscripting
+; the key with a size. You can use a key of * for a default to use when a specific
+; size is not matched. This allows adjustment of certain elements for different
+; thumbnail sizes. See the "size" setting below for an example.
 [DynamicCovers]
 ; This controls the background layer of the generated image; options:
 ; - solid: display a solid color
@@ -840,7 +845,9 @@ authors         = Wikipedia
 ; defines a WxH rectangle. wrapWidth constrains the text size (and must be no
 ; larger than the width of the canvas). topPadding and bottomPadding push the
 ; text away from the edges of the canvas.
-;size = 128
+;size[*] = 128
+;size[medium] = 200
+;size[large] = 500
 ;topPadding = 19
 ;bottomPadding = 3
 ;wrapWidth = 110

--- a/module/VuFind/src/VuFind/Cover/Loader.php
+++ b/module/VuFind/src/VuFind/Cover/Loader.php
@@ -150,11 +150,11 @@ class Loader extends \VuFind\ImageLoader
     }
 
     /**
-     * Get Cover Generator Object
+     * Get settings for the cover generator.
      *
-     * @return VuFind\Cover\Generator
+     * @return array
      */
-    public function getCoverGenerator()
+    protected function getCoverGeneratorSettings()
     {
         $settings = isset($this->config->DynamicCovers)
             ? $this->config->DynamicCovers->toArray() : [];
@@ -163,7 +163,33 @@ class Loader extends \VuFind\ImageLoader
         ) {
             $settings['backgroundMode'] = $this->config->Content->makeDynamicCovers;
         }
-        return new \VuFind\Cover\Generator($this->themeTools, $settings);
+        $size = $this->size;
+        $pickSize = function ($setting) use ($size) {
+            if (isset($setting[$size])) {
+                return $setting[$size];
+            }
+            if (isset($setting['*'])) {
+                return $setting['*'];
+            }
+            return $setting;
+        };
+        return array_map($pickSize, $settings);
+    }
+
+    /**
+     * Get Cover Generator Object (or return false if disabled)
+     *
+     * @return VuFind\Cover\Generator|bool
+     */
+    public function getCoverGenerator()
+    {
+        if (isset($this->config->Content->makeDynamicCovers)
+            && $this->config->Content->makeDynamicCovers
+        ) {
+            $settings = $this->getCoverGeneratorSettings();
+            return new \VuFind\Cover\Generator($this->themeTools, $settings);
+        }
+        return false;
     }
 
     /**
@@ -260,10 +286,8 @@ class Loader extends \VuFind\ImageLoader
         } else if (!$this->fetchFromAPI()
             && !$this->fetchFromContentType()
         ) {
-            if (isset($this->config->Content->makeDynamicCovers)
-                && $this->config->Content->makeDynamicCovers
-            ) {
-                $this->image = $this->getCoverGenerator()->generate(
+            if ($generator = $this->getCoverGenerator()) {
+                $this->image = $generator->generate(
                     $settings['title'], $settings['author'], $settings['callnumber']
                 );
                 $this->contentType = 'image/png';


### PR DESCRIPTION
Right now, dynamic cover settings can only be set one way, but since VuFind supports small, medium and large thumbnails, it makes more sense to allow some settings to be adjusted in a size-specific way. This offers a simple mechanism to support that. This is designed in part to offer better support for dynamic covers in #693.