### PR TITLE
Added flash messages to the save to favorites dialog.

### DIFF
--- a/themes/bootstrap3/templates/record/save.phtml
+++ b/themes/bootstrap3/templates/record/save.phtml
@@ -9,6 +9,7 @@
 ?>
 <h2><?=$this->transEsc("add_favorite_prefix") ?> <span class="title-in-heading"><?=$this->escapeHtml($this->driver->getBreadcrumb())?></span> <?=$this->transEsc("add_favorite_suffix") ?></h2>
 <form id="edit-save-form" class="form-horizontal" method="post" action="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" name="saveRecord" data-lightbox-onclose="checkSaveStatuses();">
+  <?=$this->flashmessages()?>
   <input type="hidden" name="submit" value="1" />
   <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>" />
   <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />


### PR DESCRIPTION
This solves the problem that a success message is not shown after adding the record to favorites, but there's still a question about what caused the problem since it used to work properly.