### PR TITLE
Added table and rowClass to constructors of all table classes so that…

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
@@ -49,15 +49,16 @@ class ChangeTracker extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'change_tracker', 'VuFind\Db\Row\ChangeTracker'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'change_tracker', $rowClass = 'VuFind\Db\Row\ChangeTracker'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Table/Comments.php
@@ -43,15 +43,16 @@ class Comments extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'comments', 'VuFind\Db\Row\Comments'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'comments', $rowClass = 'VuFind\Db\Row\Comments'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/ExternalSession.php
+++ b/module/VuFind/src/VuFind/Db/Table/ExternalSession.php
@@ -47,15 +47,16 @@ class ExternalSession extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'external_session', 'VuFind\Db\Row\ExternalSession'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'external_session', $rowClass = 'VuFind\Db\Row\ExternalSession'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Factory.php
+++ b/module/VuFind/src/VuFind/Db/Table/Factory.php
@@ -78,7 +78,10 @@ class Factory
     public static function __callStatic($name, $args)
     {
         // Strip "get" off method name, and use the remainder as the table name:
-        return static::getGenericTable(substr($name, 3), $args);
+        $name = substr($name, 3);
+        // Take only the first parameter (service manager) from args:
+        $args = array_splice($args, 0, 1);
+        return static::getGenericTable($name, $args);
     }
 
     /**
@@ -144,7 +147,9 @@ class Factory
             $sessionManager = $sm->getServiceLocator()->get('VuFind\SessionManager');
             $session = new \Zend\Session\Container('Account', $sessionManager);
         }
-        return static::getGenericTable('User', [$sm, $config, $rowClass, $session]);
+        return static::getGenericTable(
+            'User', [$sm, $config, $session, 'user', $rowClass]
+        );
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -42,15 +42,16 @@ class OaiResumption extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'oai_resumption', 'VuFind\Db\Row\OaiResumption'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'oai_resumption', $rowClass = 'VuFind\Db\Row\OaiResumption'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Record.php
+++ b/module/VuFind/src/VuFind/Db/Table/Record.php
@@ -49,13 +49,16 @@ class Record extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct($adapter, $tm, $cfg, 'record', 'VuFind\Db\Row\Record');
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'record', $rowClass = 'VuFind\Db\Row\Record'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Table/Resource.php
@@ -63,15 +63,17 @@ class Resource extends Gateway
      * @param array                  $cfg       Zend Framework configuration
      * @param \VuFind\Date\Converter $converter Date converter
      * @param Loader                 $loader    Record loader
+     * @param string                 $table     Name of database table to interface
+     * with
+     * @param string                 $rowClass  Name of class used to represent rows
      */
     public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
-        \VuFind\Date\Converter $converter, Loader $loader
+        \VuFind\Date\Converter $converter, Loader $loader,
+        $table = 'resource', $rowClass = 'VuFind\Db\Row\Resource'
     ) {
         $this->dateConverter = $converter;
         $this->recordLoader = $loader;
-        parent::__construct(
-            $adapter, $tm, $cfg, 'resource', 'VuFind\Db\Row\Resource'
-        );
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
@@ -54,13 +54,14 @@ class ResourceTags extends Gateway
      * @param PluginManager $tm            Table manager
      * @param array         $cfg           Zend Framework configuration
      * @param bool          $caseSensitive Are tags case sensitive?
+     * @param string        $table         Name of database table to interface with
+     * @param string        $rowClass      Name of class used to represent rows
      */
     public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
-        $caseSensitive = false
+        $caseSensitive = false, $table = 'resource_tags',
+        $rowClass = 'VuFind\Db\Row\ResourceTags'
     ) {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'resource_tags', 'VuFind\Db\Row\ResourceTags'
-        );
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
         $this->caseSensitive = $caseSensitive;
     }
 

--- a/module/VuFind/src/VuFind/Db/Table/Search.php
+++ b/module/VuFind/src/VuFind/Db/Table/Search.php
@@ -50,13 +50,16 @@ class Search extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct($adapter, $tm, $cfg, 'search', 'VuFind\Db\Row\Search');
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'search', $rowClass = 'VuFind\Db\Row\Search'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Session.php
+++ b/module/VuFind/src/VuFind/Db/Table/Session.php
@@ -48,13 +48,16 @@ class Session extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct($adapter, $tm, $cfg, 'session', 'VuFind\Db\Row\Session');
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'session', $rowClass = 'VuFind\Db\Row\Session'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Table/Tags.php
@@ -56,11 +56,13 @@ class Tags extends Gateway
      * @param PluginManager $tm            Table manager
      * @param array         $cfg           Zend Framework configuration
      * @param bool          $caseSensitive Are tags case sensitive?
