### PR TITLE
Use fluent interface for UrlQueryHelper.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AjaxController.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxController.php
@@ -909,9 +909,8 @@ class AjaxController extends AbstractBase
             $facets[$field]['removalURL']
                 = $results->getUrlQuery()->removeFacet(
                     $field,
-                    isset($filters[$field][0]) ? $filters[$field][0] : null,
-                    false
-                );
+                    isset($filters[$field][0]) ? $filters[$field][0] : null
+                )->getParams(false);
         }
         return $this->output($facets, self::STATUS_OK);
     }

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -365,10 +365,10 @@ class SearchController extends AbstractSearch
         // (check it's set first -- RSS feed will return a response model rather
         // than a view model):
         if (isset($view->results)) {
-            $url = $view->results->getUrlQuery();
-            $url->setDefaultParameter('range', $range);
-            $url->setDefaultParameter('department', $dept);
-            $url->setSuppressQuery(true);
+            $view->results->getUrlQuery()
+                ->setDefaultParameter('range', $range)
+                ->setDefaultParameter('department', $dept)
+                ->setSuppressQuery(true);
         }
 
         // We don't want new items hidden filters to propagate to other searches:
@@ -483,11 +483,11 @@ class SearchController extends AbstractSearch
         // (but only do this if we have access to a results object, which we
         // won't in RSS mode):
         if (isset($view->results)) {
-            $url = $view->results->getUrlQuery();
-            $url->setDefaultParameter('course', $course);
-            $url->setDefaultParameter('inst', $inst);
-            $url->setDefaultParameter('dept', $dept);
-            $url->setSuppressQuery(true);
+            $view->results->getUrlQuery()
+                ->setDefaultParameter('course', $course)
+                ->setDefaultParameter('inst', $inst)
+                ->setDefaultParameter('dept', $dept)
+                ->setSuppressQuery(true);
         }
         return $view;
     }

--- a/module/VuFind/src/VuFind/Recommend/MapSelection.php
+++ b/module/VuFind/src/VuFind/Recommend/MapSelection.php
@@ -234,9 +234,8 @@ class MapSelection implements \VuFind\Recommend\RecommendInterface
                     );
                     $this->selectedCoordinates = $reorder_coords;
                 }
