### PR TITLE
Fix database session handler to return an empty string if the session…

### DIFF
--- a/module/VuFind/src/VuFind/Session/Database.php
+++ b/module/VuFind/src/VuFind/Session/Database.php
@@ -55,7 +55,7 @@ class Database extends AbstractBase
                 ->readSession($sess_id, $this->lifetime);
         } catch (SessionExpiredException $e) {
             $this->destroy($sess_id);
-            return;
+            return '';
         }
     }
 


### PR DESCRIPTION
… had expired.

To test, configure VuFind to use database sessions, start a session and execute the following query in the database to expire all sessions:

    update session set last_used=1;

Then reload the page. Without the fix, PHP will emit the following warning:

Warning: session_start(): Failed to read session data: user (path: [session save path]) in [...]/VuFind2/vendor/zendframework/zend-session/src/SessionManager.php on line 131