### PR TITLE
Added hierarchical facet processing also to retrieveBatch context.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
@@ -151,7 +151,9 @@ class HierarchicalFacetListener
             return $event;
         }
         $context = $event->getParam('context');
-        if ($context == 'search' || $context == 'retrieve') {
+        if ($context == 'search' || $context == 'retrieve'
+            || $context == 'retrieveBatch'
+        ) {
             $this->processHierarchicalFacets($event);
         }
         return $event;


### PR DESCRIPTION
Hierarchical facet results were not properly processed in the retrieveBatch context. This was encountered e.g. with the record API when results for api/v1/record?id=xyz and api/v1/record?id[]=xyz were different.