-                $this->searchParams = $results->getUrlQuery()->removeFacet(
-                    $this->geoField, $value[0], false
-                );
+                $this->searchParams = $results->getUrlQuery()
+                    ->removeFacet($this->geoField, $value[0])->getParams(false);
             }
         }
         if ($this->searchParams == null) {

--- a/module/VuFind/src/VuFind/Recommend/RemoveFilters.php
+++ b/module/VuFind/src/VuFind/Recommend/RemoveFilters.php
@@ -122,7 +122,7 @@ class RemoveFilters implements RecommendInterface
      */
     public function getFilterlessUrl()
     {
-        return $this->results->getUrlQuery()->removeAllFilters();
+        return $this->results->getUrlQuery()->removeAllFilters()->getParams();
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -197,6 +197,16 @@ abstract class Results implements ServiceLocatorAwareInterface
     }
 
     /**
+     * Options for UrlQueryHelper
+     *
+     * @return array
+     */
+    protected function getUrlQueryHelperOptions()
+    {
+        return [];
+    }
+
+    /**
      * Get the URL helper for this object.
      *
      * @return UrlHelper
@@ -205,7 +215,9 @@ abstract class Results implements ServiceLocatorAwareInterface
     {
         // Set up URL helper:
         if (!isset($this->helpers['urlQuery'])) {
-            $this->helpers['urlQuery'] = new UrlQueryHelper($this->getParams());
+            $this->helpers['urlQuery'] = new UrlQueryHelper(
+                $this->getParams(), null, null, $this->getUrlQueryHelperOptions()
+            );
         }
         return $this->helpers['urlQuery'];
     }

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -26,7 +26,7 @@
  * @link     https://vufind.org Main Page
  */
 namespace VuFind\Search\Base;
-use VuFind\Search\UrlQueryHelper, Zend\Paginator\Paginator,
+use VuFind\Search\Factory\UrlQueryHelperFactory, Zend\Paginator\Paginator,
     Zend\ServiceManager\ServiceLocatorAwareInterface,
     Zend\ServiceManager\ServiceLocatorInterface;
 use VuFindSearch\Service as SearchService;
@@ -209,14 +209,15 @@ abstract class Results implements ServiceLocatorAwareInterface
     /**
      * Get the URL helper for this object.
      *
-     * @return UrlHelper
+     * @return \VuFind\Search\UrlQueryHelper
      */
     public function getUrlQuery()
     {
         // Set up URL helper:
         if (!isset($this->helpers['urlQuery'])) {
-            $this->helpers['urlQuery'] = new UrlQueryHelper(
-                $this->getParams(), null, null, $this->getUrlQueryHelperOptions()
+            $factory = new UrlQueryHelperFactory();
+            $this->helpers['urlQuery'] = $factory->fromParams(
+                $this->getParams(), $this->getUrlQueryHelperOptions()
             );
         }
         return $this->helpers['urlQuery'];

--- a/module/VuFind/src/VuFind/Search/Factory/UrlQueryHelperFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/UrlQueryHelperFactory.php
@@ -56,7 +56,6 @@ class UrlQueryHelperFactory
             'selectedShards' => $options->getDefaultSelectedShards(),
             'sort' => $params->getDefaultSort(),
             'view' => $options->getDefaultView(),
-            
         ];
     }
 

--- a/module/VuFind/src/VuFind/Search/Factory/UrlQueryHelperFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/UrlQueryHelperFactory.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Factory to build UrlQueryHelper.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2016.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\Search\Factory;
+use VuFind\Search\UrlQueryHelper;
+use VuFind\Search\Base\Params;
+
+/**
+ * Factory to build UrlQueryHelper.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class UrlQueryHelperFactory
+{
+    /**
+     * Extract default settings from the search parameters.
+     *
+     * @param Params $params VuFind search parameters
+     *
+     * @return array
+     */
+    protected function getDefaults(Params $params)
+    {
+        $options = $params->getOptions();
+        return [
+            'handler' => $options->getDefaultHandler(),
+            'limit' => $options->getDefaultLimit(),
+            'selectedShards' => $options->getDefaultSelectedShards(),
+            'sort' => $params->getDefaultSort(),
+            'view' => $options->getDefaultView(),
+            
+        ];
+    }
+
+    /**
+     * Load default settings into the user-provided configuration.
+     *
+     * @param Params $params VuFind search parameters
+     * @param array  $config Config options
+     *
+     * @return array
+     */
+    protected function addDefaultsToConfig(Params $params, array $config)
+    {
+        // Load defaults unless they have been overridden in existing config
+        // array.
+        foreach ($this->getDefaults($params) as $key => $value) {
+            if (!isset($config['defaults'][$key])) {
+                $config['defaults'][$key] = $value;
+            }
+        }
+
+        // Load useful callbacks if they have not been specifically overridden
+        if (!isset($config['parseFilterCallback'])) {
+            $config['parseFilterCallback'] = [$params, 'parseFilter'];
+        }
+        if (!isset($config['getAliasesForFacetFieldCallback'])) {
+            $config['getAliasesForFacetFieldCallback']
+                = [$params, 'getAliasesForFacetField'];
+        }
+        return $config;
+    }
+
+    /**
+     * Extract URL query parameters from VuFind search parameters.
+     *
+     * @param Params $params VuFind search parameters
+     * @param array  $config Config options
+     *
+     * @return array
+     */
+    protected function getUrlParams(Params $params, array $config)
+    {
+        $urlParams = [];
+        $sort = $params->getSort();
+        if (null !== $sort && $sort != $config['defaults']['sort']) {
+            $urlParams['sort'] = $sort;
+        }
+        $limit = $params->getLimit();
+        if (null !== $limit && $limit != $config['defaults']['limit']) {
+            $urlParams['limit'] = $limit;
+        }
+        $view = $params->getView();
+        if (null !== $view && $view != $config['defaults']['view']) {
+            $urlParams['view'] = $view;
+        }
+        if ($params->getPage() != 1) {
+            $urlParams['page'] = $params->getPage();
+        }
+        $filters = $params->getFilters();
+        if (!empty($filters)) {
+            $urlParams['filter'] = [];
+            foreach ($filters as $field => $values) {
+                foreach ($values as $current) {
+                    $urlParams['filter'][] = $field . ':"' . $current . '"';
+                }
+            }
+        }
+        $hiddenFilters = $params->getHiddenFilters();
+        if (!empty($hiddenFilters)) {
+            foreach ($hiddenFilters as $field => $values) {
+                foreach ($values as $current) {
+                    $urlParams['hiddenFilters'][] = $field . ':"' . $current . '"';
+                }
+            }
+        }
+        $shards = $params->getSelectedShards();
+        if (!empty($shards)) {
+            sort($shards);
+            $defaultShards = $config['defaults']['selectedShards'];
+            sort($defaultShards);
+            if (implode(':::', $shards) != implode(':::', $defaultShards)) {
+                $urlParams['shard'] = $shards;
+            }
+        }
+        if ($params->hasDefaultsApplied()) {
+            $urlParams['dfApplied'] = 1;
+        }
+        return $urlParams;
+    }
+
+    /**
+     * Construct the UrlQueryHelper
+     *
+     * @param Params $params VuFind search parameters
+     * @param array  $config Config options
+     *
+     * @return UrlQueryHelper
+     */
+    public function fromParams(Params $params, array $config = [])
+    {
+        $finalConfig = $this->addDefaultsToConfig($params, $config);
+        return new UrlQueryHelper(
+            $this->getUrlParams($params, $finalConfig),
+            $params->getQuery(),
+            $finalConfig
+        );
+    }
+}

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -174,11 +174,9 @@ class HierarchicalFacetHelper
     /**
      * Create an item for the hierarchical facet array
      *
-     * @param string         $facet      Facet name
-     * @param array          $item       Facet item received from Solr
-     * @param UrlQueryHelper $urlHelper  UrlQueryHelper for creating facet
-     * url's
-     * active children
+     * @param string         $facet     Facet name
+     * @param array          $item      Facet item received from Solr
+     * @param UrlQueryHelper $urlHelper UrlQueryHelper for creating facet URLs
      *
      * @return array Facet item
      */

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -94,13 +94,11 @@ class HierarchicalFacetHelper
      */
     public function buildFacetArray($facet, $facetList, $urlHelper = false)
     {
-        // getParamArray() is expensive, so call it just once and pass it on
-        $paramArray = $urlHelper !== false ? $urlHelper->getParamArray() : null;
         // Create a keyed (for conversion to hierarchical) array of facet data
         $keyedList = [];
         foreach ($facetList as $item) {
             $keyedList[$item['value']] = $this->createFacetItem(
-                $facet, $item, $urlHelper, $paramArray
+                $facet, $item, $urlHelper
             );
         }
 
@@ -179,12 +177,11 @@ class HierarchicalFacetHelper
      * @param array          $item       Facet item received from Solr
      * @param UrlQueryHelper $urlHelper  UrlQueryHelper for creating facet
      * url's
-     * @param array          $paramArray URL parameters
      * active children
      *
      * @return array Facet item
      */
-    protected function createFacetItem($facet, $item, $urlHelper, $paramArray)
+    protected function createFacetItem($facet, $item, $urlHelper)
     {
         $href = '';
         $exclude = '';
@@ -192,16 +189,15 @@ class HierarchicalFacetHelper
         if ($urlHelper !== false) {
             if ($item['isApplied']) {
                 $href = $urlHelper->removeFacet(
-                    $facet, $item['value'], true, $item['operator'], $paramArray
-                );
+                    $facet, $item['value'], true, $item['operator']
+                )->getParams();
             } else {
                 $href = $urlHelper->addFacet(
-                    $facet, $item['value'], $item['operator'], $paramArray
-                );
+                    $facet, $item['value'], $item['operator']
+                )->getParams();
             }
-            $exclude = $urlHelper->addFacet(
-                $facet, $item['value'], 'NOT', $paramArray
-            );
+            $exclude = $urlHelper->addFacet($facet, $item['value'], 'NOT')
+                ->getParams();
         }
 
         $displayText = $item['displayText'];

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -28,6 +28,7 @@
 namespace VuFind\Search\Solr;
 
 use VuFind\I18n\TranslatableString;
