### PR TITLE
Don’t override a title that the ILS driver might have returned.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1230,7 +1230,9 @@ class MyResearchController extends AbstractBase
                     ? $row['source'] : DEFAULT_SEARCH_BACKEND;
                 $row['driver'] = $this->serviceLocator
                     ->get('VuFind\RecordLoader')->load($row['id'], $source);
-                $row['title'] = $row['driver']->getShortTitle();
+                if (empty($row['title'])) {
+                    $row['title'] = $row['driver']->getShortTitle();
+                }
             } catch (\Exception $e) {
                 if (!isset($row['title'])) {
                     $row['title'] = null;


### PR DESCRIPTION
Similar to checkouts, allow the ILS driver to return a title that may include more information than the record driver's title.