### PR TITLE
Update to autocomplete v0.16.3

### DIFF
--- a/themes/bootstrap3/js/lib/autocomplete.js
+++ b/themes/bootstrap3/js/lib/autocomplete.js
@@ -93,10 +93,6 @@
       createList(data, input);
     }
   }
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-  function escapeRegExp(string){
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-  }
   function search(input) {
     if (xhr) { xhr.abort(); }
     if (input.val().length >= options.minLength) {
@@ -118,7 +114,7 @@
         var matches = options.static.filter(function staticFilter(_item) {
           return _item.match.match(term);
         });
-        if (typeof options.staticSort === 'functions') {
+        if (typeof options.staticSort === 'function') {
           matches.sort(options.staticSort);
         } else {
           matches.sort(function defaultStaticSort(a, b) {

--- a/themes/bootstrap3/js/lib/autocomplete.js
+++ b/themes/bootstrap3/js/lib/autocomplete.js
@@ -40,9 +40,7 @@
     hide();
   }
 
-  function createList(fulldata, input) {
-    // Limit results
-    var data = fulldata.slice(0, Math.min(options.maxResults, fulldata.length));
+  function createList(data, input) {
     input.data('length', data.length);
     // highlighting setup
     // escape term for regex - https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
@@ -85,6 +83,8 @@
   }
 
   function handleResults(input, term, data) {
+    // Limit results
+    var data = data.slice(0, Math.min(options.maxResults, data.length));
     var cid = input.data('cache-id');
     cache[cid][term] = data;
     if (data.length === 0) {
@@ -111,14 +111,15 @@
         }
       // Check for static list
       } else if (typeof options.static !== 'undefined') {
+        var lcterm = term.toLowerCase();
         var matches = options.static.filter(function staticFilter(_item) {
-          return _item.match.match(term);
+          return _item.match.match(lcterm);
         });
         if (typeof options.staticSort === 'function') {
           matches.sort(options.staticSort);
         } else {
           matches.sort(function defaultStaticSort(a, b) {
-            return a.match.indexOf(term) - b.match.indexOf(term);
+            return a.match.indexOf(lcterm) - b.match.indexOf(lcterm);
           });
         }
         handleResults(input, term, matches);

--- a/themes/bootstrap3/theme.config.php
+++ b/themes/bootstrap3/theme.config.php
@@ -15,7 +15,7 @@ return array(
         'vendor/bootstrap.min.js',
         'vendor/bootstrap-accessibility.min.js',
         'vendor/validator.min.js',
-        'autocomplete.js',
+        'lib/autocomplete.js',
         'common.js',
         'lightbox.js',
     ),


### PR DESCRIPTION
Adds a new option to run all searches against a fixed list of items, matched case insensitively.
```Javascript
$('input').autocomplete({static: myListOfAllTheAnimals});
```
[Link to relevant matching code](https://github.com/vufind-org/vufind/blob/autocomplete-static/themes/bootstrap3/js/lib/autocomplete.js#L117-L124).