+use VuFind\Search\UrlQueryHelper;
 
 /**
  * Functions for manipulating facets

--- a/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
@@ -49,9 +49,16 @@ class Results extends SolrResults
     {
         // Call parent constructor:
         parent::__construct($params);
+    }
 
-        // Set up URL helper to use appropriate search parameter:
-        $this->getUrlQuery()->setBasicSearchParam('author');
+    /**
+     * Options for UrlQueryHelper
+     *
+     * @return array
+     */
+    protected function getUrlQueryHelperOptions()
+    {
+        return ['basicSearchParam' => 'author'];
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -322,8 +322,11 @@ class UrlQueryHelper
      */
     protected function parseFilter($filter)
     {
+        // Simplistic explode/trim behavior if no callback is provided:
         if (!is_callable($this->config['parseFilterCallback'])) {
-            throw new \Exception('parseFilterCallback must be set!');
+            $parts = explode(':', $filter, 2);
+            $parts[1] = trim($parts[1], '"');
+            return $parts;
         }
         return call_user_func($this->config['parseFilterCallback'], $filter);
     }
@@ -338,8 +341,9 @@ class UrlQueryHelper
      */
     protected function getAliasesForFacetField($field)
     {
+        // If no callback is provided, aliases are unsupported:
         if (!is_callable($this->config['getAliasesForFacetFieldCallback'])) {
-            throw new \Exception('getAliasesForFacetFieldCallback must be set!');
+            return [];
         }
         return call_user_func(
             $this->config['getAliasesForFacetFieldCallback'], $field

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -118,7 +118,7 @@ class UrlQueryHelper
     {
         $this->queryObject = $query;
         $this->clearSearchQueryParams();
-        if (!empty($this->config['suppressQuery'])) {
+        if ($this->isQuerySuppressed()) {
             return;
         }
         if ($query instanceof QueryGroup) {

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -288,7 +288,7 @@ class UrlQueryHelper
      * @param string $value      Facet value
      * @param string $operator   Facet type to add (AND, OR, NOT)
      * @param array  $paramArray Optional array of parameters to use instead of
-     * getParamArray()
+     * internally stored values.
      *
      * @return UrlQueryHelper
      */
@@ -304,7 +304,7 @@ class UrlQueryHelper
      *
      * @param string $filter     Filter to add
      * @param array  $paramArray Optional array of parameters to use instead of
-     * getParamArray()
+     * internally stored values.
      *
      * @return UrlQueryHelper
      */
@@ -347,7 +347,7 @@ class UrlQueryHelper
      */
     public function getParams($escape = true)
     {
-        return '?' . $this->buildQueryString($this->getParamArray(), $escape);
+        return '?' . $this->buildQueryString($this->urlParams, $escape);
     }
 
     /**
@@ -391,7 +391,7 @@ class UrlQueryHelper
      * @param bool   $escape     Should we escape the string for use in the view?
      * @param string $operator   Facet type to add (AND, OR, NOT)
      * @param array  $paramArray Optional array of parameters to use instead of
-     * getParamArray()
+     * internally stored values.
      *
      * @return string
      */
@@ -558,7 +558,7 @@ class UrlQueryHelper
     public function asHiddenFields($filter = [])
     {
         $retVal = '';
-        foreach ($this->getParamArray() as $paramName => $paramValue) {
+        foreach ($this->urlParams as $paramName => $paramValue) {
             if (is_array($paramValue)) {
                 foreach ($paramValue as $paramValue2) {
                     if (!$this->filtered($paramName, $paramValue2, $filter)) {
@@ -608,7 +608,7 @@ class UrlQueryHelper
     protected function updateQueryString($field, $value, $default = null,
         $escape = true, $clearPage = false
     ) {
-        $params = $this->getParamArray();
+        $params = $this->urlParams;
         if (null !== $value || $value == $default) {
             unset($params[$field]);
         } else {

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -157,26 +157,6 @@ class UrlQueryHelper
     }
 
     /**
-     * Set up defaults based on a parameters object.
-     *
-     * @param Params $params VuFind search params object.
-     *
-     * @return void
-     */
-    protected function loadDefaults(Params $params)
-    {
-        $options = $params->getOptions();
-        $this->config['defaults'] = [
-            'handler' => $options->getDefaultHandler(),
-            'limit' => $options->getDefaultLimit(),
-            'selectedShards' => $options->getDefaultSelectedShards(),
-            'sort' => $params->getDefaultSort(),
-            'view' => $options->getDefaultView(),
-            
-        ];
-    }
-
-    /**
      * Look up a default value in the internal configuration array.
      *
      * @param string $key Name of default to load

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -65,20 +65,6 @@ class UrlQueryHelper
     protected $queryObject;
 
     /**
-     * URL search param
-     *
-     * @var string
-     */
-    protected $basicSearchParam = 'lookfor';
-
-    /**
-     * Should we HTML-escape the parameters by default when rendering as a string?
-     *
-     * @var bool
-     */
-    protected $escape = true;
-
-    /**
      * Constructor
      *
      * @param array         $urlParams Array of URL query parameters.
@@ -88,24 +74,20 @@ class UrlQueryHelper
     public function __construct(array $urlParams, AbstractQuery $query,
         array $options = []
     ) {
-        $this->initConfig($options);
+        $this->config = $options;
         $this->urlParams = $urlParams;
         $this->loadQuery($query);
     }
 
     /**
-     * Set up the internal configuration based on an options array.
+     * Get the name of the basic search param.
      *
-     * @param array $options Configuration options for the object.
-     *
-     * @return void
+     * @return string
      */
-    protected function initConfig(array $options)
+    protected function getBasicSearchParam()
     {
-        $this->config = $options;
-        if (isset($options['basicSearchParam'])) {
-            $this->basicSearchParam = $options['basicSearchParam'];
-        }
+        return isset($this->config['basicSearchParam'])
+            ? $this->config['basicSearchParam'] : 'lookfor';
     }
 
     /**
@@ -115,7 +97,7 @@ class UrlQueryHelper
      */
     protected function clearSearchQueryParams()
     {
-        unset($this->urlParams[$this->basicSearchParam]);
+        unset($this->urlParams[$this->getBasicSearchParam()]);
         unset($this->urlParams['join']);
         unset($this->urlParams['type']);
         $searchParams = ['bool', 'lookfor', 'type', 'op'];
@@ -165,7 +147,7 @@ class UrlQueryHelper
         } else if ($query instanceof Query) {
             $search = $query->getString();
             if (!empty($search)) {
-                $this->urlParams[$this->basicSearchParam] = $search;
+                $this->urlParams[$this->getBasicSearchParam()] = $search;
             }
             $type = $query->getHandler();
             if (!empty($type)) {
@@ -263,7 +245,8 @@ class UrlQueryHelper
      */
     public function __toString()
     {
-        return $this->getParams($this->escape);
+        $escape = isset($this->config['escape']) ? $this->config['escape'] : true;
+        return $this->getParams($escape);
     }
 
     /**
@@ -431,7 +414,7 @@ class UrlQueryHelper
         // Clear page:
         unset($params['page']);
 
-        $this->escape = $escape;
+        $this->config['escape'] = $escape;
         return new static($params, $this->queryObject, $this->config);
     }
 
@@ -609,7 +592,7 @@ class UrlQueryHelper
         $escape = true, $clearPage = false
     ) {
         $params = $this->urlParams;
-        if (null !== $value || $value == $default) {
+        if (null === $value || $value == $default) {
             unset($params[$field]);
         } else {
             $params[$field] = $value;
@@ -617,7 +600,7 @@ class UrlQueryHelper
         if ($clearPage && isset($params['page'])) {
             unset($params['page']);
         }
-        $this->escape = $escape;
+        $this->config['escape'] = $escape;
         return new static($params, $this->queryObject, $this->config);
     }
 

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -27,7 +27,6 @@
  */
 namespace VuFind\Search;
 use VuFind\Search\Base\Options;
-use VuFind\Search\Base\Params;
 use VuFindSearch\Query\AbstractQuery;
 use VuFindSearch\Query\Query;
 use VuFindSearch\Query\QueryGroup;

--- a/module/VuFind/src/VuFind/View/Helper/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/View/Helper/AbstractSearch.php
@@ -84,11 +84,11 @@ abstract class AbstractSearch extends AbstractHelper
                 }
                 $html .= '<a href="'
                     . $results->getUrlQuery()
-                        ->replaceTerm($term, $data['new_term'])
+                        ->replaceTerm($term, $data['new_term'])->getParams()
                     . '">' . $view->escapeHtml($word) . '</a>';
                 if (isset($data['expand_term']) && !empty($data['expand_term'])) {
                     $url = $results->getUrlQuery()
-                        ->replaceTerm($term, $data['expand_term']);
+                        ->replaceTerm($term, $data['expand_term'])->getParams();
                     $html .= $this->renderExpandLink($url, $view);
                 }
             }

--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
@@ -121,7 +121,7 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
             );
         }
         $feed->setLink(
-            $baseUrl . $results->getUrlQuery()->setViewParam(null, false)
+            $baseUrl . $results->getUrlQuery()->setViewParam(null)->getParams(false)
         );
         $feed->setFeedLink(
             $baseUrl . $results->getUrlQuery()->getParams(false),
@@ -137,14 +137,14 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
 
         // add atom links for easier paging
         $feed->addOpensearchLink(
-            $baseUrl . $results->getUrlQuery()->setPage(1, false),
+            $baseUrl . $results->getUrlQuery()->setPage(1)->getParams(false),
             'first',
             $params->getView()
         );
         if ($params->getPage() > 1) {
             $feed->addOpensearchLink(
                 $baseUrl . $results->getUrlQuery()
-                    ->setPage($params->getPage() - 1, false),
+                    ->setPage($params->getPage() - 1)->getParams(false),
                 'previous',
                 $params->getView()
             );
@@ -153,13 +153,13 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
         if ($params->getPage() < $lastPage) {
             $feed->addOpensearchLink(
                 $baseUrl . $results->getUrlQuery()
-                    ->setPage($params->getPage() + 1, false),
+                    ->setPage($params->getPage() + 1)->getParams(false),
                 'next',
                 $params->getView()
             );
         }
         $feed->addOpensearchLink(
-            $baseUrl . $results->getUrlQuery()->setPage($lastPage, false),
+            $baseUrl . $results->getUrlQuery()->setPage($lastPage)->getParams(false),
             'last',
             $params->getView()
         );

--- a/module/VuFind/src/VuFind/View/Helper/Root/SortFacetList.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SortFacetList.php
@@ -59,8 +59,8 @@ class SortFacetList extends AbstractHelper
         $results->getParams()->setLimit($results->getOptions()->getDefaultLimit());
         $urlHelper = $this->getView()->plugin('url');
         foreach ($list as $value) {
-            $url = $urlHelper($searchRoute)
-                . $results->getUrlQuery()->addFacet($field, $value['value']);
+            $url = $urlHelper($searchRoute) . $results->getUrlQuery()
+                ->addFacet($field, $value['value'])->getParams();
             $facets[$url] = $value['displayText'];
         }
         natcasesort($facets);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -92,15 +92,15 @@ class UrlQueryHelperTest extends TestCase
         // Test adding/removing facets and filters
         $faceted = $helper->addFacet('f', '1')->addFilter('f:2');
         $this->assertEquals(
-            '?foo=baz&filter%5B%5D=f%3A%221%22&filter%5B%5D=f%3A2&lookfor=search',
+            '?foo=baz&lookfor=search&filter%5B%5D=f%3A%221%22&filter%5B%5D=f%3A2',
             $faceted->getParams(false)
         );
         $this->assertEquals(
-            '?foo=baz&filter%5B%5D=f%3A%221%22&lookfor=search',
+            '?foo=baz&lookfor=search&filter%5B%5D=f%3A%221%22',
             $faceted->removeFacet('f', '2')->getParams(false)
         );
         $this->assertEquals(
-            '?foo=baz&filter%5B%5D=f%3A2&lookfor=search',
+            '?foo=baz&lookfor=search&filter%5B%5D=f%3A2',
             $faceted->removeFilter('f:1')->getParams(false)
         );
         $this->assertEquals(
@@ -110,7 +110,7 @@ class UrlQueryHelperTest extends TestCase
 
         // Test stacking setters
         $this->assertEquals(
-            '?foo=baz&sort=title&view=grid&limit=50&page=3&lookfor=search&type=x',
+            '?foo=baz&sort=title&view=grid&lookfor=search&type=x&limit=50&page=3',
             $helper->setSort('title')->setViewParam('grid')->setHandler('x')
                 ->setLimit(50)->setPage(3)->getParams(false)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * UrlQueryHelper unit tests.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Search;
+
+use VuFind\Search\UrlQueryHelper;
+use VuFind\Search\Factory\UrlQueryHelperFactory;
+use VuFindTest\Unit\TestCase as TestCase;
+use VuFindSearch\Query\Query;
+use VuFindSearch\Query\QueryGroup;
+
+/**
+ * UrlQueryHelper unit tests.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class UrlQueryHelperTest extends TestCase
+{
+    /**
+     * Test the basic functionality of the helper.
+     *
+     * @return void
+     */
+    public function testBasicFunctionality()
+    {
+        // Test basic getters
+        $query = new Query('search');
+        $helper = new UrlQueryHelper(['foo' => 'bar'], $query);
+        $this->assertEquals('?foo=bar&amp;lookfor=search', $helper->getParams());
+        $this->assertEquals('?foo=bar&amp;lookfor=search', (string)$helper);
+        $this->assertEquals(
+            ['foo' => 'bar', 'lookfor' => 'search'], $helper->getParamArray()
+        );
+        $this->assertEquals(
+            '<input type="hidden" name="foo" value="bar" />',
+            $helper->asHiddenFields(['lookfor' => '/.*/'])
+        );
+
+        // Test setDefaultParameters and disabling escaping
+        $this->assertEquals(
+            '?foo=baz&lookfor=search',
+            $helper->setDefaultParameter('foo', 'baz')->getParams(false)
+        );
+
+        // Test query suppression
+        $this->assertEquals(false, $helper->isQuerySuppressed());
+        $helper->setSuppressQuery(true);
+        $this->assertEquals(true, $helper->isQuerySuppressed());
+        $this->assertEquals('?foo=baz', $helper->getParams());
+        $helper->setSuppressQuery(false);
+        $this->assertEquals(false, $helper->isQuerySuppressed());
+        $this->assertEquals('?foo=baz&lookfor=search', $helper->getParams(false));
+
+        // Test replacing query terms
+        $this->assertEquals(
+            '?foo=baz&amp;lookfor=srch',
+            $helper->replaceTerm('search', 'srch')->getParams()
+        );
+        $this->assertEquals(
+            '?foo=baz&amp;lookfor=srch',
+            $helper->setSearchTerms('srch')->getParams()
+        );
+
+        // Test adding/removing facets and filters
+        $faceted = $helper->addFacet('f', '1')->addFilter('f:2');
+        $this->assertEquals(
+            '?foo=baz&filter%5B%5D=f%3A%221%22&filter%5B%5D=f%3A2&lookfor=search',
+            $faceted->getParams(false)
+        );
+        $this->assertEquals(
+            '?foo=baz&filter%5B%5D=f%3A%221%22&lookfor=search',
+            $faceted->removeFacet('f', '2')->getParams(false)
+        );
+        $this->assertEquals(
+            '?foo=baz&filter%5B%5D=f%3A2&lookfor=search',
+            $faceted->removeFilter('f:1')->getParams(false)
+        );
+        $this->assertEquals(
+            '?foo=baz&lookfor=search',
+            $faceted->removeAllFilters()->getParams(false)
+        );
+
+        // Test stacking setters
+        $this->assertEquals(
+            '?foo=baz&sort=title&view=grid&limit=50&page=3&lookfor=search&type=x',
+            $helper->setSort('title')->setViewParam('grid')->setHandler('x')
+                ->setLimit(50)->setPage(3)->getParams(false)
+        );
+    }
+
+    /**
+     * Test advanced search param building.
+     *
+     * @return void
+     */
+    public function testAdvancedSearch()
+    {
+        $fixturePath = realpath(__DIR__ . '/../../../../fixtures/searches') . '/advanced/';
+        $q = unserialize(file_get_contents($fixturePath . 'query'));
+        $helper = new UrlQueryHelper([], $q);
+        $this->assertEquals(
+            '?join=OR&bool0%5B%5D=AND&lookfor0%5B%5D=oranges&lookfor0%5B%5D=bananas'
+            . '&lookfor0%5B%5D=pears&type0%5B%5D=CallNumber&type0%5B%5D=toc'
+            . '&type0%5B%5D=ISN&bool1%5B%5D=OR&lookfor1%5B%5D=cars'
+            . '&lookfor1%5B%5D=trucks&type1%5B%5D=Title&type1%5B%5D=Subject'
+            . '&bool2%5B%5D=NOT&lookfor2%5B%5D=squid&type2%5B%5D=AllFields',
+            $helper->getParams(false)
+        );
+    }
+
+    /**
+     * Test that the factory does its job properly.
+     *
+     * @return void
+     */
+    public function testFactory()
+    {
+        $factory = new UrlQueryHelperFactory();
+        $config = $this->getMock('VuFind\Config\PluginManager');
+        $params = new \VuFindTest\Search\TestHarness\Params(
+            new \VuFindTest\Search\TestHarness\Options($config), $config
+        );
+        $params->setBasicSearch('foo', 'bar');
+        $params->setLimit(100);
+        $params->setPage(5);
+        $params->setView('grid');
+        $helper = $factory->fromParams($params);
+        $this->assertEquals(
+            '?limit=100&view=grid&page=5&lookfor=foo&type=bar',
+            $helper->getParams(false)
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -32,7 +32,6 @@ use VuFind\Search\UrlQueryHelper;
 use VuFind\Search\Factory\UrlQueryHelperFactory;
 use VuFindTest\Unit\TestCase as TestCase;
 use VuFindSearch\Query\Query;
-use VuFindSearch\Query\QueryGroup;
 
 /**
  * UrlQueryHelper unit tests.


### PR DESCRIPTION
The UrlQueryHelper object (used for generating query parameters used to run VuFind searches) has a somewhat awkward interface. This PR adjusts it in a backward-compatible way to create a more useful fluent interface where multiple operations can be stacked.

TODO
- [x] Evaluate whether we can eliminate the $rawParams property entirely, as this is a bit ugly -- but we would need to figure out a different way to expose getAliasesForFacetField and parseFilter.
- ~~Investigate whether we can change code to eliminate the need for the $escape parameter used by many methods (BC break)~~ we'll do this as a second pass later
- ~~Investigate whether we can change code to eliminate the need for the $paramArray parameter used by some methods (BC break)~~ we'll do this as a second pass later
- [x] Test, test, test
