### PR TITLE
Don’t try other Solr servers if a query fails due to timeout or inval…

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -364,6 +364,19 @@ class Connector implements \Zend\Log\LoggerAwareInterface
     }
 
     /**
+     * Check if an exception from a Solr request should be thrown rather than retried
+     *
+     * @param \Exception $ex Exception
+     *
+     * @return bool
+     */
+    protected function isRethrowableSolrException($ex)
+    {
+        return $ex instanceof TimeoutException
+            || $ex instanceof RequestErrorException;
+    }
+
+    /**
      * Try all Solr URLs until we find one that works (or throw an exception).
      *
      * @param string   $method    HTTP method to use
@@ -390,9 +403,7 @@ class Connector implements \Zend\Log\LoggerAwareInterface
             try {
                 return $this->send($client);
             } catch (\Exception $ex) {
-                if ($ex instanceof TimeoutException
-                    || $ex instanceof RequestErrorException
-                ) {
+                if ($this->isRethrowableSolrException($ex)) {
                     throw $ex;
                 }
                 $exception = $ex;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -35,12 +35,14 @@ use VuFindSearch\Query\Query;
 use VuFindSearch\ParamBag;
 
 use VuFindSearch\Backend\Exception\HttpErrorException;
+use VuFindSearch\Backend\Exception\RequestErrorException;
 
 use VuFindSearch\Backend\Solr\Document\AbstractDocument;
 
 use Zend\Http\Request;
 use Zend\Http\Client as HttpClient;
 use Zend\Http\Client\Adapter\AdapterInterface;
+use Zend\Http\Client\Adapter\Exception\TimeoutException;
 
 use InvalidArgumentException;
 
@@ -388,6 +390,11 @@ class Connector implements \Zend\Log\LoggerAwareInterface
             try {
                 return $this->send($client);
             } catch (\Exception $ex) {
+                if ($ex instanceof TimeoutException
+                    || $ex instanceof RequestErrorException
+                ) {
+                    throw $ex;
+                }
                 $exception = $ex;
             }
         }


### PR DESCRIPTION
…id request.

Timeout usually means that the query was particularly bad to handle or that the server is overloaded, so it makes sense not to try it on other servers. Likewise with invalid queries, they won't work anyway.

A connection failure, on the other hand, will cause a RuntimeException and warrants a retry.