### PR TITLE
Change default values for extraHoldFields in KohaILSDI.ini

### DIFF
--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -36,7 +36,12 @@ defaultRequiredDate = 0:1:0
 ; extraHoldFields - A colon-separated list used to display extra visible fields in the
 ; place holds form. Supported values are "comments", "requiredByDate" and
 ; "pickUpLocation"
-extraHoldFields = comments:pickUpLocation:requiredByDate
+; Note: As of the time of writing, eventhough ILSDI API docs have long declared
+; support for 'comments' and 'requiredByDate' options when placing holds, these
+; features might not yet be implemented (nulling any input passed to the appropriate
+; functions). Should you decide to use them in extraHoldFields, please check that data
+; entered in appropriate hold form is properly passed to Koha.
+extraHoldFields = pickUpLocation
 
 ; A Pick Up Location Code used to pre-select the pick up location drop
 ; down list and provide a default option if others are not


### PR DESCRIPTION
Although the ILSDI API has long declared support for comments
and expirydate (or requiredByDate) in holds, as one can see in
https://github.com/Koha-Community/Koha/blob/master/C4/ILSDI/Services.pm
as of the time of writing, the actual call to the AddReserve
function nulls any data passed via the URL.
Because of this, extraHoldFields, for the time being, should not
contain comments or requiredByDate because data entered by users
in the relevant fields of the VuFind hold form will be discarded.