### PR TITLE
Catch also exceptions from driverHold method so that the holdings dis…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
@@ -120,13 +120,13 @@ class TitleHolds
             } else if ($mode == 'driver') {
                 try {
                     $patron = $this->ilsAuth->storedCatalogLogin();
+                    if (!$patron) {
+                        return false;
+                    }
+                    return $this->driverHold($id, $patron);
                 } catch (ILSException $e) {
                     return false;
                 }
-                if (!$patron) {
-                    return false;
-                }
-                return $this->driverHold($id, $patron);
             } else {
                 try {
                     $patron = $this->ilsAuth->storedCatalogLogin();


### PR DESCRIPTION
…play doesn’t crash on that.

This requires #914 to work properly when Voyager web services are unavailable but Oracle is.

Can be tested with title holds mode set to 'driver' by e.g. setting the WebServices port to something bad in VoyagerRestful ini.