### PR TITLE
deal with unsigned lat_long values in 304 fields

### DIFF
--- a/import/index_java/src/org/vufind/index/GeoTools.java
+++ b/import/index_java/src/org/vufind/index/GeoTools.java
@@ -45,7 +45,7 @@ public class GeoTools
 {
     private static final Pattern COORDINATES_PATTERN = Pattern.compile("^([eEwWnNsS])(\\d{3})(\\d{2})(\\d{2})");
     private static final Pattern HDMSHDD_PATTERN = Pattern.compile("^([eEwWnNsS])(\\d+(\\.\\d+)?)");
-    private static final Pattern PMDD_PATTERN = Pattern.compile("^([+-])(\\d+(\\.\\d+)?)");
+    private static final Pattern PMDD_PATTERN = Pattern.compile("^([-+]?\\d+(\\.\\d+)?)");
 
     // Initialize logging category
     static Logger logger = Logger.getLogger(GeoTools.class.getName());
@@ -208,11 +208,7 @@ public class GeoTools
             }
             return coordinate;
         } else if (PMDmatcher.matches()) {
-            String hemisphere = PMDmatcher.group(1);
-            coordinate = Double.parseDouble(PMDmatcher.group(2));
-            if (hemisphere.equals("-")) {
-                coordinate *= -1;
-            }
+	    	coordinate = Double.parseDouble(PMDmatcher.group(1));
             return coordinate;
         } else {
             logger.error("Decimal Degree Coordinate Conversion Error:  Poorly formed coordinate: [" + coordinateStr + "] ... Returning null value ... ");


### PR DESCRIPTION
PR to allow indexing of both signed and unsigned lat_long values in the 304 field. 
e.g.
`=034  0\$aa$d+32.658611$e+32.658611$f25.718611$g25.718611`