### PR TITLE
Use the .always method to handle record tab ajax loading so that also…

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -183,9 +183,10 @@ function ajaxLoadTab($newTab, tabid, setHash) {
   })
   .always(function ajaxLoadTabDone(data) {
     if (typeof data === 'object') {
-      data = data.responseText ? data.responseText : VuFind.translate('error_occurred');
+      $newTab.html(data.responseText ? data.responseText : VuFind.translate('error_occurred'));
+    } else {
+      $newTab.html(data);
     }
-    $newTab.html(data);
     registerTabEvents();
     if (typeof syn_get_widget === "function") {
       syn_get_widget();

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -181,7 +181,10 @@ function ajaxLoadTab($newTab, tabid, setHash) {
     type: 'POST',
     data: {tab: tabid}
   })
-  .done(function ajaxLoadTabDone(data) {
+  .always(function ajaxLoadTabDone(data) {
+    if (typeof data === 'object') {
+      data = data.responseText ? data.responseText : VuFind.translate('error_occurred');
+    }
     $newTab.html(data);
     registerTabEvents();
     if (typeof syn_get_widget === "function") {


### PR DESCRIPTION
… tabs that fail to load properly are displayed.

Otherwise e.g. an 500 server error leaves the load indicator spinning forever.