### PR TITLE
Encode the Username

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -324,7 +324,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
      * @param string $service     Called function (GetAvailability,
      *                                             GetRecords,
      *                                             GetAuthorityRecords,
-     *                                             LookupPatron,
+     *                                             
+     ,
      *                                             AuthenticatePatron,
      *                                             GetPatronInfo,
      *                                             GetPatronStatus,
@@ -1642,7 +1643,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         //       . "&password=" . $password
         // );
         $idObj = $this->makeRequest(
-            "LookupPatron" . "&id=" . $username
+            "LookupPatron" . "&id=" . urlencode($username)
             . "&id_type=userid"
         );
 


### PR DESCRIPTION
Encode the username, so spaces in the username don't throw an error and allow login.