### PR TITLE
Improve Geo-search Search Box selection

### DIFF
--- a/themes/bootstrap3/js/map_selection.js
+++ b/themes/bootstrap3/js/map_selection.js
@@ -199,8 +199,7 @@ function loadMapSelection(geoField, boundingBox, baseURL, homeURL, searchParams,
   function addInteraction() {
     draw = new ol.interaction.Draw ({
       source: searchboxSource,
-      type: 'LineString',
-      maxPoints: 2,
+      type: 'Box',
       geometryFunction: function rectangleFunction(coords, geometryParam) {
         var geometry = geometryParam ? geometryParam : new ol.geom.Polygon(null);
         var start = coords[0];
@@ -209,7 +208,8 @@ function loadMapSelection(geoField, boundingBox, baseURL, homeURL, searchParams,
           [start, [start[0], end[1]], end, [end[0], start[1]], start]
         ]);
         return geometry;
-      }
+      },
+      freehand: true
     });
 
     draw.on('drawend', function drawSearchBox(evt) {

--- a/themes/root/templates/HelpTranslations/en/geosearch.phtml
+++ b/themes/root/templates/HelpTranslations/en/geosearch.phtml
@@ -5,9 +5,7 @@
     <h3>To draw the search box:</h3>
       <ol>
         <li>Click on the 'Draw Search Box' button.</li>
-        <li>Click and release on starting point of the search box.</li>
-        <li>Drag the search box to the cover the area of the map you wish to search.</li>
-        <li>Click and release on the ending point of the search box.</li>
+        <li>Click and drag to create the search box over the area of the map you wish to search.</li>
       </ol>
     <h3>Interacting with the search results</h3>
     <p>Search results are displayed on the map as clusters (circular icons with numbers). The numbers represent


### PR DESCRIPTION
Users have requested that the geographic search interface be changed so that the search box can be drawn with a simple "click-drag" rather than "click-release-drag-click". 

I've updated the functionality so that a user only has to select the "Draw Search Box" button and then click-drag on the map to draw the box and initiate the search query. I've also updated the corresponding help text in the "Need Help?" lightbox.  