### PR TITLE
Fix login using MultiBackend when username contain dot

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -422,6 +422,8 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
             $source = $this->getDefaultLoginDriver();
         }
         $driver = $this->getDriver($source);
+        // Loading might fail if the username contains a dot but not a source
+        // prefix; try again with the default driver if necessary.
         if (!$driver) {
             $source = $this->getDefaultLoginDriver();
             $driver = $this->getDriver($source);

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -422,6 +422,10 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
             $source = $this->getDefaultLoginDriver();
         }
         $driver = $this->getDriver($source);
+        if (!$driver) {
+            $source = $this->getDefaultLoginDriver();
+            $driver = $this->getDriver($source);
+        }
         if ($driver) {
             $patron = $driver->patronLogin(
                 $this->getLocalId($username), $password


### PR DESCRIPTION
If the login is without driver prefix (so default driver should be used) and username contain dot (for example  e-mail address is used as a username). Then the login process fail due to "technical reasons".