### PR TITLE
Fixed a possible PHP notice from the EDS record driver.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -269,7 +269,7 @@ class EDS extends SolrDefault
     {
         if (isset($this->fields['FullText']['Links'])) {
             foreach ($this->fields['FullText']['Links'] as $link) {
-                if (isset($link['Type'])
+                if (!empty($link['Type']) && !empty($link['Url'])
                     && in_array($link['Type'], $this->pdfTypes)
                 ) {
                     return $link['Url']; // return PDF link


### PR DESCRIPTION
Looks like there are record that contain links without the Url key (they only have a Type key, nothing else).