### PR TITLE
Added a missing translation for hold_record_already_on_loan and fixed…

### DIFF
--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -186,8 +186,12 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ;excludedItemLocations = "2:4:23:10"
 
 ; By default a patron can place a hold on records he/she already has on loan.
-; Uncomment this setting to prevent placing a hold on something already on loan for
-; the patron.
+; This setting can be used to modify this behavior. Must be one of the following:
+; 1) false to indicate that loans are not checked (default setting).
+; 2) true to indicate that any loan on the bibliographic record prevents further
+; holds.
+; 3) "same-item" to indicate that a loan on the specific item prevents placing a hold
+; on it.
 ;checkLoans = true
 
 ; Optional help texts that can be displayed on the hold form

--- a/languages/en.ini
+++ b/languages/en.ini
@@ -452,6 +452,7 @@ hold_place_fail_missing = "Your request failed. Some data was missing. Please co
 hold_place_success_html = "Your request was successful. <a href="%%url%%">Your Holds and Recalls</a>."
 hold_profile_html = "For hold and recall information, please establish your <a href="%%url%%">Library Catalog Profile</a>."
 hold_queue_position = "Queue Position"
+hold_record_already_on_loan = "You already have the record on loan"
 hold_request_group = "Request from"
 hold_requested_group = "Requested from"
 hold_required_by = "No longer required after"

--- a/languages/fi.ini
+++ b/languages/fi.ini
@@ -455,6 +455,7 @@ hold_place_fail_missing = "Pyyntö epäonnistui puuttuvien tietojen vuoksi. Ota 
 hold_place_success_html = "Varauspyyntö onnistui. <a href="%%url%%">Varaukset</a>."
 hold_profile_html = "Kirjaudu <a href="%%url%%">kirjastokortilla</a> nähdäksesi varaukset."
 hold_queue_position = "Sijainti jonossa"
+hold_record_already_on_loan = "Teos on jo sinulla lainassa"
 hold_request_group = "Varauksen kohde"
 hold_requested_group = "Varauksen kohde"
 hold_required_by = "Viimeinen voimassaolopäivä"

--- a/languages/sv.ini
+++ b/languages/sv.ini
@@ -450,6 +450,7 @@ hold_place_fail_missing = "Reservering misslyckades p.g.a. att uppgifter saknas.
 hold_place_success_html = "Material har reserverats. <a href="%%url%%">Reserveringar</a>."
 hold_profile_html = "Logga in <a href %%url%%>med bibliotekskortet</a> för att se reserveringsmöjligheter."
 hold_queue_position = "Placering i kön"
+hold_record_already_on_loan = "Du har detta material redan utlånad"
 hold_request_group = "Reservera från"
 hold_requested_group = "Reserverad från"
 hold_required_by = "Sista giltighetsdagen"

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -1622,14 +1622,15 @@ EOT;
     }
 
     /**
-     * Check whether the given patron has the given bib record on loan.
+     * Check whether the given patron has the given bib record or its item on loan.
      *
      * @param int $patronId Patron ID
-     * @param int $bibId    BIB ID
+     * @param int $bibId    Bib ID
+     * @param int $itemId   Item ID (optional)
      *
      * @return bool
      */
-    protected function isRecordOnLoan($patronId, $bibId)
+    protected function isRecordOnLoan($patronId, $bibId, $itemId = null)
     {
         $sqlExpressions = [
             'count(cta.ITEM_ID) CNT'
@@ -1658,6 +1659,11 @@ EOT;
         }
 
         $sqlBind = ['patronId' => $patronId, 'bibId' => $bibId];
+
+        if (null !== $itemId) {
+            $sqlWhere[] = 'cta.ITEM_ID=:itemId';
+            $sqlBind['itemId'] = $itemId;
+        }
 
         $sqlArray = [
             'expressions' => $sqlExpressions,
@@ -2022,7 +2028,8 @@ EOT;
 
         // Optional check that the patron doesn't already have the bib on loan
         if ($this->checkLoans) {
-            if ($this->isRecordOnLoan($patron['id'], $bibId)) {
+            $checkItemId = $level == 'copy' && $itemId ? $itemId : null;
+            if ($this->isRecordOnLoan($patron['id'], $bibId, $checkItemId)) {
                 return $this->holdError('hold_record_already_on_loan');
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2028,7 +2028,8 @@ EOT;
 
         // Optional check that the patron doesn't already have the bib on loan
         if ($this->checkLoans) {
-            $checkItemId = $level == 'copy' && $itemId ? $itemId : null;
+            $checkItemId = $this->checkLoans === 'same-item' && $level == 'copy'
+                && $itemId ? $itemId : null;
             if ($this->isRecordOnLoan($patron['id'], $bibId, $checkItemId)) {
                 return $this->holdError('hold_record_already_on_loan');
             }


### PR DESCRIPTION
… the check to only check the item if placing a hold on a single item.

As far as I can see it doesn't make sense to check for any item on loan if placing an item-specific hold, so limit the check for the item in question.