### PR TITLE
Install PhpDocumentor via Composer.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -35,6 +35,8 @@
     <property name="mysqlpwswitch" value="-p" />
   </then></if>
 
+  <includepath classpath="${srcdir}/vendor/phpdocumentor" />
+
   <!-- Main Target -->
   <target name="main" description="main target">
     <phingcall target="startup" />

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "behat/mink": "1.7.0",
         "behat/mink-selenium2-driver": "1.3.0",
         "friendsofphp/php-cs-fixer": "1.11.6",
+        "phpdocumentor/phpdocumentor": "2.9.0",
         "phploc/phploc": "2.0.6",
         "phpmd/phpmd": "2.4.2",
         "phpunit/phpunit": "4.8.27",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/mink": "1.7.0",
         "behat/mink-selenium2-driver": "1.3.0",
         "friendsofphp/php-cs-fixer": "1.11.6",
-        "phpdocumentor/phpdocumentor": "2.4.0",
+        "phpdocumentor/phpdocumentor": "2.8.5",
         "phploc/phploc": "2.0.6",
         "phpmd/phpmd": "2.4.2",
         "phpunit/phpunit": "4.8.27",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/mink": "1.7.0",
         "behat/mink-selenium2-driver": "1.3.0",
         "friendsofphp/php-cs-fixer": "1.11.6",
-        "phpdocumentor/phpdocumentor": "2.9.0",
+        "phpdocumentor/phpdocumentor": "2.4.0",
         "phploc/phploc": "2.0.6",
         "phpmd/phpmd": "2.4.2",
         "phpunit/phpunit": "4.8.27",


### PR DESCRIPTION
This adjusts the Phing build.xml to use a Composer-installed version of PhpDocumentor for greater control.

We'll address PHP 7 compatibility at some point in the future -- for now we can't upgrade past 2.8.5 due to our CI server running PHP 5.4. This will be addressed soon.