### PR TITLE
ILS support for other types of records

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
@@ -26,7 +26,7 @@
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
- */ 
+ */
 namespace VuFind\RecordDriver;
 
 /**

--- a/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
@@ -40,7 +40,7 @@ namespace VuFind\RecordDriver;
  * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
  */
 trait IlsAwareTrait
-{  
+{
     /**
      * ILS connection
      *

--- a/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/IlsAwareTrait.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * ILS support for MARC and other types of records.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ * Copyright (C) The National Library of Finland 2015.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind
+ * @package  RecordDrivers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
+ */ 
+namespace VuFind\RecordDriver;
+
+/**
+ * ILS support for MARC and other types of records.
+ *
+ * @category VuFind
+ * @package  RecordDrivers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
+ */
+trait IlsAwareTrait
+{  
+    /**
+     * ILS connection
+     *
+     * @var \VuFind\ILS\Connection
+     */
+    protected $ils = null;
+
+    /**
+     * Hold logic
+     *
+     * @var \VuFind\ILS\Logic\Holds
+     */
+    protected $holdLogic;
+
+    /**
+     * Title hold logic
+     *
+     * @var \VuFind\ILS\Logic\TitleHolds
+     */
+    protected $titleHoldLogic;
+
+    /**
+     * Attach an ILS connection and related logic to the driver
+     *
+     * @param \VuFind\ILS\Connection       $ils            ILS connection
+     * @param \VuFind\ILS\Logic\Holds      $holdLogic      Hold logic handler
+     * @param \VuFind\ILS\Logic\TitleHolds $titleHoldLogic Title hold logic handler
+     *
+     * @return void
+     */
+    public function attachILS(\VuFind\ILS\Connection $ils,
+        \VuFind\ILS\Logic\Holds $holdLogic,
+        \VuFind\ILS\Logic\TitleHolds $titleHoldLogic
+    ) {
+        $this->ils = $ils;
+        $this->holdLogic = $holdLogic;
+        $this->titleHoldLogic = $titleHoldLogic;
+    }
+
+    /**
+     * Do we have an attached ILS connection?
+     *
+     * @return bool
+     */
+    protected function hasILS()
+    {
+        return null !== $this->ils;
+    }
+
+    /**
+     * Get an array of information about record holdings, obtained in real-time
+     * from the ILS.
+     *
+     * @return array
+     */
+    public function getRealTimeHoldings()
+    {
+        return $this->hasILS() ? $this->holdLogic->getHoldings(
+            $this->getUniqueID(), $this->getConsortialIDs()
+        ) : [];
+    }
+
+    /**
+     * Get an array of information about record history, obtained in real-time
+     * from the ILS.
+     *
+     * @return array
+     */
+    public function getRealTimeHistory()
+    {
+        // Get Acquisitions Data
+        if (!$this->hasILS()) {
+            return [];
+        }
+        try {
+            return $this->ils->getPurchaseHistory($this->getUniqueID());
+        } catch (ILSException $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Get a link for placing a title level hold.
+     *
+     * @return mixed A url if a hold is possible, boolean false if not
+     */
+    public function getRealTimeTitleHold()
+    {
+        if ($this->hasILS()) {
+            $biblioLevel = strtolower($this->getBibliographicLevel());
+            if ("monograph" == $biblioLevel || strstr($biblioLevel, "part")) {
+                if ($this->ils->getTitleHoldsMode() != "disabled") {
+                    return $this->titleHoldLogic->getHold($this->getUniqueID());
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the record supports real-time AJAX status lookups.
+     *
+     * @return bool
+     */
+    public function supportsAjaxStatus()
+    {
+        // as AJAX status lookups are done via the ILS AJAX status lookup support is
+        // only given if the ILS is available for this record
+        return $this->hasILS();
+    }
+}

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarc.php
@@ -44,33 +44,14 @@ use VuFind\Exception\ILS as ILSException,
  */
 class SolrMarc extends SolrDefault
 {
+    use IlsAwareTrait;
+    
     /**
      * MARC record. Access only via getMarcRecord() as this is initialized lazily.
      *
      * @var \File_MARC_Record
      */
     protected $lazyMarcRecord = null;
-
-    /**
-     * ILS connection
-     *
-     * @var \VuFind\ILS\Connection
-     */
-    protected $ils = null;
-
-    /**
-     * Hold logic
-     *
-     * @var \VuFind\ILS\Logic\Holds
-     */
-    protected $holdLogic;
-
-    /**
-     * Title hold logic
-     *
-     * @var \VuFind\ILS\Logic\TitleHolds
-     */
-    protected $titleHoldLogic;
 
     /**
      * Get access restriction notes for the record.
@@ -984,97 +965,6 @@ class SolrMarc extends SolrDefault
 
         // Try the parent method:
         return parent::getXML($format, $baseUrl, $recordLink);
-    }
-
-    /**
-     * Attach an ILS connection and related logic to the driver
-     *
-     * @param \VuFind\ILS\Connection       $ils            ILS connection
-     * @param \VuFind\ILS\Logic\Holds      $holdLogic      Hold logic handler
-     * @param \VuFind\ILS\Logic\TitleHolds $titleHoldLogic Title hold logic handler
-     *
-     * @return void
-     */
-    public function attachILS(\VuFind\ILS\Connection $ils,
-        \VuFind\ILS\Logic\Holds $holdLogic,
-        \VuFind\ILS\Logic\TitleHolds $titleHoldLogic
-    ) {
-        $this->ils = $ils;
-        $this->holdLogic = $holdLogic;
-        $this->titleHoldLogic = $titleHoldLogic;
-    }
-
-    /**
-     * Do we have an attached ILS connection?
-     *
-     * @return bool
-     */
-    protected function hasILS()
-    {
-        return null !== $this->ils;
-    }
-
-    /**
-     * Get an array of information about record holdings, obtained in real-time
-     * from the ILS.
-     *
-     * @return array
-     */
-    public function getRealTimeHoldings()
-    {
-        return $this->hasILS() ? $this->holdLogic->getHoldings(
-            $this->getUniqueID(), $this->getConsortialIDs()
-        ) : [];
-    }
-
-    /**
-     * Get an array of information about record history, obtained in real-time
-     * from the ILS.
-     *
-     * @return array
-     */
-    public function getRealTimeHistory()
-    {
-        // Get Acquisitions Data
-        if (!$this->hasILS()) {
-            return [];
-        }
-        try {
-            return $this->ils->getPurchaseHistory($this->getUniqueID());
-        } catch (ILSException $e) {
-            return [];
-        }
-    }
-
-    /**
-     * Get a link for placing a title level hold.
-     *
-     * @return mixed A url if a hold is possible, boolean false if not
-     */
-    public function getRealTimeTitleHold()
-    {
-        if ($this->hasILS()) {
-            $biblioLevel = strtolower($this->getBibliographicLevel());
-            if ("monograph" == $biblioLevel || strstr($biblioLevel, "part")) {
-                if ($this->ils->getTitleHoldsMode() != "disabled") {
-                    return $this->titleHoldLogic->getHold($this->getUniqueID());
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns true if the record supports real-time AJAX status lookups.
-     *
-     * @return bool
-     */
-    public function supportsAjaxStatus()
-    {
-        // as AJAX status lookups are done via the ILS AJAX status lookup support is
-        // only given if the ILS is available for this record
-        return $this->hasILS();
     }
 
     /**


### PR DESCRIPTION
Refactored SolrMarc to have ILS support in an external trait.  This allows for other record drivers to make use of ILS support.