### PR TITLE
Use checkbox-select-all’s form attribute if it exists and the closest…

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -138,14 +138,17 @@ class CartTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Add the current page of results to the cart.
      *
-     * @param Element $page       Page element
-     * @param Element $updateCart Add to cart button
+     * @param Element $page        Page element
+     * @param Element $updateCart  Add to cart button
+     * @param string  $selectAllId ID of select all checkbox
      *
      * @return void
      */
-    protected function addCurrentPageToCart(Element $page, Element $updateCart)
+    protected function addCurrentPageToCart(Element $page, Element $updateCart,
+        $selectAllId = '#addFormCheckboxSelectAll'
+    )
     {
-        $selectAll = $page->find('css', '#addFormCheckboxSelectAll');
+        $selectAll = $page->find('css', $selectAllId);
         $selectAll->check();
         $updateCart->click();
     }
@@ -169,10 +172,14 @@ class CartTest extends \VuFindTest\Unit\MinkTestCase
      * into the cart, then opening the lightbox so that additional actions may
      * be attempted.
      *
+     * @param array  $extraConfigs Extra config settings
+     * @param string $selectAllId  ID of select all checkbox
+     *
      * @return Element
      */
-    protected function setUpGenericCartTest($extraConfigs = [])
-    {
+    protected function setUpGenericCartTest($extraConfigs = [],
+        $selectAllId = '#addFormCheckboxSelectAll'
+    ) {
         // Activate the cart:
         $extraConfigs['config']['Site'] = ['showBookBag' => true];
         $this->changeConfigs($extraConfigs);
@@ -183,7 +190,7 @@ class CartTest extends \VuFindTest\Unit\MinkTestCase
         $updateCart = $this->findCss($page, '#updateCart');
 
         // Now actually select something:
-        $this->addCurrentPageToCart($page, $updateCart);
+        $this->addCurrentPageToCart($page, $updateCart, $selectAllId);
         $this->assertEquals('2', $this->findCss($page, '#cartItems strong')->getText());
 
         // Open the cart and empty it:
@@ -425,6 +432,16 @@ class CartTest extends \VuFindTest\Unit\MinkTestCase
         // Confirm that the cart has truly been emptied:
         $this->snooze(); // wait for display to update
         $this->assertEquals('0', $this->findCss($page, '#cartItems strong')->getText());
+    }
+
+    /**
+     * Test that we can put items in the cart using the bottom checkbox.
+     *
+     * @return void
+     */
+    public function testFillCartUsingBottomCheckbox()
+    {
+        $this->setUpGenericCartTest([], '#bottom_addFormCheckboxSelectAll');
     }
 
     /**

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -351,15 +351,14 @@ $(document).ready(function commonDocReady() {
 
   // Checkbox select all
   $('.checkbox-select-all').change(function selectAllCheckboxes() {
-    var $form = $(this).closest('form');
+    var $form = this.form ? $(this.form) : $(this).closest('form');
     $form.find('.checkbox-select-item').prop('checked', this.checked);
     $('[form="' + $form.attr('id') + '"]').prop('checked', this.checked);
+    $form.find('.checkbox-select-all').prop('checked', this.checked);
+    $('.checkbox-select-all[form="' + $form.attr('id') + '"]').prop('checked', this.checked);
   });
   $('.checkbox-select-item').change(function selectAllDisable() {
-    var $form = $(this).closest('form');
-    if ($form.length === 0 && this.form) {
-      $form = $(this.form);
-    }
+    var $form = this.form ? $(this.form) : $(this).closest('form');
     if ($form.length === 0) {
       return;
     }


### PR DESCRIPTION
… form only if it doesn’t. Make sure to update checked state of any other select-all checkbox when one changes state.