### PR TITLE
Added `search-query-time` span around query time field in results

### DIFF
--- a/themes/bootstrap3/templates/search/controls/showing.phtml
+++ b/themes/bootstrap3/templates/search/controls/showing.phtml
@@ -22,7 +22,7 @@
 <? endif; ?>
 <? $this->layout()->srmessage = $showingResults; ?>
 <? if ($qtime = $this->results->getQuerySpeed()): ?>
-  <?=$showingResults; ?>, <?=$this->transEsc('query time')?>: <?=$this->localizedNumber($qtime, 2).$this->transEsc('seconds_abbrev')?>
+  <?=$showingResults; ?><span class="search-query-time">, <?=$this->transEsc('query time')?>: <?=$this->localizedNumber($qtime, 2).$this->transEsc('seconds_abbrev')?></span>
 <? else: ?>
   <?=$showingResults; ?>
 <? endif; ?>


### PR DESCRIPTION
A small change to add a span with a class of `search-query-time` around the query time field shown at the top of the results list.  This is so that the field can be targeted in CSS so that it can be hidden or shown depending on the theme in use.