### PR TITLE
Koha get account blocks

### DIFF
--- a/config/vufind/Koha.ini
+++ b/config/vufind/Koha.ini
@@ -25,3 +25,18 @@ PROC        = "Processing Center"
 REF         = "Reference Shelf"
 STAFF       = "Staff Office"
 
+; This section translates Koha's internal block types into strings for on-screen
+; display.
+[Blocks]
+;SUSPENSION = "Account Suspended"
+;OVERDUES = "Account Blocked (Overdue Items)"
+;MANUAL = "Account Blocked"
+;DISCHARGE = "Account Discharge"
+
+; This section lets you choose whether to display block comments based upon the
+; blocks type
+[Show_Block_Comments]
+;SUSPENSION = false
+;OVERDUES = false
+;MANUAL = false
+;DISCHARGE = false

--- a/config/vufind/Koha.ini
+++ b/config/vufind/Koha.ini
@@ -34,7 +34,8 @@ STAFF       = "Staff Office"
 ;DISCHARGE = "Account Blocked for Discharge"
 
 ; This section lets you choose whether to display block comments based upon the
-; blocks type
+; blocks type (defaults to false, meaning that the name of the block type will
+; be displayed, but not any additional comment information from the database).
 [Show_Block_Comments]
 ;SUSPENSION = false
 ;OVERDUES = false

--- a/config/vufind/Koha.ini
+++ b/config/vufind/Koha.ini
@@ -31,7 +31,7 @@ STAFF       = "Staff Office"
 ;SUSPENSION = "Account Suspended"
 ;OVERDUES = "Account Blocked (Overdue Items)"
 ;MANUAL = "Account Blocked"
-;DISCHARGE = "Account Discharge"
+;DISCHARGE = "Account Blocked for Discharge"
 
 ; This section lets you choose whether to display block comments based upon the
 ; blocks type

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -104,6 +104,31 @@ class Koha extends AbstractBase
         // option isn't present in Koha.ini then ILS passwords will be validated)
         $this->validatePasswords
             = empty($this->config['Catalog']['dontValidatePasswords']);
