### PR TITLE
Add a path converter to make any css files minified by the asset pipe…

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/Minify/CSS.php
+++ b/module/VuFindTheme/src/VuFindTheme/Minify/CSS.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * CSS minifier extension
+ *
+ * PHP version 5
+ *
+ * Copyright (C) The National Library of Finland 2017.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFindTheme\Minify;
+
+/**
+ * CSS minifier extensions
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class CSS extends \MatthiasMullie\Minify\CSS
+{
+    /**
+     * Return a converter to update relative paths to be relative to the new
+     * destination.
+     *
+     * @param string $source Source path
+     * @param string $target Target path
+     *
+     * @return \MatthiasMullie\PathConverter\ConverterInterface
+     */
+    protected function getPathConverter($source, $target)
+    {
+        return new PathConverter($source, $target);
+    }
+}

--- a/module/VuFindTheme/src/VuFindTheme/Minify/PathConverter.php
+++ b/module/VuFindTheme/src/VuFindTheme/Minify/PathConverter.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * CSS path converter extension
+ *
+ * PHP version 5
+ *
+ * Copyright (C) The National Library of Finland 2017.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFindTheme\Minify;
+
+/**
+ * CSS path converter extension
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class PathConverter extends \MatthiasMullie\PathConverter\Converter
+{
+    /**
+     * Normalize path.
+     *
+     * @param string $path Path
+     *
+     * @return string
+     */
+    protected function normalize($path)
+    {
+        $path = parent::normalize($path);
+
+        $path = str_replace('/local/cache/public', '/cache', $path);
+
+        return $path;
+    }
+}

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
@@ -24,7 +24,7 @@
  * @package  View_Helpers
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ * @link     https://vufind.org/wiki/development Wiki
  */
 namespace VuFindTheme\View\Helper;
 use VuFindTheme\ThemeInfo;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -203,6 +203,6 @@ class HeadLink extends \Zend\View\Helper\HeadLink
      */
     protected function getMinifier()
     {
-        return new \MatthiasMullie\Minify\CSS();
+        return new \VuFindTheme\Minify\CSS();
     }
 }


### PR DESCRIPTION
…line use correct paths for any relative url(…) directives.

The problem can be easily reproduced with bootstrap3 by uncommenting ‘vendor/font-awesome.min.css’ in theme.config.php when asset pipeline is enabled for css. Reloading the page would try to load the font file from wrong path.