### PR TITLE
Fix editing of advanced search with Internet Explorer.

### DIFF
--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -12,7 +12,7 @@ function addSearch(group, _fieldValues) {
   $newSearch.find('input.form-control')
     .attr('id', 'search_lookfor' + inputID)
     .attr('name', 'lookfor' + group + '[]')
-    .attr('value', '');
+    .val('');
   $newSearch.find('select.adv-term-type option:first-child').attr('selected', 1);
   $newSearch.find('select.adv-term-type')
     .attr('id', 'search_type' + inputID)
@@ -21,7 +21,7 @@ function addSearch(group, _fieldValues) {
     .attr('onClick', 'return deleteSearch(' + group + ',' + groupLength[group] + ')');
   // Preset Values
   if (typeof fieldValues.term !== "undefined") {
-    $newSearch.find('input.form-control').attr('value', fieldValues.term);
+    $newSearch.find('input.form-control').val(fieldValues.term);
   }
   if (typeof fieldValues.field !== "undefined") {
     $newSearch.find('select.adv-term-type option[value="' + fieldValues.field + '"]').attr('selected', 1);


### PR DESCRIPTION
At least scandinavian characters cause the attr() method to not handle the value attribute properly with Internet Explorer. To reproduce, do an advanced search for e.g. "väitöskirja" OR "dissertation", then try to edit the search. "dissertation" would get replaced with "väitöskirja". Fixed by using jQuery's val() method instead.