### PR TITLE
Limit the Voyager barcode statuses allowed to login by default so tha…

### DIFF
--- a/config/vufind/Voyager.ini
+++ b/config/vufind/Voyager.ini
@@ -20,6 +20,11 @@ login_field = LAST_NAME
 ; user has no PIN code. Disabled by default.
 ;fallback_login_field = LAST_NAME
 
+; Colon-separated list of barcode statuses ( see PATRON_BARCODE_STATUS table in
+; Voyager's database) that allow a user to log in. By default only barcodes with
+; status 1 (active) or 4 (expired) are allowed.
+;allowed_barcode_statuses = 1:4:5
+
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -20,6 +20,11 @@ login_field = LAST_NAME
 ; user has no PIN code. Disabled by default.
 ;fallback_login_field = LAST_NAME
 
+; Colon-separated list of barcode statuses ( see PATRON_BARCODE_STATUS table in
+; Voyager's database) that allow a user to log in. By default only barcodes with
+; status 1 (active) or 4 (expired) are allowed.
+;allowed_barcode_statuses = 1:4:5
+
 ; This is the timeout value for making HTTP requests to the Voyager API.
 http_timeout = 30
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -1227,6 +1227,20 @@ class Voyager extends AbstractBase
                "WHERE PATRON.PATRON_ID = PATRON_BARCODE.PATRON_ID AND " .
                "lower(PATRON_BARCODE.PATRON_BARCODE) = :barcode";
 
+        // Limit the barcode statuses that allow logging in. By default only
+        // 1 (active) and 4 (expired) are allowed.
+        $allowedStatuses = preg_replace(
+            '/[^:\d]*/',
+            '',
+            isset($this->config['Catalog']['allowed_barcode_statuses'])
+                ? $this->config['Catalog']['allowed_barcode_statuses']
+                : '1:4'
+        );
+        if ($allowedStatuses) {
+            $sql .= ' AND PATRON_BARCODE.BARCODE_STATUS IN ('
+                . str_replace(':', ',', $allowedStatuses) . ')';
+        }
+
         try {
             $bindBarcode = strtolower(utf8_decode($barcode));
             $compareLogin = mb_strtolower($login, 'UTF-8');


### PR DESCRIPTION
…t e.g. a lost card cannot be used anymore. Accepted statuses can be configured via the ini file.