### PR TITLE
Fixed an issue where the login dialog breaks with ChoiceAuth if CSRF check fails for any reason (like session timeout).

### DIFF
--- a/module/VuFind/src/VuFind/Auth/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Auth/AbstractBase.php
@@ -96,6 +96,17 @@ abstract class AbstractBase implements \VuFind\Db\Table\DbTableAwareInterface,
     }
 
     /**
+     * Reset any internal status; this is essentially an event hook which most auth
+     * modules can ignore. See ChoiceAuth for a use case example.
+     *
+     * @return void
+     */
+    public function resetState()
+    {
+        // By default, do no checking.
+    }
+
+    /**
      * Set configuration.
      *
      * @param \Zend\Config\Config $config Configuration to set

--- a/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
@@ -139,6 +139,17 @@ class ChoiceAuth extends AbstractBase
     }
 
     /**
+     * Reset any internal status; this is essentially an event hook which most auth
+     * modules can ignore. See ChoiceAuth for a use case example.
+     *
+     * @return void
+     */
+    public function resetState()
+    {
+        $this->strategy = false;
+    }
+
+    /**
      * Attempt to authenticate the current user.  Throws exception if login fails.
      *
      * @param Request $request Request object containing account credentials.

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -558,6 +558,7 @@ class Manager implements \ZfcRbac\Identity\IdentityProviderInterface
         if (!$this->getAuth()->getSessionInitiator(null)
             && !$this->csrf->isValid($request->getPost()->get('csrf'))
         ) {
+            $this->getAuth()->resetState();
             throw new AuthException('authentication_error_technical');
         }
 


### PR DESCRIPTION
The strategy was left active in ChoiceAuth, which caused only its login form (that didn't really work) to be displayed.

Easy to test by altering the CSRF token in the login form.