### PR TITLE
Make it possible to add a hidden filter with value ’0’.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1483,7 +1483,7 @@ class Params
         if (!$this->hasHiddenFilter($newFilter)) {
             // Extract field and value from filter string:
             list($field, $value) = $this->parseFilter($newFilter);
-            if (!empty($field) && !empty($value)) {
+            if (!empty($field) && '' !== $value) {
                 $this->hiddenFilters[$field][] = $value;
             }
         }


### PR DESCRIPTION
Since empty() returns true for '0', e.g. a hidden filter such as "test_str_mv:0" is ignored.