### PR TITLE
Fix character set used to connect to Voyager.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -172,7 +172,7 @@ class Voyager extends AbstractBase
                    ')';
             try {
                 $this->lazyDb = new Oci8(
-                    "oci:dbname=$tns;charset=US_ASCII",
+                    "oci:dbname=$tns;charset=US7ASCII",
                     $this->config['Catalog']['user'],
                     $this->config['Catalog']['password']
                 );


### PR DESCRIPTION
US_ASCII was actually invalid (noticed because of a warning in when running in debugger) and I believe the system defaulted to US7ASCII. Double-checked to make sure this doesn't break umlauts or such, so I believe this change should be safe.

Note: While it would be tempting to specify a UTF-8 charset, that would break fetching unicode data such as MARC records from the Voyager database since they're wrongly defined to be US ASCII in Oracle.