### PR TITLE
Check that a highlighted field contents is available before trying to…

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -652,7 +652,7 @@ class SolrDefault extends AbstractBase
                 && is_array($this->highlightDetails)
             ) {
                 foreach ($this->highlightDetails as $key => $value) {
-                    if (!in_array($key, $this->forbiddenSnippetFields)) {
+                    if ($value && !in_array($key, $this->forbiddenSnippetFields)) {
                         return [
                             'snippet' => $value[0],
                             'caption' => $this->getSnippetCaption($key)


### PR DESCRIPTION
… return it. Fixes at least usage with Solr’s new UnifiedHighlighter that returns empty arrays for fields without highlighting matches.