### PR TITLE
Return properly formatted results from SolrDefault::getRealTimeHoldin…

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -1198,7 +1198,7 @@ class SolrDefault extends AbstractBase
     public function getRealTimeHoldings()
     {
         // Not supported by the Solr index -- implement in child classes.
-        return [];
+        return ['holdings' => []];
     }
 
     /**


### PR DESCRIPTION
…gs to avoid notices in holdingsils.phtml. Probably only an issue when Site->hideHoldingsTabWhenEmpty = false.