### PR TITLE
Tolerate backend exceptions when loading records in favorite lists.

### DIFF
--- a/module/VuFind/src/VuFind/Record/Loader.php
+++ b/module/VuFind/src/VuFind/Record/Loader.php
@@ -203,12 +203,12 @@ class Loader implements \Zend\Log\LoggerAwareInterface
      * separated source|id strings), load all of the requested records in the
      * requested order.
      *
-     * @param array $ids                        Array of associative arrays with
+     * @param array $ids                       Array of associative arrays with
      * id/source keys or strings in source|id format.  In associative array formats,
      * there is also an optional "extra_fields" key which can be used to pass in data
      * formatted as if it belongs to the Solr schema; this is used to create
      * a mock driver object if the real data source is unavailable.
-     * @param bool   $tolerateBackendExceptions Whether to tolerate backend
+     * @param bool  $tolerateBackendExceptions Whether to tolerate backend
      * exceptions that may be caused by e.g. connection issues or changes in
      * subcscriptions
      *

--- a/module/VuFind/src/VuFind/Record/Loader.php
+++ b/module/VuFind/src/VuFind/Record/Loader.php
@@ -43,8 +43,10 @@ use VuFind\Exception\RecordMissing as RecordMissingException,
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class Loader
+class Loader implements \Zend\Log\LoggerAwareInterface
 {
+    use \VuFind\Log\LoggerAwareTrait;
+
     /**
      * Record factory
      *
@@ -131,14 +133,18 @@ class Loader
      * Given an array of IDs and a record source, load a batch of records for
      * that source.
      *
-     * @param array  $ids    Record IDs
-     * @param string $source Record source
+     * @param array  $ids                       Record IDs
+     * @param string $source                    Record source
+     * @param bool   $tolerateBackendExceptions Whether to tolerate backend
+     * exceptions that may be caused by e.g. connection issues or changes in
+     * subcscriptions
      *
      * @throws \Exception
      * @return array
      */
-    public function loadBatchForSource($ids, $source = DEFAULT_SEARCH_BACKEND)
-    {
+    public function loadBatchForSource($ids, $source = DEFAULT_SEARCH_BACKEND,
+        $tolerateBackendExceptions = false
+    ) {
         $cachedRecords = [];
         if (null !== $this->recordCache && $this->recordCache->isPrimary($source)) {
             // Try to load records from cache if source is cachable
@@ -155,8 +161,18 @@ class Loader
         // Try to load the uncached records from the original $source
         $genuineRecords = [];
         if (!empty($ids)) {
-            $genuineRecords = $this->searchService->retrieveBatch($source, $ids)
-                ->getRecords();
+            try {
+                $genuineRecords = $this->searchService->retrieveBatch($source, $ids)
+                    ->getRecords();
+            } catch (\VuFindSearch\Backend\Exception\BackendException $e) {
+                if (!$tolerateBackendExceptions) {
+                    throw $e;
+                }
+                $this->logWarning(
+                    "Exception when trying to retrieve records from $source: "
+                    . $e->getMessage()
+                );
+            }
 
             foreach ($genuineRecords as $genuineRecord) {
                 $key = array_search($genuineRecord->getUniqueId(), $ids);
@@ -187,16 +203,19 @@ class Loader
      * separated source|id strings), load all of the requested records in the
      * requested order.
      *
-     * @param array $ids Array of associative arrays with id/source keys or
-     * strings in source|id format.  In associative array formats, there is
-     * also an optional "extra_fields" key which can be used to pass in data
+     * @param array $ids                        Array of associative arrays with
+     * id/source keys or strings in source|id format.  In associative array formats,
+     * there is also an optional "extra_fields" key which can be used to pass in data
      * formatted as if it belongs to the Solr schema; this is used to create
      * a mock driver object if the real data source is unavailable.
+     * @param bool   $tolerateBackendExceptions Whether to tolerate backend
+     * exceptions that may be caused by e.g. connection issues or changes in
+     * subcscriptions
      *
      * @throws \Exception
      * @return array     Array of record drivers
      */
-    public function loadBatch($ids)
+    public function loadBatch($ids, $tolerateBackendExceptions = false)
     {
         // Sort the IDs by source -- we'll create an associative array indexed by
         // source and record ID which points to the desired position of the indexed
@@ -216,7 +235,9 @@ class Loader
         // Retrieve the records and put them back in order:
         $retVal = [];
         foreach ($idBySource as $source => $details) {
-            $records = $this->loadBatchForSource(array_keys($details), $source);
+            $records = $this->loadBatchForSource(
+                array_keys($details), $source, $tolerateBackendExceptions
+            );
             foreach ($records as $current) {
                 $id = $current->getUniqueId();
                 // In theory, we should be able to assume that $details[$id] is

--- a/module/VuFind/src/VuFind/Search/Favorites/Results.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/Results.php
@@ -211,7 +211,7 @@ class Results extends BaseResults
         }
 
         $this->recordLoader->setCacheContext(Cache::CONTEXT_FAVORITE);
-        $this->results = $this->recordLoader->loadBatch($recordsToRequest);
+        $this->results = $this->recordLoader->loadBatch($recordsToRequest, true);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Exception.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Exception.php
@@ -35,7 +35,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class EbscoEdsApiException extends Exception
+class EbscoEdsApiException extends \VuFindSearch\Backend\Exception\BackendException
 {
     /**
      * Error message details returned from the API


### PR DESCRIPTION
Changes EbscoEdsApiException to inherit from BackendException so that it can be caught while letting any other exceptions propagate. Other backends seem to already return BackendExceptions.