+     * @param string        $table         Name of database table to interface with
+     * @param string        $rowClass      Name of class used to represent rows
      */
     public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
-        $caseSensitive = false
+        $caseSensitive = false, $table = 'tags', $rowClass = 'VuFind\Db\Row\Tags'
     ) {
-        parent::__construct($adapter, $tm, $cfg, 'tags', 'VuFind\Db\Row\Tags');
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
         $this->caseSensitive = $caseSensitive;
     }
 

--- a/module/VuFind/src/VuFind/Db/Table/User.php
+++ b/module/VuFind/src/VuFind/Db/Table/User.php
@@ -62,17 +62,18 @@ class User extends Gateway
      * @param PluginManager $tm       Table manager
      * @param array         $cfg      Zend Framework configuration
      * @param Config        $config   VuFind configuration
-     * @param string        $rowClass Name of class for representing rows
      * @param Container     $session  Session container to inject into rows
      * (optional; used for privacy mode)
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
     public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
-        Config $config, $rowClass = 'VuFind\Db\Row\User',
-        Container $session = null
+        Config $config, Container $session = null, $table = 'user',
+        $rowClass = 'VuFind\Db\Row\User'
     ) {
         $this->config = $config;
         $this->session = $session;
-        parent::__construct($adapter, $tm, $cfg, 'user', $rowClass);
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/UserCard.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserCard.php
@@ -42,14 +42,15 @@ class UserCard extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'user_card', 'VuFind\Db\Row\UserCard'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'user_card', $rowClass = 'VuFind\Db\Row\UserCard'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Table/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserList.php
@@ -52,19 +52,21 @@ class UserList extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter                 $adapter Database adapter
-     * @param PluginManager           $tm      Table manager
-     * @param array                   $cfg     Zend Framework configuration
-     * @param \Zend\Session\Container $session Session container (must use same
+     * @param Adapter                 $adapter  Database adapter
+     * @param PluginManager           $tm       Table manager
+     * @param array                   $cfg      Zend Framework configuration
+     * @param \Zend\Session\Container $session  Session container (must use same
      * namespace as container provided to \VuFind\View\Helper\Root\UserList).
+     * @param string                  $table    Name of database table to interface
+     * with
+     * @param string                  $rowClass Name of class used to represent rows
      */
     public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
-        \Zend\Session\Container $session
+        \Zend\Session\Container $session, $table = 'user_list',
+        $rowClass = 'VuFind\Db\Row\UserList'
     ) {
         $this->session = $session;
-        parent::__construct(
-            $adapter, $tm, $cfg, 'user_list', 'VuFind\Db\Row\UserList'
-        );
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/UserResource.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserResource.php
@@ -43,15 +43,16 @@ class UserResource extends Gateway
     /**
      * Constructor
      *
-     * @param Adapter       $adapter Database adapter
-     * @param PluginManager $tm      Table manager
-     * @param array         $cfg     Zend Framework configuration
+     * @param Adapter       $adapter  Database adapter
+     * @param PluginManager $tm       Table manager
+     * @param array         $cfg      Zend Framework configuration
+     * @param string        $table    Name of database table to interface with
+     * @param string        $rowClass Name of class used to represent rows
      */
-    public function __construct(Adapter $adapter, PluginManager $tm, $cfg)
-    {
-        parent::__construct(
-            $adapter, $tm, $cfg, 'user_resource', 'VuFind\Db\Row\UserResource'
-        );
+    public function __construct(Adapter $adapter, PluginManager $tm, $cfg,
+        $table = 'user_resource', $rowClass = 'VuFind\Db\Row\UserResource'
+    ) {
+        parent::__construct($adapter, $tm, $cfg, $table, $rowClass);
     }
 
     /**


### PR DESCRIPTION
… they can be easily overloaded. Fixed __callStatic to not pass extra parameters to getGenericTable().

Do you think this would be a viable change? $table is perhaps not as important as $rowClass, but I included it for the sake of completeness. It used to be easy to just set $this->rowClass in a subclass constructor, but the latest ZF makes it a bit more convoluted with a couple of required method calls.

The calls to __callStatic() included two versions of the class name, and it doesn't make sense to pass them on as extra parameters (and it would break the optional $table and $rowClass).