### PR TITLE
Close popups when zooming on map

### DIFF
--- a/themes/bootstrap3/js/map_selection.js
+++ b/themes/bootstrap3/js/map_selection.js
@@ -191,6 +191,10 @@ function loadMapSelection(geoField, boundingBox, baseURL, homeURL, searchParams,
         }
       }
     });
+    // close popup if zoom in / out occurs
+    map.getView().on('change:resolution', function closePopupsOnZoom() {
+      $(element).popover('destroy');
+    });
   };
   function addInteraction() {
     draw = new ol.interaction.Draw ({

--- a/themes/bootstrap3/js/map_tab_ol.js
+++ b/themes/bootstrap3/js/map_tab_ol.js
@@ -186,6 +186,10 @@ function loadMapTab(mapData, popupTitle) {
           document.getElementById(target).style.cursor = "default";
         }
       });
+      // close popup if zoom in / out occurs
+      map.getView().on('change:resolution', function closePopupsOnZoom() {
+        $(element).popover('destroy');
+      });
     }
   };
   init();


### PR DESCRIPTION
Fixes bug in geographic search and geographic display code so that popup information windows will close when the user changes the resolution of the map via zooming. 