### PR TITLE
Make empty search relevance override more robust so that it works whe…

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -548,9 +548,12 @@ class Params extends \VuFind\Search\Base\Params
         // Sort
         $sort = $this->getSort();
         if ($sort) {
-            // If we have an empty search with relevance sort, see if there is
-            // an override configured:
-            if ($sort == 'relevance' && $this->getQuery()->getAllTerms() == ''
+            // If we have an empty search with relevance sort as the primary sort
+            // field, see if there is an override configured:
+            $sortFields = explode(',', $sort);
+            $allTerms = trim($this->getQuery()->getAllTerms());
+            if ('relevance' === $sortFields[0]
+                && ('' === $allTerms || '*:*' === $allTerms)
                 && ($relOv = $this->getOptions()->getEmptySearchRelevanceOverride())
             ) {
                 $sort = $relOv;


### PR DESCRIPTION
…n there are additional fields in the selected sort or *:* is specified as the search term.