### PR TITLE
Refactor initializers to prepare for ServiceManager v3.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -249,7 +249,7 @@ $config = [
             'VuFind\Session\Settings' => 'VuFind\Session\Settings',
         ],
         'initializers' => [
-            'VuFind\ServiceManager\Initializer::initInstance',
+            'VuFind\ServiceManager\ServiceInitializer',
         ],
         'aliases' => [
             'mvctranslator' => 'VuFind\Translator',
@@ -259,7 +259,7 @@ $config = [
     'translator' => [],
     'view_helpers' => [
         'initializers' => [
-            'VuFind\ServiceManager\Initializer::initZendPlugin',
+            'VuFind\ServiceManager\ZendPluginInitializer',
         ],
     ],
     'view_manager' => [

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -83,9 +83,8 @@ class CoverController extends AbstractBase
                 $this->serviceLocator->get('VuFind\Http')->createClient(),
                 $cacheDir
             );
-            \VuFind\ServiceManager\Initializer::initInstance(
-                $this->loader, $this->serviceLocator
-            );
+            $initializer = new \VuFind\ServiceManager\ServiceInitializer();
+            $initializer->initialize($this->loader, $this->serviceLocator);
         }
         return $this->loader;
     }

--- a/module/VuFind/src/VuFind/Controller/QRCodeController.php
+++ b/module/VuFind/src/VuFind/Controller/QRCodeController.php
@@ -62,9 +62,8 @@ class QRCodeController extends AbstractBase
                 $this->getConfig(),
                 $this->serviceLocator->get('VuFindTheme\ThemeInfo')
             );
-            \VuFind\ServiceManager\Initializer::initInstance(
-                $this->loader, $this->serviceLocator
-            );
+            $initializer = new \VuFind\ServiceManager\ServiceInitializer();
+            $initializer->initialize($this->loader, $this->serviceLocator);
         }
         return $this->loader;
     }

--- a/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManager.php
+++ b/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManager.php
@@ -57,7 +57,7 @@ abstract class AbstractPluginManager extends Base
     ) {
         parent::__construct($configOrContainerInstance, $v3config);
         $this->addInitializer(
-            ['VuFind\ServiceManager\Initializer', 'initPlugin'], false
+            'VuFind\ServiceManager\VuFindPluginInitializer', false
         );
     }
 

--- a/module/VuFind/src/VuFind/ServiceManager/VuFindPluginInitializer.php
+++ b/module/VuFind/src/VuFind/ServiceManager/VuFindPluginInitializer.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * VuFind Plugin Initializer
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\ServiceManager;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * VuFind Plugin Initializer
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class VuFindPluginInitializer extends ZendPluginInitializer
+{
+    /**
+     * Given an instance and a Plugin Manager, initialize the instance.
+     *
+     * @param object                  $instance Instance to initialize
+     * @param ServiceLocatorInterface $manager  Plugin manager
+     *
+     * @return object
+     */
+    public function initialize($instance, ServiceLocatorInterface $manager)
+    {
+        if (method_exists($instance, 'setPluginManager')) {
+            $instance->setPluginManager($manager);
+        }
+        return parent::initialize($instance, $manager);
+    }
+}

--- a/module/VuFind/src/VuFind/ServiceManager/ZendPluginInitializer.php
+++ b/module/VuFind/src/VuFind/ServiceManager/ZendPluginInitializer.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework Plugin Initializer
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\ServiceManager;
+
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Zend Framework Plugin Initializer
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class ZendPluginInitializer extends ServiceInitializer
+{
+    /**
+     * Given an instance and a Plugin Manager, initialize the instance.
+     *
+     * @param object                  $instance Instance to initialize
+     * @param ServiceLocatorInterface $manager  Plugin manager
+     *
+     * @return object
+     */
+    public function initialize($instance, ServiceLocatorInterface $manager)
+    {
+        $sm = $manager->getServiceLocator();
+        return (null !== $sm)
+            ? parent::initialize($instance, $sm) : $instance;
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
@@ -80,9 +80,8 @@ class ShibbolethTest extends \VuFindTest\Unit\DbTestCase
             $config = $this->getAuthConfig();
         }
         $obj = new Shibboleth($this->createMock('Zend\Session\ManagerInterface'));
-        \VuFind\ServiceManager\Initializer::initInstance(
-            $obj, $this->getServiceManager()
-        );
+        $initializer = new \VuFind\ServiceManager\ServiceInitializer();
+        $initializer->initialize($obj, $this->getServiceManager());
         $obj->setConfig($config);
         return $obj;
     }


### PR DESCRIPTION
Version 3 of the Zend Framework ServiceManager doesn't play nicely with legacy static initializer methods; this PR refactors the code to Initializer classes, which will make eventual migration slightly easier.