### PR TITLE
Allow sending records by sms to be disabled in config

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -467,6 +467,12 @@ maximum_recipients = 1
 ; setting from the [Site] section used as a last resort.
 disable_from = false
 
+; Being a special case of mail message, sending record results via SMS ("Text this")
+; may be "enabled" or "disabled" ("enabled" by default).
+; Should you choose to leave it enabled, see also sms.ini for further
+; configuration options.
+sms = enabled
+
 ; This section needs to be changed to match your database connection information
 [Database]
 database          = mysql://root@localhost/vufind

--- a/module/VuFind/src/VuFind/Config/AccountCapabilities.php
+++ b/module/VuFind/src/VuFind/Config/AccountCapabilities.php
@@ -136,6 +136,18 @@ class AccountCapabilities
     }
 
     /**
+     * Get sms setting.
+     *
+     * @return string
+     */
+    public function getSmsSetting()
+    {
+        return isset($this->config->Mail->sms)
+            && $this->config->Mail->sms === 'disabled'
+            ? 'disabled' : 'enabled';
+    }
+
+    /**
      * Is a user account capable of saving data currently available?
      *
      * @return bool

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/toolbar.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/toolbar.phtml
@@ -12,7 +12,9 @@
   <? if (count($this->driver->getCitationFormats()) > 0): ?>
     <li><a class="cite-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'Cite')?>" rel="nofollow"><i class="fa fa-asterisk" aria-hidden="true"></i> <?=$this->transEsc('Cite this')?></a></li>
   <? endif; ?>
-  <li><a class="sms-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'SMS')?>" rel="nofollow"><i class="fa fa-mobile" aria-hidden="true"></i> <?=$this->transEsc('Text this')?></a></li>
+  <? if ($this->accountCapabilities()->getSmsSetting() !== 'disabled'): ?>
+    <li><a class="sms-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'SMS')?>" rel="nofollow"><i class="fa fa-mobile" aria-hidden="true"></i> <?=$this->transEsc('Text this')?></a></li>
+  <? endif; ?>
   <li><a class="mail-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'Email')?>" rel="nofollow"><i class="fa fa-envelope" aria-hidden="true"></i> <?=$this->transEsc('Email this')?></a></li>
 
   <? $exportFormats = $this->export()->getFormatsForRecord($this->driver); ?>


### PR DESCRIPTION
Currently, sending record results by sms ("Text this" feature) is
always shown in the record page, even though it may not be applicable
to some installations.

Although still left enabled by default, with this patch, the admin
has the option to suppress the sms link in the record page, if needed.

The [Mail] section in main config file has been chosen to hold the new
parameter because sending sms messages uses the underline mailer
infrastructure.