### PR TITLE
Verify that any existing session path is correct and avoid trying to …

### DIFF
--- a/module/VuFind/src/VuFind/Service/Factory.php
+++ b/module/VuFind/src/VuFind/Service/Factory.php
@@ -205,6 +205,9 @@ class Factory
             && $config->Cookies->limit_by_path
         ) {
             $path = $sm->get('Request')->getBasePath();
+            if (empty($path)) {
+                $path = '/';
+            }
         }
         $secure = isset($config->Cookies->only_secure)
             ? $config->Cookies->only_secure

--- a/module/VuFind/src/VuFind/Session/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Session/AbstractBase.php
@@ -67,6 +67,16 @@ abstract class AbstractBase implements SaveHandlerInterface,
     protected $writesDisabled = false;
 
     /**
+     * Enable session writing (default)
+     *
+     * @return void
+     */
+    public function enableWrites()
+    {
+        $this->writesDisabled = false;
+    }
+
+    /**
      * Disable session writing, i.e. make it read-only
      *
      * @return void

--- a/module/VuFind/src/VuFind/Session/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Session/ManagerFactory.php
@@ -128,6 +128,23 @@ class ManagerFactory implements \Zend\ServiceManager\FactoryInterface
         // Start up the session:
         $sessionManager->start();
 
+        // Verify that any existing session has the correct path to avoid using
+        // a cookie from a service higher up in the path hierarchy.
+        $storage = new \Zend\Session\Container('SessionState', $sessionManager);
+        if (null !== $storage->cookiePath) {
+            if ($storage->cookiePath != $sessionConfig->getCookiePath()) {
+                // Disable writes temporarily to keep the existing session intact
+                $sessionManager->getSaveHandler()->disableWrites();
+                // Regenerate session ID and reset the session data
+                $sessionManager->regenerateId(false);
+                session_unset();
+                $sessionManager->getSaveHandler()->enableWrites();
+                $storage->cookiePath = $sessionConfig->getCookiePath();
+            }
+        } else {
+            $storage->cookiePath = $sessionConfig->getCookiePath();
+        }
+
         // Check if we need to immediately stop it based on the settings object
         // (which may have been informed by a controller that sessions should not
         // be written as part of the current process):


### PR DESCRIPTION
…set an empty path for the session cookie.

We have cases where there is a common VuFind instance in domain root and sub-instances in subdirectories. Currently, if a user enters the common instance first, he'll get a session cookie with '/' as the path, and it will also be used for the sub-instances. This causes trouble when e.g. login methods differ between the instances. Since the cookie headers a browser sends don't include information on the cookie path, this PR adds storing of the path to the session and verification of its correctness. This of course applies in practice only when [Session] limit_by_path is enabled.

The other small change is to ensure that an empty path is never used, otherwise Zend will throw an InvalidArgumentException. That would have happened with VuFind installed in domain root with limit_by_path enabled.