### PR TITLE
Group holdings by holdings ID and location by default to accommodate …

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -250,7 +250,8 @@ title_level_holds_mode = "disabled"
 ; the item information provided by the ILS driver.
 ;
 ; Most commonly-used values:
-; - holdings_id (Use holdings record id if available, location name otherwise - Default)
+; - holdings_id,location (Use holdings record id if available, location name as
+;   secondary - Default)
 ; - location (Use location name)
 ;
 ; See https://vufind.org/wiki/development:plugins:ils_drivers#getholding for
@@ -263,7 +264,7 @@ title_level_holds_mode = "disabled"
 ;
 ; You may use multiple group keys (delimited by comma), e.g.,
 ; - item_agency_id,location
-;holdings_grouping = holdings_id
+;holdings_grouping = holdings_id,location
 
 ; Text fields such as holdings_notes gathered from items to be displayed in each
 ; holdings group in the display order.

--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -524,9 +524,9 @@ class Holds
      */
     protected function getHoldingsGroupKey($copy)
     {
-        // Group by holdings id unless configured otherwise
+        // Group by holdings id and location unless configured otherwise
         $grouping = isset($this->config->Catalog->holdings_grouping)
-            ? $this->config->Catalog->holdings_grouping : 'holdings_id';
+            ? $this->config->Catalog->holdings_grouping : 'holdings_id,location';
 
         $groupKey = "";
 


### PR DESCRIPTION
…a situation where the items under a single holding have multiple actual locations.

It's a valid situation where under a single holding there are items in multiple locations. Therefore the default grouping should use both holding id and location.