### PR TITLE
Fix Browse author by alphabetical

### DIFF
--- a/module/VuFind/src/VuFind/Controller/BrowseController.php
+++ b/module/VuFind/src/VuFind/Controller/BrowseController.php
@@ -457,7 +457,7 @@ class BrowseController extends AbstractBase
             'era'          => 'By Era'
         ];
 
-        return $this->performBrowse('Author', $categoryList, false);
+        return $this->performBrowse('Author', $categoryList, true);
     }
 
     /**


### PR DESCRIPTION
This is a fix to BrowseController.php so that Browse -> Author -> By Alphabetical displays authors in the correct alphabetical category. Previously authors were displayed in an alphabetical category if any of the co-authors had a last name that was in that category. For example, author Smith, J. would have been displayed in category A because Smith, J. and Anderson, M. were authors on the same publication. 

This fix enables the facet_prefix setting in the authorAction module which is an additional Solr filter used for browsing multi-valued fields. 