### PR TITLE
make cart cookies respect limit_by_path setting in config.ini

### DIFF
--- a/module/VuFind/src/VuFind/Cart.php
+++ b/module/VuFind/src/VuFind/Cart.php
@@ -307,6 +307,16 @@ class Cart
     }
 
     /**
+     * Get cookie path context (null if unset).
+     *
+     * @return string
+     */
+    public function getCookiePath()
+    {
+        return $this->cookieManager->getPath();
+    }
+    
+    /**
      * Process parameters and return the cart content.
      *
      * @return array $records The cart content

--- a/themes/dev/js/cart.js
+++ b/themes/dev/js/cart.js
@@ -1,0 +1,237 @@
+/*global Cookies, VuFind */
+/*exported cartFormHandler */
+
+VuFind.register('cart', function Cart() {
+  var _COOKIE = 'vufind_cart';
+  var _COOKIE_SOURCES = 'vufind_cart_src';
+  var _COOKIE_DELIM = "\t";
+  var _COOKIE_DOMAIN = false;
+  var _COOKIE_PATH = '';
+  
+  function setDomain(domain) {
+    _COOKIE_DOMAIN = domain;
+  }
+
+  function setPath(path) {
+	  _COOKIE_PATH = path;
+  }
+  function _uniqueArray(op) {
+    var ret = [];
+    for (var i = 0; i < op.length; i++) {
+      if (ret.indexOf(op[i]) < 0) {
+        ret.push(op[i]);
+      }
+    }
+    return ret;
+  }
+
+  function _getItems() {
+    var items = Cookies.getItem(_COOKIE);
+    if (items) {
+      return items.split(_COOKIE_DELIM);
+    }
+    return [];
+  }
+  function _getSources() {
+    var items = Cookies.getItem(_COOKIE_SOURCES);
+    if (items) {
+      return items.split(_COOKIE_DELIM);
+    }
+    return [];
+  }
+  function getFullItems() {
+    var items = _getItems();
+    var sources = _getSources();
+    var full = [];
+    if (items.length === 0) {
+      return [];
+    }
+    for (var i = items.length; i--;) {
+      full[full.length] = sources[items[i].charCodeAt(0) - 65] + '|' + items[i].substr(1);
+    }
+    return full;
+  }
+
+  function updateCount() {
+    var items = VuFind.cart.getFullItems();
+    $('#cartItems strong').html(items.length);
+    if (items.length === parseInt(VuFind.translate('bookbagMax'), 10)) {
+      $('#cartItems .full').removeClass('hidden');
+    } else {
+      $('#cartItems .full').addClass('hidden');
+    }
+  }
+
+  function addItem(id, _source) {
+    var source = _source || VuFind.defaultSearchBackend;
+    var cartItems = _getItems();
+    var cartSources = _getSources();
+    if (cartItems.length >= parseInt(VuFind.translate('bookbagMax'), 10)) {
+      return false;
+    }
+    var sIndex = cartSources.indexOf(source);
+    if (sIndex < 0) {
+      // Add source to source cookie
+      cartItems[cartItems.length] = String.fromCharCode(65 + cartSources.length) + id;
+      cartSources[cartSources.length] = source;
+      Cookies.setItem(_COOKIE_SOURCES, cartSources.join(_COOKIE_DELIM), false, _COOKIE_PATH, _COOKIE_DOMAIN);
+    } else {
+      cartItems[cartItems.length] = String.fromCharCode(65 + sIndex) + id;
+    }
+    Cookies.setItem(_COOKIE, _uniqueArray(cartItems).join(_COOKIE_DELIM), false, _COOKIE_PATH, _COOKIE_DOMAIN);
+    updateCount();
+    return true;
+  }
+  function removeItem(id, source) {
+    var cartItems = _getItems();
+    var cartSources = _getSources();
+    // Find
+    var cartIndex = cartItems.indexOf(String.fromCharCode(65 + cartSources.indexOf(source)) + id);
+    if (cartIndex > -1) {
+      var sourceIndex = cartItems[cartIndex].charCodeAt(0) - 65;
+      var saveSource = false;
+      for (var i = cartItems.length; i--;) {
+        if (i === cartIndex) {
+          continue;
+        }
+        // If this source is shared by another, keep it
+        if (cartItems[i].charCodeAt(0) - 65 === sourceIndex) {
+          saveSource = true;
+          break;
+        }
+      }
+      cartItems.splice(cartIndex, 1);
+      // Remove unused sources
+      if (!saveSource) {
+        var oldSources = cartSources.slice(0);
+        cartSources.splice(sourceIndex, 1);
+        // Adjust source index characters
+        for (var j = cartItems.length; j--;) {
+          var si = cartItems[j].charCodeAt(0) - 65;
+          var ni = cartSources.indexOf(oldSources[si]);
+          cartItems[j] = String.fromCharCode(65 + ni) + cartItems[j].substring(1);
+        }
+      }
+      if (cartItems.length > 0) {
+        Cookies.setItem(_COOKIE, _uniqueArray(cartItems).join(_COOKIE_DELIM), false, _COOKIE_PATH, _COOKIE_DOMAIN);
+        Cookies.setItem(_COOKIE_SOURCES, _uniqueArray(cartSources).join(_COOKIE_DELIM), false, _COOKIE_PATH, _COOKIE_DOMAIN);
+      } else {
+        Cookies.removeItem(_COOKIE, _COOKIE_PATH, _COOKIE_DOMAIN);
+        Cookies.removeItem(_COOKIE_SOURCES, _COOKIE_PATH, _COOKIE_DOMAIN);
+      }
+      updateCount();
+      return true;
+    }
+    return false;
+  }
+
+  var _cartNotificationTimeout = false;
+  function _registerUpdate($form) {
+    if ($form) {
+      $("#updateCart, #bottom_updateCart").unbind('click').click(function cartUpdate() {
+        var elId = this.id;
+        var selectedBoxes = $("input[name='ids[]']:checked", $form);
+        var selected = [];
+        $(selectedBoxes).each(function cartCheckboxValues(i) {
+          selected[i] = this.value;
+        });
+        if (selected.length > 0) {
+          var msg = "";
+          var orig = getFullItems();
+          $(selected).each(function cartCheckedItemsAdd() {
+            var data = this.split('|');
+            addItem(data[1], data[0]);
+          });
+          var updated = getFullItems();
+          var added = updated.length - orig.length;
+          var inCart = selected.length - added;
+          msg += added + " " + VuFind.translate('itemsAddBag');
+          if (updated.length >= parseInt(VuFind.translate('bookbagMax'), 10)) {
+            msg += "<br/>" + VuFind.translate('bookbagFull');
+          }
+          if (inCart > 0 && orig.length > 0) {
+            msg += "<br/>" + inCart + " " + VuFind.translate('itemsInBag');
+          }
+          $('#' + elId).data('bs.popover').options.content = msg;
+          $('#cartItems strong').html(updated.length);
+        } else {
+          $('#' + elId).data('bs.popover').options.content = VuFind.translate('bulk_noitems_advice');
+        }
+        $('#' + elId).popover('show');
+        if (_cartNotificationTimeout !== false) {
+          clearTimeout(_cartNotificationTimeout);
+        }
+        _cartNotificationTimeout = setTimeout(function notificationHide() {
+          $('#' + elId).popover('hide');
+        }, 5000);
+        return false;
+      });
+    }
+  }
+
+  function init() {
+    // Record buttons
+    var $cartId = $('.cartId');
+    if ($cartId.length > 0) {
+      $cartId.each(function cartIdEach() {
+        var cartId = this.value.split('|');
+        var currentId = cartId[1];
+        var currentSource = cartId[0];
+        var $parent = $(this).parent();
+        $parent.find('.cart-add.correct,.cart-remove.correct').removeClass('correct hidden');
+        $parent.find('.cart-add').click(function cartAddClick() {
+          if (addItem(currentId, currentSource)) {
+            $parent.find('.cart-add,.cart-remove').toggleClass('hidden');
+          } else {
+            $parent.popover({content: VuFind.translate('bookbagFull')});
+            setTimeout(function recordCartFullHide() {
+              $parent.popover('hide');
+            }, 5000);
+          }
+        });
+        $parent.find('.cart-remove').click(function cartRemoveClick() {
+          removeItem(currentId, currentSource);
+          $parent.find('.cart-add,.cart-remove').toggleClass('hidden');
+        });
+      });
+    } else {
+      // Search results
+      var $form = $('form[name="bulkActionForm"]');
+      _registerUpdate($form);
+    }
+    $("#updateCart, #bottom_updateCart").popover({content: '', html: true, trigger: 'manual'});
+    updateCount();
+  }
+
+  // Reveal
+  return {
+    // Methods
+    addItem: addItem,
+    removeItem: removeItem,
+    getFullItems: getFullItems,
+    updateCount: updateCount,
+    setDomain: setDomain,
+    setPath: setPath,
+    // Init
+    init: init
+  };
+});
+
+// Building an array and checking indexes prevents a race situation
+// We want to prioritize empty over printing
+function cartFormHandler(event, data) {
+  var keys = [];
+  for (var i in data) {
+    if (data.hasOwnProperty(i)) {
+      keys.push(data[i].name);
+    }
+  }
+  if (keys.indexOf('ids[]') === -1) {
+    return null;
+  }
+  if (keys.indexOf('print') > -1) {
+    return true;
+  }
+}
+
+document.addEventListener('VuFind.lightbox.closed', VuFind.cart.updateCount, false);