+
+
+        // Set our default terms for block types
+        $this->blockTerms = array(
+            'SUSPENSION' => 'Account Suspended',
+            'OVERDUES' => 'Account Blocked (Overdue Items)',
+            'MANUAL' => 'Account Blocked',
+            'DISCHARGE' => 'Account Discharge',
+        );
+
+        // Now override the default with any defined in the `Koha.ini` config file
+        foreach (array('SUSPENSION','OVERDUES','MANUAL','DISCHARGE') as $blockType) {
+            if (!empty($this->config['Blocks'][$blockType])) {
+                $this->blockTerms[$blockType] = $this->config['Blocks'][$blockType];
+            }
+        }
+
+        // Allow the users to set if an account block's comments should be included by
+        // setting the block type to true or flase () in the `Koha.ini` config file
+        // (defaults to false if not present)
+        $this->showBlockComments = array();
+
+        foreach (array('SUSPENSION','OVERDUES','MANUAL','DISCHARGE') as $blockType) {
+            $this->showBlockComments[$blockType] = !empty($this->config['Show_Block_Comments'][$blockType]);
+        }
     }
 
     /**
@@ -399,6 +424,52 @@ class Koha extends AbstractBase
         catch (PDOException $e) {
             throw new ILSException($e->getMessage());
         }
+    }
+
+    /**
+     * Check whether the patron has any blocks on their account.
+     *
+     * @param array $patron Patron data from patronLogin
+     *
+     * @throws ILSException
+     *
+     * @return mixed A boolean false if no blocks are in place and an array
+     * of block reasons if blocks are in place
+     *
+     */
+    public function getAccountBlocks($patron)
+    {
+        $blocks = [];
+
+        try {
+            $id = $patron['id'];
+            $sql = "select type as TYPE, comment as COMMENT " .
+                "from borrower_debarments " .
+                "where (expiration is null or expiration >= NOW()) " .
+                "and borrowernumber = :id";
+            $sqlStmt = $this->db->prepare($sql);
+            $sqlStmt->execute([':id' => $id]);
+
+            foreach ($sqlStmt->fetchAll() as $row) {
+                $block = [$this->blockTerms[$row['TYPE']]
+                    ? $this->blockTerms[$row['TYPE']]
+                    : $row['TYPE']];
+
+                if (!empty($this->showBlockComments[$row['TYPE']])
+                    && !empty($row['COMMENT'])) {
+
+                    $block[] = $row['COMMENT'];
+                }
+
+                $blocks[] = implode(' - ', $block);
+            }
+        }
+        catch (PDOException $e) {
+            throw new ILSException($e->getMessage());
+        }
+        
+
+        return count($blocks) ? $blocks : false;
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -451,7 +451,7 @@ class Koha extends AbstractBase
 
             foreach ($sqlStmt->fetchAll() as $row) {
                 $block = empty($this->blockTerms[$row['TYPE']])
-                    ? [$row['TYPE']]]
+                    ? [$row['TYPE']]
                     : [$this->blockTerms[$row['TYPE']]];
 
                 if (!empty($this->showBlockComments[$row['TYPE']])

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -121,7 +121,7 @@ class Koha extends AbstractBase
         }
 
         // Allow the users to set if an account block's comments should be included
-        // by setting the block type to true or flase () in the `Koha.ini` config
+        // by setting the block type to true or false () in the `Koha.ini` config
         // file (defaults to false if not present)
         $this->showBlockComments = [];
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -105,17 +105,16 @@ class Koha extends AbstractBase
         $this->validatePasswords
             = empty($this->config['Catalog']['dontValidatePasswords']);
 
-
         // Set our default terms for block types
-        $this->blockTerms = array(
+        $this->blockTerms = [
             'SUSPENSION' => 'Account Suspended',
             'OVERDUES' => 'Account Blocked (Overdue Items)',
             'MANUAL' => 'Account Blocked',
             'DISCHARGE' => 'Account Blocked for Discharge',
-        );
+        ];
 
         // Now override the default with any defined in the `Koha.ini` config file
-        foreach (array('SUSPENSION','OVERDUES','MANUAL','DISCHARGE') as $blockType) {
+        foreach (['SUSPENSION','OVERDUES','MANUAL','DISCHARGE'] as $blockType) {
             if (!empty($this->config['Blocks'][$blockType])) {
                 $this->blockTerms[$blockType] = $this->config['Blocks'][$blockType];
             }
@@ -124,9 +123,9 @@ class Koha extends AbstractBase
         // Allow the users to set if an account block's comments should be included
         // by setting the block type to true or flase () in the `Koha.ini` config
         // file (defaults to false if not present)
-        $this->showBlockComments = array();
+        $this->showBlockComments = [];
 
-        foreach (array('SUSPENSION','OVERDUES','MANUAL','DISCHARGE') as $blockType) {
+        foreach (['SUSPENSION','OVERDUES','MANUAL','DISCHARGE'] as $blockType) {
             $this->showBlockComments[$blockType]
                 = !empty($this->config['Show_Block_Comments'][$blockType]);
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -111,7 +111,7 @@ class Koha extends AbstractBase
             'SUSPENSION' => 'Account Suspended',
             'OVERDUES' => 'Account Blocked (Overdue Items)',
             'MANUAL' => 'Account Blocked',
-            'DISCHARGE' => 'Account Discharge',
+            'DISCHARGE' => 'Account Blocked for Discharge',
         );
 
         // Now override the default with any defined in the `Koha.ini` config file

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -450,14 +450,13 @@ class Koha extends AbstractBase
             $sqlStmt->execute([':id' => $id]);
 
             foreach ($sqlStmt->fetchAll() as $row) {
-                $block = [$this->blockTerms[$row['TYPE']]
-                    ? $this->blockTerms[$row['TYPE']]
-                    : $row['TYPE']];
+                $block = empty($this->blockTerms[$row['TYPE']])
+                    ? [$row['TYPE']]]
+                    : [$this->blockTerms[$row['TYPE']]];
 
                 if (!empty($this->showBlockComments[$row['TYPE']])
                     && !empty($row['COMMENT'])
                 ) {
-
                     $block[] = $row['COMMENT'];
                 }
 
@@ -467,7 +466,6 @@ class Koha extends AbstractBase
         catch (PDOException $e) {
             throw new ILSException($e->getMessage());
         }
-        
 
         return count($blocks) ? $blocks : false;
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -121,13 +121,14 @@ class Koha extends AbstractBase
             }
         }
 
-        // Allow the users to set if an account block's comments should be included by
-        // setting the block type to true or flase () in the `Koha.ini` config file
-        // (defaults to false if not present)
+        // Allow the users to set if an account block's comments should be included
+        // by setting the block type to true or flase () in the `Koha.ini` config
+        // file (defaults to false if not present)
         $this->showBlockComments = array();
 
         foreach (array('SUSPENSION','OVERDUES','MANUAL','DISCHARGE') as $blockType) {
-            $this->showBlockComments[$blockType] = !empty($this->config['Show_Block_Comments'][$blockType]);
+            $this->showBlockComments[$blockType]
+                = !empty($this->config['Show_Block_Comments'][$blockType]);
         }
     }
 
@@ -435,7 +436,6 @@ class Koha extends AbstractBase
      *
      * @return mixed A boolean false if no blocks are in place and an array
      * of block reasons if blocks are in place
-     *
      */
     public function getAccountBlocks($patron)
     {
@@ -456,7 +456,8 @@ class Koha extends AbstractBase
                     : $row['TYPE']];
 
                 if (!empty($this->showBlockComments[$row['TYPE']])
-                    && !empty($row['COMMENT'])) {
+                    && !empty($row['COMMENT'])
+                ) {
 
                     $block[] = $row['COMMENT'];
                 }


### PR DESCRIPTION
This pull request adds getAccountBlocks functionality to the Koha.php ILS Driver.

Two new sections are added to the Koha.ini config file to support this:

* Blocks - Sets the text used for each of the four Koha account block types (SUSPENSION, OVERDUES, MANUAL and DISCHARGE).

* Show_Block_Comment - Sets whether, for each Koha account block type, the related comment will be included in the text shown to the user.
