### PR TITLE
Run eslint before slower tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
     - $HOME/.composer/cache
 
 script:
-  - vendor/bin/phing phpunitfast phpcs-console php-cs-fixer-dryrun eslint
+  - vendor/bin/phing eslint phpunitfast phpcs-console php-cs-fixer-dryrun


### PR DESCRIPTION
This allows any JS problems to be detected early before running other slower checks.