### PR TITLE
Made getCombinedSearchResults in Piwik helper not crash if we don’t h…

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -530,7 +530,7 @@ EOT;
         $searchType = $escape($params->getSearchType());
         $resultCount = 0;
         foreach ($combinedResults as $currentSearch) {
-            if ($currentSearch['ajax']) {
+            if (!empty($currentSearch['ajax'])) {
                 // Some results fetched via ajax, so report that we don't know the
                 // result count.
                 $resultCount = 'false';

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -266,7 +266,11 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getCombinedSearchResults()
     {
         $viewModel = $this->getView()->plugin('view_model');
-        $children = $viewModel->getCurrent()->getChildren();
+        $current = $viewModel->getCurrent();
+        if (null === $current) {
+            return null;
+        }
+        $children = $current->getChildren();
         if (isset($children[0])) {
             $results = $children[0]->getVariable('combinedResults');
             if (is_array($results)) {


### PR DESCRIPTION
…ave a current view model.

This could happen e.g. if a template that calls Piwik helper is rendered with ViewRenderer without ViewModel.