### PR TITLE
Don’t consider a request a search if it’s in lightbox or a facet list…

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -244,10 +244,13 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getSearchResults()
     {
         $viewModel = $this->getView()->plugin('view_model');
+        if ('layout/lightbox' === $viewModel->getCurrent()->getTemplate()) {
+            return null;
+        }
         $children = $viewModel->getCurrent()->getChildren();
         if (isset($children[0])) {
             $template = $children[0]->getTemplate();
-            if (!strstr($template, '/home')) {
+            if (!strstr($template, '/home') && !strstr($template, 'facet-list')) {
                 $results = $children[0]->getVariable('results');
                 if (is_a($results, 'VuFind\Search\Base\Results')) {
                     return $results;


### PR DESCRIPTION
… request.

In addition to fixing statistics this avoids calling getResultTotal() for the facet list results object which would cause the search object to fetch full (well, maybe not full but like 100 each) facets for all facet fields (might be useful to somehow fix that too, but it would be a separate issue). 
