### PR TITLE
Fix a problem fetching hierarchy from Solr when using a sharded index…

### DIFF
--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
@@ -111,11 +111,12 @@ class Solr extends AbstractBase
      * Search Solr.
      *
      * @param string $q    Search query
-     * @param int    $rows Max rows to retrieve (default = int max)
+     * @param int    $rows Max rows to retrieve (default = int max / 2 since Solr
+     * may choke with higher values)
      *
      * @return array
      */
-    protected function searchSolr($q, $rows = 2147483647)
+    protected function searchSolr($q, $rows = 1073741823)
     {
         $params = new ParamBag(
             [


### PR DESCRIPTION
…. Using max int as the rows parameter may cause an int overflow in Solr internal processing at least with a sharded index.

This could be considered a problem with Solr, but maybe sending int max as the rows _is_ pushing it a bit..