### PR TITLE
Check if a hold has already been placed for an item by the same user

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -607,9 +607,9 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         // The following check is mainly required for certain old buggy Koha versions
         // that allowed multiple holds from the same user to the same item
         $sql = "select count(*) as RCOUNT from reserves where borrowernumber = :rid "
-            . "and biblionumber = :bid";
+            . "and itemnumber = :iid";
         $reservesSqlStmt = $this->db->prepare($sql);
-        $reservesSqlStmt->execute([':rid' => $patron_id, ':bid' => $bib_id]);
+        $reservesSqlStmt->execute([':rid' => $patron_id, ':iid' => $item_id]);
         $reservesCount = $reservesSqlStmt->fetch()["RCOUNT"];
 
         if ($reservesCount > 0) {

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -604,6 +604,22 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         $this->debug("Needed before date: " . $needed_before_date);
         $this->debug("Level: " . $level);
 
+        // The following check is mainly required for certain old buggy Koha versions
+        // that allowed multiple holds from the same user to the same item
+        $sql = "select count(*) as RCOUNT from reserves where borrowernumber = :rid "
+            . "and biblionumber = :bid";
+        $reservesSqlStmt = $this->db->prepare($sql);
+        $reservesSqlStmt->execute([':rid' => $patron_id, ':bid' => $bib_id]);
+        $reservesCount = $reservesSqlStmt->fetch()["RCOUNT"];
+
+        if ($reservesCount > 0) {
+            $this->debug("Fatal error: Patron has already reserved this item.");
+            return [
+                "success" => false,
+                "sysMessage" => "It seems you have already reserved this item."
+            ];
+        }
+
         if ($level == "title") {
             $rqString = "HoldTitle&patron_id=$patron_id&bib_id=$bib_id"
                 . "&request_location=$request_location"


### PR DESCRIPTION
The check is mainly required for certain old buggy Koha versions
that allowed multiple holds from the same user to the same item
via ILS-DI.
In addition, it presents an error message to end users in case
the hold could not be placed on an item because it already existed
(even in cases where Koha ILS-DI erroneously does not return an
error code).