--- a/themes/dev/templates/layout/layout.phtml
+++ b/themes/dev/templates/layout/layout.phtml
@@ -1,0 +1,208 @@
+<?=$this->doctype('HTML5')?>
+<html lang="<?=$this->layout()->userLang?>">
+  <head>
+    <?$this->headThemeResources()?>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <?=$this->headMeta()?>
+    <?=$this->headTitle()?>
+    <?
+      // Set up OpenSearch link:
+      $this->headLink(
+        array(
+          'href' => $this->url('search-opensearch') . '?method=describe',
+          'type' => 'application/opensearchdescription+xml',
+          'title' => $this->transEsc('Library Catalog Search'),
+          'rel' => 'search'
+        )
+      );
+    ?>
+    <!-- RTL styling -->
+    <? if ($this->layout()->rtl) {
+      $this->headLink()->appendStylesheet('vendor/bootstrap-rtl.min.css');
+    } ?>
+    <?=$this->headLink()?>
+    <?=$this->headStyle()?>
+    <?
+      if (!isset($this->renderingError)) {
+        // Add translation strings
+        $this->jsTranslations()->addStrings(
+          array(
+            'add_tag_success' => 'add_tag_success',
+            'bulk_email_success' => 'bulk_email_success',
+            'bulk_noitems_advice' => 'bulk_noitems_advice',
+            'bulk_save_success' => 'bulk_save_success',
+            'close' => 'close',
+            'collection_empty' => 'collection_empty',
+            'error_occurred' => 'An error has occurred',
+            'go_to_list' => 'go_to_list',
+            'libphonenumber_invalid' => 'libphonenumber_invalid',
+            'libphonenumber_invalidcountry' => 'libphonenumber_invalidcountry',
+            'libphonenumber_invalidregion' => 'libphonenumber_invalidregion',
+            'libphonenumber_notanumber' => 'libphonenumber_notanumber',
+            'libphonenumber_toolong' => 'libphonenumber_toolong',
+            'libphonenumber_tooshort' => 'libphonenumber_tooshort',
+            'libphonenumber_tooshortidd' => 'libphonenumber_tooshortidd',
+            'loading' => 'Loading',
+            'more' => 'more',
+            'number_thousands_separator' => [
+                'number_thousands_separator', null, ','
+            ],
+            'sms_success' => 'sms_success'
+          )
+        );
+        // Add libphonenumber.js strings
+        $this->jsTranslations()->addStrings(
+          array(
+            "Phone number invalid" => 'libphonenumber_invalid',
+            "Invalid country calling code" => 'libphonenumber_invalidcountry',
+            "Invalid region code" => 'libphonenumber_invalidregion',
+            "The string supplied did not seem to be a phone number" => 'libphonenumber_notanumber',
+            "The string supplied is too long to be a phone number" => 'libphonenumber_toolong',
+            "The string supplied is too short to be a phone number" => 'libphonenumber_tooshort',
+            "Phone number too short after IDD" => 'libphonenumber_tooshortidd'
+          )
+        );
+        // Deal with cart stuff:
+        $cart = $this->cart();
+        if ($cart->isActive()) {
+          $this->headScript()->appendFile("vendor/cookies.js");
+          $this->headScript()->appendFile("cart.js");
+          $domain = $cart->getCookieDomain();
+          if (!empty($domain)) {
+            $this->headScript()->appendScript(
+              'VuFind.cart.setDomain("' . $domain . '")'
+            );
+          }
+          $path = $cart->getCookiePath();
+          if (!empty($path)) {
+            $this->headScript()->appendScript(
+              'VuFind.cart.setPath("' . $path . '")'
+            );
+          }
+          $this->jsTranslations()->addStrings(
+            array(
+              'addBookBag' => 'Add to Book Bag',
+              'bookbagFull' => 'bookbag_full_msg',
+              'bookbagMax' => $cart->getMaxSize(),
+              'bookbagStatusFull' => 'bookbag_full',
+              'confirmDelete' => 'confirm_delete',
+              'confirmEmpty' => 'bookbag_confirm_empty',
+              'itemsAddBag' => 'items_added_to_bookbag',
+              'itemsInBag' => 'items_already_in_bookbag',
+              'removeBookBag' => 'Remove from Book Bag',
+              'viewBookBag' => 'View Book Bag'
+            )
+          );
+        }
+        $this->headScript()->appendScript(
+          'var userIsLoggedIn = ' . ($this->auth()->isLoggedIn() ? 'true' : 'false') . ';'
+        );
+        
+      }
+
+      // Session keep-alive
+      if ($this->KeepAlive()) {
+          $this->headScript()->appendScript('var keepAliveInterval = '
+            . $this->KeepAlive());
+          $this->headScript()->appendFile("keep_alive.js");
+      }
+    ?>
+    <?
+      $root = rtrim($this->url('home'), '/');
+      $translations = $this->jsTranslations()->getJSON();
+      $dsb = DEFAULT_SEARCH_BACKEND;
+      $setupJS = <<<JS
+VuFind.path = '{$root}';
+VuFind.defaultSearchBackend = '{$dsb}';
+VuFind.addTranslations({$translations});
+JS;
+      $this->headScript()->appendScript($setupJS);
+    ?>
+    
+    <?
+      if ($this->auth()->isLoggedIn()) {
+        $this->headScript()->appendFile("post_login.js");
+      };
+    ?>
+
+    <?=$this->headScript()?>
+  </head>
+  <body class="<?=$this->layoutClass('offcanvas-row')?><? if ($this->layout()->rtl): ?> rtl<? endif; ?>">
+    <? // Set up the search box -- there are three possible cases:
+      // 1. No search box was set; we should default to the normal box
+      // 2. It was set to false; we should display nothing
+      // 3. It is set to a custom string; we should display the provided version
+      // Set up default search box if no data was provided from the template;
+      // this covers case 1.  Cases 2 and 3 are then covered by logic below.
+      if (!isset($this->layout()->searchbox)) {
+        $this->layout()->searchbox = $this->render('search/searchbox.phtml');
+      }
+    ?>
+    <header class="hidden-print">
+      <div class="container navbar">
+        <? if (isset($this->layout()->srmessage)): // message for benefit of screen-reader users ?>
+          <span class="sr-only"><?=$this->layout()->srmessage ?></span>
+        <? endif; ?>
+        <a class="sr-only" href="#content"><?=$this->transEsc('Skip to content') ?></a>
+        <?=$this->render('header.phtml')?>
+      </div>
+      <div class="container">
+        <nav class="nav searchbox hidden-lg hidden-print">
+          <?=$this->layout()->searchbox ?>
+        </nav>
+        <? if((!isset($this->layout()->showBreadcrumbs) || $this->layout()->showBreadcrumbs == true)
+          && !empty($this->layout()->breadcrumbs)
+          && $this->layout()->breadcrumbs !== false
+        ): ?>
+          <ul class="breadcrumb hidden-print">
+            <? if(is_array($this->layout()->breadcrumbs)): ?>
+              <? if(count($this->layout()->breadcrumbs) > 1): ?>
+                <?=$this->render('breadcrumbs/multi.phtml', array(
+                    'parents' => $this->layout()->breadcrumbs,
+                    'title'   => $this->layout()->title,
+                    'from'    => $this->layout()->from
+                  )) ?>
+              <? else: ?>
+                <?=$this->render('breadcrumbs/default.phtml', array(
+                    'parents' => $this->layout()->breadcrumbs,
+                    'title'   => $this->layout()->title
+                  )) ?>
+              <? endif; ?>
+            <? else: ?>
+              <?=$this->layout()->breadcrumbs ?>
+            <? endif; ?>
+          </ul>
+        <? endif; ?>
+      </div>
+    </header>
+    <div role="main" class="main template-dir-<?=$this->templateDir?> template-name-<?=$this->templateName?>">
+      <div id="content" class="container">
+        <?=$this->layout()->content ?>
+      </div>
+    </div>
+    <footer class="hidden-print">
+      <div class="container">
+        <?=$this->render('footer.phtml')?>
+        <?=$this->layout()->poweredBy ?>
+      </div>
+    </footer>
+    <!-- MODAL IN CASE WE NEED ONE -->
+    <div id="modal" class="modal fade hidden-print" tabindex="-1" role="dialog" aria-labelledby="modalTitle" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+          <div class="modal-body"><?=$this->transEsc('Loading') ?>...</div>
+        </div>
+      </div>
+    </div>
+    <div class="offcanvas-toggle" data-toggle="offcanvas"><i class="fa" title="<?=$this->transEsc('sidebar_expand') ?>"></i></div>
+    <div class="offcanvas-overlay" data-toggle="offcanvas"></div>
+    <?=$this->googleanalytics()?>
+    <?=$this->piwik()?>
+    <? if ($this->recaptcha()->active()): ?>
+      <?=$this->inlineScript(\Zend\View\Helper\HeadScript::FILE, "https://www.google.com/recaptcha/api.js?onload=recaptchaOnLoad&render=explicit&hl=" . $this->layout()->userLang, 'SET')?>
+    <? endif; ?>
+  </body>
+</html>


### PR DESCRIPTION
Hello Demian,

we have noticed that the cookies set by cart.js do not respect the Cookie related settings in config.ini.
(that is if you set limit_by_path in section [Cookies] this has no effect on the cart cookies)
So if you have two vufind instances on one server the bookbags are shared between those.

The following code tries to fix this issue. Hope you could integrate it in the vufind base code.

Greetings 
Markus


