### PR TITLE
GeoIndexing - Fix EW Validation Indexing bug

### DIFF
--- a/import/index_java/src/org/vufind/index/GeoTools.java
+++ b/import/index_java/src/org/vufind/index/GeoTools.java
@@ -359,7 +359,7 @@ public class GeoTools
    public boolean validateEastWest(Record record, Double east, Double west) {
     if (east < west) {
        // Convert to 360 degree grid
-       if (east < 0) {
+       if (east <= 0) {
            east = 360 + east;
        }
        if (west < 0) {


### PR DESCRIPTION
This fixes the validateEastWest routine so it will allow coordinates with this scenario to be indexed: `E<W and E=0 and W>0`. Previously this routine considered this scenario as invalid (which it shouldn't have). 
