### PR TITLE
Added a new bool parameter to getRemoteCallSlips that when set to tru…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2398,11 +2398,12 @@ EOT;
         $requests = [];
         if (isset($results->callslips->institution)) {
             foreach ($results->callslips->institution as $institution) {
-                if ($this->isLocalInst((string)$institution->attributes()->id)) {
-                    // Ignore local callslips, we have them already
-                    if (! $local) {
-                        continue;
-                    }
+                if (!$local
+                    && $this->isLocalInst((string)$institution->attributes()->id)
+                ) {
+                    // Unless $local is set, ignore local callslips; we have them
+                    // already....
+                    continue;
                 }
                 foreach ($institution->callslip as $callslip) {
                     $item = $callslip->requestItem;

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2366,24 +2366,10 @@ EOT;
     }
 
     /**
-     * Get Patron Remote Storage Retrieval Requests (Call Slips). Gets remote
-     * callslips via the API.
-     *
-     * This is a wrapper around getCallSlips designed for legacy
-     * compatibility. It can probably be removed in the future.
-     *
-     * @param array $patron The patron array from patronLogin
-     *
-     * @return mixed        Array of the patron's storage retrieval requests.
-     */
-    protected function getRemoteCallSlips($patron)
-    {
-        return $this->getCallSlips($patron, false);
-    }
-
-    /**
      * Get Patron Storage Retrieval Requests (Call Slips). Gets callslips via
-     * the API.
+     * the API. Returns only remote slips by default since more complete data
+     * can be retrieved directly from the local database; however, the $local
+     * parameter exists to support potential local customizations.
      *
      * @param array $patron The patron array from patronLogin
      * @param bool  $local  Whether to include local callslips

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2369,12 +2369,28 @@ EOT;
      * Get Patron Remote Storage Retrieval Requests (Call Slips). Gets remote
      * callslips via the API.
      *
+     * This is a wrapper around getCallSlips designed for legacy
+     * compatibility. It can probably be removed in the future.
+     *
+     * @param array $patron The patron array from patronLogin
+     *
+     * @return mixed        Array of the patron's storage retrieval requests.
+     */
+    protected function getRemoteCallSlips($patron)
+    {
+        return $this->getCallSlips($patron, false);
+    }
+
+    /**
+     * Get Patron Storage Retrieval Requests (Call Slips). Gets callslips via
+     * the API.
+     *
      * @param array $patron The patron array from patronLogin
      * @param bool  $local  Whether to include local callslips
      *
      * @return mixed        Array of the patron's storage retrieval requests.
      */
-    protected function getRemoteCallSlips($patron, $local = false)
+    protected function getCallSlips($patron, $local = false)
     {
         // Build Hierarchy
         $hierarchy = [
@@ -3151,7 +3167,7 @@ EOT;
     {
         return array_merge(
             $this->getHoldsFromApi($patron, false),
-            $this->getRemoteCallSlips($patron)
+            $this->getCallSlips($patron, false) // remote only
         );
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2370,10 +2370,11 @@ EOT;
      * callslips via the API.
      *
      * @param array $patron The patron array from patronLogin
+     * @param bool  $local  Whether to include local callslips
      *
      * @return mixed        Array of the patron's storage retrieval requests.
      */
-    protected function getRemoteCallSlips($patron)
+    protected function getRemoteCallSlips($patron, $local = false)
     {
         // Build Hierarchy
         $hierarchy = [
@@ -2399,7 +2400,9 @@ EOT;
             foreach ($results->callslips->institution as $institution) {
                 if ($this->isLocalInst((string)$institution->attributes()->id)) {
                     // Ignore local callslips, we have them already
-                    continue;
+                    if (! $local) {
+                        continue;
+                    }
                 }
                 foreach ($institution->callslip as $callslip) {
                     $item = $callslip->requestItem;


### PR DESCRIPTION
…e will return local CallSlip information along with Remote CallSlip information (default is false).

We have a use case where we actually need the local callslip information that is returned by Voyager Web Services (VXWS). This new parameter is optional and if not set (default is false) will not alter the functionality of this driver in any way.