### PR TITLE
Option to trust the VuFind authentication source over the Koha Driver (supports SAML/Shibboleth)

### DIFF
--- a/config/vufind/Koha.ini
+++ b/config/vufind/Koha.ini
@@ -6,6 +6,11 @@ password    = mysqlpassword
 database    = koha
 url         = http://library.myuniversity.edu
 
+; If we trust our authentication source and know it to be the same as the one used by
+; koha then we can choose to not validate our patron's passwords (Useful if you are
+; using SAML/Shibboleth for authentication for both VuFind and Koha)
+dontValidatePasswords = false
+
 ; This section translates Koha's internal location codes into strings for on-screen
 ; display.  You can customize the text to your liking.
 [Location_Codes]

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -98,11 +98,12 @@ class Koha extends AbstractBase
         // version (3.02)
         $this->locCodes = $this->config['Location_Codes'];
 
-        // If we are using SAML/Shibboleth for authentication for both ourselves and Koha then we
-        // can't validate the patrons passwords against Koha as they won't have one. (Double negative
-        // logic used so that if the config option isn't present in Koha.ini then ILS passwords will 
-        // be validated)
-        $this->validatePasswords = empty($this->config['Catalog']['dontValidatePasswords']);
+        // If we are using SAML/Shibboleth for authentication for both ourselves
+        // and Koha then we can't validate the patrons passwords against Koha as
+        // they won't have one. (Double negative logic used so that if the config
+        // option isn't present in Koha.ini then ILS passwords will be validated)
+        $this->validatePasswords
+            = empty($this->config['Catalog']['dontValidatePasswords']);
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -97,6 +97,12 @@ class Koha extends AbstractBase
         // Location codes are defined in 'Koha.ini' file according to current
         // version (3.02)
         $this->locCodes = $this->config['Location_Codes'];
+
+        // If we are using SAML/Shibboleth for authentication for both ourselves and Koha then we
+        // can't validate the patrons passwords against Koha as they won't have one. (Double negative
+        // logic used so that if the config option isn't present in Koha.ini then ILS passwords will 
+        // be validated)
+        $this->validatePasswords = empty($this->config['Catalog']['dontValidatePasswords']);
     }
 
     /**
@@ -510,11 +516,19 @@ class Koha extends AbstractBase
 
         $sql = "select borrowernumber as ID, firstname as FNAME, " .
             "surname as LNAME, email as EMAIL from borrowers " .
-            "where userid = :username and password = :db_pwd";
+            "where userid = :username";
         
+        $parameters = [':username' => $username];
+
+        if ($this->validatePasswords) {
+            $sql .= " and password = :db_pwd";
+            $parameters[':db_pwd'] = $db_pwd;
+        }
+
         try {
             $sqlStmt = $this->db->prepare($sql);
-            $sqlStmt->execute([':username' => $username, ':db_pwd' => $db_pwd]);
+            $sqlStmt->execute($parameters);
+
             $row = $sqlStmt->fetch();
             if ($row) {
                 // NOTE: Here, 'cat_password' => $password is used, password is


### PR DESCRIPTION
When using SAML/Shibboleth as the authentication method for both VuFind and the Koha ILS the patron may not actually have a password in the Koha database to authenticate the user against to validate Patron Account actions (e.g. view their checked out items).

This branch adds a `dontValidatePasswords` configuration option to the Koha.php ILS Driver which, when set, stops the driver from validating the user's password against the Koha database.