### PR TITLE
Use configured username field when updating password.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -202,7 +202,8 @@ class ILS extends AbstractBase
         }
 
         // Update the user and send it back to the caller:
-        $user = $this->getUserTable()->getByUsername($patron['cat_username']);
+        $username = $patron[$this->getUsernameField()];
+        $user = $this->getUserTable()->getByUsername($username);
         $user->saveCredentials($patron['cat_username'], $params['password']);
         return $user;
     }
@@ -219,9 +220,7 @@ class ILS extends AbstractBase
     {
         // Figure out which field of the response to use as an identifier; fail
         // if the expected field is missing or empty:
-        $config = $this->getConfig();
-        $usernameField = isset($config->Authentication->ILS_username_field)
-            ? $config->Authentication->ILS_username_field : 'cat_username';
+        $usernameField = $this->getUsernameField();
         if (!isset($info[$usernameField]) || empty($info[$usernameField])) {
             throw new AuthException('authentication_error_technical');
         }
@@ -288,5 +287,17 @@ class ILS extends AbstractBase
     {
         $patron = $this->authenticator->storedCatalogLogin();
         return $patron ? $patron : null;
+    }
+
+    /**
+     * Gets the configured username field.
+     *
+     * @return string
+     */
+    protected function getUsernameField()
+    {
+        $config = $this->getConfig();
+        return isset($config->Authentication->ILS_username_field)
+            ? $config->Authentication->ILS_username_field : 'cat_username';
     }
 }


### PR DESCRIPTION
The configured value for `ILS_username_field` should also be used when updating a users password.

Currently an additional user is created when updating the password in case `ILS_username_field` is different from `cat_username`.