### PR TITLE
Use error description as the basic exception message so that it is di…

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Exception.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Exception.php
@@ -53,7 +53,10 @@ class EbscoEdsApiException extends Exception
     {
         if (is_array($apiErrorMessage)) {
             $this->setApiError($apiErrorMessage);
-            parent::__construct();
+            parent::__construct(
+                isset($this->apiErrorDetails['Description'])
+                ? $this->apiErrorDetails['Description'] : ''
+            );
         } else {
             parent::__construct($apiErrorMessage);
         }
@@ -83,7 +86,6 @@ class EbscoEdsApiException extends Exception
             $this->apiErrorDetails['Description'] = $message['ErrorDescription'];
             $this->apiErrorDetails['DetailedDescription']
                 = $message['DetailedErrorDescription'];
-
         }
     }
 


### PR DESCRIPTION
…splayed in the exception view in development mode (i.e. $exception->getMessage() returns something instead of an empty string).