### PR TITLE
Avoid querying e.g. home page facets from the backend if none are enabled.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -581,11 +581,17 @@ class SearchController extends AbstractSearch
             $params = $results->getParams();
             $params->$initMethod();
 
-            // We only care about facet lists, so don't get any results (this helps
-            // prevent problems with serialized File_MARC objects in the cache):
-            $params->setLimit(0);
-
-            $list = $results->getFacetList();
+            // Avoid a backend request if there are no facets configured by the given
+            // init method.
+            if (!empty($params->getFacetConfig())) {
+                // We only care about facet lists, so don't get any results (this
+                // helps prevent problems with serialized File_MARC objects in the
+                // cache):
+                $params->setLimit(0);
+                $list = $results->getFacetList();
+            } else {
+                $list = [];
+            }
             $cache->setItem($cacheName, $list);
         }
 


### PR DESCRIPTION
This avoids a potentially slow (but always useless) backend request when the facets are not cached or the cache entry has expired.