### PR TITLE
Add BackendRegistry to eliminate use of scoped service manager.

### DIFF
--- a/module/VuFind/src/VuFind/Search/BackendRegistry.php
+++ b/module/VuFind/src/VuFind/Search/BackendRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Registry for search backends.
+ *
+ * PHP version 5
+ *
+ * Copyright (C) Villanova University 2017.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\Search;
+
+/**
+ * Registry for search backends.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class BackendRegistry extends \VuFind\ServiceManager\AbstractPluginManager
+{
+    /**
+     * Return the name of the base class or interface that plug-ins must conform
+     * to.
+     *
+     * @return string
+     */
+    protected function getExpectedInterface()
+    {
+        return 'VuFindSearch\Backend\BackendInterface';
+    }
+}

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -135,7 +135,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $this->config         = $this->serviceLocator->get('VuFind\Config');
         if ($this->serviceLocator->has('VuFind\Logger')) {
             $this->logger = $this->serviceLocator->get('VuFind\Logger');

--- a/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
@@ -77,7 +77,7 @@ class BrowZineBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $configReader = $this->serviceLocator->get('VuFind\Config');
         $this->browzineConfig = $configReader->get('BrowZine');
         if ($this->serviceLocator->has('VuFind\Logger')) {

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -79,7 +79,7 @@ class EITBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $this->config = $this->serviceLocator->get('VuFind\Config')->get('EIT');
         if ($this->serviceLocator->has('VuFind\Logger')) {
             $this->logger = $this->serviceLocator->get('VuFind\Logger');

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -85,7 +85,7 @@ class EdsBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $this->edsConfig = $this->serviceLocator->get('VuFind\Config')->get('EDS');
         if ($this->serviceLocator->has('VuFind\Logger')) {
             $this->logger = $this->serviceLocator->get('VuFind\Logger');

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
@@ -78,7 +78,7 @@ class LibGuidesBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $configReader = $this->serviceLocator->get('VuFind\Config');
         $this->libGuidesConfig = $configReader->get('LibGuides');
         if ($this->serviceLocator->has('VuFind\Logger')) {

--- a/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
@@ -78,7 +78,7 @@ class Pazpar2BackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $this->config = $this->serviceLocator->get('VuFind\Config')->get('Pazpar2');
         if ($this->serviceLocator->has('VuFind\Logger')) {
             $this->logger = $this->serviceLocator->get('VuFind\Logger');

--- a/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
@@ -81,7 +81,7 @@ class PrimoBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $configReader = $this->serviceLocator->get('VuFind\Config');
         $this->primoConfig = $configReader->get('Primo');
         if ($this->serviceLocator->has('VuFind\Logger')) {

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -86,7 +86,7 @@ class SummonBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $configReader = $this->serviceLocator->get('VuFind\Config');
         $this->config = $configReader->get('config');
         $this->summonConfig = $configReader->get('Summon');

--- a/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
@@ -85,7 +85,7 @@ class WorldCatBackendFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $this->serviceLocator = $serviceLocator;
+        $this->serviceLocator = $serviceLocator->getServiceLocator();
         $this->config = $this->serviceLocator->get('VuFind\Config')->get('config');
         $this->wcConfig = $this->serviceLocator
             ->get('VuFind\Config')->get('WorldCat');

--- a/module/VuFind/src/VuFind/Service/Factory.php
+++ b/module/VuFind/src/VuFind/Service/Factory.php
@@ -736,11 +736,9 @@ class Factory
     public static function getSearchBackendManager(ServiceManager $sm)
     {
         $config = $sm->get('config');
-        $smConfig = new \Zend\ServiceManager\Config(
-            $config['vufind']['plugin_managers']['search_backend']
+        $registry = new \VuFind\Search\BackendRegistry(
+            $sm, $config['vufind']['plugin_managers']['search_backend']
         );
-        $registry = $sm->createScopedServiceManager();
-        $smConfig->configureServiceManager($registry);
         $manager = new \VuFind\Search\BackendManager($registry);
 
         return $manager;

--- a/module/VuFind/src/VuFindTest/Unit/TestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/TestCase.php
@@ -112,16 +112,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function setupSearchService()
     {
-        $smConfig = new \Zend\ServiceManager\Config(
-            [
-                'factories' => [
-                    'Solr' => 'VuFind\Search\Factory\SolrDefaultBackendFactory',
-                    'SolrAuth' => 'VuFind\Search\Factory\SolrAuthBackendFactory',
-                ]
+        $config = [
+            'factories' => [
+                'Solr' => 'VuFind\Search\Factory\SolrDefaultBackendFactory',
+                'SolrAuth' => 'VuFind\Search\Factory\SolrAuthBackendFactory',
             ]
+        ];
+        $registry = new \VuFind\Search\BackendRegistry(
+            $this->serviceManager, $config
         );
-        $registry = $this->serviceManager->createScopedServiceManager();
-        $smConfig->configureServiceManager($registry);
         $bm = new \VuFind\Search\BackendManager($registry);
         $this->serviceManager->setService('VuFind\Search\BackendManager', $bm);
         $ss = new \VuFindSearch\Service();


### PR DESCRIPTION
Scoped service managers no longer exist in ServiceManager v3; this is a more future-proof approach to creating a backend registry. (Work to support #1067).

TODO:
- [x] Run full integration test suite