### PR TITLE
EDS apparently returns error 135 when access to the database indicate…

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -314,6 +314,10 @@ class Backend extends AbstractBackend
                     throw new BackendException($e->getMessage(), $e->getCode(), $e);
                 }
                 break;
+            case 135:
+                // DbId not in profile, fall through to treat as "record not found"
+                $response = [];
+                break;
             default:
                 throw $e;
             }


### PR DESCRIPTION
…d by record’s ID is not allowed. Treat it like the requested record wasn’t found.