### PR TITLE
Make sure not to add a second question mark to Shibboleth logout URL.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -256,7 +256,10 @@ class Shibboleth extends AbstractBase
         if (isset($config->Shibboleth->logout)
             && !empty($config->Shibboleth->logout)
         ) {
-            $url = $config->Shibboleth->logout . '?return=' . urlencode($url);
+            $append = (strpos($config->Shibboleth->logout, '?') !== false) ? '&'
+                : '?';
+            $url = $config->Shibboleth->logout . $append . 'return='
+                . urlencode($url);
         }
 
         // Send back the redirect URL (possibly modified):


### PR DESCRIPTION
If there was a logout URL like:

    [Shibboleth]
    logout = "https://server?method=logout"

The code would have blindly appended another ? to it.