### PR TITLE
Disabled highlighting when looking for child records.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -1922,7 +1922,13 @@ class SolrDefault extends AbstractBase
         $query = new \VuFindSearch\Query\Query(
             'hierarchy_parent_id:"' . $safeId . '"'
         );
-        return $this->searchService->search('Solr', $query, 0, 0)->getTotal();
+        $params = new \VuFindSearch\ParamBag(
+            [
+                'hl' => ['false']
+            ]
+        );
+        return $this->searchService->search('Solr', $query, 0, 0, $params)
+            ->getTotal();
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -1922,11 +1922,8 @@ class SolrDefault extends AbstractBase
         $query = new \VuFindSearch\Query\Query(
             'hierarchy_parent_id:"' . $safeId . '"'
         );
-        $params = new \VuFindSearch\ParamBag(
-            [
-                'hl' => ['false']
-            ]
-        );
+        // Disable highlighting for efficiency; not needed here:
+        $params = new \VuFindSearch\ParamBag(['hl' => ['false']]);
         return $this->searchService->search('Solr', $query, 0, 0, $params)
             ->getTotal();
     }


### PR DESCRIPTION
It probably doesn't account for much since no rows are returned, but it's the proper way anyway.