### PR TITLE
Solr options flag

### DIFF
--- a/solr.bat
+++ b/solr.bat
@@ -21,6 +21,9 @@ rem
 rem JAVA_HOME
 rem   Home of Java installation (not directly used by this script, but passed along to
 rem   the standard Solr control script).
+rem
+rem SOLR_ADDITIONAL_JVM_OPTIONS
+rem   Additional options to pass to the JVM when launching Solr.
 
 rem Make sure that environment edits are local and that we have access to the
 rem Windows command extensions.
@@ -74,7 +77,7 @@ if not "!%SOLR_PORT%!"=="!!" goto solrportset
 set SOLR_PORT=8080
 :solrportset
 
-call %SOLR_BIN%\solr.cmd %1 -p %SOLR_PORT% -s %SOLR_HOME% -m %SOLR_HEAP% -a "-Dsolr.log=%SOLR_LOGS_DIR%"
+call %SOLR_BIN%\solr.cmd %1 -p %SOLR_PORT% -s %SOLR_HOME% -m %SOLR_HEAP% -a "-Dsolr.log=%SOLR_LOGS_DIR% %SOLR_ADDITIONAL_JVM_OPTIONS%"
 goto end
 
 :usage

--- a/solr.sh
+++ b/solr.sh
@@ -23,6 +23,9 @@
 #   Home of Java installation (not directly used by this script, but passed along to
 #   the standard Solr control script).
 #
+# SOLR_ADDITIONAL_OPTIONS
+#   Additional options to pass to the launch_solr() function in solr/vendor/bin/solr.
+#
 
 usage()
 {
@@ -64,5 +67,10 @@ then
   SOLR_PORT="8080"
 fi
 
+if [ -z "$SOLR_ADDITIONAL_OPTIONS" ]
+then
+  SOLR_ADDITIONAL_OPTIONS=""
+fi
+
 export SOLR_LOGS_DIR=$SOLR_LOGS_DIR
-"$SOLR_BIN/solr" "$1" -p "$SOLR_PORT" -s "$SOLR_HOME" -m "$SOLR_HEAP" -a "-Dsolr.log=$SOLR_LOGS_DIR"
+"$SOLR_BIN/solr" "$1" -p "$SOLR_PORT" -s "$SOLR_HOME" -m "$SOLR_HEAP" -a "-Dsolr.log=$SOLR_LOGS_DIR $SOLR_ADDITIONAL_OPTIONS"

--- a/solr.sh
+++ b/solr.sh
@@ -23,7 +23,7 @@
 #   Home of Java installation (not directly used by this script, but passed along to
 #   the standard Solr control script).
 #
-# SOLR_ADDITIONAL_OPTIONS
+# SOLR_ADDITIONAL_JVM_OPTIONS
 #   Additional options to pass to the launch_solr() function in solr/vendor/bin/solr.
 #
 
@@ -67,10 +67,10 @@ then
   SOLR_PORT="8080"
 fi
 
-if [ -z "$SOLR_ADDITIONAL_OPTIONS" ]
+if [ -z "$SOLR_ADDITIONAL_JVM_OPTIONS" ]
 then
-  SOLR_ADDITIONAL_OPTIONS=""
+  SOLR_ADDITIONAL_JVM_OPTIONS=""
 fi
 
 export SOLR_LOGS_DIR=$SOLR_LOGS_DIR
-"$SOLR_BIN/solr" "$1" -p "$SOLR_PORT" -s "$SOLR_HOME" -m "$SOLR_HEAP" -a "-Dsolr.log=$SOLR_LOGS_DIR $SOLR_ADDITIONAL_OPTIONS"
+"$SOLR_BIN/solr" "$1" -p "$SOLR_PORT" -s "$SOLR_HOME" -m "$SOLR_HEAP" -a "-Dsolr.log=$SOLR_LOGS_DIR $SOLR_ADDITIONAL_JVM_OPTIONS"

--- a/solr.sh
+++ b/solr.sh
@@ -24,7 +24,7 @@
 #   the standard Solr control script).
 #
 # SOLR_ADDITIONAL_JVM_OPTIONS
-#   Additional options to pass to the launch_solr() function in solr/vendor/bin/solr.
+#   Additional options to pass to the JVM when launching Solr.
 #
 
 usage()


### PR DESCRIPTION
Add environment variable $SOLR_ADDITIONAL_OPTIONS to solr.sh and add to -a switch so that users can specify additional options to be passed to jvm. 

TODO

- [x] Windows support