### PR TITLE
Fix issues with IE 9 and 10 by using jQuery to handle data attributes…

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -166,7 +166,7 @@ function recaptchaOnLoad() {
   if (typeof grecaptcha !== 'undefined') {
     var captchas = $('.g-recaptcha:empty');
     for (var i = 0; i < captchas.length; i++) {
-      captchas[i].dataset.captchaId = grecaptcha.render(captchas[i], captchas[i].dataset);
+      $(captchas[i]).data('captchaId', grecaptcha.render(captchas[i], $(captchas[i]).data()));
     }
   }
 }
@@ -321,6 +321,16 @@ function setupFacets() {
   $('.facet.list-group .collapse').on('hidden.bs.collapse', facetSessionStorage);
 }
 
+function setupIeSupport() {
+  // Disable Bootstrap modal focus enforce on IE since it breaks Recaptcha.
+  // Cannot use conditional comments since IE 11 doesn't support them but still has
+  // the issue
+  var ua = window.navigator.userAgent;
+  if (ua.indexOf('MSIE') || ua.indexOf('Trident/')) {
+    $.fn.modal.Constructor.prototype.enforceFocus = function emptyEnforceFocus() { };
+  }
+}
+
 $(document).ready(function commonDocReady() {
   // Start up all of our submodules
   VuFind.init();
@@ -382,4 +392,6 @@ $(document).ready(function commonDocReady() {
     $('.searchFormKeepFilters').prop('checked', state);
     $('.applied-filter').prop('checked', state);
   }
+  
+  setupIeSupport();
 });

--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -104,7 +104,7 @@ VuFind.register('lightbox_facets', function LightboxFacets() {
   function lightboxFacetSorting() {
     var sortButtons = $('.js-facet-sort');
     function sortAjax(button) {
-      var sort = button.dataset.sort;
+      var sort = $(button).data('sort');
       var list = $('#facet-list-' + sort);
       if (list.find('.js-facet-item').length === 0) {
         list.find('.js-facet-next-page').text(VuFind.translate('loading') + '...');
@@ -129,7 +129,7 @@ VuFind.register('lightbox_facets', function LightboxFacets() {
     lightboxFacetSorting();
     $('.js-facet-next-page').click(function facetLightboxMore() {
       var button = $(this);
-      var page = parseInt(this.dataset.page, 10);
+      var page = parseInt(button.data('page'), 10);
       if (button.attr('disabled')) {
         return false;
       }

--- a/themes/bootstrap3/js/openurl.js
+++ b/themes/bootstrap3/js/openurl.js
@@ -35,7 +35,7 @@ VuFind.register('openurl', function OpenUrl() {
     // If the target is already visible, a previous click has populated it;
     // don't waste time doing redundant work.
     if (target.hasClass('hidden')) {
-      _loadResolverLinks(target.removeClass('hidden'), openUrl, element.data('search-class-id'));
+      _loadResolverLinks(target.removeClass('hidden'), openUrl, element.data('searchClassId'));
     }
   }
 

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -267,10 +267,10 @@ function applyRecordTabHash() {
   var newTab = typeof window.location.hash !== 'undefined'
     ? window.location.hash.toLowerCase() : '';
 
-  // Open tag in url hash
-  if (newTab.length === 0 || newTab === '#tabnav') {
+  // Open tab in url hash
+  if (newTab.length <= 1 || newTab === '#tabnav') {
     $initiallyActiveTab.click();
-  } else if (newTab.length > 0 && '#' + activeTab !== newTab) {
+  } else if (newTab.length > 1 && '#' + activeTab !== newTab) {
     $('.' + newTab.substr(1)).click();
   }
 }


### PR DESCRIPTION
… and ignore hash as a record tab if its length is <= 1. Fix issue with all IE versions where Recaptcha dialogs don't accept any button presses.

- Once again: data attributes cannot be accessed with IE 9 or 10 using the dataset attribute.

- At least IE 9 also returns an empty hash as '#', and taking substr(1) from it results in an empty selector, which causes a jQuery error.

- The Recaptcha dialog that appears if automatic verification doesn't work (try e.g. in a private browser window) with Bootstrap's code that tries to make sure focus stays in the modal. See http://stackoverflow.com/questions/27886618/problems-with-new-google-recaptcha-in-ie-when-inside-modal-or-dialog for more information.