### PR TITLE
Only cache composer's cache/files to avoid caching of regularly changing files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 cache:
   directories:
     - downloads
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 script:
   - vendor/bin/phing phpunitfast phpcs-console php-cs-fixer-dryrun eslint


### PR DESCRIPTION
It is recommended (see e.g. https://github.com/travis-ci/travis-ci/issues/4579) to only cache $HOME/.composer/cache/files since at least the repo directory there may change regularly forcing the cache to be constantly updated. 