### PR TITLE
Use long tags instead of short tags in templates.

### DIFF
--- a/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
@@ -1,23 +1,23 @@
-<? $account = $this->auth()->getManager(); ?>
-<? $sessionInitiator = $account->getSessionInitiator($this->serverUrl($this->url('myresearch-home'))); ?>
-<? if (!$sessionInitiator): // display default login form if no login URL provided ?>
+<?php $account = $this->auth()->getManager(); ?>
+<?php $sessionInitiator = $account->getSessionInitiator($this->serverUrl($this->url('myresearch-home'))); ?>
+<?php if (!$sessionInitiator): // display default login form if no login URL provided ?>
   <form method="post" class="form-horizontal" action="<?=$this->url('myresearch-home')?>" name="loginForm">
     <?=$this->auth()->getLoginFields()?>
     <input type="hidden" name="auth_method" value="<?=$account->getAuthMethod()?>">
     <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($account->getCsrfHash(true))?>" />
     <div class="form-group">
       <div class="col-sm-offset-3 col-sm-9">
-        <? if ($account->supportsCreation()): ?>
+        <?php if ($account->supportsCreation()): ?>
           <a class="btn btn-link createAccountLink" href="<?=$this->url('myresearch-account') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Create New Account')?></a>
-        <? endif; ?>
+        <?php endif; ?>
         <input class="btn btn-primary" type="submit" name="processLogin" value="<?=$this->transEsc('Login')?>">
-        <? if ($account->supportsRecovery()): ?>
+        <?php if ($account->supportsRecovery()): ?>
           <br/>
           <a class="btn btn-link" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
     </div>
   </form>
-<? else: ?>
+<?php else: ?>
   <a href="<?=$this->escapeHtmlAttr($sessionInitiator)?>" class="btn btn-link" data-lightbox-ignore><?=$this->transEsc("Institutional Login")?></a>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Auth/AbstractBase/newpassword.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/newpassword.phtml
@@ -1,12 +1,12 @@
-<? if (isset($this->username)): ?>
+<?php if (isset($this->username)): ?>
   <div class="form-group">
     <label class="col-sm-3 control-label"><?=$this->transEsc('Username') ?>:</label>
     <div class="col-sm-9">
       <p class="form-control-static"><?=$this->username ?></p>
     </div>
   </div>
-<? endif; ?>
-<? if (isset($this->verifyold) && $this->verifyold || isset($this->oldpwd)): ?>
+<?php endif; ?>
+<?php if (isset($this->verifyold) && $this->verifyold || isset($this->oldpwd)): ?>
   <div class="form-group">
     <label class="col-sm-3 control-label"><?=$this->transEsc('old_password') ?>:</label>
     <div class="col-sm-9">
@@ -14,8 +14,8 @@
       <div class="help-block with-errors"></div>
     </div>
   </div>
-<? endif; ?>
-<?
+<?php endif; ?>
+<?php
   $pattern = '';
   if (isset($this->passwordPolicy['pattern'])) {
     if ($this->passwordPolicy['pattern'] == 'numeric') {
@@ -35,9 +35,9 @@
       <?=isset($this->passwordPolicy['maxLength']) ? ' maxlength="' . $this->passwordPolicy['maxLength'] . '"' : '' ?>
       <?=$pattern ? ' pattern="' . $pattern . '"' : '' ?>
     />
-    <? if ($this->passwordPolicy['hint']): ?>
+    <?php if ($this->passwordPolicy['hint']): ?>
       <div class="help-block"><?=$this->transEsc($this->passwordPolicy['hint']) ?></div>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="help-block with-errors"></div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/Auth/ChoiceAuth/login.phtml
+++ b/themes/bootstrap3/templates/Auth/ChoiceAuth/login.phtml
@@ -1,13 +1,13 @@
 <p><?=$this->transEsc('choose_login_method')?></p>
 <div id="authcontainer">
-<? $methods = $this->auth()->getManager()->getSelectableAuthOptions(); ?>
-<? $count = count($methods); ?>
-<? foreach ($methods as $loop=>$method):?>
+<?php $methods = $this->auth()->getManager()->getSelectableAuthOptions(); ?>
+<?php $count = count($methods); ?>
+<?php foreach ($methods as $loop=>$method):?>
   <div class="authmethod<?=$loop?> span<?=floor(12/$count) ?>">
-    <? $this->auth()->getManager()->setAuthMethod($method) ?>
+    <?php $this->auth()->getManager()->setAuthMethod($method) ?>
     <?=$this->auth()->getLoginDesc() ?>
     <?=$this->auth()->getLogin() ?>
   </div>
-<? endforeach ?>
+<?php endforeach ?>
 </div>
-<? $this->auth()->getManager()->setAuthMethod('ChoiceAuth') ?>
+<?php $this->auth()->getManager()->setAuthMethod('ChoiceAuth') ?>

--- a/themes/bootstrap3/templates/Auth/Database/create.phtml
+++ b/themes/bootstrap3/templates/Auth/Database/create.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $pattern = '';
   if (isset($this->passwordPolicy['pattern'])) {
     if ($this->passwordPolicy['pattern'] == 'numeric') {
@@ -44,9 +44,9 @@
       <?=isset($this->passwordPolicy['maxLength']) ? ' maxlength="' . $this->passwordPolicy['maxLength'] . '"' : ''?>
       <?=$pattern ? ' pattern="' . $pattern . '"' : '' ?>
     />
-    <? if ($this->passwordPolicy['hint']): ?>
+    <?php if ($this->passwordPolicy['hint']): ?>
       <div class="help-block"><?=$this->transEsc($this->passwordPolicy['hint']) ?></div>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="help-block with-errors"></div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
@@ -5,7 +5,7 @@
     <select id="login_target" name="target" class="form-control">
     <?foreach ($this->auth()->getManager()->getLoginTargets() as $target):?>
       <option value="<?=$this->escapeHtmlAttr($target)?>"<?=($target == $currentTarget ? ' selected="selected"' : '')?>><?=$this->transEsc("source_$target", null, $target)?></option>
-    <? endforeach ?>
+    <?php endforeach ?>
     </select>
   </div>
 </div>

--- a/themes/bootstrap3/templates/Helpers/email-form-fields.phtml
+++ b/themes/bootstrap3/templates/Helpers/email-form-fields.phtml
@@ -2,38 +2,38 @@
   <label class="col-sm-3 control-label" for="email_to"><?=$this->transEsc('To')?>:</label>
   <div class="col-sm-9">
     <input type="<?=$this->maxRecipients != 1 ? 'text' : 'email'?>" id="email_to" class="form-control" oninvalid="$('#modal .fa-spinner').remove()" name="to" value="<?=isset($this->to) ? $this->to : ''?>"/>
-    <? if ($this->maxRecipients != 1): ?>
+    <?php if ($this->maxRecipients != 1): ?>
       <br />
       <?=$this->transEsc('email_multiple_recipients_note')?>
-      <? if ($this->maxRecipients > 1): ?>
+      <?php if ($this->maxRecipients > 1): ?>
         <?=$this->transEsc('email_maximum_recipients_note', ['%%max%%' => $this->maxRecipients])?>
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
   </div>
 </div>
-<? if (!$this->disableFrom): ?>
+<?php if (!$this->disableFrom): ?>
   <div class="form-group">
     <label class="col-sm-3 control-label" for="email_from"><?=$this->transEsc('From')?>:</label>
     <div class="col-sm-9">
       <input type="email" id="email_from" oninvalid="$('#modal .fa-spinner').remove()" name="from" value="<?=isset($this->from) ? $this->from : ''?>" size="40" class="form-control"/>
     </div>
   </div>
-<? endif; ?>
-<? if ($this->editableSubject): ?>
+<?php endif; ?>
+<?php if ($this->editableSubject): ?>
   <div class="form-group">
     <label class="col-sm-3 control-label" for="email_subject"><?=$this->transEsc('email_subject')?>:</label>
     <div class="col-sm-9">
       <input type="text" id="email_subject" oninvalid="$('#modal .fa-spinner').remove()" name="subject" value="<?=isset($this->subject) ? $this->subject : ''?>" size="40" class="form-control"/>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>
 <div class="form-group">
   <label class="col-sm-3 control-label" for="email_message"><?=$this->transEsc('Message')?>:</label>
   <div class="col-sm-9">
     <textarea id="email_message" class="form-control" name="message" rows="4"><?=isset($this->message) ? $this->message : ''?></textarea>
   </div>
 </div>
-<? if ($this->disableFrom && $this->userEmailInFrom): ?>
+<?php if ($this->disableFrom && $this->userEmailInFrom): ?>
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <div class="checkbox">
@@ -43,7 +43,7 @@
       </div>
     </div>
   </div>
-<? endif ?>
+<?php endif ?>
 <?=$this->recaptcha()->html($this->useRecaptcha) ?>
 <div class="form-group">
   <div class="col-sm-9 col-sm-offset-3">

--- a/themes/bootstrap3/templates/Helpers/ils-offline.phtml
+++ b/themes/bootstrap3/templates/Helpers/ils-offline.phtml
@@ -2,6 +2,6 @@
   <h2><?=$this->transEsc('ils_offline_title')?></h2>
   <p><strong><?=$this->transEsc('ils_offline_status')?></strong></p>
   <p><?=$this->transEsc($this->offlineModeMsg)?></p>
-  <? $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+  <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
   <p><a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a></p>
 </div>

--- a/themes/bootstrap3/templates/Helpers/openurl.phtml
+++ b/themes/bootstrap3/templates/Helpers/openurl.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   echo $this->inlineScript(\Zend\View\Helper\HeadScript::FILE, 'openurl.js', 'SET');
   $classes = '';
   if ($this->openUrlEmbed) {
@@ -14,13 +14,13 @@
   }
 ?>
 
-<span class="openUrlControls<? if ($this->openUrlEmbed): ?> openUrlEmbed<? if ($this->openUrlEmbedAutoLoad): ?> openUrlEmbedAutoLoad<? endif; ?><? endif; ?>">
-  <? if (!$this->openUrlImageBasedSrc || $this->openUrlImageBasedMode == 'both'): ?>
+<span class="openUrlControls<?php if ($this->openUrlEmbed): ?> openUrlEmbed<?php if ($this->openUrlEmbedAutoLoad): ?> openUrlEmbedAutoLoad<?php endif; ?><?php endif; ?>">
+  <?php if (!$this->openUrlImageBasedSrc || $this->openUrlImageBasedMode == 'both'): ?>
   <a href="<?=$this->escapeHtmlAttr($this->resolverUrl)?>"<?=$class?> data-search-class-id="<?=$this->escapeHtmlAttr($this->searchClassId) ?>">
-    <? /* put the openUrl here in a span (COinS almost) so we can retrieve it later */ ?>
+    <?php /* put the openUrl here in a span (COinS almost) so we can retrieve it later */ ?>
     <span title="<?=$this->escapeHtmlAttr($this->openUrl)?>" class="openUrl"></span>
-    <? if ($this->openUrlGraphic): ?>
-      <?
+    <?php if ($this->openUrlGraphic): ?>
+      <?php
         $style = '';
         if ($this->openUrlGraphicWidth) {
           $style .= 'width:' . $this->escapeHtmlAttr($this->openUrlGraphicWidth) . 'px;';
@@ -30,21 +30,21 @@
         }
       ?>
       <img src="<?=$this->escapeHtmlAttr($this->openUrlGraphic)?>" alt="<?=$this->transEsc('Get full text')?>" style="<?=$style?>" />
-    <? else: ?>
+    <?php else: ?>
       <?=$this->transEsc('Get full text')?>
-    <? endif; ?>
+    <?php endif; ?>
   </a>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if ($this->openUrlImageBasedSrc): ?>
-    <? $ibOpenUrl = $this->openUrlImageBasedOverride ? $this->openUrlImageBasedOverride : $this->openUrl; ?>
+  <?php if ($this->openUrlImageBasedSrc): ?>
+    <?php $ibOpenUrl = $this->openUrlImageBasedOverride ? $this->openUrlImageBasedOverride : $this->openUrl; ?>
     <a href="<?=$this->escapeHtmlAttr($this->openUrlBase . '?' . $ibOpenUrl)?>"<?=$class_ib?>>
       <span title="<?=$this->escapeHtmlAttr($ibOpenUrl)?>" class="openUrl"></span>
       <img data-recordid="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" src="<?=$this->escapeHtmlAttr($this->openUrlImageBasedSrc)?>" alt="<?=$this->transEsc('Get full text')?>" />
     </a>
-  <? endif; ?>
+  <?php endif; ?>
 </span>
 
-<? if ($this->openUrlEmbed): ?>
+<?php if ($this->openUrlEmbed): ?>
   <div class="resolver hidden"><?=$this->transEsc('Loading')?>...</div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Helpers/pagination.phtml
+++ b/themes/bootstrap3/templates/Helpers/pagination.phtml
@@ -1,60 +1,60 @@
-<? if ($this->pageCount): ?>
+<?php if ($this->pageCount): ?>
   <ul class="pagination">
     <!-- Previous page link -->
-    <li<? if (isset($this->previous)): ?>>
-      <? $newParams = $this->params; $newParams['page'] = $this->previous; ?>
+    <li<?php if (isset($this->previous)): ?>>
+      <?php $newParams = $this->params; $newParams['page'] = $this->previous; ?>
       <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
         &laquo; <?=$this->translate('Prev')?>
       </a>
-    <? else: ?>
+    <?php else: ?>
        class="disabled"> <span>&laquo; <?=$this->translate('Prev')?></span>
-    <? endif; ?>
+    <?php endif; ?>
     </li>
 
     <!-- First page link -->
-    <li<? if (isset($this->first) && $this->first != $this->current): ?>>
-      <? $newParams = $this->params; $newParams['page'] = $this->first; ?>
+    <li<?php if (isset($this->first) && $this->first != $this->current): ?>>
+      <?php $newParams = $this->params; $newParams['page'] = $this->first; ?>
       <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
         <?=$this->translate('First')?>
       </a>
-    <? else: ?>
+    <?php else: ?>
        class="disabled"> <span><?=$this->translate('First')?></span>
-    <? endif; ?>
+    <?php endif; ?>
     </li>
 
     <!-- Numbered page links -->
-    <? foreach ($this->pagesInRange as $page): ?>
-      <li<? if ($page != $this->current): ?>>
-        <? $newParams = $this->params; $newParams['page'] = $page; ?>
+    <?php foreach ($this->pagesInRange as $page): ?>
+      <li<?php if ($page != $this->current): ?>>
+        <?php $newParams = $this->params; $newParams['page'] = $page; ?>
         <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
-            <? echo $page; ?>
+            <?php echo $page; ?>
         </a>
-      <? else: ?>
-         class="active"> <span><? echo $page; ?></span>
-      <? endif; ?>
+      <?php else: ?>
+         class="active"> <span><?php echo $page; ?></span>
+      <?php endif; ?>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
 
     <!-- Last page link -->
-    <li<? if (isset($this->last)  && $this->last != $this->current): ?>>
-      <? $newParams = $this->params; $newParams['page'] = $this->last; ?>
+    <li<?php if (isset($this->last)  && $this->last != $this->current): ?>>
+      <?php $newParams = $this->params; $newParams['page'] = $this->last; ?>
       <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
         <?=$this->translate('Last')?>
       </a>
-    <? else: ?>
+    <?php else: ?>
        class="disabled"> <span><?=$this->translate('Last')?></span>
-    <? endif; ?>
+    <?php endif; ?>
     </li>
 
     <!-- Next page link -->
-    <li<? if (isset($this->next)): ?>>
-      <? $newParams = $this->params; $newParams['page'] = $this->next; ?>
+    <li<?php if (isset($this->next)): ?>>
+      <?php $newParams = $this->params; $newParams['page'] = $this->next; ?>
       <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
         <?=$this->translate('Next')?> >
       </a>
-    <? else: ?>
+    <?php else: ?>
        class="disabled"> <span><?=$this->translate('Next')?> &raquo;</span>
-    <? endif; ?>
+    <?php endif; ?>
     </li>
   </ul>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/AlphaBrowseLink.phtml
+++ b/themes/bootstrap3/templates/Recommend/AlphaBrowseLink.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $index = $this->recommend->getIndex();
   $from = $this->recommend->getQuery();
   $link = $this->translate(

--- a/themes/bootstrap3/templates/Recommend/AuthorFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/AuthorFacets.phtml
@@ -1,22 +1,22 @@
-<? if ($this->recommend->getResults()->getResultTotal() > 0): ?>
-  <? $similarAuthors = $this->recommend->getSimilarAuthors(); ?>
-  <? if (!empty($similarAuthors['list'])): ?>
+<?php if ($this->recommend->getResults()->getResultTotal() > 0): ?>
+  <?php $similarAuthors = $this->recommend->getSimilarAuthors(); ?>
+  <?php if (!empty($similarAuthors['list'])): ?>
     <div class="row">
       <p><?=$this->transEsc('Author Results for')?> <strong><?=$this->escapeHtml($this->recommend->getSearchTerm()) ?></strong></p>
       <div class="col-sm-4">
-      <? foreach($similarAuthors['list'] as $i => $author): ?>
-        <? if ($i == 5): ?>
+      <?php foreach($similarAuthors['list'] as $i => $author): ?>
+        <?php if ($i == 5): ?>
         <a href="<?=$this->url('author-search') . '?lookfor=' . urlencode($this->recommend->getSearchTerm()) ?>"><strong><?=$this->transEsc("see all") ?> <?=(isset($similarAuthors['count']) && $similarAuthors['count']) ? $similarAuthors['count'] : ''?> &raquo;</strong></a>
       </div>
       <div class="col-sm-4">
-        <? endif; ?>
-        <a href="<?=$this->url('author-home') . '?author=' . urlencode($author['value'])?>"><?=$author['value'] ?><? /* count disabled -- uncomment to add: echo ' - ' . $author['count']; */ ?></a>
-        <? if ($i+1<count($similarAuthors['list'])): ?>
+        <?php endif; ?>
+        <a href="<?=$this->url('author-home') . '?author=' . urlencode($author['value'])?>"><?=$author['value'] ?><?php /* count disabled -- uncomment to add: echo ' - ' . $author['count']; */ ?></a>
+        <?php if ($i+1<count($similarAuthors['list'])): ?>
           <br/>
-        <? endif; ?>
-      <? endforeach; ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
       </div>
     </div>
     <br/>
-  <? endif; ?>
-<? endif; ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/AuthorInfo.phtml
+++ b/themes/bootstrap3/templates/Recommend/AuthorInfo.phtml
@@ -1,14 +1,14 @@
-<? $this->info = $this->recommend->getAuthorInfo() ?>
-<? if (!(empty($this->info['description']) || empty($this->info))): ?>
+<?php $this->info = $this->recommend->getAuthorInfo() ?>
+<?php if (!(empty($this->info['description']) || empty($this->info))): ?>
 <div class="wikipedia well clearfix">
   <h2><?=$this->info['name'] ?></h2>
 
-  <? if (isset($this->info['image'])): ?>
+  <?php if (isset($this->info['image'])): ?>
     <img class="pull-left flip" src="<?=$this->info['image'] ?>" alt="<?=$this->escapeHtmlAttr($this->info['altimage']) ?>" width="150px"/>
-  <? endif; ?>
+  <?php endif; ?>
 
   <?=preg_replace('/___baseurl___/', $this->url('search-results'), $this->info['description']) ?>
 
   <a href="http://<?=$this->info['wiki_lang'] ?>.wikipedia.org/wiki/<?=$this->escapeHtmlAttr($this->info['name']/*url*/) ?>" target="new"><?=$this->transEsc('wiki_link') ?></a>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/AuthorityRecommend.phtml
+++ b/themes/bootstrap3/templates/Recommend/AuthorityRecommend.phtml
@@ -1,19 +1,19 @@
-<?
+<?php
     $data = $this->recommend->getRecommendations();
     $results = $this->recommend->getResults();
 ?>
-<? if (is_array($data) && !empty($data)): ?>
+<?php if (is_array($data) && !empty($data)): ?>
   <div class="authoritybox">
     <div><strong><?=$this->transEsc('See also')?>:</strong></div>
     <div>
-      <? for ($i = 0; $i < count($data); $i++): ?>
-        <?
+      <?php for ($i = 0; $i < count($data); $i++): ?>
+        <?php
             // Generate a new search URL that replaces the user's current term with the authority term:
             $url = $this->url($results->getOptions()->getSearchAction())
                 . $results->getUrlQuery()->replaceTerm($results->getParams()->getDisplayQuery(), $data[$i]['heading']);
         ?>
-        <a href="<?=$url?>"><?=$this->escapeHtml($data[$i]['heading'])?></a><? if ($i != count($data) - 1): ?>, <? endif; ?>
-      <? endfor; ?>
+        <a href="<?=$url?>"><?=$this->escapeHtml($data[$i]['heading'])?></a><?php if ($i != count($data) - 1): ?>, <?php endif; ?>
+      <?php endfor; ?>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/CatalogResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/CatalogResults.phtml
@@ -1,29 +1,29 @@
-<? $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
+<?php $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
   <h4><?=$this->transEsc('Catalog Results')?></h4>
   <ul class="list-group">
-    <? foreach ($results as $driver): ?>
+    <?php foreach ($results as $driver): ?>
       <li class="list-group-item catalog-result">
-        <? $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
+        <?php $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
         <a href="<?=$this->recordLink()->getUrl($driver)?>" class="title <?=$this->record($driver)->getFormatClass($format)?>">
           <?=$this->record($driver)->getTitleHtml()?>
         </a>
-        <? $summDate = $driver->getPublicationDates(); ?>
-        <? $summAuthors = $driver->getPrimaryAuthorsWithHighlighting(); ?>
-        <? if (!empty($summDate) || !empty($summAuthors)): ?>
-          <? if (!empty($summDate)): ?>
+        <?php $summDate = $driver->getPublicationDates(); ?>
+        <?php $summAuthors = $driver->getPrimaryAuthorsWithHighlighting(); ?>
+        <?php if (!empty($summDate) || !empty($summAuthors)): ?>
+          <?php if (!empty($summDate)): ?>
             <br/>
             <span class="small author">
               <?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($summDate[0])?>)
             </span>
-          <? endif; ?>
-          <? if (!empty($summAuthors)): ?>
+          <?php endif; ?>
+          <?php if (!empty($summAuthors)): ?>
             <br/>
             <span class="small"><?=$this->transEsc('By')?></span>
-            <a class="small date" href="<?=$this->record($driver)->getLink('author', $this->highlight($summAuthors[0], null, true, false))?>"><?=$this->highlight($summAuthors[0])?></a><? if (count($summAuthors) > 1): ?><span class="small">, <?=$this->transEsc('more_authors_abbrev')?></span><? endif; ?>
-          <? endif; ?>
-        <? endif; ?>
+            <a class="small date" href="<?=$this->record($driver)->getLink('author', $this->highlight($summAuthors[0], null, true, false))?>"><?=$this->highlight($summAuthors[0])?></a><?php if (count($summAuthors) > 1): ?><span class="small">, <?=$this->transEsc('more_authors_abbrev')?></span><?php endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     <a class="list-group-item" href="<?=$this->url($searchObject->getOptions()->getSearchAction()) . $searchObject->getUrlQuery()->setLimit($searchObject->getOptions()->getDefaultLimit())?>"><?=$this->transEsc('More catalog results')?>...</a>
   </ul>
-<? endif ?>
+<?php endif ?>

--- a/themes/bootstrap3/templates/Recommend/CollectionSideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/CollectionSideFacets.phtml
@@ -1,8 +1,8 @@
-<?
+<?php
     $this->overrideSideFacetCaption = 'In This Collection';
 ?>
-<? if ($this->recommend->keywordFilterEnabled()): ?>
-  <?
+<?php if ($this->recommend->keywordFilterEnabled()): ?>
+  <?php
     $keywordFilter = $this->recommend->getKeywordFilter();
     if (!empty($keywordFilter)) {
       $this->extraSideFacetFilters = [
@@ -17,7 +17,7 @@
       ];
     }
   ?>
-  <? ob_start() ?>
+  <?php ob_start() ?>
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title">
@@ -27,16 +27,16 @@
     <div class="panel-body">
       <form class="form-inline" role="form" method="get" name="keywordFilterForm" id="keywordFilterForm">
         <input id="keywordFilter_lookfor" type="text" name="lookfor" value="<?=$this->escapeHtmlAttr($keywordFilter)?>" class="form-control"/>
-        <? foreach ($this->recommend->getResults()->getParams()->getFilterList(true) as $field => $filters): ?>
-          <? foreach ($filters as $filter): ?>
+        <?php foreach ($this->recommend->getResults()->getParams()->getFilterList(true) as $field => $filters): ?>
+          <?php foreach ($filters as $filter): ?>
             <input type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($filter['field'])?>:&quot;<?=$this->escapeHtmlAttr($filter['value'])?>&quot;" />
-          <? endforeach; ?>
-        <? endforeach; ?>
+          <?php endforeach; ?>
+        <?php endforeach; ?>
         <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEsc('Set')?>"/>
       </form>
     </div>
   </div>
-  <? $this->sideFacetExtraControls = ob_get_contents(); ?>
-  <? ob_end_clean(); ?>
-<? endif; ?>
+  <?php $this->sideFacetExtraControls = ob_get_contents(); ?>
+  <?php ob_end_clean(); ?>
+<?php endif; ?>
 <?=$this->render('Recommend/SideFacets.phtml')?>

--- a/themes/bootstrap3/templates/Recommend/DOI.phtml
+++ b/themes/bootstrap3/templates/Recommend/DOI.phtml
@@ -1,10 +1,10 @@
-<? $doi = $this->recommend->getDOI(); if (!empty($doi)): ?>
-  <? $url = $this->recommend->getURL(); ?>
+<?php $doi = $this->recommend->getDOI(); if (!empty($doi)): ?>
+  <?php $url = $this->recommend->getURL(); ?>
   <div class="alert alert-info">
     <?=$this->translate('doi_detected_html', ['%%url%%' => $url, '%%doi%%' => $doi])?>
   </div>
-  <? if ($this->recommend->isFullMatch()): ?>
-    <? $redirect = 'document.location.href = "' . $this->escapeJs($url) . '";'; ?>
+  <?php if ($this->recommend->isFullMatch()): ?>
+    <?php $redirect = 'document.location.href = "' . $this->escapeJs($url) . '";'; ?>
     <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $redirect, 'SET')?>
-  <? endif; ?>
-<? endif; ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/DPLATerms.phtml
+++ b/themes/bootstrap3/templates/Recommend/DPLATerms.phtml
@@ -1,18 +1,18 @@
-<? $results = $this->recommend->getResults(); ?>
-<? if(!empty($results)): ?>
+<?php $results = $this->recommend->getResults(); ?>
+<?php if(!empty($results)): ?>
   <ul class="list-group" id="side-panel-dpla">
-    <li class="list-group-item title<? if($this->recommend->isCollapsed()): ?> collapsed<? endif ?>" data-toggle="collapse" href="#side-collapse-dpla">
+    <li class="list-group-item title<?php if($this->recommend->isCollapsed()): ?> collapsed<?php endif ?>" data-toggle="collapse" href="#side-collapse-dpla">
       DPLA
     </li>
-    <div id="side-collapse-dpla" class="collapse<? if(!$this->recommend->isCollapsed()): ?> in<? endif ?>">
-    <? foreach($results as $item): ?>
+    <div id="side-collapse-dpla" class="collapse<?php if(!$this->recommend->isCollapsed()): ?> in<?php endif ?>">
+    <?php foreach($results as $item): ?>
       <li class="list-group-item">
         <a href="<?=$item['link'] ?>" target="new"><?=$this->escapeHtml($item['title']) ?></a><br/>
-        <? if(!empty($item['desc'])): ?>
+        <?php if(!empty($item['desc'])): ?>
           <span class="desc" title="<?=$item['desc'] ?>"><?=$this->escapeHtml($this->truncate($item['desc'], 50)) ?></span><br/>
-        <? endif; ?>
+        <?php endif; ?>
         (<span class="from"><?=$this->transEsc('Provider') ?>: <?=$this->escapeHtml($item['provider']) ?></span>)
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/Deprecated.phtml
+++ b/themes/bootstrap3/templates/Recommend/Deprecated.phtml
@@ -1,2 +1,2 @@
-<? /* do nothing -- this module is a placeholder for old deprecated features
+<?php /* do nothing -- this module is a placeholder for old deprecated features
       to prevent legacy configurations from causing fatal errors. */ ?>

--- a/themes/bootstrap3/templates/Recommend/EuropeanaResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/EuropeanaResults.phtml
@@ -1,4 +1,4 @@
-<? $data = $this->recommend->getResults(); if (is_array($data)): ?>
+<?php $data = $this->recommend->getResults(); if (is_array($data)): ?>
   <div class="sidegroup rssResults">
     <div class="suggestionHeader">
     <a href="http://www.europeana.eu/portal/" title="Europeana.eu" target="_blank">
@@ -7,18 +7,18 @@
     </div>
     <div>
       <ul class="list-group">
-        <? $i = 0; foreach ($data['worksArray'] as $workKey => $work): ?>
-          <li class="list-group-item suggestedResult <? (++$i % 2) ? 'alt ' : ''?>record<?=$i?>">
+        <?php $i = 0; foreach ($data['worksArray'] as $workKey => $work): ?>
+          <li class="list-group-item suggestedResult <?php (++$i % 2) ? 'alt ' : ''?>record<?=$i?>">
             <div class="resultitem clearfix">
-              <? if (isset($work['enclosure'])): ?>
+              <?php if (isset($work['enclosure'])): ?>
                 <span class="europeanaImg"><img src="<?=$this->escapeHtmlAttr($work['enclosure'])?>" id="europeanaImage<?=$this->escapeHtmlAttr($workKey)?>"/></span>
-              <? endif; ?>
+              <?php endif; ?>
               <a href="<?=$this->escapeHtmlAttr($work['link'])?>" target="_blank">
                 <span><?=$this->escapeHtml($this->truncate($work['title'], 90))?></span>
               </a>
             </div>
           </li>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </ul>
       <p class="olSubjectMore">
         <a href="<?=$this->escapeHtmlAttr($data['sourceLink'])?>" title="<?=$this->escapeHtmlAttr($data['feedTitle'])?>" target="_blank">
@@ -28,4 +28,4 @@
     </div>
   </div>
   <div class="clearfix"></div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/EuropeanaResultsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/EuropeanaResultsDeferred.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up Javascript for use below:
     $loadJs = 'var url = VuFind.path + "/AJAX/Recommend?' . $this->recommend->getUrlParams() . '";'
         . "\$('#EuropeanaDeferredRecommend').load(url);";

--- a/themes/bootstrap3/templates/Recommend/ExpandFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/ExpandFacets.phtml
@@ -1,17 +1,17 @@
-<?
+<?php
   $expandFacetSet = $this->recommend->getExpandedSet();
   // Get empty search object to use as basis for parameter generation below:
   $blankResults = $this->recommend->getEmptyResults();
 ?>
-<? if ($expandFacetSet): ?>
+<?php if ($expandFacetSet): ?>
   <div class="sidegroup">
- <? foreach ($expandFacetSet as $title=>$cluster): ?>
+ <?php foreach ($expandFacetSet as $title=>$cluster): ?>
     <h4><?=$this->transEsc($cluster['label']) ?></h4>
     <div class="list-group">
-      <? foreach ($cluster['list'] as $thisFacet): ?>
+      <?php foreach ($cluster['list'] as $thisFacet): ?>
         <a class="list-group-item" href="<?=$this->url('search-results') . $blankResults->getUrlQuery()->addFacet($title, $thisFacet['value'])?>"><?=$this->escapeHtml($thisFacet['displayText'])?></a>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
- <? endforeach; ?>
+ <?php endforeach; ?>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/FacetCloud.phtml
+++ b/themes/bootstrap3/templates/Recommend/FacetCloud.phtml
@@ -1,15 +1,15 @@
-<?
+<?php
     $expandFacetSet = $this->recommend->getExpandedSet();
     // Get empty search object to use as basis for parameter generation below:
     $blankResults = $this->recommend->getEmptyResults();
     $cloudLimit = $this->recommend->getFacetLimit();
 ?>
-<? if ($expandFacetSet): ?>
+<?php if ($expandFacetSet): ?>
   <div class="sidegroup">
-    <? foreach ($expandFacetSet as $title=>$facets): ?>
+    <?php foreach ($expandFacetSet as $title=>$facets): ?>
       <dl class="narrowList navmenu">
         <dt><?=$this->transEsc($facets['label']) ?></dt>
-        <?
+        <?php
         foreach ($facets['list'] as $i => $facetItem) {
             if ($i < $cloudLimit) {
                 echo (($i == 0) ? '' : ', ')
@@ -23,6 +23,6 @@
         }
         ?>
       </dl>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/FavoriteFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/FavoriteFacets.phtml
@@ -1,28 +1,28 @@
-<? $results = $this->recommend->getResults(); ?>
-<? $sideFacetSet = $this->recommend->getFacetSet(); ?>
+<?php $results = $this->recommend->getResults(); ?>
+<?php $sideFacetSet = $this->recommend->getFacetSet(); ?>
 
-<? if (isset($sideFacetSet['tags']) && !empty($sideFacetSet['tags']['list'])): ?>
+<?php if (isset($sideFacetSet['tags']) && !empty($sideFacetSet['tags']['list'])): ?>
   <h4 class="tag"><?=$this->transEsc($sideFacetSet['tags']['label'])?></h4>
   <ul class="list-group">
-  <? $filterList = $results->getParams()->getFilterList(true);
+  <?php $filterList = $results->getParams()->getFilterList(true);
      $tagFilterList = isset($filterList[$sideFacetSet['tags']['label']]) ? $filterList[$sideFacetSet['tags']['label']] : null; ?>
-    <? if (!empty($tagFilterList)): ?>
-      <? $field = $sideFacetSet['tags']['label']; ?>
-      <? foreach ($tagFilterList as $filter): ?>
-        <? $removeLink = $this->currentPath().$results->getUrlQuery()->removeFacet($filter['field'], $filter['value']); ?>
+    <?php if (!empty($tagFilterList)): ?>
+      <?php $field = $sideFacetSet['tags']['label']; ?>
+      <?php foreach ($tagFilterList as $filter): ?>
+        <?php $removeLink = $this->currentPath().$results->getUrlQuery()->removeFacet($filter['field'], $filter['value']); ?>
         <a class="list-group-item active" href="<?=$removeLink?>">
           <span class="pull-right flip"><i class="fa fa-minus-circle" aria-hidden="true"></i></span>
           <?=$this->escapeHtml($filter['displayText'])?>
         </a>
-      <? endforeach; ?>
-    <? endif; ?>
-    <? foreach($sideFacetSet['tags']['list'] as $thisFacet): ?>
-      <? if(!$thisFacet['isApplied']): ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
+    <?php foreach($sideFacetSet['tags']['list'] as $thisFacet): ?>
+      <?php if(!$thisFacet['isApplied']): ?>
         <a class="list-group-item" href="<?=$this->currentPath().$results->getUrlQuery()->addFacet('tags', $thisFacet['value'])?>">
           <span class="badge"><?=$this->escapeHtml($thisFacet['count'])?></span>
           <?=$this->escapeHtml($thisFacet['displayText'])?>
         </a>
-      <? endif ?>
-    <? endforeach; ?>
+      <?php endif ?>
+    <?php endforeach; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/MapSelection.phtml
+++ b/themes/bootstrap3/templates/Recommend/MapSelection.phtml
@@ -1,5 +1,5 @@
-<? if ($this->recommend->getSearchResultCoordinates()) :?>
-<?
+<?php if ($this->recommend->getSearchResultCoordinates()) :?>
+<?php
   $this->headScript()->appendFile('vendor/ol/ol.js');
   $this->headScript()->appendFile('map_selection.js');
   $this->headLink()->appendStylesheet('vendor/ol/ol.css');
@@ -34,10 +34,10 @@ EOF;
       <div id="popup"></div>
     </div>
   </div>
-  <? if ($showSelection) :?>
+  <?php if ($showSelection) :?>
     <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET');?>
-  <? else: ?>
+  <?php else: ?>
     <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $addSearchOption, 'SET');?>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/OpenLibrarySubjects.phtml
+++ b/themes/bootstrap3/templates/Recommend/OpenLibrarySubjects.phtml
@@ -1,26 +1,26 @@
-<? $data = $this->recommend->getResult(); if (is_array($data)): ?>
+<?php $data = $this->recommend->getResult(); if (is_array($data)): ?>
 <div class="sidegroup">
-  <h4>Open Library <? /* Intentionally not translated -- this is a site name, not a phrase */ ?></h4>
+  <h4>Open Library <?php /* Intentionally not translated -- this is a site name, not a phrase */ ?></h4>
   <div><?=$this->transEsc('Results for')?> <?=$this->escapeHtmlAttr($data['subject'])?> ...</div>
   <ul class="similar">
-    <? foreach ($data['worksArray'] as $work): ?>
+    <?php foreach ($data['worksArray'] as $work): ?>
       <li>
         <a href="http://openlibrary.org<?=$work['key']?>" title="<?=$this->transEsc('Get full text')?>" target="_blank">
           <span class="olSubjectCover">
-          <? if (isset($work['cover_id'])  && !empty($work['cover_id'])): ?>
+          <?php if (isset($work['cover_id'])  && !empty($work['cover_id'])): ?>
             <img src="http://covers.openlibrary.org/b/<?=$this->escapeHtmlAttr($work['cover_id_type'])?>/<?=$this->escapeHtmlAttr($work['cover_id'])?>-S.jpg" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>" />
-          <? else: ?>
+          <?php else: ?>
             <img src="<?=$this->imageLink('noCover2.gif')?>" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>" />
-          <? endif; ?>
+          <?php endif; ?>
           </span>
           <span><?=$this->escapeHtmlAttr($this->truncate($work['title'], 50))?></span>
-          <? if (isset($work['mainAuthor'])): ?>
+          <?php if (isset($work['mainAuthor'])): ?>
             <span class="olSubjectAuthor"><?=$this->transEsc('by')?> <?=$this->escapeHtmlAttr($this->truncate($work['mainAuthor'], 40))?></span>
-          <? endif; ?>
+          <?php endif; ?>
         </a>
         <div class="clearfix"></div>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
   <p class="olSubjectMore">
     <a href="http://openlibrary.org/subjects" title="Open Library" target="_blank">
@@ -28,4 +28,4 @@
     </a>
   </p>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/OpenLibrarySubjectsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/OpenLibrarySubjectsDeferred.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up Javascript for use below:
     $loadJs = 'var url = VuFind.path + "/AJAX/Recommend?' . $this->recommend->getUrlParams() . '";'
         . "\$('#openLibraryDeferredRecommend').load(url);";

--- a/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
@@ -1,29 +1,29 @@
-<? $visFacets = $this->recommend->getVisFacets(); ?>
-<? if ($visFacets): ?>
+<?php $visFacets = $this->recommend->getVisFacets(); ?>
+<?php if ($visFacets): ?>
 
-  <? /* load jQuery flot */ ?>
+  <?php /* load jQuery flot */ ?>
 <?$this->headScript()->appendFile('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
   $this->headScript()->appendFile('vendor/flot/jquery.flot.min.js');
   $this->headScript()->appendFile('vendor/flot/jquery.flot.resize.min.js');
   $this->headScript()->appendFile('vendor/flot/jquery.flot.selection.min.js');
   $this->headScript()->appendFile('pubdate_vis.js'); ?>
 
-  <? foreach ($visFacets as $facetField=>$facetRange): ?>
+  <?php foreach ($visFacets as $facetField=>$facetRange): ?>
     <div class="authorbox">
       <div id="datevis<?=$this->escapeHtml($facetField)?>xWrapper" class="hidden">
         <strong><?=$this->transEsc($facetRange['label']) ?></strong>
-        <? /* space the flot visualisation */ ?>
+        <?php /* space the flot visualisation */ ?>
         <div id="datevis<?=$facetField ?>x" style="margin:0 10px;width:auto;height:80px;cursor:crosshair;"></div>
         <div id="clearButtonText" style="display: none"><?=$this->transEsc('Clear') ?></div>
       </div>
     </div>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <div id="dateVisColorSettings"><!-- do not delete! used for passing CSS to Javascript --></div>
-  <?
+  <?php
     $js = "loadVis('" . $this->recommend->getFacetFields() . "', '"
         . $this->recommend->getSearchParams() . "', VuFind.path, "
         . $this->recommend->getZooming() . ");";
     echo $this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $js, 'SET');
   ?>
 
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/RandomRecommend.phtml
+++ b/themes/bootstrap3/templates/Recommend/RandomRecommend.phtml
@@ -1,36 +1,36 @@
-<? $recommend = $this->recommend->getResults(); if (count($recommend)> 0): ?>
+<?php $recommend = $this->recommend->getResults(); if (count($recommend)> 0): ?>
   <ul class="list-group random <?=$this->recommend->getDisplayMode()?>">
     <li class="list-group-item title" data-toggle="collapse" href="#side-collapse-randomrecommend">
       <?=$this->transEsc("random_recommendation_title")?>
     </li>
-    <div id="side-collapse-randomrecommend" class="collapse<? if(!in_array('RandomRecommend', $collapsedFacets)): ?> in<? endif ?>">
-    <? foreach ($recommend as $driver): ?>
+    <div id="side-collapse-randomrecommend" class="collapse<?php if(!in_array('RandomRecommend', $collapsedFacets)): ?> in<?php endif ?>">
+    <?php foreach ($recommend as $driver): ?>
       <li class="list-group-item">
         <?if($this->recommend->getDisplayMode() === "images" || $this->recommend->getDisplayMode() === "mixed"):?>
 
-          <? /* Display thumbnail if appropriate: */ ?>
+          <?php /* Display thumbnail if appropriate: */ ?>
           <?=$this->record($driver)->getCover('RandomRecommend', 'small:medium', $this->recordLink()->getUrl($driver)); ?>
         <?endif;?>
 
-        <? $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
+        <?php $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
         <a href="<?=$this->recordLink()->getUrl($driver)?>" class="title <?=$this->record($driver)->getFormatClass($format)?> clearfix">
           <?=$this->record($driver)->getTitleHtml()?>
-          <? $summAuthors = $driver->getPrimaryAuthors(); ?>
-          <span class="small<? if (!empty($summAuthors)): ?> pull-right flip<? endif; ?>">
-            <? $summDate = $driver->getPublicationDates(); ?>
-            <? if (!empty($summDate)): ?>
+          <?php $summAuthors = $driver->getPrimaryAuthors(); ?>
+          <span class="small<?php if (!empty($summAuthors)): ?> pull-right flip<?php endif; ?>">
+            <?php $summDate = $driver->getPublicationDates(); ?>
+            <?php if (!empty($summDate)): ?>
               <?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($summDate[0])?>)
-            <? endif; ?>
+            <?php endif; ?>
           </span>
         </a>
-        <? if (!empty($summAuthors)): ?>
+        <?php if (!empty($summAuthors)): ?>
           <span class="small text-right">
             <?=$this->transEsc('By')?>
-            <a href="<?=$this->record($driver)->getLink('author', $summAuthors[0])?>"><?=$this->escapeHtml($summAuthors[0])?></a><? if (count($summAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?>
+            <a href="<?=$this->record($driver)->getLink('author', $summAuthors[0])?>"><?=$this->escapeHtml($summAuthors[0])?></a><?php if (count($summAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
           </span>
-        <? endif; ?>
+        <?php endif; ?>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     </div>
   </ul>
 <?endif;?>

--- a/themes/bootstrap3/templates/Recommend/RemoveFilters.phtml
+++ b/themes/bootstrap3/templates/Recommend/RemoveFilters.phtml
@@ -1,6 +1,6 @@
-<? if ($this->recommend->hasFilters()): ?>
+<?php if ($this->recommend->hasFilters()): ?>
   <div class="alert alert-info">
     <?=$this->transEsc('nohit_active_filters')?> 
     <a href="<?=$this->recommend->getFilterlessUrl()?>"><?=$this->transEsc('nohit_query_without_filters')?></a>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/ResultGoogleMapAjax.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $searchParams = $this->recommend->getSearchParams();
 
   $this->headScript()->appendFile('https://maps.googleapis.com/maps/api/js?key=' . urlencode($this->recommend->getGoogleMapApiKey()) . '&sensor=false&language='.$this->layout()->userLang);

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -1,14 +1,14 @@
-<?
+<?php
   $this->headScript()->appendFile('facets.js');
 
   $results = $this->recommend->getResults();
   $options = $this->searchOptions($this->searchClassId);
 ?>
-<? if ($results->getResultTotal() > 0): ?>
+<?php if ($results->getResultTotal() > 0): ?>
   <h4><?=$this->transEsc(isset($this->overrideSideFacetCaption) ? $this->overrideSideFacetCaption : 'Narrow Search')?></h4>
-<? endif; ?>
-<? $checkboxFilters = $results->getParams()->getCheckboxFacets(); if (count($checkboxFilters) > 0): ?>
-<?
+<?php endif; ?>
+<?php $checkboxFilters = $results->getParams()->getCheckboxFacets(); if (count($checkboxFilters) > 0): ?>
+<?php
   $html = '';
   $shown = 0;
   foreach ($checkboxFilters as $current) {
@@ -23,18 +23,18 @@
       onclick="document.location.href=\''.($current['selected'] ? $results->getUrlQuery()->removeFilter($current['filter']) : $results->getUrlQuery()->addFilter($current['filter'])).'\';" />'.$this->transEsc($current['desc']).'</label>';
   }
 ?>
-  <div class="checkboxFilter<?if($shown == 0):?> hidden<? endif; ?>"><?=$html ?></div>
-<? endif; ?>
-<? $extraFilters = isset($this->extraSideFacetFilters) ? $this->extraSideFacetFilters : []; ?>
-<? $collapsedFacets = $this->recommend->getCollapsedFacets() ?>
-<? $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
-<? $hierarchicalFacets = $this->recommend->getHierarchicalFacets() ?>
-<? $filterList = array_merge($results->getParams()->getFilterList(true), $extraFilters); if (!empty($filterList)): ?>
+  <div class="checkboxFilter<?if($shown == 0):?> hidden<?php endif; ?>"><?=$html ?></div>
+<?php endif; ?>
+<?php $extraFilters = isset($this->extraSideFacetFilters) ? $this->extraSideFacetFilters : []; ?>
+<?php $collapsedFacets = $this->recommend->getCollapsedFacets() ?>
+<?php $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
+<?php $hierarchicalFacets = $this->recommend->getHierarchicalFacets() ?>
+<?php $filterList = array_merge($results->getParams()->getFilterList(true), $extraFilters); if (!empty($filterList)): ?>
   <div class="list-group filters">
     <div class="list-group-item title"><?=$this->transEsc('Remove Filters')?></div>
-    <? foreach ($filterList as $field => $filters): ?>
-      <? foreach ($filters as $i => $filter): ?>
-        <?
+    <?php foreach ($filterList as $field => $filters): ?>
+      <?php foreach ($filters as $i => $filter): ?>
+        <?php
           $index = isset($filter['field']) ? array_search($filter['field'], $collapsedFacets) : false;
           if ($index !== false) {
               unset($collapsedFacets[$index]); // Open if we have a match
@@ -50,31 +50,31 @@
         ?>
         <a class="list-group-item active" href="<?=$removeLink?>" title="<?=$this->transEsc('clear_tag_filter') ?>">
           <span class="pull-right flip"><i class="fa fa-times" aria-hidden="true"></i></span>
-          <? if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?><?=$this->transEsc($field)?>: <?=$this->escapeHtml($filter['displayText'])?>
+          <?php if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?><?=$this->transEsc($field)?>: <?=$this->escapeHtml($filter['displayText'])?>
         </a>
-      <? endforeach; ?>
-    <? endforeach; ?>
+      <?php endforeach; ?>
+    <?php endforeach; ?>
   </div>
-<? endif; ?>
+<?php endif; ?>
 <?= isset($this->sideFacetExtraControls) ? $this->sideFacetExtraControls : '' ?>
-<? $sideFacetSet = $this->recommend->getFacetSet(); $rangeFacets = $this->recommend->getAllRangeFacets(); ?>
-<? if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
-  <? foreach ($sideFacetSet as $title => $cluster): ?>
-    <? $allowExclude = $this->recommend->excludeAllowed($title); ?>
-    <? $facets_before_more = $this->recommend->getShowMoreSetting($title); ?>
-    <? $showMoreInLightbox = $this->recommend->getShowInLightboxSetting($title); ?>
+<?php $sideFacetSet = $this->recommend->getFacetSet(); $rangeFacets = $this->recommend->getAllRangeFacets(); ?>
+<?php if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
+  <?php foreach ($sideFacetSet as $title => $cluster): ?>
+    <?php $allowExclude = $this->recommend->excludeAllowed($title); ?>
+    <?php $facets_before_more = $this->recommend->getShowMoreSetting($title); ?>
+    <?php $showMoreInLightbox = $this->recommend->getShowInLightboxSetting($title); ?>
     <div class="list-group facet" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>">
-      <div class="list-group-item title<? if(in_array($title, $collapsedFacets)): ?> collapsed<? endif ?>" data-toggle="collapse" href="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
+      <div class="list-group-item title<?php if(in_array($title, $collapsedFacets)): ?> collapsed<?php endif ?>" data-toggle="collapse" href="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
         <?=$this->transEsc($cluster['label'])?>
       </div>
-      <div id="side-collapse-<?=$this->escapeHtmlAttr($title) ?>" class="collapse<? if(!in_array($title, $collapsedFacets)): ?> in<? endif ?>">
-        <? if (isset($rangeFacets[$title])): ?>
+      <div id="side-collapse-<?=$this->escapeHtmlAttr($title) ?>" class="collapse<?php if(!in_array($title, $collapsedFacets)): ?> in<?php endif ?>">
+        <?php if (isset($rangeFacets[$title])): ?>
           <div class="list-group-item">
             <form name="<?=$this->escapeHtmlAttr($title)?>Filter" id="<?=$this->escapeHtmlAttr($title)?>Filter">
               <?=$results->getUrlQuery()->asHiddenFields(['page' => "/./", 'filter' => "/^{$title}:.*/"])?>
               <input type="hidden" name="<?=$this->escapeHtmlAttr($rangeFacets[$title]['type'])?>range[]" value="<?=$this->escapeHtmlAttr($title)?>"/>
               <div class="row">
-                <? $extraInputAttribs = ($rangeFacets[$title]['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
+                <?php $extraInputAttribs = ($rangeFacets[$title]['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
                 <div class="col-sm-6">
                   <label for="<?=$this->escapeHtmlAttr($title)?>from">
                     <?=$this->transEsc('date_from')?>:
@@ -88,16 +88,16 @@
                   <input type="text" class="form-control" name="<?=$this->escapeHtmlAttr($title)?>to" id="<?=$this->escapeHtmlAttr($title)?>to" value="<?=isset($rangeFacets[$title]['values'][1])?$this->escapeHtmlAttr($rangeFacets[$title]['values'][1]):''?>" <?=$extraInputAttribs?>/>
                 </div>
               </div>
-              <? if ($rangeFacets[$title]['type'] == 'date'): ?>
+              <?php if ($rangeFacets[$title]['type'] == 'date'): ?>
                 <div class="slider-container"><input type="text" class="hidden" id="<?=$this->escapeHtmlAttr($title)?><?=$this->escapeHtml($rangeFacets[$title]['type'])?>Slider"/></div>
-              <? endif; ?>
+              <?php endif; ?>
               <input class="btn btn-default" type="submit" value="<?=$this->transEsc('Set')?>"/>
             </form>
           </div>
-          <? if ($rangeFacets[$title]['type'] == 'date'): ?>
-            <? $this->headScript()->appendFile('vendor/bootstrap-slider.min.js'); ?>
-            <? $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css'); ?>
-            <?
+          <?php if ($rangeFacets[$title]['type'] == 'date'): ?>
+            <?php $this->headScript()->appendFile('vendor/bootstrap-slider.min.js'); ?>
+            <?php $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css'); ?>
+            <?php
               $min = !empty($rangeFacets[$title]['values'][0]) ? min($rangeFacets[$title]['values'][0], 1400) : 1400;
               $future = date('Y', time()+31536000);
               $max = !empty($rangeFacets[$title]['values'][1]) ? max($future, $rangeFacets[$title]['values'][1]) : $future;
@@ -139,13 +139,13 @@ $('#{$this->escapeHtmlAttr($title)}from, #{$this->escapeHtmlAttr($title)}to').ch
 JS;
             ?>
             <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
-          <? endif; ?>
-        <? else: ?>
-          <? if (in_array($title, $hierarchicalFacets)): ?>
-            <? $this->headScript()->appendFile('vendor/jsTree/jstree.min.js'); ?>
-            <? $sort = isset($hierarchicalFacetSortOptions[$title]) ? $hierarchicalFacetSortOptions[$title] : ''; ?>
-            <? if (!in_array($title, $collapsedFacets)): ?>
-              <?
+          <?php endif; ?>
+        <?php else: ?>
+          <?php if (in_array($title, $hierarchicalFacets)): ?>
+            <?php $this->headScript()->appendFile('vendor/jsTree/jstree.min.js'); ?>
+            <?php $sort = isset($hierarchicalFacetSortOptions[$title]) ? $hierarchicalFacetSortOptions[$title] : ''; ?>
+            <?php if (!in_array($title, $collapsedFacets)): ?>
+              <?php
               $script = <<<JS
 $(document).ready(function() {
   initFacetTree($('#facet_{$this->escapeHtml($title)}'), true);
@@ -153,8 +153,8 @@ $(document).ready(function() {
 JS;
               ?>
               <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
-            <? else: ?>
-              <?
+            <?php else: ?>
+              <?php
               $script = <<<JS
 $('#side-collapse-{$this->escapeHtmlAttr($title)}').on('show.bs.collapse', function() {
   initFacetTree($('#facet_{$this->escapeHtml($title)}'), true);
@@ -162,7 +162,7 @@ $('#side-collapse-{$this->escapeHtmlAttr($title)}').on('show.bs.collapse', funct
 JS;
               ?>
               <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
-            <? endif; ?>
+            <?php endif; ?>
             <li id="facet_<?=$this->escapeHtml($title)?>" class="jstree-facet"
                   data-facet="<?=$this->escapeHtmlAttr($title)?>"
                   data-path="<?=$this->currentPath()?>"
@@ -172,75 +172,75 @@ JS;
                   data-sort="<?=isset($hierarchicalFacetSortOptions[$title]) ? $hierarchicalFacetSortOptions[$title] : ''?>">
             </li>
             <noscript>
-          <? endif; ?>
-          <? foreach ($cluster['list'] as $i=>$thisFacet): ?>
-              <?
+          <?php endif; ?>
+          <?php foreach ($cluster['list'] as $i=>$thisFacet): ?>
+              <?php
                 if(strlen($thisFacet['displayText']) == 0) {
                   $thisFacet['displayText'] = "-";
                 }
               ?>
-              <? $moreClass = 'narrowGroupHidden-'.$this->escapeHtmlAttr($title).' hidden'; ?>
-            <? if ($i == $facets_before_more): ?>
-              <? $idAndClass = 'id="more-narrowGroupHidden-'.$this->escapeHtmlAttr($title).'" class="list-group-item narrow-toggle"'; ?>
-              <? if ($facetLightbox = $options->getFacetListAction()): ?>
-                <? $moreUrl = $this->url($facetLightbox) . $results->getUrlQuery()->getParams().'&amp;facet='.$title.'&amp;facetop='.$thisFacet['operator'].'&amp;facetexclude='.($allowExclude ? 1 : 0); ?>
-              <? else: ?>
-                <? $moreUrl = '#'; ?>
-              <? endif; ?>
-              <? if (($showMoreInLightbox && $showMoreInLightbox !== 'more') && $facetLightbox): ?>
+              <?php $moreClass = 'narrowGroupHidden-'.$this->escapeHtmlAttr($title).' hidden'; ?>
+            <?php if ($i == $facets_before_more): ?>
+              <?php $idAndClass = 'id="more-narrowGroupHidden-'.$this->escapeHtmlAttr($title).'" class="list-group-item narrow-toggle"'; ?>
+              <?php if ($facetLightbox = $options->getFacetListAction()): ?>
+                <?php $moreUrl = $this->url($facetLightbox) . $results->getUrlQuery()->getParams().'&amp;facet='.$title.'&amp;facetop='.$thisFacet['operator'].'&amp;facetexclude='.($allowExclude ? 1 : 0); ?>
+              <?php else: ?>
+                <?php $moreUrl = '#'; ?>
+              <?php endif; ?>
+              <?php if (($showMoreInLightbox && $showMoreInLightbox !== 'more') && $facetLightbox): ?>
                 <a <?=$idAndClass ?> data-lightbox href="<?=$moreUrl ?>" rel="nofollow"><?=$this->transEsc('more')?> ...</a>
-                <? break; ?>
-              <? else: ?>
+                <?php break; ?>
+              <?php else: ?>
                 <a <?=$idAndClass ?> href="<?=$moreUrl ?>" onclick="return moreFacets('narrowGroupHidden-<?=$this->escapeHtmlAttr($title) ?>')" rel="nofollow"><?=$this->transEsc('more')?> ...</a>
-              <? endif; ?>
-            <? endif; ?>
-            <? if ($thisFacet['isApplied']): ?>
-              <a class="list-group-item active<? if ($i >= $facets_before_more): ?><?=$moreClass ?><?endif ?><? if ($thisFacet['operator'] == 'OR'): ?> facetOR applied<? endif ?>" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], $thisFacet['operator']) ?>" title="<?=$this->transEsc('applied_filter') ?>">
-                <? if ($thisFacet['operator'] == 'OR'): ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php if ($thisFacet['isApplied']): ?>
+              <a class="list-group-item active<?php if ($i >= $facets_before_more): ?><?=$moreClass ?><?endif ?><?php if ($thisFacet['operator'] == 'OR'): ?> facetOR applied<?php endif ?>" href="<?=$this->currentPath().$results->getUrlQuery()->removeFacet($title, $thisFacet['value'], $thisFacet['operator']) ?>" title="<?=$this->transEsc('applied_filter') ?>">
+                <?php if ($thisFacet['operator'] == 'OR'): ?>
                   <i class="fa fa-check-square-o" aria-hidden="true"></i>
-                <? else: ?>
+                <?php else: ?>
                   <span class="pull-right flip"><i class="fa fa-check" aria-hidden="true"></i></span>
-                <? endif; ?>
+                <?php endif; ?>
                 <?=$this->escapeHtml($thisFacet['displayText'])?>
               </a>
-            <? else: ?>
-              <? $addURL = $this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator']); ?>
-              <? if ($allowExclude): ?>
-                <div class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i >= $facets_before_more): ?> <?=$moreClass ?><?endif ?>">
-              <? else: ?>
-                <a href="<?=$addURL ?>" class="list-group-item facet<?=$thisFacet['operator'] ?><? if ($i >= $facets_before_more): ?> <?=$moreClass ?><?endif ?>">
-              <? endif; ?>
+            <?php else: ?>
+              <?php $addURL = $this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator']); ?>
+              <?php if ($allowExclude): ?>
+                <div class="list-group-item facet<?=$thisFacet['operator'] ?><?php if ($i >= $facets_before_more): ?> <?=$moreClass ?><?endif ?>">
+              <?php else: ?>
+                <a href="<?=$addURL ?>" class="list-group-item facet<?=$thisFacet['operator'] ?><?php if ($i >= $facets_before_more): ?> <?=$moreClass ?><?endif ?>">
+              <?php endif; ?>
               <span class="badge">
                 <?=$this->localizedNumber($thisFacet['count'])?>
-                <? if ($allowExclude): ?>
+                <?php if ($allowExclude): ?>
                   <a href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT') ?>" title="<?=$this->transEsc('exclude_facet') ?>"><i class="fa fa-times" aria-hidden="true"></i></a>
-                <? endif; ?>
+                <?php endif; ?>
               </span>
-              <? if ($allowExclude): ?>
+              <?php if ($allowExclude): ?>
                 <a href="<?=$addURL ?>">
-              <? endif; ?>
-              <? if($thisFacet['operator'] == 'OR'): ?>
+              <?php endif; ?>
+              <?php if($thisFacet['operator'] == 'OR'): ?>
                 <i class="fa fa-square-o" aria-hidden="true"></i>
-              <? endif; ?>
+              <?php endif; ?>
               <?=$this->escapeHtml($thisFacet['displayText'])?>
-              <? if ($allowExclude): ?>
+              <?php if ($allowExclude): ?>
                   </a>
                 </div>
-              <? else: ?>
+              <?php else: ?>
                 </a>
-              <? endif; ?>
-            <? endif; ?>
-          <? endforeach; ?>
-          <? if ($showMoreInLightbox === 'more' && $facetLightbox = $options->getFacetListAction()): ?>
-            <? $moreUrl = $this->url($facetLightbox) . $results->getUrlQuery()->getParams().'&amp;facet='.$title.'&amp;facetop='.$thisFacet['operator'].'&amp;facetexclude='.($allowExclude ? 1 : 0); ?>
+              <?php endif; ?>
+            <?php endif; ?>
+          <?php endforeach; ?>
+          <?php if ($showMoreInLightbox === 'more' && $facetLightbox = $options->getFacetListAction()): ?>
+            <?php $moreUrl = $this->url($facetLightbox) . $results->getUrlQuery()->getParams().'&amp;facet='.$title.'&amp;facetop='.$thisFacet['operator'].'&amp;facetexclude='.($allowExclude ? 1 : 0); ?>
             <a class="list-group-item narrow-toggle <?=$moreClass ?>" data-lightbox href="<?=$moreUrl ?>" rel="nofollow"><?=$this->transEsc('see all')?> ...</a>
-          <? endif; ?>
-          <? if ($i >= $facets_before_more): ?><a class="list-group-item narrow-toggle <?=$moreClass ?>" href="#" onclick="return lessFacets('narrowGroupHidden-<?=$this->escapeHtmlAttr($title) ?>')"><?=$this->transEsc('less')?> ...</a><? endif; ?>
-        <? endif; ?>
-        <? if (in_array($title, $hierarchicalFacets)): ?>
+          <?php endif; ?>
+          <?php if ($i >= $facets_before_more): ?><a class="list-group-item narrow-toggle <?=$moreClass ?>" href="#" onclick="return lessFacets('narrowGroupHidden-<?=$this->escapeHtmlAttr($title) ?>')"><?=$this->transEsc('less')?> ...</a><?php endif; ?>
+        <?php endif; ?>
+        <?php if (in_array($title, $hierarchicalFacets)): ?>
           </noscript>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
     </div>
-  <? endforeach; ?>
-<? endif; ?>
+  <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SpellingSuggestions.phtml
+++ b/themes/bootstrap3/templates/Recommend/SpellingSuggestions.phtml
@@ -1,10 +1,10 @@
-<?
+<?php
     $results = $this->recommend->getResults();
     $label = $results->getResultTotal() > 0
         ? '<strong>' . $this->transEsc('spell_suggest') . '</strong>:'
         : $this->transEsc('nohit_spelling') . ':';
     $suggestions = $this->search()->renderSpellingSuggestions($label, $results, $this);
 ?>
-<? if (!empty($suggestions)): ?>
+<?php if (!empty($suggestions)): ?>
   <?=$suggestions?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SummonBestBets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonBestBets.phtml
@@ -1,14 +1,14 @@
-<? $summonBestBets = $this->recommend->getResults(); if (!empty($summonBestBets)): ?>
+<?php $summonBestBets = $this->recommend->getResults(); if (!empty($summonBestBets)): ?>
 <div class="authorbox">
-  <? foreach ($summonBestBets as $current): ?>
+  <?php foreach ($summonBestBets as $current): ?>
     <p>
-      <? if (isset($current['link']) && !empty($current['link'])):?>
+      <?php if (isset($current['link']) && !empty($current['link'])):?>
         <a href="<?=$this->escapeHtmlAttr($current['link'])?>"><?=$this->escapeHtml($current['title'])?></a>
-      <? else: ?>
+      <?php else: ?>
         <b><?=$this->escapeHtml($current['title'])?></b>
-      <? endif; ?>
+      <?php endif; ?>
       <br/><?=$current['description']?>
     </p>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SummonBestBetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonBestBetsDeferred.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up Javascript for use below:
   $loadJs = 'var url = VuFind.path + "/AJAX/Recommend?' . $this->recommend->getUrlParams() . '";'
     . "\$('#SummonDeferredBestBets').load(url);";

--- a/themes/bootstrap3/templates/Recommend/SummonDatabases.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonDatabases.phtml
@@ -1,8 +1,8 @@
-<? $summonDatabases = $this->recommend->getResults(); if (!empty($summonDatabases)): ?>
+<?php $summonDatabases = $this->recommend->getResults(); if (!empty($summonDatabases)): ?>
 <div class="authorbox">
   <p><?=$this->transEsc('summon_database_recommendations')?></p>
-  <? foreach ($summonDatabases as $current): ?>
+  <?php foreach ($summonDatabases as $current): ?>
     <p><a href="<?=$this->escapeHtmlAttr($current['link'])?>"><?=$this->escapeHtml($current['title'])?></a><br/><?=$this->escapeHtml($current['description'])?></p>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SummonDatabasesDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonDatabasesDeferred.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up Javascript for use below:
   $loadJs = 'var url = VuFind.path + "/AJAX/Recommend?' . $this->recommend->getUrlParams() . '";'
     . "\$('#SummonDeferredDatabases').load(url);";

--- a/themes/bootstrap3/templates/Recommend/SummonResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonResults.phtml
@@ -1,22 +1,22 @@
-<? $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
+<?php $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
   <h4><?=$this->transEsc('Summon Results')?></h4>
   <div class="list-group">
-    <? foreach ($results as $driver): ?>
+    <?php foreach ($results as $driver): ?>
       <div class="list-group-item">
         <span>
-          <? $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
+          <?php $formats = $driver->getFormats(); $format = isset($formats[0]) ? $formats[0] : ''; ?>
           <a href="<?=$this->recordLink()->getUrl($driver)?>" class="title <?=$this->record($driver)->getFormatClass($format)?>">
             <?=$this->record($driver)->getTitleHtml()?>
           </a>
-          <? $summAuthors = $driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
+          <?php $summAuthors = $driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
           <span class="small">
             <?=$this->transEsc('by')?>
-            <a href="<?=$this->record($driver)->getLink('author', $this->highlight($summAuthors[0], null, true, false))?>"><?=$this->highlight($summAuthors[0])?></a><? if (count($summAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?>
+            <a href="<?=$this->record($driver)->getLink('author', $this->highlight($summAuthors[0], null, true, false))?>"><?=$this->highlight($summAuthors[0])?></a><?php if (count($summAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
           </span>
-          <? endif; ?>
+          <?php endif; ?>
         </span>
       </div>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     <a class="list-group-item" href="<?=$this->url($searchObject->getOptions()->getSearchAction()) . $searchObject->getUrlQuery()->setLimit($searchObject->getOptions()->getDefaultLimit())?>"><?=$this->transEsc('More Summon results')?>...</a>
   </div>
-<? endif ?>
+<?php endif ?>

--- a/themes/bootstrap3/templates/Recommend/SummonResultsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonResultsDeferred.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up Javascript for use below:
   $loadJs = 'var url = VuFind.path + "/AJAX/Recommend?' . $this->recommend->getUrlParams() . '";'
     . "\$('#SummonDeferredRecommend').load(url);";

--- a/themes/bootstrap3/templates/Recommend/SummonTopics.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonTopics.phtml
@@ -1,18 +1,18 @@
-<? $summonTopics = $this->recommend->getResults(); if (!empty($summonTopics)): $summonTopics = current($summonTopics); ?>
+<?php $summonTopics = $this->recommend->getResults(); if (!empty($summonTopics)): $summonTopics = current($summonTopics); ?>
 <div class="authorbox">
   <p><b><?=$this->transEsc('Suggested Topics')?></b></p>
-  <? if (isset($summonTopics['title'])): ?>
+  <?php if (isset($summonTopics['title'])): ?>
     <p>
       <a href="<?=$this->url('summon-search')?>?lookfor=%22<?=urlencode($summonTopics['title'])?>%22"><?=$this->escapeHtml($summonTopics['title'])?></a><br />
-      <? if (isset($summonTopics['snippet'])): ?><?=$this->escapeHtml($summonTopics['snippet'])?><? endif; ?>
-      <? if (isset($summonTopics['sourceLink'])): ?><a href="<?=$this->escapeHtmlAttr($summonTopics['sourceLink'])?>"><?=$this->transEsc('more')?>...</a><? endif; ?>
+      <?php if (isset($summonTopics['snippet'])): ?><?=$this->escapeHtml($summonTopics['snippet'])?><?php endif; ?>
+      <?php if (isset($summonTopics['sourceLink'])): ?><a href="<?=$this->escapeHtmlAttr($summonTopics['sourceLink'])?>"><?=$this->transEsc('more')?>...</a><?php endif; ?>
     </p>
-  <? endif; ?>
-  <? if (isset($summonTopics['relatedTopics']) && !empty($summonTopics['relatedTopics'])): ?>
+  <?php endif; ?>
+  <?php if (isset($summonTopics['relatedTopics']) && !empty($summonTopics['relatedTopics'])): ?>
     <p>
       <b><?=$this->transEsc('wcterms_exact')?>:</b>
-      <? foreach ($summonTopics['relatedTopics'] as $i => $topic): ?><? if ($i > 0): ?>, <? endif; ?><a href="<?=$this->url('summon-search')?>?lookfor=%22<?=urlencode($topic['title'])?>%22"><?=$this->escapeHtml($topic['title'])?></a><? endforeach; ?>
+      <?php foreach ($summonTopics['relatedTopics'] as $i => $topic): ?><?php if ($i > 0): ?>, <?php endif; ?><a href="<?=$this->url('summon-search')?>?lookfor=%22<?=urlencode($topic['title'])?>%22"><?=$this->escapeHtml($topic['title'])?></a><?php endforeach; ?>
     </p>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SwitchQuery.phtml
+++ b/themes/bootstrap3/templates/Recommend/SwitchQuery.phtml
@@ -1,10 +1,10 @@
-<? $suggestions = $this->recommend->getSuggestions(); if (!empty($suggestions)): ?>
+<?php $suggestions = $this->recommend->getSuggestions(); if (!empty($suggestions)): ?>
   <div class="alert alert-info">
     <p><?=$this->transEsc('switchquery_intro')?></p>
     <ul>
-      <? foreach ($suggestions as $desc => $query): ?>
+      <?php foreach ($suggestions as $desc => $query): ?>
         <li><?=$this->transEsc($desc)?>: <a href="<?=$this->recommend->getResults()->getUrlQuery()->setSearchTerms($query)?>"><?=$this->escapeHtml($query)?></a>.</li>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </ul>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SwitchTab.phtml
+++ b/themes/bootstrap3/templates/Recommend/SwitchTab.phtml
@@ -1,19 +1,19 @@
-<?
+<?php
   $searchTabs = is_object($this->params)
     ? $this->searchtabs()->getTabConfigForParams($this->params) : [];
 ?>
-<? if (count($searchTabs) > 0): ?>
+<?php if (count($searchTabs) > 0): ?>
   <div class="alert alert-info">
     <?=$this->transEsc('nohit_change_tab', ['%%activeTab%%' => $this->translate($this->recommend->getActiveTab($searchTabs)['label'])])?>
     <ul>
-    <? $inactiveTabs = $this->recommend->getInactiveTabs($searchTabs); ?>
-    <? foreach ($inactiveTabs as $tab): ?>
+    <?php $inactiveTabs = $this->recommend->getInactiveTabs($searchTabs); ?>
+    <?php foreach ($inactiveTabs as $tab): ?>
       <li>
-        <? if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><? endif; ?>
+        <?php if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><?php endif; ?>
           <?=$this->transEsc($tab['label']); ?>
-        <? if (!$tab['selected']): ?></a><? endif; ?>
+        <?php if (!$tab['selected']): ?></a><?php endif; ?>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     </ul>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SwitchType.phtml
+++ b/themes/bootstrap3/templates/Recommend/SwitchType.phtml
@@ -1,6 +1,6 @@
-<? if ($handler = $this->recommend->getNewHandler()): ?>
+<?php if ($handler = $this->recommend->getNewHandler()): ?>
   <div class="alert alert-info">
     <?=$this->transEsc('widen_prefix')?>
     <a href="<?=$this->recommend->getResults()->getUrlQuery()->setHandler($handler)?>"><?=$this->transEsc($this->recommend->getNewHandlerName())?></a>.
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/TopFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/TopFacets.phtml
@@ -1,26 +1,26 @@
-<?
+<?php
   // TODO: This file needs love
   $topFacetSet = $this->recommend->getTopFacetSet();
   $topFacetSettings = $this->recommend->getTopFacetSettings();
   $results = $this->recommend->getResults();
 ?>
-<? if (isset($topFacetSet)): ?>
-  <? $row=0; foreach($topFacetSet as $title => $cluster): ?>
-    <? $moreClass = ' NarrowGroupHidden_'.$this->escapeHtml($title).' hidden'; ?>
-    <? $allowExclude = $this->recommend->excludeAllowed($title); ?>
+<?php if (isset($topFacetSet)): ?>
+  <?php $row=0; foreach($topFacetSet as $title => $cluster): ?>
+    <?php $moreClass = ' NarrowGroupHidden_'.$this->escapeHtml($title).' hidden'; ?>
+    <?php $allowExclude = $this->recommend->excludeAllowed($title); ?>
     <strong><?=$this->transEsc($cluster['label'])?></strong><?=$this->transEsc("top_facet_suffix") ?>
     <div class="row top-row">
-    <? $iter=1;$corner=$topFacetSettings['rows']*$topFacetSettings['cols']; ?>
-    <? foreach($cluster['list'] as $thisFacet): ?>
-      <? /* More link */ ?>
-      <? if ($iter == $corner+1): ?>
+    <?php $iter=1;$corner=$topFacetSettings['rows']*$topFacetSettings['cols']; ?>
+    <?php foreach($cluster['list'] as $thisFacet): ?>
+      <?php /* More link */ ?>
+      <?php if ($iter == $corner+1): ?>
         </div><div id="more-NarrowGroupHidden_<?=$this->escapeHtml($title)?>" class="row top-row">
           <span class="col-sm-12 narrow-toggle"><a href="#" onclick="moreFacets('NarrowGroupHidden_<?=$this->escapeHtml($title)?>'); return false;"><?=$this->transEsc('more') ?> ...</a></span>
         </div><div class="row top-row <?=$moreClass ?>">
-      <? endif; ?>
-      <? /* Columns */ ?>
-      <span class="col-sm-<?=floor(12/$topFacetSettings['cols'])?><? if ($iter == $corner+1) echo $moreClass ?>">
-        <? if ($thisFacet['isApplied']):
+      <?php endif; ?>
+      <?php /* Columns */ ?>
+      <span class="col-sm-<?=floor(12/$topFacetSettings['cols'])?><?php if ($iter == $corner+1) echo $moreClass ?>">
+        <?php if ($thisFacet['isApplied']):
           if (isset($thisFacet['specialType']) && $thisFacet['specialType'] == 'keyword') {
             $removeLink = $this->currentPath().$results->getUrlQuery()->replaceTerm($thisFacet['value'], '');
           } else {
@@ -29,22 +29,22 @@
           <a href="<?=$removeLink ?>" class="applied">
             <?=$this->escapeHtml($thisFacet['displayText'])?> <i class="fa fa-check" aria-hidden="true"></i>
           </a>
-        <? else: ?>
+        <?php else: ?>
           <a href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], $thisFacet['operator'])?>"><?=$this->escapeHtml($thisFacet['displayText'])?></a> <span class="badge"><?=$this->localizedNumber($thisFacet['count']) ?>
-          <? if ($allowExclude): ?>
+          <?php if ($allowExclude): ?>
             <a href="<?=$this->currentPath().$results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>" title="<?=$this->transEsc('exclude_facet')?>"><i class="fa fa-times" aria-hidden="true"></i></a>
-          <? endif; ?>
+          <?php endif; ?>
           </span>
-        <? endif; ?>
+        <?php endif; ?>
       </span>
-      <? /* Close rows */ ?>
-      <? if ($iter%$topFacetSettings['cols'] == 0 && $iter > 0): ?></div><div class="row top-row<? if(++$row > $topFacetSettings['rows']) echo $moreClass ?>"><? endif; ?>
-      <? /* Less link */ ?>
-      <? if (count($cluster['list']) > $corner && $iter == count($cluster['list'])): ?>
+      <?php /* Close rows */ ?>
+      <?php if ($iter%$topFacetSettings['cols'] == 0 && $iter > 0): ?></div><div class="row top-row<?php if(++$row > $topFacetSettings['rows']) echo $moreClass ?>"><?php endif; ?>
+      <?php /* Less link */ ?>
+      <?php if (count($cluster['list']) > $corner && $iter == count($cluster['list'])): ?>
         <a class="col-sm-12 narrow-toggle" href="#" onclick="lessFacets('NarrowGroupHidden_<?=$title ?>'); return false;"><?=$this->transEsc('less') ?> ...</a>
-      <? endif; ?>
-      <? $iter++; ?>
-    <? endforeach; ?>
+      <?php endif; ?>
+      <?php $iter++; ?>
+    <?php endforeach; ?>
     </div>
-  <? endforeach; ?>
-<? endif; ?>
+  <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $this->headScript()->appendFile("vendor/d3.js");
 
   $visualFacetSet = $this->recommend->getPivotFacetSet();
@@ -28,9 +28,9 @@
   }
 ?>
 
-<? if (isset($visualFacetSet)): ?>
+<?php if (isset($visualFacetSet)): ?>
   <script type="text/javascript">
-  <? $pivotdata = json_encode($visualFacetSet);
+  <?php $pivotdata = json_encode($visualFacetSet);
   echo "var pivotdata = " . $pivotdata . ";"; ?>
   jQuery(document).ready(function(data) {
   if (!d3.select("#visualResults").empty()) {
@@ -233,4 +233,4 @@ function settitle() {
 
 </script>
 
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/WebResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/WebResults.phtml
@@ -1,23 +1,23 @@
-<? $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
+<?php $searchObject = $this->recommend->getResults(); $results = $searchObject->getResults(); if (!empty($results)): ?>
 <div class="sidegroup">
   <h4><?=$this->transEsc('Library Web Search')?></h4>
 
   <ul class="similar">
-    <? foreach ($results as $driver): ?>
+    <?php foreach ($results as $driver): ?>
     <li>
       <a href="<?=$this->escapeHtmlAttr($driver->getUrl())?>" class="title">
         <?=$this->record($driver)->getTitleHtml()?>
       </a>
-      <? $snippet = $driver->getHighlightedSnippet(); ?>
-      <? $summary = $driver->getSummary(); ?>
-      <? if (!empty($snippet)): ?>
+      <?php $snippet = $driver->getHighlightedSnippet(); ?>
+      <?php $summary = $driver->getSummary(); ?>
+      <?php if (!empty($snippet)): ?>
         <br /><?=$this->highlight($snippet['snippet'])?>
-      <? elseif (!empty($summary)): ?>
+      <?php elseif (!empty($summary)): ?>
         <br /><?=$this->escapeHtml($summary[0])?>
-      <? endif; ?>
+      <?php endif; ?>
     </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
   <p><a href="<?=$this->url($searchObject->getOptions()->getSearchAction()) . $searchObject->getUrlQuery()->setLimit($searchObject->getOptions()->getDefaultLimit())?>"><?=$this->transEsc('Find More')?>...</a></p>
 </div>
-<? endif ?>
+<?php endif ?>

--- a/themes/bootstrap3/templates/Recommend/WorldCatIdentities.phtml
+++ b/themes/bootstrap3/templates/Recommend/WorldCatIdentities.phtml
@@ -1,29 +1,29 @@
-<? $worldCatIdentities = $this->recommend->getIdentities(); if (!empty($worldCatIdentities)): ?>
+<?php $worldCatIdentities = $this->recommend->getIdentities(); if (!empty($worldCatIdentities)): ?>
   <div>
     <h3><?=$this->transEsc('Authors Related to Your Search')?></h3>
     <dl>
-      <? $i = 0; foreach ($worldCatIdentities as $author => $subjects): ?>
-        <? if (++$i == 4): ?>
+      <?php $i = 0; foreach ($worldCatIdentities as $author => $subjects): ?>
+        <?php if (++$i == 4): ?>
           <dd id="moreWCIdents"><a href="#" onclick="moreFacets('WCIdents'); return false;"><?=$this->transEsc('more')?> ...</a></dd>
           <span class="hidden" id="narrowGroupHidden_WCIdents">
-        <? endif; ?>
+        <?php endif; ?>
         <dd>
         <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($author)?>%22&amp;type=Author"><?=$this->escapeHtml($author)?></a>
-        <? if (count($subjects) > 0): ?>
+        <?php if (count($subjects) > 0): ?>
           <dl>
           <dd><?=$this->transEsc('Related Subjects')?>:</dd>
-          <? $j = 0; foreach ($subjects as $subj): ?>
-            <? if (++$j == 3): ?>
+          <?php $j = 0; foreach ($subjects as $subj): ?>
+            <?php if (++$j == 3): ?>
               <dd id="moreWCIdents<?=$i?>"><a href="#" onclick="moreFacets('WCIdents<?=$i?>'); return false;"><?=$this->transEsc('more')?> ...</a></dd>
-            <? endif; ?>
+            <?php endif; ?>
             <dd>&bull; <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($subj)?>%22&amp;type=Subject"><?=$this->escapeHtml($subj)?></a></dd>
-          <? endforeach; ?>
-          <? if ($j > 2): ?><dd><a href="#" onclick="lessFacets('WCIdents<?=$i?>'); return false;"><?=$this->transEsc('less')?> ...</a></dd></span><? endif; ?>
+          <?php endforeach; ?>
+          <?php if ($j > 2): ?><dd><a href="#" onclick="lessFacets('WCIdents<?=$i?>'); return false;"><?=$this->transEsc('less')?> ...</a></dd></span><?php endif; ?>
           </dl>
-        <? endif; ?>
+        <?php endif; ?>
         </dd>
-      <? endforeach; ?>
-      <? if ($i > 3): ?><dd><a href="#" onclick="lessFacets('WCIdents'); return false;"><?=$this->transEsc('less')?> ...</a></dd></span><? endif; ?>
+      <?php endforeach; ?>
+      <?php if ($i > 3): ?><dd><a href="#" onclick="lessFacets('WCIdents'); return false;"><?=$this->transEsc('less')?> ...</a></dd></span><?php endif; ?>
     </dl>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewdata.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewdata.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $previews = isset($this->config->Content->previews)
         ? explode(',', $this->config->Content->previews) : array();
     if (!empty($previews)) {

--- a/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewlink.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewlink.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $previews = isset($this->config->Content->previews)
         ? explode(',', $this->config->Content->previews) : array();
     if (!empty($previews)) {

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -1,5 +1,5 @@
-<? $this->headLink()->appendStylesheet('EDS.css'); ?>
-<?
+<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php
     $items = $this->driver->getItems();
     $dbLabel = $this->driver->getDbLabel();
     $thumb = $this->driver->getThumbnail('medium');
@@ -10,62 +10,62 @@
 ?>
 <div class="row" vocab="http://schema.org/" resource="#record" typeof="<?=$this->driver->getSchemaOrgFormats()?> Product">
   <div class="col-sm-3 img-col">
-    <? if ($thumb): ?>
+    <?php if ($thumb): ?>
         <img src="<?=$this->escapeHtmlAttr($thumb)?>" class="recordcover" alt="<?=$this->transEsc('Cover Image')?>"/>
-    <? else: ?>
+    <?php else: ?>
       <div class="clearfix">
         <span class="recordcover pt-icon pt-<?=$this->driver->getPubTypeId()?>"></span>
       </div>
-    <? endif; ?>
-    <? if ($pubType): ?>
+    <?php endif; ?>
+    <?php if ($pubType): ?>
       <p><?=$this->transEsc($pubType)?></p>
-    <? endif; ?>
+    <?php endif; ?>
 
     <div class="external-links">
-      <? $pLink = $this->driver->getPLink();
+      <?php $pLink = $this->driver->getPLink();
           if($pLink): ?>
         <span>
           <a href="<?=$this->escapeHtmlAttr($pLink)?>">
             <?=$this->transEsc('View in EDS')?>
           </a>
         </span><br />
-      <? endif; ?>
-      <? $pdfLink = $this->driver->getPdfLink();
+      <?php endif; ?>
+      <?php $pdfLink = $this->driver->getPdfLink();
           if ($pdfLink): ?>
         <span>
           <a href="<?=$pdfLink?>" class="icon pdf fulltext">
             <?=$this->transEsc('PDF Full Text')?>
           </a>
         </span><br />
-      <? endif; ?>
-      <? if ($this->driver->hasHTMLFullTextAvailable()): ?>
+      <?php endif; ?>
+      <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
         <span>
           <a href="<?=$this->recordLink()->getUrl($this->driver, 'fulltext')?>#html" class="icon html fulltext">
             <?=$this->transEsc('HTML Full Text')?>
           </a>
         </span><br />
-      <? endif; ?>
+      <?php endif; ?>
     </div>
   </div>
   <div class="col-sm-9 info-col">
     <h3 property="name"><?=$this->driver->getTitle()?></h3>
 
     <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
-      <? foreach ($items as $key => $item): ?>
-        <? if (!empty($item['Data'])): ?>
+      <?php foreach ($items as $key => $item): ?>
+        <?php if (!empty($item['Data'])): ?>
         <tr>
           <th><?=$this->transEsc($item['Label'])?>:</th>
           <td><?=$this->driver->linkUrls($item['Data'])?></td>
         </tr>
-        <? endif; ?>
-      <? endforeach; ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
 
-      <? if ($dbLabel): ?>
+      <?php if ($dbLabel): ?>
         <tr>
           <th><?=$this->transEsc('Database')?>:</th>
           <td><?=$this->escapeHtml($dbLabel)?></td>
         </tr>
-      <? endif; ?>
+      <?php endif; ?>
 
       <?if ($this->driver->hasHTMLFullTextAvailable() && !$restrictedView):
           $fullText = $this->driver->getHtmlFullText();?>
@@ -74,7 +74,7 @@
             <?=$fullText?>
           </td>
         </tr>
-      <? elseif ($this->driver->hasHTMLFullTextAvailable() && $restrictedView): ?>
+      <?php elseif ($this->driver->hasHTMLFullTextAvailable() && $restrictedView): ?>
         <tr id="html">
           <td>
             <?=$this->transEsc('Full text is not displayed to guests')?>
@@ -85,26 +85,26 @@
             </a>
           </td>
         </tr>
-      <? endif; ?>
+      <?php endif; ?>
     </table>
 
     <div class="resultItemLine4 custom-links">
 
-    <? $customLinks = array_merge($this->driver->getFTCustomLinks(), $this->driver->getCustomLinks());
+    <?php $customLinks = array_merge($this->driver->getFTCustomLinks(), $this->driver->getCustomLinks());
     if (!empty($customLinks)): ?>
-      <? foreach ($customLinks as $customLink): ?>
-      <? $url = isset($customLink['Url']) ? $customLink['Url'] : '';
+      <?php foreach ($customLinks as $customLink): ?>
+      <?php $url = isset($customLink['Url']) ? $customLink['Url'] : '';
           $mot = isset($customLink['MouseOverText'])? $customLink['MouseOverText'] : '';
           $icon = isset ($customLink['Icon']) ? $customLink['Icon'] : '';
           $name = isset($customLink['Text']) ? $customLink['Text'] : '';
       ?>
       <span>
         <a href="<?=$this->escapeHtmlAttr($url)?>" target="_blank" title="<?=$this->escapeHtmlAttr($mot)?>" class="custom-link">
-          <? if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <? endif; ?><?=$this->escapeHtml($name)?>
+          <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <?php endif; ?><?=$this->escapeHtml($name)?>
         </a>
       </span>
-      <? endforeach; ?>
-    <? endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
     </div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -1,50 +1,50 @@
-<?
+<?php
   $this->headLink()->appendStylesheet('EDS.css');
   $accessLevel = $this->driver->getAccessLevel();
   $restrictedView = empty($accessLevel) ? false : true;
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLink()->getUrl($this->driver));
 ?>
-<?
+<?php
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment ?> <?=$this->escapeHtml($coverDetails['size'])?>">
-    <? if ($coverDetails['cover']): ?>
+    <?php if ($coverDetails['cover']): ?>
       <a href="<?=$this->recordLink()->getUrl($this->driver)?>" class="_record_link">
         <img src="<?=$this->escapeHtmlAttr($coverDetails['cover'])?>" class="recordcover" alt="<?=$this->transEsc('Cover Image')?>"/>
       </a>
-    <? else: ?>
+    <?php else: ?>
       <span class="recordcover pt-icon pt-<?=$this->driver->getPubTypeId()?>"></span>
       <div><?=$this->driver->getPubType()?></div>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
-<? $thumbnail = ob_get_contents(); ?>
-<? ob_end_clean(); ?>
+<?php $thumbnail = ob_get_contents(); ?>
+<?php ob_end_clean(); ?>
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
 <div class="media<?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
-  <? if ($thumbnail && $thumbnailAlignment == 'left'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="media-body">
     <div class="row short-view">
       <div class="col-sm-8 middle">
-        <? $items = $this->driver->getItems();
+        <?php $items = $this->driver->getItems();
           if (isset($items) && !empty($items)):
             foreach ($items as $item):
               if (!empty($item)): ?>
                 <div class="resultItemLine1">
-                  <? if('Ti' == $item['Group']): ?>
+                  <?php if('Ti' == $item['Group']): ?>
                     <a href="<?=$this->recordLink()->getUrl($this->driver)?>" class="title getFull _record_link"  data-view="<?=$this->params->getOptions()->getListViewOption()?>">
                     <?=$item['Data']?> </a>
-                  <? else:?>
+                  <?php else:?>
                     <p>
                       <b><?=$this->transEsc($item['Label'])?>:</b>
                       <?=$item['Data']?>
                     </p>
-                  <? endif;?>
+                  <?php endif;?>
                 </div>
-              <? endif;
+              <?php endif;
             endforeach;
           elseif ($restrictedView): ?>
             <div class="resultItemLine1">
@@ -56,43 +56,43 @@
                 </a>
               </p>
             </div>
-          <? endif; ?>
+          <?php endif; ?>
 
         <div class="resultItemLine4 custom-links">
-          <? $customLinks = array_merge($this->driver->getFTCustomLinks(), $this->driver->getCustomLinks());
+          <?php $customLinks = array_merge($this->driver->getFTCustomLinks(), $this->driver->getCustomLinks());
           if (!empty($customLinks)): ?>
-            <? foreach ($customLinks as $customLink): ?>
-            <? $url = isset($customLink['Url']) ? $customLink['Url'] : '';
+            <?php foreach ($customLinks as $customLink): ?>
+            <?php $url = isset($customLink['Url']) ? $customLink['Url'] : '';
                 $mot = isset($customLink['MouseOverText'])? $customLink['MouseOverText'] : '';
                 $icon = isset ($customLink['Icon']) ? $customLink['Icon'] : '';
                 $name = isset($customLink['Text']) ? $customLink['Text'] : '';
             ?>
             <span>
               <a href="<?=$this->escapeHtmlAttr($url)?>" target="_blank" title="<?=$this->escapeHtmlAttr($mot)?>" class="custom-link">
-                <? if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <? endif; ?><?=$this->escapeHtml($name)?>
+                <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <?php endif; ?><?=$this->escapeHtml($name)?>
               </a>
             </span>
-            <? endforeach; ?>
-          <? endif; ?>
+            <?php endforeach; ?>
+          <?php endif; ?>
         </div>
 
-        <? if ($this->driver->hasHTMLFullTextAvailable()): ?>
+        <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
           <a href="<?= $this->recordLink()->getUrl($this->driver, 'fulltext') ?>#html" class="icon html fulltext _record_link" target="_blank">
             <?=$this->transEsc('HTML Full Text')?>
           </a>
           &nbsp; &nbsp;
-        <? endif; ?>
+        <?php endif; ?>
 
-        <? if ($this->driver->hasPdfAvailable()): ?>
+        <?php if ($this->driver->hasPdfAvailable()): ?>
           <a href="<?= $this->recordLink()->getUrl($this->driver).'/PDF'; ?>" class="icon pdf fulltext" target="_blank">
             <?=$this->transEsc('PDF Full Text')?>
           </a>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
       <div class="col-sm-4 right hidden-print">
-        <? /* Display qrcode if appropriate: */ ?>
-        <? if ($QRCode = $this->record($this->driver)->getQRCode("results")): ?>
-          <?
+        <?php /* Display qrcode if appropriate: */ ?>
+        <?php if ($QRCode = $this->record($this->driver)->getQRCode("results")): ?>
+          <?php
             // Add JS Variables for QrCode
             $this->jsTranslations()->addStrings(array('qrcode_hide' => 'qrcode_hide', 'qrcode_show' => 'qrcode_show'));
           ?>
@@ -104,34 +104,34 @@
               </script>
             </div><br/>
           </span>
-        <? endif; ?>
+        <?php endif; ?>
 
-        <? if ($this->userlist()->getMode() !== 'disabled'): ?>
-          <? /* Add to favorites */ ?>
+        <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
+          <?php /* Add to favorites */ ?>
           <i class="fa fa-fw fa-star" aria-hidden="true"></i> <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record" data-lightbox id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><?=$this->transEsc('Add to favorites')?></a><br/>
 
-          <? /* Saved lists */ ?>
+          <?php /* Saved lists */ ?>
           <div class="savedLists alert alert-info hidden">
             <strong><?=$this->transEsc("Saved in")?>:</strong>
           </div>
-        <? endif; ?>
+        <?php endif; ?>
 
-        <? /* Hierarchy tree link */ ?>
-        <? $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
-          <? foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
+        <?php /* Hierarchy tree link */ ?>
+        <?php $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
+          <?php foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
             <div class="hierarchyTreeLink">
               <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId" />
               <i class="fa fa-fw fa-sitemap" aria-hidden="true"></i>
               <a class="hierarchyTreeLinkText" data-lightbox href="<?=$this->recordLink()->getTabUrl($this->driver, 'HierarchyTree')?>?hierarchy=<?=urlencode($hierarchyID)?>#tabnav" title="<?=$this->transEsc('hierarchy_tree')?>">
-                <?=$this->transEsc('hierarchy_view_context')?><? if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><? endif; ?>
+                <?=$this->transEsc('hierarchy_view_context')?><?php if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><?php endif; ?>
               </a>
             </div>
-          <? endforeach; ?>
-        <? endif; ?>
+          <?php endforeach; ?>
+        <?php endif; ?>
       </div>
     </div>
   </div>
-  <? if ($thumbnail && $thumbnailAlignment == 'right'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>
     <?=$thumbnail ?>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/LibGuides/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/LibGuides/result-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $url = $this->driver->getUniqueId();
 ?>
 <div class="media">

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLink()->getUrl($this->driver));
   $cover = $coverDetails['html'];
   $thumbnail = false;
@@ -8,15 +8,15 @@
     <div class="media-<?=$thumbnailAlignment ?> <?=$this->escapeHtmlAttr($coverDetails['size'])?>">
       <?=$cover ?>
     </div>
-    <? $thumbnail = ob_get_contents(); ?>
-  <? ob_end_clean(); ?>
-<? endif; ?>
+    <?php $thumbnail = ob_get_contents(); ?>
+  <?php ob_end_clean(); ?>
+<?php endif; ?>
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
 <div class="media<?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
-  <? if ($thumbnail && $thumbnailAlignment == 'left'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="media-body">
     <div>
       <b>
@@ -25,38 +25,38 @@
     </div>
 
     <div>
-      <? $summAuthors = $this->driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
+      <?php $summAuthors = $this->driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
         <?=$this->transEsc('by')?>
-        <? $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
+        <?php $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
           <a href="<?=$this->record($this->driver)->getLink('author', $this->highlight($summAuthor, null, true, false))?>"><?=$this->highlight($summAuthor)?></a><?=$i + 1 < $authorCount ? ',' : ''?>
-        <? endforeach; ?>
-      <? endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
 
-      <? $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
-      <? if (!empty($journalTitle)): ?>
+      <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
+      <?php if (!empty($journalTitle)): ?>
         <?=!empty($summAuthor) ? '<br />' : ''?>
         <?=/* TODO: handle highlighting more elegantly here */ $this->transEsc('Published in') . ' <a href="' . $this->record($this->driver)->getLink('journaltitle', str_replace(array('{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'), '', $journalTitle)) . '">' . $this->highlight($journalTitle) . '</a>';?>
         <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
-      <? elseif (!empty($summDate)): ?>
+      <?php elseif (!empty($summDate)): ?>
         <?=!empty($summAuthor) ? '<br />' : ''?>
         <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
-      <? endif; ?>
-      <? $summInCollection = $this->driver->getContainingCollections();
+      <?php endif; ?>
+      <?php $summInCollection = $this->driver->getContainingCollections();
       if (!empty($summInCollection)): ?>
-        <? foreach ($summInCollection as $collId => $collText): ?>
+        <?php foreach ($summInCollection as $collId => $collText): ?>
           <div>
             <b><?=$this->transEsc("in_collection_label")?></b>
             <a class="collectionLinkText" href="<?=$this->url('collection', array('id' => $collId))?>?recordID=<?=urlencode($this->driver->getUniqueID())?>">
               <?=$this->escapeHtml($collText)?>
             </a>
           </div>
-        <? endforeach; ?>
-      <? endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
     </div>
 
     <div>
       <div class="callnumAndLocation ajax-availability hidden">
-        <? if ($this->driver->supportsAjaxStatus()): ?>
+        <?php if ($this->driver->supportsAjaxStatus()): ?>
           <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
           <span class="callnumber ajax-availability hidden">
             <?=$this->transEsc('Loading')?>...
@@ -66,14 +66,14 @@
             <?=$this->transEsc('Loading')?>...
           </span>
           <div class="locationDetails"></div>
-        <? else: ?>
-          <? $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
+        <?php else: ?>
+          <?php $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
             <strong><?=$this->transEsc('Call Number')?>:</strong> <?=$this->escapeHtml($summCallNo)?>
-          <? endif; ?>
-        <? endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
       </div>
 
-      <? /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
+      <?php /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
             but even if we don't plan to display the link, we still want to get the $openUrl
             value for use in generating a COinS (Z3988) tag -- see bottom of file.
           */
@@ -82,31 +82,31 @@
         // Account for replace_other_urls setting
         $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
         if ($openUrlActive || !empty($urls)): ?>
-        <? if ($openUrlActive): ?>
+        <?php if ($openUrlActive): ?>
           <br/>
           <?=$openUrl->renderTemplate()?>
-        <? endif; ?>
-        <? if (!is_array($urls)) $urls = array();
+        <?php endif; ?>
+        <?php if (!is_array($urls)) $urls = array();
           if(!$this->driver->isCollection()):
             foreach ($urls as $current): ?>
               <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new"><i class="fa fa-external-link" aria-hidden="true"></i> <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></a><br/>
-          <? endforeach; ?>
-        <? endif; ?>
-      <? endif; ?>
+          <?php endforeach; ?>
+        <?php endif; ?>
+      <?php endif; ?>
 
       <?=$this->record($this->driver)->getFormatList() ?>
 
-      <? if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
+      <?php if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
         <span class="status ajax-availability small">
           <span class="label label-default"><?=$this->transEsc('Loading')?>...</span>
         </span>
-      <? endif; ?>
+      <?php endif; ?>
       <?=$this->record($this->driver)->getPreviews()?>
 
       <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="'.$this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()).'"></span>':''?>
     </div>
   </div>
-  <? if ($thumbnail && $thumbnailAlignment == 'right'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>
     <?=$thumbnail ?>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/Primo/format-class.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/format-class.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Convert Primo formats to VuFind formats so icons display correctly:
   switch ($this->format) {
       case 'Audio Recording':

--- a/themes/bootstrap3/templates/RecordDriver/SolrAuth/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrAuth/result-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $heading = $this->driver->getTitle();
   if (empty($heading)) {
     $heading = $this->translate('Heading unavailable.');
@@ -13,21 +13,21 @@
     </div>
 
     <div class="resultItemLine2">
-      <? if (!empty($seeAlso)): ?>
+      <?php if (!empty($seeAlso)): ?>
         <?=$this->transEsc("See also")?>:<br/>
-        <? foreach ($seeAlso as $current): ?>
+        <?php foreach ($seeAlso as $current): ?>
           <a href="<?=$this->url('authority-search')?>?lookfor=%22<?=urlencode($current)?>%22&amp;type=MainHeading"><?=$this->escapeHtml($current)?></a><br/>
-        <? endforeach; ?>
-      <? endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
     </div>
 
     <div class="resultItemLine3">
-      <? if (!empty($useFor)): ?>
+      <?php if (!empty($useFor)): ?>
         <?=$this->transEsc("Use for")?>:<br/>
-        <? foreach ($useFor as $current): ?>
+        <?php foreach ($useFor as $current): ?>
           <?=$this->escapeHtml($current)?><br/>
-        <? endforeach; ?>
-      <? endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
     </div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/collection-info.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/collection-info.phtml
@@ -1,57 +1,57 @@
-<? $this->headScript()->appendFile('collection_record.js'); ?>
+<?php $this->headScript()->appendFile('collection_record.js'); ?>
 <div class="row">
-  <? $QRCode = $this->record($this->driver)->getQRCode("core");
+  <?php $QRCode = $this->record($this->driver)->getQRCode("core");
      $cover = $this->record($this->driver)->getCover('collection-info', 'medium', $this->record($this->driver)->getThumbnail('large'));
      $preview = $this->record($this->driver)->getPreviews(); ?>
-  <? if ($QRCode || $cover || $preview): ?>
+  <?php if ($QRCode || $cover || $preview): ?>
   <div class="col-sm-3">
     <div class="text-center">
-      <? /* Display thumbnail if appropriate: */ ?>
-      <? if($cover): ?>
+      <?php /* Display thumbnail if appropriate: */ ?>
+      <?php if($cover): ?>
         <?=$cover?>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? /* Display qrcode if appropriate: */ ?>
-      <? if($QRCode): ?>
+      <?php /* Display qrcode if appropriate: */ ?>
+      <?php if($QRCode): ?>
         <span class="hidden-xs">
           <br/><img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
         </span>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
 
-    <? if ($preview): ?><?=$preview?><? endif; ?>
+    <?php if ($preview): ?><?=$preview?><?php endif; ?>
   </div>
 
   <div class="col-sm-6">
-  <? else: ?>
+  <?php else: ?>
   <div class="col-sm-9">
-  <? endif; ?>
+  <?php endif; ?>
 
     <h2><?=$this->escapeHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection())?></h2>
 
-    <? $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $summary[0] : false; ?>
-    <? if ($summary): ?>
+    <?php $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $summary[0] : false; ?>
+    <?php if ($summary): ?>
       <p><?=$this->escapeHtml($summary)?></p>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? /* Display the lists that this record is saved to */ ?>
+    <?php /* Display the lists that this record is saved to */ ?>
     <div class="savedLists hidden alert alert-info" id="savedLists">
       <strong><?=$this->transEsc("Saved in")?>:</strong>
     </div>
 
     <a id="moreInfoToggle" href="#" class="hidden"><?=$this->transEsc('more_info_toggle')?></a>
     <?/* Display Main Details */?>
-    <?
+    <?php
       $formatter = $this->recordDataFormatter();
       $fields = $formatter->getData($driver, $formatter->getDefaults('collection-info'));
     ?>
-    <? if (!empty($fields)): ?>
+    <?php if (!empty($fields)): ?>
       <table id="collectionInfo" class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
-        <? foreach ($fields as $key => $value): ?>
+        <?php foreach ($fields as $key => $value): ?>
           <tr><th><?=$this->transEsc($key)?>:</th><td><?=$value?></td></tr>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </table>
-    <? endif; ?>
+    <?php endif; ?>
     <?/* End Main Details */?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/collection-record.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/collection-record.phtml
@@ -1,14 +1,14 @@
 <h2><?=$this->escapeHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection())?></h2>
 <a href="<?=$this->recordLink()->getUrl($this->driver)?>"><?=$this->transEsc('View Full ' . ($this->driver->isCollection() ? 'Collection' : 'Record'))?></a>
 
-<?
+<?php
   $formatter = $this->recordDataFormatter();
   $fields = $formatter->getData($driver, $formatter->getDefaults('collection-record'));
 ?>
-<? if (!empty($fields)): ?>
+<?php if (!empty($fields)): ?>
   <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
-    <? foreach ($fields as $key => $value): ?>
+    <?php foreach ($fields as $key => $value): ?>
       <tr><th><?=$this->transEsc($key)?>:</th><td><?=$value?></td></tr>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </table>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/core.phtml
@@ -1,65 +1,65 @@
 <div class="row" vocab="http://schema.org/" resource="#record" typeof="<?=$this->driver->getSchemaOrgFormats()?> Product">
-  <? $QRCode = $this->record($this->driver)->getQRCode("core");
+  <?php $QRCode = $this->record($this->driver)->getQRCode("core");
      $cover = $this->record($this->driver)->getCover('core', 'medium', $this->record($this->driver)->getThumbnail('large'));
      $preview = $this->record($this->driver)->getPreviews(); ?>
-  <? if ($QRCode || $cover || $preview): ?>
+  <?php if ($QRCode || $cover || $preview): ?>
   <div class="col-sm-3 img-col">
     <div class="text-center">
-      <? /* Display thumbnail if appropriate: */ ?>
-      <? if($cover): ?>
+      <?php /* Display thumbnail if appropriate: */ ?>
+      <?php if($cover): ?>
         <?=$cover?>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? /* Display qrcode if appropriate: */ ?>
-      <? if($QRCode): ?>
+      <?php /* Display qrcode if appropriate: */ ?>
+      <?php if($QRCode): ?>
         <span class="hidden-xs">
           <br/><img alt="<?=$this->transEsc('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
         </span>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
 
-    <? // if you have a preview tab but want to move or remove the preview link
+    <?php // if you have a preview tab but want to move or remove the preview link
        // from this area of the record view, this can be split into
        // getPreviewData() (should stay here) and
        // getPreviewLink() (can go in your desired tab) ?>
-    <? if ($preview): ?><?=$preview?><? endif; ?>
+    <?php if ($preview): ?><?=$preview?><?php endif; ?>
   </div>
 
   <div class="col-sm-9 info-col">
-  <? else: ?>
+  <?php else: ?>
   <div class="col-sm-12">
-  <? endif; ?>
+  <?php endif; ?>
 
     <h3 property="name"><?=$this->escapeHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection())?></h3>
 
-    <? $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $this->escapeHtml($summary[0]) : false; ?>
-    <? if ($summary): ?>
+    <?php $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $this->escapeHtml($summary[0]) : false; ?>
+    <?php if ($summary): ?>
       <p><?=$this->truncate($summary, 300)?></p>
 
-      <? if(strlen($summary) > 300): ?>
+      <?php if(strlen($summary) > 300): ?>
         <p><a href='<?=$this->recordLink()->getTabUrl($this->driver, 'Description')?>#tabnav'><?=$this->transEsc('Full description')?></a></p>
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
 
-    <? if ($this->userlist()->getMode() !== 'disabled'): ?>
-      <? /* Display the lists that this record is saved to */ ?>
+    <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
+      <?php /* Display the lists that this record is saved to */ ?>
       <div class="savedLists hidden alert alert-info">
         <strong><?=$this->transEsc("Saved in")?>:</strong>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
     <?/* Display Main Details */?>
-    <?
+    <?php
       $formatter = $this->recordDataFormatter();
       $coreFields = $formatter->getData($driver, $formatter->getDefaults('core'));
     ?>
-    <? if (!empty($coreFields)): ?>
+    <?php if (!empty($coreFields)): ?>
       <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
-        <? foreach ($coreFields as $key => $value): ?>
+        <?php foreach ($coreFields as $key => $value): ?>
           <tr><th><?=$this->transEsc($key)?>:</th><td><?=$value?></td></tr>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </table>
-    <? endif; ?>
+    <?php endif; ?>
     <?/* End Main Details */?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-allRecordLinks.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-allRecordLinks.phtml
@@ -1,11 +1,11 @@
-<? foreach ($data as $recordLink): ?>
+<?php foreach ($data as $recordLink): ?>
   <?=$this->transEsc($recordLink['title'])?>:
   <a href="<?=$this->recordLink()->related($recordLink['link'])?>"><?=$this->escapeHtml($recordLink['value'])?></a><br />
-<? endforeach; ?>
-<? /* if we have record links, display relevant explanatory notes */
+<?php endforeach; ?>
+<?php /* if we have record links, display relevant explanatory notes */
   $related = $this->driver->getRelationshipNotes();
   if (!empty($related)): ?>
-    <? foreach ($related as $field): ?>
+    <?php foreach ($related as $field): ?>
       <?=$this->escapeHtml($field)?><br/>
-    <? endforeach; ?>
-<? endif; ?>
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-allSubjectHeadings.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-allSubjectHeadings.phtml
@@ -1,11 +1,11 @@
-<? foreach ($data as $field): ?>
+<?php foreach ($data as $field): ?>
   <div class="subject-line" property="keywords">
-    <? $subject = ''; ?>
-    <? if(count($field) == 1) $field = explode('--', $field[0]); ?>
-    <? $i = 0; foreach ($field as $subfield): ?>
+    <?php $subject = ''; ?>
+    <?php if(count($field) == 1) $field = explode('--', $field[0]); ?>
+    <?php $i = 0; foreach ($field as $subfield): ?>
       <?=($i++ == 0) ? '' : ' &gt; '?>
-      <? $subject = trim($subject . ' ' . $subfield); ?>
+      <?php $subject = trim($subject . ' ' . $subfield); ?>
       <a title="<?=$this->escapeHtmlAttr($subject)?>" href="<?=$this->record($this->driver)->getLink('subject', $subject)?>" rel="nofollow"><?=trim($this->escapeHtml($subfield))?></a>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
-<? endforeach; ?>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-authorNotes.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-authorNotes.phtml
@@ -1,8 +1,8 @@
-<? $isbn = $this->driver->getCleanISBN(); ?>
-<? $authorNotes = empty($isbn) ? [] : $this->authorNotes($isbn); if (!empty($authorNotes)): ?>
-  <? foreach ($authorNotes as $provider => $list): ?>
-    <? foreach ($list as $field): ?>
+<?php $isbn = $this->driver->getCleanISBN(); ?>
+<?php $authorNotes = empty($isbn) ? [] : $this->authorNotes($isbn); if (!empty($authorNotes)): ?>
+  <?php foreach ($authorNotes as $provider => $list): ?>
+    <?php foreach ($list as $field): ?>
       <?=$field['Content']?><br />
-    <? endforeach; ?>
-  <? endforeach; ?>
-<? endif; ?>
+    <?php endforeach; ?>
+  <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-authors.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-authors.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 $formatProperty = function ($datafield, $name, $label) {
     if (count($datafield) == 0) {
         return '';
@@ -11,14 +11,14 @@ $formatProperty = function ($datafield, $name, $label) {
 };
 $formattedAuthors = [];
 ?>
-<? if (!empty($data[$type])): ?>
-  <? foreach ($data[$type] as $author => $dataFields): ?>
-    <? ob_start(); ?>
+<?php if (!empty($data[$type])): ?>
+  <?php foreach ($data[$type] as $author => $dataFields): ?>
+    <?php ob_start(); ?>
     <span class="author-data" property="<?=$this->escapeHtml($schemaLabel)?>">
       <a href="<?=$this->record($this->driver)->getLink('author', $author)?>">
         <?=$this->escapeHtml($author)?>
       </a>
-      <?
+      <?php
         // Display additional data using the appropriate translation prefix
         // (for example, to render author roles correctly):
         foreach ($requiredDataFields as $field) {
@@ -30,11 +30,11 @@ $formattedAuthors = [];
         }
       ?>
     </span>
-    <?
+    <?php
       // Strip whitespace before close tags to avoid spaces in front of commas:
       $formattedAuthors[] = trim(preg_replace('/\s+<\//', '</', ob_get_contents()));
       ob_end_clean();
     ?>
-  <? endforeach; ?>
-<? endif; ?>
+  <?php endforeach; ?>
+<?php endif; ?>
 <?=implode(', ', $formattedAuthors)?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-containerTitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-containerTitle.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $containerSource = $this->driver->getSourceIdentifier();
   $containerID = $this->driver->getContainerRecordID();
   $ref = $this->driver->getContainerReference();

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-onlineAccess.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-onlineAccess.phtml
@@ -1,14 +1,14 @@
-<?
+<?php
   $openUrl = $this->openUrl($this->driver, 'record');
   $openUrlActive = $openUrl->isActive();
   // Account for replace_other_urls setting
   $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
 ?>
-<? if (!empty($urls) || $openUrlActive): ?>
-  <? foreach ($urls as $current): ?>
+<?php if (!empty($urls) || $openUrlActive): ?>
+  <?php foreach ($urls as $current): ?>
     <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br/>
-  <? endforeach; ?>
-  <? if ($openUrlActive): ?>
+  <?php endforeach; ?>
+  <?php if ($openUrlActive): ?>
     <?=$openUrl->renderTemplate()?><br/>
-  <? endif; ?>
-<? endif; ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-publicationDetails.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-publicationDetails.phtml
@@ -1,14 +1,14 @@
-<? foreach ($data as $field): ?>
+<?php foreach ($data as $field): ?>
   <span property="publisher" typeof="Organization">
-  <? $pubPlace = $field->getPlace(); if (!empty($pubPlace)): ?>
+  <?php $pubPlace = $field->getPlace(); if (!empty($pubPlace)): ?>
     <span property="location"><?=$this->escapeHtml($pubPlace)?></span>
-  <? endif; ?>
-  <? $pubName = $field->getName(); if (!empty($pubName)): ?>
+  <?php endif; ?>
+  <?php $pubName = $field->getName(); if (!empty($pubName)): ?>
     <span property="name"><?=$this->escapeHtml($pubName)?></span>
-  <? endif; ?>
+  <?php endif; ?>
   </span>
-  <? $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
+  <?php $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
     <span property="publicationDate"><?=$this->escapeHtml($pubDate)?></span>
-  <? endif; ?>
+  <?php endif; ?>
   <br/>
-<? endforeach; ?>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-series.phtml
@@ -1,16 +1,16 @@
-<? foreach ($data as $field): ?>
+<?php foreach ($data as $field): ?>
   <?/* Depending on the record driver, $field may either be an array with
      "name" and "number" keys or a flat string containing only the series
      name.  We should account for both cases to maximize compatibility. */?>
-  <? if (is_array($field)): ?>
-    <? if (!empty($field['name'])): ?>
+  <?php if (is_array($field)): ?>
+    <?php if (!empty($field['name'])): ?>
       <a href="<?=$this->record($this->driver)->getLink('series', $field['name'])?>"><?=$this->escapeHtml($field['name'])?></a>
-      <? if (!empty($field['number'])): ?>
+      <?php if (!empty($field['number'])): ?>
         <?=$this->escapeHtml($field['number'])?>
-      <? endif; ?>
+      <?php endif; ?>
       <br/>
-    <? endif; ?>
-  <? else: ?>
+    <?php endif; ?>
+  <?php else: ?>
     <a href="<?=$this->record($this->driver)->getLink('series', $field)?>"><?=$this->escapeHtml($field)?></a><br/>
-  <? endif; ?>
-<? endforeach; ?>
+  <?php endif; ?>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-tags.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/data-tags.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   if($loggedin = $this->auth()->isLoggedIn()) {
     $user_id = $loggedin->id;
     $loggedin = true;
@@ -6,10 +6,10 @@
     $user_id = false;
   }
 ?>
-<? if ($this->usertags()->getMode() !== 'disabled'): ?>
-  <? $tagList = $this->driver->getTags(null, null, 'count', $user_id); ?>
+<?php if ($this->usertags()->getMode() !== 'disabled'): ?>
+  <?php $tagList = $this->driver->getTags(null, null, 'count', $user_id); ?>
     <a class="tag-record btn btn-link pull-right flip" href="<?=$this->recordLink()->getActionUrl($this->driver, 'AddTag')?>" data-lightbox>
       <i class="fa fa-plus" aria-hidden="true"></i> <?=$this->transEsc('Add Tag')?>
     </a>
     <?=$this->context($this)->renderInContext('record/taglist', array('tagList'=>$tagList, 'loggedin'=>$loggedin)) ?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/format-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/format-list.phtml
@@ -1,3 +1,3 @@
-<? foreach ($this->driver->getFormats() as $format): ?>
+<?php foreach ($this->driver->getFormats() as $format): ?>
   <span class="format <?=$this->record($this->driver)->getFormatClass($format) ?>"><?=$this->transEsc($format) ?></span>
-<? endforeach; ?>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/list-entry.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up some convenience variables:
   $id = $this->driver->getUniqueId();
   $source = $this->driver->getSourceIdentifier();
@@ -19,64 +19,64 @@
     <div class="media-<?=$thumbnailAlignment ?> <?=$this->escapeHtmlAttr($coverDetails['size'])?>">
       <?=$cover ?>
     </div>
-    <? $thumbnail = ob_get_contents(); ?>
-  <? ob_end_clean(); ?>
-<? endif; ?>
-<div class="result<? if($this->driver->supportsAjaxStatus()): ?> ajaxItem<? endif ?>">
+    <?php $thumbnail = ob_get_contents(); ?>
+  <?php ob_end_clean(); ?>
+<?php endif; ?>
+<div class="result<?php if($this->driver->supportsAjaxStatus()): ?> ajaxItem<?php endif ?>">
   <input type="hidden" value="<?=$this->escapeHtmlAttr($id) ?>" class="hiddenId"/>
   <input type="hidden" value="<?=$this->escapeHtmlAttr($source) ?>" class="hiddenSource"/>
   <div class="checkbox hidden-print">
     <label><?=$this->record($this->driver)->getCheckbox()?></label>
   </div>
   <div class="media">
-    <? if ($thumbnail && $thumbnailAlignment == 'left'): ?>
+    <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
       <?=$thumbnail ?>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="media-body">
       <div class="row short-view">
         <div class="col-sm-8">
           <div class="resultItemLine1">
-            <? $missing = $this->driver instanceof \VuFind\RecordDriver\Missing; ?>
-            <? if (!$missing): ?><a href="<?=$this->recordLink()->getUrl($this->driver)?>" class="getFull" data-view="<?=$this->params->getOptions()->getListViewOption() ?>"><? endif; ?>
+            <?php $missing = $this->driver instanceof \VuFind\RecordDriver\Missing; ?>
+            <?php if (!$missing): ?><a href="<?=$this->recordLink()->getUrl($this->driver)?>" class="getFull" data-view="<?=$this->params->getOptions()->getListViewOption() ?>"><?php endif; ?>
               <span class="title"><?=$this->record($this->driver)->getTitleHtml()?></span>
-            <? if (!$missing): ?></a><? endif; ?>
+            <?php if (!$missing): ?></a><?php endif; ?>
           </div>
 
           <div class="resultItemLine2">
-            <? if($this->driver->isCollection()): ?>
+            <?php if($this->driver->isCollection()): ?>
               <?=implode('<br>', array_map(array($this, 'escapeHtml'), $this->driver->getSummary())); ?>
-            <? else: ?>
-              <? $summAuthors = $this->driver->getPrimaryAuthors(); if (!empty($summAuthors)): ?>
+            <?php else: ?>
+              <?php $summAuthors = $this->driver->getPrimaryAuthors(); if (!empty($summAuthors)): ?>
                 <?=$this->transEsc('by')?>
-                <? $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
+                <?php $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
                   <a href="<?=$this->record($this->driver)->getLink('author', $summAuthor)?>"><?=$this->escapeHtml($summAuthor)?></a><?=($i + 1 < $authorCount ? ';' : '') ?>
-                <? endforeach; ?>
-              <? endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
 
-              <? $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
-              <? if (!empty($journalTitle)): ?>
+              <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
+              <?php if (!empty($journalTitle)): ?>
                 <?=!empty($summAuthor) ? '<br/>' : ''?>
                 <?=/* TODO: handle highlighting more elegantly here */ $this->transEsc('Published in') . ' <a href="' . $this->record($this->driver)->getLink('journaltitle', str_replace(array('{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'), '', $journalTitle)) . '">' . $this->highlight($journalTitle) . '</a>';?>
                 <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
-              <? elseif (!empty($summDate)): ?>
+              <?php elseif (!empty($summDate)): ?>
                 <?=!empty($summAuthor) ? '<br/>' : ''?>
                 <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
-              <? endif; ?>
-              <? $summInCollection = $this->driver->getContainingCollections(); if (false && !empty($summInCollection)): ?>
-                <? foreach ($summInCollection as $collId => $collText): ?>
+              <?php endif; ?>
+              <?php $summInCollection = $this->driver->getContainingCollections(); if (false && !empty($summInCollection)): ?>
+                <?php foreach ($summInCollection as $collId => $collText): ?>
                   <div>
                     <b><?=$this->transEsc("in_collection_label")?></b>
                     <a class="collectionLinkText" href="<?=$this->url('collection', array('id' => $collId))?>?recordID=<?=urlencode($this->driver->getUniqueID())?>">
                       <?=$this->escapeHtml($collText)?>
                     </a>
                   </div>
-                <? endforeach; ?>
-              <? endif; ?>
-            <? endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
+            <?php endif; ?>
           </div>
 
           <div class="last">
-            <? if(!$this->driver->isCollection()) {
+            <?php if(!$this->driver->isCollection()) {
                 if ($snippet = $this->driver->getHighlightedSnippet()) {
                   if (!empty($snippet['caption'])) {
                     echo '<strong>' . $this->transEsc($snippet['caption']) . ':</strong> ';
@@ -87,37 +87,37 @@
                 }
               } ?>
 
-            <? $listTags = ($this->usertags()->getMode() !== 'disabled') ? $this->driver->getTags(
+            <?php $listTags = ($this->usertags()->getMode() !== 'disabled') ? $this->driver->getTags(
                 null === $list_id ? true : $list_id, // get tags for all lists if no single list is selected
                 $user_id, 'tag'
                ) : array();
             ?>
-            <? if (count($listTags) > 0): ?>
+            <?php if (count($listTags) > 0): ?>
               <strong><?=$this->transEsc('Your Tags')?>:</strong>
-              <? foreach ($listTags as $tag): ?>
+              <?php foreach ($listTags as $tag): ?>
                 <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet('tags', $tag->tag)?>"><?=$this->escapeHtml($tag->tag)?></a>
-              <? endforeach; ?>
+              <?php endforeach; ?>
               <br/>
-            <? endif; ?>
-            <? $listNotes = $this->driver->getListNotes($list_id, $user_id); ?>
-            <? if (count($listNotes) > 0): ?>
+            <?php endif; ?>
+            <?php $listNotes = $this->driver->getListNotes($list_id, $user_id); ?>
+            <?php if (count($listNotes) > 0): ?>
               <strong><?=$this->transEsc('Notes')?>:</strong>
-              <? if (count($listNotes) > 1): ?><br/><? endif; ?>
-              <? foreach ($listNotes as $note): ?>
+              <?php if (count($listNotes) > 1): ?><br/><?php endif; ?>
+              <?php foreach ($listNotes as $note): ?>
                 <?=$this->escapeHtml($note)?><br/>
-              <? endforeach; ?>
-            <? endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
 
-            <? if (count($this->lists) > 0): ?>
+            <?php if (count($this->lists) > 0): ?>
                 <strong><?=$this->transEsc('Saved in')?>:</strong>
-                <? $i=0;foreach($this->lists as $current): ?>
-                    <a href="<?=$this->url('userList', array('id' => $current->id))?>"><?=$this->escapeHtml($current->title)?></a><? if($i++ < count($this->lists)-1): ?>,<? endif; ?>
-                <? endforeach; ?>
+                <?php $i=0;foreach($this->lists as $current): ?>
+                    <a href="<?=$this->url('userList', array('id' => $current->id))?>"><?=$this->escapeHtml($current->title)?></a><?php if($i++ < count($this->lists)-1): ?>,<?php endif; ?>
+                <?php endforeach; ?>
                 <br/>
-            <? endif; ?>
+            <?php endif; ?>
 
             <div class="callnumAndLocation ajax-availability hidden">
-              <? if ($this->driver->supportsAjaxStatus()): ?>
+              <?php if ($this->driver->supportsAjaxStatus()): ?>
                 <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
                 <span class="callnumber ajax-availability hidden">
                   <?=$this->transEsc('Loading')?>...<br/>
@@ -127,14 +127,14 @@
                   <?=$this->transEsc('Loading')?>...
                 </span>
                 <div class="locationDetails"></div>
-              <? else: ?>
-                <? $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
+              <?php else: ?>
+                <?php $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
                   <strong><?=$this->transEsc('Call Number')?>:</strong> <?=$this->escapeHtml($summCallNo)?>
-                <? endif; ?>
-              <? endif; ?>
+                <?php endif; ?>
+              <?php endif; ?>
             </div>
 
-            <? /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
+            <?php /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
                   but even if we don't plan to display the link, we still want to get the $openUrl
                   value for use in generating a COinS (Z3988) tag -- see bottom of file.
                 */
@@ -145,33 +145,33 @@
 
               if ($openUrlActive || !empty($urls)):
             ?>
-              <? if ($openUrlActive): ?>
+              <?php if ($openUrlActive): ?>
                 <br/>
                 <?=$openUrl->renderTemplate()?>
-              <? endif;?>
+              <?php endif;?>
 
-              <? if (!is_array($urls)) { $urls = array(); }
+              <?php if (!is_array($urls)) { $urls = array(); }
                 if(!$this->driver->isCollection()):
                   foreach ($urls as $current): ?>
                     <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new"><i class="fa fa-external-link" aria-hidden="true"></i> <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></a>
-                  <? endforeach; ?>
-                <? endif; ?>
-              <? endif; ?>
+                  <?php endforeach; ?>
+                <?php endif; ?>
+              <?php endif; ?>
             <br/>
 
             <?=$this->record($this->driver)->getFormatList() ?>
 
-            <? if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
+            <?php if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
               <span class="status ajax-availability hidden"><?=$this->transEsc('Loading')?>...</span>
               <br/><br/>
-            <? endif; ?>
+            <?php endif; ?>
             <?=$this->record($this->driver)->getPreviews()?>
           </div>
         </div>
 
         <div class="col-sm-4 right">
-          <i class="fa fa-fw fa-edit" aria-hidden="true"></i> <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><? if (!is_null($list_id)):?>&amp;list_id=<?=urlencode($list_id)?><? endif; ?>" class="edit tool"><?=$this->transEsc('Edit')?></a><br/>
-          <? /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
+          <i class="fa fa-fw fa-edit" aria-hidden="true"></i> <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (!is_null($list_id)):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool"><?=$this->transEsc('Edit')?></a><br/>
+          <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
             $deleteUrl = null === $list_id
                 ? $this->url('myresearch-favorites')
                 : $this->url('userList', array('id' => $list_id));
@@ -193,8 +193,8 @@
         </div>
       </div>
     </div>
-    <? if ($thumbnail && $thumbnailAlignment == 'right'): ?>
+    <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>
       <?=$thumbnail ?>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-grid.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-grid.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
    but even if we don't plan to display the link, we still want to get the $openUrl
    value for use in generating a COinS (Z3988) tag -- see bottom of file.
@@ -11,32 +11,32 @@ $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
 
 <div class="result <?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
   <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
-  <? if ((isset($this->showCartControls) && $this->showCartControls)
+  <?php if ((isset($this->showCartControls) && $this->showCartControls)
       || (isset($this->showBulkOptions) && $this->showBulkOptions)): ?>
     <?=$this->record($this->driver)->getCheckbox() ?></br>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="text-center">
     <?=$this->record($this->driver)->getCover('result-grid', 'small', $this->recordLink()->getUrl($this->driver)); ?>
   </div>
-  <? if (!$openUrlActive && empty($urls)): ?>
-    <? if ($this->driver->supportsAjaxStatus()): ?>
+  <?php if (!$openUrlActive && empty($urls)): ?>
+    <?php if ($this->driver->supportsAjaxStatus()): ?>
       <div class="status ajax-availability hidden text-center"><span class="label label-default"><?=$this->transEsc('Loading')?>...</span></div>
-    <? endif; ?>
-  <? endif; ?>
+    <?php endif; ?>
+  <?php endif; ?>
   <div>
     <a class="title" href="<?=$this->recordLink()->getUrl($this->driver)?>">
       <?=$this->record($this->driver)->getTitleHtml(80)?>
     </a>
-    <? if ($openUrlActive || !empty($urls)): ?>
+    <?php if ($openUrlActive || !empty($urls)): ?>
       <br/><br/>
-      <? if ($openUrlActive): ?>
+      <?php if ($openUrlActive): ?>
         <?=$openUrl->renderTemplate()?><br />
-      <? endif; ?>
-      <? if (!is_array($urls)) $urls = array(); foreach ($urls as $current): ?>
+      <?php endif; ?>
+      <?php if (!is_array($urls)) $urls = array(); foreach ($urls as $current): ?>
         <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new"><i class="fa fa-external-link" aria-hidden="true"></i> <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></a>
         <br/>
-      <? endforeach; ?>
-    <? endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
   </div>
 </div>
 

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/result-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLink()->getUrl($this->driver));
   $cover = $coverDetails['html'];
   $thumbnail = false;
@@ -8,15 +8,15 @@
     <div class="media-<?=$thumbnailAlignment ?> <?=$this->escapeHtmlAttr($coverDetails['size'])?>">
       <?=$cover ?>
     </div>
-    <? $thumbnail = ob_get_contents(); ?>
-  <? ob_end_clean(); ?>
-<? endif; ?>
+    <?php $thumbnail = ob_get_contents(); ?>
+  <?php ob_end_clean(); ?>
+<?php endif; ?>
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
 <div class="media">
-  <? if ($thumbnail && $thumbnailAlignment == 'left'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
-  <? endif ?>
+  <?php endif ?>
   <div class="media-body">
     <div class="row short-view">
       <div class="col-sm-8 middle">
@@ -27,79 +27,79 @@
         </div>
 
         <div>
-          <? if($this->driver->isCollection()): ?>
+          <?php if($this->driver->isCollection()): ?>
             <?=implode('<br>', array_map(array($this, 'escapeHtml'), $this->driver->getSummary())); ?>
-          <? else: ?>
-            <? $summAuthors = $this->driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
+          <?php else: ?>
+            <?php $summAuthors = $this->driver->getPrimaryAuthorsWithHighlighting(); if (!empty($summAuthors)): ?>
               <?=$this->transEsc('by')?>
-              <? $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
+              <?php $authorCount = count($summAuthors); foreach ($summAuthors as $i => $summAuthor): ?>
                 <a href="<?=$this->record($this->driver)->getLink('author', $this->highlight($summAuthor, null, true, false))?>"><?=$this->highlight($summAuthor)?></a><?=$i + 1 < $authorCount ? ',' : ''?>
-              <? endforeach; ?>
-            <? endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
 
-            <? $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
-            <? if (!empty($journalTitle)): ?>
+            <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
+            <?php if (!empty($journalTitle)): ?>
               <?=!empty($summAuthor) ? '<br />' : ''?>
               <?=$this->transEsc('Published in')?>
-              <? $containerSource = $this->driver->getSourceIdentifier(); ?>
-              <? $containerID = $this->driver->getContainerRecordID(); ?>
-              <? /* TODO: handle highlighting more elegantly here: */?>
+              <?php $containerSource = $this->driver->getSourceIdentifier(); ?>
+              <?php $containerID = $this->driver->getContainerRecordID(); ?>
+              <?php /* TODO: handle highlighting more elegantly here: */?>
               <a href="<?=($containerID ? $this->recordLink()->getUrl("$containerSource|$containerID") : $this->record($this->driver)->getLink('journaltitle', str_replace(array('{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'), '', $journalTitle)))?>"><?=$this->highlight($journalTitle) ?></a>
               <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
-            <? elseif (!empty($summDate)): ?>
+            <?php elseif (!empty($summDate)): ?>
               <?=!empty($summAuthor) ? '<br />' : ''?>
               <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
-            <? endif; ?>
-            <? $summInCollection = $this->driver->getContainingCollections(); if (!empty($summInCollection)): ?>
-              <? foreach ($summInCollection as $collId => $collText): ?>
+            <?php endif; ?>
+            <?php $summInCollection = $this->driver->getContainingCollections(); if (!empty($summInCollection)): ?>
+              <?php foreach ($summInCollection as $collId => $collText): ?>
                 <div>
                   <b><?=$this->transEsc("in_collection_label")?></b>
                   <a class="collectionLinkText" href="<?=$this->url('collection', array('id' => $collId))?>?recordID=<?=urlencode($this->driver->getUniqueID())?>">
                     <?=$this->escapeHtml($collText)?>
                   </a>
                 </div>
-              <? endforeach; ?>
-            <? endif; ?>
-          <? endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          <?php endif; ?>
         </div>
 
-        <? if(!$this->driver->isCollection()): ?>
-          <? if ($snippet = $this->driver->getHighlightedSnippet()): ?>
-            <? if (!empty($snippet['caption'])): ?>
+        <?php if(!$this->driver->isCollection()): ?>
+          <?php if ($snippet = $this->driver->getHighlightedSnippet()): ?>
+            <?php if (!empty($snippet['caption'])): ?>
               <strong><?=$this->transEsc($snippet['caption']) ?>:</strong> ';
-            <? endif; ?>
-            <? if (!empty($snippet['snippet'])): ?>
+            <?php endif; ?>
+            <?php if (!empty($snippet['snippet'])): ?>
               <span class="quotestart">&#8220;</span>...<?=$this->highlight($snippet['snippet']) ?>...<span class="quoteend">&#8221;</span><br/>
-            <? endif; ?>
-          <? endif; ?>
-        <? endif; ?>
+            <?php endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
 
-        <?
+        <?php
         /* Display information on duplicate records if available */
         if ($dedupData = $this->driver->getDedupData()): ?>
           <div class="dedupInformation">
-          <?
+          <?php
             $i = 0;
             foreach ($dedupData as $source => $current) {
               if (++$i == 1) {
-                ?><span class="currentSource"><a href="<?=$this->recordLink()->getUrl($this->driver)?>"><?=$this->transEsc("source_$source", array(), $source)?></a></span><?
+                ?><span class="currentSource"><a href="<?=$this->recordLink()->getUrl($this->driver)?>"><?=$this->transEsc("source_$source", array(), $source)?></a></span><?php
               } else {
                 if ($i == 2) {
-                  ?> <span class="otherSources">(<?=$this->transEsc('Other Sources')?>: <?
+                  ?> <span class="otherSources">(<?=$this->transEsc('Other Sources')?>: <?php
                 } else {
-                  ?>, <?
+                  ?>, <?php
                 }
-                ?><a href="<?=$this->recordLink()->getUrl($current['id'])?>"><?=$this->transEsc("source_$source", array(), $source)?></a><?
+                ?><a href="<?=$this->recordLink()->getUrl($current['id'])?>"><?=$this->transEsc("source_$source", array(), $source)?></a><?php
               }
             }
             if ($i > 1) {
-              ?>)</span><?
+              ?>)</span><?php
             }?>
           </div>
-        <? endif; ?>
+        <?php endif; ?>
 
         <div class="callnumAndLocation ajax-availability hidden">
-          <? if ($this->driver->supportsAjaxStatus()): ?>
+          <?php if ($this->driver->supportsAjaxStatus()): ?>
             <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
             <span class="callnumber ajax-availability hidden">
               <?=$this->transEsc('Loading')?>...<br/>
@@ -109,14 +109,14 @@
               <?=$this->transEsc('Loading')?>...
             </span>
             <div class="locationDetails"></div>
-          <? else: ?>
-            <? $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
+          <?php else: ?>
+            <?php $summCallNo = $this->driver->getCallNumber(); if (!empty($summCallNo)): ?>
               <strong><?=$this->transEsc('Call Number')?>:</strong> <?=$this->escapeHtml($summCallNo)?>
-            <? endif; ?>
-          <? endif; ?>
+            <?php endif; ?>
+          <?php endif; ?>
         </div>
 
-        <? /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
+        <?php /* We need to find out if we're supposed to display an OpenURL link ($openUrlActive),
               but even if we don't plan to display the link, we still want to get the $openUrl
               value for use in generating a COinS (Z3988) tag -- see bottom of file.
             */
@@ -126,31 +126,31 @@
           $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
 
           if ($openUrlActive || !empty($urls)): ?>
-          <? if ($openUrlActive): ?>
+          <?php if ($openUrlActive): ?>
             <br/>
             <?=$openUrl->renderTemplate()?>
-          <? endif; ?>
-          <? if (!is_array($urls)) $urls = array();
+          <?php endif; ?>
+          <?php if (!is_array($urls)) $urls = array();
             if(!$this->driver->isCollection()):
               foreach ($urls as $current): ?>
                 <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new"><i class="fa fa-external-link" aria-hidden="true"></i> <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></a><br/>
-            <? endforeach; ?>
-          <? endif; ?>
-        <? endif; ?>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        <?php endif; ?>
 
         <?=$this->record($this->driver)->getFormatList() ?>
 
-        <? if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
+        <?php if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
           <span class="status ajax-availability hidden">
             <span class="label label-default"><?=$this->transEsc('Loading')?>...</span>
           </span>
-        <? endif; ?>
+        <?php endif; ?>
         <?=$this->record($this->driver)->getPreviews()?>
       </div>
       <div class="col-sm-4 right hidden-print">
-        <? /* Display qrcode if appropriate: */ ?>
-        <? if ($QRCode = $this->record($this->driver)->getQRCode("results")): ?>
-          <?
+        <?php /* Display qrcode if appropriate: */ ?>
+        <?php if ($QRCode = $this->record($this->driver)->getQRCode("results")): ?>
+          <?php
             // Add JS Variables for QrCode
             $this->jsTranslations()->addStrings(array('qrcode_hide' => 'qrcode_hide', 'qrcode_show' => 'qrcode_show'));
           ?>
@@ -162,35 +162,35 @@
               </script>
             </div><br/>
           </span>
-        <? endif; ?>
+        <?php endif; ?>
 
-        <? if ($this->userlist()->getMode() !== 'disabled'): ?>
-          <? /* Add to favorites */ ?>
+        <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
+          <?php /* Add to favorites */ ?>
           <i class="fa fa-fw fa-star" aria-hidden="true"></i> <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" data-lightbox class="save-record" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>"><?=$this->transEsc('Add to favorites')?></a><br/>
-          <? /* Saved lists */ ?>
+          <?php /* Saved lists */ ?>
           <div class="savedLists alert alert-info hidden">
             <strong><?=$this->transEsc("Saved in")?>:</strong>
           </div>
-        <? endif; ?>
+        <?php endif; ?>
 
-        <? /* Hierarchy tree link */ ?>
-        <? $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
-          <? foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
+        <?php /* Hierarchy tree link */ ?>
+        <?php $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
+          <?php foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
             <div class="hierarchyTreeLink">
               <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId" />
               <i class="fa fa-fw fa-sitemap" aria-hidden="true"></i>
               <a class="hierarchyTreeLinkText" data-lightbox href="<?=$this->recordLink()->getTabUrl($this->driver, 'HierarchyTree')?>?hierarchy=<?=urlencode($hierarchyID)?>#tabnav" title="<?=$this->transEsc('hierarchy_tree')?>" data-lightbox-href="<?=$this->recordLink()->getTabUrl($this->driver, 'AjaxTab')?>?hierarchy=<?=urlencode($hierarchyID)?>" data-lightbox-post="tab=hierarchytree">
-                <?=$this->transEsc('hierarchy_view_context')?><? if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><? endif; ?>
+                <?=$this->transEsc('hierarchy_view_context')?><?php if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><?php endif; ?>
               </a>
             </div>
-          <? endforeach; ?>
-        <? endif; ?>
+          <?php endforeach; ?>
+        <?php endif; ?>
 
         <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="'.$this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()).'"></span>':''?>
       </div>
     </div>
   </div>
-  <? if ($thumbnail && $thumbnailAlignment == 'right'): ?>
+  <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>
     <?=$thumbnail ?>
-  <? endif ?>
+  <?php endif ?>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/SolrDefault/toolbar.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrDefault/toolbar.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $addThis = $this->addThis();
   if (!empty($addThis)) {
     $this->headScript()->appendFile('https://s7.addthis.com/js/250/addthis_widget.js?pub=' . urlencode($addThis));
@@ -9,47 +9,47 @@
   $cartId = $this->driver->getSourceIdentifier() . '|' . $this->driver->getUniqueId();
 ?>
 <ul class="nav nav-pills hidden-print">
-  <? if (count($this->driver->getCitationFormats()) > 0): ?>
+  <?php if (count($this->driver->getCitationFormats()) > 0): ?>
     <li><a class="cite-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'Cite')?>" rel="nofollow"><i class="fa fa-asterisk" aria-hidden="true"></i> <?=$this->transEsc('Cite this')?></a></li>
-  <? endif; ?>
-  <? if ($this->accountCapabilities()->getSmsSetting() !== 'disabled'): ?>
+  <?php endif; ?>
+  <?php if ($this->accountCapabilities()->getSmsSetting() !== 'disabled'): ?>
     <li><a class="sms-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'SMS')?>" rel="nofollow"><i class="fa fa-mobile" aria-hidden="true"></i> <?=$this->transEsc('Text this')?></a></li>
-  <? endif; ?>
+  <?php endif; ?>
   <li><a class="mail-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'Email')?>" rel="nofollow"><i class="fa fa-envelope" aria-hidden="true"></i> <?=$this->transEsc('Email this')?></a></li>
 
-  <? $exportFormats = $this->export()->getFormatsForRecord($this->driver); ?>
-  <? if(count($exportFormats) > 0): ?>
+  <?php $exportFormats = $this->export()->getFormatsForRecord($this->driver); ?>
+  <?php if(count($exportFormats) > 0): ?>
     <li class="dropdown">
       <a class="export-toggle dropdown-toggle" data-toggle="dropdown" href="<?=$this->recordLink()->getActionUrl($this->driver, 'Export')?>" rel="nofollow"><i class="fa fa-list-alt" aria-hidden="true"></i> <?=$this->transEsc('Export Record') ?></a>
       <ul class="dropdown-menu" role="menu">
-        <? foreach ($exportFormats as $exportFormat): ?>
-          <li><a <? if ($this->export()->needsRedirect($exportFormat)): ?>target="<?=$this->escapeHtmlAttr($exportFormat)?>Main" <? endif; ?>href="<?=$this->recordLink()->getActionUrl($this->driver, 'Export')?>?style=<?=$this->escapeHtmlAttr($exportFormat)?>" rel="nofollow"><?=$this->transEsc('Export to')?> <?=$this->transEsc($this->export()->getLabelForFormat($exportFormat))?></a></li>
-        <? endforeach; ?>
+        <?php foreach ($exportFormats as $exportFormat): ?>
+          <li><a <?php if ($this->export()->needsRedirect($exportFormat)): ?>target="<?=$this->escapeHtmlAttr($exportFormat)?>Main" <?php endif; ?>href="<?=$this->recordLink()->getActionUrl($this->driver, 'Export')?>?style=<?=$this->escapeHtmlAttr($exportFormat)?>" rel="nofollow"><?=$this->transEsc('Export to')?> <?=$this->transEsc($this->export()->getLabelForFormat($exportFormat))?></a></li>
+        <?php endforeach; ?>
       </ul>
     </li>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if ($this->userlist()->getMode() !== 'disabled'): ?>
+  <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
     <li><a class="save-record" data-lightbox href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" rel="nofollow"><i class="fa fa-star" aria-hidden="true"></i> <?=$this->transEsc('Add to favorites')?></a></li>
-  <? endif; ?>
-  <? if (!empty($addThis)): ?>
+  <?php endif; ?>
+  <?php if (!empty($addThis)): ?>
     <li><a class="addThis addthis_button" href="https://www.addthis.com/bookmark.php?v=250&amp;pub=<?=urlencode($addThis)?>"><i class="fa fa-bookmark" aria-hidden="true"></i> <?=$this->transEsc('Bookmark')?></a></li>
-  <? endif; ?>
-  <? if ($cart->isActive()): ?>
+  <?php endif; ?>
+  <?php if ($cart->isActive()): ?>
     <li class="bookbag-menu">
       <input class="cartId" type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($cartId)?>" />
-      <a class="cart-add hidden<? if(!$cart->contains($cartId)): ?> correct<? endif ?>" href="#"><i class="fa fa-plus" aria-hidden="true"></i> <?=$this->transEsc('Add to Book Bag') ?></a>
-      <a class="cart-remove hidden<? if($cart->contains($cartId)): ?> correct<? endif ?>"href="#"><i class="fa fa-minus-circle" aria-hidden="true"></i> <?=$this->transEsc('Remove from Book Bag') ?></a>
+      <a class="cart-add hidden<?php if(!$cart->contains($cartId)): ?> correct<?php endif ?>" href="#"><i class="fa fa-plus" aria-hidden="true"></i> <?=$this->transEsc('Add to Book Bag') ?></a>
+      <a class="cart-remove hidden<?php if($cart->contains($cartId)): ?> correct<?php endif ?>"href="#"><i class="fa fa-minus-circle" aria-hidden="true"></i> <?=$this->transEsc('Remove from Book Bag') ?></a>
       <noscript>
         <form method="post" name="addForm" action="<?=$this->url('cart-processor')?>">
           <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($cartId)?>" />
-          <? if ($cart->contains($cartId)): ?>
+          <?php if ($cart->contains($cartId)): ?>
             <input class="btn btn-default" type="submit" name="delete" value="<?=$this->transEsc('Remove from Book Bag')?>"/>
-          <? else: ?>
+          <?php else: ?>
             <input class="btn btn-default" type="submit" name="add" value="<?=$this->transEsc('Add to Book Bag')?>"/>
-          <? endif; ?>
+          <?php endif; ?>
         </form>
       </noscript>
     </li>
-  <? endif; ?>
+  <?php endif; ?>
 </ul>

--- a/themes/bootstrap3/templates/RecordDriver/SolrWeb/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrWeb/result-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $url = $this->driver->getUrl();
 ?>
 <div class="media">
@@ -10,20 +10,20 @@
     </div>
 
     <div class="resultItemLine2">
-      <? $snippet = $this->driver->getHighlightedSnippet(); ?>
-      <? $summary = $this->driver->getSummary(); ?>
-      <? if (!empty($snippet)): ?>
+      <?php $snippet = $this->driver->getHighlightedSnippet(); ?>
+      <?php $summary = $this->driver->getSummary(); ?>
+      <?php if (!empty($snippet)): ?>
         <?=$this->highlight($snippet['snippet'])?>
-      <? elseif (!empty($summary)): ?>
+      <?php elseif (!empty($summary)): ?>
         <?=$this->escapeHtml($summary[0])?>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
 
     <div class="resultItemLine3">
       <?=$this->escapeHtml($url)?>
-      <? $lastMod = $this->driver->getLastModified(); if (!empty($lastMod)): ?>
+      <?php $lastMod = $this->driver->getLastModified(); if (!empty($lastMod)): ?>
         <br /><?=$this->transEsc('Last Modified')?>: <?=$this->escapeHtml(trim(str_replace(array('T', 'Z'), ' ', $lastMod)))?>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/Summon/format-class.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/format-class.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Convert Summon formats to VuFind formats so icons display correctly:
   switch ($this->format) {
       case 'Audio Recording':

--- a/themes/bootstrap3/templates/RecordTab/collectionhierarchytree.phtml
+++ b/themes/bootstrap3/templates/RecordTab/collectionhierarchytree.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $this->mainTreeClass = 'col-sm-6';
     $this->treeContext = 'Collection';
 ?>
@@ -9,13 +9,13 @@
   <div class="col-sm-6">
     <div id="hierarchyRecordHolder">
       <div id="hierarchyRecord">
-        <? if (($collectionRecord = $this->tab->getActiveRecord()) !== false): ?>
-          <? if ($collectionRecord === null): ?>
+        <?php if (($collectionRecord = $this->tab->getActiveRecord()) !== false): ?>
+          <?php if ($collectionRecord === null): ?>
             <?=$this->render('collection/collection-record-error.phtml')?>
-          <? else: ?>
+          <?php else: ?>
             <?=html_entity_decode($this->record($collectionRecord)->getCollectionBriefRecord())?>
-          <? endif; ?>
-        <? endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
       </div>
     </div>
   </div>

--- a/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
+++ b/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Collection Items') . ': ' . $this->driver->getBreadcrumb());
 
@@ -7,17 +7,17 @@
   $params = $this->tab->getParams();
   $searchDetails = ['results' => $results, 'params' => $params, 'indexStart' => 1];
 ?>
-<? if (($recordTotal = $results->getResultTotal()) > 0): // only display these at very top if we have results ?>
-  <? foreach ($results->getRecommendations('top') as $current): ?>
+<?php if (($recordTotal = $results->getResultTotal()) > 0): // only display these at very top if we have results ?>
+  <?php foreach ($results->getRecommendations('top') as $current): ?>
     <?=$this->recommend($current)?>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <div class="clearfix hidden-print">
     <div class="pull-left flip">
       <?=$this->transEsc("Showing")?>
       <strong><?=$this->localizedNumber($results->getStartRecord())?></strong> - <strong><?=$this->localizedNumber($results->getEndRecord())?></strong>
-      <? if (!isset($this->skipTotalCount)): ?>
+      <?php if (!isset($this->skipTotalCount)): ?>
         <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($recordTotal)?></strong> <?=$this->transEsc('Items')?>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
     <div class="pull-right flip">
       <?=$this->render('search/controls/limit.phtml', $searchDetails)?>
@@ -29,6 +29,6 @@
     <?=$this->render('search/list-' . $results->getParams()->getView() . '.phtml', $searchDetails)?>
     <?=$this->paginationControl($results->getPaginator(), 'Sliding', 'search/pagination.phtml', ['results' => $results])?>
   </form>
-<? else: ?>
+<?php else: ?>
   <?=$this->transEsc('collection_empty')?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/description.phtml
+++ b/themes/bootstrap3/templates/RecordTab/description.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Description') . ': ' . $this->driver->getBreadcrumb());
 
@@ -6,11 +6,11 @@
     $mainFields = $formatter->getData($driver, $formatter->getDefaults('description'));
 ?>
 <table class="table table-striped" summary="<?=$this->transEsc('Description')?>">
-  <? if (!empty($mainFields)): ?>
-    <? foreach ($mainFields as $key => $value): ?>
+  <?php if (!empty($mainFields)): ?>
+    <?php foreach ($mainFields as $key => $value): ?>
       <tr><th><?=$this->transEsc($key)?>:</th><td><?=$value?></td></tr>
-    <? endforeach; ?>
-  <? else: ?>
+    <?php endforeach; ?>
+  <?php else: ?>
     <tr><td><?=$this->transEsc('no_description')?></td></tr>
-  <? endif; ?>
+  <?php endif; ?>
 </table>

--- a/themes/bootstrap3/templates/RecordTab/excerpt.phtml
+++ b/themes/bootstrap3/templates/RecordTab/excerpt.phtml
@@ -1,18 +1,18 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Excerpt') . ': ' . $this->driver->getBreadcrumb());
 
     // Grab excerpt data:
     $excerpts = $this->tab->getContent();
 ?>
-<? if (count($excerpts) > 0): ?>
-  <? foreach ($excerpts as $provider => $list): ?>
-    <? foreach ($list as $excerpt): ?>
+<?php if (count($excerpts) > 0): ?>
+  <?php foreach ($excerpts as $provider => $list): ?>
+    <?php foreach ($list as $excerpt): ?>
       <p class="summary"><?=$excerpt['Content']?></p>
       <?=isset($excerpt['Copyright']) ? $excerpt['Copyright'] : ''?>
       <hr/>
-    <? endforeach; ?>
-  <? endforeach; ?>
-<? else: ?>
+    <?php endforeach; ?>
+  <?php endforeach; ?>
+<?php else: ?>
   <?=$this->transEsc('No excerpts were found for this record.')?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
+++ b/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('hierarchy_tree') . ': ' . $this->driver->getBreadcrumb());
   $hierarchyTreeList = $this->tab->getTreeList();
@@ -19,20 +19,20 @@
   $this->inlineScript(\Zend\View\Helper\HeadScript::FILE, 'hierarchyTree.js');
   echo $this->inlineScript();
 ?>
-<? if (count($hierarchyTreeList) > 1): ?>
+<?php if (count($hierarchyTreeList) > 1): ?>
   <div id="treeSelector">
-    <? foreach ($hierarchyTreeList as $hierarchy => $hierarchyTitle): ?>
-      <? if($activeTree == $hierarchy): ?>
+    <?php foreach ($hierarchyTreeList as $hierarchy => $hierarchyTitle): ?>
+      <?php if($activeTree == $hierarchy): ?>
         <i class="fa fa-sitemap" aria-hidden="true"></i> <?=$this->escapeHtml($hierarchyTitle)?>
-      <? else: ?>
+      <?php else: ?>
         <i class="fa fa-sitemap text-muted" aria-hidden="true"></i> <a href="<?=$this->recordLink()->getTabUrl($this->driver, 'HierarchyTree')?>?hierarchy=<?=urlencode($hierarchy)?>"><?=$this->escapeHtml($hierarchyTitle)?></a>
-      <? endif; ?>
-    <? endforeach; ?>
+      <?php endif; ?>
+    <?php endforeach; ?>
   </div>
-<? endif; ?>
-<? if ($activeTree): ?>
+<?php endif; ?>
+<?php if ($activeTree): ?>
   <div id="hierarchyTreeHolder">
-    <? if ($this->tab->searchActive()): ?>
+    <?php if ($this->tab->searchActive()): ?>
       <div id="treeSearch" class="form-inline hidden">
         <input type="text" id="treeSearchText" class="form-control search-query" value="">
         <select class="form-control" id="treeSearchType" name="type">
@@ -44,19 +44,19 @@
       </div>
       <div id="treeSearchNoResults" class="alert alert-danger hidden"><?=$this->translate('nohit_heading')?></div>
       <div id="treeSearchLimitReached" class="alert alert-danger hidden"><?=$this->translate('tree_search_limit_reached_html', ['%%url%%' => $this->url('search-results'), '%%limit%%' => $this->tab->getSearchLimit()])?></div>
-    <? endif; ?>
+    <?php endif; ?>
     <div id="hierarchyLoading" class="hide"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> <?=$this->transEsc("Loading")?>...</div>
     <div id="hierarchyTree" class="hierarchy-tree">
       <input type="hidden" value="<?=$this->escapeHtml($this->driver->getUniqueId())?>" class="hiddenRecordId" />
       <input type="hidden" value="<?=$this->escapeHtml($activeTree)?>" class="hiddenHierarchyId" />
       <input type="hidden" value="<?=isset($this->treeContext) ? $this->treeContext : 'Record'?>" class="hiddenContext" />
-      <? if ($this->layout()->getTemplate() != 'layout/lightbox'): ?>
+      <?php if ($this->layout()->getTemplate() != 'layout/lightbox'): ?>
         <noscript>
           <ul class="fa-ul">
             <?=$this->tab->renderTree($this->url('home'))?>
           </ul>
         </noscript>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up convenience variables:
     $account = $this->auth()->getManager();
     $user = $account->isLoggedIn();
@@ -19,165 +19,165 @@
 
 <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-<? if (!empty($holdings['blocks'])):?>
+<?php if (!empty($holdings['blocks'])):?>
   <div id="account-block-msg" class="alert alert-danger">
     <?=$this->transEsc('account_block_options_missing', ['%%details%%' => implode('; ', $holdings['blocks'])]) ?>
   </div>
-<? endif; ?>
+<?php endif; ?>
 
 <?=($offlineMode == "ils-offline") ? $this->render('Helpers/ils-offline.phtml', ['offlineModeMsg' => 'ils_offline_holdings_message']) : ''?>
-<? if (($this->ils()->getHoldsMode() == 'driver' && !empty($holdings['holdings'])) || $this->ils()->getTitleHoldsMode() == 'driver'): ?>
-  <? if ($account->loginEnabled() && $offlineMode != 'ils-offline'): ?>
-    <? if (!$user): ?>
+<?php if (($this->ils()->getHoldsMode() == 'driver' && !empty($holdings['holdings'])) || $this->ils()->getTitleHoldsMode() == 'driver'): ?>
+  <?php if ($account->loginEnabled() && $offlineMode != 'ils-offline'): ?>
+    <?php if (!$user): ?>
       <div class="alert alert-info">
         <a href="<?=$this->recordLink()->getTabUrl($this->driver, 'Holdings')?>?login=true&amp;catalogLogin=true" data-lightbox><?=$this->transEsc("Login")?></a> <?=$this->transEsc("hold_login")?>
       </div>
-    <? elseif (!$user->cat_username): ?>
+    <?php elseif (!$user->cat_username): ?>
       <div class="alert alert-info">
         <?=$this->translate("hold_profile_html", ['%%url%%' => $this->recordLink()->getTabUrl($this->driver, 'Holdings') . '?catalogLogin=true'])?>
       </div>
-    <? endif; ?>
-  <? endif; ?>
-<? endif; ?>
-<? $holdingTitleHold = $this->driver->tryMethod('getRealTimeTitleHold'); if (!empty($holdingTitleHold)): ?>
+    <?php endif; ?>
+  <?php endif; ?>
+<?php endif; ?>
+<?php $holdingTitleHold = $this->driver->tryMethod('getRealTimeTitleHold'); if (!empty($holdingTitleHold)): ?>
   <a class="placehold" data-lightbox title="<?=$this->transEsc('request_place_text')?>" href="<?=$this->recordLink()->getRequestUrl($holdingTitleHold)?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc('title_hold_place')?></a>
-<? endif; ?>
-<? if (!empty($urls) || $openUrlActive): ?>
+<?php endif; ?>
+<?php if (!empty($urls) || $openUrlActive): ?>
   <h3><?=$this->transEsc("Internet")?></h3>
-  <? if (!empty($urls)): ?>
-    <? foreach ($urls as $current): ?>
+  <?php if (!empty($urls)): ?>
+    <?php foreach ($urls as $current): ?>
       <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br/>
-    <? endforeach; ?>
-  <? endif; ?>
-  <? if ($openUrlActive): ?><?=$openUrl->renderTemplate()?><? endif; ?>
-<? endif; ?>
-<? foreach ($holdings['holdings'] as $holding): ?>
+    <?php endforeach; ?>
+  <?php endif; ?>
+  <?php if ($openUrlActive): ?><?=$openUrl->renderTemplate()?><?php endif; ?>
+<?php endif; ?>
+<?php foreach ($holdings['holdings'] as $holding): ?>
 <h3>
-  <? $locationText = $this->transEsc('location_' . $holding['location'], [], $holding['location']); ?>
-  <? if (isset($holding['locationhref']) && $holding['locationhref']): ?>
+  <?php $locationText = $this->transEsc('location_' . $holding['location'], [], $holding['location']); ?>
+  <?php if (isset($holding['locationhref']) && $holding['locationhref']): ?>
     <a href="<?=$holding['locationhref']?>" target="_blank"><?=$locationText?></a>
-  <? else: ?>
+  <?php else: ?>
     <?=$locationText?>
-  <? endif; ?>
+  <?php endif; ?>
 </h3>
 <table class="table table-striped" summary="<?=$this->transEsc('Holdings details from')?> <?=$this->transEsc($holding['location'])?>">
-  <? $callNos = $this->tab->getUniqueCallNumbers($holding['items']); if (!empty($callNos)): ?>
+  <?php $callNos = $this->tab->getUniqueCallNumbers($holding['items']); if (!empty($callNos)): ?>
   <tr>
     <th><?=$this->transEsc("Call Number")?>: </th>
     <td width="50%">
-      <? foreach ($callNos as $callNo): ?>
-        <? if ($this->callnumberHandler): ?>
+      <?php foreach ($callNos as $callNo): ?>
+        <?php if ($this->callnumberHandler): ?>
           <a href="<?=$this->url('alphabrowse-home') ?>?source=<?=$this->escapeHtmlAttr($this->callnumberHandler) ?>&amp;from=<?=$this->escapeHtmlAttr($callNo) ?>"><?=$this->escapeHtml($callNo)?></a>
-        <? else: ?>
+        <?php else: ?>
           <?=$this->escapeHtml($callNo)?>
-        <? endif; ?>
+        <?php endif; ?>
         <br />
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </td>
   </tr>
-  <? endif; ?>
-  <? if (isset($holding['textfields'])): foreach ($holding['textfields'] as $textFieldName => $textFields): ?>
+  <?php endif; ?>
+  <?php if (isset($holding['textfields'])): foreach ($holding['textfields'] as $textFieldName => $textFields): ?>
     <tr>
-      <? // Translation for summary is a special case for backwards-compatibility ?>
+      <?php // Translation for summary is a special case for backwards-compatibility ?>
       <th><?=$textFieldName == 'summary' ? $this->transEsc("Volume Holdings") : $this->transEsc(ucfirst($textFieldName))?>:</th>
       <td>
-        <? foreach ($textFields as $current): ?>
+        <?php foreach ($textFields as $current): ?>
           <?=$this->escapeHtml($current)?><br/>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </td>
     </tr>
-  <? endforeach; endif; ?>
-  <? foreach ($holding['items'] as $row): ?>
-    <?
+  <?php endforeach; endif; ?>
+  <?php foreach ($holding['items'] as $row): ?>
+    <?php
       // AJAX Check record?
       $check = isset($row['check']) && $row['check'];
       $checkStorageRetrievalRequest = isset($row['checkStorageRetrievalRequest']) && $row['checkStorageRetrievalRequest'];
       $checkILLRequest = isset($row['checkILLRequest']) && $row['checkILLRequest'];
     ?>
-    <? if (isset($row['barcode']) && $row['barcode'] != ""): ?>
+    <?php if (isset($row['barcode']) && $row['barcode'] != ""): ?>
       <tr vocab="http://schema.org/" typeof="Offer">
         <th><?=$this->transEsc("Copy")?> <?=$this->escapeHtml($row['number'])?></th>
         <td>
-          <? if ($row['reserve'] == "Y"): ?>
+          <?php if ($row['reserve'] == "Y"): ?>
             <link property="availability" href="http://schema.org/InStoreOnly" />
             <?=$this->transEsc("On Reserve - Ask at Circulation Desk")?><br />
-          <? endif; ?>
-          <? if (isset($row['use_unknown_message']) && $row['use_unknown_message']): ?>
+          <?php endif; ?>
+          <?php if (isset($row['use_unknown_message']) && $row['use_unknown_message']): ?>
             <span class="text-muted"><?=$this->transEsc("status_unknown_message")?></span>
-          <? else: ?>
-            <? if ($row['availability']): ?>
-              <? /* Begin Available Items (Holds) */ ?>
+          <?php else: ?>
+            <?php if ($row['availability']): ?>
+              <?php /* Begin Available Items (Holds) */ ?>
                <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock" /></span>
-              <? if (isset($row['link']) && $row['link']): ?>
+              <?php if (isset($row['link']) && $row['link']): ?>
                 <a class="<?=$check ? 'checkRequest ' : ''?>placehold" data-lightbox href="<?=$this->recordLink()->getRequestUrl($row['link'])?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc($check ? "Check Hold" : "Place a Hold")?></a>
-              <? endif; ?>
-              <? if (isset($row['storageRetrievalRequestLink']) && $row['storageRetrievalRequestLink']): ?>
+              <?php endif; ?>
+              <?php if (isset($row['storageRetrievalRequestLink']) && $row['storageRetrievalRequestLink']): ?>
                 <a class="<?=$checkStorageRetrievalRequest ? 'checkStorageRetrievalRequest ' : ''?> placeStorageRetrievalRequest" data-lightbox href="<?=$this->recordLink()->getRequestUrl($row['storageRetrievalRequestLink'])?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc($checkStorageRetrievalRequest ? "storage_retrieval_request_check_text" : "storage_retrieval_request_place_text")?></a>
-              <? endif; ?>
-              <? if (isset($row['ILLRequestLink']) && $row['ILLRequestLink']): ?>
+              <?php endif; ?>
+              <?php if (isset($row['ILLRequestLink']) && $row['ILLRequestLink']): ?>
                 <a class="<?=$checkILLRequest ? 'checkILLRequest ' : ''?>placeILLRequest" data-lightbox href="<?=$this->recordLink()->getRequestUrl($row['ILLRequestLink'])?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc($checkILLRequest ? "ill_request_check_text" : "ill_request_place_text")?></a>
-              <? endif; ?>
-            <? else: ?>
-              <? /* Begin Unavailable Items (Recalls) */ ?>
+              <?php endif; ?>
+            <?php else: ?>
+              <?php /* Begin Unavailable Items (Recalls) */ ?>
               <span class="text-danger"><?=$this->transEsc($row['status'])?><link property="availability" href="http://schema.org/OutOfStock" /></span>
-              <? if (isset($row['returnDate']) && $row['returnDate']): ?>&ndash; <span class="small"><?=$this->escapeHtml($row['returnDate'])?></span><? endif; ?>
-              <? if (isset($row['duedate']) && $row['duedate']): ?>
+              <?php if (isset($row['returnDate']) && $row['returnDate']): ?>&ndash; <span class="small"><?=$this->escapeHtml($row['returnDate'])?></span><?php endif; ?>
+              <?php if (isset($row['duedate']) && $row['duedate']): ?>
                 &ndash; <span class="small"><?=$this->transEsc("Due")?>: <?=$this->escapeHtml($row['duedate'])?></span>
-              <? endif; ?>
-              <? if (isset($row['requests_placed']) && $row['requests_placed'] > 0): ?>
+              <?php endif; ?>
+              <?php if (isset($row['requests_placed']) && $row['requests_placed'] > 0): ?>
                 <span><?=$this->transEsc("Requests")?>: <?=$this->escapeHtml($row['requests_placed'])?></span>
-              <? endif; ?>
-              <? if (isset($row['link']) && $row['link']): ?>
+              <?php endif; ?>
+              <?php if (isset($row['link']) && $row['link']): ?>
                 <a class="<?=$check ? 'checkRequest' : ''?> placehold" data-lightbox href="<?=$this->recordLink()->getRequestUrl($row['link'])?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc($check ? "Check Recall" : "Recall This")?></a>
-              <? endif; ?>
-            <? endif; ?>
-            <? if (isset($row['item_notes'])): ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php if (isset($row['item_notes'])): ?>
               <div class="item-notes">
                 <b><?=$this->transEsc("Item Notes")?>:</b>
                 <ul>
-                  <? foreach ($row['item_notes'] as $item_note): ?>
+                  <?php foreach ($row['item_notes'] as $item_note): ?>
                     <li><?=$this->escapeHtml($item_note) ?></li>
-                  <? endforeach; ?>
+                  <?php endforeach; ?>
                 </ul>
               </div>
-            <? endif; ?>
-          <? endif; ?>
-          <? /* Embed item structured data: library, barcode, call number */ ?>
-          <? if ($row['location']): ?>
+            <?php endif; ?>
+          <?php endif; ?>
+          <?php /* Embed item structured data: library, barcode, call number */ ?>
+          <?php if ($row['location']): ?>
             <meta property="seller" content="<?=$this->escapeHtmlAttr($row['location'])?>" />
-          <? endif; ?>
-          <? if ($row['barcode']): ?>
+          <?php endif; ?>
+          <?php if ($row['barcode']): ?>
             <meta property="serialNumber" content="<?=$this->escapeHtmlAttr($row['barcode'])?>" />
-          <? endif; ?>
-          <? if ($row['callnumber']): ?>
+          <?php endif; ?>
+          <?php if ($row['callnumber']): ?>
             <meta property="sku" content="<?=$this->escapeHtmlAttr($row['callnumber'])?>" />
-          <? endif; ?>
-          <? /* Declare that the item is to be borrowed, not for sale */ ?>
+          <?php endif; ?>
+          <?php /* Declare that the item is to be borrowed, not for sale */ ?>
             <link property="businessFunction" href="http://purl.org/goodrelations/v1#LeaseOut" />
             <link property="itemOffered" href="#record" />
         </td>
       </tr>
-    <? endif; ?>
-  <? endforeach; ?>
-  <? if (!empty($holding['purchase_history'])): ?>
+    <?php endif; ?>
+  <?php endforeach; ?>
+  <?php if (!empty($holding['purchase_history'])): ?>
     <tr>
       <th><?=$this->transEsc("Most Recent Received Issues")?>:</th>
       <td>
-        <? foreach ($holding['purchase_history'] as $current): ?>
+        <?php foreach ($holding['purchase_history'] as $current): ?>
           <?=$this->escapeHtml($current['issue'])?><br/>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </td>
     </tr>
-  <? endif; ?>
+  <?php endif; ?>
 </table>
-<? endforeach; ?>
+<?php endforeach; ?>
 
-<? $history = $this->driver->getRealTimeHistory(); ?>
-<? if (is_array($history) && !empty($history)): ?>
+<?php $history = $this->driver->getRealTimeHistory(); ?>
+<?php if (is_array($history) && !empty($history)): ?>
 <h3><?=$this->transEsc("Most Recent Received Issues")?></h3>
 <table class="table table-striped">
-  <? foreach ($history as $row): ?>
+  <?php foreach ($history as $row): ?>
     <tr><td><?=$this->escapeHtml($row['issue'])?></td></tr>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </table>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsworldcat.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsworldcat.phtml
@@ -1,14 +1,14 @@
-<? $holdings = $this->tab->getHoldings(); if ($holdings && count($holdings) > 0): ?>
+<?php $holdings = $this->tab->getHoldings(); if ($holdings && count($holdings) > 0): ?>
 <h3><?=$this->transEsc('Holdings at Other Libraries')?></h3>
 <table class="table table-striped">
-<? foreach ($holdings as $holding): ?>
+<?php foreach ($holdings as $holding): ?>
   <tr>
     <th colspan="2">
-      <? if (isset($holding->electronicAddress->text) && !empty($holding->electronicAddress->text)): ?>
+      <?php if (isset($holding->electronicAddress->text) && !empty($holding->electronicAddress->text)): ?>
       <a href="<?=$this->escapeHtmlAttr($holding->electronicAddress->text)?>"><?=$this->escapeHtml($holding->physicalLocation)?></a>
-      <? else: ?>
+      <?php else: ?>
       <?=$this->escapeHtml($holding->physicalLocation)?>
-      <? endif; ?>
+      <?php endif; ?>
     </th>
   </tr>
   <tr>
@@ -19,6 +19,6 @@
     <th><?=$this->transEsc('Copies')?>: </th>
     <td><?=$this->escapeHtml($holding->holdingSimple->copiesSummary->copiesCount)?></td>
   </tr>
-<? endforeach; ?>
+<?php endforeach; ?>
 </table>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/map.phtml
+++ b/themes/bootstrap3/templates/RecordTab/map.phtml
@@ -1,6 +1,6 @@
-<? $mapType = $this->tab->getMapType(); ?>
-<? if (isset($mapType) && ($mapType == 'openlayers')) : ?>
-  <? $this->headScript()->appendFile('vendor/ol/ol.js');
+<?php $mapType = $this->tab->getMapType(); ?>
+<?php if (isset($mapType) && ($mapType == 'openlayers')) : ?>
+  <?php $this->headScript()->appendFile('vendor/ol/ol.js');
   $this->headScript()->appendFile('map_tab_ol.js');
   $this->headLink()->appendStylesheet('vendor/ol/ol.css');
   $mapTabData = $this->tab->getMapTabData();
@@ -12,8 +12,8 @@
     <div id="map-canvas" style="width: 100%; height: 100%"><div id="popup"></div></div>
     <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET');?>
   </div>
-<? endif; ?>
-<? if (isset($mapType) && ($mapType == 'google')) : ?>
+<?php endif; ?>
+<?php if (isset($mapType) && ($mapType == 'google')) : ?>
   <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<?=$this->tab->getGoogleMapApiKey()?>&amp;language=<?=$this->layout()->userLang?>"></script>
   <script type="text/javascript">
   var markers;
@@ -76,4 +76,4 @@
 <div id="wrap" onload="initialize()" style="width: 674px; height: 479px">
   <div id="map_canvas" style="width: 100%; height: 100%"></div>
 </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/preview.phtml
+++ b/themes/bootstrap3/templates/RecordTab/preview.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Preview') . ': ' . $this->driver->getBreadcrumb());
 

--- a/themes/bootstrap3/templates/RecordTab/reviews.phtml
+++ b/themes/bootstrap3/templates/RecordTab/reviews.phtml
@@ -1,32 +1,32 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Reviews') . ': ' . $this->driver->getBreadcrumb());
 
     // Grab review data:
     $reviews = $this->tab->getContent();
 ?>
-<? if (count($reviews) > 0): ?>
-  <? foreach ($reviews as $provider => $list): ?>
-    <? foreach ($list as $review): ?>
-      <? if (isset($review['Summary']) && !empty($review['Summary'])): ?>
+<?php if (count($reviews) > 0): ?>
+  <?php foreach ($reviews as $provider => $list): ?>
+    <?php foreach ($list as $review): ?>
+      <?php if (isset($review['Summary']) && !empty($review['Summary'])): ?>
         <p>
-          <? if (isset($review['Rating'])): ?>
+          <?php if (isset($review['Rating'])): ?>
             <img src="<?=$this->imageLink($review['Rating'] . '.gif')?>" alt="<?=$review['Rating']?>/5 Stars"/>
-          <? endif; ?>
+          <?php endif; ?>
           <strong><?=$review['Summary']?></strong> <?=isset($review['Date']) ? strftime('%B %e, %Y', strtotime($review['Date'])) : ''?>
         </p>
-      <? endif; ?>
-      <? if (isset($review['Source'])): ?><strong><?=$this->transEsc('Review by')?> <?=$review['Source']?></strong><? endif; ?>
+      <?php endif; ?>
+      <?php if (isset($review['Source'])): ?><strong><?=$this->transEsc('Review by')?> <?=$review['Source']?></strong><?php endif; ?>
       <p class="summary">
         <?=isset($review['Content']) ? $review['Content'] : ''?>
-        <? if ((!isset($review['Content']) || empty($review['Content'])) && isset($review['ReviewURL'])): ?>
+        <?php if ((!isset($review['Content']) || empty($review['Content'])) && isset($review['ReviewURL'])): ?>
           <a target="new" href="<?=$this->escapeHtmlAttr($review['ReviewURL'])?>"><?=$this->transEsc('Read the full review online...')?></a>
-        <? endif; ?>
+        <?php endif; ?>
       </p>
       <?=isset($review['Copyright']) ? $review['Copyright'] : ''?>
       <hr/>
-    <? endforeach; ?>
-  <? endforeach; ?>
-<? else: ?>
+    <?php endforeach; ?>
+  <?php endforeach; ?>
+<?php else: ?>
   <?=$this->transEsc('No reviews were found for this record')?>.
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
@@ -1,45 +1,45 @@
 <h4><?=$this->transEsc('Similar Items')?></h4>
-<? $similarRecords = $this->tab->getResults(); ?>
-<? if (!empty($similarRecords)): ?>
-  <? $perPage = 4 ?>
+<?php $similarRecords = $this->tab->getResults(); ?>
+<?php if (!empty($similarRecords)): ?>
+  <?php $perPage = 4 ?>
   <div id="similar-items-carousel" class="carousel slide" data-ride="carousel">
     <!-- Indicators -->
     <ol class="carousel-indicators">
       <li data-target="#similar-items-carousel" data-slide-to="0" class="active"></li>
-      <? for($i=1;$i<count($similarRecords)/$perPage;$i++): ?>
+      <?php for($i=1;$i<count($similarRecords)/$perPage;$i++): ?>
         <li data-target="#similar-items-carousel" data-slide-to="<?=$i ?>"></li>
-      <? endfor; ?>
+      <?php endfor; ?>
     </ol>
 
     <!-- Wrapper for slides -->
     <div class="carousel-inner">
       <div class="item active">
         <div class="row">
-          <? foreach ($similarRecords as $index=>$data): ?>
+          <?php foreach ($similarRecords as $index=>$data): ?>
             <div class="col-sm-<?=floor(12/$perPage) ?>">
               <a class="hover-overlay" href="<?=$this->recordLink()->getUrl($data)?>">
-                <? $thumb = $this->record($data)->getThumbnail('large'); ?>
+                <?php $thumb = $this->record($data)->getThumbnail('large'); ?>
                 <img src="<?=$thumb ?>" title="<?=$data->getTitle() ?>"/>
                 <div class="content">
-                  <? $formats = $data->getFormats(); ?>
-                  <i class="fa fa-x<? if (count($formats) > 0): ?> fa-<?=preg_replace('/[^a-z0-9]/', '', strtolower($formats[0]))?>" title="<?=$formats[0] ?><? endif; ?>"></i>
+                  <?php $formats = $data->getFormats(); ?>
+                  <i class="fa fa-x<?php if (count($formats) > 0): ?> fa-<?=preg_replace('/[^a-z0-9]/', '', strtolower($formats[0]))?>" title="<?=$formats[0] ?><?php endif; ?>"></i>
                   <b><?=$this->escapeHtml($data->getTitle())?></b>
-                  <? $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
-                    <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><? if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?>
-                  <? endif; ?>
-                  <? $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
+                  <?php $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
+                    <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
+                  <?php endif; ?>
+                  <?php $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
                     <br/><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
-                  <? endif; ?>
+                  <?php endif; ?>
                 </div>
               </a>
             </div>
-            <? if(($index+1) % $perPage == 0 && $index < count($similarRecords)-1): ?>
+            <?php if(($index+1) % $perPage == 0 && $index < count($similarRecords)-1): ?>
           </div>
         </div>
         <div class="item">
           <div class="row">
-            <? endif; ?>
-          <? endforeach; ?>
+            <?php endif; ?>
+          <?php endforeach; ?>
         </div>
       </div>
     </div>
@@ -52,10 +52,10 @@
       <span class="fa fa-chevron-right glyphicon-chevron-right" title="<?=$this->transEsc('Next') ?>"></span>
     </a>
   </div>
-<? else: ?>
+<?php else: ?>
   <p><?=$this->transEsc('Cannot find similar records')?></p>
-<? endif; ?>
-<?
+<?php endif; ?>
+<?php
   $script = <<<JS
 var normalizeHeightCount = $('#similar-items-carousel img').length;
 function normalizeHeights() {

--- a/themes/bootstrap3/templates/RecordTab/staffviewarray.phtml
+++ b/themes/bootstrap3/templates/RecordTab/staffviewarray.phtml
@@ -1,17 +1,17 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Staff View') . ': ' . $this->driver->getBreadcrumb());
 ?>
 <table class="citation table table-striped">
-  <? foreach ($this->driver->getRawData() as $field => $values): ?>
+  <?php foreach ($this->driver->getRawData() as $field => $values): ?>
     <tr>
       <th><?=$this->escapeHtml($field)?></th>
       <td>
-        <? if (!is_array($values)) { $values = [$values]; } ?>
-        <? foreach ($values as $value): ?>
+        <?php if (!is_array($values)) { $values = [$values]; } ?>
+        <?php foreach ($values as $value): ?>
           <?=$this->escapeHtml(is_array($value) ? print_r($value, true) : $value)?><br />
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </td>
     </tr>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </table>

--- a/themes/bootstrap3/templates/RecordTab/staffviewmarc.phtml
+++ b/themes/bootstrap3/templates/RecordTab/staffviewmarc.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Staff View') . ': ' . $this->driver->getBreadcrumb());
 ?>

--- a/themes/bootstrap3/templates/RecordTab/toc.phtml
+++ b/themes/bootstrap3/templates/RecordTab/toc.phtml
@@ -1,16 +1,16 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Table of Contents') . ': ' . $this->driver->getBreadcrumb());
 
     $toc = $this->driver->getTOC();
 ?>
-<? if (!empty($toc)): ?>
+<?php if (!empty($toc)): ?>
   <strong><?=$this->transEsc('Table of Contents')?>: </strong>
   <ul class="toc">
-    <? foreach ($toc as $line): ?>
+    <?php foreach ($toc as $line): ?>
       <li><?=$this->escapeHtml($line)?></li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
-<? else: ?>
+<?php else: ?>
   <?=$this->transEsc("Table of Contents unavailable")?>.
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/usercomments.phtml
+++ b/themes/bootstrap3/templates/RecordTab/usercomments.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Comments') . ': ' . $this->driver->getBreadcrumb());
 ?>
@@ -14,16 +14,16 @@
       <strong><?=$this->transEsc("Your Comment")?></strong>
     </div>
     <div class="col-sm-9">
-      <? $user = $this->auth()->isLoggedIn() ?>
-      <? if($user): ?>
+      <?php $user = $this->auth()->isLoggedIn() ?>
+      <?php if($user): ?>
         <textarea name="comment" class="form-control" rows="3" required></textarea><br/>
-        <? if ($this->tab->isRecaptchaActive()): ?>
+        <?php if ($this->tab->isRecaptchaActive()): ?>
           <?=$this->recaptcha()->html(true, false) ?><br/>
-        <? endif; ?>
+        <?php endif; ?>
         <input class="btn btn-primary" data-loading-text="<?=$this->transEsc('Submitting') ?>..." type="submit" value="<?=$this->transEsc("Add your comment")?>"/>
-      <? else: ?>
+      <?php else: ?>
         <a href="<?=$this->url('myresearch-userlogin') ?>" class="btn btn-primary" data-lightbox title="Login"><i class="fa fa-sign-in" aria-hidden="true"></i> <?=$this->transEsc("You must be logged in first") ?></a>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
   </div>
 </form>

--- a/themes/bootstrap3/templates/Related/Deprecated.phtml
+++ b/themes/bootstrap3/templates/Related/Deprecated.phtml
@@ -1,2 +1,2 @@
-<? /* do nothing -- this module is a placeholder for old deprecated features
+<?php /* do nothing -- this module is a placeholder for old deprecated features
       to prevent legacy configurations from causing fatal errors. */ ?>

--- a/themes/bootstrap3/templates/Related/Similar.phtml
+++ b/themes/bootstrap3/templates/Related/Similar.phtml
@@ -1,23 +1,23 @@
 <h4><?=$this->transEsc('Similar Items')?></h4>
-<? $similarRecords = $this->related->getResults(); ?>
-<? if (!empty($similarRecords)): ?>
+<?php $similarRecords = $this->related->getResults(); ?>
+<?php if (!empty($similarRecords)): ?>
   <ul class="list-group">
-    <? foreach ($similarRecords as $data): ?>
+    <?php foreach ($similarRecords as $data): ?>
       <li class="list-group-item">
-        <? $formats = $data->getFormats(); ?>
-        <i class="fa fa-x<? if (count($formats) > 0): ?> fa-<?=preg_replace('/[^a-z0-9]/', '', strtolower($formats[0]))?>" title="<?=$formats[0] ?><? endif; ?>"></i>
+        <?php $formats = $data->getFormats(); ?>
+        <i class="fa fa-x<?php if (count($formats) > 0): ?> fa-<?=preg_replace('/[^a-z0-9]/', '', strtolower($formats[0]))?>" title="<?=$formats[0] ?><?php endif; ?>"></i>
         <a href="<?=$this->recordLink()->getUrl($data)?>">
           <?=$this->escapeHtml($data->getTitle())?>
         </a>
-        <? $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
-          <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><? if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?>
-        <? endif; ?>
-        <? $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
+        <?php $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
+          <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
+        <?php endif; ?>
+        <?php $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
           <br/><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
-        <? endif; ?>
+        <?php endif; ?>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
-<? else: ?>
+<?php else: ?>
   <p><?=$this->transEsc('Cannot find similar records')?></p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/admin/config/home.phtml
+++ b/themes/bootstrap3/templates/admin/config/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('VuFind Administration - Configuration'));
 ?>
@@ -8,12 +8,12 @@
     <?=$this->flashmessages()?>
     <p>Most VuFind configuration is handled by editing the configuration files in <strong><?=$this->escapeHtml($this->baseConfigPath)?></strong>.</p>
     <p>Some basic settings can also be adjusted through the auto-configuration tool.</p>
-    <? if (!$this->showInstallLink): ?>
+    <?php if (!$this->showInstallLink): ?>
       <p><?=$this->transEsc('Auto configuration is currently disabled') ?>.</p>
       <p><a href="<?=$this->url('admin/config', array('action' => 'EnableAutoConfig'))?>"><?=$this->transEsc('Enable Auto Config')?></a></p>
-    <? else: ?>
+    <?php else: ?>
       <p><a href="<?=$this->url('install-home')?>"><?=$this->transEsc('auto_configure_title')?></a></p>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/admin/home.phtml
+++ b/themes/bootstrap3/templates/admin/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('VuFind Administration - Home'));
 
@@ -13,34 +13,34 @@
 <div class="row">
   <div class="<?=$this->layoutClass('mainbody')?>">
     <h2><?=$this->transEsc('VuFind Administration')?></h2>
-    <? $cores = is_object($this->xml) ? $this->xml->xpath('/response/lst[@name="status"]/lst') : []; ?>
-    <? foreach ($cores as $core): ?>
-      <? $coreName = (string)$core['name']; ?>
-      <? $coreLabel = isset($coreLabels[$coreName]) ? $coreLabels[$coreName] : ucwords($coreName) . ' Index'; ?>
+    <?php $cores = is_object($this->xml) ? $this->xml->xpath('/response/lst[@name="status"]/lst') : []; ?>
+    <?php foreach ($cores as $core): ?>
+      <?php $coreName = (string)$core['name']; ?>
+      <?php $coreLabel = isset($coreLabels[$coreName]) ? $coreLabels[$coreName] : ucwords($coreName) . ' Index'; ?>
       <h3><?=$this->transEsc($coreLabel)?></h3>
       <table class="table table-striped">
         <tr>
           <th><?=$this->transEsc('Record Count')?>: </th>
-          <? $recordCount = $core->xpath('//lst[@name="' . $coreName . '"]/lst/int[@name="numDocs"]') ?>
+          <?php $recordCount = $core->xpath('//lst[@name="' . $coreName . '"]/lst/int[@name="numDocs"]') ?>
           <td><?=$this->escapeHtml((string)array_pop($recordCount))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Start Time')?>: </th>
-          <? $startTime = $core->xpath('//lst[@name="' . $coreName . '"]/date[@name="startTime"]') ?>
+          <?php $startTime = $core->xpath('//lst[@name="' . $coreName . '"]/date[@name="startTime"]') ?>
           <td><?=$this->escapeHtml(strftime("%b %d, %Y %l:%M:%S%p", strtotime((string)array_pop($startTime))))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Last Modified')?>: </th>
-          <? $lastModified = $core->xpath('//lst[@name="' . $coreName . '"]/lst/date[@name="lastModified"]') ?>
+          <?php $lastModified = $core->xpath('//lst[@name="' . $coreName . '"]/lst/date[@name="lastModified"]') ?>
           <td><?=$this->escapeHtml(strftime("%b %d, %Y %l:%M:%S%p", strtotime((string)array_pop($lastModified))))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Uptime')?>: </th>
-          <? $uptime = $core->xpath('//lst[@name="' . $coreName . '"]/long[@name="uptime"]') ?>
+          <?php $uptime = $core->xpath('//lst[@name="' . $coreName . '"]/long[@name="uptime"]') ?>
           <td><?=$this->printms((string)array_pop($uptime))?></td>
         </tr>
       </table>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/admin/maintenance/home.phtml
+++ b/themes/bootstrap3/templates/admin/maintenance/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('VuFind Administration - System Maintenance'));
 ?>
@@ -22,9 +22,9 @@
     <hr />
     <form method="get" action="<?=$this->url('admin/maintenance', array('action' => 'ClearCache'))?>">
       Clear cache(s):
-      <? foreach ($caches as $cache): ?>
+      <?php foreach ($caches as $cache): ?>
         <input type="checkbox" checked="checked" name="cache[]" value="<?=$this->escapeHtmlAttr($cache)?>" /> <?=$this->escapeHtml($cache) ?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       <input type="submit" name="submit" value="<?=$this->transEsc('Submit')?>"/>
     </form>
   </div>

--- a/themes/bootstrap3/templates/admin/socialstats/home.phtml
+++ b/themes/bootstrap3/templates/admin/socialstats/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('VuFind Administration - Social Statistics'));
 ?>

--- a/themes/bootstrap3/templates/admin/tags/home.phtml
+++ b/themes/bootstrap3/templates/admin/tags/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('VuFind Administration - Tag Management'));
 ?>

--- a/themes/bootstrap3/templates/admin/tags/list.phtml
+++ b/themes/bootstrap3/templates/admin/tags/list.phtml
@@ -23,41 +23,41 @@
               <label for="user_id"><?=$this->translate('Username')?></label>
               <select name="user_id" id="user_id" class="form-control">
                 <option value="ALL"><?=$this->translate('All')?></option>
-                <? foreach($this->uniqueUsers as $user):?>
-                  <option value="<?= $user['user_id'] ?>"<? if(isset($this->params['user_id']) && $user['user_id'] == $this->params['user_id']): ?> selected="selected"<? endif;?>>
+                <?php foreach($this->uniqueUsers as $user):?>
+                  <option value="<?= $user['user_id'] ?>"<?php if(isset($this->params['user_id']) && $user['user_id'] == $this->params['user_id']): ?> selected="selected"<?php endif;?>>
                     <?=$user['username'] ?>
                   </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-3">
               <label for="tag_id"><?=$this->translate('Tag')?></label>
               <select name="tag_id" id="tag_id" class="form-control">
                 <option value="ALL"><?=$this->translate('All')?></option>
-                <? foreach($this->uniqueTags as $tag):?>
-                <option value="<?= $tag['tag_id'] ?>"<? if(isset($this->params['tag_id']) && $tag['tag_id'] == $this->params['tag_id']): ?> selected="selected"<? endif;?>>
+                <?php foreach($this->uniqueTags as $tag):?>
+                <option value="<?= $tag['tag_id'] ?>"<?php if(isset($this->params['tag_id']) && $tag['tag_id'] == $this->params['tag_id']): ?> selected="selected"<?php endif;?>>
                     <?=$tag['tag'] ?>
                 </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-3">
               <label for="resource_id"><?=$this->translate('Title')?></label>
               <select name="resource_id" id="resource_id" class="form-control">
                 <option value="ALL"><?=$this->translate('All')?></option>
-                <? foreach($this->uniqueResources as $resource):?>
-                <option value="<?= $resource['resource_id']; ?>" title="<?=$resource['title'] ?>"<? if(isset($this->params['resource_id']) && $resource['resource_id'] == $this->params['resource_id']): ?> selected="selected"<? endif;?>>
+                <?php foreach($this->uniqueResources as $resource):?>
+                <option value="<?= $resource['resource_id']; ?>" title="<?=$resource['title'] ?>"<?php if(isset($this->params['resource_id']) && $resource['resource_id'] == $this->params['resource_id']): ?> selected="selected"<?php endif;?>>
                     <?=$this->truncate($resource['title'], 80) ?> (<?=$resource['resource_id'] ?>)
                 </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-3">
               <label for="taglistsubmit">&nbsp;</label><br />
               <input type="submit" id="taglistsubmit" value="<?=$this->transEsc('Filter')?>" class="btn btn-primary">
-              <? if((isset($this->params['user_id']) && !is_null($this->params['user_id'])) || (isset($this->params['tag_id']) && !is_null($this->params['tag_id'])) || (isset($this->params['resource_id']) && !is_null($this->params['resource_id']))):?>
+              <?php if((isset($this->params['user_id']) && !is_null($this->params['user_id'])) || (isset($this->params['tag_id']) && !is_null($this->params['tag_id'])) || (isset($this->params['resource_id']) && !is_null($this->params['resource_id']))):?>
                 <a href="<?= $this->url('admin/tags', array('action' => 'List')); ?>"><?=$this->translate('clear_tag_filter')?></a>
-              <? endif;?>
+              <?php endif;?>
             </div>
           </div>
 
@@ -66,7 +66,7 @@
       </form>
     </div>
 
-    <? if(count($this->results) > 0):?>
+    <?php if(count($this->results) > 0):?>
       <div class="tagsList">
         <form action="<?= $this->url('admin/tags', array('action' => 'Delete'))?>" method="post">
           <input type="hidden" name="user_id" value="<?=isset($this->params['user_id']) ? $this->params['user_id'] : '' ?>" />
@@ -82,14 +82,14 @@
               <th><?=$this->translate('Title')?></th>
             </tr>
 
-            <? foreach ($this->results as $tag): ?>
+            <?php foreach ($this->results as $tag): ?>
               <tr>
                 <td><?=$this->render('admin/tags/checkbox', array('tag'=>$tag)) ; ?></td>
                 <td><?=$tag->username ?> (<?= $tag->user_id?>)</td>
                 <td><?=$tag->tag?> (<?= $tag->tag_id?>)</td>
                 <td><?=$tag->title?> (<?= $tag->resource_id?>)</td>
               </tr>
-            <? endforeach;?>
+            <?php endforeach;?>
           </table>
 
           <input type="submit" name="deleteSelected" value="<?=$this->transEsc('delete_selected')?>" class="btn btn-default">
@@ -99,9 +99,9 @@
         </form>
       </div>
       <?=$this->paginationControl($this->results, 'Sliding', 'Helpers/pagination.phtml', array('params' => $this->params))?>
-    <? else:?>
+    <?php else:?>
       <p><?=$this->translate('tag_filter_empty')?></p>
-    <? endif;?>
+    <?php endif;?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/admin/tags/manage.phtml
+++ b/themes/bootstrap3/templates/admin/tags/manage.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('VuFind Administration - Tag Maintenance'));
 ?>
@@ -16,9 +16,9 @@
         <label for="type" class="col-sm-2 control-label"><?=$this->translate('delete_tags_by')?>:</label>
         <div class="col-sm-6">
           <select id="type" name="type" class="form-control">
-            <option value="user" <? if("user" == $this->type) echo " selected=selected";?>><?=$this->translate('Username')?></option>
-            <option value="tag" <? if("tag" == $this->type) echo " selected=selected";?>><?=$this->translate('Tag')?></option>
-            <option value="resource" <? if("resource" == $this->type) echo " selected=selected";?>><?=$this->translate('Title')?></option>
+            <option value="user" <?php if("user" == $this->type) echo " selected=selected";?>><?=$this->translate('Username')?></option>
+            <option value="tag" <?php if("tag" == $this->type) echo " selected=selected";?>><?=$this->translate('Tag')?></option>
+            <option value="resource" <?php if("resource" == $this->type) echo " selected=selected";?>><?=$this->translate('Title')?></option>
           </select>
         </div>
         <div class="col-sm-4">
@@ -27,61 +27,61 @@
       </div>
     </form>
 
-    <? if(false !== $this->type):?>
+    <?php if(false !== $this->type):?>
       <form class="form-horizontal" action="<?= $this->url('admin/tags', array('action' => 'Delete'))?>" method="post">
         <input type="hidden" name="origin" value="manage" />
         <input type="hidden" name="type" value="<?= $this->type; ?>" />
-        <? if("user" == $type):?>
+        <?php if("user" == $type):?>
           <div class="form-group">
             <label for="user_id" class="col-sm-2 control-label"><?=$this->translate('Username')?></label>
             <div class="col-sm-6">
               <select name="user_id" id="user_id" class="form-control">
-                <? foreach($this->uniqueUsers as $user):?>
+                <?php foreach($this->uniqueUsers as $user):?>
                 <option value="<?= $user['user_id'] ?>">
                   <?= $user['username'] ?>
                 </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-4">
               <input type="submit"  name="deleteFilter" value="<?=$this->translate('delete_tags')?>" class="btn btn-primary"/>
             </div>
           </div>
-        <? elseif("tag" == $type):?>
+        <?php elseif("tag" == $type):?>
           <div class="form-group">
             <label for="tag_id" class="col-sm-2 control-label"><?=$this->translate('Tag')?></label>
             <div class="col-sm-6">
               <select name="tag_id" id="tag_id" class="form-control">
-                <? foreach($this->uniqueTags as $tag):?>
+                <?php foreach($this->uniqueTags as $tag):?>
                 <option value="<?= $tag['tag_id'] ?>">
                     <?= $tag['tag'] ?>
                 </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-4">
               <input type="submit" name="deleteFilter" value="<?=$this->translate('delete_tags')?>" class="btn btn-primary"/>
             </div>
           </div>
-        <? elseif("resource" == $type):?>
+        <?php elseif("resource" == $type):?>
           <div class="form-group">
             <label for="resource_id" class="col-sm-2 control-label"><?=$this->translate('Title')?></label>
             <div class="col-sm-6">
               <select name="resource_id" id="resource_id" class="form-control">
-                <? foreach($this->uniqueResources as $resource):?>
+                <?php foreach($this->uniqueResources as $resource):?>
                 <option value="<?=$resource['resource_id'] ?>" title="<?=$resource['title'] ?>">
                   <?=$this->truncate($resource['title'], 80) ?> (<?= $resource['resource_id'] ?>)
                 </option>
-                <? endforeach;?>
+                <?php endforeach;?>
               </select>
             </div>
             <div class="col-sm-4">
               <input type="submit" name="deleteFilter" value="<?=$this->translate('delete_tags')?>" class="btn btn-primary"/>
             </div>
           </div>
-        <? endif;?>
+        <?php endif;?>
       </form>
-    <? endif;?>
+    <?php endif;?>
 
   </div>
 

--- a/themes/bootstrap3/templates/ajax/resolverLinks.phtml
+++ b/themes/bootstrap3/templates/ajax/resolverLinks.phtml
@@ -1,48 +1,48 @@
 <div>
-  <? if (!empty($this->electronic)): ?>
+  <?php if (!empty($this->electronic)): ?>
     <div class="openurls">
       <strong><?=$this->transEsc('Electronic')?></strong>
       <ul>
-        <? foreach ($this->electronic as $link): ?>
+        <?php foreach ($this->electronic as $link): ?>
           <li>
-            <? if (!empty($link['href'])): ?>
+            <?php if (!empty($link['href'])): ?>
               <a href="<?=$this->escapeHtmlAttr($link['href'])?>" title="<?=isset($link['service_type'])?$this->escapeHtmlAttr($link['service_type']):''?>"<?=!empty($link['access'])?' class="access-'.$link['access'].'"':''?>><?=isset($link['title'])?$this->escapeHtml($link['title']):''?></a> <?=isset($link['coverage'])?$this->escapeHtml($link['coverage']):''?>
-            <? else: ?>
+            <?php else: ?>
               <?=isset($link['title'])?$this->escapeHtml($link['title']):''?> <?=isset($link['coverage'])?$this->escapeHtml($link['coverage']):''?>
-            <? endif; ?>
+            <?php endif; ?>
           </li>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </ul>
     </div>
-  <? endif; ?>
-  <? if (!empty($this->print)): ?>
+  <?php endif; ?>
+  <?php if (!empty($this->print)): ?>
     <div class="openurls">
       <strong><?=$this->transEsc('Holdings')?></strong>
       <ul>
-        <? foreach ($this->print as $link): ?>
+        <?php foreach ($this->print as $link): ?>
           <li>
-            <? if (!empty($link['href'])): ?>
+            <?php if (!empty($link['href'])): ?>
               <a href="<?=$this->escapeHtmlAttr($link['href'])?>" title="<?=isset($link['service_type'])?$this->escapeHtmlAttr($link['service_type']):''?>"<?=!empty($link['access'])?' class="access-'.$link['access'].'"':''?>><?=isset($link['title'])?$this->escapeHtml($link['title']):''?></a> <?=isset($link['coverage'])?$this->escapeHtml($link['coverage']):''?>
-            <? else: ?>
+            <?php else: ?>
               <?=isset($link['title'])?$this->escapeHtml($link['title']):''?> <?=isset($link['coverage'])?$this->escapeHtml($link['coverage']):''?>
-            <? endif; ?>
+            <?php endif; ?>
           </li>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </ul>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="openurls">
-    <? if (!empty($this->moreOptionsLink)): ?><strong><a href="<?=$this->escapeHtmlAttr($this->moreOptionsLink)?>"><?=$this->transEsc('More options')?></a></strong><?endif; ?>
-    <? if (!empty($this->services)): ?>
+    <?php if (!empty($this->moreOptionsLink)): ?><strong><a href="<?=$this->escapeHtmlAttr($this->moreOptionsLink)?>"><?=$this->transEsc('More options')?></a></strong><?endif; ?>
+    <?php if (!empty($this->services)): ?>
       <ul>
-        <? foreach ($this->services as $link): ?>
-          <? if (!empty($link['href'])): ?>
+        <?php foreach ($this->services as $link): ?>
+          <?php if (!empty($link['href'])): ?>
             <li>
               <a href="<?=$this->escapeHtmlAttr($link['href'])?>" title="<?=isset($link['service_type'])?$this->escapeHtmlAttr($link['service_type']):''?>"<?=!empty($link['access'])?' class="access-'.$link['access'].'"':''?>><?=isset($link['title'])?$this->escapeHtml($link['title']):''?></a>
             </li>
-          <? endif; ?>
-        <? endforeach; ?>
+          <?php endif; ?>
+        <?php endforeach; ?>
       </ul>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/ajax/resultgooglemapinfo.phtml
+++ b/themes/bootstrap3/templates/ajax/resultgooglemapinfo.phtml
@@ -1,29 +1,29 @@
 <div class="mapInfoWrapper">
   <h4><?=$this->transEsc('map_results_label')?></h4>
   <div class="mapInfoResults">
-    <? $i = 0; ?>
-    <? foreach($this->recordSet as $record): ?>
-    <? $i++; ?>
-      <div class="mapInfoResult <? if ($i % 2 == 0): ?>alt <? endif; ?>record<?=$i ?>">
+    <?php $i = 0; ?>
+    <?php foreach($this->recordSet as $record): ?>
+    <?php $i++; ?>
+      <div class="mapInfoResult <?php if ($i % 2 == 0): ?>alt <?php endif; ?>record<?=$i ?>">
         <div class="mapInfoResultThumb">
-          <? if ($thumb = $this->record($record)->getThumbnail()): ?><img class="mapInfoResultThumbImg" src="<?=$this->escapeHtmlAttr($thumb) ?>"/><? endif; ?>
+          <?php if ($thumb = $this->record($record)->getThumbnail()): ?><img class="mapInfoResultThumbImg" src="<?=$this->escapeHtmlAttr($thumb) ?>"/><?php endif; ?>
         </div>
 
         &bull; <a href="<?=$this->recordLink()->getUrl($record)?>"><?=($title = $record->getTitle()) ? $title : $this->transEsc('Title not available') ?></a>
-        <? $authors = $record->getPrimaryAuthors(); if (!empty($authors)): ?>
+        <?php $authors = $record->getPrimaryAuthors(); if (!empty($authors)): ?>
           <span class="small">
-            <?=$this->transEsc('by')?> <a href="<?=$this->record($record)->getLink('author', $authors[0])?>"><?=$this->escapeHtml($authors[0]);?></a><? if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?>
+            <?=$this->transEsc('by')?> <a href="<?=$this->record($record)->getLink('author', $authors[0])?>"><?=$this->escapeHtml($authors[0]);?></a><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
           </span><br/>
-        <? endif; ?>
+        <?php endif; ?>
 
       </div>
       <div class="clearfix"></div>
-    <? if ($i == 5) break; ?>
-    <? endforeach; ?>
+    <?php if ($i == 5) break; ?>
+    <?php endforeach; ?>
   </div>
-  <? if ($this->recordCount > 5): ?>
+  <?php if ($this->recordCount > 5): ?>
     <div class="mapSeeAllDiv">
       <a href="<?=$this->url('search-results') ?><?=$this->results->getUrlQuery()->getParams() ?>"><?=$this->transEsc('see all') ?> <?=$this->escapeHtml($this->recordCount) ?>...</a>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/ajax/status-available-services.phtml
+++ b/themes/bootstrap3/templates/ajax/status-available-services.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // defaultServiceStatusMessage for multiple status and as fallback for missing translations
 $defaultServiceStatusMessage = 'HoldingStatus::services_available_html';
 

--- a/themes/bootstrap3/templates/ajax/status-full.phtml
+++ b/themes/bootstrap3/templates/ajax/status-full.phtml
@@ -4,36 +4,36 @@
     <th><?=$this->transEsc('Call Number')?></th>
     <th><?=$this->transEsc('Status')?></th>
   </tr>
-  <? $i = 0; foreach ($this->statusItems as $item): ?>
-    <? if (++$i == 5) break; // Show no more than 5 items ?>
+  <?php $i = 0; foreach ($this->statusItems as $item): ?>
+    <?php if (++$i == 5) break; // Show no more than 5 items ?>
     <tr>
       <td class="fullLocation">
-        <? $locationText = $this->transEsc('location_' . $item['location'], [], $item['location']); ?>
-        <? if (isset($item['locationhref']) && $item['locationhref']): ?>
+        <?php $locationText = $this->transEsc('location_' . $item['location'], [], $item['location']); ?>
+        <?php if (isset($item['locationhref']) && $item['locationhref']): ?>
           <a href="<?=$item['locationhref']?>" target="_blank"><?=$locationText?></a>
-        <? else: ?>
+        <?php else: ?>
           <?=$locationText?>
-        <? endif; ?>
+        <?php endif; ?>
       </td>
       <td class="fullCallnumber">
-        <? if ($this->callnumberHandler): ?>
+        <?php if ($this->callnumberHandler): ?>
           <a href="<?=$this->url('alphabrowse-home') ?>?source=<?=$this->escapeHtmlAttr($this->callnumberHandler) ?>&amp;from=<?=$this->escapeHtmlAttr($item['callnumber']) ?>"><?=$this->escapeHtml($item['callnumber'])?></a>
-        <? else: ?>
+        <?php else: ?>
           <?=$this->escapeHtml($item['callnumber'])?>
-        <? endif; ?>
+        <?php endif; ?>
       </td>
       <td class="fullAvailability">
-        <? if (isset($item['use_unknown_message']) && $item['use_unknown_message']): ?>
+        <?php if (isset($item['use_unknown_message']) && $item['use_unknown_message']): ?>
           <span><?=$this->transEsc("status_unknown_message")?></span>
-        <? elseif ($item['availability']): ?>
+        <?php elseif ($item['availability']): ?>
           <span class="text-success"><?=($item['reserve'] == 'Y') ? $this->transEsc("On Reserve") : $this->transEsc("Available")?></span>
-        <? else: ?>
+        <?php else: ?>
           <span class="text-danger"><?=$this->transEsc($item['status'])?></span>
-        <? endif; ?>
+        <?php endif; ?>
       </td>
     </tr>
-  <? endforeach; ?>
-<? if (count($this->statusItems) > 5): ?>
+  <?php endforeach; ?>
+<?php if (count($this->statusItems) > 5): ?>
   <tr><td colspan="3"><a href="<?=$this->url('record', ['id' => $this->statusItems[0]['id']])?>"><?=count($this->statusItems) - 5?> <?=$this->transEsc('more')?> ...</a></td></tr>
-<? endif; ?>
+<?php endif; ?>
 </table>

--- a/themes/bootstrap3/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap3/templates/alphabrowse/home.phtml
@@ -1,40 +1,40 @@
-<?
+<?php
   $this->headTitle($this->translate('Browse the Collection Alphabetically'));
   $this->layout()->breadcrumbs = '<a href="' . $this->url('alphabrowse-home') . '">' . $this->transEsc('Browse Alphabetically') . '</a>';
   $baseQuery = ['source' => $this->source, 'from' => $this->from];
 ?>
 
-<? /* LOAD THE LINK INFORMATION INTO $pageLinks, similar to smarty's {capture} */ ?>
-<? ob_start(); ?>
+<?php /* LOAD THE LINK INFORMATION INTO $pageLinks, similar to smarty's {capture} */ ?>
+<?php ob_start(); ?>
   <ul class="pager">
-    <? if (isset($this->prevpage)): ?>
+    <?php if (isset($this->prevpage)): ?>
       <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->prevpage]]))?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
-    <? else: ?>
+    <?php else: ?>
       <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (isset($this->nextpage)): ?>
+    <?php if (isset($this->nextpage)): ?>
       <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->nextpage]]))?>"><?=$this->transEsc('Next')?> &raquo;</a></li>
-    <? else: ?>
+    <?php else: ?>
       <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
-    <? endif; ?>
+    <?php endif; ?>
   </ul>
-<? $pageLinks = ob_get_contents(); ?>
-<? ob_end_clean(); ?>
+<?php $pageLinks = ob_get_contents(); ?>
+<?php ob_end_clean(); ?>
 
 <form class="form-inline" method="get" action="<?=$this->url('alphabrowse-home')?>" name="alphaBrowseForm" id="alphaBrowseForm">
   <label for="alphaBrowseForm_source"><?=$this->transEsc('Browse Alphabetically') ?></label>
   <select id="alphaBrowseForm_source" name="source" class="form-control">
-    <? foreach ($this->alphaBrowseTypes as $key => $item): ?>
-      <option value="<?=$this->escapeHtmlAttr($key) ?>"<? if ($this->source == $key): ?> selected="selected"<? endif; ?>><?=$this->transEsc($item) ?></option>
-    <? endforeach; ?>
+    <?php foreach ($this->alphaBrowseTypes as $key => $item): ?>
+      <option value="<?=$this->escapeHtmlAttr($key) ?>"<?php if ($this->source == $key): ?> selected="selected"<?php endif; ?>><?=$this->transEsc($item) ?></option>
+    <?php endforeach; ?>
   </select>
   <label for="alphaBrowseForm_from"><?=$this->transEsc('starting from') ?></label>
   <input type="text" name="from" id="alphaBrowseForm_from" value="<?=$this->escapeHtmlAttr($this->from) ?>" class="form-control"/>
   <input class="btn btn-default" type="submit" value="<?=$this->transEsc('Browse') ?>"/>
 </form>
 
-<? if ($this->result): ?>
+<?php if ($this->result): ?>
   <?=$pageLinks ?>
   <table class="alphabrowse table table-striped">
     <thead>
@@ -42,70 +42,70 @@
         <th class="<?=$this->source ?>">
           <?=$this->transEsc("browse_" . $this->source) ?>
         </th>
-        <? foreach ($this->extras as $e): ?>
+        <?php foreach ($this->extras as $e): ?>
           <th><?=$this->transEsc("browse_" . $e) ?></th>
-        <? endforeach; ?>
+        <?php endforeach; ?>
         <th class="titles"><?=$this->transEsc("alphabrowse_matches") ?></th>
       </tr>
     </thead>
     <tbody>
-      <? $row = 0; ?>
-      <? foreach ($this->result['Browse']['items'] as $item): ?>
-        <? if (isset($this->highlight_row) && $row == $this->highlight_row): ?>
+      <?php $row = 0; ?>
+      <?php foreach ($this->result['Browse']['items'] as $item): ?>
+        <?php if (isset($this->highlight_row) && $row == $this->highlight_row): ?>
           <tr class="browse-match">
-          <? if (isset($this->match_type) && ($this->match_type == "NONE")): ?>
+          <?php if (isset($this->match_type) && ($this->match_type == "NONE")): ?>
             <?// this is the right row but query doesn't match value ?>
             <td colspan="<?=count($this->extras) + 2;?>"><?=$this->transEsc('your_match_would_be_here')?></td>
             </tr>
             <tr>
-          <? endif; ?>
-        <? else: ?>
+          <?php endif; ?>
+        <?php else: ?>
           <tr>
-        <? endif; ?>
+        <?php endif; ?>
           <td class="<?=$this->source ?>">
             <b>
-              <? if ($url = $this->alphabrowse()->getUrl($this->source, $item)): ?>
+              <?php if ($url = $this->alphabrowse()->getUrl($this->source, $item)): ?>
                 <a href="<?=$this->escapeHtmlAttr($url)?>"><?=$this->escapeHtml($item['heading'])?></a>
-              <? else: ?>
+              <?php else: ?>
                 <?=$this->escapeHtml($item['heading'])?>
-              <? endif; ?>
+              <?php endif; ?>
             </b>
 
-            <? if (count($item['useInstead']) > 0): ?>
+            <?php if (count($item['useInstead']) > 0): ?>
               <div>
                 <?=$this->transEsc('Use instead') ?>:
                 <ul>
-                  <? foreach ($item['useInstead'] as $heading): ?>
+                  <?php foreach ($item['useInstead'] as $heading): ?>
                   <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => ['from' => $heading] + $baseQuery]))?>"><?=$this->escapeHtml($heading)?></a></li>
-                  <? endforeach; ?>
+                  <?php endforeach; ?>
                 </ul>
               </div>
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (count($item['seeAlso']) > 0): ?>
+            <?php if (count($item['seeAlso']) > 0): ?>
               <div>
                 <?=$this->transEsc('See also') ?>:
                 <ul>
-                  <? foreach ($item['seeAlso'] as $heading): ?>
+                  <?php foreach ($item['seeAlso'] as $heading): ?>
                   <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => ['from' => $heading] + $baseQuery]))?>"><?=$this->escapeHtml($heading)?></a></li>
-                  <? endforeach; ?>
+                  <?php endforeach; ?>
                 </ul>
               </div>
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if ($item['note']): ?>
+            <?php if ($item['note']): ?>
               <div>
                 <?=$this->transEsc('Note') ?>:
                 <ul>
                   <li><?=$this->escapeHtml($item['note'])?></li>
                 </ul>
               </div>
-            <? endif; ?>
+            <?php endif; ?>
           </td>
 
-          <? foreach ($this->extras as $extraName): ?>
+          <?php foreach ($this->extras as $extraName): ?>
             <td>
-              <?
+              <?php
                 $extraDisplayArray = [];
                 foreach ($item['extras'][$extraName] as $j => $e):
                   $extraDisplayArray = array_unique(array_merge($extraDisplayArray, $e));
@@ -113,22 +113,22 @@
                 echo empty($extraDisplayArray) ? '&nbsp;' : implode('<br />', $extraDisplayArray);
               ?>
             </td>
-          <? endforeach; ?>
+          <?php endforeach; ?>
 
           <td class="titles">
-            <? if ($item['count'] > 0): ?>
+            <?php if ($item['count'] > 0): ?>
               <?=$item['count']; ?>
-            <? endif; ?>
+            <?php endif; ?>
           </td>
         </tr>
-        <? $row++; ?>
-        <? endforeach; ?>
-        <? if (isset($this->highlight_end)): ?>
+        <?php $row++; ?>
+        <?php endforeach; ?>
+        <?php if (isset($this->highlight_end)): ?>
           <tr class="browse-match">
             <td colspan="<?=count($this->extras) + 2;?>"><?=$this->transEsc('your_match_would_be_here')?></td>
           </tr>
-        <? endif; ?>
+        <?php endif; ?>
     </tbody>
   </table>
   <?= $pageLinks ?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/author/home.phtml
+++ b/themes/bootstrap3/templates/author/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Author'));
 

--- a/themes/bootstrap3/templates/author/results.phtml
+++ b/themes/bootstrap3/templates/author/results.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 

--- a/themes/bootstrap3/templates/author/search.phtml
+++ b/themes/bootstrap3/templates/author/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Hide the total result count -- because of limitations in the way facet
     // paging works, we can't actually determine an accurate total count.  (Note
     // that this setting simply modifies the behavior of search/results.phtml below).

--- a/themes/bootstrap3/templates/authority/record.phtml
+++ b/themes/bootstrap3/templates/authority/record.phtml
@@ -1,2 +1,2 @@
-<? $this->layout()->breadcrumbs = false; ?>
+<?php $this->layout()->breadcrumbs = false; ?>
 <?=$this->record($this->driver)->getTab($this->tabs['Details'])?>

--- a/themes/bootstrap3/templates/authority/search.phtml
+++ b/themes/bootstrap3/templates/authority/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/breadcrumbs/default.phtml
+++ b/themes/bootstrap3/templates/breadcrumbs/default.phtml
@@ -1,11 +1,11 @@
 <li><a href="<?=$this->url('home')?>"><?=$this->transEsc('Home')?></a></li>
-<? $current = $this->layout()->breadcrumbs; $current = current($current); ?>
-<? foreach($current as $id=>$parent): ?>
+<?php $current = $this->layout()->breadcrumbs; $current = current($current); ?>
+<?php foreach($current as $id=>$parent): ?>
   <li><a href="<?=$this->url('collection', ['id'=>$id]) ?>"><?=$parent ?></a></li>
-<? endforeach; ?>
-<? if(isset($this->layout()->end)): ?>
+<?php endforeach; ?>
+<?php if(isset($this->layout()->end)): ?>
   <li title="<?=$this->layout()->title ?>"><?=$this->truncate($this->layout()->title, 100) ?></li>
   <li class="active"><?=$this->layout()->end ?></li>
-<? else: ?>
+<?php else: ?>
   <li class="active" title="<?=$this->layout()->title ?>"><?=$this->truncate($this->layout()->title, 100) ?></li>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/breadcrumbs/multi.phtml
+++ b/themes/bootstrap3/templates/breadcrumbs/multi.phtml
@@ -2,19 +2,19 @@
 <li class="dropdown">
   <a data-toggle="dropdown" href="#">In <?=count($this->layout()->breadcrumbs) ?> Collections</a>
   <div class="dropdown-menu" role="menu" aria-labelledby="dLabel">
-    <? foreach ($this->layout()->breadcrumbs as $trail): ?>
+    <?php foreach ($this->layout()->breadcrumbs as $trail): ?>
       <ul class="sub-breadcrumb">
-      <? foreach ($trail as $id=>$title): ?>
+      <?php foreach ($trail as $id=>$title): ?>
         <li><a href="<?=$this->url('record', ['id'=>$id])?>"><?=$title ?></a></li>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       </ul>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
 </li>
-<? if(isset($this->layout()->end)): ?>
+<?php if(isset($this->layout()->end)): ?>
   <li title="<?=$this->layout()->title ?>"><?=$this->truncate($this->layout()->title, 100) ?></li>
   <li class="active"><?=$this->layout()->end ?></li>
-<? else: ?>
+<?php else: ?>
   <li class="active" title="<?=$this->layout()->title ?>"><?=$this->truncate($this->layout()->title, 100) ?></li>
-<? endif; ?>
+<?php endif; ?>
 <script>$('.dropdown-toggle').dropdown()</script>

--- a/themes/bootstrap3/templates/browse/home.phtml
+++ b/themes/bootstrap3/templates/browse/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $this->headTitle($this->translate('Browse the Catalog'));
   $this->layout()->breadcrumbs = '<a href="' . $this->url('browse-home') . '">' . $this->transEsc('Browse') . '</a>';
 
@@ -6,40 +6,40 @@
   $SEARCH_BASE = $this->url($this->currentAction == 'Tag' ? 'tag-home' : 'search-results');
 ?>
 
-<? if (!isset($this->currentAction)): ?>
+<?php if (!isset($this->currentAction)): ?>
   <h2><?=$this->transEsc('Choose a Category to Begin Browsing') ?>:</h2>
-<? endif; ?>
+<?php endif; ?>
 
 <div class="row">
-  <div class="browse list-group col-sm-3<? if (!empty($this->categoryList)): ?> hidden-xs<? endif ?>" id="list1">
-    <? foreach ($this->browseOptions as $item=>$currentOption): ?>
-      <a href="<?=$this->url('browse-' . strtolower($currentOption['action'])); ?>" class="list-group-item<? if($currentOption['action'] == $this->currentAction): ?> active<? endif; ?>">
+  <div class="browse list-group col-sm-3<?php if (!empty($this->categoryList)): ?> hidden-xs<?php endif ?>" id="list1">
+    <?php foreach ($this->browseOptions as $item=>$currentOption): ?>
+      <a href="<?=$this->url('browse-' . strtolower($currentOption['action'])); ?>" class="list-group-item<?php if($currentOption['action'] == $this->currentAction): ?> active<?php endif; ?>">
         <?=$this->transEsc($currentOption['description']) ?>
         <span class="pull-right flip"><i class="fa fa-angle-right" title="<?=$this->transEsc('more') ?>"></i></span>
       </a>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
 
-  <? if (!empty($this->categoryList)): ?>
-    <div class="browse list-group col-sm-3<? if (!empty($this->secondaryList) || !empty($this->resultList)): ?> hidden-xs<? endif ?>" id="list2">
-      <? foreach($this->categoryList as $findby=>$category): ?>
-        <a href="<?=$BROWSE_BASE ?>?findby=<?=urlencode($findby) ?>&amp;query_field=<?=$this->browse()->getSolrField($findby, $this->currentAction) ?>" class="list-group-item clearfix<? if ($this->findby == $findby): ?> active<? endif; ?>">
-          <? if(is_string($category)): ?>
+  <?php if (!empty($this->categoryList)): ?>
+    <div class="browse list-group col-sm-3<?php if (!empty($this->secondaryList) || !empty($this->resultList)): ?> hidden-xs<?php endif ?>" id="list2">
+      <?php foreach($this->categoryList as $findby=>$category): ?>
+        <a href="<?=$BROWSE_BASE ?>?findby=<?=urlencode($findby) ?>&amp;query_field=<?=$this->browse()->getSolrField($findby, $this->currentAction) ?>" class="list-group-item clearfix<?php if ($this->findby == $findby): ?> active<?php endif; ?>">
+          <?php if(is_string($category)): ?>
             <?=$this->transEsc($category)?>
             <span class="pull-right flip"><i class="fa fa-angle-right" title="<?=$this->transEsc('more') ?>"></i></span>
-          <? else: ?>
+          <?php else: ?>
             <?=$this->transEsc($category['text'])?>
             <span class="badge"><?=number_format($category['count'])?></span>
-          <? endif; ?>
+          <?php endif; ?>
         </a>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if (!empty($this->secondaryList)): ?>
-    <div class="browse list-group col-sm-3<? if (!empty($this->resultList)): ?> hidden-xs<? endif ?>" id="list3">
-    <? foreach($this->secondaryList as $secondary): ?>
-      <? $url = $BROWSE_BASE . '?findby=' . urlencode($this->findby)
+  <?php if (!empty($this->secondaryList)): ?>
+    <div class="browse list-group col-sm-3<?php if (!empty($this->resultList)): ?> hidden-xs<?php endif ?>" id="list3">
+    <?php foreach($this->secondaryList as $secondary): ?>
+      <?php $url = $BROWSE_BASE . '?findby=' . urlencode($this->findby)
           . '&amp;category=' . urlencode($this->category)
           . '&amp;query=' . urlencode($secondary['value']);
         if ($this->facetPrefix) {
@@ -52,33 +52,33 @@
         }
         $viewRecord = !empty($this->categoryList) && $this->currentAction != 'Tag' && $this->findby != 'alphabetical';
       ?>
-      <a href="<?=$url ?>" class="list-group-item clearfix<? if ($this->query == $secondary['value'].'' || $this->query == $secondary['value'].'*'): ?> active<? endif; ?>">
+      <a href="<?=$url ?>" class="list-group-item clearfix<?php if ($this->query == $secondary['value'].'' || $this->query == $secondary['value'].'*'): ?> active<?php endif; ?>">
         <?=$this->escapeHtml($secondary['displayText']) ?>
-        <? if ($this->findby != 'alphabetical' && isset($secondary['count'])): ?>
+        <?php if ($this->findby != 'alphabetical' && isset($secondary['count'])): ?>
           <span class="badge"><?=number_format($secondary['count']) ?></span>
-        <? else: ?>
+        <?php else: ?>
           <span class="pull-right flip"><i class="fa fa-angle-right" title="<?=$this->transEsc('more') ?>"></i></span>
-        <? endif; ?>
+        <?php endif; ?>
       </a>
-      <? if($viewRecord): ?>
-        <a class="list-group-item view-record" href="<?=$SEARCH_BASE ?>?lookfor=<? if ($this->filter): ?>&amp;filter[]=<?=urlencode($this->filter) ?>%3A<?=str_replace('+AND+','&amp;filter[]=', urlencode($secondary['value'])) ?><? endif; ?>&amp;filter[]=<?=$this->browse()->getSolrField($this->currentAction) ?>%3A[* TO *]<? if($this->dewey_flag):?>&amp;sort=dewey-sort<?endif;?>"><?=$this->transEsc('View Records') ?></a>
-      <? endif; ?>
-    <? endforeach; ?>
+      <?php if($viewRecord): ?>
+        <a class="list-group-item view-record" href="<?=$SEARCH_BASE ?>?lookfor=<?php if ($this->filter): ?>&amp;filter[]=<?=urlencode($this->filter) ?>%3A<?=str_replace('+AND+','&amp;filter[]=', urlencode($secondary['value'])) ?><?php endif; ?>&amp;filter[]=<?=$this->browse()->getSolrField($this->currentAction) ?>%3A[* TO *]<?php if($this->dewey_flag):?>&amp;sort=dewey-sort<?endif;?>"><?=$this->transEsc('View Records') ?></a>
+      <?php endif; ?>
+    <?php endforeach; ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if (!empty($this->resultList)): ?>
+  <?php if (!empty($this->resultList)): ?>
     <div class="browse list-group col-sm-3" id="list4">
-    <? foreach($this->resultList as $result): ?>
-      <a class="list-group-item clearfix" href="<?=$SEARCH_BASE ?>?<?=$this->paramTitle ?><?=urlencode($result['value']) ?><? if ($this->searchParams): foreach($this->searchParams as $var=>$val): ?>&amp;<?=$var ?>=<?=urlencode($val) ?><? endforeach;endif; ?>">
+    <?php foreach($this->resultList as $result): ?>
+      <a class="list-group-item clearfix" href="<?=$SEARCH_BASE ?>?<?=$this->paramTitle ?><?=urlencode($result['value']) ?><?php if ($this->searchParams): foreach($this->searchParams as $var=>$val): ?>&amp;<?=$var ?>=<?=urlencode($val) ?><?php endforeach;endif; ?>">
         <?=$this->escapeHtml($result['displayText'])?>
         <span class="badge"><?=number_format($result['count']) ?></span>
       </a>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     </div>
-  <? elseif (isset($this->query)): ?>
+  <?php elseif (isset($this->query)): ?>
     <ul class="browse list-group col-sm-3" id="list4">
       <li class="list-group-item"><?=$this->transEsc('nohit_heading') ?></li>
     </ul>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/cart/cart.phtml
+++ b/themes/bootstrap3/templates/cart/cart.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Book Bag'));
 
@@ -9,7 +9,7 @@
 <?=$this->flashmessages()?>
 <form class="form-inline" action="<?=$this->url('cart-processor')?>" method="post"  name="cartForm" data-lightbox-onsubmit="cartFormHandler">
   <input type="hidden" id="dropdown_value"/>
-  <? if (!$this->cart()->isEmpty()): ?>
+  <?php if (!$this->cart()->isEmpty()): ?>
     <div class="cart-controls clearfix">
       <div class="checkbox pull-left flip">
         <label>
@@ -17,22 +17,22 @@
           <?=$this->transEsc('select_page')?>
         </label>
       </div>
-      <? if ($this->userlist()->getMode() !== 'disabled'): ?>
+      <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
         <button type="submit" class="btn btn-default" name="saveCart" title="<?=$this->transEsc('bookbag_save')?>" value="1">
           <i class="fa fa-save" aria-hidden="true"></i>
           <?=$this->transEsc('Save')?>
         </button>
-      <? endif; ?>
+      <?php endif; ?>
       <button type="submit" class="btn btn-default" name="email" title="<?=$this->transEsc('bookbag_email')?>" value="1">
         <i class="fa fa-envelope-o" aria-hidden="true"></i>
         <?=$this->transEsc('Email')?>
       </button>
-      <? $exportOptions = $this->export()->getActiveFormats('bulk'); if (count($exportOptions) > 0): ?>
+      <?php $exportOptions = $this->export()->getActiveFormats('bulk'); if (count($exportOptions) > 0): ?>
         <button type="submit" class="btn btn-default" name="export" title="<?=$this->transEsc('bookbag_export')?>" value="1">
           <i class="fa fa-list-alt" aria-hidden="true"></i>
           <?=$this->transEsc('Export')?>
         </button>
-      <? endif; ?>
+      <?php endif; ?>
       <button type="submit" class="btn btn-default dropdown-toggle" name="print" title="<?=$this->transEsc('print_selected')?>" value="1">
         <i class="fa fa-printer" aria-hidden="true"></i>
         <?=$this->transEsc('Print')?>
@@ -58,11 +58,11 @@
         </ul>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <?=$this->render('cart/contents.phtml')?>
 </form>
 
-<?
+<?php
   $script = <<<JS
   function submitFormWithButton(link, name) {
     $('#dropdown_value').attr('name', name).val(1);

--- a/themes/bootstrap3/templates/cart/contents.phtml
+++ b/themes/bootstrap3/templates/cart/contents.phtml
@@ -1,7 +1,7 @@
-<? $records = $this->cart()->getRecordDetails(); if (!empty($records)): ?>
+<?php $records = $this->cart()->getRecordDetails(); if (!empty($records)): ?>
   <hr/>
   <ul class="list-unstyled">
-  <? foreach ($records as $i => $record): ?>
+  <?php foreach ($records as $i => $record): ?>
     <li>
       <div class="checkbox">
         <label>
@@ -10,8 +10,8 @@
         </label>
       </div>
     </li>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   </ul>
-<? else: ?>
+<?php else: ?>
   <p class="alert alert-info"><?=$this->transEsc('bookbag_is_empty')?>.</p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/cart/email.phtml
+++ b/themes/bootstrap3/templates/cart/email.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('email_selected_favorites'));
 
@@ -10,31 +10,31 @@
 <h2><?=$this->transEsc('bookbag_email_selected') ?></h2>
 <?=$this->flashmessages()?>
 <form class="form-horizontal" action="<?=$this->url('cart-email')?>" method="post"  name="bulkEmail">
-  <? foreach ($this->records as $current): ?>
+  <?php foreach ($this->records as $current): ?>
     <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <div class="form-group">
     <label class="col-sm-3 control-label"><?=$this->transEsc('Title')?></label>
     <div class="col-sm-9">
-    <? if(count($this->records) > 1): ?>
+    <?php if(count($this->records) > 1): ?>
         <button type="button" class="btn btn-default hidden" data-toggle="collapse" data-target="#itemhide">
           <?=count($this->records).' '.$this->transEsc('items') ?>
         </button>
         <div id="itemhide" class="collapse in">
           <ul>
-            <? foreach ($this->records as $current): ?>
+            <?php foreach ($this->records as $current): ?>
               <li><?=$this->escapeHtml($current->getBreadcrumb())?></li>
-            <? endforeach; ?>
+            <?php endforeach; ?>
           </ul>
         </div>
-    <? else: ?>
+    <?php else: ?>
       <p class="form-control-static"><?=$this->records[0]->getBreadcrumb() ?></p>
-    <? endif; ?>
+    <?php endif; ?>
     </div>
   </div>
   <?=$this->render('Helpers/email-form-fields.phtml')?>
 </form>
-<?
+<?php
   $script = <<<JS
     $('button.btn.hidden').removeClass('hidden');
     $('#itemhide').removeClass('in');

--- a/themes/bootstrap3/templates/cart/export.phtml
+++ b/themes/bootstrap3/templates/cart/export.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Export Favorites'));
 
@@ -11,50 +11,50 @@
 
 <?=$this->flashmessages()?>
 
-<? if (!empty($this->exportOptions)): ?>
+<?php if (!empty($this->exportOptions)): ?>
   <form class="form-horizontal" method="post" action="<?=$this->url('cart-export')?>" name="exportForm" title="<?=$this->transEsc('Export Items')?>">
-    <? foreach ($this->records as $current): ?>
+    <?php foreach ($this->records as $current): ?>
       <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
-    <? endforeach; ?>
+    <?php endforeach; ?>
     <div class="form-group">
       <label class="col-sm-3 control-label"><?=$this->transEsc('Title')?></label>
       <div class="col-sm-9">
-      <? if(count($this->records) > 1): ?>
+      <?php if(count($this->records) > 1): ?>
         <button type="button" class="btn btn-default hidden" data-toggle="collapse" data-target="#itemhide">
           <?=count($this->records).' '.$this->transEsc('items') ?>
         </button>
         <div id="itemhide" class="collapse in">
           <ul>
-            <? foreach ($this->records as $current): ?>
+            <?php foreach ($this->records as $current): ?>
               <li><?=$this->escapeHtml($current->getBreadcrumb())?></li>
-            <? endforeach; ?>
+            <?php endforeach; ?>
           </ul>
         </div>
-      <? else: ?>
+      <?php else: ?>
         <p class="form-control-static"><?=$this->records[0]->getBreadcrumb() ?></p>
-      <? endif; ?>
+      <?php endif; ?>
       </div>
     </div>
     <div class="form-group">
       <label for="format" class="col-sm-3 control-label"><?=$this->transEsc('Format')?>:</label>
       <div class="col-sm-9">
         <select name="format" id="format" class="form-control">
-          <? $firstOption = null; ?>
-          <? foreach ($this->exportOptions as $exportOption): ?>
-            <? if ($firstOption == null) $firstOption = $exportOption; ?>
-            <option value="<?=$this->escapeHtmlAttr($exportOption)?>"<? if($this->export()->needsRedirect($exportOption)): ?> data-redirect<? endif; ?>><?=$this->transEsc($this->export()->getLabelForFormat($exportOption))?></option>
-          <? endforeach; ?>
+          <?php $firstOption = null; ?>
+          <?php foreach ($this->exportOptions as $exportOption): ?>
+            <?php if ($firstOption == null) $firstOption = $exportOption; ?>
+            <option value="<?=$this->escapeHtmlAttr($exportOption)?>"<?php if($this->export()->needsRedirect($exportOption)): ?> data-redirect<?php endif; ?>><?=$this->transEsc($this->export()->getLabelForFormat($exportOption))?></option>
+          <?php endforeach; ?>
         </select>
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
-        <input class="export btn btn-default" type="submit" name="submit" value="<?=$this->transEsc('Export')?>"<? if($this->export()->needsRedirect($firstOption)): ?> data-lightbox-ignore<? endif; ?>/>
+        <input class="export btn btn-default" type="submit" name="submit" value="<?=$this->transEsc('Export')?>"<?php if($this->export()->needsRedirect($firstOption)): ?> data-lightbox-ignore<?php endif; ?>/>
       </div>
     </div>
   </form>
-<? endif; ?>
-<?
+<?php endif; ?>
+<?php
   $script = <<<JS
   $('button.btn.hidden').removeClass('hidden');
   $('#itemhide').removeClass('in');

--- a/themes/bootstrap3/templates/cart/save.phtml
+++ b/themes/bootstrap3/templates/cart/save.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('bookbag_save_selected'));
 
@@ -11,28 +11,28 @@
 <?=$this->flashmessages()?>
 
 <form class="form-horizontal" method="post" action="<?=$this->url('cart-save')?>" name="bulkSave">
-  <? $idParams = []; ?>
-  <? foreach ($this->records as $current): ?>
-    <? $idParams[] = urlencode('ids[]') . '=' . urlencode($current->getSourceIdentifier() . '|' . $current->getUniqueId()) ?>
+  <?php $idParams = []; ?>
+  <?php foreach ($this->records as $current): ?>
+    <?php $idParams[] = urlencode('ids[]') . '=' . urlencode($current->getSourceIdentifier() . '|' . $current->getUniqueId()) ?>
     <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <div class="form-group">
     <label class="col-sm-3 control-label"><?=$this->transEsc('Title')?></label>
     <div class="col-sm-9">
-    <? if(count($this->records) > 1): ?>
+    <?php if(count($this->records) > 1): ?>
       <button type="button" class="btn btn-default hidden" data-toggle="collapse" data-target="#itemhide">
         <?=count($this->records).' '.$this->transEsc('items') ?>
       </button>
       <div id="itemhide" class="collapse in">
         <ul>
-          <? foreach ($this->records as $current): ?>
+          <?php foreach ($this->records as $current): ?>
             <li><?=$this->escapeHtml($current->getBreadcrumb())?></li>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </ul>
       </div>
-    <? else: ?>
+    <?php else: ?>
       <p class="form-control-static"><?=$this->records[0]->getBreadcrumb() ?></p>
-    <? endif; ?>
+    <?php endif; ?>
     </div>
   </div>
 
@@ -40,19 +40,19 @@
     <label class="col-sm-3 control-label" for="save_list"><?=$this->transEsc('Choose a List') ?></label>
     <div class="col-sm-9">
       <select id="save_list" name="list" class="form-control">
-        <? if (count($this->lists) > 0): ?>
-          <? foreach ($this->lists as $list): ?>
-            <option value="<?=$list['id'] ?>"<? if ($list['id']==$this->userList()->lastUsed()): ?> selected="selected"<? endif; ?>><?=$this->escapeHtml($list['title'])?></option>
-          <? endforeach; ?>
-        <? else: ?>
+        <?php if (count($this->lists) > 0): ?>
+          <?php foreach ($this->lists as $list): ?>
+            <option value="<?=$list['id'] ?>"<?php if ($list['id']==$this->userList()->lastUsed()): ?> selected="selected"<?php endif; ?>><?=$this->escapeHtml($list['title'])?></option>
+          <?php endforeach; ?>
+        <?php else: ?>
           <option value=""><?=$this->transEsc('My Favorites') ?></option>
-        <? endif; ?>
+        <?php endif; ?>
       </select>
       <a class="btn btn-link" id="make-list"  href="<?=$this->url('editList', ['id' => 'NEW']) . '?' . implode('&amp;', $idParams) ?>"><?=$this->transEsc('or create a new list'); ?></a>
     </div>
   </div>
 
-  <? if ($this->usertags()->getMode() !== 'disabled'): ?>
+  <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
     <div class="form-group">
       <label class="col-sm-3 control-label" for="add_mytags"><?=$this->transEsc('Add Tags') ?></label>
       <div class="col-sm-9">
@@ -60,7 +60,7 @@
         <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEsc('Save') ?>"/>
@@ -68,7 +68,7 @@
   </div>
 </form>
 
-<?
+<?php
   $script = <<<JS
   $('button.btn.hidden').removeClass('hidden');
   $('#itemhide').removeClass('in');

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up standard record scripts:
   $this->headScript()->appendFile("record.js");
   $this->headScript()->appendFile("check_save_statuses.js");
@@ -24,41 +24,41 @@
      . '<li class="active">' . $this->recordLink()->getBreadcrumb($this->driver) . '</li>';
 ?>
 
-<? if (isset($this->scrollData) && ($this->scrollData['previousRecord'] || $this->scrollData['nextRecord'])): ?>
+<?php if (isset($this->scrollData) && ($this->scrollData['previousRecord'] || $this->scrollData['nextRecord'])): ?>
   <ul class="pager">
-    <? if ($this->scrollData['previousRecord']): ?>
-      <? if ($this->scrollData['firstRecord']): ?>
+    <?php if ($this->scrollData['previousRecord']): ?>
+      <?php if ($this->scrollData['firstRecord']): ?>
         <li>
           <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('First')?></a>
         </li>
-      <? endif; ?>
+      <?php endif; ?>
       <li>
         <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('Prev')?></a>
       </li>
-    <? else: ?>
-      <? if ($this->scrollData['firstRecord']): ?>
+    <?php else: ?>
+      <?php if ($this->scrollData['firstRecord']): ?>
         <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('First')?></a></li>
-      <? endif; ?>
+      <?php endif; ?>
       <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
-    <? endif; ?>
+    <?php endif; ?>
     #<?=$this->localizedNumber($this->scrollData['currentPosition']) . ' ' . $this->transEsc('of') . ' ' . $this->localizedNumber($this->scrollData['resultTotal']) . ' ' . $this->transEsc('results') ?>
-    <? if ($this->scrollData['nextRecord']): ?>
+    <?php if ($this->scrollData['nextRecord']): ?>
       <li>
         <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> &raquo;</a>
       </li>
-      <? if ($this->scrollData['lastRecord']): ?>
+      <?php if ($this->scrollData['lastRecord']): ?>
         <li>
           <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> &raquo;</a>
         </li>
-      <? endif; ?>
-     <? else: ?>
+      <?php endif; ?>
+     <?php else: ?>
       <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
-      <? if ($this->scrollData['lastRecord']): ?>
+      <?php if ($this->scrollData['lastRecord']): ?>
         <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> &raquo;</a></li>
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>
 
 <?=$this->record($this->driver)->getToolbar()?>
 
@@ -69,12 +69,12 @@
     <?=$this->flashmessages()?>
     <?=$this->record($this->driver)->getCollectionMetadata()?>
 
-    <? if (count($this->tabs) > 0): ?>
+    <?php if (count($this->tabs) > 0): ?>
       <a name="tabnav"></a>
       <div class="record-tabs">
         <ul class="nav nav-tabs">
-          <? foreach ($this->tabs as $tab => $obj): ?>
-            <? // add current tab to breadcrumbs if applicable:
+          <?php foreach ($this->tabs as $tab => $obj): ?>
+            <?php // add current tab to breadcrumbs if applicable:
               $desc = $obj->getDescription();
               $tab_classes = [];
               if (0 === strcasecmp($this->activeTab, $tab)) {
@@ -89,30 +89,30 @@
               if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
             ?>
             <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
-              <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"<? if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<? endif ?>><?=$this->transEsc($desc)?></a>
+              <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>><?=$this->transEsc($desc)?></a>
             </li>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </ul>
 
         <div class="tab-content collectionDetails<?=$tree ? 'Tree' : ''?>">
-          <? if (!$this->loadInitialTabWithAjax || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
+          <?php if (!$this->loadInitialTabWithAjax || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
             <div class="tab-pane active <?=$this->activeTab ?>-tab">
               <?=isset($activeTabObj) ? $this->record($this->driver)->getTab($activeTabObj) : '' ?>
             </div>
-          <? endif; ?>
+          <?php endif; ?>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
     <?=$this->driver->supportsCoinsOpenURL()?'<span class="Z3988" title="'.$this->escapeHtmlAttr($this->driver->getCoinsOpenURL()).'"></span>':''?>
   </div>
 
-  <? if (isset($activeTabObj) && is_callable([$activeTabObj, 'getSideRecommendations'])): ?>
+  <?php if (isset($activeTabObj) && is_callable([$activeTabObj, 'getSideRecommendations'])): ?>
     <div class="<?=$this->layoutClass('sidebar')?>">
-      <? foreach ($activeTabObj->getSideRecommendations() as $current): ?>
+      <?php foreach ($activeTabObj->getSideRecommendations() as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
 <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>

--- a/themes/bootstrap3/templates/collections/bytitle.phtml
+++ b/themes/bootstrap3/templates/collections/bytitle.phtml
@@ -1,22 +1,22 @@
-<? $this->layout()->breadcrumbs = '<a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a>'; ?>
+<?php $this->layout()->breadcrumbs = '<a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a>'; ?>
 <div id="bd">
   <div id="yui-main" class="content">
     <div class="disambiguationDiv" >
-      <? if (empty($collections)): ?>
+      <?php if (empty($collections)): ?>
         <h2><?=$this->transEsc('collection_empty')?></h2>
-        <? $this->headTitle($this->translate('collection_empty')); ?>
-      <? else: ?>
+        <?php $this->headTitle($this->translate('collection_empty')); ?>
+      <?php else: ?>
         <h2><?=$this->transEsc('collection_disambiguation')?></h2>
-        <? $this->headTitle($this->translate('collection_disambiguation')); ?>
+        <?php $this->headTitle($this->translate('collection_disambiguation')); ?>
         <div id="disambiguationItemsDiv">
-          <? foreach ($collections as $i => $collection): ?>
+          <?php foreach ($collections as $i => $collection): ?>
            <div class="disambiguationItem <?=$i % 2 ? 'alt ' : ''?>record<?=$i?>">
              <a href="<?=$this->url('collection', ['id' => $collection->getUniqueId()])?>"><?=$this->escapeHtml($collection->getTitle())?></a>
              <p><?=$this->escapeHtml(implode(' ', $collection->getSummary()))?></p>
            </div>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </div>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/collections/home.phtml
+++ b/themes/bootstrap3/templates/collections/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $this->headTitle($this->translate('Collection Browse'));
   $this->layout()->breadcrumbs = '<a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a>';
   $filterList = [];
@@ -10,35 +10,35 @@
   }
 ?>
 
-<? /* LOAD THE LINK INFORMATION INTO $pageLinks, similar to smarty's {capture} */ ?>
-<? ob_start(); ?>
+<?php /* LOAD THE LINK INFORMATION INTO $pageLinks, similar to smarty's {capture} */ ?>
+<?php ob_start(); ?>
   <form class="form-inline" method="GET" action="<?=$this->url('collections-home')?>">
     <ul class="pager">
-      <? if (isset($prevpage)): ?>
+      <?php if (isset($prevpage)): ?>
         <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($prevpage)?><?=$this->escapeHtmlAttr($filterString)?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
-      <? else: ?>
+      <?php else: ?>
         <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
-      <? endif; ?>
-      <? if (isset($nextpage)): ?>
+      <?php endif; ?>
+      <?php if (isset($nextpage)): ?>
         <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($nextpage)?><?=$this->escapeHtmlAttr($filterString)?>"><?=$this->transEsc('Next')?> &raquo;</a></li>
-      <? else: ?>
+      <?php else: ?>
         <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
-      <? endif; ?>
+      <?php endif; ?>
       <input type="submit" class="btn btn-default" value="<?=$this->transEsc('Jump to')?>" />
       <input type="text" name="from" value="<?=$this->escapeHtmlAttr($from)?>" />
     </ul>
   </form>
-<? $pageLinks = ob_get_contents(); ?>
-<? ob_end_clean(); ?>
+<?php $pageLinks = ob_get_contents(); ?>
+<?php ob_end_clean(); ?>
 
 <h2><?=$this->transEsc('Collection Browse')?></h2>
 
-<? if (!empty($filterList)): ?>
+<?php if (!empty($filterList)): ?>
   <strong><?=$this->transEsc('Remove Filters')?></strong>
   <ul class="filters">
-  <? foreach ($filterList as $filter): ?>
+  <?php foreach ($filterList as $filter): ?>
     <li>
-      <?
+      <?php
         $removalUrl = $this->url('collections-home') . '?from=' . urlencode($from);
         foreach ($filterList as $current) {
           if ($current['urlPart'] != $filter['urlPart']) {
@@ -49,14 +49,14 @@
       <a href="<?=$this->escapeHtmlAttr($removalUrl)?>"><img src="<?=$this->imageLink('silk/delete.png')?>" alt="Delete"/></a>
       <a href="<?=$this->escapeHtmlAttr($removalUrl)?>"><?=$this->escapeHtml($filter['displayText'])?></a>
     </li>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>
 
 <ul class="pagination">
-  <? foreach ($letters as $letter): ?>
-    <li<? if($letter === $from): ?> class="active"<?endif?>><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($letter)?><?=$this->escapeHtmlAttr($filterString)?>"><?=$this->escapeHtml($letter)?></a></li>
-  <? endforeach; ?>
+  <?php foreach ($letters as $letter): ?>
+    <li<?php if($letter === $from): ?> class="active"<?endif?>><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($letter)?><?=$this->escapeHtmlAttr($filterString)?>"><?=$this->escapeHtml($letter)?></a></li>
+  <?php endforeach; ?>
 </ul>
 <?=$pageLinks ?>
 <div class="clearfix">

--- a/themes/bootstrap3/templates/collections/list.phtml
+++ b/themes/bootstrap3/templates/collections/list.phtml
@@ -1,5 +1,5 @@
 <div class="list-group">
-  <? foreach ($result as $i => $item): ?>
+  <?php foreach ($result as $i => $item): ?>
     <a class="list-group-item" href="<?=$this->url('collection', ['id' => $item['value']])?>">
       <strong><?=$this->escapeHtml($item['displayText'])?></strong>
       <span class="badge">
@@ -7,5 +7,5 @@
         <i class="fa fa-angle-right" title="<?=$this->transEsc('Find More') ?>"></i>
       </span>
     </a>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap3/templates/combined/results-ajax.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Make sure OpenURL support is loaded
     $this->headScript()->appendFile("openurl.js");
 

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $view = $currentSearch['view'];
   $results = $view->results;
   $params = $results->getParams();
@@ -11,64 +11,64 @@
   $moreUrl = $this->url($params->getOptions()->getSearchAction()) . $results->getUrlQuery()->setPage(1);
   $params->setLimit($limit);
 ?>
-<? if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
+<?php if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
   <div class="pull-right flip">
     <a href="<?=$moreUrl?>" class="btn btn-link"><i class="fa fa-gears" aria-hidden="true"></i> <?=$this->transEsc('More options')?></a>
   </div>
   <h2><a href="<?=$moreUrl?>"><?=$this->transEsc($currentSearch['label'])?></a></h2>
-<? else: ?>
+<?php else: ?>
   <h2><?=$this->transEsc($currentSearch['label'])?></h2>
-<? endif; ?>
-<? if (isset($currentSearch['sublabel'])): ?>
+<?php endif; ?>
+<?php if (isset($currentSearch['sublabel'])): ?>
   <p><i><?=$this->transEsc($currentSearch['sublabel'])?></i></p>
-<? endif; ?>
+<?php endif; ?>
 <div class="clearfix">
   <div class="pull-left flip help-block">
-    <? if ($recordTotal > 0): ?>
-      <? foreach (($top = $results->getRecommendations('top')) as $current): ?>
+    <?php if ($recordTotal > 0): ?>
+      <?php foreach (($top = $results->getRecommendations('top')) as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       <?=$this->transEsc("Showing")?>
       <strong><?=$this->localizedNumber($results->getStartRecord())?></strong> - <strong><?=$this->localizedNumber($results->getEndRecord())?></strong>
-      <? if (!isset($view->skipTotalCount)): ?>
+      <?php if (!isset($view->skipTotalCount)): ?>
         <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($recordTotal)?></strong>
-      <? endif; ?>
-      <? if (isset($view->overrideSearchHeading)): ?>
+      <?php endif; ?>
+      <?php if (isset($view->overrideSearchHeading)): ?>
         <?=$view->overrideSearchHeading?>
-      <? elseif ($params->getSearchType() == 'basic'): ?>
+      <?php elseif ($params->getSearchType() == 'basic'): ?>
         <?=$this->transEsc('for search')?>: <strong>'<?=$this->escapeHtml($lookfor)?>'</strong>,
-      <? endif; ?>
-      <? if ($qtime = $results->getQuerySpeed()): ?>
+      <?php endif; ?>
+      <?php if ($qtime = $results->getQuerySpeed()): ?>
         <?=$this->transEsc('query time')?>: <?=$this->localizedNumber($qtime, 2).$this->transEsc('seconds_abbrev')?>
-      <? endif; ?>
-    <? else: ?>
+      <?php endif; ?>
+    <?php else: ?>
       <h3><?=$this->transEsc('nohit_heading')?></h3>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 </div>
-<? /* End Listing Options */ ?>
+<?php /* End Listing Options */ ?>
 
-<? if ($recordTotal < 1): ?>
+<?php if ($recordTotal < 1): ?>
   <p class="alert alert-danger">
-    <? if (isset($view->overrideEmptyMessage)): ?>
+    <?php if (isset($view->overrideEmptyMessage)): ?>
       <?=$view->overrideEmptyMessage?>
-    <? else: ?>
+    <?php else: ?>
       <?=$this->transEsc('nohit_prefix')?> - <strong><?=$this->escapeHtml($lookfor)?></strong> - <?=$this->transEsc('nohit_suffix')?>
-    <? endif; ?>
+    <?php endif; ?>
   </p>
-  <? if (isset($view->parseError)): ?>
+  <?php if (isset($view->parseError)): ?>
     <p class="alert alert-danger"><?=$this->transEsc('nohit_parse_error')?></p>
-  <? endif; ?>
-  <? foreach (($top = $results->getRecommendations('top')) as $current): ?>
+  <?php endif; ?>
+  <?php foreach (($top = $results->getRecommendations('top')) as $current): ?>
     <?=$this->recommend($current)?>
-  <? endforeach; ?>
-  <? foreach ($results->getRecommendations('noresults') as $current): ?>
-    <? if (!in_array($current, $top)): ?>
+  <?php endforeach; ?>
+  <?php foreach ($results->getRecommendations('noresults') as $current): ?>
+    <?php if (!in_array($current, $top)): ?>
       <?=$this->recommend($current)?>
-    <? endif; ?>
-  <? endforeach; ?>
-<? else: ?>
-  <?
+    <?php endif; ?>
+  <?php endforeach; ?>
+<?php else: ?>
+  <?php
     $viewType = in_array('list', array_keys($params->getViewList()))
       ? 'list' : $params->getView();
     $viewParams = [
@@ -79,7 +79,7 @@
     ];
   ?>
   <?=$this->render('search/list-' . $viewType . '.phtml', $viewParams)?>
-  <? if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
+  <?php if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
     <p><a href="<?=$moreUrl?>"><?=$this->transEsc($currentSearch['more_link'])?> <i class="fa fa-long-arrow-right" aria-hidden="true"></i></a></p>
-  <? endif; ?>
-<? endif; ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $lookfor = $this->params->getDisplayQuery();
   if (isset($this->overrideTitle)) {
@@ -48,15 +48,15 @@
 ?>
 <?=$this->flashmessages()?>
 <form class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
-  <? $recs = $combinedResults->getRecommendations('top'); if (!empty($recs)): ?>
+  <?php $recs = $combinedResults->getRecommendations('top'); if (!empty($recs)): ?>
     <div>
-      <? foreach ($recs as $current): ?>
+      <?php foreach ($recs as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>
-  <?
+  <?php
     $viewParams = [
       'searchClassId' => $searchClassId,
       'combinedResults' => $this->combinedResults,
@@ -66,11 +66,11 @@
     ];
   ?>
   <?=$this->context($this)->renderInContext('combined/stack-'.$placement.'.phtml', $viewParams)?>
-  <? $recs = $combinedResults->getRecommendations('bottom'); if (!empty($recs)): ?>
+  <?php $recs = $combinedResults->getRecommendations('bottom'); if (!empty($recs)): ?>
     <div>
-      <? foreach ($recs as $current): ?>
+      <?php foreach ($recs as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </form>

--- a/themes/bootstrap3/templates/combined/stack-distributed.phtml
+++ b/themes/bootstrap3/templates/combined/stack-distributed.phtml
@@ -1,20 +1,20 @@
 <div class="row">
-  <? $span = floor(12/$columns); ?>
-  <? $sectionCount = count($this->combinedResults); ?>
-  <? $keys = []; ?>
-  <? $searches = []; ?>
-  <? foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
-    <? $keys[] = $searchClassId; ?>
-    <? $searches[] = $currentSearch; ?>
-  <? endforeach; ?>
-  <? for ($column=0;$column<$columns;$column++): ?>
-    <? $columnIndex = $column; ?>
+  <?php $span = floor(12/$columns); ?>
+  <?php $sectionCount = count($this->combinedResults); ?>
+  <?php $keys = []; ?>
+  <?php $searches = []; ?>
+  <?php foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
+    <?php $keys[] = $searchClassId; ?>
+    <?php $searches[] = $currentSearch; ?>
+  <?php endforeach; ?>
+  <?php for ($column=0;$column<$columns;$column++): ?>
+    <?php $columnIndex = $column; ?>
     <div class="col-sm-<?=$span ?> combined-list">
-      <? while ($columnIndex < $sectionCount): ?>
-        <? $searchClassId = $keys[$columnIndex]; ?>
-        <? $currentSearch = $searches[$columnIndex]; ?>
-        <? if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { $columnIndex += $columns; continue; } ?>
-          <?
+      <?php while ($columnIndex < $sectionCount): ?>
+        <?php $searchClassId = $keys[$columnIndex]; ?>
+        <?php $currentSearch = $searches[$columnIndex]; ?>
+        <?php if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { $columnIndex += $columns; continue; } ?>
+          <?php
             $viewParams = ['searchClassId' => $searchClassId, 'currentSearch' => $currentSearch];
             // Enable cart if appropriate:
             $viewParams['showCartControls'] = $this->supportsCartOptions[$columnIndex] && $this->showCartControls;
@@ -22,11 +22,11 @@
             $viewParams['showBulkOptions'] = $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions;
           ?>
           <div id="<?=$this->escapeHtmlAttr($currentSearch['domId'])?>">
-            <? $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
+            <?php $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
             <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $viewParams)?>
           </div>
-        <? $columnIndex += $columns ?>
-      <? endwhile; ?>
+        <?php $columnIndex += $columns ?>
+      <?php endwhile; ?>
     </div>
-  <? endfor; ?>
+  <?php endfor; ?>
 </div>

--- a/themes/bootstrap3/templates/combined/stack-left.phtml
+++ b/themes/bootstrap3/templates/combined/stack-left.phtml
@@ -1,13 +1,13 @@
 <div class="row">
-  <? $columnIndex = 0; ?>
-  <? $span = floor(12/$columns); ?>
-  <? $sectionCount = count($this->combinedResults); ?>
-  <? foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
-    <? if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { continue; } ?>
-    <? if ($columnIndex < $columns): ?>
-      <div class="col-sm-<?=$span ?><? if($columnIndex == $columns-1): ?> col-sm-pull-<?=$span*($columns-1) ?><? else: ?> col-sm-push-<?=$span ?><? endif; ?> combined-list">
-    <? endif; ?>
-    <?
+  <?php $columnIndex = 0; ?>
+  <?php $span = floor(12/$columns); ?>
+  <?php $sectionCount = count($this->combinedResults); ?>
+  <?php foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
+    <?php if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { continue; } ?>
+    <?php if ($columnIndex < $columns): ?>
+      <div class="col-sm-<?=$span ?><?php if($columnIndex == $columns-1): ?> col-sm-pull-<?=$span*($columns-1) ?><?php else: ?> col-sm-push-<?=$span ?><?php endif; ?> combined-list">
+    <?php endif; ?>
+    <?php
       $viewParams = ['searchClassId' => $searchClassId, 'currentSearch' => $currentSearch];
       // Enable cart if appropriate:
       $viewParams['showCartControls'] = $this->supportsCartOptions[$columnIndex] && $this->showCartControls;
@@ -15,12 +15,12 @@
       $viewParams['showBulkOptions'] = $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions;
     ?>
     <div id="<?=$this->escapeHtmlAttr($currentSearch['domId'])?>">
-      <? $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
+      <?php $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
       <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $viewParams)?>
     </div>
-    <? ++$columnIndex ?>
-    <? if($columnIndex < $columns || $columnIndex == $sectionCount): ?>
+    <?php ++$columnIndex ?>
+    <?php if($columnIndex < $columns || $columnIndex == $sectionCount): ?>
       </div>
-    <? endif; ?>
-  <? endforeach; ?>
+    <?php endif; ?>
+  <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/combined/stack-right.phtml
+++ b/themes/bootstrap3/templates/combined/stack-right.phtml
@@ -1,13 +1,13 @@
 <div class="row">
-  <? $columnIndex = 0; ?>
-  <? $span = floor(12/$columns); ?>
-  <? $sectionCount = count($this->combinedResults); ?>
-  <? foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
-    <? if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { continue; } ?>
-    <? if ($columnIndex < $columns): ?>
+  <?php $columnIndex = 0; ?>
+  <?php $span = floor(12/$columns); ?>
+  <?php $sectionCount = count($this->combinedResults); ?>
+  <?php foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
+    <?php if ((!isset($currentSearch['ajax']) || !$currentSearch['ajax']) && isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty'] && $currentSearch['view']->results->getResultTotal() == 0) { continue; } ?>
+    <?php if ($columnIndex < $columns): ?>
       <div class="col-sm-<?=$span ?> combined-list">
-    <? endif; ?>
-    <?
+    <?php endif; ?>
+    <?php
       $viewParams = ['searchClassId' => $searchClassId, 'currentSearch' => $currentSearch];
       // Enable cart if appropriate:
       $viewParams['showCartControls'] = $this->supportsCartOptions[$columnIndex] && $this->showCartControls;
@@ -15,12 +15,12 @@
       $viewParams['showBulkOptions'] = $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions;
     ?>
     <div id="<?=$this->escapeHtmlAttr($currentSearch['domId'])?>">
-      <? $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
+      <?php $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
       <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $viewParams)?>
     </div>
-    <? ++$columnIndex ?>
-    <? if($columnIndex < $columns || $columnIndex == $sectionCount): ?>
+    <?php ++$columnIndex ?>
+    <?php if($columnIndex < $columns || $columnIndex == $sectionCount): ?>
       </div>
-    <? endif; ?>
-  <? endforeach; ?>
+    <?php endif; ?>
+  <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/confirm/confirm.phtml
+++ b/themes/bootstrap3/templates/confirm/confirm.phtml
@@ -1,4 +1,4 @@
-<? $this->headTitle($this->title) ?>
+<?php $this->headTitle($this->title) ?>
 <div class="alignleft">
   <h3><?=$this->transEsc($this->title) ?></h3>
 
@@ -6,17 +6,17 @@
 
   <div id="popupDetails" class="confirmDialog">
     <form class="pull-left flip" action="<?=$this->escapeHtmlAttr($this->confirm)?>" method="post">
-      <? if (isset($this->extras)): ?>
-        <? foreach ($this->extras as $extra=>$value): ?>
-          <? if (is_array($value)): ?>
-            <? foreach ($value as $current): ?>
+      <?php if (isset($this->extras)): ?>
+        <?php foreach ($this->extras as $extra=>$value): ?>
+          <?php if (is_array($value)): ?>
+            <?php foreach ($value as $current): ?>
               <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>[]" value="<?=$this->escapeHtmlAttr($current) ?>" />
-            <? endforeach; ?>
-          <? else: ?>
+            <?php endforeach; ?>
+          <?php else: ?>
             <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>" value="<?=$this->escapeHtmlAttr($value) ?>" />
-          <? endif; ?>
-        <? endforeach; ?>
-      <? endif;?>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      <?php endif;?>
       <input class="btn btn-primary" type="submit" name="confirm" value="<?=$this->transEsc('confirm_dialog_yes') ?>" />
     </form>
     <form action="<?=$this->escapeHtmlAttr($this->cancel) ?>" method="post">

--- a/themes/bootstrap3/templates/content/asklibrary.phtml
+++ b/themes/bootstrap3/templates/content/asklibrary.phtml
@@ -1,4 +1,4 @@
-<? $this->headTitle($this->translate('Ask a Librarian')); ?>
+<?php $this->headTitle($this->translate('Ask a Librarian')); ?>
 
 <h1><?=$this->transEsc('Ask a Librarian') ?></h1>
 

--- a/themes/bootstrap3/templates/content/asklibrary_en.phtml
+++ b/themes/bootstrap3/templates/content/asklibrary_en.phtml
@@ -1,4 +1,4 @@
-<? $this->headTitle($this->translate('Ask a Librarian')); ?>
+<?php $this->headTitle($this->translate('Ask a Librarian')); ?>
 
 <h1><?=$this->transEsc('Ask a Librarian') ?></h1>
 

--- a/themes/bootstrap3/templates/content/faq.phtml
+++ b/themes/bootstrap3/templates/content/faq.phtml
@@ -1,13 +1,13 @@
-<? $this->headTitle($this->translate('FAQs')); ?>
+<?php $this->headTitle($this->translate('FAQs')); ?>
 
 <h1><?=$this->transEsc('FAQs') ?></h1>
 
-<? if ($this->auth()->getManager()->supportsRecovery()): ?>
+<?php if ($this->auth()->getManager()->supportsRecovery()): ?>
   <p>
     Q: How do I reset my password?<br/>
     A: Go to the login screen and click the "Forgot password" link. Enter either your user name or email address, and you will get an email containing a link to reset your password.
   </p>
-<? endif; ?>
+<?php endif; ?>
 <p>
   Q: Why does the service use cookies?<br/>
   A: Cookies are used to manage sessions, which include selected language, last search, book bag contents, any login information, etc.

--- a/themes/bootstrap3/templates/devtools/deminify.phtml
+++ b/themes/bootstrap3/templates/devtools/deminify.phtml
@@ -1,39 +1,39 @@
-<?
+<?php
     $this->headTitle('Deminifier');
 ?>
 
 <h2>Deminifier</h2>
 
-<? if (!$min): ?>
+<?php if (!$min): ?>
   <form method='POST'>
     Minified text:
     <textarea name="min"></textarea>
     <input type="submit" />
   </form>
-<? else: ?>
+<?php else: ?>
   <h3>Minified Object</h3>
-  <pre><? print_r($min) ?></pre>
-<? endif; ?>
+  <pre><?php print_r($min) ?></pre>
+<?php endif; ?>
 
-<? if ($results): ?>
+<?php if ($results): ?>
   <h3>Results Object</h3>
   <p>Class: <?=get_class($results)?></p>
-<? endif; ?>
+<?php endif; ?>
 
-<? if ($query): ?>
+<?php if ($query): ?>
   <h3>Query Object</h3>
-  <pre><? print_r($query) ?></pre>
-<? endif; ?>
+  <pre><?php print_r($query) ?></pre>
+<?php endif; ?>
 
-<? if ($backendParams || $queryParams): ?>
+<?php if ($backendParams || $queryParams): ?>
   <h3>Backend Parameters</h3>
-  <? if ($queryParams): ?>
+  <?php if ($queryParams): ?>
     <h4>Query Parameters</h4>
-    <pre><? print_r($queryParams) ?></pre>
-  <? endif ; ?>
-  <? if ($backendParams): ?>
+    <pre><?php print_r($queryParams) ?></pre>
+  <?php endif ; ?>
+  <?php if ($backendParams): ?>
     <h4>Non-query Parameters</h4>
-    <pre><? print_r($backendParams) ?></pre>
-  <? endif ; ?>
-<? endif; ?>
+    <pre><?php print_r($backendParams) ?></pre>
+  <?php endif ; ?>
+<?php endif; ?>
 

--- a/themes/bootstrap3/templates/devtools/home.phtml
+++ b/themes/bootstrap3/templates/devtools/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $this->headTitle('Development Tools');
 ?>
 

--- a/themes/bootstrap3/templates/devtools/language.phtml
+++ b/themes/bootstrap3/templates/devtools/language.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $this->headTitle($this->translate('Language'));
 ?>
 
@@ -8,21 +8,21 @@
 
 <table class="table table-striped">
   <tr><th>Language</th><th>Missing Lines</th><th>Extra Lines</th><th>Percent Translated</th><th>Extra Help Files</th></tr>
-  <? foreach ($details as $langCode => $diffs): ?>
-    <?
+  <?php foreach ($details as $langCode => $diffs): ?>
+    <?php
       $extraCount = count($diffs['notInL1']);
       $missingCount = count($diffs['notInL2']);
     ?>
     <tr>
       <td><?=$this->escapeHtml($langCode . ' (' . $diffs['name'] . ')')?></td>
-      <td><?=$missingCount ?><? if($missingCount > 0): ?> (<a href="#" onclick="diffManager.showMissing('<?=$langCode ?>')"><?=$this->transEsc('show') ?></a>)<? endif; ?></td>
-      <td><?=$extraCount ?><? if($extraCount > 0): ?> (<a href="#" onclick="diffManager.showExtra('<?=$langCode ?>')"><?=$this->transEsc('show') ?></a>)<? endif; ?></td>
+      <td><?=$missingCount ?><?php if($missingCount > 0): ?> (<a href="#" onclick="diffManager.showMissing('<?=$langCode ?>')"><?=$this->transEsc('show') ?></a>)<?php endif; ?></td>
+      <td><?=$extraCount ?><?php if($extraCount > 0): ?> (<a href="#" onclick="diffManager.showExtra('<?=$langCode ?>')"><?=$this->transEsc('show') ?></a>)<?php endif; ?></td>
       <td><?=$this->escapeHtml($diffs['l2Percent'])?></td>
       <td><?=count($diffs['helpFiles'])?></td>
     </tr>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </table>
-<?
+<?php
   $json = json_encode($details);
   $script = <<<JS
   function createDiffManager() {

--- a/themes/bootstrap3/templates/eds/advanced.phtml
+++ b/themes/bootstrap3/templates/eds/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Load the EDS-specific advanced search controls and inject them into the
   // standard advanced search layout:
   $this->extraAdvancedControls = $this->render('search/advanced/eds.phtml');
@@ -10,15 +10,15 @@
   <div class="group well clearfix">
     <input type="hidden" name="join" value="AND"/>
     <input type="hidden" name="bool0[]" value="AND"/>
-    <? for ($search=0;$search<3;$search++): ?>
-      <? if ($search == 0): ?>
+    <?php for ($search=0;$search<3;$search++): ?>
+      <?php if ($search == 0): ?>
         <div id="new_search_template">
-      <? endif; ?>
+      <?php endif; ?>
       <div class="search row">
         <div class="col-sm-3">
           <input type="hidden" value="AND" class="first-op"/>
-          <label class="help-block<? if ($search > 0): ?> hidden<?endif;?>"><?=$this->transEsc("adv_search_label")?>:</label>
-          <select id="search_op0_<?=$search ?>" name="op0[]" class="op col-sm-9 form-control<? if ($search == 0): ?> hidden<?endif;?>">
+          <label class="help-block<?php if ($search > 0): ?> hidden<?endif;?>"><?=$this->transEsc("adv_search_label")?>:</label>
+          <select id="search_op0_<?=$search ?>" name="op0[]" class="op col-sm-9 form-control<?php if ($search == 0): ?> hidden<?endif;?>">
             <option value="AND"><?=$this->transEsc("AND")?></option>
             <option value="OR"><?=$this->transEsc("OR")?></option>
             <option value="NOT"><?=$this->transEsc("NOT")?></option>
@@ -32,9 +32,9 @@
             <span class="col-sm-1 help-block hidden-xs"><?=$this->transEsc("in")?></span>
             <div class="col-sm-4 middle">
               <select id="search_type0_<?=$search ?>" name="type0[]" class="type form-control">
-                <? foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
+                <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
                   <option value="<?=$this->escapeHtml($searchVal)?>"><?=$this->transEsc($searchDesc)?></option>
-                <? endforeach; ?>
+                <?php endforeach; ?>
               </select>
             </div>
             <div class="close">
@@ -44,14 +44,14 @@
         </div>
         <br class="hidden-lg"/>
       </div>
-      <? if ($search == 0): ?>
+      <?php if ($search == 0): ?>
         </div>
-      <? endif; ?>
-    <? endfor; ?>
+      <?php endif; ?>
+    <?php endfor; ?>
     <i class="fa fa-plus-circle search_place_holder hidden" aria-hidden="true"></i> <a href="#" class="add_search_link hidden"><?=$this->transEsc("add_search")?></a>
   </div>
 </div>
-<?
+<?php
   $this->formOverride = ob_get_contents();
   ob_end_clean();
 

--- a/themes/bootstrap3/templates/eds/home.phtml
+++ b/themes/bootstrap3/templates/eds/home.phtml
@@ -1,3 +1,3 @@
-<?
+<?php
   echo $this->render('search/home.phtml');
 ?>

--- a/themes/bootstrap3/templates/eds/search.phtml
+++ b/themes/bootstrap3/templates/eds/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Load standard settings from the default search results screen:
   $this->overrideSideFacetCaption = 'Refine Results';
   $this->paginationOptions = ['disableFirst' => true, 'disableLast' => true];

--- a/themes/bootstrap3/templates/eit/advanced.phtml
+++ b/themes/bootstrap3/templates/eit/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // There are no EIT-specific advanced search controls, so just load the
   // standard advanced search layout:
   echo $this->render('search/advanced/layout.phtml');

--- a/themes/bootstrap3/templates/eit/search.phtml
+++ b/themes/bootstrap3/templates/eit/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/error/index.phtml
+++ b/themes/bootstrap3/templates/error/index.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('An error has occurred'));
 
@@ -10,19 +10,19 @@
   <p>
     <?=$this->transEsc('Please contact the Library Reference Department for assistance')?>
     <br/>
-    <? $supportEmail = $this->escapeHtmlAttr($this->systememail()); ?>
+    <?php $supportEmail = $this->escapeHtmlAttr($this->systememail()); ?>
     <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
   </p>
 </div>
 
-<? if ($this->showInstallLink): ?>
+<?php if ($this->showInstallLink): ?>
   <h2><a href="<?=$this->url('install-home')?>"><?=$this->transEsc('auto_configure_title', [], 'Auto Configure')?></a></h2>
   <?=$this->transEsc('auto_configure_description', [], 'If this is a new installation, you may be able to fix the error using VuFind\'s Auto Configure tool.')?>
   <h2><a href="<?=$this->url('upgrade-home')?>"><?=$this->transEsc('Upgrade VuFind')?></a></h2>
   <?=$this->transEsc('upgrade_description', [], 'If you are upgrading a previous VuFind version, you can load your old settings with this tool.')?>
-<? endif; ?>
+<?php endif; ?>
 
-<? if (isset($this->display_exceptions) && $this->display_exceptions): ?>
+<?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
   <h2><?=$this->transEsc('Exception')?>:</h2>
   <p>
     <b><?=$this->transEsc('Message')?>:</b> <?=$this->escapeHtml($this->exception->getMessage())?>
@@ -32,18 +32,18 @@
   <pre><?=$this->exception->getTraceAsString()?>
   </pre>
 
-  <? if ($e = $this->exception->getPrevious()): ?>
+  <?php if ($e = $this->exception->getPrevious()): ?>
     <h3>Previous exceptions:</h3>
-    <? while($e): ?>
+    <?php while($e): ?>
         <h4><?php echo get_class($e); ?></h4>
         <p><?=$e->getMessage()?></p>
         <pre><?=$e->getTraceAsString()?></pre>
-        <? $e = $e->getPrevious(); ?>
-    <? endwhile; ?>
-  <? endif; ?>
+        <?php $e = $e->getPrevious(); ?>
+    <?php endwhile; ?>
+  <?php endif; ?>
 
-  <? if (isset($this->request)): ?>
+  <?php if (isset($this->request)): ?>
     <h2><?=$this->transEsc('error_page_parameter_list_heading')?>:</h2>
     <pre><?=$this->escapeHtml(var_export($this->request->getParams(), true))?></pre>
-  <? endif; ?>
-<? endif ?>
+  <?php endif; ?>
+<?php endif ?>

--- a/themes/bootstrap3/templates/error/unavailable.phtml
+++ b/themes/bootstrap3/templates/error/unavailable.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('System Unavailable'));
 
@@ -16,7 +16,7 @@
   <p>
     <?=$this->transEsc('Please contact the Library Reference Department for assistance')?>
     <br/>
-    <? $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+    <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
     <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
   </p>
 </div>

--- a/themes/bootstrap3/templates/externalauth/ezproxylogin.phtml
+++ b/themes/bootstrap3/templates/externalauth/ezproxylogin.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title
     $this->headTitle($this->translate('external_auth_heading'));
 ?>
@@ -6,13 +6,13 @@
 <div class="row external-content-access">
   <div class="col-sm-12">
     <?=$this->flashmessages()?>
-    <? if ($this->unauthorized): ?>
+    <?php if ($this->unauthorized): ?>
       <div class="unauthorized-description">
         <p><?=$this->transEsc('external_auth_unauthorized_desc'); ?></p>
       </div>
       <div>
         <a href="<?=$this->url('myresearch-logout')?>" class="logout btn btn-primary" title="<?=$this->transEsc("Log Out")?>"><strong><?=$this->transEsc("Log Out")?></strong></a>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/feedback/email.phtml
+++ b/themes/bootstrap3/templates/feedback/email.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title
     $this->headTitle($this->translate('Feedback'));
     // Get rid of the feedback tab since this uses the same variables

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -1,4 +1,4 @@
-<? $account = $this->auth()->getManager(); ?>
+<?php $account = $this->auth()->getManager(); ?>
 <div class="banner container navbar">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#header-collapse">
@@ -7,70 +7,70 @@
     </button>
     <a class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="<?=$this->url('home')?>">VuFind</a>
   </div>
-  <? if (!isset($this->layout()->renderingError)): ?>
+  <?php if (!isset($this->layout()->renderingError)): ?>
     <div class="collapse navbar-collapse" id="header-collapse">
       <nav>
         <ul role="navigation" class="nav navbar-nav navbar-right flip">
-          <? if ($this->feedback()->tabEnabled()): ?>
+          <?php if ($this->feedback()->tabEnabled()): ?>
             <li>
               <a id="feedbackLink" data-lightbox href="<?=$this->url('feedback-home') ?>"><i class="fa fa-envelope" aria-hidden="true"></i> <?=$this->transEsc("Feedback")?></a>
             </li>
-          <? endif; ?>
-          <? $cart = $this->cart(); if ($cart->isActive()): ?>
+          <?php endif; ?>
+          <?php $cart = $this->cart(); if ($cart->isActive()): ?>
             <li id="cartSummary">
               <a id="cartItems" data-lightbox title="<?=$this->transEsc('View Book Bag')?>" href="<?=$this->url('cart-home')?>">
                 <i class="fa fa-suitcase" aria-hidden="true"></i> <strong><?=count($cart->getItems())?></strong> <?=$this->transEsc('items')?>
                 <span class="full<?=!$cart->isFull() ? ' hidden' : '' ?>">(<?=$this->transEsc('bookbag_full') ?>)</span>
               </a>
             </li>
-          <? endif; ?>
-          <? if (is_object($account) && $account->loginEnabled()): // hide login/logout if unavailable ?>
-            <li class="logoutOptions<? if(!$account->isLoggedIn()): ?> hidden<? endif ?>">
+          <?php endif; ?>
+          <?php if (is_object($account) && $account->loginEnabled()): // hide login/logout if unavailable ?>
+            <li class="logoutOptions<?php if(!$account->isLoggedIn()): ?> hidden<?php endif ?>">
               <a href="<?=$this->url('myresearch-home', array(), array('query' => array('redirect' => 0)))?>"><i class="fa fa-home" aria-hidden="true"></i> <?=$this->transEsc("Your Account")?></a>
             </li>
-            <li class="logoutOptions<? if(!$account->isLoggedIn()): ?> hidden<? endif ?>">
+            <li class="logoutOptions<?php if(!$account->isLoggedIn()): ?> hidden<?php endif ?>">
               <a href="<?=$this->url('myresearch-logout')?>" class="logout"><i class="fa fa-sign-out" aria-hidden="true"></i> <?=$this->transEsc("Log Out")?></a>
             </li>
-            <li id="loginOptions"<? if($account->isLoggedIn()): ?> class="hidden"<? endif ?>>
-              <? if ($account->getSessionInitiator($this->serverUrl($this->url('myresearch-home')))): ?>
+            <li id="loginOptions"<?php if($account->isLoggedIn()): ?> class="hidden"<?php endif ?>>
+              <?php if ($account->getSessionInitiator($this->serverUrl($this->url('myresearch-home')))): ?>
                 <a href="<?=$this->url('myresearch-userlogin')?>"><i class="fa fa-sign-in" aria-hidden="true"></i> <?=$this->transEsc("Institutional Login")?></a>
-              <? else: ?>
+              <?php else: ?>
                 <a href="<?=$this->url('myresearch-userlogin')?>" data-lightbox><i class="fa fa-sign-in" aria-hidden="true"></i> <?=$this->transEsc("Login")?></a>
-              <? endif; ?>
+              <?php endif; ?>
             </li>
-          <? endif; ?>
+          <?php endif; ?>
 
-          <? if (isset($this->layout()->themeOptions) && count($this->layout()->themeOptions) > 1): ?>
+          <?php if (isset($this->layout()->themeOptions) && count($this->layout()->themeOptions) > 1): ?>
             <li class="theme dropdown">
               <form method="post" name="themeForm" id="themeForm">
                 <input type="hidden" name="ui"/>
               </form>
               <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?=$this->transEsc("Theme")?> <b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <? foreach ($this->layout()->themeOptions as $current): ?>
+                <?php foreach ($this->layout()->themeOptions as $current): ?>
                   <li<?=$current['selected'] ? ' class="active"' : ''?>><a href="#" onClick="document.themeForm.ui.value='<?=$this->escapeHtmlAttr($current['name'])?>';document.themeForm.submit()"><?=$this->transEsc($current['desc'])?></a></li>
-                <? endforeach; ?>
+                <?php endforeach; ?>
               </ul>
             </li>
-          <? endif; ?>
+          <?php endif; ?>
 
-          <? if (isset($this->layout()->allLangs) && count($this->layout()->allLangs) > 1): ?>
+          <?php if (isset($this->layout()->allLangs) && count($this->layout()->allLangs) > 1): ?>
             <li class="language dropdown">
               <form method="post" name="langForm" id="langForm">
                 <input type="hidden" name="mylang"/>
               </form>
               <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?=$this->transEsc("Language")?> <b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <? foreach ($this->layout()->allLangs as $langCode => $langName): ?>
+                <?php foreach ($this->layout()->allLangs as $langCode => $langName): ?>
                   <li<?=$this->layout()->userLang == $langCode ? ' class="active"' : ''?>><a href="#" onClick="document.langForm.mylang.value='<?=$langCode?>';document.langForm.submit()"><?=$this->displayLanguageOption($langName)?></a></li>
-                <? endforeach; ?>
+                <?php endforeach; ?>
               </ul>
             </li>
-          <? endif; ?>
+          <?php endif; ?>
         </ul>
       </nav>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
 <div class="search container navbar">
   <nav class="nav searchbox hidden-print">

--- a/themes/bootstrap3/templates/help/home.phtml
+++ b/themes/bootstrap3/templates/help/home.phtml
@@ -1,9 +1,9 @@
-<? $this->headTitle($this->translate('Help')); ?>
-<? if ($help = $this->helpText()->render($topic)): ?>
-  <? foreach ($this->helpText()->getWarnings() as $warning): ?>
+<?php $this->headTitle($this->translate('Help')); ?>
+<?php if ($help = $this->helpText()->render($topic)): ?>
+  <?php foreach ($this->helpText()->getWarnings() as $warning): ?>
     <p class="alert alert-warning"><?=$this->transEsc($warning)?></p>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <?=$help?>
-<? else: ?>
+<?php else: ?>
   <p class="alert alert-danger"><?=$this->transEsc('help_page_missing')?></p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/install/disabled.phtml
+++ b/themes/bootstrap3/templates/install/disabled.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 

--- a/themes/bootstrap3/templates/install/done.phtml
+++ b/themes/bootstrap3/templates/install/done.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 

--- a/themes/bootstrap3/templates/install/fixbasicconfig.phtml
+++ b/themes/bootstrap3/templates/install/fixbasicconfig.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -7,7 +7,7 @@
 ?>
 <h2><?=$this->transEsc('auto_configure_title')?></h2>
 
-<? if (isset($this->configDir)): ?>
+<?php if (isset($this->configDir)): ?>
   <p>VuFind cannot write to <b><?=$this->escapeHtml($this->configDir)?></b>.</p>
 
   <p>Please make sure that write permissions are available on this directory.</p>
@@ -15,12 +15,12 @@
   <p>In Linux, try this command (note that you may need to prefix with "sudo" on some flavors):</p>
 
   <pre>
-    <? if (isset($this->runningUser)): ?>
+    <?php if (isset($this->runningUser)): ?>
       chown <?=$this->escapeHtml($this->runningUser)?>:<?=$this->escapeHtml($this->runningUser)?> <?=$this->escapeHtml($this->configDir)?>
-    <? else: ?>
+    <?php else: ?>
       chmod 777 <?=$this->escapeHtml($this->configDir)?>
-    <? endif; ?>
+    <?php endif; ?>
   </pre>
-<? else: ?>
+<?php else: ?>
   <p>Your configuration has been successfully updated.</p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/install/fixcache.phtml
+++ b/themes/bootstrap3/templates/install/fixcache.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -14,9 +14,9 @@
 <p>In Linux, try this command (note that you may need to prefix with "sudo" on some flavors):</p>
 
 <pre>
-  <? if (isset($this->runningUser)): ?>
+  <?php if (isset($this->runningUser)): ?>
     chown <?=$this->escapeHtml($this->runningUser)?>:<?=$this->escapeHtml($this->runningUser)?> <?=$this->escapeHtml($this->cacheDir)?>
-  <? else: ?>
+  <?php else: ?>
     chmod 777 <?=$this->escapeHtml($this->cacheDir)?>
-  <? endif; ?>
+  <?php endif; ?>
 </pre>

--- a/themes/bootstrap3/templates/install/fixdatabase.phtml
+++ b/themes/bootstrap3/templates/install/fixdatabase.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -17,7 +17,7 @@
     <div class="col-sm-9">
       <select name="driver" class="form-control">
         <option value="mysql">MySQL</option>
-        <option <? if ($driver == 'pgsql'): ?>selected="selected" <? endif; ?>value="pgsql">PostgreSQL</option>
+        <option <?php if ($driver == 'pgsql'): ?>selected="selected" <?php endif; ?>value="pgsql">PostgreSQL</option>
       </select>
     </div>
   </div>

--- a/themes/bootstrap3/templates/install/fixdependencies.phtml
+++ b/themes/bootstrap3/templates/install/fixdependencies.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -9,4 +9,4 @@
 
 <?=$this->flashmessages()?>
 
-<? if ($this->problems == 0): ?><p><?=$this->transEsc('No dependency problems found') ?>.</p><? endif; ?>
+<?php if ($this->problems == 0): ?><p><?=$this->transEsc('No dependency problems found') ?>.</p><?php endif; ?>

--- a/themes/bootstrap3/templates/install/fixils.phtml
+++ b/themes/bootstrap3/templates/install/fixils.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -7,7 +7,7 @@
 ?>
 <h2><?=$this->transEsc('auto_configure_title')?></h2>
 
-<? if (isset($this->demo)): ?>
+<?php if (isset($this->demo)): ?>
   <p>You are using one of VuFind's simulated Integrated Library System (ILS) drivers, which display fake information
   in order to demonstrate the capabilities of the system.  If you want real patron and status information to display,
   you should change your configuration to communicate with a real ILS.</p>
@@ -17,9 +17,9 @@
       <label for="driver" class="col-sm-2 control-label">Pick a driver:</label>
       <div class="col-sm-10">
         <select id="driver" name="driver" class="form-control">
-          <? foreach ($this->drivers as $driver): ?>
+          <?php foreach ($this->drivers as $driver): ?>
             <option value="<?=$this->escapeHtmlAttr($driver)?>"><?=$this->escapeHtml($driver)?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
     </div>
@@ -32,8 +32,8 @@
 
   <p>If your ILS is not available in this list, you may be able to write your own driver.  See the
   <a href="https://vufind.org/wiki/development" target="_new">Developer Manual</a>.</p>
-<? else: ?>
+<?php else: ?>
   <p>VuFind is having trouble communicating with your Integrated Library System (ILS).  Check your configuration.
   You may need to edit the file at <strong><?=$this->escapeHtml($this->configPath)?></strong> and fill in some
   connection details.</p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/install/fixsecurity.phtml
+++ b/themes/bootstrap3/templates/install/fixsecurity.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 
@@ -9,7 +9,7 @@
 
 <?=$this->flashmessages()?>
 
-<? if (isset($this->confirmUserFix) && $this->confirmUserFix): ?>
+<?php if (isset($this->confirmUserFix) && $this->confirmUserFix): ?>
   <p>You have existing user data in your database containing non-encrypted passwords.</p>
   <p>If you continue with enabling security, all of your passwords will be hashed and/or encrypted.</p>
   <p><b>Please make a database backup before proceeding.</b></p>
@@ -22,6 +22,6 @@
     <input type="submit" name="fix-user-table" value="Yes" class="btn btn-default"/>
     <input type="submit" name="fix-user-table" value="No" class="btn btn-default"/>
   </form>
-<? else: ?>
+<?php else: ?>
   <p>No security problems found.</p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/install/fixsolr.phtml
+++ b/themes/bootstrap3/templates/install/fixsolr.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 

--- a/themes/bootstrap3/templates/install/fixsslcerts.phtml
+++ b/themes/bootstrap3/templates/install/fixsslcerts.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('auto_configure_title'));
 

--- a/themes/bootstrap3/templates/install/home.phtml
+++ b/themes/bootstrap3/templates/install/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('auto_configure_title'));
 
@@ -7,11 +7,11 @@
 ?>
 <h2><?=$this->transEsc('auto_configure_title')?></h2>
 <?=$this->flashmessages()?>
-<? $errors = 0; foreach ($this->checks as $check): ?>
-<? if (!$check['status']) $errors++; ?>
+<?php $errors = 0; foreach ($this->checks as $check): ?>
+<?php if (!$check['status']) $errors++; ?>
   <div class="alert alert-<?=$check['status'] ? 'success':'danger'?>"><?=$this->escapeHtml($check['title'])?>... <?=$check['status'] ? $this->transEsc('test_ok') : $this->transesc('test_fail') . ' <a class="btn btn-danger" href="' . $this->url('install-' . strtolower($check['fix'])) . '">' . $this->transEsc('test_fix') . '</a>' ?></div>
-<? endforeach; ?>
+<?php endforeach; ?>
 
-<? if ($errors == 0): ?>
+<?php if ($errors == 0): ?>
   <p>No problems were found.  You may wish to <a href="<?=$this->url('install-done')?>">Disable Auto Configuration</a> at this time.</p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/install/showsql.phtml
+++ b/themes/bootstrap3/templates/install/showsql.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Install VuFind'));
 

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
     <?=$this->headMeta()?>
     <?=$this->headTitle()?>
-    <?
+    <?php
       // Set up OpenSearch link:
       $this->headLink(
         [
@@ -19,12 +19,12 @@
       );
     ?>
     <!-- RTL styling -->
-    <? if ($this->layout()->rtl) {
+    <?php if ($this->layout()->rtl) {
       $this->headLink()->appendStylesheet('vendor/bootstrap-rtl.min.css');
     } ?>
     <?=$this->headLink()?>
     <?=$this->headStyle()?>
-    <?
+    <?php
       if (!isset($this->renderingError)) {
         // Add translation strings
         $this->jsTranslations()->addStrings(
@@ -108,7 +108,7 @@
           $this->headScript()->appendFile("keep_alive.js");
       }
     ?>
-    <?
+    <?php
       $root = rtrim($this->url('home'), '/');
       $translations = $this->jsTranslations()->getJSON();
       $dsb = DEFAULT_SEARCH_BACKEND;
@@ -121,8 +121,8 @@ JS;
     ?>
     <?=$this->headScript()?>
   </head>
-  <body class="<?=$this->layoutClass('offcanvas-row')?><? if ($this->layout()->rtl): ?> rtl<? endif; ?>">
-    <? // Set up the search box -- there are three possible cases:
+  <body class="<?=$this->layoutClass('offcanvas-row')?><?php if ($this->layout()->rtl): ?> rtl<?php endif; ?>">
+    <?php // Set up the search box -- there are three possible cases:
       // 1. No search box was set; we should default to the normal box
       // 2. It was set to false; we should display nothing
       // 3. It is set to a custom string; we should display the provided version
@@ -133,35 +133,35 @@ JS;
       }
     ?>
     <header class="hidden-print">
-      <? if (isset($this->layout()->srmessage)): // message for benefit of screen-reader users ?>
+      <?php if (isset($this->layout()->srmessage)): // message for benefit of screen-reader users ?>
         <span class="sr-only"><?=$this->layout()->srmessage ?></span>
-      <? endif; ?>
+      <?php endif; ?>
       <a class="sr-only" href="#content"><?=$this->transEsc('Skip to content') ?></a>
       <?=$this->render('header.phtml')?>
       <div class="breadcrumbs container">
-        <? if((!isset($this->layout()->showBreadcrumbs) || $this->layout()->showBreadcrumbs == true)
+        <?php if((!isset($this->layout()->showBreadcrumbs) || $this->layout()->showBreadcrumbs == true)
           && !empty($this->layout()->breadcrumbs)
           && $this->layout()->breadcrumbs !== false
         ): ?>
           <ul class="breadcrumb hidden-print">
-            <? if(is_array($this->layout()->breadcrumbs)): ?>
-              <? if(count($this->layout()->breadcrumbs) > 1): ?>
+            <?php if(is_array($this->layout()->breadcrumbs)): ?>
+              <?php if(count($this->layout()->breadcrumbs) > 1): ?>
                 <?=$this->render('breadcrumbs/multi.phtml', [
                     'parents' => $this->layout()->breadcrumbs,
                     'title'   => $this->layout()->title,
                     'from'    => $this->layout()->from
                   ]) ?>
-              <? else: ?>
+              <?php else: ?>
                 <?=$this->render('breadcrumbs/default.phtml', [
                     'parents' => $this->layout()->breadcrumbs,
                     'title'   => $this->layout()->title
                   ]) ?>
-              <? endif; ?>
-            <? else: ?>
+              <?php endif; ?>
+            <?php else: ?>
               <?=$this->layout()->breadcrumbs ?>
-            <? endif; ?>
+            <?php endif; ?>
           </ul>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
     </header>
     <div role="main" class="main template-dir-<?=$this->templateDir?> template-name-<?=$this->templateName?>">
@@ -188,8 +188,8 @@ JS;
     <div class="offcanvas-overlay" data-toggle="offcanvas"></div>
     <?=$this->googleanalytics()?>
     <?=$this->piwik()?>
-    <? if ($this->recaptcha()->active()): ?>
+    <?php if ($this->recaptcha()->active()): ?>
       <?=$this->inlineScript(\Zend\View\Helper\HeadScript::FILE, "https://www.google.com/recaptcha/api.js?onload=recaptchaOnLoad&render=explicit&hl=" . $this->layout()->userLang, 'SET')?>
-    <? endif; ?>
+    <?php endif; ?>
   </body>
 </html>

--- a/themes/bootstrap3/templates/libguides/results.phtml
+++ b/themes/bootstrap3/templates/libguides/results.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/librarycards/editcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/editcard.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $pageTitle = empty($this->card->id) ? 'Add a Library Card' : "Edit Library Card";
   $this->headTitle($this->translate($pageTitle));
@@ -21,18 +21,18 @@
       <input id="card_name" class="form-control" type="text" name="card_name" value="<?=$this->escapeHtmlAttr($this->cardName)?>"/>
     </div>
   </div>
-  <? if ($this->targets !== null): ?>
+  <?php if ($this->targets !== null): ?>
   <div class="form-group">
     <label class="col-sm-3 control-label" for="login_target"><?=$this->transEsc('login_target')?>:</label>
     <div class="col-sm-9">
       <select id="login_target" name="target" class="form-control">
-      <? foreach ($this->targets as $target): ?>
+      <?php foreach ($this->targets as $target): ?>
         <option value="<?=$this->escapeHtmlAttr($target)?>"<?=($target == $this->target ? ' selected="selected"' : '')?>><?=$this->transEsc("source_$target", null, $target)?></option>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       </select>
     </div>
   </div>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="form-group">
     <label class="col-sm-3 control-label" for="login_username"><?=$this->transEsc('Username')?>:</label>
     <div class="col-sm-9">

--- a/themes/bootstrap3/templates/librarycards/home.phtml
+++ b/themes/bootstrap3/templates/librarycards/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Library Cards'));
 
@@ -11,28 +11,28 @@
     <?=$this->flashmessages()?>
 
     <h2><?=$this->transEsc('Library Cards')?></h2>
-    <? if ($this->libraryCards->count() == 0): ?>
+    <?php if ($this->libraryCards->count() == 0): ?>
       <div><?=$this->transEsc('You do not have any library cards')?></div>
-    <? else: ?>
+    <?php else: ?>
       <table class="table table-striped" summary="<?=$this->transEsc('Library Cards')?>">
       <tr>
         <th><?=$this->transEsc('Library Card Name')?></th>
-        <? if ($this->multipleTargets): ?>
+        <?php if ($this->multipleTargets): ?>
         <th><?=$this->transEsc('login_target')?></th>
-        <? endif; ?>
+        <?php endif; ?>
         <th><?=$this->transEsc('Username')?></th>
         <th>&nbsp;</th>
       </tr>
-      <? foreach ($this->libraryCards as $record): ?>
+      <?php foreach ($this->libraryCards as $record): ?>
         <tr>
           <td><?=$this->escapeHtml($record['card_name'])?></td>
-          <? $username = $record['cat_username']; if ($this->multipleTargets): ?>
-            <? $target = ''; ?>
-            <? if (strstr($username, '.')): ?>
-              <? list($target, $username) = explode('.', $username, 2); ?>
-            <? endif; ?>
+          <?php $username = $record['cat_username']; if ($this->multipleTargets): ?>
+            <?php $target = ''; ?>
+            <?php if (strstr($username, '.')): ?>
+              <?php list($target, $username) = explode('.', $username, 2); ?>
+            <?php endif; ?>
             <td><?=$target ? $this->transEsc("source_$target", null, $target) : '&nbsp;' ?></td>
-          <? endif; ?>
+          <?php endif; ?>
           <td><?=$this->escapeHtml($username)?></td>
           <td>
             <div class="btn-group">
@@ -47,9 +47,9 @@
             </div>
           </td>
         </tr>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       </table>
-    <? endif; ?>
+    <?php endif; ?>
 
     <div class="btn-group">
       <a href="<?=$this->url('editLibraryCard') ?>NEW" class="btn btn-link"><i class="fa fa-edit" aria-hidden="true"></i> <?=$this->transEsc('Add a Library Card')?></a>

--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -1,10 +1,10 @@
-<? if ($this->user): ?>
+<?php if ($this->user): ?>
   <?$cards = $this->user->getLibraryCards(); if ($cards->count() > 1): ?>
     <form class="form-inline" action="<?=$this->url('librarycards-selectcard')?>" method="get">
       <label for="library_card"><?=$this->transEsc('Library Card')?></label>
       <select id="library_card" name="cardID" class="jumpMenu form-control">
-        <? foreach ($cards as $card): ?>
-          <?
+        <?php foreach ($cards as $card): ?>
+          <?php
             $target = '';
             $username = $card->cat_username;
             if (strstr($username, '.')) {
@@ -16,9 +16,9 @@
             }
           ?>
           <option value="<?=$this->escapeHtmlAttr($card->id)?>"<?=$card->cat_username == $this->user->cat_username ? ' selected="selected"' : ''?>><?=$display ?></option>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </select>
       <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEsc("Set")?>" /></noscript>
     </form>
-  <? endif; ?>
-<? endif; ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/account.phtml
+++ b/themes/bootstrap3/templates/myresearch/account.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('User Account'));
 

--- a/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
@@ -1,8 +1,8 @@
-<? if (isset($list)): ?>
+<?php if (isset($list)): ?>
   <input type="hidden" name="listID" value="<?=$this->escapeHtmlAttr($list->id)?>" />
   <input type="hidden" name="listName" value="<?=$this->escapeHtmlAttr($list->title)?>" />
-<? endif; ?>
-<? $user = $this->auth()->isLoggedIn(); ?>
+<?php endif; ?>
+<?php $user = $this->auth()->isLoggedIn(); ?>
 <div class="bulkActionButtons">
   <div class="checkbox">
     <label>
@@ -12,15 +12,15 @@
   </div>
   <div class="btn-group">
     <input class="btn btn-default" type="submit" name="email" value="<?=$this->transEsc('Email')?>" title="<?=$this->transEsc('email_selected')?>"/>
-    <? if ((!is_null($this->list) && $this->list->editAllowed($user)) || is_null($this->list) && $user): ?>
+    <?php if ((!is_null($this->list) && $this->list->editAllowed($user)) || is_null($this->list) && $user): ?>
       <input class="btn btn-default" id="<?=$this->idPrefix?>delete_list_items_<?=!is_null($this->list) ? $this->escapeHtmlAttr($this->list->id) : ''?>" type="submit" name="delete" value="<?=$this->transEsc('Delete')?>" title="<?=$this->transEsc('delete_selected')?>"/>
-    <? endif; ?>
-    <? $exportOptions = $this->export()->getActiveFormats('bulk'); if (count($exportOptions) > 0): ?>
+    <?php endif; ?>
+    <?php $exportOptions = $this->export()->getActiveFormats('bulk'); if (count($exportOptions) > 0): ?>
       <input class="btn btn-default" type="submit" name="export" value="<?=$this->transEsc('Export')?>" title="<?=$this->transEsc('export_selected')?>"/>
-    <? endif; ?>
+    <?php endif; ?>
     <input class="btn btn-default" type="submit" name="print" value="<?=$this->transEsc('Print')?>" title="<?=$this->transEsc('print_selected')?>" data-lightbox-ignore/>
-    <? if ($this->cart()->isActive()): ?>
+    <?php if ($this->cart()->isActive()): ?>
       <input class="btn btn-default" id="<?=$this->idPrefix?>updateCart" type="submit" name="add" value="<?=$this->transEsc('Add to Book Bag')?>"/>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Login'));
 
@@ -8,25 +8,25 @@
     // Convenience variable:
     $offlineMode = $this->ils()->getOfflineMode();
 ?>
-<? if ($offlineMode == "ils-offline"): ?>
+<?php if ($offlineMode == "ils-offline"): ?>
   <?=$this->render('Helpers/ils-offline.phtml', ['offlineModeMsg' => 'ils_offline_login_message'])?>
-<? else: ?>
+<?php else: ?>
   <h3><?=$this->transEsc('Library Catalog Profile')?></h3>
   <?=$this->flashmessages()?>
   <p><?=$this->transEsc('cat_establish_account')?></p>
   <form method="post" action="<?=$this->serverUrl(true)?>" class="form-horizontal">
-    <? if ($this->targets !== null): ?>
+    <?php if ($this->targets !== null): ?>
     <div class="form-group">
       <label class="col-sm-2 control-label" for="login_target"><?=$this->transEsc('login_target')?>:</label>
       <div class="col-sm-10">
         <select id="login_target" name="target" class="form-control">
-        <? foreach ($this->targets as $target): ?>
+        <?php foreach ($this->targets as $target): ?>
           <option value="<?=$this->escapeHtmlAttr($target)?>"><?=$this->transEsc("source_$target", null, $target)?></option>
-        <? endforeach; ?>
+        <?php endforeach; ?>
         </select>
       </div>
     </div>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="form-group">
       <label class="col-sm-2 control-label" for="profile_cat_username"><?=$this->transEsc('Library Catalog Username')?>:</label>
       <div class="col-sm-10">
@@ -45,4 +45,4 @@
       </div>
     </div>
   </form>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Checked Out Items'));
 
@@ -13,8 +13,8 @@
 
     <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-    <? if (!empty($this->transactions)): ?>
-      <? if ($this->renewForm): ?>
+    <?php if (!empty($this->transactions)): ?>
+      <?php if ($this->renewForm): ?>
       <form name="renewals" method="post" id="renewals">
         <div class="toolbar">
           <div class="checkbox">
@@ -26,62 +26,62 @@
             <input type="submit" class="btn btn-default" id="renewAll" name="renewAll" value="<?=$this->transEsc('renew_all')?>" />
           </div>
         </div>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? if ($paginator): ?>
+      <?php if ($paginator): ?>
         <?=$this->transEsc("Showing")?>
-        <? $start = $paginator->getAbsoluteItemNumber(1);
+        <?php $start = $paginator->getAbsoluteItemNumber(1);
            $end = $paginator->getAbsoluteItemNumber($paginator->getItemCountPerPage());
            $total = $paginator->getTotalItemCount();
         ?>
         <strong><?=$this->localizedNumber($start)?></strong> - <strong><?=$this->localizedNumber($end > $total ? $total : $end)?></strong>
         <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($total)?></strong>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? foreach ($hiddenTransactions as $ilsDetails): ?>
-        <? if (isset($this->renewResult[$ilsDetails['item_id']])): ?>
-          <? $renewDetails = $this->renewResult[$ilsDetails['item_id']]; ?>
-          <? $prefix = isset($ilsDetails['title']) ? $ilsDetails['title'] : $ilsDetails['item_id']; ?>
-          <? if (isset($renewDetails['success']) && $renewDetails['success']): ?>
+      <?php foreach ($hiddenTransactions as $ilsDetails): ?>
+        <?php if (isset($this->renewResult[$ilsDetails['item_id']])): ?>
+          <?php $renewDetails = $this->renewResult[$ilsDetails['item_id']]; ?>
+          <?php $prefix = isset($ilsDetails['title']) ? $ilsDetails['title'] : $ilsDetails['item_id']; ?>
+          <?php if (isset($renewDetails['success']) && $renewDetails['success']): ?>
             <div class="alert alert-success"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_success')?></div>
-          <? else: ?>
-            <div class="alert alert-danger"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_fail')?><? if (isset($renewDetails['sysMessage'])): ?>: <?=$this->escapeHtml($renewDetails['sysMessage'])?><? endif; ?></div>
-          <? endif; ?>
-        <? endif; ?>
-        <? if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
-          <? $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
+          <?php else: ?>
+            <div class="alert alert-danger"><?=$this->escapeHtml($prefix . ': ') . $this->transEsc('renew_fail')?><?php if (isset($renewDetails['sysMessage'])): ?>: <?=$this->escapeHtml($renewDetails['sysMessage'])?><?php endif; ?></div>
+          <?php endif; ?>
+        <?php endif; ?>
+        <?php if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
+          <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
           <input class="pull-left flip" type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
-        <? endif; ?>
-      <? endforeach; ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
 
-      <? $i = 0; foreach ($this->transactions as $resource): ?>
+      <?php $i = 0; foreach ($this->transactions as $resource): ?>
         <hr/>
-        <? $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
+        <?php $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
         <div id="record<?=$this->escapeHtmlAttr($resource->getUniqueId())?>" class="row result">
-          <? if ($this->renewForm): ?>
-            <? if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
-              <? $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
+          <?php if ($this->renewForm): ?>
+            <?php if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
+              <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
               <div class="col-xs-1">
                 <input class="checkbox-select-item" type="checkbox" name="renewSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" id="checkbox_<?=$safeId?>" />
                 <input type="hidden" name="selectAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
                 <input type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
               </div>
-            <? endif; ?>
-          <? endif; ?>
+            <?php endif; ?>
+          <?php endif; ?>
 
-          <? $cover = $this->record($resource)->getCover('checkedout', 'small'); ?>
-          <? if ($cover): ?>
+          <?php $cover = $this->record($resource)->getCover('checkedout', 'small'); ?>
+          <?php if ($cover): ?>
             <div class="col-sm-2 col-xs-11 text-center">
-            <? /* Display thumbnail if appropriate: */ ?>
+            <?php /* Display thumbnail if appropriate: */ ?>
               <?=$cover?>
             </div>
 
             <div class="col-sm-6 col-xs-12">
-         <? else: ?>
+         <?php else: ?>
             <div class="col-sm-9">
-         <? endif; ?>
+         <?php endif; ?>
 
-            <?
+            <?php
               // If this is a non-missing Solr record, we should display a link:
               if (is_a($resource, 'VuFind\\RecordDriver\\SolrDefault') && !is_a($resource, 'VuFind\\RecordDriver\\Missing')) {
                 $title = $resource->getTitle();
@@ -96,79 +96,79 @@
                 echo $this->transEsc('Title not available');
               }
             ?><br/>
-            <? $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
+            <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
               <?=$this->transEsc('by')?>:
-              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><? if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?><br/>
-            <? endif; ?>
-            <? if (count($resource->getFormats()) > 0): ?>
+              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+            <?php endif; ?>
+            <?php if (count($resource->getFormats()) > 0): ?>
               <?=$this->record($resource)->getFormatList() ?>
               <br/>
-            <? endif; ?>
-            <? if (!empty($ilsDetails['volume'])): ?>
+            <?php endif; ?>
+            <?php if (!empty($ilsDetails['volume'])): ?>
               <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['publication_year'])): ?>
+            <?php if (!empty($ilsDetails['publication_year'])): ?>
               <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['institution_name']) && (empty($ilsDetails['borrowingLocation']) || $ilsDetails['institution_name'] != $ilsDetails['borrowingLocation'])): ?>
+            <?php if (!empty($ilsDetails['institution_name']) && (empty($ilsDetails['borrowingLocation']) || $ilsDetails['institution_name'] != $ilsDetails['borrowingLocation'])): ?>
               <strong><?=$this->transEsc('location_' . $ilsDetails['institution_name'], [], $ilsDetails['institution_name'])?></strong>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['borrowingLocation'])): ?>
+            <?php if (!empty($ilsDetails['borrowingLocation'])): ?>
               <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEsc('location_' . $ilsDetails['borrowingLocation'], [], $ilsDetails['borrowingLocation'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['renew'])): ?>
+            <?php if (isset($ilsDetails['renew'])): ?>
               <strong><?=$this->transEsc('Renewed')?>:</strong> <?=$this->transEsc($ilsDetails['renew'])?>
-              <? if (isset($ilsDetails['renewLimit'])): ?>
+              <?php if (isset($ilsDetails['renewLimit'])): ?>
                 / <?=$this->transEsc($ilsDetails['renewLimit'])?>
-              <? endif; ?>
+              <?php endif; ?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? $showStatus = true; ?>
+            <?php $showStatus = true; ?>
 
-            <? if (isset($this->renewResult[$ilsDetails['item_id']])): ?>
-              <? $renewDetails = $this->renewResult[$ilsDetails['item_id']]; ?>
-              <? if (isset($renewDetails['success']) && $renewDetails['success']): ?>
-                <? $showStatus = false; ?>
-                <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($renewDetails['new_date'])?> <? if (isset($renewDetails['new_time'])): ?><?=$this->escapeHtml($renewDetails['new_time'])?><? endif; ?></strong>
+            <?php if (isset($this->renewResult[$ilsDetails['item_id']])): ?>
+              <?php $renewDetails = $this->renewResult[$ilsDetails['item_id']]; ?>
+              <?php if (isset($renewDetails['success']) && $renewDetails['success']): ?>
+                <?php $showStatus = false; ?>
+                <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($renewDetails['new_date'])?> <?php if (isset($renewDetails['new_time'])): ?><?=$this->escapeHtml($renewDetails['new_time'])?><?php endif; ?></strong>
                 <div class="alert alert-success"><?=$this->transEsc('renew_success')?></div>
-              <? else: ?>
-                <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($ilsDetails['duedate'])?><? if (isset($ilsDetails['dueTime'])): ?> <?=$this->escapeHtml($ilsDetails['dueTime'])?><? endif; ?></strong>
-                <div class="alert alert-danger"><?=$this->transEsc('renew_fail')?><? if (isset($renewDetails['sysMessage'])): ?>: <?=$this->escapeHtml($renewDetails['sysMessage'])?><? endif; ?></div>
-              <? endif; ?>
-            <? else: ?>
-              <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($ilsDetails['duedate'])?><? if (isset($ilsDetails['dueTime'])): ?> <?=$this->escapeHtml($ilsDetails['dueTime'])?><? endif; ?></strong>
-              <? if ($showStatus): ?>
-                <? if (isset($ilsDetails['dueStatus']) && $ilsDetails['dueStatus'] == "overdue"): ?>
+              <?php else: ?>
+                <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($ilsDetails['duedate'])?><?php if (isset($ilsDetails['dueTime'])): ?> <?=$this->escapeHtml($ilsDetails['dueTime'])?><?php endif; ?></strong>
+                <div class="alert alert-danger"><?=$this->transEsc('renew_fail')?><?php if (isset($renewDetails['sysMessage'])): ?>: <?=$this->escapeHtml($renewDetails['sysMessage'])?><?php endif; ?></div>
+              <?php endif; ?>
+            <?php else: ?>
+              <strong><?=$this->transEsc('Due Date')?>: <?=$this->escapeHtml($ilsDetails['duedate'])?><?php if (isset($ilsDetails['dueTime'])): ?> <?=$this->escapeHtml($ilsDetails['dueTime'])?><?php endif; ?></strong>
+              <?php if ($showStatus): ?>
+                <?php if (isset($ilsDetails['dueStatus']) && $ilsDetails['dueStatus'] == "overdue"): ?>
                   <div class="alert alert-danger"><?=$this->transEsc("renew_item_overdue")?></div>
-                <? elseif (isset($ilsDetails['dueStatus']) && $ilsDetails['dueStatus'] == "due"): ?>
+                <?php elseif (isset($ilsDetails['dueStatus']) && $ilsDetails['dueStatus'] == "due"): ?>
                   <div class="alert alert-info"><?=$this->transEsc("renew_item_due")?></div>
-                <? endif; ?>
-              <? endif; ?>
-            <? endif; ?>
+                <?php endif; ?>
+              <?php endif; ?>
+            <?php endif; ?>
 
-            <? if ($showStatus && isset($ilsDetails['message']) && !empty($ilsDetails['message'])): ?>
+            <?php if ($showStatus && isset($ilsDetails['message']) && !empty($ilsDetails['message'])): ?>
               <div class="alert alert-info"><?=$this->transEsc($ilsDetails['message'])?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_link'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_link'])): ?>
               <a href="<?=$this->escapeHtmlAttr($ilsDetails['renew_link'])?>"><?=$this->transEsc('renew_item')?></a>
-            <? endif; ?>
+            <?php endif; ?>
           </div>
         </div>
-      <? endforeach; ?>
-      <? if ($this->renewForm): ?></form><? endif; ?>
+      <?php endforeach; ?>
+      <?php if ($this->renewForm): ?></form><?php endif; ?>
       <?=$paginator ? $this->paginationControl($paginator, 'Sliding', 'Helpers/pagination.phtml') : ''?>
-    <? else: ?>
+    <?php else: ?>
       <?=$this->transEsc('You do not have any items checked out')?>.
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/myresearch/delete.phtml
+++ b/themes/bootstrap3/templates/myresearch/delete.phtml
@@ -2,21 +2,21 @@
  <form action="<?=$this->url('myresearch-delete')?>" method="post" name="bulkDelete" data-lightbox-onclose="VuFind.refreshPage">
   <div id="popupMessages"><?=$this->flashmessages()?></div>
   <div id="popupDetails">
-    <? if (!$this->list): ?>
+    <?php if (!$this->list): ?>
       <div class="alert alert-info"><?=$this->transEsc("fav_delete_warn") ?></div>
-    <? else: ?>
+    <?php else: ?>
       <h3><?=$this->transEsc("List") ?>: <?=$this->escapeHtml($this->list->title) ?></h3>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? foreach ($this->records as $favorite): ?>
+    <?php foreach ($this->records as $favorite): ?>
       <strong><?=$this->transEsc('Title') ?>:</strong>
       <?=$this->escapeHtml($favorite->getBreadcrumb())?><br />
-    <? endforeach; ?>
+    <?php endforeach; ?>
     <br />
     <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Delete')?>"/>
-    <? foreach ($this->deleteIDS as $deleteID): ?>
+    <?php foreach ($this->deleteIDS as $deleteID): ?>
       <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($deleteID)?>" />
-    <? endforeach; ?>
+    <?php endforeach; ?>
       <input type="hidden" name="listID" value="<?=$this->list?$this->escapeHtmlAttr($this->list->id):''?>" />
   </div>
 </form>

--- a/themes/bootstrap3/templates/myresearch/edit.phtml
+++ b/themes/bootstrap3/templates/myresearch/edit.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $this->headTitle($this->translate('Edit') . ' : ' . $this->driver->getBreadcrumb());
 
@@ -12,22 +12,22 @@
   <h2><?=$this->escapeHtml($this->driver->getBreadcrumb())?></h2>
 
   <form class="form-horizontal" method="post" name="editForm">
-  <? if (empty($this->savedData)): ?>
+  <?php if (empty($this->savedData)): ?>
     <p class="alert alert-info">
-      <? if (isset($listFilter)): ?>
+      <?php if (isset($listFilter)): ?>
         <?=$this->transEsc('The record you selected is not part of the selected list.') ?>
-      <? else: ?>
+      <?php else: ?>
         <?=$this->transEsc('The record you selected is not part of any of your lists.') ?>
-      <? endif; ?>
+      <?php endif; ?>
     </p>
-  <? else: ?>
-    <? foreach ($this->savedData as $i=>$current): ?>
+  <?php else: ?>
+    <?php foreach ($this->savedData as $i=>$current): ?>
       <fieldset>
         <legend>
           <a href="<?=$this->url('userList', ['id' => $current['listId']]) ?>?delete=<?=urlencode($this->driver->getUniqueId())?>&amp;source=<?=urlencode($this->driver->getSourceIdentifier())?>" id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>delete<?=$current['listId'] ?>" title="<?=$this->transEsc('confirm_delete')?>" class="close">&times;</a> <?=$this->transEsc('List') ?>: <?=$this->escapeHtml($current['listTitle'])?>
         </legend>
         <input type="hidden" name="lists[]" value="<?=$current['listId'] ?>"/>
-        <? if ($this->usertags()->getMode() !== 'disabled'): ?>
+        <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
           <div class="form-group">
             <label class="col-sm-2 control-label" for="edit_tags<?=$current['listId'] ?>"><?=$this->transEsc('Tags') ?>:</label>
             <div class="col-sm-10">
@@ -35,7 +35,7 @@
               <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
             </div>
           </div>
-        <? endif; ?>
+        <?php endif; ?>
         <div class="form-group">
           <label class="col-sm-2 control-label" for="edit_notes<?=$current['listId'] ?>"><?=$this->transEsc('Notes') ?>:</label>
           <div class="col-sm-10">
@@ -43,30 +43,30 @@
           </div>
         </div>
       </fieldset>
-      <? if($i < count($this->savedData)-1): ?>
+      <?php if($i < count($this->savedData)-1): ?>
         <hr/>
-      <? endif; ?>
-    <? endforeach; ?>
-  <? endif; ?>
-  <? if (count($this->lists) > 0): ?>
+      <?php endif; ?>
+    <?php endforeach; ?>
+  <?php endif; ?>
+  <?php if (count($this->lists) > 0): ?>
     <hr />
     <div class="form-group">
       <div class="col-sm-10 col-sm-offset-2">
         <select name="addToList" class="form-control">
           <option value="-1">- <?=$this->transEsc('Add to another list')?> -</option>
-          <? foreach ($this->lists as $listID=>$listTitle): ?>
+          <?php foreach ($this->lists as $listID=>$listTitle): ?>
             <option value="<?=$listID ?>"><?=$this->escapeHtml($listTitle) ?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
     </div>
-  <? endif; ?>
-  <? if (!empty($this->savedData) || count($this->lists) > 0): ?>
+  <?php endif; ?>
+  <?php if (!empty($this->savedData) || count($this->lists) > 0): ?>
     <div class="form-group">
       <div class="col-sm-10 col-sm-offset-2">
         <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Save') ?>"/>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   </form>
 </div>

--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $pageTitle = empty($this->list->id) ? 'Create a List' : "edit_list";
   $this->headTitle($this->translate($pageTitle));
@@ -26,27 +26,27 @@
       <textarea id="list_desc" class="form-control" name="desc" rows="3"><?=isset($this->list['description']) ? $this->escapeHtml($this->list['description']) : ''?></textarea>
     </div>
   </div>
-  <? if ($this->userlist()->getMode() === 'public_only'): ?>
+  <?php if ($this->userlist()->getMode() === 'public_only'): ?>
     <input type="hidden" name="public" value="1" />
-  <? elseif ($this->userlist()->getMode() === 'private_only'): ?>
+  <?php elseif ($this->userlist()->getMode() === 'private_only'): ?>
     <input type="hidden" name="public" value="0" />
-  <? else: ?>
+  <?php else: ?>
     <div class="form-group">
       <label class="col-sm-3 control-label"><?=$this->transEsc('Access') ?></label>
       <div class="col-sm-9">
         <div class="radio inline">
           <label>
-            <input id="list_public_1" type="radio" name="public" value="1"<? if ($this->list->isPublic()): ?> checked="checked"<? endif; ?>/> <?=$this->transEsc('Public') ?>
+            <input id="list_public_1" type="radio" name="public" value="1"<?php if ($this->list->isPublic()): ?> checked="checked"<?php endif; ?>/> <?=$this->transEsc('Public') ?>
           </label>
         </div>
         <div class="radio inline">
           <label>
-            <input id="list_public_0" type="radio" name="public" value="0"<? if (!$this->list->isPublic()): ?> checked="checked"<? endif; ?>/> <?=$this->transEsc('Private') ?>
+            <input id="list_public_0" type="radio" name="public" value="0"<?php if (!$this->list->isPublic()): ?> checked="checked"<?php endif; ?>/> <?=$this->transEsc('Private') ?>
           </label>
         </div>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Save') ?>"/>

--- a/themes/bootstrap3/templates/myresearch/fines.phtml
+++ b/themes/bootstrap3/templates/myresearch/fines.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('My Fines'));
 
@@ -11,9 +11,9 @@
 
   <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-  <? if (empty($this->fines)): ?>
+  <?php if (empty($this->fines)): ?>
     <?=$this->transEsc('You do not have any fines')?>
-  <? else: ?>
+  <?php else: ?>
     <table class="table table-striped" summary="<?=$this->transEsc('Your Fines')?>">
     <tr>
       <th><?=$this->transEsc('Title')?></th>
@@ -23,17 +23,17 @@
       <th><?=$this->transEsc('Fee')?></th>
       <th><?=$this->transEsc('Balance')?></th>
     </tr>
-    <? $totalDue = 0; ?>
-    <? foreach ($this->fines as $record): ?>
+    <?php $totalDue = 0; ?>
+    <?php foreach ($this->fines as $record): ?>
       <tr>
         <td>
-          <? if (empty($record['title'])): ?>
+          <?php if (empty($record['title'])): ?>
             <?=$this->transEsc('not_applicable')?>
-          <? elseif (!isset($record['driver']) || !is_object($record['driver'])): ?>
+          <?php elseif (!isset($record['driver']) || !is_object($record['driver'])): ?>
             <?=$this->escapeHtml(trim($record['title'], '/:'))?>
-          <? else: ?>
+          <?php else: ?>
             <a href="<?=$this->recordLink()->getUrl($record['driver'])?>"><?=$this->escapeHtml(trim($record['title'], '/:'))?></a>
-          <? endif; ?>
+          <?php endif; ?>
         </td>
         <td><?=isset($record['checkout']) ? $this->escapeHtml($record['checkout']) : ''?></td>
         <td><?=isset($record['duedate']) ? $this->escapeHtml($record['duedate']) : ''?></td>
@@ -41,11 +41,11 @@
         <td><?=isset($record['amount']) ? $this->safeMoneyFormat($record['amount']/100.00) : ''?></td>
         <td><?=isset($record['balance']) ? $this->safeMoneyFormat($record['balance']/100.00) : ''?></td>
       </tr>
-      <? $totalDue += $record['balance']; ?>
-    <? endforeach; ?>
+      <?php $totalDue += $record['balance']; ?>
+    <?php endforeach; ?>
       <tr style="font-weight:bold"><td colspan="5"><?=$this->transEsc('Total Balance Due')?></td><td><?=$this->safeMoneyFormat($totalDue/100.00) ?></td></tr>
     </table>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
 
 <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/myresearch/holds.phtml
+++ b/themes/bootstrap3/templates/myresearch/holds.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('My Holds'));
 
@@ -14,8 +14,8 @@
 
     <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-    <? if (!empty($this->recordList)): ?>
-      <? if ($this->cancelForm): ?>
+    <?php if (!empty($this->recordList)): ?>
+      <?php if ($this->cancelForm): ?>
         <form name="cancelForm" class="inline" method="post" id="cancelHold">
           <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
           <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
@@ -35,35 +35,35 @@
               <li><a href="#" onClick="return false;"><?=$this->transEsc('confirm_dialog_no')?></a></li>
             </ul>
           </div>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? $iteration = 0; ?>
-      <? foreach ($this->recordList as $resource): ?>
+      <?php $iteration = 0; ?>
+      <?php foreach ($this->recordList as $resource): ?>
         <hr/>
-        <? $iteration++; ?>
-        <? $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
+        <?php $iteration++; ?>
+        <?php $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
         <div id="record<?=$this->escapeHtmlAttr($resource->getUniqueId()) ?>" class="row result">
-          <? if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
-            <? $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
+          <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
+            <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
             <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
             <div class="col-xs-1">
               <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" />
             </div>
-          <? endif; ?>
-          <? $cover = $this->record($resource)->getCover('holds', 'small'); ?>
-          <? if ($cover): ?>
+          <?php endif; ?>
+          <?php $cover = $this->record($resource)->getCover('holds', 'small'); ?>
+          <?php if ($cover): ?>
             <div class="col-sm-2 col-xs-11 text-center">
-            <? /* Display thumbnail if appropriate: */ ?>
-            <? if($cover): ?>
+            <?php /* Display thumbnail if appropriate: */ ?>
+            <?php if($cover): ?>
               <?=$cover?>
-            <? endif; ?>
+            <?php endif; ?>
             </div>
 
             <div class="col-sm-6 col-xs-12">
-         <? else: ?>
+         <?php else: ?>
             <div class="col-sm-9 col-xs-11">
-         <? endif; ?>
-            <?
+         <?php endif; ?>
+            <?php
               // If this is a non-missing Solr record, we should display a link:
               if (is_a($resource, 'VuFind\\RecordDriver\\SolrDefault') && !is_a($resource, 'VuFind\\RecordDriver\\Missing')) {
                 $title = $resource->getTitle();
@@ -78,88 +78,88 @@
                 echo $this->transEsc('Title not available');
               }
             ?><br/>
-            <? $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
+            <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
               <?=$this->transEsc('by')?>:
-              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><? if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?><br/>
-            <? endif; ?>
+              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+            <?php endif; ?>
 
-            <? if (count($resource->getFormats()) > 0): ?>
+            <?php if (count($resource->getFormats()) > 0): ?>
               <?=$this->record($resource)->getFormatList() ?>
               <br/>
-            <? endif; ?>
-            <? if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
               <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
+            <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
               <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['requestGroup'])): ?>
+            <?php if (!empty($ilsDetails['requestGroup'])): ?>
               <strong><?=$this->transEsc('hold_requested_group') ?>:</strong> <?=$this->transEsc('request_group_' . $ilsDetails['requestGroup'], null, $ilsDetails['requestGroup'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
+            <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
                value to display... */ ?>
-            <? $pickupDisplay = ''; ?>
-            <? $pickupTranslate = false; ?>
-            <? if (isset($ilsDetails['location'])): ?>
-              <? if ($this->pickup): ?>
-                <? foreach ($this->pickup as $library): ?>
-                  <? if ($library['locationID'] == $ilsDetails['location']): ?>
-                    <? $pickupDisplay = $library['locationDisplay']; ?>
-                    <? $pickupTranslate = true; ?>
-                  <? endif; ?>
-                <? endforeach; ?>
-              <? endif; ?>
-              <? if (empty($pickupDisplay)): ?>
-                <? $pickupDisplay = $ilsDetails['location']; ?>
-              <? endif; ?>
-            <? endif; ?>
-            <? if (!empty($pickupDisplay)): ?>
+            <?php $pickupDisplay = ''; ?>
+            <?php $pickupTranslate = false; ?>
+            <?php if (isset($ilsDetails['location'])): ?>
+              <?php if ($this->pickup): ?>
+                <?php foreach ($this->pickup as $library): ?>
+                  <?php if ($library['locationID'] == $ilsDetails['location']): ?>
+                    <?php $pickupDisplay = $library['locationDisplay']; ?>
+                    <?php $pickupTranslate = true; ?>
+                  <?php endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
+              <?php if (empty($pickupDisplay)): ?>
+                <?php $pickupDisplay = $ilsDetails['location']; ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($pickupDisplay)): ?>
               <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
               <?=$pickupTranslate ? $this->transEsc('location_' . $pickupDisplay, null, $pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['create'])): ?>
+            <?php if (!empty($ilsDetails['create'])): ?>
               <strong><?=$this->transEsc('Created') ?>:</strong> <?=$this->escapeHtml($ilsDetails['create']) ?>
-              <? if (!empty($ilsDetails['expire'])): ?>|<? endif; ?>
-            <? endif; ?>
-            <? if (!empty($ilsDetails['expire'])): ?>
+              <?php if (!empty($ilsDetails['expire'])): ?>|<?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($ilsDetails['expire'])): ?>
               <strong><?=$this->transEsc('Expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
-            <? endif; ?>
+            <?php endif; ?>
             <br />
 
-            <? if (isset($this->cancelResults['items'])): ?>
-              <? foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
-                <? if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
-                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><? if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
-                <? endif; ?>
-              <? endforeach; ?>
-            <? endif; ?>
+            <?php if (isset($this->cancelResults['items'])): ?>
+              <?php foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
+                <?php if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
+                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><?php if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
+                <?php endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['available']) && $ilsDetails['available'] == true): ?>
+            <?php if (isset($ilsDetails['available']) && $ilsDetails['available'] == true): ?>
               <div class="text-success"><?=$this->transEsc("hold_available") ?></div>
-            <? elseif (isset($ilsDetails['in_transit']) && $ilsDetails['in_transit']): ?>
+            <?php elseif (isset($ilsDetails['in_transit']) && $ilsDetails['in_transit']): ?>
               <div class="text-success"><?=$this->transEsc('request_in_transit') . (is_string($ilsDetails['in_transit']) ? ': ' . $this->transEsc('institution_' . $ilsDetails['in_transit'], [], $ilsDetails['in_transit']) : '') ?></div>
-            <? elseif (isset($ilsDetails['position'])): ?>
+            <?php elseif (isset($ilsDetails['position'])): ?>
               <p><strong><?=$this->transEsc("hold_queue_position") ?>:</strong> <?=$this->escapeHtml($ilsDetails['position']) ?></p>
-            <? endif; ?>
-            <? if (isset($ilsDetails['cancel_link'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['cancel_link'])): ?>
               <p><a href="<?=$this->escapeHtmlAttr($ilsDetails['cancel_link']) ?>"><?=$this->transEsc("hold_cancel") ?></a></p>
-            <? endif; ?>
+            <?php endif; ?>
 
           </div>
         </div>
-      <? endforeach; ?>
-      <? if ($this->cancelForm): ?></form><? endif; ?>
-    <? else: ?>
+      <?php endforeach; ?>
+      <?php if ($this->cancelForm): ?></form><?php endif; ?>
+    <?php else: ?>
       <?=$this->transEsc('You do not have any holds or recalls placed') ?>.
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/illrequests.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Interlibrary Loan Requests'));
 
@@ -15,8 +15,8 @@
 
     <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-    <? if (!empty($this->recordList)): ?>
-      <? if ($this->cancelForm): ?>
+    <?php if (!empty($this->recordList)): ?>
+      <?php if ($this->cancelForm): ?>
         <form name="cancelForm" class="inline" method="post" id="cancelILLRequest">
           <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
           <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
@@ -36,35 +36,35 @@
               <li><a href="#" onClick="return false;"><?=$this->transEsc('confirm_dialog_no')?></a></li>
             </ul>
           </div>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? $iteration = 0; ?>
-      <? foreach ($this->recordList as $resource): ?>
+      <?php $iteration = 0; ?>
+      <?php foreach ($this->recordList as $resource): ?>
         <hr/>
-        <? $iteration++; ?>
-        <? $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
+        <?php $iteration++; ?>
+        <?php $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
         <div id="record<?=$this->escapeHtmlAttr($resource->getUniqueId()) ?>" class="row result">
-          <? if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
-            <? $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
+          <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
+            <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
             <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
             <div class="pull-left flip">
               <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" />
             </div>
-          <? endif; ?>
-          <? $cover = $this->record($resource)->getCover('illrequests', 'small'); ?>
-          <? if ($cover): ?>
+          <?php endif; ?>
+          <?php $cover = $this->record($resource)->getCover('illrequests', 'small'); ?>
+          <?php if ($cover): ?>
             <div class="col-sm-2 text-center">
-            <? /* Display thumbnail if appropriate: */ ?>
-            <? if($cover): ?>
+            <?php /* Display thumbnail if appropriate: */ ?>
+            <?php if($cover): ?>
               <?=$cover?>
-            <? endif; ?>
+            <?php endif; ?>
             </div>
 
             <div class="col-sm-6">
-         <? else: ?>
+         <?php else: ?>
             <div class="col-sm-9">
-         <? endif; ?>
-            <?
+         <?php endif; ?>
+            <?php
               // If this is a non-missing Solr record, we should display a link:
               if (is_a($resource, 'VuFind\\RecordDriver\\SolrDefault') && !is_a($resource, 'VuFind\\RecordDriver\\Missing')) {
                 $title = $resource->getTitle();
@@ -79,88 +79,88 @@
                 echo $this->transEsc('Title not available');
               }
             ?><br/>
-            <? $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
+            <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
               <?=$this->transEsc('by')?>:
-              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><? if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?><br/>
-            <? endif; ?>
+              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+            <?php endif; ?>
 
-            <? if (count($resource->getFormats()) > 0): ?>
+            <?php if (count($resource->getFormats()) > 0): ?>
               <?=$this->record($resource)->getFormatList() ?>
               <br/>
-            <? endif; ?>
-            <? if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
               <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
+            <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
               <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
+            <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
                value to display... */ ?>
-            <? $pickupDisplay = ''; ?>
-            <? $pickupTranslate = false; ?>
-            <? if (isset($ilsDetails['location'])): ?>
-              <? if ($this->pickup): ?>
-                <? foreach ($this->pickup as $library): ?>
-                  <? if ($library['locationID'] == $ilsDetails['location']): ?>
-                    <? $pickupDisplay = $library['locationDisplay']; ?>
-                    <? $pickupTranslate = true; ?>
-                  <? endif; ?>
-                <? endforeach; ?>
-              <? endif; ?>
-              <? if (empty($pickupDisplay)): ?>
-                <? $pickupDisplay = $ilsDetails['location']; ?>
-              <? endif; ?>
-            <? endif; ?>
-            <? if (!empty($pickupDisplay)): ?>
+            <?php $pickupDisplay = ''; ?>
+            <?php $pickupTranslate = false; ?>
+            <?php if (isset($ilsDetails['location'])): ?>
+              <?php if ($this->pickup): ?>
+                <?php foreach ($this->pickup as $library): ?>
+                  <?php if ($library['locationID'] == $ilsDetails['location']): ?>
+                    <?php $pickupDisplay = $library['locationDisplay']; ?>
+                    <?php $pickupTranslate = true; ?>
+                  <?php endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
+              <?php if (empty($pickupDisplay)): ?>
+                <?php $pickupDisplay = $ilsDetails['location']; ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($pickupDisplay)): ?>
               <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
               <?=$pickupTranslate ? $this->transEsc($pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['create'])): ?>
+            <?php if (!empty($ilsDetails['create'])): ?>
               <strong><?=$this->transEsc('Created') ?>:</strong> <?=$this->escapeHtml($ilsDetails['create']) ?>
-              <? if (!empty($ilsDetails['expire'])): ?>|<? endif; ?>
-            <? endif; ?>
-            <? if (!empty($ilsDetails['expire'])): ?>
+              <?php if (!empty($ilsDetails['expire'])): ?>|<?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($ilsDetails['expire'])): ?>
               <strong><?=$this->transEsc('Expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
-            <? endif; ?>
+            <?php endif; ?>
             <br />
 
-            <? if (isset($this->cancelResults['items'])): ?>
-              <? foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
-                <? if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
-                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><? if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
-                <? endif; ?>
-              <? endforeach; ?>
-            <? endif; ?>
+            <?php if (isset($this->cancelResults['items'])): ?>
+              <?php foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
+                <?php if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
+                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><?php if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
+                <?php endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['in_transit']) && $ilsDetails['in_transit']): ?>
+            <?php if (isset($ilsDetails['in_transit']) && $ilsDetails['in_transit']): ?>
               <div class="text-success"><?=$this->transEsc("request_in_transit") . (is_string($ilsDetails['in_transit']) ? ': ' . $this->transEsc('institution_' . $ilsDetails['in_transit'], [], $ilsDetails['in_transit']) : '') ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['processed']) && $ilsDetails['processed']): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['processed']) && $ilsDetails['processed']): ?>
               <div class="text-success"><?=$this->transEsc("ill_request_processed") . (is_string($ilsDetails['processed']) ? ': ' . $ilsDetails['processed'] : '') ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['available']) && $ilsDetails['available']): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['available']) && $ilsDetails['available']): ?>
               <div class="text-success"><?=$this->transEsc("ill_request_available") ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['canceled']) && $ilsDetails['canceled']): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['canceled']) && $ilsDetails['canceled']): ?>
               <div class="text-success"><?=$this->transEsc("ill_request_canceled") . (is_string($ilsDetails['canceled']) ? ': ' . $ilsDetails['canceled'] : '') ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['cancel_link'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['cancel_link'])): ?>
               <p><a href="<?=$this->escapeHtmlAttr($ilsDetails['cancel_link']) ?>"><?=$this->transEsc("ill_request_cancel") ?></a></p>
-            <? endif; ?>
+            <?php endif; ?>
 
           </div>
         </div>
-      <? endforeach; ?>
-      <? if ($this->cancelForm): ?></form><? endif; ?>
-    <? else: ?>
+      <?php endforeach; ?>
+      <?php if ($this->cancelForm): ?></form><?php endif; ?>
+    <?php else: ?>
       <?=$this->transEsc('You do not have any interlibrary loan requests placed') ?>.
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/myresearch/login.phtml
+++ b/themes/bootstrap3/templates/myresearch/login.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $this->headTitle($this->translate('Login'));
 
@@ -11,15 +11,15 @@
   $offlineMode = $this->ils()->getOfflineMode();
 ?>
 
-<? if ($offlineMode == "ils-offline"): ?>
+<?php if ($offlineMode == "ils-offline"): ?>
   <?=$this->render('Helpers/ils-offline.phtml', ['offlineModeMsg' => 'ils_offline_login_message'])?>
-<? endif; ?>
+<?php endif; ?>
 
 <h2 class="lightbox-header"><?=$this->transEsc('Login')?></h2>
 <?=$this->flashmessages()?>
 
-<? if ($hideLogin): ?>
+<?php if ($hideLogin): ?>
   <div class="alert alert-danger"><?=$this->transEsc('login_disabled')?></div>
-<? else: ?>
+<?php else: ?>
   <?=$this->auth()->getLogin()?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -1,81 +1,81 @@
 <h4><?=$this->transEsc('Your Account')?></h4>
 <div class="list-group">
-  <? if ($this->userlist()->getMode() !== 'disabled'): ?>
+  <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
     <a href="<?=$this->url('myresearch-favorites')?>" class="list-group-item<?=$this->active == 'favorites' ? ' active' : ''?>">
       <i class="fa fa-fw fa-star" aria-hidden="true"></i> <?=$this->transEsc('Favorites')?>
     </a>
-  <? endif; ?>
-  <? if ('ils-none' !== $this->ils()->getOfflineMode()): ?>
-    <? if ($this->ils()->checkCapability('getMyTransactions')): ?>
+  <?php endif; ?>
+  <?php if ('ils-none' !== $this->ils()->getOfflineMode()): ?>
+    <?php if ($this->ils()->checkCapability('getMyTransactions')): ?>
       <a href="<?=$this->url('myresearch-checkedout')?>" class="list-group-item<?=$this->active == 'checkedout' ? ' active' : ''?>">
         <i class="fa fa-fw fa-book" aria-hidden="true"></i> <?=$this->transEsc('Checked Out Items')?>
       </a>
-    <? endif; ?>
-    <? if ($this->ils()->checkCapability('getMyHolds')): ?>
+    <?php endif; ?>
+    <?php if ($this->ils()->checkCapability('getMyHolds')): ?>
       <a href="<?=$this->url('myresearch-holds')?>" class="list-group-item<?=$this->active == 'holds' ? ' active' : ''?>">
         <i class="fa fa-fw fa-flag" aria-hidden="true"></i> <?=$this->transEsc('Holds and Recalls')?>
       </a>
-    <? endif; ?>
-    <? if ($this->ils()->checkFunction('StorageRetrievalRequests')): ?>
+    <?php endif; ?>
+    <?php if ($this->ils()->checkFunction('StorageRetrievalRequests')): ?>
       <a href="<?=$this->url('myresearch-storageretrievalrequests')?>" class="list-group-item<?=$this->active == 'storageRetrievalRequests' ? ' active' : ''?>">
         <i class="fa fa-fw fa-archive" aria-hidden="true"></i> <?=$this->transEsc('Storage Retrieval Requests')?>
       </a>
-    <? endif; ?>
-    <? if ($this->ils()->checkFunction('ILLRequests')): ?>
+    <?php endif; ?>
+    <?php if ($this->ils()->checkFunction('ILLRequests')): ?>
     <a href="<?=$this->url('myresearch-illrequests')?>" class="list-group-item<?=$this->active == 'ILLRequests' ? ' active' : ''?>">
       <i class="fa fa-fw fa-exchange" aria-hidden="true"></i> <?=$this->transEsc('Interlibrary Loan Requests')?>
     </a>
-    <? endif; ?>
-    <? if ($this->ils()->checkCapability('getMyFines')): ?>
+    <?php endif; ?>
+    <?php if ($this->ils()->checkCapability('getMyFines')): ?>
       <a href="<?=$this->url('myresearch-fines')?>" class="list-group-item<?=$this->active == 'fines' ? ' active' : ''?>">
         <i class="fa fa-fw fa-usd" aria-hidden="true"></i> <?=$this->transEsc('Fines')?>
       </a>
-    <? endif; ?>
-    <? if ($this->ils()->checkCapability('getMyProfile')): ?>
+    <?php endif; ?>
+    <?php if ($this->ils()->checkCapability('getMyProfile')): ?>
       <a href="<?=$this->url('myresearch-profile')?>" class="list-group-item<?=$this->active == 'profile' ? ' active' : ''?>">
         <i class="fa fa-fw fa-user" aria-hidden="true"></i> <?=$this->transEsc('Profile')?>
       </a>
-    <? endif; ?>
-    <? $user = $this->auth()->isLoggedIn(); if ($user && $user->libraryCardsEnabled()): ?>
+    <?php endif; ?>
+    <?php $user = $this->auth()->isLoggedIn(); if ($user && $user->libraryCardsEnabled()): ?>
       <a href="<?=$this->url('librarycards-home')?>" class="list-group-item<?=$this->active == 'librarycards' ? ' active' : ''?>">
         <i class="fa fa-fw fa-barcode" aria-hidden="true"></i> <?=$this->transEsc('Library Cards')?>
       </a>
-    <? endif; ?>
-  <? endif; ?>
-  <? if ($this->accountCapabilities()->getSavedSearchSetting() === 'enabled'): ?>
+    <?php endif; ?>
+  <?php endif; ?>
+  <?php if ($this->accountCapabilities()->getSavedSearchSetting() === 'enabled'): ?>
     <a href="<?=$this->url('search-history')?>?require_login" class="list-group-item<?=$this->active == 'history' ? ' active' : ''?>">
       <i class="fa fa-fw fa-search" aria-hidden="true"></i> <?=$this->transEsc('history_saved_searches')?>
     </a>
-  <? endif; ?>
-  <? if ($user = $this->auth()->isLoggedIn()): ?>
+  <?php endif; ?>
+  <?php if ($user = $this->auth()->isLoggedIn()): ?>
     <a href="<?=$this->url('myresearch-logout')?>" class="list-group-item">
       <i class="fa fa-fw fa-sign-out" aria-hidden="true"></i> <?=$this->transEsc("Log Out")?>
     </a>
-  <? endif; ?>
+  <?php endif; ?>
 </div>
-<? if ($this->auth()->isLoggedIn() && $this->auth()->getManager()->supportsPasswordChange()): ?>
+<?php if ($this->auth()->isLoggedIn() && $this->auth()->getManager()->supportsPasswordChange()): ?>
   <h4><?=$this->transEsc('Preferences')?></h4>
   <div class="list-group">
     <a href="<?=$this->url('myresearch-changepassword') ?>" class="list-group-item<?=$this->active == 'newpassword' ? ' active' : ''?>">
       <i class="fa fa-fw fa-lock" aria-hidden="true"></i> <?=$this->transEsc('Change Password') ?>
     </a>
   </div>
-<? endif; ?>
-<? if ($this->userlist()->getMode() !== 'disabled' && $user = $this->auth()->isLoggedIn()): ?>
+<?php endif; ?>
+<?php if ($this->userlist()->getMode() !== 'disabled' && $user = $this->auth()->isLoggedIn()): ?>
   <h4><?=$this->transEsc('Your Lists')?></h4>
   <div class="list-group">
     <a href="<?=$this->url('myresearch-favorites')?>" class="list-group-item<?=$this->active == 'favorites' ? ' active' : ''?>">
       <i class="fa fa-fw fa-star" aria-hidden="true"></i> <?=$this->transEsc('Your Favorites')?>
     </a>
-    <? $lists = $user->getLists() ?>
-    <? foreach ($lists as $list): ?>
+    <?php $lists = $user->getLists() ?>
+    <?php foreach ($lists as $list): ?>
         <a href="<?=$this->url('userList', ['id' => $list['id']])?>" class="list-group-item<?=$this->active == 'list' . $list['id'] ? ' active' : ''?>">
           <?=$this->escapeHtml($list['title'])?>
           <span class="badge"><?=$list->cnt?></span>
         </a>
-    <? endforeach; ?>
+    <?php endforeach; ?>
     <a href="<?=$this->url('editList', ['id'=>'NEW'])?>" class="list-group-item">
       <i class="fa fa-fw fa-plus" aria-hidden="true"></i> <?=$this->transEsc('Create a List') ?>
     </a>
   </div>
-<? endif ?>
+<?php endif ?>

--- a/themes/bootstrap3/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap3/templates/myresearch/mylist.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Grab list object from search results (if applicable):
   $list = $this->results->getListObject();
 
@@ -32,8 +32,8 @@
     <div class="clearfix hidden-print">
       <h2 class="pull-left flip"><?=$list ? $this->escapeHtml($list->title) : $this->transEsc("Your Favorites")?></h2>
       <div class="pull-right flip">
-        <? if (isset($list)): ?>
-          <? if ($list->editAllowed($account->isLoggedIn())): ?>
+        <?php if (isset($list)): ?>
+          <?php if ($list->editAllowed($account->isLoggedIn())): ?>
             <a href="<?=$this->url('editList', ['id' => $list->id]) ?>" class="btn btn-link"><i class="fa fa-edit" aria-hidden="true"></i> <?=$this->transEsc("edit_list")?></a>
             <div class="btn-group">
               <a class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="<?=$this->url('myresearch-deletelist') ?>?listID=<?=urlencode($list->id)?>">
@@ -44,19 +44,19 @@
                 <li><a href="#"><?=$this->transEsc('confirm_dialog_no')?></a></li>
               </ul>
             </div>
-          <? endif; ?>
-        <? endif; ?>
-        <? if ($recordTotal > 0): ?>
+          <?php endif; ?>
+        <?php endif; ?>
+        <?php if ($recordTotal > 0): ?>
           <?=$this->transEsc("Showing")?>
           <strong><?=$this->localizedNumber($this->results->getStartRecord())?></strong> - <strong><?=$this->localizedNumber($this->results->getEndRecord())?></strong>
           <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($recordTotal)?></strong>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
     </div>
-  <? if ($list && !empty($list->description)): ?>
+  <?php if ($list && !empty($list->description)): ?>
     <p><?=$this->escapeHtml($list->description)?></p>
-  <? endif; ?>
-    <? if ($recordTotal > 0): ?>
+  <?php endif; ?>
+    <?php if ($recordTotal > 0): ?>
       <div class="resulthead">
         <div class="pull-right flip">
           <?=$this->render('search/controls/limit.phtml')?>
@@ -65,20 +65,20 @@
       </div>
       <form class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-myresearchbulk')?>" data-lightbox data-lightbox-onsubmit="bulkFormHandler">
         <?=$this->context($this)->renderInContext('myresearch/bulk-action-buttons.phtml', ['idPrefix' => '', 'list' => isset($list) ? $list : null, 'account' => $this->account])?>
-        <? foreach ($this->results->getResults() as $i=>$current): ?>
+        <?php foreach ($this->results->getResults() as $i=>$current): ?>
           <?=$this->record($current)->getListEntry($list, $user)?>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </form>
       <?=$this->paginationControl($this->results->getPaginator(), 'Sliding', 'search/pagination.phtml', ['results' => $this->results])?>
-    <? else: ?>
+    <?php else: ?>
       <p><?=$this->transEsc('You do not have any saved resources')?></p>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">
     <?=$this->context($this)->renderInContext("myresearch/menu.phtml", ['active' => isset($list) ? 'list' . $list['id'] : 'favorites'])?>
-    <? foreach ($this->results->getRecommendations('side') as $current): ?>
+    <?php foreach ($this->results->getRecommendations('side') as $current): ?>
       <?=$this->recommend($current)?>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
 </div>

--- a/themes/bootstrap3/templates/myresearch/newpassword.phtml
+++ b/themes/bootstrap3/templates/myresearch/newpassword.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Create New Password'));
 
@@ -6,19 +6,19 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
         . '<li class="active">' . $this->transEsc('Create New Password') . '</li>';
 ?>
-<? if ($this->auth()->isLoggedIn()): ?>
+<?php if ($this->auth()->isLoggedIn()): ?>
   <div class="row">
     <div class="<?=$this->layoutClass('mainbody')?>">
-<? endif; ?>
+<?php endif; ?>
 
 <h2><?=$this->transEsc('Create New Password') ?></h2>
 <?=$this->flashmessages() ?>
 
-<? if (!$this->auth()->getManager()->supportsPasswordChange($this->auth_method)): ?>
+<?php if (!$this->auth()->getManager()->supportsPasswordChange($this->auth_method)): ?>
   <div class="error"><?=$this->transEsc('recovery_new_disabled') ?></div>
-<? elseif (!isset($this->hash)): ?>
+<?php elseif (!isset($this->hash)): ?>
   <div class="error"><?=$this->transEsc('recovery_user_not_found') ?></div>
-<? else: ?>
+<?php else: ?>
   <form id="newpassword" class="form-horizontal" action="<?=$this->url('myresearch-newpassword') ?>" method="post" data-toggle="validator" role="form">
     <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash(true))?>" name="csrf"/>
     <input type="hidden" value="<?=$this->escapeHtmlAttr($this->hash) ?>" name="hash"/>
@@ -32,12 +32,12 @@
       </div>
     </div>
   </form>
-<? endif; ?>
+<?php endif; ?>
 
-<? if ($this->auth()->isLoggedIn()): ?>
+<?php if ($this->auth()->isLoggedIn()): ?>
     </div>
     <div class="<?=$this->layoutClass('sidebar')?>">
       <?=$this->context($this)->renderInContext("myresearch/menu.phtml", ['active' => 'newpassword'])?>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('My Profile'));
 
@@ -20,7 +20,7 @@
     <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
     <table class="table table-striped">
-      <?
+      <?php
         echo $this->renderArray(
           $arrTemplate, $this->profile,
           [
@@ -29,24 +29,24 @@
           ]
         );
        ?>
-      <? if ($showHomeLibForm): ?>
+      <?php if ($showHomeLibForm): ?>
         <tr><th><?=$this->transEsc('Preferred Library')?>:</th>
-        <?
+        <?php
           $selected = (isset($this->profile['home_library']) && $this->profile['home_library'] != "")
               ? $this->profile['home_library'] : $this->defaultPickupLocation
         ?>
         <td>
           <form id="profile_form" class="form-inline" method="post">
             <select id="home_library" name="home_library" class="form-control">
-              <? foreach ($this->pickup as $lib): ?>
+              <?php foreach ($this->pickup as $lib): ?>
                 <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID'])?' selected="selected"':''?>><?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?></option>
-              <? endforeach; ?>
+              <?php endforeach; ?>
             </select>
             <input class="btn btn-default" type="submit" value="<?=$this->transEsc('Save')?>" />
           </form>
         </td>
-      <? endif; ?>
-      <?
+      <?php endif; ?>
+      <?php
         echo $this->renderArray(
           $arrTemplate, $this->profile,
           [

--- a/themes/bootstrap3/templates/myresearch/recover.phtml
+++ b/themes/bootstrap3/templates/myresearch/recover.phtml
@@ -1,9 +1,9 @@
 <h2><?=$this->transEsc('recovery_title') ?></h2>
 <?=$this->flashmessages()?>
-<? if (!$this->auth()->getManager()->supportsRecovery()): ?>
+<?php if (!$this->auth()->getManager()->supportsRecovery()): ?>
   <div class="error"><?=$this->transEsc('recovery_disabled') ?></div>
-<? else: ?>
+<?php else: ?>
   <form class="form-horizontal" method="post">
     <?=$this->auth()->getPasswordRecoveryForm() ?>
   </form>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $this->headTitle($this->translate('Storage Retrieval Requests'));
 
@@ -13,8 +13,8 @@
 
     <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
 
-    <? if (!empty($this->recordList)): ?>
-      <? if ($this->cancelForm): ?>
+    <?php if (!empty($this->recordList)): ?>
+      <?php if ($this->cancelForm): ?>
         <form name="cancelForm" class="inline" method="post" id="cancelStorageRetrievalRequest">
           <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
           <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
@@ -34,34 +34,34 @@
               <li><a href="#" onClick="return false;"><?=$this->transEsc('confirm_dialog_no')?></a></li>
             </ul>
           </div>
-      <? endif; ?>
+      <?php endif; ?>
 
-      <? $iteration = 0; ?>
-      <? foreach ($this->recordList as $resource): ?>
+      <?php $iteration = 0; ?>
+      <?php foreach ($this->recordList as $resource): ?>
         <hr/>
-        <? $iteration++; ?>
-        <? $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
+        <?php $iteration++; ?>
+        <?php $ilsDetails = $resource->getExtraDetail('ils_details'); ?>
         <div id="record<?=$this->escapeHtmlAttr($resource->getUniqueId()) ?>" class="row result">
-          <? if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
-            <? $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
+          <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
+            <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
             <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
             <div class="pull-left flip">
               <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" />
             </div>
-          <? endif; ?>
-          <? $cover = $this->record($resource)->getCover('storageretrievalrequests', 'small'); ?>
-          <? if ($cover): ?>
+          <?php endif; ?>
+          <?php $cover = $this->record($resource)->getCover('storageretrievalrequests', 'small'); ?>
+          <?php if ($cover): ?>
             <div class="col-sm-2 text-center">
-              <? /* Display thumbnail if appropriate: */ ?>
+              <?php /* Display thumbnail if appropriate: */ ?>
               <?=$cover?>
             </div>
 
             <div class="col-sm-7">
-         <? else: ?>
+         <?php else: ?>
             <div class="col-sm-9">
-         <? endif; ?>
+         <?php endif; ?>
 
-            <?
+            <?php
               // If this is a non-missing Solr record, we should display a link:
               if (is_a($resource, 'VuFind\\RecordDriver\\SolrDefault') && !is_a($resource, 'VuFind\\RecordDriver\\Missing')) {
                 $title = $resource->getTitle();
@@ -76,85 +76,85 @@
                 echo $this->transEsc('Title not available');
               }
             ?><br/>
-            <? $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
+            <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
               <?=$this->transEsc('by')?>:
-              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><? if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><? endif; ?><br/>
-            <? endif; ?>
+              <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+            <?php endif; ?>
 
-            <? if (count($resource->getFormats()) > 0): ?>
+            <?php if (count($resource->getFormats()) > 0): ?>
               <?=$this->record($resource)->getFormatList() ?>
               <br/>
-            <? endif; ?>
-            <? if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
               <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
+            <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
               <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
+            <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
                value to display... */ ?>
-            <? $pickupDisplay = ''; ?>
-            <? $pickupTranslate = false; ?>
-            <? if (isset($ilsDetails['location'])): ?>
-              <? if ($this->pickup): ?>
-                <? foreach ($this->pickup as $library): ?>
-                  <? if ($library['locationID'] == $ilsDetails['location']): ?>
-                    <? $pickupDisplay = $library['locationDisplay']; ?>
-                    <? $pickupTranslate = true; ?>
-                  <? endif; ?>
-                <? endforeach; ?>
-              <? endif; ?>
-              <? if (empty($pickupDisplay)): ?>
-                <? $pickupDisplay = $ilsDetails['location']; ?>
-              <? endif; ?>
-            <? endif; ?>
-            <? if (!empty($pickupDisplay)): ?>
+            <?php $pickupDisplay = ''; ?>
+            <?php $pickupTranslate = false; ?>
+            <?php if (isset($ilsDetails['location'])): ?>
+              <?php if ($this->pickup): ?>
+                <?php foreach ($this->pickup as $library): ?>
+                  <?php if ($library['locationID'] == $ilsDetails['location']): ?>
+                    <?php $pickupDisplay = $library['locationDisplay']; ?>
+                    <?php $pickupTranslate = true; ?>
+                  <?php endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
+              <?php if (empty($pickupDisplay)): ?>
+                <?php $pickupDisplay = $ilsDetails['location']; ?>
+              <?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($pickupDisplay)): ?>
               <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
               <?=$pickupTranslate ? $this->transEsc($pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
               <br />
-            <? endif; ?>
+            <?php endif; ?>
 
-            <? if (!empty($ilsDetails['create'])): ?>
+            <?php if (!empty($ilsDetails['create'])): ?>
               <strong><?=$this->transEsc('Created') ?>:</strong> <?=$this->escapeHtml($ilsDetails['create']) ?>
-              <? if (!empty($ilsDetails['expire'])): ?>|<? endif; ?>
-            <? endif; ?>
-            <? if (!empty($ilsDetails['expire'])): ?>
+              <?php if (!empty($ilsDetails['expire'])): ?>|<?php endif; ?>
+            <?php endif; ?>
+            <?php if (!empty($ilsDetails['expire'])): ?>
               <strong><?=$this->transEsc('Expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
-            <? endif; ?>
+            <?php endif; ?>
             <br />
 
-            <? if (isset($this->cancelResults['items'])): ?>
-              <? foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
-                <? if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
-                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><? if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
-                <? endif; ?>
-              <? endforeach; ?>
-            <? endif; ?>
+            <?php if (isset($this->cancelResults['items'])): ?>
+              <?php foreach ($this->cancelResults['items'] as $itemId=>$cancelResult): ?>
+                <?php if ($itemId == $ilsDetails['item_id'] && $cancelResult['success'] == false): ?>
+                  <div class="alert alert-danger"><?=$this->transEsc($cancelResult['status']) ?><?php if ($cancelResult['sysMessage']) echo ' : ' . $this->transEsc($cancelResult['sysMessage']); ?></div>
+                <?php endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
 
-            <? if (isset($ilsDetails['processed']) && $ilsDetails['processed']): ?>
+            <?php if (isset($ilsDetails['processed']) && $ilsDetails['processed']): ?>
               <div class="text-success"><?=$this->transEsc("storage_retrieval_request_processed") . (is_string($ilsDetails['processed']) ? ': ' . $ilsDetails['processed'] : '') ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['available']) && $ilsDetails['available']): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['available']) && $ilsDetails['available']): ?>
               <div class="text-success"><?=$this->transEsc("storage_retrieval_request_available") ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['canceled']) && $ilsDetails['canceled']): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['canceled']) && $ilsDetails['canceled']): ?>
               <div class="text-success"><?=$this->transEsc("storage_retrieval_request_canceled") . (is_string($ilsDetails['canceled']) ? ': ' . $ilsDetails['canceled'] : '') ?></div>
-            <? endif; ?>
-            <? if (isset($ilsDetails['cancel_link'])): ?>
+            <?php endif; ?>
+            <?php if (isset($ilsDetails['cancel_link'])): ?>
               <p><a href="<?=$this->escapeHtmlAttr($ilsDetails['cancel_link']) ?>"><?=$this->transEsc("storage_retrieval_request_cancel") ?></a></p>
-            <? endif; ?>
+            <?php endif; ?>
 
           </div>
         </div>
-      <? endforeach; ?>
-      <? if ($this->cancelForm): ?></form><? endif; ?>
-    <? else: ?>
+      <?php endforeach; ?>
+      <?php if ($this->cancelForm): ?></form><?php endif; ?>
+    <?php else: ?>
       <?=$this->transEsc('You do not have any storage retrieval requests placed') ?>.
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/oai/home.phtml
+++ b/themes/bootstrap3/templates/oai/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $this->headTitle($this->translate('OAI Server'));
   $this->layout()->breadcrumbs = $this->transEsc('OAI Server');
   $baseUrl = $this->url('oai-server');

--- a/themes/bootstrap3/templates/pazpar2/search.phtml
+++ b/themes/bootstrap3/templates/pazpar2/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/primo/advanced.phtml
+++ b/themes/bootstrap3/templates/primo/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Advanced Search'));
 
@@ -28,20 +28,20 @@
   <div class="row">
     <div class="<?=$this->layoutClass('mainbody')?>">
       <h3><?=$this->transEsc('Advanced Search')?></h3>
-      <? /* fallback to a fixed set of search groups/fields if JavaScript is turned off */ ?>
-      <? if ($groups !== false) {
+      <?php /* fallback to a fixed set of search groups/fields if JavaScript is turned off */ ?>
+      <?php if ($groups !== false) {
           $numGroups = count($groups);
         }
         if (!isset($numGroups) || $numGroups < 3) {
           $numGroups = 1;
         }
       ?>
-      <? for ($i = 0; $i < $numGroups; $i++): ?>
+      <?php for ($i = 0; $i < $numGroups; $i++): ?>
         <input type="hidden" name="bool<?=$i?>[]" value="AND" />
         <div class="group well row" id="group<?=$i?>">
           <div class="col-sm-2" id="group<?=$i?>SearchHolder"><label><?=$this->transEsc("adv_search_label")?>:</label></div>
           <div class="col-sm-10">
-            <?
+            <?php
               if (isset($groups[$i])) {
                 $currentGroup = $groups[$i]->getQueries();
                 $numRows = count($currentGroup);
@@ -52,43 +52,43 @@
                 $numRows = 3;
               }
             ?>
-            <? for ($j = 0; $j < $numRows; $j++): ?>
-              <? $currRow = isset($currentGroup[$j]) ? $currentGroup[$j] : false; ?>
+            <?php for ($j = 0; $j < $numRows; $j++): ?>
+              <?php $currRow = isset($currentGroup[$j]) ? $currentGroup[$j] : false; ?>
               <div class="row">
                 <div class="col-sm-3">
                   <select id="search_type<?=$i?>_<?=$j?>" name="type<?=$i?>[]" class="form-control">
-                  <? foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
+                  <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
                     <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getHandler() == $searchVal)?' selected="selected"':''?>><?=$this->transEsc($searchDesc)?></option>
-                  <? endforeach; ?>
+                  <?php endforeach; ?>
                   </select>
                 </div>
                 <div class="col-sm-3">
                   <select name="op<?=$i?>[]" id="searchForm_op<?=$i?>_<?=$j?>" class="form-control">
-                    <? foreach ($this->options->getAdvancedOperators() as $searchVal => $searchDesc): ?>
+                    <?php foreach ($this->options->getAdvancedOperators() as $searchVal => $searchDesc): ?>
                       <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getOperator() == $searchVal)?' selected="selected"':''?>><?=$this->transEsc($searchDesc)?></option>
-                    <? endforeach; ?>
+                    <?php endforeach; ?>
                   </select>
                 </div>
                 <div class="col-sm-6">
                   <input id="search_lookfor<?=$i?>_<?=$j?>" type="text" value="<?=$currRow?$this->escapeHtmlAttr($currRow->getString()):''?>" size="30" name="lookfor<?=$i?>[]" class="form-control"/>
                 </div>
               </div>
-            <? endfor; ?>
+            <?php endfor; ?>
           </div>
         </div>
-      <? endfor; ?>
-      <? $lastSort = $this->searchMemory()->getLastSort($this->options->getSearchClassId()); ?>
-      <? if (!empty($lastSort)): ?>
+      <?php endfor; ?>
+      <?php $lastSort = $this->searchMemory()->getLastSort($this->options->getSearchClassId()); ?>
+      <?php if (!empty($lastSort)): ?>
         <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>" />
-      <? endif; ?>
+      <?php endif; ?>
       <input type="submit" class="btn btn-primary" name="submit" value="<?=$this->transEsc("Find")?>"/>
     </div>
 
     <div class="<?=$this->layoutClass('sidebar')?>">
-      <? if ($hasDefaultsApplied): ?>
+      <?php if ($hasDefaultsApplied): ?>
         <input type="hidden" name="dfApplied" value="1" />
-      <? endif ?>
-      <? if (!empty($searchFilters)): ?>
+      <?php endif ?>
+      <?php if (!empty($searchFilters)): ?>
         <h4><?=$this->transEsc("adv_search_filters")?></h4>
         <ul class="list-group">
           <li class="list-group-item">
@@ -100,11 +100,11 @@
             </div>
           </li>
         </ul>
-        <? foreach ($searchFilters as $field => $data): ?>
+        <?php foreach ($searchFilters as $field => $data): ?>
           <div>
             <ul class="list-group">
               <li class="list-group-item title"><?=$this->transEsc($field)?></li>
-              <? foreach ($data as $value): ?>
+              <?php foreach ($data as $value): ?>
                 <li class="list-group-item">
                   <div class="checkbox">
                     <label>
@@ -112,11 +112,11 @@
                     </label>
                   </div>
                 </li>
-              <? endforeach; ?>
+              <?php endforeach; ?>
             </ul>
           </div>
-        <? endforeach; ?>
-      <? endif; ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
     </div>
   </div>
 </form>

--- a/themes/bootstrap3/templates/primo/search.phtml
+++ b/themes/bootstrap3/templates/primo/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/record/addtag.phtml
+++ b/themes/bootstrap3/templates/record/addtag.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Add Tag'));
 

--- a/themes/bootstrap3/templates/record/ajaxtab.phtml
+++ b/themes/bootstrap3/templates/record/ajaxtab.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 foreach ($this->tabs as $tab => $obj) {
     if (strtolower($this->activeTab) == strtolower($tab)) {
         echo $this->record($this->driver)->getTab($obj);

--- a/themes/bootstrap3/templates/record/ajaxview-accordion.phtml
+++ b/themes/bootstrap3/templates/record/ajaxview-accordion.phtml
@@ -1,11 +1,11 @@
-<?
+<?php
   $this->defaultTab = strtolower($this->defaultTab);
   $idSuffix = $this->escapeHtmlAttr(md5($this->driver->getUniqueId() . '|' . $this->driver->getSourceIdentifier()));
 ?>
 
 <div class="list-tabs panel-group" id="accordion_<?=$idSuffix?>">
-  <? $coreMetadata = $this->record($this->driver)->getCoreMetadata(); ?>
-  <? if (!empty($coreMetadata)): ?>
+  <?php $coreMetadata = $this->record($this->driver)->getCoreMetadata(); ?>
+  <?php if (!empty($coreMetadata)): ?>
     <div class="panel panel-default">
       <div id="information_<?=$idSuffix?>" class="list-tab-toggle panel-heading loaded" data-toggle="collapse" data-parent="#accordion_<?=$idSuffix?>" data-target="#information_<?=$idSuffix?>-content">
         <h4 class="panel-title">
@@ -14,7 +14,7 @@
           </a>
         </h4>
       </div>
-      <div id="information_<?=$idSuffix?>-content" class="panel-collapse collapse<? if($this->defaultTab === 'information'): ?> in<? endif; ?>">
+      <div id="information_<?=$idSuffix?>-content" class="panel-collapse collapse<?php if($this->defaultTab === 'information'): ?> in<?php endif; ?>">
         <div class="list-tab-content record panel-body">
           <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffix?>" />
           <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getResourceSource()) ?>" class="hiddenSource" />
@@ -22,10 +22,10 @@
         </div>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? $toolbar = $this->record($this->driver)->getToolbar(); ?>
-  <? if (!empty($toolbar)): ?>
+  <?php $toolbar = $this->record($this->driver)->getToolbar(); ?>
+  <?php if (!empty($toolbar)): ?>
     <div class="panel panel-default">
       <div id="tools_<?=$idSuffix?>" class="list-tab-toggle panel-heading loaded" data-toggle="collapse" data-parent="#accordion_<?=$idSuffix?>" data-target="#tools_<?=$idSuffix?>-content">
         <h4 class="panel-title">
@@ -34,16 +34,16 @@
           </a>
         </h4>
       </div>
-      <div id="tools_<?=$idSuffix?>-content" class="panel-collapse collapse<? if($this->defaultTab === 'tools'): ?> in<? endif; ?>">
+      <div id="tools_<?=$idSuffix?>-content" class="panel-collapse collapse<?php if($this->defaultTab === 'tools'): ?> in<?php endif; ?>">
         <div class="list-tab-content panel-body">
           <?=$toolbar ?>
         </div>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? $relatedList = $this->related()->getList($this->driver); ?>
-  <? if ($relatedList != null): ?>
+  <?php $relatedList = $this->related()->getList($this->driver); ?>
+  <?php if ($relatedList != null): ?>
     <div class="panel panel-default">
       <div id="related_<?=$idSuffix?>" class="list-tab-toggle panel-heading loaded" data-toggle="collapse" data-parent="#accordion_<?=$idSuffix?>" data-target="#related_<?=$idSuffix?>-content">
         <h4 class="panel-title">
@@ -52,18 +52,18 @@
           </a>
         </h4>
       </div>
-      <div id="related_<?=$idSuffix?>-content" class="panel-collapse collapse<? if($this->defaultTab === 'related'): ?> in<? endif; ?>">
+      <div id="related_<?=$idSuffix?>-content" class="panel-collapse collapse<?php if($this->defaultTab === 'related'): ?> in<?php endif; ?>">
         <div class="list-tab-content panel-body">
-          <? foreach ($relatedList as $current): ?>
+          <?php foreach ($relatedList as $current): ?>
             <?=$this->related()->render($current)?>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </div>
       </div>
     </div>
-  <? endif; ?>
-  <? if (count($this->tabs) > 0): ?>
-    <? foreach ($this->tabs as $tab => $obj): ?>
-      <? // add current tab to breadcrumbs if applicable:
+  <?php endif; ?>
+  <?php if (count($this->tabs) > 0): ?>
+    <?php foreach ($this->tabs as $tab => $obj): ?>
+      <?php // add current tab to breadcrumbs if applicable:
         $desc = $obj->getDescription();
         $tab_classes = [];
         if (!$obj->isVisible()) { $tab_classes[] = 'hidden'; }
@@ -71,13 +71,13 @@
         if ($this->defaultTab === strtolower($tab)) { $tab_classes[] = 'default'; }
       ?>
       <div class="panel panel-default <?=implode(' ', $tab_classes) ?>">
-        <div id="<?=strtolower($tab)?>_<?=$idSuffix?>" class="list-tab-toggle panel-heading" data-toggle="collapse" data-parent="#accordion_<?=$idSuffix?>" data-target="#<?=strtolower($tab)?>_<?=$idSuffix?>-content"<? if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<? endif ?>>
+        <div id="<?=strtolower($tab)?>_<?=$idSuffix?>" class="list-tab-toggle panel-heading" data-toggle="collapse" data-parent="#accordion_<?=$idSuffix?>" data-target="#<?=strtolower($tab)?>_<?=$idSuffix?>-content"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>>
           <h4 class="panel-title">
             <a class="accordion-toggle" data-href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"><?=$this->transEsc($desc) ?></a>
           </h4>
         </div>
-        <div id="<?=strtolower($tab)?>_<?=$idSuffix?>-content" class="list-tab-content panel-collapse collapse<? if($this->defaultTab === strtolower($tab)): ?> in<? endif; ?>"></div>
+        <div id="<?=strtolower($tab)?>_<?=$idSuffix?>-content" class="list-tab-content panel-collapse collapse<?php if($this->defaultTab === strtolower($tab)): ?> in<?php endif; ?>"></div>
       </div>
-    <? endforeach; ?>
-  <? endif; ?>
+    <?php endforeach; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/record/ajaxview-tabs.phtml
+++ b/themes/bootstrap3/templates/record/ajaxview-tabs.phtml
@@ -1,37 +1,37 @@
-<?
+<?php
   $this->defaultTab = strtolower($this->defaultTab);
   $idSuffix = $this->escapeHtmlAttr(md5($this->driver->getUniqueId() . '|' . $this->driver->getSourceIdentifier()));
 ?>
 <ul class="list-tabs nav nav-tabs">
-  <? $coreMetadata = trim($this->record($this->driver)->getCoreMetadata()); ?>
-  <? if (!empty($coreMetadata)): ?>
-    <li<? if($this->defaultTab === 'information'): ?> class="active"<? endif; ?>>
+  <?php $coreMetadata = trim($this->record($this->driver)->getCoreMetadata()); ?>
+  <?php if (!empty($coreMetadata)): ?>
+    <li<?php if($this->defaultTab === 'information'): ?> class="active"<?php endif; ?>>
       <a id="information_<?=$idSuffix?>" class="list-tab-toggle loaded" data-toggle="tab" data-target="#information_<?=$idSuffix?>-content" class="noajax">
         <?=$this->translate('ajaxview_label_information') ?>
       </a>
     </li>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? $toolbar = trim($this->record($this->driver)->getToolbar()); ?>
-  <? if (!empty($toolbar)): ?>
-    <li<? if($this->defaultTab === 'tools'): ?> class="active"<? endif; ?>>
+  <?php $toolbar = trim($this->record($this->driver)->getToolbar()); ?>
+  <?php if (!empty($toolbar)): ?>
+    <li<?php if($this->defaultTab === 'tools'): ?> class="active"<?php endif; ?>>
       <a id="tools_<?=$idSuffix?>" class="list-tab-toggle loaded" data-toggle="tab" data-target="#tools_<?=$idSuffix?>-content" class="noajax">
       <?=$this->translate('ajaxview_label_tools') ?>
       </a>
     </li>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? $list = $this->related()->getList($this->driver); ?>
-  <? if (!empty($list)): ?>
-    <li<? if($this->defaultTab === 'related'): ?> class="active"<? endif; ?>>
+  <?php $list = $this->related()->getList($this->driver); ?>
+  <?php if (!empty($list)): ?>
+    <li<?php if($this->defaultTab === 'related'): ?> class="active"<?php endif; ?>>
       <a id="related_<?=$idSuffix?>" class="list-tab-toggle loaded" data-toggle="tab" data-target="#related_<?=$idSuffix?>-content" class="noajax">
         <?=$this->transEsc("Related Items")?>
       </a>
     </li>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? foreach ($this->tabs as $tab => $obj): ?>
-    <? // add current tab to breadcrumbs if applicable:
+  <?php foreach ($this->tabs as $tab => $obj): ?>
+    <?php // add current tab to breadcrumbs if applicable:
       $desc = $obj->getDescription();
       $tab_classes = [];
       if ($this->defaultTab === strtolower($tab)) {
@@ -43,31 +43,31 @@
       if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
     ?>
     <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
-      <a id="<?=strtolower($tab)?>_<?=$idSuffix?>" class="list-tab-toggle" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav" data-toggle="tab" data-target="#<?=strtolower($tab)?>_<?=$idSuffix?>-content"<? if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<? endif ?>><?=$this->transEsc($desc)?></a>
+      <a id="<?=strtolower($tab)?>_<?=$idSuffix?>" class="list-tab-toggle" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav" data-toggle="tab" data-target="#<?=strtolower($tab)?>_<?=$idSuffix?>-content"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>><?=$this->transEsc($desc)?></a>
     </li>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </ul>
 <div class="tab-content">
-  <? if (!empty($coreMetadata)): ?>
-    <div class="list-tab-content record tab-pane<? if($this->defaultTab === 'information'): ?> active<? endif; ?>" id="information_<?=$idSuffix?>-content">
+  <?php if (!empty($coreMetadata)): ?>
+    <div class="list-tab-content record tab-pane<?php if($this->defaultTab === 'information'): ?> active<?php endif; ?>" id="information_<?=$idSuffix?>-content">
       <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffix?>" />
       <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getResourceSource()) ?>" class="hiddenSource" />
       <?=$coreMetadata ?>
     </div>
-  <? endif; ?>
-  <? if (!empty($toolbar)): ?>
-    <div class="list-tab-content tab-pane<? if($this->defaultTab === 'tools'): ?> active<? endif; ?>" id="tools_<?=$idSuffix?>-content">
+  <?php endif; ?>
+  <?php if (!empty($toolbar)): ?>
+    <div class="list-tab-content tab-pane<?php if($this->defaultTab === 'tools'): ?> active<?php endif; ?>" id="tools_<?=$idSuffix?>-content">
       <?=$toolbar ?>
     </div>
-  <? endif; ?>
-  <? if (!empty($list)): ?>
-    <div class="list-tab-content tab-pane<? if($this->defaultTab === 'related'): ?> active<? endif; ?>" id="related_<?=$idSuffix?>-content">
-      <? foreach ($list as $current): ?>
+  <?php endif; ?>
+  <?php if (!empty($list)): ?>
+    <div class="list-tab-content tab-pane<?php if($this->defaultTab === 'related'): ?> active<?php endif; ?>" id="related_<?=$idSuffix?>-content">
+      <?php foreach ($list as $current): ?>
         <?=$this->related()->render($current)?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
-  <? endif; ?>
-  <? foreach ($this->tabs as $tab => $obj): ?>
-    <div class="list-tab-content tab-pane<? if($this->defaultTab === strtolower($tab)): ?> active<? endif; ?>" id="<?=strtolower($tab)?>_<?=$idSuffix?>-content"></div>
-  <? endforeach; ?>
+  <?php endif; ?>
+  <?php foreach ($this->tabs as $tab => $obj): ?>
+    <div class="list-tab-content tab-pane<?php if($this->defaultTab === strtolower($tab)): ?> active<?php endif; ?>" id="<?=strtolower($tab)?>_<?=$idSuffix?>-content"></div>
+  <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -1,2 +1,2 @@
-<input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<? if(isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<? endif; ?>/>
-<input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<? if(isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<? endif; ?>/>
+<input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if(isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
+<input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if(isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>

--- a/themes/bootstrap3/templates/record/cite.phtml
+++ b/themes/bootstrap3/templates/record/cite.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Record Citations'));
 
@@ -14,14 +14,14 @@
     $citations[$format . ' Citation'] = $helper->getCitation($format);
   }
 ?>
-<? if (count($citations) == 0): ?>
+<?php if (count($citations) == 0): ?>
   <?=$this->transEsc('No citations are available for this record')?>
-<? else: ?>
-  <? foreach ($citations as $caption => $citation): ?>
+<?php else: ?>
+  <?php foreach ($citations as $caption => $citation): ?>
     <strong><?=$this->transEsc($caption)?></strong>
     <p class="text-left">
       <?=$citation?>
     </p>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <div class="text-muted text-center"><?=$this->transEsc('Warning: These citations may not always be 100% accurate')?>.</div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/record/comments-list.phtml
+++ b/themes/bootstrap3/templates/record/comments-list.phtml
@@ -1,21 +1,21 @@
-<? $comments = $this->driver->getComments(); ?>
-<? if (empty($comments) || count($comments) == 0): ?>
+<?php $comments = $this->driver->getComments(); ?>
+<?php if (empty($comments) || count($comments) == 0): ?>
   <div class="alert alert-info"><?=$this->transEsc('Be the first to leave a comment')?>!</div>
-<? else: ?>
-  <? foreach ($comments as $comment): ?>
+<?php else: ?>
+  <?php foreach ($comments as $comment): ?>
     <div class="comment row">
       <div class="col-sm-3 name">
         <strong><?=$this->escapeHtml(trim($comment->firstname . ' ' . $comment->lastname))?></strong><br/>
         <small>
           <?=$this->escapeHtml($comment->created)?>
-          <? if (($user = $this->auth()->isLoggedIn()) && $comment->user_id == $user->id): ?>
+          <?php if (($user = $this->auth()->isLoggedIn()) && $comment->user_id == $user->id): ?>
             <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'DeleteComment')?>?delete=<?=urlencode($comment->id)?>" id="recordComment<?=$this->escapeHtml($comment->id)?>" class="delete text-danger"><?=$this->transEsc('Delete')?></a>
-          <? endif; ?>
+          <?php endif; ?>
         </small>
       </div>
       <div class="col-sm-9">
         <?=$this->escapeHtml($comment->comment)?>
       </div>
     </div>
-  <? endforeach; ?>
-<? endif; ?>
+  <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/record/cover.phtml
+++ b/themes/bootstrap3/templates/record/cover.phtml
@@ -1,8 +1,8 @@
-<? /* Display thumbnail if appropriate: */ ?>
-<? if ($cover): ?>
-  <? if ($this->link): ?><a href="<?=$this->escapeHtmlAttr($this->link)?>"><? endif; ?>
-  <img alt="<?=$this->transEsc('Cover Image')?>" <? if ($linkPreview): ?>data-linkpreview="true" <? endif; ?>class="recordcover" src="<?=$this->escapeHtmlAttr($cover); ?>"/>
-  <? if ($this->link): ?></a><? endif; ?>
-<? else: ?>
-  <img src="<?=$this->url('cover-unavailable')?>" <? if ($linkPreview): ?>data-linkpreview="true" <? endif; ?>class="recordcover" alt="<?=$this->transEsc('No Cover Image')?>"/>
-<? endif; ?>
+<?php /* Display thumbnail if appropriate: */ ?>
+<?php if ($cover): ?>
+  <?php if ($this->link): ?><a href="<?=$this->escapeHtmlAttr($this->link)?>"><?php endif; ?>
+  <img alt="<?=$this->transEsc('Cover Image')?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" src="<?=$this->escapeHtmlAttr($cover); ?>"/>
+  <?php if ($this->link): ?></a><?php endif; ?>
+<?php else: ?>
+  <img src="<?=$this->url('cover-unavailable')?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="<?=$this->transEsc('No Cover Image')?>"/>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/record/email.phtml
+++ b/themes/bootstrap3/templates/record/email.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Email Record'));
 

--- a/themes/bootstrap3/templates/record/export-menu.phtml
+++ b/themes/bootstrap3/templates/record/export-menu.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Export Record'));
 
@@ -8,14 +8,14 @@
     . '<li class="active">' . $this->transEsc('Export Record') . '</li>';
 ?>
 <?=$this->flashmessages()?>
-<? $exportFormats = $this->export()->getFormatsForRecord($this->driver); if (count($exportFormats) > 0): ?>
+<?php $exportFormats = $this->export()->getFormatsForRecord($this->driver); if (count($exportFormats) > 0): ?>
   <?=$this->transEsc('export_choose_format')?>
   <ul>
-  <? foreach ($exportFormats as $exportFormat): ?>
+  <?php foreach ($exportFormats as $exportFormat): ?>
     <li><a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Export')?>?style=<?=$this->escapeHtml($exportFormat)?>"><?=$this->transEsc('Export to')?> <?=$this->transEsc($this->export()->getLabelForFormat($exportFormat))?></a></li>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   </ul>
-<? else: ?>
+<?php else: ?>
   <?=$this->transEsc('export_no_formats')?>
-<? endif; ?>
+<?php endif; ?>
 

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('request_place_text') . ': ' . $this->driver->getBreadcrumb());
 
@@ -8,9 +8,9 @@
         . '<li class="active">' . $this->transEsc('request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('request_place_text')?></h2>
-<? if ($this->helpText): ?>
+<?php if ($this->helpText): ?>
 <p class="helptext"><?=$this->helpText?></p>
-<? endif; ?>
+<?php endif; ?>
 
 <div class="hold-form">
   <form class="form-horizontal" method="post" name="placeHold">
@@ -19,16 +19,16 @@
     <div class="col-sm-9">
       <p class="form-control-static"><?=$this->driver->getBreadcrumb() ?></p>
     </div>
-    <? if (in_array("comments", $this->extraHoldFields)): ?>
+    <?php if (in_array("comments", $this->extraHoldFields)): ?>
       <div class="form-group hold-comment">
         <label class="col-sm-3 control-label"><?=$this->transEsc("Comments")?>:</label>
         <div class="col-sm-9">
           <textarea rows="3" cols="20" name="gatheredDetails[comment]" class="form-control"><?=isset($this->gatheredDetails['comment']) ? $this->escapeHtml($this->gatheredDetails['comment']) : ''?></textarea>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("requiredByDate", $this->extraHoldFields)): ?>
+    <?php if (in_array("requiredByDate", $this->extraHoldFields)): ?>
       <div class="form-group hold-required-by">
         <label class="col-sm-3 control-label"><?=$this->transEsc("hold_required_by")?>:</label>
         <div class="col-sm-9">
@@ -36,11 +36,11 @@
           (<?=$this->dateTime()->getDisplayDateFormat()?>)
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if ($this->requestGroupNeeded): ?>
+    <?php if ($this->requestGroupNeeded): ?>
       <div class="form-group hold-request-group">
-        <?
+        <?php
           if (isset($this->gatheredDetails['requestGroupId']) && $this->gatheredDetails['requestGroupId'] !== "") {
               $selected = $this->gatheredDetails['requestGroupId'];
           } else {
@@ -50,23 +50,23 @@
         <label class="col-sm-3 control-label"><?=$this->transEsc("hold_request_group")?>:</label>
         <div class="col-sm-9">
           <select id="requestGroupId" name="gatheredDetails[requestGroupId]" class="form-control">
-          <? if ($selected === false): ?>
+          <?php if ($selected === false): ?>
             <option value="" selected="selected">
               <?=$this->transEsc('select_request_group')?>
             </option>
-          <? endif; ?>
-          <? foreach ($this->requestGroups as $group): ?>
+          <?php endif; ?>
+          <?php foreach ($this->requestGroups as $group): ?>
             <option value="<?=$this->escapeHtmlAttr($group['id'])?>"<?=($selected == $group['id']) ? ' selected="selected"' : ''?>>
               <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
             </option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
           </select>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("pickUpLocation", $this->extraHoldFields)): ?>
-      <?
+    <?php if (in_array("pickUpLocation", $this->extraHoldFields)): ?>
+      <?php
         if (isset($this->gatheredDetails['pickUpLocation']) && $this->gatheredDetails['pickUpLocation'] !== "") {
             $selected = $this->gatheredDetails['pickUpLocation'];
         } elseif (isset($this->homeLibrary) && $this->homeLibrary !== "") {
@@ -75,45 +75,45 @@
             $selected = $this->defaultPickup;
         }
       ?>
-      <? if ($this->requestGroupNeeded): ?>
+      <?php if ($this->requestGroupNeeded): ?>
         <div class="form-group hold-pickup-location">
           <label id="pickUpLocationLabel" class="col-sm-3 control-label"><i></i> <?=$this->transEsc("pick_up_location")?>:
-            <? if (in_array("requestGroup", $this->extraHoldFields)): ?>
+            <?php if (in_array("requestGroup", $this->extraHoldFields)): ?>
               <noscript> (<?=$this->transEsc("Please enable JavaScript.")?>)</noscript>
-            <? endif; ?>
+            <?php endif; ?>
           </label>
           <div class="col-sm-9">
             <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-control">
-              <? if ($selected === false): ?>
+              <?php if ($selected === false): ?>
               <option value="" selected="selected">
                 <?=$this->transEsc('select_pickup_location')?>
               </option>
-              <? endif; ?>
+              <?php endif; ?>
             </select>
           </div>
         </div>
-      <? elseif ($this->pickup): ?>
+      <?php elseif ($this->pickup): ?>
         <div class="form-group hold-pickup-location">
           <label class="col-sm-3 control-label"><?=$this->transEsc("pick_up_location")?>:</label>
           <div class="col-sm-9">
             <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" class="form-control">
-            <? if ($selected === false && count($this->pickup) > 1): ?>
+            <?php if ($selected === false && count($this->pickup) > 1): ?>
               <option value="" selected="selected">
                 <?=$this->transEsc('select_pickup_location')?>
               </option>
-            <? endif; ?>
-            <? foreach ($this->pickup as $lib): ?>
+            <?php endif; ?>
+            <?php foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
                 <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
-            <? endforeach; ?>
+            <?php endforeach; ?>
             </select>
           </div>
         </div>
-      <? else: ?>
+      <?php else: ?>
         <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
         <input class="btn btn-primary" type="submit" name="placeHold" value="<?=$this->transEsc('request_submit_text')?>"/>
@@ -122,7 +122,7 @@
   </form>
 </div>
 
-<?
+<?php
     // Set up hold script; we do this inline instead of in the header for lightbox compatibility:
     $this->inlineScript()->appendFile('hold.js');
 

--- a/themes/bootstrap3/templates/record/illrequest.phtml
+++ b/themes/bootstrap3/templates/record/illrequest.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('ill_request_place_text') . ': ' . $this->driver->getBreadcrumb());
 
@@ -8,57 +8,57 @@
         . '<li class="active">' . $this->transEsc('ill_request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('ill_request_place_text')?></h2>
-<? if ($this->helpText): ?>
+<?php if ($this->helpText): ?>
 <p class="helptext"><?=$this->helpText?></p>
-<? endif; ?>
+<?php endif; ?>
 
 <div id="ILLRequestForm" class="storage-retrieval-request-form">
   <form name="placeILLRequest" class="form-horizontal" method="post">
     <?=$this->flashmessages()?>
-    <? if (in_array("itemId", $this->extraFields)): ?>
+    <?php if (in_array("itemId", $this->extraFields)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc('ill_request_item')?>:</label>
         <div class="col-sm-9">
           <select id="itemId" name="gatheredDetails[itemId]" class="form-control">
-          <? foreach ($this->items as $item): ?>
+          <?php foreach ($this->items as $item): ?>
             <option value="<?=$this->escapeHtmlAttr($item['id'])?>"<?=($this->gatheredDetails['itemId'] == $item['id']) ? ' selected="selected"' : ''?>>
               <?=$this->escapeHtml($item['name'])?>
             </option>
-         <? endforeach; ?>
+         <?php endforeach; ?>
           </select>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("pickUpLibrary", $this->extraFields) && !empty($this->pickupLibraries)): ?>
+    <?php if (in_array("pickUpLibrary", $this->extraFields) && !empty($this->pickupLibraries)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc("ill_request_pick_up_library")?>:</label>
         <div class="col-sm-9">
-          <? if (count($this->pickupLibraries) > 1): ?>
+          <?php if (count($this->pickupLibraries) > 1): ?>
             <select id="pickupLibrary" name="gatheredDetails[pickUpLibrary]" class="form-control">
-            <?
+            <?php
               if (isset($this->gatheredDetails['pickUpLibrary']) && $this->gatheredDetails['pickUpLibrary'] !== "") {
                   $selected = $this->gatheredDetails['pickUpLibrary'];
               } else {
                   $selected = false;
               }
             ?>
-            <? foreach ($this->pickupLibraries as $lib): ?>
+            <?php foreach ($this->pickupLibraries as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['id'])?>"<?=(($selected === false && isset($lib['isDefault']) && $lib['isDefault']) || $selected === $lib['id']) ? ' selected="selected"' : ''?>>
                 <?=$this->transEsc('library_' . $lib['name'], null, $lib['name'])?>
               </option>
-            <? endforeach; ?>
+            <?php endforeach; ?>
             </select>
-          <? else: ?>
-            <? $lib = $this->pickupLibraries[0]; ?>
+          <?php else: ?>
+            <?php $lib = $this->pickupLibraries[0]; ?>
             <input type="text" class="form-control" size="40" readonly="readonly" value="<?=$this->escapeHtmlAttr($this->translate('library_' . $lib['name'], null, $lib['name']))?>" />
             <input type="hidden" id="pickupLibrary" name="gatheredDetails[pickUpLibrary]" value="<?=$this->escapeHtmlAttr($lib['id'])?>" />
-          <? endif; ?>
+          <?php endif; ?>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("pickUpLibraryLocation", $this->extraFields)): ?>
+    <?php if (in_array("pickUpLibraryLocation", $this->extraFields)): ?>
       <div class="form-group">
         <label id="pickupLibraryLocationLabel" class="col-sm-3 control-label"><i></i>&nbsp;<?=$this->transEsc("ill_request_pick_up_location")?>:<noscript> (<?=$this->transEsc("Please enable JavaScript.")?>)</noscript></label>
         <div class="col-sm-9">
@@ -66,12 +66,12 @@
           </select>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("pickUpLocation", $this->extraFields)): ?>
-      <? if (count($this->pickup) > 1): ?>
+    <?php if (in_array("pickUpLocation", $this->extraFields)): ?>
+      <?php if (count($this->pickup) > 1): ?>
         <div class="form-group">
-          <?
+          <?php
             if (isset($this->gatheredDetails['pickUpLocation']) && $this->gatheredDetails['pickUpLocation'] !== "") {
                 $selected = $this->gatheredDetails['pickUpLocation'];
             } elseif (isset($this->homeLibrary) && $this->homeLibrary !== "") {
@@ -83,20 +83,20 @@
           <label class="col-sm-3 control-label"><?=$this->transEsc("pick_up_location")?>:</label>
           <div class="col-sm-9">
             <select name="gatheredDetails[pickUpLocation]" class="form-control">
-            <? foreach ($this->pickup as $lib): ?>
+            <?php foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
                 <?=$this->escapeHtml($lib['locationDisplay'])?>
               </option>
-            <? endforeach; ?>
+            <?php endforeach; ?>
             </select>
           </div>
         </div>
-      <? else: ?>
+      <?php else: ?>
         <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("requiredByDate", $this->extraFields)): ?>
+    <?php if (in_array("requiredByDate", $this->extraFields)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc("hold_required_by")?>:</label>
         <div class="col-sm-9">
@@ -104,16 +104,16 @@
           (<?=$this->dateTime()->getDisplayDateFormat()?>)
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("comments", $this->extraFields)): ?>
+    <?php if (in_array("comments", $this->extraFields)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc("Comments")?>:</label>
         <div class="col-sm-9">
           <textarea rows="3" cols="20" name="gatheredDetails[comment]" class="form-control"><?=isset($this->gatheredDetails['comment']) ? $this->escapeHtml($this->gatheredDetails['comment']) : ''?></textarea>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">
@@ -123,7 +123,7 @@
   </form>
 </div>
 
-<?
+<?php
     // Set up ill script; we do this inline instead of in the header for lightbox compatibility:
     $this->inlineScript()->appendFile('ill.js');
 

--- a/themes/bootstrap3/templates/record/save.phtml
+++ b/themes/bootstrap3/templates/record/save.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Save'));
 
@@ -12,40 +12,40 @@
   <input type="hidden" name="submit" value="1" />
   <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>" />
   <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
-  <? if (!empty($this->containingLists)): ?>
+  <?php if (!empty($this->containingLists)): ?>
     <p><?=$this->transEsc('This item is already part of the following list/lists') ?>:
-    <? foreach ($this->containingLists as $i=>$list): ?>
-      <a href="<?=$this->url('userList', ['id' => $list['id']]) ?>" data-lightbox-ignore><?=$this->escapeHtml($list['title'])?></a><? if($i<count($this->containingLists)-1): ?>, <? endif; ?>
-    <? endforeach; ?>
+    <?php foreach ($this->containingLists as $i=>$list): ?>
+      <a href="<?=$this->url('userList', ['id' => $list['id']]) ?>" data-lightbox-ignore><?=$this->escapeHtml($list['title'])?></a><?php if($i<count($this->containingLists)-1): ?>, <?php endif; ?>
+    <?php endforeach; ?>
     </p><hr/>
-  <? endif; ?>
+  <?php endif; ?>
 
   <?/* Only display the list drop-down if the user has lists that do not contain
   this item OR if they have no lists at all and need to create a default list */?>
-  <? $showLists = (!empty($this->nonContainingLists) || (empty($this->containingLists) && empty($this->nonContainingLists))); ?>
+  <?php $showLists = (!empty($this->nonContainingLists) || (empty($this->containingLists) && empty($this->nonContainingLists))); ?>
 
   <div class="form-group">
-    <? if ($showLists): ?>
+    <?php if ($showLists): ?>
       <label class="col-sm-3 control-label" for="save_list"><?=$this->transEsc('Choose a List') ?></label>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="col-sm-9">
-    <? if ($showLists): ?>
+    <?php if ($showLists): ?>
       <select class="form-control" id="save_list" name="list">
-      <? if ($this->nonContainingLists): ?>
-        <? foreach ($this->nonContainingLists as $list): ?>
-          <option value="<?=$list['id'] ?>"<? if ($list['id']==$this->userList()->lastUsed()): ?> selected="selected"<? endif; ?>><?=$this->escapeHtml($list['title'])?></option>
-        <? endforeach; ?>
-      <? else: ?>
+      <?php if ($this->nonContainingLists): ?>
+        <?php foreach ($this->nonContainingLists as $list): ?>
+          <option value="<?=$list['id'] ?>"<?php if ($list['id']==$this->userList()->lastUsed()): ?> selected="selected"<?php endif; ?>><?=$this->escapeHtml($list['title'])?></option>
+        <?php endforeach; ?>
+      <?php else: ?>
         <option value=""><?=$this->transEsc('My Favorites') ?></option>
-      <? endif; ?>
+      <?php endif; ?>
       </select>
-    <? endif; ?>
+    <?php endif; ?>
       <a class="btn btn-link" id="make-list" href="<?=$this->url('editList', ['id' => 'NEW'])?>?recordId=<?=urlencode($this->driver->getUniqueId())?>&amp;recordSource=<?=urlencode($this->driver->getSourceIdentifier())?>"><?=$showLists ? $this->transEsc('or create a new list') : $this->transEsc('Create a List'); ?></a>
     </div>
   </div>
 
-  <? if ($showLists): ?>
-    <? if ($this->usertags()->getMode() !== 'disabled'): ?>
+  <?php if ($showLists): ?>
+    <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label" for="add_mytags"><?=$this->transEsc('Add Tags') ?></label>
         <div class="col-sm-9">
@@ -53,7 +53,7 @@
           <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="form-group">
       <label class="col-sm-3 control-label" for="add_notes"><?=$this->transEsc('Add a Note') ?></label>
       <div class="col-sm-9">
@@ -65,5 +65,5 @@
         <input class="btn btn-primary" type="submit" value="<?=$this->transEsc('Save') ?>"/>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </form>

--- a/themes/bootstrap3/templates/record/sms.phtml
+++ b/themes/bootstrap3/templates/record/sms.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Text this'));
   echo $this->inlineScript(\Zend\View\Helper\HeadScript::FILE, 'vendor/libphonenumber.js', 'SET');
@@ -8,7 +8,7 @@
     . '<li>' . $this->recordLink()->getBreadcrumb($this->driver) . '</li> '
     . '<li class="active">' . $this->transEsc('Text this') . '</li>';
 ?>
-<? $validatorCallback = <<<JS
+<?php $validatorCallback = <<<JS
   function phoneNumberValidation() {
     return phoneNumberFormHandler('sms_to', '{$this->validation}');
   }
@@ -16,7 +16,7 @@ JS;
 ?>
 <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $validatorCallback, 'SET'); ?>
 <h2><?=$this->transEsc('Text this') ?>: <span class="title-in-heading"><?=$this->escapeHtml($this->driver->getBreadcrumb())?></span></h2>
-<form method="post" name="smsRecord" class="form-horizontal"<? if(isset($this->validation) && !empty($this->validation)):?> data-lightbox-onsubmit="phoneNumberValidation"<? endif; ?>>
+<form method="post" name="smsRecord" class="form-horizontal"<?php if(isset($this->validation) && !empty($this->validation)):?> data-lightbox-onsubmit="phoneNumberValidation"<?php endif; ?>>
   <?=$this->flashmessages()?>
   <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
   <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
@@ -27,22 +27,22 @@ JS;
       <div class="help-block with-errors"></div>
     </div>
   </div>
-  <? if (is_array($this->carriers) && count($this->carriers) > 1): ?>
+  <?php if (is_array($this->carriers) && count($this->carriers) > 1): ?>
     <div class="form-group">
       <label class="col-sm-3 control-label" for="sms_provider"><?=$this->transEsc('Provider')?>:</label>
       <div class="col-sm-9">
         <select id="sms_provider" name="provider" class="form-control">
           <option selected="selected" value=""><?=$this->transEsc('Select your carrier')?></option>
-          <? foreach ($this->carriers as $val => $details): ?>
+          <?php foreach ($this->carriers as $val => $details): ?>
             <option value="<?=$this->escapeHtmlAttr($val)?>"><?=$this->escapeHtml($details['name'])?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
     </div>
-  <? else: ?>
-    <? $keys = is_array($this->carriers) ? array_keys($this->carriers) : []; ?>
+  <?php else: ?>
+    <?php $keys = is_array($this->carriers) ? array_keys($this->carriers) : []; ?>
     <input type="hidden" name="provider" value="<?=isset($keys[0]) ? $keys[0] : ''?>" />
-  <? endif; ?>
+  <?php endif; ?>
   <?=$this->recaptcha()->html($this->useRecaptcha) ?>
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">

--- a/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('storage_retrieval_request_place_text') . ': ' . $this->driver->getBreadcrumb());
 
@@ -8,14 +8,14 @@
         . '<li class="active">' . $this->transEsc('storage_retrieval_request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('storage_retrieval_request_place_text')?></h2>
-<? if ($this->helpText): ?>
+<?php if ($this->helpText): ?>
 <p class="helptext"><?=$this->helpText?></p>
-<? endif; ?>
+<?php endif; ?>
 
 <div class="storage-retrieval-request-form">
   <form name="placeStorageRetrievalRequest" class="form-horizontal" method="post">
     <?=$this->flashmessages()?>
-    <? if (in_array("item-issue", $this->extraFields)): ?>
+    <?php if (in_array("item-issue", $this->extraFields)): ?>
       <div class="form-group">
         <div class="col-sm-3 controls">
           <div class="radio">
@@ -49,9 +49,9 @@
           </div>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("requiredByDate", $this->extraFields)): ?>
+    <?php if (in_array("requiredByDate", $this->extraFields)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc("hold_required_by")?>:</label>
         <div class="col-sm-9">
@@ -59,12 +59,12 @@
           (<?=$this->dateTime()->getDisplayDateFormat()?>)
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("pickUpLocation", $this->extraFields)): ?>
-      <? if ($this->pickup): ?>
+    <?php if (in_array("pickUpLocation", $this->extraFields)): ?>
+      <?php if ($this->pickup): ?>
         <div class="form-group">
-          <?
+          <?php
             if (isset($this->gatheredDetails['pickUpLocation']) && $this->gatheredDetails['pickUpLocation'] !== "") {
                 $selected = $this->gatheredDetails['pickUpLocation'];
             } elseif (isset($this->homeLibrary) && $this->homeLibrary !== "") {
@@ -76,32 +76,32 @@
           <label class="col-sm-3 control-label"><?=$this->transEsc("pick_up_location")?>:</label>
           <div class="col-sm-9">
             <select name="gatheredDetails[pickUpLocation]" class="form-control">
-            <? if ($selected === false && count($this->pickup) > 1): ?>
+            <?php if ($selected === false && count($this->pickup) > 1): ?>
               <option value="" selected="selected">
                 <?=$this->transEsc('select_pickup_location')?>
               </option>
-            <? endif; ?>
-            <? foreach ($this->pickup as $lib): ?>
+            <?php endif; ?>
+            <?php foreach ($this->pickup as $lib): ?>
               <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>>
                 <?=$this->transEsc('location_' . $lib['locationDisplay'], null, $lib['locationDisplay'])?>
               </option>
-            <? endforeach; ?>
+            <?php endforeach; ?>
             </select>
           </div>
         </div>
-      <? else: ?>
+      <?php else: ?>
         <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
 
-    <? if (in_array("comments", $this->extraFields)): ?>
+    <?php if (in_array("comments", $this->extraFields)): ?>
       <div class="form-group">
         <label class="col-sm-3 control-label"><?=$this->transEsc("Comments")?>:</label>
         <div class="col-sm-9">
           <textarea rows="3" cols="20" name="gatheredDetails[comment]" class="form-control"><?=isset($this->gatheredDetails['comment']) ? $this->escapeHtml($this->gatheredDetails['comment']) : ''?></textarea>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
     <div class="form-group">
       <div class="col-sm-9 col-sm-offset-3">

--- a/themes/bootstrap3/templates/record/taglist.phtml
+++ b/themes/bootstrap3/templates/record/taglist.phtml
@@ -1,26 +1,26 @@
 <div class="tagList<?=$loggedin ? ' loggedin' : ''?>">
-  <? if (count($tagList) > 0): ?>
-    <? foreach ($tagList as $tag): ?>
-      <? $is_me = isset($tag['is_me']) && !is_null($tag['is_me']) ? $tag['is_me'] : false; ?>
+  <?php if (count($tagList) > 0): ?>
+    <?php foreach ($tagList as $tag): ?>
+      <?php $is_me = isset($tag['is_me']) && !is_null($tag['is_me']) ? $tag['is_me'] : false; ?>
       <div class="tag<?=$is_me ? ' selected' : ''?>">
         <a href="<?=$this->url('tag-home')?>?lookfor=<?=urlencode($tag['tag'])?>"><?=$this->escapeHtml($tag['tag'])?></a>
-        <? if($loggedin): ?>
+        <?php if($loggedin): ?>
           <form method="POST" action="<?=$this->recordLink()->getActionUrl($this->driver, $is_me ? 'DeleteTag' : 'AddTag') ?>" class="tag-form">
             <input type="hidden" name="tag" value="<?=$this->escapeHtmlAttr($tag['tag'])?>"/>
             <button type="submit" class="badge" onClick="ajaxTagUpdate(this, '<?=$this->escapeHtmlAttr($tag['tag'])?>', <?=$is_me ? 'true' : 'false' ?>);return false;"><?=$this->escapeHtml($tag['cnt']) ?>
-            <? if($is_me): ?>
+            <?php if($is_me): ?>
               <i class="fa fa-close" title="<?=$this->transEsc('delete_tag') ?>"></i>
-            <? else: ?>
+            <?php else: ?>
               <i class="fa fa-plus" title="<?=$this->transEsc('Add Tag') ?>"></i>
-            <? endif; ?>
+            <?php endif; ?>
             </button>
           </form>
-        <? else: ?>
+        <?php else: ?>
           <span class="badge"><?=$this->escapeHtml($tag['cnt'])?></span>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
-    <? endforeach; ?>
-  <? else: ?>
+    <?php endforeach; ?>
+  <?php else: ?>
     <?=$this->transEsc('No Tags')?>, <?=$this->transEsc('Be the first to tag this record')?>!
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up standard record scripts:
   $this->headScript()->appendFile("record.js");
   $this->headScript()->appendFile("check_save_statuses.js");
@@ -18,41 +18,41 @@
   $this->layout()->title = $this->driver->getShortTitle();
 ?>
 
-<? if (isset($this->scrollData) && ($this->scrollData['previousRecord'] || $this->scrollData['nextRecord'])): ?>
+<?php if (isset($this->scrollData) && ($this->scrollData['previousRecord'] || $this->scrollData['nextRecord'])): ?>
   <ul class="pager hidden-print">
-    <? if ($this->scrollData['previousRecord']): ?>
-      <? if ($this->scrollData['firstRecord']): ?>
+    <?php if ($this->scrollData['previousRecord']): ?>
+      <?php if ($this->scrollData['firstRecord']): ?>
         <li>
           <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('First')?></a>
         </li>
-      <? endif; ?>
+      <?php endif; ?>
       <li>
         <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('Prev')?></a>
       </li>
-    <? else: ?>
-      <? if ($this->scrollData['firstRecord']): ?>
+    <?php else: ?>
+      <?php if ($this->scrollData['firstRecord']): ?>
         <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('First')?></a></li>
-      <? endif; ?>
+      <?php endif; ?>
       <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
-    <? endif; ?>
+    <?php endif; ?>
     #<?=$this->localizedNumber($this->scrollData['currentPosition']) . ' ' . $this->transEsc('of') . ' ' . $this->localizedNumber($this->scrollData['resultTotal']) . ' ' . $this->transEsc('results') ?>
-    <? if ($this->scrollData['nextRecord']): ?>
+    <?php if ($this->scrollData['nextRecord']): ?>
       <li>
         <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> &raquo;</a>
       </li>
-      <? if ($this->scrollData['lastRecord']): ?>
+      <?php if ($this->scrollData['lastRecord']): ?>
         <li>
           <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> &raquo;</a>
         </li>
-      <? endif; ?>
-     <? else: ?>
+      <?php endif; ?>
+     <?php else: ?>
       <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
-      <? if ($this->scrollData['lastRecord']): ?>
+      <?php if ($this->scrollData['lastRecord']): ?>
         <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> &raquo;</a></li>
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>
 
 <?=$this->record($this->driver)->getToolbar()?>
 
@@ -63,12 +63,12 @@
     <?=$this->flashmessages()?>
     <?=$this->record($this->driver)->getCoreMetadata()?>
 
-    <? if (count($this->tabs) > 0): ?>
+    <?php if (count($this->tabs) > 0): ?>
       <a name="tabnav"></a>
       <div class="record-tabs">
         <ul class="nav nav-tabs">
-          <? foreach ($this->tabs as $tab => $obj): ?>
-            <? // add current tab to breadcrumbs if applicable:
+          <?php foreach ($this->tabs as $tab => $obj): ?>
+            <?php // add current tab to breadcrumbs if applicable:
               $desc = $obj->getDescription();
               $tab_classes = [];
               if (0 === strcasecmp($this->activeTab, $tab)) {
@@ -83,28 +83,28 @@
               if (!$obj->supportsAjax()) { $tab_classes[] = 'noajax'; }
             ?>
             <li<?=count($tab_classes) > 0 ? ' class="' . implode(' ', $tab_classes) . '"' : ''?>>
-              <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"<? if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<? endif ?>><?=$this->transEsc($desc)?></a>
+              <a class="<?=strtolower($tab) ?>" href="<?=$this->recordLink()->getTabUrl($this->driver, $tab)?>#tabnav"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>><?=$this->transEsc($desc)?></a>
             </li>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </ul>
 
         <div class="tab-content">
-          <? if (!$this->loadInitialTabWithAjax || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
+          <?php if (!$this->loadInitialTabWithAjax || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
             <div class="tab-pane active <?=$this->activeTab ?>-tab">
               <?=isset($activeTabObj) ? $this->record($this->driver)->getTab($activeTabObj) : '' ?>
             </div>
-          <? endif; ?>
+          <?php endif; ?>
         </div>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
 
     <?=$this->driver->supportsCoinsOpenURL()?'<span class="Z3988" title="'.$this->escapeHtmlAttr($this->driver->getCoinsOpenURL()).'"></span>':''?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">
-    <? foreach ($this->related()->getList($this->driver) as $current): ?>
+    <?php foreach ($this->related()->getList($this->driver) as $current): ?>
       <?=$this->related()->render($current)?>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
 </div>
 <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>

--- a/themes/bootstrap3/templates/records/home.phtml
+++ b/themes/bootstrap3/templates/records/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     $this->overrideTitle = $this->translate('View Records');
     $this->overrideSearchHeading = '';
 

--- a/themes/bootstrap3/templates/search/advanced.phtml
+++ b/themes/bootstrap3/templates/search/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Load the Solr-specific advanced search controls and inject them into the
   // standard advanced search layout:
   $this->extraAdvancedControls = $this->render('search/advanced/solr.phtml');

--- a/themes/bootstrap3/templates/search/advanced/build_page.phtml
+++ b/themes/bootstrap3/templates/search/advanced/build_page.phtml
@@ -11,19 +11,19 @@ $(document).ready(function() {
   $('#new_group_template .search').remove();
   $('#advSearchForm .no-js').remove();
   // Build page
-  <? if (isset($this->searchDetails) && is_object($this->searchDetails)): ?>
-    <? foreach ($this->searchDetails->getQueries() as $searchGroup): ?>
-      <? $i = 0; foreach ($searchGroup->getQueries() as $search): ?>
-        <? if (++$i == 1): ?>
+  <?php if (isset($this->searchDetails) && is_object($this->searchDetails)): ?>
+    <?php foreach ($this->searchDetails->getQueries() as $searchGroup): ?>
+      <?php $i = 0; foreach ($searchGroup->getQueries() as $search): ?>
+        <?php if (++$i == 1): ?>
           var new_group = addGroup('<?=addslashes($search->getString())?>', '<?=addslashes($search->getHandler())?>', '<?=$searchGroup->isNegated() ? 'NOT' : $searchGroup->getOperator()?>');
-        <? else: ?>
+        <?php else: ?>
           addSearch(new_group, {term:'<?=addslashes($search->getString())?>', field:'<?=addslashes($search->getHandler())?>'});
-        <? endif; ?>
-      <? endforeach; ?>
-    <? endforeach; ?>
-  <? else: ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    <?php endforeach; ?>
+  <?php else: ?>
     var group = addGroup();
     addSearch(group);
     addSearch(group);
-  <? endif; ?>
+  <?php endif; ?>
 });

--- a/themes/bootstrap3/templates/search/advanced/build_page_eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/build_page_eds.phtml
@@ -10,27 +10,27 @@ $(document).ready(function() {
   $('#advSearchForm .no-js').remove();
   $('#groupJoin').remove();
   // Build page
-  <? if (isset($this->searchDetails) && is_object($this->searchDetails)): ?>
-    <? foreach ($this->searchDetails->getQueries() as $searchGroup): ?>
-      <? $i = 0; foreach ($searchGroup->getQueries() as $search): ?>
-        <? if (++$i == 1): ?>
+  <?php if (isset($this->searchDetails) && is_object($this->searchDetails)): ?>
+    <?php foreach ($this->searchDetails->getQueries() as $searchGroup): ?>
+      <?php $i = 0; foreach ($searchGroup->getQueries() as $search): ?>
+        <?php if (++$i == 1): ?>
           var new_group = addGroup(
             '<?=addslashes($search->getString())?>',
             '<?=addslashes($search->getHandler())?>',
             '<?=$searchGroup->isNegated() ? 'NOT' : $searchGroup->getOperator()?>'
           );
-        <? else: ?>
+        <?php else: ?>
           addSearch(new_group, {
             term :'<?=addslashes($search->getString())?>',
             field:'<?=addslashes($search->getHandler())?>',
             op   :'<?=addslashes($search->getOperator())?>'
           });
-        <? endif; ?>
-      <? endforeach; ?>
-    <? endforeach; ?>
-  <? else: ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    <?php endforeach; ?>
+  <?php else: ?>
     var new_group = addGroup();
     addSearch(new_group);
     addSearch(new_group);
-  <? endif; ?>
+  <?php endif; ?>
 });

--- a/themes/bootstrap3/templates/search/advanced/checkbox-filters.phtml
+++ b/themes/bootstrap3/templates/search/advanced/checkbox-filters.phtml
@@ -1,12 +1,12 @@
-<? if (isset($this->checkboxFacets) && count($this->checkboxFacets) > 0): ?>
+<?php if (isset($this->checkboxFacets) && count($this->checkboxFacets) > 0): ?>
   <fieldset class="checkboxFilter">
-    <? foreach ($this->checkboxFacets as $current): ?>
+    <?php foreach ($this->checkboxFacets as $current): ?>
       <div class="checkbox">
         <label>
-          <input type="checkbox" name="filter[]" value="<?=$this->escapeHtmlAttr($current['filter'])?>" id="<?=$this->escapeHtmlAttr(str_replace(' ', '', $current['desc']))?>"<? if ($current['selected']): ?> checked="checked"<? endif; ?>/>
+          <input type="checkbox" name="filter[]" value="<?=$this->escapeHtmlAttr($current['filter'])?>" id="<?=$this->escapeHtmlAttr(str_replace(' ', '', $current['desc']))?>"<?php if ($current['selected']): ?> checked="checked"<?php endif; ?>/>
           <?=$this->transEsc($current['desc'])?>
         </label>
       </div>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </fieldset>
 <?endif;?>

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -1,9 +1,9 @@
 <div class="clearfix"></div>
 <div class="row">
-  <? if (!empty($this->expanderList)): ?>
+  <?php if (!empty($this->expanderList)): ?>
     <fieldset class="col-sm-4">
       <legend><?=$this->transEsc('eds_modes_and_expanders')?></legend>
-      <? foreach ($this->expanderList as $field => $expander):
+      <?php foreach ($this->expanderList as $field => $expander):
         $value = $expander['Value'] ?>
         <div class="checkbox">
           <label for="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
@@ -11,35 +11,35 @@
             <?=$this->transEsc('eds_expander_' . $value, array(), $expander['Label'])?>
           </label>
         </div>
-      <? endforeach; ?>
+      <?php endforeach; ?>
 
       <label class="displayBlock" for="searchModes"><?=$this->transEsc('Search Mode')?></label>
       <select id="searchMode_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" class="form-control">
-        <? foreach ($this->searchModes as $field => $searchMode):
+        <?php foreach ($this->searchModes as $field => $searchMode):
           $value = $searchMode['Value'] ?>
           <option <?=(isset($searchMode['selected']) && $searchMode['selected'])?'selected="selected"':''?> value="SEARCHMODE:<?=$this->escapeHtmlAttr($value)?>">
             <?= /* 'Label' comes from API and is always in English; try to translate structured value before using it: */ $this->transEsc('eds_mode_' . $value, array(), $searchMode['Label']) ?>
           </option>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </select>
     </fieldset>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if (!empty($this->limiterList)): ?>
+  <?php if (!empty($this->limiterList)): ?>
     <fieldset class="col-sm-4">
       <legend><?=$this->transEsc('Limit To')?></legend>
-      <? foreach ($this->limiterList as $field => $facet): ?>
-        <? switch($facet['Type']){
+      <?php foreach ($this->limiterList as $field => $facet): ?>
+        <?php switch($facet['Type']){
             case 'multiselectvalue': ?>
               <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>"><?=$this->transEsc($facet['Label'])?></label><br/>
               <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-control">
-                <? foreach ($facet['LimiterValues'] as $id => $facetValue): ?>
-                  <? $value = $facetValue['Value']; ?>
+                <?php foreach ($facet['LimiterValues'] as $id => $facetValue): ?>
+                  <?php $value = $facetValue['Value']; ?>
                   <option value="<?='LIMIT|'.$this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
-                <? endforeach; ?>
+                <?php endforeach; ?>
               </select>
               <!-- <br/> -->
-              <? break;
+              <?php break;
             case 'select':
               $value = $facet['LimiterValues'][0]['Value'] ?>
               <div class="checkbox">
@@ -48,33 +48,33 @@
                   <?=$this->transEsc('eds_limiter_' . $field, array(), $facet['Label'])?>
                 </label>
               </div>
-              <? break;
+              <?php break;
             case 'text': ?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'numeric':?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'numericrange':?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'ymrange': ?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'yrange': ?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'historicalrange':?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
             case 'singleselectvalue':?>
               <!-- not implemented -->
-              <? break;
+              <?php break;
           }; ?>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </fieldset>
-  <? endif; ?>
-  <? if (isset($this->dateRangeLimit)): ?>
+  <?php endif; ?>
+  <?php if (isset($this->dateRangeLimit)): ?>
     <fieldset class="col-sm-4">
       <legend><?=$this->transEsc('adv_search_year')?></legend>
       <input type="hidden" name="daterange[]" value="PublicationDate"/>
@@ -91,7 +91,7 @@
         <div class="slider-container">
           <input type="text" id="PublicationDateSlider">
         </div>
-        <?
+        <?php
           $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
           $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
           $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
@@ -127,5 +127,5 @@ JS;
       ?>
       <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
     </fieldset>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Advanced Search'));
 
@@ -64,40 +64,40 @@
 <?=$this->flashmessages()?>
 <div role="search">
   <form name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
-    <? foreach ($hiddenFilters as $key => $filter): ?>
-      <? foreach ($filter as $value): ?>
+    <?php foreach ($hiddenFilters as $key => $filter): ?>
+      <?php foreach ($filter as $value): ?>
         <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr($value)?>" />
-      <? endforeach; ?>
-    <? endforeach; ?>
+      <?php endforeach; ?>
+    <?php endforeach; ?>
     <div class="row">
       <div class="<?=$this->layoutClass('mainbody')?>">
-        <? $lastSort = $this->searchMemory()->getLastSort($this->searchClassId); ?>
-        <? if (!empty($lastSort)): ?>
+        <?php $lastSort = $this->searchMemory()->getLastSort($this->searchClassId); ?>
+        <?php if (!empty($lastSort)): ?>
           <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>" />
-        <? endif; ?>
+        <?php endif; ?>
         <div class="clearfix">
           <h2 class="pull-left flip"><?=$this->transEsc('Advanced Search')?></h2>
           <div id="groupJoin" class="form-inline pull-right flip">
             <label for="groupJoinOptions"><?=$this->transEsc("search_match")?>:</label>
             <select id="groupJoinOptions" name="join" class="form-control">
-              <option value="AND"<? if($searchDetails && $searchDetails->getOperator()=='ALL'):?> selected<?endif?>><?= $this->transEsc('group_AND') ?></option>
-              <option value="OR"<? if($searchDetails && $searchDetails->getOperator()=='OR'):?> selected<?endif?>><?= $this->transEsc('group_OR') ?></option>
+              <option value="AND"<?php if($searchDetails && $searchDetails->getOperator()=='ALL'):?> selected<?endif?>><?= $this->transEsc('group_AND') ?></option>
+              <option value="OR"<?php if($searchDetails && $searchDetails->getOperator()=='OR'):?> selected<?endif?>><?= $this->transEsc('group_OR') ?></option>
             </select>
           </div>
         </div>
-        <? /* An empty div. This is the target for the javascript that builds this screen */ ?>
+        <?php /* An empty div. This is the target for the javascript that builds this screen */ ?>
         <span id="groupPlaceHolder" class="hidden">
           <i class="fa fa-plus-circle" aria-hidden="true"></i> <a href="#" onClick="addGroup()"><?= $this->transEsc('add_search_group') ?></a>
         </span>
-        <? /* fallback to a fixed set of search groups/fields if JavaScript is turned off */ ?>
+        <?php /* fallback to a fixed set of search groups/fields if JavaScript is turned off */ ?>
         <div class="no-js">
-          <? if(!empty($this->formOverride)): ?>
+          <?php if(!empty($this->formOverride)): ?>
             <?=$this->formOverride ?>
-          <? else: ?>
-            <? for($group=0 ; $group<3 || $group<=$setGroupCount ; $group++): ?>
-              <? if($group == 0): ?>
+          <?php else: ?>
+            <?php for($group=0 ; $group<3 || $group<=$setGroupCount ; $group++): ?>
+              <?php if($group == 0): ?>
                 <div id="new_group_template">
-              <? endif; ?>
+              <?php endif; ?>
               <div id="group<?=$group ?>" class="group row">
                 <a href="#" class="group-close hidden" title="<?=$this->transEsc("del_search")?>">&times;</a>
                 <div class="col-sm-9">
@@ -106,10 +106,10 @@
                       <label class="help-block"><?=$this->transEsc("adv_search_label")?>:</label>
                     </div>
                     <div class="col-sm-9">
-                      <? for($search=0 ; $search<3 || (isset($setQueries[$group]) && $search<count($setQueries[$group])) ; $search++): ?>
-                        <? if($group == 0 && $search == 0): ?>
+                      <?php for($search=0 ; $search<3 || (isset($setQueries[$group]) && $search<count($setQueries[$group])) ; $search++): ?>
+                        <?php if($group == 0 && $search == 0): ?>
                           <div id="new_search_template">
-                        <? endif; ?>
+                        <?php endif; ?>
                         <div id="search<?=$group.'_'.$search ?>" class="search">
                           <div class="row">
                             <div class="col-sm-7 left">
@@ -117,9 +117,9 @@
                             </div>
                             <div class="col-sm-4 middle">
                               <select class="type form-control" name="type<?=$group ?>[]">
-                                <? foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
+                                <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
                                   <option value="<?=$this->escapeHtml($searchVal)?>"<?if(isset($setQueries[$group][$search]) && $searchVal == $setQueries[$group][$search]->getHandler()):?> selected<?endif;?>><?=$this->transEsc($searchDesc)?></option>
-                                <? endforeach; ?>
+                                <?php endforeach; ?>
                               </select>
                             </div>
                             <div class="col-sm-1 close hidden">
@@ -127,47 +127,47 @@
                             </div>
                           </div>
                         </div>
-                        <? if($group == 0 && $search == 0): ?>
+                        <?php if($group == 0 && $search == 0): ?>
                             </div>
                           <i class="fa fa-plus-circle search_place_holder hidden" aria-hidden="true"></i> <a href="#" class="add_search_link hidden"><?=$this->transEsc("add_search")?></a>
-                        <? endif; ?>
-                      <? endfor; ?>
+                        <?php endif; ?>
+                      <?php endfor; ?>
                     </div>
                   </div>
                 </div>
                 <div class="col-sm-3 match">
                   <label class="search_bool"><?=$this->transEsc("search_match")?>:&nbsp;</label>
                   <select name="bool<?=$group ?>[]" id="search_bool<?=$group ?>" class="form-control">
-                    <option value="AND"<? if(isset($setSearchGroups[$group]) && 'AND' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_AND")?></option>
-                    <option value="OR"<? if(isset($setSearchGroups[$group]) && 'OR' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_OR")?></option>
-                    <option value="NOT"<? if(isset($setSearchGroups[$group]) && 'NOT' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_NOT")?></option>
+                    <option value="AND"<?php if(isset($setSearchGroups[$group]) && 'AND' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_AND")?></option>
+                    <option value="OR"<?php if(isset($setSearchGroups[$group]) && 'OR' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_OR")?></option>
+                    <option value="NOT"<?php if(isset($setSearchGroups[$group]) && 'NOT' == $setSearchGroups[$group]):?> selected<?endif;?>><?=$this->transEsc("search_NOT")?></option>
                   </select>
                 </div>
               </div>
-              <? if($group == 0): ?>
+              <?php if($group == 0): ?>
                 </div>
-              <? endif; ?>
-            <? endfor; ?>
-          <? endif; ?>
+              <?php endif; ?>
+            <?php endfor; ?>
+          <?php endif; ?>
         </div>
         <div class="clearfix">
           <input class="btn btn-default clear-btn" type="button" value="<?= $this->transEsc('Clear')?>">
           <input class="btn btn-primary pull-right flip" type="submit" value="<?= $this->transEsc('Find')?>">
         </div>
-        <? if (isset($this->extraAdvancedControls)): ?>
+        <?php if (isset($this->extraAdvancedControls)): ?>
           <?=$this->extraAdvancedControls ?>
           <div class="clearfix">
             <input class="btn btn-default clear-btn" type="button" value="<?= $this->transEsc('Clear')?>">
             <input class="btn btn-primary pull-right flip" type="submit" value="<?= $this->transEsc('Find')?>">
           </div>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
 
       <div class="<?=$this->layoutClass('sidebar')?>">
-        <? if ($hasDefaultsApplied): ?>
+        <?php if ($hasDefaultsApplied): ?>
           <input type="hidden" name="dfApplied" value="1" />
-        <? endif ?>
-        <? if (!empty($searchFilters)): ?>
+        <?php endif ?>
+        <?php if (!empty($searchFilters)): ?>
           <h4><?=$this->transEsc("adv_search_filters")?></h4>
           <div class="list-group">
             <label class="list-group-item checkbox">
@@ -175,15 +175,15 @@
               <?=$this->transEsc("adv_search_select_all")?>
             </label>
           </div>
-          <? foreach ($searchFilters as $field => $data): ?>
+          <?php foreach ($searchFilters as $field => $data): ?>
             <div class="list-group">
               <div class="list-group-item title"><?=$this->transEsc($field)?></div>
-              <? foreach ($data as $value): ?>
+              <?php foreach ($data as $value): ?>
                 <label class="list-group-item checkbox"><input class="checkbox-select-item" type="checkbox" checked="checked" name="filter[]" value='<?=$this->escapeHtmlAttr($value['field'])?>:"<?=$this->escapeHtmlAttr($value['value'])?>"' /> <?=$this->escapeHtml($value['displayText'])?></label>
-              <? endforeach; ?>
+              <?php endforeach; ?>
             </div>
-          <? endforeach; ?>
-        <? endif; ?>
+          <?php endforeach; ?>
+        <?php endif; ?>
         <div class="sidegroup">
           <h4><?=$this->transEsc("Search Tips")?></h4>
           <div class="list-group">

--- a/themes/bootstrap3/templates/search/advanced/limit.phtml
+++ b/themes/bootstrap3/templates/search/advanced/limit.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up convenience variables:
     $limitList = $this->options->getLimitOptions();
 
@@ -6,13 +6,13 @@
     $lastLimit = $this->searchMemory()->getLastLimit($this->options->getSearchClassId());
     $defaultLimit = empty($lastLimit) ? $this->options->getDefaultLimit() : $lastLimit;
 ?>
-<? if (count($limitList) > 1): ?>
+<?php if (count($limitList) > 1): ?>
   <fieldset class="col-sm-4">
     <legend><?=$this->transEsc('Results per page')?></legend>
     <select id="limit" name="limit" class="form-control">
-      <? foreach ($limitList as $limitVal): ?>
+      <?php foreach ($limitList as $limitVal): ?>
         <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=($limitVal == $defaultLimit) ? 'selected="selected"' : ''?>><?=$this->escapeHtml($limitVal)?></option>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </select>
   </fieldset>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap3/templates/search/advanced/ranges.phtml
@@ -1,7 +1,7 @@
-<? if (isset($this->ranges) && !empty($this->ranges)): ?>
-  <? $params = $this->searchParams($this->searchClassId); $params->activateAllFacets(); ?>
-  <? foreach ($this->ranges as $current): $escField = $this->escapeHtmlAttr($current['field']); ?>
-    <? $extraInputAttribs = ($current['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
+<?php if (isset($this->ranges) && !empty($this->ranges)): ?>
+  <?php $params = $this->searchParams($this->searchClassId); $params->activateAllFacets(); ?>
+  <?php foreach ($this->ranges as $current): $escField = $this->escapeHtmlAttr($current['field']); ?>
+    <?php $extraInputAttribs = ($current['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
     <fieldset class="col-sm-4">
       <legend><?=$this->transEsc($params->getFacetLabel($current['field']))?></legend>
       <input type="hidden" name="<?=$this->escapeHtmlAttr($current['type'])?>range[]" value="<?=$escField?>"/>
@@ -15,11 +15,11 @@
           <input type="text" name="<?=$escField?>to" id="<?=$escField?>to" value="<?=isset($current['values'][1])?$this->escapeHtmlAttr($current['values'][1]):''?>" class="form-control" <?=$extraInputAttribs?>/>
         </div>
       </div>
-      <? if ($current['type'] == 'date'): ?>
+      <?php if ($current['type'] == 'date'): ?>
         <div class="slider-container">
           <input type="text" id="<?=$escField?><?=$this->escapeHtmlAttr($current['type'])?>Slider">
         </div>
-        <?
+        <?php
           $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
           $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
           $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
@@ -70,6 +70,6 @@ JS;
         ?>
         <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
       </fieldset>
-    <? endif; ?>
-  <? endforeach; ?>
-<? endif; ?>
+    <?php endif; ?>
+  <?php endforeach; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -1,22 +1,22 @@
-<? if (!empty($this->facetList) || !empty($this->checkboxFacets)): ?>
+<?php if (!empty($this->facetList) || !empty($this->checkboxFacets)): ?>
   <div class="row">
     <fieldset class="col-sm-12">
       <legend><?=$this->transEsc('Limit To')?></legend>
-      <? if (!empty($this->checkboxFacets)): ?>
+      <?php if (!empty($this->checkboxFacets)): ?>
         <?=$this->render('search/advanced/checkbox-filters.phtml')?>
-      <? endif; ?>
+      <?php endif; ?>
       <div class="row">
-        <? foreach ($this->facetList as $field => $list): ?>
+        <?php foreach ($this->facetList as $field => $list): ?>
           <div class="col-sm-<?=floor(12/count($this->facetList)) ?>">
             <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '', $field))?>"><?=$this->transEsc($list['label'])?>:</label>
             <select class="form-control" id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '', $field))?>" name="filter[]" multiple="multiple" size="10">
-              <? if (is_array($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
-                <? foreach ($list['list'] as $value): ?>
-                  <? $display = str_pad('', 4 * $value['level'] * 6, '&nbsp;', STR_PAD_LEFT) . $this->escapeHtml($value['displayText']); ?>
+              <?php if (is_array($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
+                <?php foreach ($list['list'] as $value): ?>
+                  <?php $display = str_pad('', 4 * $value['level'] * 6, '&nbsp;', STR_PAD_LEFT) . $this->escapeHtml($value['displayText']); ?>
                   <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$display?></option>
-                <? endforeach; ?>
-              <? else: ?>
-                <?
+                <?php endforeach; ?>
+              <?php else: ?>
+                <?php
                 // Sort the current facet list alphabetically; we'll use this data
                 // along with the foreach below to display facet options in the
                 // correct order.
@@ -28,28 +28,28 @@
                 }
                 natcasesort($sorted);
                 ?>
-                <? foreach ($sorted as $i => $display): ?>
-                  <? $value = $list['list'][$i]; ?>
+                <?php foreach ($sorted as $i => $display): ?>
+                  <?php $value = $list['list'][$i]; ?>
                   <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($display)?></option>
-                <? endforeach; ?>
-              <? endif; ?>
+                <?php endforeach; ?>
+              <?php endif; ?>
             </select>
           </div>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </div>
     </fieldset>
   </div>
-<? endif; ?>
+<?php endif; ?>
 <div class="row">
-  <? if (isset($this->illustratedLimit)): ?>
+  <?php if (isset($this->illustratedLimit)): ?>
     <fieldset class="col-sm-4">
       <legend><?=$this->transEsc("Illustrated")?>:</legend>
-      <? foreach ($this->illustratedLimit as $current): ?>
+      <?php foreach ($this->illustratedLimit as $current): ?>
         <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked"':''?>/>
         <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br/>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </fieldset>
-  <? endif; ?>
+  <?php endif; ?>
   <?=$this->render('search/advanced/limit.phtml')?>
   <?=$this->render('search/advanced/ranges.phtml')?>
 </div>

--- a/themes/bootstrap3/templates/search/advanced/summon.phtml
+++ b/themes/bootstrap3/templates/search/advanced/summon.phtml
@@ -1,15 +1,15 @@
-<? if (!empty($this->facetList) || !empty($this->checkboxFacets)): ?>
+<?php if (!empty($this->facetList) || !empty($this->checkboxFacets)): ?>
   <fieldset>
     <legend><?=$this->transEsc('Limit To')?></legend>
-    <? if (!empty($this->checkboxFacets)): ?>
+    <?php if (!empty($this->checkboxFacets)): ?>
       <?=$this->render('search/advanced/checkbox-filters.phtml')?>
-    <? endif; ?>
+    <?php endif; ?>
     <div class="row">
-      <? foreach ($this->facetList as $field => $list): ?>
+      <?php foreach ($this->facetList as $field => $list): ?>
         <div class="col-sm-<?=floor(12/count($this->facetList)) ?>">
           <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '', $field))?>"><?=$this->transEsc($list['label'])?>:</label>
           <select class="form-control" id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '', $field))?>" name="filter[]" multiple="multiple" size="10">
-            <?
+            <?php
               // Sort the current facet list alphabetically; we'll use this data
               // along with the foreach below to display facet options in the
               // correct order.
@@ -19,16 +19,16 @@
               }
               natcasesort($sorted);
             ?>
-            <? foreach ($sorted as $i => $display): ?>
-              <? $value = $list['list'][$i]; ?>
+            <?php foreach ($sorted as $i => $display): ?>
+              <?php $value = $list['list'][$i]; ?>
               <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($display)?></option>
-            <? endforeach; ?>
+            <?php endforeach; ?>
           </select>
         </div>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </div>
   </fieldset>
-<? endif; ?>
+<?php endif; ?>
 <div class="row">
   <?=$this->render('search/advanced/limit.phtml')?>
   <?=$this->render('search/advanced/ranges.phtml')?>

--- a/themes/bootstrap3/templates/search/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/search/bulk-action-buttons.phtml
@@ -1,26 +1,26 @@
-<? if((isset($this->showBulkOptions)  && $this->showBulkOptions)
+<?php if((isset($this->showBulkOptions)  && $this->showBulkOptions)
    || (isset($this->showCartControls) && $this->showCartControls)): ?>
   <div class="bulkActionButtons hidden-print">
     <div class="checkbox">
       <label>
-        <input type="checkbox" class="checkbox-select-all" name="selectAll" id="<?=$this->idPrefix?>addFormCheckboxSelectAll"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/> <?=$this->transEsc('select_page')?>
+        <input type="checkbox" class="checkbox-select-all" name="selectAll" id="<?=$this->idPrefix?>addFormCheckboxSelectAll"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/> <?=$this->transEsc('select_page')?>
         &#124; <?=$this->transEsc('with_selected')?>:
       </label>
     </div>
     <div class="btn-group">
-      <? if (isset($this->showBulkOptions) && $this->showBulkOptions): ?>
-        <input id="ribbon-email" class="btn btn-default" type="submit" name="email" title="<?=$this->transEsc('bookbag_email_selected')?>" value="<?=$this->transEsc('Email')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/>
-        <? $exportOptions = $this->export()->getBulkOptions(); if (count($exportOptions) > 0): ?>
-          <input id="ribbon-export" class="btn btn-default" type="submit" name="export" title="<?=$this->transEsc('bookbag_export_selected')?>" value="<?=$this->transEsc('Export')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/>
-        <? endif; ?>
-        <input id="ribbon-print" class="btn btn-default" type="submit" name="print" title="<?=$this->transEsc('bookbag_print_selected')?>" value="<?=$this->transEsc('Print')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/>
-        <? if ($this->userlist()->getMode() !== 'disabled'): ?>
-          <input id="ribbon-save" class="btn btn-default" type="submit" name="saveCart" title="<?=$this->transEsc('bookbag_save_selected')?>" value="<?=$this->transEsc('Save')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/>
-        <? endif; ?>
-      <? endif; ?>
-      <? if (isset($this->showCartControls) && $this->showCartControls): ?>
-        <input id="<?=$this->idPrefix?>updateCart" type="submit" class="btn btn-default" name="add" value="<?=$this->transEsc('Add to Book Bag')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<? endif; ?>/>
-      <? endif; ?>
+      <?php if (isset($this->showBulkOptions) && $this->showBulkOptions): ?>
+        <input id="ribbon-email" class="btn btn-default" type="submit" name="email" title="<?=$this->transEsc('bookbag_email_selected')?>" value="<?=$this->transEsc('Email')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+        <?php $exportOptions = $this->export()->getBulkOptions(); if (count($exportOptions) > 0): ?>
+          <input id="ribbon-export" class="btn btn-default" type="submit" name="export" title="<?=$this->transEsc('bookbag_export_selected')?>" value="<?=$this->transEsc('Export')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+        <?php endif; ?>
+        <input id="ribbon-print" class="btn btn-default" type="submit" name="print" title="<?=$this->transEsc('bookbag_print_selected')?>" value="<?=$this->transEsc('Print')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+        <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
+          <input id="ribbon-save" class="btn btn-default" type="submit" name="saveCart" title="<?=$this->transEsc('bookbag_save_selected')?>" value="<?=$this->transEsc('Save')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+        <?php endif; ?>
+      <?php endif; ?>
+      <?php if (isset($this->showCartControls) && $this->showCartControls): ?>
+        <input id="<?=$this->idPrefix?>updateCart" type="submit" class="btn btn-default" name="add" value="<?=$this->transEsc('Add to Book Bag')?>"<?if($this->formAttr):?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+      <?php endif; ?>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -1,12 +1,12 @@
-<? $limitList = $this->params->getLimitList(); ?>
-<? if (count($limitList) > 1): ?>
+<?php $limitList = $this->params->getLimitList(); ?>
+<?php if (count($limitList) > 1): ?>
   <form class="form-inline" action="<?=$this->currentPath() . $this->results->getUrlQuery()->setLimit(null)?>" method="post">
     <label for="limit"><?=$this->transEsc('Results per page')?></label>
     <select id="limit" name="limit" class="jumpMenu form-control">
-      <? foreach ($limitList as $limitVal => $limitData): ?>
+      <?php foreach ($limitList as $limitVal => $limitData): ?>
         <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=$limitData['selected']?' selected="selected"':''?>><?=$this->escapeHtml($limitData['desc'])?></option>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </select>
     <noscript><input type="submit" value="<?=$this->transEsc("Set")?>" /></noscript>
   </form>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/sort.phtml
+++ b/themes/bootstrap3/templates/search/controls/sort.phtml
@@ -1,12 +1,12 @@
-<? $list = $this->params->getSortList(); if (!empty($list)): ?>
+<?php $list = $this->params->getSortList(); if (!empty($list)): ?>
   <form class="form-inline" action="<?=$this->currentPath()?>" method="get" name="sort">
     <?=$this->results->getUrlQuery()->asHiddenFields(array('sort' => '/.*/'));?>
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
     <select id="sort_options_1" name="sort" class="jumpMenu form-control">
-      <? foreach ($list as $sortType => $sortData): ?>
+      <?php foreach ($list as $sortType => $sortData): ?>
         <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
-      <? endforeach; ?>
+      <?php endforeach; ?>
     </select>
     <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEsc("Set")?>" /></noscript>
   </form>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/view.phtml
+++ b/themes/bootstrap3/templates/search/controls/view.phtml
@@ -1,11 +1,11 @@
 <div class="view-buttons hidden-xs">
-  <? $viewList = $this->params->getViewList(); if (count($viewList) > 1): ?>
-    <? foreach ($viewList as $viewType => $viewData): ?>
-      <? if (!$viewData['selected']): ?>
+  <?php $viewList = $this->params->getViewList(); if (count($viewList) > 1): ?>
+    <?php foreach ($viewList as $viewType => $viewData): ?>
+      <?php if (!$viewData['selected']): ?>
         <a href="<?=$this->results->getUrlQuery()->setViewParam($viewType)?>" title="<?=$this->transEsc('Switch view to')?> <?=$this->transEsc($viewData['desc'])?>" >
-      <? endif; ?>
-      <i class="fa fa-<?=$viewType ?>"<? if($viewData['selected']): ?> title="<?=$this->transEsc($viewData['desc']) ?> <?=$this->transEsc('view already selected') ?>" <? endif ?> alt="<?=$this->transEsc($viewData['desc'])?>"></i>
-      <?=$this->transEsc($viewData['desc']) ?><? if (!$viewData['selected']): ?></a><? endif; ?>&nbsp;
-    <? endforeach; ?>
-  <? endif; ?>
+      <?php endif; ?>
+      <i class="fa fa-<?=$viewType ?>"<?php if($viewData['selected']): ?> title="<?=$this->transEsc($viewData['desc']) ?> <?=$this->transEsc('view already selected') ?>" <?php endif ?> alt="<?=$this->transEsc($viewData['desc'])?>"></i>
+      <?=$this->transEsc($viewData['desc']) ?><?php if (!$viewData['selected']): ?></a><?php endif; ?>&nbsp;
+    <?php endforeach; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/search/email.phtml
+++ b/themes/bootstrap3/templates/search/email.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Email this Search'));
 

--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   $options = $this->searchOptions($this->searchClassId);
   $facetLightbox = $options->getFacetListAction();
   if (empty($this->sortOptions)) {
@@ -8,68 +8,68 @@
   $urlBase = $this->url($facetLightbox) . $results->getUrlQuery()->getParams() . '&amp;facet=' . urlencode($this->facet) . '&amp;facetexclude=' . $this->exclude . '&amp;facetop=' . $this->operator;
 ?>
 <h2><?=$this->transEsc($this->facetLabel) ?></h2>
-<? if (count($this->sortOptions) > 1): ?>
+<?php if (count($this->sortOptions) > 1): ?>
   <div class="full-facet-sort-options">
     <label><?=$this->translate('Sort') ?></label>
     <div class="btn-group">
-      <? foreach ($this->sortOptions as $key=>$sort): ?>
-        <a href="<?=$urlBase . '&amp;facetpage=1&amp;facetsort=' . urlencode($key) ?>" class="btn btn-default js-facet-sort<? if($this->sort == $key): ?> active<? endif; ?>" data-sort="<?=$key ?>" data-lightbox-ignore><?=$this->translate($sort) ?></a>
-      <? endforeach; ?>
+      <?php foreach ($this->sortOptions as $key=>$sort): ?>
+        <a href="<?=$urlBase . '&amp;facetpage=1&amp;facetsort=' . urlencode($key) ?>" class="btn btn-default js-facet-sort<?php if($this->sort == $key): ?> active<?php endif; ?>" data-sort="<?=$key ?>" data-lightbox-ignore><?=$this->translate($sort) ?></a>
+      <?php endforeach; ?>
     </div>
   </div>
-<? endif; ?>
+<?php endif; ?>
 <div class="lightbox-scroll full-facets">
-  <? foreach ($this->sortOptions as $key=>$sort): ?>
-    <? $active = $this->sort == $key; ?>
-    <div class="full-facet-list list-group<? if(!$active): ?> hidden<? endif; ?>" id="facet-list-<?=$this->escapeHtmlAttr($key) ?>">
-      <? if ($active): ?>
-        <? if ($this->page > 1): ?>
+  <?php foreach ($this->sortOptions as $key=>$sort): ?>
+    <?php $active = $this->sort == $key; ?>
+    <div class="full-facet-list list-group<?php if(!$active): ?> hidden<?php endif; ?>" id="facet-list-<?=$this->escapeHtmlAttr($key) ?>">
+      <?php if ($active): ?>
+        <?php if ($this->page > 1): ?>
           <a href="<?=$urlBase . '&amp;facetpage=' . ($this->page-1) . '&amp;facetsort=' . $this->sort ?>" class="list-group-item js-facet-prev-page" data-page="<?=($this->page+1) ?>" data-sort="<?=$this->sort ?>" data-limit="<?=count($this->data) ?>" data-lightbox-ignore><?=$this->translate('prev') ?> ...</a>
-        <? endif; ?>
-        <? foreach ($this->data as $item): ?>
-          <? $toggleUrl = $item['isApplied']
+        <?php endif; ?>
+        <?php foreach ($this->data as $item): ?>
+          <?php $toggleUrl = $item['isApplied']
               ? $this->url($options->getSearchAction()) . $this->results->getUrlQuery()->removeFacet($this->facet, $item['value'], $item['operator'])
               : $this->url($options->getSearchAction()) . $this->results->getUrlQuery()->addFacet($this->facet, $item['value'], $item['operator'])
           ?>
-          <? $subLinks = $this->exclude && !$item['isApplied']; ?>
-          <? if ($subLinks): ?>
+          <?php $subLinks = $this->exclude && !$item['isApplied']; ?>
+          <?php if ($subLinks): ?>
             <li class="list-group-item js-facet-item">
-              <a href="<?=$toggleUrl ?>" data-lightbox-ignore data-title="<?=$this->escapeHtmlAttr($item['displayText']) ?>" data-count="<?=$item['count'] ?>"<? if($item['isApplied']): ?> title="<?=$this->transEsc('applied_filter') ?>"<? endif;?>>
-          <? else: ?>
-            <a href="<?=$toggleUrl ?>" data-lightbox-ignore class="js-facet-item list-group-item<? if($item['isApplied']): ?> active<?endif;?>" data-title="<?=$this->escapeHtmlAttr($item['displayText']) ?>" data-count="<?=$item['count'] ?>"<? if($item['isApplied']): ?> title="<?=$this->transEsc('applied_filter') ?>"<? endif;?>>
-          <? endif; ?>
-              <? if (!empty($item['displayText'])): ?>
+              <a href="<?=$toggleUrl ?>" data-lightbox-ignore data-title="<?=$this->escapeHtmlAttr($item['displayText']) ?>" data-count="<?=$item['count'] ?>"<?php if($item['isApplied']): ?> title="<?=$this->transEsc('applied_filter') ?>"<?php endif;?>>
+          <?php else: ?>
+            <a href="<?=$toggleUrl ?>" data-lightbox-ignore class="js-facet-item list-group-item<?php if($item['isApplied']): ?> active<?endif;?>" data-title="<?=$this->escapeHtmlAttr($item['displayText']) ?>" data-count="<?=$item['count'] ?>"<?php if($item['isApplied']): ?> title="<?=$this->transEsc('applied_filter') ?>"<?php endif;?>>
+          <?php endif; ?>
+              <?php if (!empty($item['displayText'])): ?>
                 <?=$this->escapeHtml($item['displayText']) ?>
-              <? else: ?>
+              <?php else: ?>
                 <?=$this->escapeHtml($item['value']) ?>
-              <? endif; ?>
-            <? if ($subLinks): ?>
+              <?php endif; ?>
+            <?php if ($subLinks): ?>
               </a>
-            <? endif; ?>
-            <? if($item['isApplied']): ?>
-              <? if ($item['operator'] == 'OR'): ?>
+            <?php endif; ?>
+            <?php if($item['isApplied']): ?>
+              <?php if ($item['operator'] == 'OR'): ?>
                 <i class="fa fa-check-square-o" aria-hidden="true"></i>
-              <? else: ?>
+              <?php else: ?>
                 <span class="pull-right flip">
                   <i class="fa fa-check" aria-hidden="true"></i>
                 </span>
-              <? endif; ?>
-            <? else: ?>
+              <?php endif; ?>
+            <?php else: ?>
               <span class="badge">
                 <?=$this->localizedNumber($item['count']) ?>
-                <? if ($this->exclude): ?>
+                <?php if ($this->exclude): ?>
                   <a href="<?=$this->url($options->getSearchAction()) . $this->results->getUrlQuery()->addFacet($this->facet, $item['value'], 'NOT') ?>" title="<?=$this->transEsc('exclude_facet') ?>" data-lightbox-ignore><i class="fa fa-times" aria-hidden="true"></i></a>
-                <? endif; ?>
+                <?php endif; ?>
               </span>
-            <? endif; ?>
+            <?php endif; ?>
           <?=$subLinks ? '</li>' : '</a>'; ?>
-        <? endforeach; ?>
-      <? endif; ?>
-      <? if ($this->anotherPage): ?>
+        <?php endforeach; ?>
+      <?php endif; ?>
+      <?php if ($this->anotherPage): ?>
         <a href="<?=$urlBase . '&amp;facetpage=' . ($this->page+1) . '&amp;facetsort=' . urlencode($key) ?>" class="list-group-item js-facet-next-page" data-page="<?=($this->page+1) ?>" data-sort="<?=$this->escapeHtmlAttr($key) ?>" data-lightbox-ignore><?=$this->translate('more') ?> ...</a>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </div>
 <button class="btn btn-default lightbox-only" data-dismiss="modal"><?=$this->translate('close') ?></button>
 <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '(typeof VuFind.lightbox_facets !== "undefined") && VuFind.lightbox_facets.setup();', 'SET'); ?>

--- a/themes/bootstrap3/templates/search/history-table.phtml
+++ b/themes/bootstrap3/templates/search/history-table.phtml
@@ -1,45 +1,45 @@
-<? $saveSupported = $this->accountCapabilities()->getSavedSearchSetting() === 'enabled'; ?>
+<?php $saveSupported = $this->accountCapabilities()->getSavedSearchSetting() === 'enabled'; ?>
 <table class="table table-striped">
   <tr>
     <th width="20%"><?=$this->transEsc("history_time")?></th>
     <th><?=$this->transEsc("history_search")?></th>
     <th><?=$this->transEsc("history_limits")?></th>
     <th><?=$this->transEsc("history_results")?></th>
-    <? if ($saveSupported): ?><th><?=$this->transEsc($this->showSaved ? "history_delete" : "history_save")?></th><? endif; ?>
+    <?php if ($saveSupported): ?><th><?=$this->transEsc($this->showSaved ? "history_delete" : "history_save")?></th><?php endif; ?>
   </tr>
-  <? foreach (($this->showSaved ? array_reverse($this->saved) : array_reverse($this->unsaved)) as $iteration => $info): ?>
+  <?php foreach (($this->showSaved ? array_reverse($this->saved) : array_reverse($this->unsaved)) as $iteration => $info): ?>
     <tr class="<?=$iteration % 2 == 1 ? 'even' : 'odd'?>row">
       <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime("U", $info->getStartTime()))?></td>
       <td>
         <?=$this->historylabel($info->getParams()->getSearchClassId())?>
-        <a href="<?=$this->url($info->getOptions()->getSearchAction()) . $info->getUrlQuery()->getParams()?>"><?
+        <a href="<?=$this->url($info->getOptions()->getSearchAction()) . $info->getUrlQuery()->getParams()?>"><?php
           $desc = $info->getParams()->getDisplayQuery();
           echo empty($desc) ? $this->transEsc("history_empty_search") : $this->escapeHtml($desc);
         ?></a>
       </td>
       <td>
-        <? $info->getParams()->activateAllFacets(); foreach ($info->getParams()->getFilterList(true) as $field => $filters): ?>
-          <? foreach ($filters as $i => $filter): ?>
-            <? if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?>
+        <?php $info->getParams()->activateAllFacets(); foreach ($info->getParams()->getFilterList(true) as $field => $filters): ?>
+          <?php foreach ($filters as $i => $filter): ?>
+            <?php if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?>
             <strong><?=$this->transEsc($field)?></strong>: <?=$this->escapeHtml($filter['displayText'])?><br/>
-          <? endforeach; ?>
-        <? endforeach; ?>
-        <? foreach($info->getParams()->getCheckboxFacets() as $facet): ?>
-          <? if ($facet['selected']): ?>
+          <?php endforeach; ?>
+        <?php endforeach; ?>
+        <?php foreach($info->getParams()->getCheckboxFacets() as $facet): ?>
+          <?php if ($facet['selected']): ?>
             <strong><?=$this->transEsc($facet['desc'])?></strong><br/>
-          <? endif; ?>
-        <? endforeach; ?>
+          <?php endif; ?>
+        <?php endforeach; ?>
       </td>
       <td><?=$this->escapeHtml($this->localizedNumber($info->getResultTotal()))?></td>
-      <? if ($saveSupported): ?>
+      <?php if ($saveSupported): ?>
         <td>
-          <? if ($this->showSaved): ?>
+          <?php if ($this->showSaved): ?>
             <a href="<?=$this->url('myresearch-savesearch')?>?delete=<?=urlencode($info->getSearchId())?>&amp;mode=history"><i class="fa fa-remove" aria-hidden="true"></i> <?=$this->transEsc("history_delete_link")?></a>
-          <? else: ?>
+          <?php else: ?>
             <a href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($info->getSearchId())?>&amp;mode=history"><i class="fa fa-save" aria-hidden="true"></i> <?=$this->transEsc("history_save_link")?></a>
-          <? endif; ?>
+          <?php endif; ?>
         </td>
-      <? endif; ?>
+      <?php endif; ?>
     </tr>
-  <? endforeach; ?>
+  <?php endforeach; ?>
 </table>

--- a/themes/bootstrap3/templates/search/history.phtml
+++ b/themes/bootstrap3/templates/search/history.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Search History'));
 
@@ -12,21 +12,21 @@
 <div class="row">
   <div class="<?=$this->layoutClass('mainbody')?>">
     <?=$this->flashmessages()?>
-    <? if ($saveSupported && !empty($this->saved)): ?>
+    <?php if ($saveSupported && !empty($this->saved)): ?>
       <h2><?=$this->transEsc("history_saved_searches")?></h2>
       <?=$this->context()->renderInContext('search/history-table.phtml', ['showSaved' => true]);?>
-    <? endif; ?>
+    <?php endif; ?>
 
     <h2><?=$this->transEsc("history_recent_searches")?></h2>
-    <? if (!empty($this->unsaved)): ?>
+    <?php if (!empty($this->unsaved)): ?>
       <?=$this->context()->renderInContext('search/history-table.phtml', ['showSaved' => false]);?>
       <a href="?purge=true"><i class="fa fa-remove" aria-hidden="true"></i> <?=$this->transEsc("history_purge")?></a>
-    <? else: ?>
+    <?php else: ?>
       <?=$this->transEsc("history_no_searches")?>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
-  <? if ($saveSupported): ?>
+  <?php if ($saveSupported): ?>
     <div class="<?=$this->layoutClass('sidebar')?>">
       <?=$this->context($this)->renderInContext(
           "myresearch/menu.phtml",
@@ -35,5 +35,5 @@
        );
        ?>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </div>

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set page title.
   $this->headTitle($this->translate('Search Home'));
 
@@ -19,7 +19,7 @@
 ?>
 
 <div class="searchHomeContent">
-  <?
+  <?php
   $ilsStatusScript = <<<JS
       $(document).ready(function() {
         $.ajax({
@@ -41,14 +41,14 @@ JS;
   <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, '$("#searchForm_lookfor").focus();', 'SET'); ?>
 </div>
 
-<? if (isset($facetList) && is_array($facetList)): ?>
+<?php if (isset($facetList) && is_array($facetList)): ?>
   <div class="row">
-    <? foreach ($facetList as $field => $details): ?>
-      <? if (isset($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
-        <? $this->headScript()->appendFile('vendor/jsTree/jstree.min.js'); ?>
-        <? $this->headScript()->appendFile('facets.js'); ?>
-        <? $sort = isset($this->hierarchicalFacetSortOptions[$field]) ? $this->hierarchicalFacetSortOptions[$field] : ''; ?>
-        <?
+    <?php foreach ($facetList as $field => $details): ?>
+      <?php if (isset($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
+        <?php $this->headScript()->appendFile('vendor/jsTree/jstree.min.js'); ?>
+        <?php $this->headScript()->appendFile('facets.js'); ?>
+        <?php $sort = isset($this->hierarchicalFacetSortOptions[$field]) ? $this->hierarchicalFacetSortOptions[$field] : ''; ?>
+        <?php
         $script = <<<JS
 $(document).ready(function() {
   initFacetTree($('#facet_{$this->escapeHtml($field)}'), false);
@@ -68,50 +68,50 @@ JS;
           </div>
         </div>
         <noscript>
-      <? endif; ?>
-      <? $sortedList = $this->sortFacetList($this->results, $field, $details['list'], $basicSearch); ?>
+      <?php endif; ?>
+      <?php $sortedList = $this->sortFacetList($this->results, $field, $details['list'], $basicSearch); ?>
       <div class="<?=$field=='callnumber-first' ? 'col-sm-6' : 'col-sm-3' ?>">
         <h2><?=$this->transEsc('home_browse') . ' ' . $this->transEsc($details['label'])?></h2>
         <div class="row">
           <ul class="list-unstyled <?=$field == "callnumber-first" ? 'col-sm-6' : 'col-sm-12' ?>">
-          <? /* Special case: two columns for LC call numbers... */ ?>
-          <? if ($field == "callnumber-first"): ?>
-            <? $i = 0; foreach ($sortedList as $url => $value): ?>
-              <? if (!empty($value)): ?>
+          <?php /* Special case: two columns for LC call numbers... */ ?>
+          <?php if ($field == "callnumber-first"): ?>
+            <?php $i = 0; foreach ($sortedList as $url => $value): ?>
+              <?php if (!empty($value)): ?>
                 <li><a href="<?=$url?>"><?=$this->escapeHtml($value)?></a></li>
-              <? else: $i--; ?>
-              <? endif; ?>
-              <? if (++$i == 10): ?>
+              <?php else: $i--; ?>
+              <?php endif; ?>
+              <?php if (++$i == 10): ?>
                 </ul><ul class="list-unstyled col-sm-6">
-              <? endif; ?>
-            <? endforeach; ?>
-          <? /* Special case: collections */ ?>
-          <? elseif ($field == 'hierarchy_top_title'): ?>
-            <? $i = 0; foreach ($sortedList as $url => $value): ?>
-              <? if (++$i > 10): ?>
+              <?php endif; ?>
+            <?php endforeach; ?>
+          <?php /* Special case: collections */ ?>
+          <?php elseif ($field == 'hierarchy_top_title'): ?>
+            <?php $i = 0; foreach ($sortedList as $url => $value): ?>
+              <?php if (++$i > 10): ?>
                 <li><a href="<?=$this->url('collections-home')?>"><strong><?=$this->transEsc("More options")?>...</strong></a></li>
-                <? break; ?>
-              <? else: ?>
+                <?php break; ?>
+              <?php else: ?>
                 <li><a href="<?=$this->url('collections-bytitle')?>?title=<?=urlencode($value)?>"><?=$this->escapeHtml($value)?></a></li>
-              <? endif; ?>
-            <? endforeach; ?>
-          <? else: ?>
-            <? $i = 0; foreach ($sortedList as $url => $value): ?>
-              <? if (++$i > 10): ?>
+              <?php endif; ?>
+            <?php endforeach; ?>
+          <?php else: ?>
+            <?php $i = 0; foreach ($sortedList as $url => $value): ?>
+              <?php if (++$i > 10): ?>
                 <li><a href="<?=$this->url($advSearch)?>"><strong><?=$this->transEsc("More options")?>...</strong></a></li>
-                <? break; ?>
-              <? elseif (!empty($value)): ?>
+                <?php break; ?>
+              <?php elseif (!empty($value)): ?>
                 <li><a href="<?=$url?>"><?=$this->escapeHtml($value)?></a></li>
-              <? else: $i--; ?>
-              <? endif; ?>
-            <? endforeach; ?>
-          <? endif; ?>
+              <?php else: $i--; ?>
+              <?php endif; ?>
+            <?php endforeach; ?>
+          <?php endif; ?>
           </ul>
         </div>
       </div>
-      <? if (isset($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
+      <?php if (isset($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
         </noscript>
-      <? endif; ?>
-    <? endforeach; ?>
+      <?php endif; ?>
+    <?php endforeach; ?>
   </div>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/list-authorfacets.phtml
+++ b/themes/bootstrap3/templates/search/list-authorfacets.phtml
@@ -3,11 +3,11 @@
     <tr>
       <th><?=$this->transEsc("Author")?></th><th><?=$this->transEsc("sort_author_relevance")?></th>
     </tr>
-    <? foreach ($this->results->getResults() as $record): ?>
+    <?php foreach ($this->results->getResults() as $record): ?>
     <tr>
       <td><a href="<?=$this->url('author-home')?>?author=<?=urlencode($record['value'])?>"><?=$this->escapeHtml($record['value'])?></a></td>
       <td><?=$this->escapeHtml($record['count'])?></td>
     </tr>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </tbody>
 </table>

--- a/themes/bootstrap3/templates/search/list-grid.phtml
+++ b/themes/bootstrap3/templates/search/list-grid.phtml
@@ -1,8 +1,8 @@
 <div class="row">
-<? $i = 0; foreach ($this->results->getResults() as $current): ?>
+<?php $i = 0; foreach ($this->results->getResults() as $current): ?>
   <div id="result<?=$i++ ?>" class="col-sm-3 col-xs-6 grid">
     <?=$this->record($current)->getSearchResult('grid')?>
   </div>
   <?=($i%4==0)?'</div><div class="row">':''?>
-<? endforeach; ?>
+<?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/search/list-list.phtml
+++ b/themes/bootstrap3/templates/search/list-list.phtml
@@ -1,19 +1,19 @@
-<? if (!isset($this->indexStart)) $this->indexStart = 0; ?>
-<? $showCheckboxes = (isset($this->showCartControls) && $this->showCartControls)
+<?php if (!isset($this->indexStart)) $this->indexStart = 0; ?>
+<?php $showCheckboxes = (isset($this->showCartControls) && $this->showCartControls)
   || (isset($this->showBulkOptions) && $this->showBulkOptions); ?>
-<? $i = $this->indexStart; foreach ($this->results->getResults() as $current):
+<?php $i = $this->indexStart; foreach ($this->results->getResults() as $current):
   $recordNumber = $this->results->getStartRecord()+$i-$this->indexStart; ?>
   <div id="result<?=$i++ ?>" class="result<?=$current->supportsAjaxStatus()?' ajaxItem':''?>">
     <div class="checkbox hidden-print">
-      <? if ($showCheckboxes): ?>
+      <?php if ($showCheckboxes): ?>
         <label>
           <?=$this->record($current)->getCheckbox('', 'search-cart-form')?>
           <?=$recordNumber ?>
         </label>
-      <? else: ?>
+      <?php else: ?>
         <?=$recordNumber ?>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
     <?=$this->record($current)->getSearchResult('list')?>
   </div>
-<? endforeach; ?>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/search/newitem.phtml
+++ b/themes/bootstrap3/templates/search/newitem.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('New Item Search'));
 
@@ -11,27 +11,27 @@
     <label class="col-sm-3 control-label"><?=$this->transEsc('Range')?>:</label>
     <div class="col-sm-9">
       <div class="btn-group" data-toggle="buttons">
-        <? foreach ($this->ranges as $key => $range): ?>
-          <label class="btn btn-primary<? if($key == 0): ?> active<? endif ?>">
+        <?php foreach ($this->ranges as $key => $range): ?>
+          <label class="btn btn-primary<?php if($key == 0): ?> active<?php endif ?>">
             <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked"' : ''?>/>
             <?=($range == 1) ? $this->transEsc('Yesterday') : $this->transEsc('Past') . ' ' . $this->escapeHtml($range) . ' ' . $this->transEsc('Days')?>
           </label>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </div>
     </div>
   </div>
-  <? if (is_array($this->fundList) && !empty($this->fundList)): ?>
+  <?php if (is_array($this->fundList) && !empty($this->fundList)): ?>
     <div class="form-group">
       <label class="col-sm-3 control-label" for="newitem_department"><?=$this->transEsc('Department')?>:</label>
       <div class="col-sm-9">
         <select id="newitem_department" name="department" size="10" class="form-control">
-        <? foreach ($this->fundList as $fundId => $fund): ?>
+        <?php foreach ($this->fundList as $fundId => $fund): ?>
           <option value="<?=$this->escapeHtmlAttr($fundId)?>"><?=$this->transEsc($fund)?></option>
-        <? endforeach; ?>
+        <?php endforeach; ?>
         </select>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Find')?>"/>

--- a/themes/bootstrap3/templates/search/newitemresults.phtml
+++ b/themes/bootstrap3/templates/search/newitemresults.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set some overrides, then call the standard search results action:
   $this->overrideTitle = $this->translate('New Items');
   $this->overrideSearchHeading = $this->transEsc('New Items');

--- a/themes/bootstrap3/templates/search/pagination.phtml
+++ b/themes/bootstrap3/templates/search/pagination.phtml
@@ -1,27 +1,27 @@
-<? if ($this->pageCount): ?>
+<?php if ($this->pageCount): ?>
   <ul class="pagination">
-    <? if (isset($this->previous)): ?>
-      <? if (!isset($this->options['disableFirst']) || !$this->options['disableFirst']): ?>
+    <?php if (isset($this->previous)): ?>
+      <?php if (!isset($this->options['disableFirst']) || !$this->options['disableFirst']): ?>
         <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage(1)?>">[1]</a></li>
-      <? endif; ?>
+      <?php endif; ?>
       <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->previous)?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? if (count($this->pagesInRange) > 1): ?>
-      <? foreach ($this->pagesInRange as $page): ?>
-        <? if ($page != $this->current): ?>
+    <?php if (count($this->pagesInRange) > 1): ?>
+      <?php foreach ($this->pagesInRange as $page): ?>
+        <?php if ($page != $this->current): ?>
           <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($page)?>"><?=$page?></a></li>
-        <? else: ?>
+        <?php else: ?>
           <li class="active"><span><?=$page?></span></li>
-        <? endif; ?>
-      <? endforeach; ?>
-    <? endif; ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
 
-    <? if (isset($this->next)): ?>
+    <?php if (isset($this->next)): ?>
       <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->next)?>"><?=$this->transEsc('Next');?> &raquo;</a></li>
-      <? if (!isset($this->options['disableLast']) || !$this->options['disableLast']): ?>
+      <?php if (!isset($this->options['disableLast']) || !$this->options['disableLast']): ?>
         <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->pageCount)?>">[<?=$this->pageCount?>]</a></li>
-      <? endif; ?>
-    <? endif; ?>
+      <?php endif; ?>
+    <?php endif; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/reserves.phtml
+++ b/themes/bootstrap3/templates/search/reserves.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Reserves Search'));
 
@@ -7,54 +7,54 @@
 ?>
 <h2><?=$this->transEsc('Search For Items on Reserve')?></h2>
 <form method="get" name="searchForm" class="form-horizontal">
-  <? if (is_array($this->courseList)): ?>
+  <?php if (is_array($this->courseList)): ?>
     <div class="form-group">
       <label for="reserves_by_course" class="col-sm-2 control-label"><?=$this->transEsc('By Course')?>:</label>
       <div class="col-sm-5">
         <select name="course" id="reserves_by_course" class="form-control">
           <option></option>
-          <? foreach ($this->courseList as $courseId => $courseName): ?>
+          <?php foreach ($this->courseList as $courseId => $courseName): ?>
             <option value="<?=$this->escapeHtmlAttr($courseId)?>"><?=$this->escapeHtml($courseName)?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
       <div class="col-sm-2">
         <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Find')?>"/>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if (is_array($this->instList)): ?>
+  <?php if (is_array($this->instList)): ?>
     <div class="form-group">
       <label for="reserves_by_inst" class="col-sm-2 control-label"><?=$this->transEsc('By Instructor')?>:</label>
       <div class="col-sm-5">
         <select name="inst" id="reserves_by_inst" class="form-control">
           <option></option>
-          <? foreach ($this->instList as $instId => $instName): ?>
+          <?php foreach ($this->instList as $instId => $instName): ?>
             <option value="<?=$this->escapeHtmlAttr($instId)?>"><?=$this->escapeHtml($instName)?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
       <div class="col-sm-2">
         <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Find')?>"/>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 
-  <? if (is_array($this->deptList)): ?>
+  <?php if (is_array($this->deptList)): ?>
     <div class="form-group">
       <label for="reserves_by_dept" class="col-sm-2 control-label"><?=$this->transEsc('By Department')?>:</label>
       <div class="col-sm-5">
         <select name="dept" id="reserves_by_dept" class="form-control">
           <option></option>
-          <? foreach ($this->deptList as $deptId => $deptName): ?>
+          <?php foreach ($this->deptList as $deptId => $deptName): ?>
             <option value="<?=$this->escapeHtmlAttr($deptId)?>"><?=$this->escapeHtml($deptName)?></option>
-          <? endforeach; ?>
+          <?php endforeach; ?>
         </select>
       </div>
       <div class="col-sm-2">
         <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEsc('Find')?>"/>
       </div>
     </div>
-  <? endif; ?>
+  <?php endif; ?>
 </form>

--- a/themes/bootstrap3/templates/search/reservesresults.phtml
+++ b/themes/bootstrap3/templates/search/reservesresults.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set some overrides, then call the standard search results action:
     $this->overrideTitle = $this->translate('Reserves Search Results');
     $this->overrideSearchHeading = $this->transEsc('Reserves');

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set up page title:
     $this->headTitle($this->translate('Reserves Search'));
 
@@ -23,29 +23,29 @@
 
     <div class="resulthead">
       <div class="pull-left flip">
-        <? if (($recordTotal = $this->results->getResultTotal()) > 0): ?>
+        <?php if (($recordTotal = $this->results->getResultTotal()) > 0): ?>
           <?=$this->transEsc("Showing")?>
           <strong><?=$this->localizedNumber($this->results->getStartRecord())?></strong> - <strong><?=$this->localizedNumber($this->results->getEndRecord())?></strong>
           <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($recordTotal)?></strong>
           <?=$this->transEsc('for search')?>: <strong>'<?=$this->escapeHtml($reservesLookfor)?>'</strong>,
-          <? if ($qtime = $this->results->getQuerySpeed()): ?>
+          <?php if ($qtime = $this->results->getQuerySpeed()): ?>
             <?=$this->transEsc('query time')?>: <?=$this->localizedNumber($qtime, 2).$this->transEsc('seconds_abbrev')?>
-          <? endif; ?>
-        <? endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
       </div>
 
-      <? if ($recordTotal > 0): ?>
+      <?php if ($recordTotal > 0): ?>
         <div class="pull-right flip">
           <?=$this->render('search/controls/sort.phtml')?>
         </div>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
-    <? if ($recordTotal < 1): ?>
+    <?php if ($recordTotal < 1): ?>
       <p class="error"><?=$this->transEsc('nohit_prefix')?> - <strong><?=$this->escapeHtml($reservesLookfor)?></strong> - <?=$this->transEsc('nohit_suffix')?></p>
-      <? if (isset($this->parseError)): ?>
+      <?php if (isset($this->parseError)): ?>
         <p class="error"><?=$this->transEsc('nohit_parse_error')?></p>
-      <? endif; ?>
-    <? else: ?>
+      <?php endif; ?>
+    <?php else: ?>
       <table class="table table-striped">
       <tr>
         <th class="department"><?=$this->transEsc('Department')?></th>
@@ -53,8 +53,8 @@
         <th class="instructor"><?=$this->transEsc('Instructor')?></th>
         <th class="items"><?=$this->transEsc('Items')?></th>
       </tr>
-      <? foreach ($this->results->getResults() as $record): ?>
-        <?
+      <?php foreach ($this->results->getResults() as $record): ?>
+        <?php
             $url = $this->currentPath() . $this->escapeHtmlAttr(
                 '?inst=' . urlencode($record->getInstructorId())
                 . '&course=' . urlencode($record->getCourseId())
@@ -67,17 +67,17 @@
           <td class="instructor"><a href="<?=$url?>"><?=$this->escapeHtml($record->getInstructor())?></a></td>
           <td class="items"><?=$this->escapeHtml($record->getItemCount())?></td>
         </tr>
-      <? endforeach; ?>
+      <?php endforeach; ?>
       </table>
       <?=$this->paginationControl($this->results->getPaginator(), 'Sliding', 'search/pagination.phtml', ['results' => $this->results])?>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
 
-  <? /* Narrow Search Options */ ?>
+  <?php /* Narrow Search Options */ ?>
   <div class="<?=$this->layoutClass('sidebar')?>">
-    <? foreach ($this->results->getRecommendations('side') as $current): ?>
+    <?php foreach ($this->results->getRecommendations('side') as $current): ?>
       <?=$this->recommend($current)?>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
-  <? /* End Narrow Search Options */ ?>
+  <?php /* End Narrow Search Options */ ?>
 </div>

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Set up page title:
   $lookfor = $this->results->getUrlQuery()->isQuerySuppressed() ? '' : $this->params->getDisplayQuery();
   if (isset($this->overrideTitle)) {
@@ -50,65 +50,65 @@
 
 <div class="row">
   <div class="<?=$this->layoutClass('mainbody')?>">
-    <? if (($recordTotal = $this->results->getResultTotal()) > 0): // only display these at very top if we have results ?>
-      <? foreach ($this->results->getRecommendations('top') as $current): ?>
+    <?php if (($recordTotal = $this->results->getResultTotal()) > 0): // only display these at very top if we have results ?>
+      <?php foreach ($this->results->getRecommendations('top') as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
-    <? endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
     <?=$this->flashmessages()?>
     <div class="hidden-print search-controls row">
       <div class="col-sm-6">
-        <? if ($recordTotal > 0): ?>
+        <?php if ($recordTotal > 0): ?>
           <?=$this->transEsc("Showing")?>
           <strong><?=$this->localizedNumber($this->results->getStartRecord())?></strong> - <strong><?=$this->localizedNumber($this->results->getEndRecord())?></strong>
-          <? if (!isset($this->skipTotalCount)): ?>
-            <? $this->layout()->srmessage = $this->transEsc('result_count', ['%%count%%' => $this->localizedNumber($recordTotal)]); ?>
+          <?php if (!isset($this->skipTotalCount)): ?>
+            <?php $this->layout()->srmessage = $this->transEsc('result_count', ['%%count%%' => $this->localizedNumber($recordTotal)]); ?>
             <?=$this->transEsc('of')?> <strong><?=$this->localizedNumber($recordTotal)?></strong>
-          <? endif; ?>
-          <? if (isset($this->overrideSearchHeading)): ?>
+          <?php endif; ?>
+          <?php if (isset($this->overrideSearchHeading)): ?>
             <?=$this->overrideSearchHeading?>
-          <? elseif ($this->params->getSearchType() == 'basic'): ?>
+          <?php elseif ($this->params->getSearchType() == 'basic'): ?>
             <?=$this->transEsc('for search')?>: <strong>'<?=$this->escapeHtml($lookfor)?>'</strong>,
-          <? endif; ?>
-          <? if ($qtime = $this->results->getQuerySpeed()): ?>
+          <?php endif; ?>
+          <?php if ($qtime = $this->results->getQuerySpeed()): ?>
             <?=$this->transEsc('query time')?>: <?=$this->localizedNumber($qtime, 2).$this->transEsc('seconds_abbrev')?>
-          <? endif; ?>
-        <? else: ?>
+          <?php endif; ?>
+        <?php else: ?>
           <h2><?=$this->transEsc('nohit_heading')?></h2>
-        <? endif; ?>
+        <?php endif; ?>
       </div>
 
-      <? if ($recordTotal > 0): ?>
+      <?php if ($recordTotal > 0): ?>
         <div class="col-sm-6 text-right">
           <?=$this->render('search/controls/limit.phtml')?>
           <?=$this->render('search/controls/sort.phtml')?>
           <?=$this->render('search/controls/view.phtml')?>
         </div>
-      <? endif; ?>
+      <?php endif; ?>
     </div>
-    <? /* End Listing Options */ ?>
+    <?php /* End Listing Options */ ?>
 
-    <? if ($recordTotal < 1): ?>
+    <?php if ($recordTotal < 1): ?>
       <p>
-        <? if (isset($this->overrideEmptyMessage)): ?>
+        <?php if (isset($this->overrideEmptyMessage)): ?>
           <?=$this->overrideEmptyMessage?>
-        <? else: ?>
-          <? $this->layout()->srmessage = $this->transEsc('nohit_prefix') . ' - ' . $this->escapeHtml($lookfor) . ' - ' . $this->transEsc('nohit_suffix'); ?>
+        <?php else: ?>
+          <?php $this->layout()->srmessage = $this->transEsc('nohit_prefix') . ' - ' . $this->escapeHtml($lookfor) . ' - ' . $this->transEsc('nohit_suffix'); ?>
           <?=$this->layout()->srmessage ?>
-        <? endif; ?>
+        <?php endif; ?>
       </p>
-      <? if (isset($this->parseError)): ?>
+      <?php if (isset($this->parseError)): ?>
         <p class="alert alert-danger"><?=$this->transEsc('nohit_parse_error')?></p>
-      <? endif; ?>
-      <? foreach (($top = $this->results->getRecommendations('top')) as $current): ?>
+      <?php endif; ?>
+      <?php foreach (($top = $this->results->getRecommendations('top')) as $current): ?>
         <?=$this->recommend($current)?>
-      <? endforeach; ?>
-      <? foreach ($this->results->getRecommendations('noresults') as $current): ?>
-        <? if (!in_array($current, $top)): ?>
+      <?php endforeach; ?>
+      <?php foreach ($this->results->getRecommendations('noresults') as $current): ?>
+        <?php if (!in_array($current, $top)): ?>
           <?=$this->recommend($current)?>
-        <? endif; ?>
-      <? endforeach; ?>
-    <? else: ?>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    <?php else: ?>
       <form id="search-cart-form" class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>" data-lightbox data-lightbox-onsubmit="bulkFormHandler">
         <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>
       </form>
@@ -123,26 +123,26 @@
         <a href="<?=$this->url('search-email')?>" class="mailSearch" data-lightbox id="mailSearch<?=$this->escapeHtmlAttr($this->results->getSearchId())?>">
           <i class="fa fa-envelope" aria-hidden="true"></i> <?=$this->transEsc('Email this Search')?>
         </a>
-        <? if ($this->accountCapabilities()->getSavedSearchSetting() === 'enabled'): ?>
+        <?php if ($this->accountCapabilities()->getSavedSearchSetting() === 'enabled'): ?>
           &mdash;
-          <? if (is_numeric($this->results->getSearchId())): ?>
-            <? if ($this->results->isSavedSearch()): ?>
+          <?php if (is_numeric($this->results->getSearchId())): ?>
+            <?php if ($this->results->isSavedSearch()): ?>
               <a href="<?=$this->url('myresearch-savesearch')?>?delete=<?=urlencode($this->results->getSearchId())?>"><i class="fa fa-remove" aria-hidden="true"></i> <?=$this->transEsc('save_search_remove')?></a>
-            <? else: ?>
+            <?php else: ?>
               <a href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($this->results->getSearchId())?>"><i class="fa fa-save" aria-hidden="true"></i> <?=$this->transEsc('save_search')?></a>
-            <? endif; ?>
-          <? endif; ?>
-        <? endif; ?>
+            <?php endif; ?>
+          <?php endif; ?>
+        <?php endif; ?>
       </div>
-    <? endif; ?>
+    <?php endif; ?>
   </div>
-  <? /* End Main Listing */ ?>
+  <?php /* End Main Listing */ ?>
 
-  <? /* Narrow Search Options */ ?>
+  <?php /* Narrow Search Options */ ?>
   <div class="<?=$this->layoutClass('sidebar')?>">
-    <? foreach ($this->results->getRecommendations('side') as $current): ?>
+    <?php foreach ($this->results->getRecommendations('side') as $current): ?>
       <?=$this->recommend($current)?>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </div>
-  <? /* End Narrow Search Options */ ?>
+  <?php /* End Narrow Search Options */ ?>
 </div>

--- a/themes/bootstrap3/templates/search/searchTabs.phtml
+++ b/themes/bootstrap3/templates/search/searchTabs.phtml
@@ -1,9 +1,9 @@
-<? if (count($searchTabs) > 0): ?>
+<?php if (count($searchTabs) > 0): ?>
   <ul class="nav nav-tabs">
-    <? foreach ($searchTabs as $tab): ?>
+    <?php foreach ($searchTabs as $tab): ?>
       <li<?=$tab['selected'] ? ' class="active"' : ''?>>
         <a <?=$tab['selected'] ? '' : 'href="' . $this->escapeHtmlAttr($tab['url']) . '"' ?>><?=$this->transEsc($tab['label']); ?></a>
       </li>
-    <? endforeach; ?>
+    <?php endforeach; ?>
   </ul>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set default value if necessary:
     if (!isset($this->searchClassId)) {
         $this->searchClassId = 'Solr';
@@ -27,60 +27,60 @@
     }
     $hiddenFilterParams = $this->searchtabs()->getCurrentHiddenFilterParams($this->searchClassId, $ignoreHiddenFilterMemory, '?');
 ?>
-<? $searchTabs = $this->searchtabs()->getTabConfig($this->searchClassId, $this->lookfor, $this->searchIndex, $this->searchType, $hiddenFilters); ?>
-<? if ($this->searchType == 'advanced'): ?>
+<?php $searchTabs = $this->searchtabs()->getTabConfig($this->searchClassId, $this->lookfor, $this->searchIndex, $this->searchType, $hiddenFilters); ?>
+<?php if ($this->searchType == 'advanced'): ?>
   <div class="navbar-form navbar-left flip">
-    <? $tabs = $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $searchTabs['tabs']]); ?>
-    <? if (!empty($tabs)): ?><?=$tabs ?><div class="tab-content clearfix"><? endif; ?>
+    <?php $tabs = $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $searchTabs['tabs']]); ?>
+    <?php if (!empty($tabs)): ?><?=$tabs ?><div class="tab-content clearfix"><?php endif; ?>
       <p class="adv_search_terms"><?=$this->transEsc("Your search terms")?> : "<strong><?=$this->escapeHtml($this->lookfor)?></strong>"</p>
       <p class="adv_search_links">
         <a href="<?=$this->url($advSearch)?>?edit=<?=$this->escapeHtmlAttr($this->searchId)?>"><?=$this->transEsc("Edit this Advanced Search")?></a> |
         <a href="<?=$this->url($advSearch) . $hiddenFilterParams?>"><?=$this->transEsc("Start a new Advanced Search")?></a> |
         <a href="<?=$this->url($searchHome) . $hiddenFilterParams?>"><?=$this->transEsc("Start a new Basic Search")?></a>
       </p>
-    <? if (!empty($tabs)): ?></div><? endif; ?>
+    <?php if (!empty($tabs)): ?></div><?php endif; ?>
   </div>
-<? else: ?>
+<?php else: ?>
   <form id="searchForm" class="searchForm navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" autocomplete="off">
     <?= $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $searchTabs['tabs']]); ?>
-    <? $placeholder = $this->searchbox()->getPlaceholderText(isset($searchTabs['selected']['id']) ? $searchTabs['selected']['id'] : null); ?>
-    <input id="searchForm_lookfor" class="searchForm_lookfor form-control search-query<? if($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><? endif ?>" type="text" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"<? if ($placeholder): ?> placeholder="<?=$this->transEsc($placeholder) ?>"<? endif ?> />
-    <? if ($handlerCount > 1): ?>
+    <?php $placeholder = $this->searchbox()->getPlaceholderText(isset($searchTabs['selected']['id']) ? $searchTabs['selected']['id'] : null); ?>
+    <input id="searchForm_lookfor" class="searchForm_lookfor form-control search-query<?php if($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><?php endif ?>" type="text" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"<?php if ($placeholder): ?> placeholder="<?=$this->transEsc($placeholder) ?>"<?php endif ?> />
+    <?php if ($handlerCount > 1): ?>
       <select id="searchForm_type" class="searchForm_type form-control" name="type" data-native-menu="false">
-        <? foreach ($handlers as $handler): ?>
+        <?php foreach ($handlers as $handler): ?>
           <option value="<?=$this->escapeHtmlAttr($handler['value'])?>"<?=$handler['selected'] ? ' selected="selected"' : ''?>><?=$handler['indent'] ? '-- ' : ''?><?=$this->transEsc($handler['label'])?></option>
-        <? endforeach; ?>
+        <?php endforeach; ?>
       </select>
-    <? elseif ($handlerCount == 1): ?>
+    <?php elseif ($handlerCount == 1): ?>
       <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($handlers[0]['value'])?>" />
-    <? endif; ?>
+    <?php endif; ?>
     <button type="submit" class="btn btn-primary"><i class="fa fa-search" aria-hidden="true"></i> <?=$this->transEsc("Find")?></button>
-    <? if ($advSearch): ?>
+    <?php if ($advSearch): ?>
       <a href="<?=$this->url($advSearch) . ((isset($this->searchId) && $this->searchId) ? '?edit=' . $this->escapeHtmlAttr($this->searchId) : $hiddenFilterParams) ?>" class="btn btn-link" rel="nofollow"><?=$this->transEsc("Advanced")?></a>
-    <? endif; ?>
-    <? if ($geoUrl = $this->geocoords()->getSearchUrl($options)) : ?>
+    <?php endif; ?>
+    <?php if ($geoUrl = $this->geocoords()->getSearchUrl($options)) : ?>
         <a href="<?=$geoUrl ?>" class="btn btn-link"><?=$this->transEsc('Geographic Search')?></a>
-    <? endif; ?>
+    <?php endif; ?>
 
-    <? $shards = $options->getShards(); if ($options->showShardCheckboxes() && !empty($shards)): ?>
-      <?
+    <?php $shards = $options->getShards(); if ($options->showShardCheckboxes() && !empty($shards)): ?>
+      <?php
       $selectedShards = isset($this->selectedShards)
           ? $this->selectedShards : $options->getDefaultSelectedShards();
       ?>
       <br />
-      <? foreach ($shards as $shard => $val): ?>
-        <? $isSelected = empty($selectedShards) || in_array($shard, $selectedShards); ?>
+      <?php foreach ($shards as $shard => $val): ?>
+        <?php $isSelected = empty($selectedShards) || in_array($shard, $selectedShards); ?>
           <input type="checkbox" <?=$isSelected ? 'checked="checked" ' : ''?>name="shard[]" value='<?=$this->escapeHtmlAttr($shard)?>' /> <?=$this->transEsc($shard)?>
-      <? endforeach; ?>
-    <? endif; ?>
-    <?
+      <?php endforeach; ?>
+    <?php endif; ?>
+    <?php
       $filterDetails = $this->searchbox()->getFilterDetails(
           isset($this->filterList) && is_array($this->filterList) ? $this->filterList : [],
           isset($this->checkboxFilters) && is_array($this->checkboxFilters) ? $this->checkboxFilters : []
       );
     ?>
-    <? if ((isset($hasDefaultsApplied) && $hasDefaultsApplied) || !empty($filterDetails)): ?>
-      <? $defaultFilterState = $options->getRetainFilterSetting() ? ' checked="checked"' : ''; ?>
+    <?php if ((isset($hasDefaultsApplied) && $hasDefaultsApplied) || !empty($filterDetails)): ?>
+      <?php $defaultFilterState = $options->getRetainFilterSetting() ? ' checked="checked"' : ''; ?>
       <div class="checkbox">
         <label>
           <input onChange="$('.applied-filter').click()" type="checkbox"<?=$defaultFilterState?> class="searchFormKeepFilters"/>
@@ -88,23 +88,23 @@
         </label>
       </div>
       <div class="hidden">
-        <? foreach ($filterDetails as $current): ?>
+        <?php foreach ($filterDetails as $current): ?>
           <input class="applied-filter" id="<?=$this->escapeHtmlAttr($current['id'])?>" type="checkbox"<?=$defaultFilterState?> name="filter[]" value="<?=$this->escapeHtmlAttr($current['value'])?>" />
           <label for="<?=$this->escapeHtmlAttr($current['id'])?>"><?=$this->escapeHtml($current['value'])?></label>
-        <? endforeach; ?>
-        <? if (isset($hasDefaultsApplied) && $hasDefaultsApplied): ?>
+        <?php endforeach; ?>
+        <?php if (isset($hasDefaultsApplied) && $hasDefaultsApplied): ?>
           <!-- this is a hidden element that flags whether or not default filters have been applied;
                it is intentionally unlabeled, as users are not meant to manipulate it directly. -->
           <input class="applied-filter" id="dfApplied" type="checkbox" name="dfApplied" value="1"<?=$defaultFilterState?> />
-        <? endif; ?>
+        <?php endif; ?>
       </div>
-    <? endif; ?>
-    <? foreach ($hiddenFilters as $key => $filter): ?>
-      <? foreach ($filter as $value): ?>
+    <?php endif; ?>
+    <?php foreach ($hiddenFilters as $key => $filter): ?>
+      <?php foreach ($filter as $value): ?>
         <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr($value)?>" />
-      <? endforeach; ?>
-    <? endforeach; ?>
-    <?
+      <?php endforeach; ?>
+    <?php endforeach; ?>
+    <?php
       /* Show hidden field for active search class when in combined handler mode. */
       if ($this->searchbox()->combinedHandlersActive()) {
         echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '" />';
@@ -118,4 +118,4 @@
       }
     ?>
   </form>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/summon/advanced.phtml
+++ b/themes/bootstrap3/templates/summon/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // Load the Summon-specific advanced search controls and inject them into the
   // standard advanced search layout:
   $this->extraAdvancedControls = $this->render('search/advanced/summon.phtml');

--- a/themes/bootstrap3/templates/summon/search.phtml
+++ b/themes/bootstrap3/templates/summon/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/tag/home.phtml
+++ b/themes/bootstrap3/templates/tag/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/upgrade/error.phtml
+++ b/themes/bootstrap3/templates/upgrade/error.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/getdbcredentials.phtml
+++ b/themes/bootstrap3/templates/upgrade/getdbcredentials.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/getdbencodingpreference.phtml
+++ b/themes/bootstrap3/templates/upgrade/getdbencodingpreference.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/upgrade/getsourcedir.phtml
+++ b/themes/bootstrap3/templates/upgrade/getsourcedir.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 
@@ -20,10 +20,10 @@
     <input type="text" name="sourceversion" />
   </p>
   <p>Options:<br />
-  <? foreach (['config' => 'Configuration', 'database' => 'Database Structure', 'metadata' => 'Stored Metadata'] as $key => $value): ?>
+  <?php foreach (['config' => 'Configuration', 'database' => 'Database Structure', 'metadata' => 'Stored Metadata'] as $key => $value): ?>
     <input type="checkbox" name="skip[]" id="skip-<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($key)?>" />
     <label for="skip-<?=$this->escapeHtmlAttr($key)?>">Skip <?=$this->escapeHtml($value); ?> Upgrade</label><br />
-  <? endforeach; ?>
+  <?php endforeach; ?>
   </p>
   <input class="btn btn-default" type="submit" />
 </form>

--- a/themes/bootstrap3/templates/upgrade/home.phtml
+++ b/themes/bootstrap3/templates/upgrade/home.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 
@@ -10,15 +10,15 @@
 <p>Upgrade complete.  You may still have some work to do:</p>
 
 <ol>
-  <? if ($oldVersion < 2): ?>
+  <?php if ($oldVersion < 2): ?>
     <li>If you have customized your SolrMarc import settings, your marc_local.properties file has been migrated, but you will need to move custom translation maps, index scripts, etc. by hand.  Custom import files belong under <?=$this->escapeHtml($this->importDir)?> -- this will make future upgrades easier.</li>
     <li>You should look over the configuration files in <?=$this->escapeHtml($this->configDir)?> and make sure settings look correct.  The automatic update process sometimes re-enables disabled settings and removes comments.</li>
     <li>If you have customized any of the YAML searchspecs files without using the *_local.yaml override mechanism, you will need to reapply those changes.</li>
     <li>If you have customized code or templates in your previous version, you will need to adapt those changes to the new architecture.</li>
-  <? else: ?>
+  <?php else: ?>
     <li>You should look over the configuration files in <?=$this->escapeHtml($this->configDir)?> and make sure settings look correct.  The automatic update process sometimes re-enables disabled settings and removes comments.  Backups of your old configurations have been created for comparison purposes.</li>
     <li>If you have customized code or templates in your previous version, you should test them to be sure they still work correctly; see the <a href="https://vufind.org/wiki/changelog">changelog</a> for notes on possible breaks in backward compatibility.</li>
-  <? endif; ?>
+  <?php endif; ?>
   <li>You should reindex all of your content.</li>
   <li>You may want to check for problems on the <a href="<?=$this->url('install-home')?>"><?=$this->transEsc('auto_configure_title')?></a> page.</li>
 </ol>

--- a/themes/bootstrap3/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap3/templates/upgrade/showsql.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Set page title.
     $this->headTitle($this->translate('Upgrade VuFind'));
 

--- a/themes/bootstrap3/templates/web/results.phtml
+++ b/themes/bootstrap3/templates/web/results.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/bootstrap3/templates/worldcat/advanced.phtml
+++ b/themes/bootstrap3/templates/worldcat/advanced.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
   // There are no WorldCat-specific advanced search controls, so just load the
   // standard advanced search layout:
   echo $this->render('search/advanced/layout.phtml');

--- a/themes/bootstrap3/templates/worldcat/search.phtml
+++ b/themes/bootstrap3/templates/worldcat/search.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // Load standard settings from the default search results screen:
     echo $this->render('search/results.phtml');
 ?>

--- a/themes/root/templates/Citation/apa-article.phtml
+++ b/themes/root/templates/Citation/apa-article.phtml
@@ -1,8 +1,8 @@
-<? if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?> <? endif; ?>
-<? if (!empty($this->date)): ?>(<?=$this->escapeHtml($this->date)?>). <? endif; ?>
-<?=$this->escapeHtml($this->title)?><? if ($this->periodAfterTitle): ?>.<? endif ?> 
-<span style="font-style:italic;"><?=$this->escapeHtml($this->journal)?><? if (!empty($this->volume) || !empty($this->issue) || !empty($this->pageRange)): ?>, <? endif; ?>
-<? if (!empty($this->volume)): ?><?=$this->escapeHtml($this->volume)?><? endif; ?></span><? if (!empty($this->issue)): ?>(<?=$this->escapeHtml($this->issue)?>)<? endif; ?>
-<? if (!empty($this->volume) || !empty($this->issue)): ?>, <? endif; ?>
-<? if (!empty($this->pageRange)) echo strstr($this->pageRange, '-') ? 'pp. ' : 'p. '; ?>
-<?=$this->escapeHtml($this->pageRange)?>. <? if (isset($this->doi)): ?>doi:<?=$this->escapeHtml($this->doi)?><? endif; ?>
+<?php if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?> <?php endif; ?>
+<?php if (!empty($this->date)): ?>(<?=$this->escapeHtml($this->date)?>). <?php endif; ?>
+<?=$this->escapeHtml($this->title)?><?php if ($this->periodAfterTitle): ?>.<?php endif ?> 
+<span style="font-style:italic;"><?=$this->escapeHtml($this->journal)?><?php if (!empty($this->volume) || !empty($this->issue) || !empty($this->pageRange)): ?>, <?php endif; ?>
+<?php if (!empty($this->volume)): ?><?=$this->escapeHtml($this->volume)?><?php endif; ?></span><?php if (!empty($this->issue)): ?>(<?=$this->escapeHtml($this->issue)?>)<?php endif; ?>
+<?php if (!empty($this->volume) || !empty($this->issue)): ?>, <?php endif; ?>
+<?php if (!empty($this->pageRange)) echo strstr($this->pageRange, '-') ? 'pp. ' : 'p. '; ?>
+<?=$this->escapeHtml($this->pageRange)?>. <?php if (isset($this->doi)): ?>doi:<?=$this->escapeHtml($this->doi)?><?php endif; ?>

--- a/themes/root/templates/Citation/apa.phtml
+++ b/themes/root/templates/Citation/apa.phtml
@@ -1,5 +1,5 @@
-<? if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?> <? endif; ?>
-<? if (!empty($this->year)): ?>(<?=$this->escapeHtml($this->year)?>). <? endif; ?>
-<span style="font-style:italic;"><?=$this->escapeHtml($this->title)?></span><? if ($this->periodAfterTitle): ?>.<? endif ?> 
-<? if (!empty($this->edition)): ?>(<?=$this->escapeHtml($this->edition)?>). <? endif; ?>
-<? if (!empty($this->publisher)): ?><?=$this->escapeHtml($this->publisher)?>.<? endif; ?>
+<?php if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?> <?php endif; ?>
+<?php if (!empty($this->year)): ?>(<?=$this->escapeHtml($this->year)?>). <?php endif; ?>
+<span style="font-style:italic;"><?=$this->escapeHtml($this->title)?></span><?php if ($this->periodAfterTitle): ?>.<?php endif ?> 
+<?php if (!empty($this->edition)): ?>(<?=$this->escapeHtml($this->edition)?>). <?php endif; ?>
+<?php if (!empty($this->publisher)): ?><?=$this->escapeHtml($this->publisher)?>.<?php endif; ?>

--- a/themes/root/templates/Citation/mla-article.phtml
+++ b/themes/root/templates/Citation/mla-article.phtml
@@ -1,5 +1,5 @@
-<? if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?>. <? endif; ?>
-&quot;<?=$this->title?><? if ($this->periodAfterTitle): ?>.<? endif ?>&quot; 
+<?php if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?>. <?php endif; ?>
+&quot;<?=$this->title?><?php if ($this->periodAfterTitle): ?>.<?php endif ?>&quot; 
 <span style="font-style:italic;"><?=$this->escapeHtml($this->journal)?></span> 
-<? if (!empty($this->numberAndDate)): ?><?=$this->escapeHtml($this->numberAndDate)?><? if (!empty($this->pageRange)): ?>: <? endif; ?><? endif; ?>
-<? if (!empty($this->pageRange)): ?><?=$this->escapeHtml($this->pageRange)?><? endif; ?>.
+<?php if (!empty($this->numberAndDate)): ?><?=$this->escapeHtml($this->numberAndDate)?><?php if (!empty($this->pageRange)): ?>: <?php endif; ?><?php endif; ?>
+<?php if (!empty($this->pageRange)): ?><?=$this->escapeHtml($this->pageRange)?><?php endif; ?>.

--- a/themes/root/templates/Citation/mla.phtml
+++ b/themes/root/templates/Citation/mla.phtml
@@ -1,5 +1,5 @@
-<? if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?>. <? endif; ?>
-<span style="font-style:italic;"><?=$this->escapeHtml($this->title)?></span><? if ($this->periodAfterTitle): ?>.<? endif ?> 
-<? if (!empty($this->edition)): ?><?=$this->escapeHtml($this->edition)?> <? endif; ?>
-<? if (!empty($this->publisher)): ?><?=$this->escapeHtml($this->publisher)?><? endif; ?>
-<? if (!empty($this->year)): ?><? if (!empty($this->publisher)): ?>, <? endif; ?><?=$this->escapeHtml($this->year)?><? endif; ?><? if (!empty($this->year) || !empty($this->publisher)): ?>.<? endif; ?>
+<?php if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?>. <?php endif; ?>
+<span style="font-style:italic;"><?=$this->escapeHtml($this->title)?></span><?php if ($this->periodAfterTitle): ?>.<?php endif ?> 
+<?php if (!empty($this->edition)): ?><?=$this->escapeHtml($this->edition)?> <?php endif; ?>
+<?php if (!empty($this->publisher)): ?><?=$this->escapeHtml($this->publisher)?><?php endif; ?>
+<?php if (!empty($this->year)): ?><?php if (!empty($this->publisher)): ?>, <?php endif; ?><?=$this->escapeHtml($this->year)?><?php endif; ?><?php if (!empty($this->year) || !empty($this->publisher)): ?>.<?php endif; ?>

--- a/themes/root/templates/Email/record-sms.phtml
+++ b/themes/root/templates/Email/record-sms.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
     // This is a text-only email template; do not include HTML!
 
     // If this record supports real-time status, we'll assume it's a local

--- a/themes/root/templates/Email/record.phtml
+++ b/themes/root/templates/Email/record.phtml
@@ -1,4 +1,4 @@
-<? // This is a text-only email template; do not include HTML! ?>
+<?php // This is a text-only email template; do not include HTML! ?>
 <?=$this->translate('This email was sent from')?>: <?=$this->from?>
 
 ------------------------------------------------------------
@@ -7,6 +7,6 @@
   <?=$this->translate('email_link')?>: <?=$this->serverUrl($this->recordLink()->getUrl($this->driver))?>
 
 ------------------------------------------------------------
-<? if (!empty($this->message)): ?><?=$this->translate("Message From Sender")?>:
+<?php if (!empty($this->message)): ?><?=$this->translate("Message From Sender")?>:
 <?=$this->message?>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/root/templates/Email/share-link.phtml
+++ b/themes/root/templates/Email/share-link.phtml
@@ -1,12 +1,12 @@
-<? // This is a text-only email template; do not include HTML! ?>
+<?php // This is a text-only email template; do not include HTML! ?>
 <?=$this->translate('This email was sent from')?>: <?=$this->from?>
 
 ------------------------------------------------------------
-<? if (!empty($this->message)): ?><?=$this->translate("Message From Sender")?>:
+<?php if (!empty($this->message)): ?><?=$this->translate("Message From Sender")?>:
 <?=$this->message?>
 
 
-<? endif; ?>
+<?php endif; ?>
   <?=$this->translate('email_link')?>: <<?=$this->msgUrl?>>
 
 ------------------------------------------------------------

--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // TODO: fold this logic into record driver methods at some point:
 $marc = $this->driver->tryMethod('getMarcRecord');
 if (is_object($marc)) {

--- a/themes/root/templates/RecordDriver/AbstractBase/export-endnote.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-endnote.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // A driver-specific template may pass in format overrides; check for these before going to the driver itself:
 $formats = isset($this->overrideFormats) ? $this->overrideFormats : $this->driver->tryMethod('getFormats');
 if (is_array($formats) && !empty($formats)) {

--- a/themes/root/templates/RecordDriver/AbstractBase/export-endnoteweb.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-endnoteweb.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // A driver-specific template may pass in format overrides; check for these before going to the driver itself:
 $formats = isset($this->overrideFormats) ? $this->overrideFormats : $this->driver->tryMethod('getFormats');
 if (is_array($formats)) {

--- a/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // A driver-specific template may pass in format overrides; check for these before going to the driver itself:
 $formats = isset($this->overrideFormats) ? $this->overrideFormats : $this->driver->tryMethod('getFormats');
 if (is_array($formats)) {

--- a/themes/root/templates/RecordDriver/AbstractBase/export-ris.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-ris.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // TODO: fold this logic into record driver methods at some point:
 $marc = $this->driver->tryMethod('getMarcRecord');
 if (is_object($marc)) {

--- a/themes/root/templates/RecordDriver/Primo/export-endnote.phtml
+++ b/themes/root/templates/RecordDriver/Primo/export-endnote.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // Convert Primo format to EndNote format:
 $formats = $this->driver->tryMethod('getFormats');
 if (is_array($formats) && !empty($formats[0])) {

--- a/themes/root/templates/RecordDriver/Primo/export-refworks.phtml
+++ b/themes/root/templates/RecordDriver/Primo/export-refworks.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // Convert Primo format to RefWorks format:
 $formats = $this->driver->tryMethod('getFormats');
 if (is_array($formats) && !empty($formats[0])) {

--- a/themes/root/templates/RecordDriver/Summon/export-endnote.phtml
+++ b/themes/root/templates/RecordDriver/Summon/export-endnote.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // Convert Summon formats to EndNote formats:
 $formats = $this->driver->getFormats();
 foreach ($formats as $i => $format) {

--- a/themes/root/templates/RecordDriver/Summon/export-refworks.phtml
+++ b/themes/root/templates/RecordDriver/Summon/export-refworks.phtml
@@ -1,4 +1,4 @@
-<?
+<?php
 // Convert Summon formats to RefWorks formats:
 $formats = $this->driver->getFormats();
 foreach ($formats as $i => $format) {

--- a/themes/root/templates/api/swagger.phtml
+++ b/themes/root/templates/api/swagger.phtml
@@ -1,5 +1,5 @@
-<? // This template is a JSON Swagger specification ?>
-<? $basePath = rtrim($this->url('home'), '/') . '/api/v1'; ?>
+<?php // This template is a JSON Swagger specification ?>
+<?php $basePath = rtrim($this->url('home'), '/') . '/api/v1'; ?>
 {
     "swagger": "2.0",
     "info": {

--- a/themes/root/templates/error/404.phtml
+++ b/themes/root/templates/error/404.phtml
@@ -1,3 +1,3 @@
 <h1><?=$this->transEsc('An error has occurred')?></h1>
 <h2><?=$this->transEsc($this->message)?></h2>
-<? if (isset($this->reason) && $this->reason): ?><b><?=$this->transEsc('Message')?>:</b> <?=$this->transEsc($this->reason)?><? endif; ?>
+<?php if (isset($this->reason) && $this->reason): ?><b><?=$this->transEsc('Message')?>:</b> <?=$this->transEsc($this->reason)?><?php endif; ?>

--- a/themes/root/templates/error/index.phtml
+++ b/themes/root/templates/error/index.phtml
@@ -1,14 +1,14 @@
 <h1><?=$this->transEsc('An error has occurred')?></h1>
 <h2><?=$this->transEsc($this->message)?></h2>
 
-<? if ($this->showInstallLink): ?>
+<?php if ($this->showInstallLink): ?>
   <h3><a href="<?=$this->url('install-home')?>"><?=$this->transEsc('auto_configure_title', array(), 'Auto Configure')?></a></h3>
   <?=$this->transEsc('auto_configure_description', array(), 'If this is a new installation, you may be able to fix the error using VuFind\'s Auto Configure tool.')?>
   <h3><a href="<?=$this->url('upgrade-home')?>"><?=$this->transEsc('Upgrade VuFind')?></a></h3>
   <?=$this->transEsc('upgrade_description', array(), 'If you are upgrading a previous VuFind version, you can load your old settings with this tool.')?>
-<? endif; ?>
+<?php endif; ?>
 
-<? if (isset($this->display_exceptions) && $this->display_exceptions): ?>
+<?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
   <h3><?=$this->transEsc('Exception')?>:</h3>
   <p>
     <b><?=$this->transEsc('Message')?>:</b> <?=$this->escapeHtml($this->exception->getMessage())?>
@@ -18,18 +18,18 @@
   <pre><?=$this->exception->getTraceAsString()?>
   </pre>
 
-  <? if ($e = $this->exception->getPrevious()): ?>
+  <?php if ($e = $this->exception->getPrevious()): ?>
     <h3>Previous exceptions:</h3>
-    <? while($e): ?>
+    <?php while($e): ?>
         <h4><?php echo get_class($e); ?></h4>
         <p><?=$e->getMessage()?></p>
         <pre><?=$e->getTraceAsString()?></pre>
-        <? $e = $e->getPrevious(); ?>
-    <? endwhile; ?>
-  <? endif; ?>
+        <?php $e = $e->getPrevious(); ?>
+    <?php endwhile; ?>
+  <?php endif; ?>
 
-  <? if (isset($this->request)): ?>
+  <?php if (isset($this->request)): ?>
     <h3><?=$this->transEsc('error_page_parameter_list_heading')?>:</h3>
     <pre><?=$this->escapeHtml(var_export($this->request->getParams(), true))?></pre>
-  <? endif; ?>
-<? endif ?>
+  <?php endif; ?>
+<?php endif ?>

--- a/themes/root/templates/help/home.phtml
+++ b/themes/root/templates/help/home.phtml
@@ -1,9 +1,9 @@
-<? $this->headTitle($this->translate('Help')); ?>
-<? if ($help = $this->helpText()->render($topic)): ?>
-  <? foreach ($this->helpText()->getWarnings() as $warning): ?>
+<?php $this->headTitle($this->translate('Help')); ?>
+<?php if ($help = $this->helpText()->render($topic)): ?>
+  <?php foreach ($this->helpText()->getWarnings() as $warning): ?>
     <p class="warning"><?=$this->transEsc($warning)?></p>
-  <? endforeach; ?>
+  <?php endforeach; ?>
   <?=$help?>
-<? else: ?>
+<?php else: ?>
   <p class="warning"><?=$this->transEsc('help_page_missing')?></p>
-<? endif; ?>
+<?php endif; ?>

--- a/themes/root/templates/search/opensearch-describe.phtml
+++ b/themes/root/templates/search/opensearch-describe.phtml
@@ -1,5 +1,5 @@
-<? $searchBase = $this->serverUrl($this->url('search-results')); ?>
-<? $suggestions = $this->serverUrl($this->url('search-suggest')); ?>
+<?php $searchBase = $this->serverUrl($this->url('search-results')); ?>
+<?php $suggestions = $this->serverUrl($this->url('search-suggest')); ?>
 <?='<'?>?xml version="1.0"?<?='>'?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <ShortName><?=$this->escapeHtml($this->site->title)?></ShortName>

--- a/themes/root/templates/searchapi/swagger.phtml
+++ b/themes/root/templates/searchapi/swagger.phtml
@@ -1,18 +1,18 @@
-<? // This template is a JSON fragment of a complete Swagger specification ?>
-<? ob_start(); ?>
+<?php // This template is a JSON fragment of a complete Swagger specification ?>
+<?php ob_start(); ?>
                     {
                         "name": "field[]",
                         "in": "query",
-                        "description": "Fields to return.<? if ($this->defaultFields): ?> If not specified, a set of default fields is returned.\n\nThe default fields are:\n- <?=implode('\n- ', array_map('addslashes', $this->defaultFields)) ?><? endif; ?>",
+                        "description": "Fields to return.<?php if ($this->defaultFields): ?> If not specified, a set of default fields is returned.\n\nThe default fields are:\n- <?=implode('\n- ', array_map('addslashes', $this->defaultFields)) ?><?php endif; ?>",
                         "type": "array",
                         "collectionFormat": "multi",
                         "items": {
                             "type": "string"
                         }
                     }
-<? $field = ob_get_contents(); ?>
-<? ob_end_clean(); ?>
-<? ob_start(); ?>
+<?php $field = ob_get_contents(); ?>
+<?php ob_end_clean(); ?>
+<?php ob_start(); ?>
                     {
                         "name": "prettyPrint",
                         "in": "query",
@@ -34,8 +34,8 @@
                         "description": "A callback that can be used for JSONP.",
                         "type": "string"
                     }
-<? $commonFields = ob_get_contents(); ?>
-<? ob_end_clean(); ?>
+<?php $commonFields = ob_get_contents(); ?>
+<?php ob_end_clean(); ?>
 {
     "paths": {
         "/record": {
@@ -117,7 +117,7 @@
                     {
                         "name": "facet[]",
                         "in": "query",
-                        "description": "Fields to facet on. Repeat for every field. <? if ($this->facetConfig): ?>At least the following fields are available for faceting (there may be additional facetable index fields not published here):\n- <?=implode('\n- ', array_map('addslashes', array_keys($this->facetConfig))) ?><? endif; ?>",
+                        "description": "Fields to facet on. Repeat for every field. <?php if ($this->facetConfig): ?>At least the following fields are available for faceting (there may be additional facetable index fields not published here):\n- <?=implode('\n- ', array_map('addslashes', array_keys($this->facetConfig))) ?><?php endif; ?>",
                         "type": "array",
                         "collectionFormat": "multi",
                         "items": {


### PR DESCRIPTION
Discussion of #913 brought up this idea -- short tags are not really recommended PHP practice at this point. Can we live with using regular `<?php` tags in our templates? This PR shows what it would look like. Please discuss below.

TODO
- [ ] Test
- [ ] Make sure php-cs-fixer is configured to prevent regressions in future (may depend on #897)