### PR TITLE
Changed date display in the KohaILSDI ILS Driver to use the standard Date Converter to format dates

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1162,12 +1162,12 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
 
                 $transactionLst[] = [
                     'amount'     => $row['amount'],
-                    'checkout'   => $this->displayDateTime( $row['issuedate'] ),
+                    'checkout'   => $this->displayDateTime($row['issuedate']),
                     'title'      => $row['title'],
                     'fine'       => $fineValue,
                     'balance'    => $row['balance'],
                     'createdate' => $row['createdat'],
-                    'duedate'    => $this->displayDate( $row['duedate'] ),
+                    'duedate'    => $this->displayDate($row['duedate']),
                     'id'         => isset($row['id']) ? $row['id'] : -1,
                 ];
             }
@@ -1525,7 +1525,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
 
             $transactionLst[] = [
                 'duedate'   => $this->displayDate(
-                        $this->getField($loan->{'date_due'})
+                    $this->getField($loan->{'date_due'})
                 ),
                 'id'        => $this->getField($loan->{'biblionumber'}),
                 'item_id'   => $this->getField($loan->{'itemnumber'}),

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1243,9 +1243,11 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             $holdLst[] = [
                 'id'       => $this->getField($hold->{'biblionumber'}),
                 'location' => $this->getField($hold->{'branchname'}),
-                'expire'   => $this->displayDate(
-                    $this->getField($hold->{'expirationdate'})
-                ),
+                'expire'   => isset($hold->{'expirationdate'})
+                    ? $this->displayDate(
+                        $this->getField($hold->{'expirationdate'})
+                    )
+                    : "N/A",
                 'create'   => $this->displayDate(
                     $this->getField($hold->{'reservedate'})
                 ),

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1200,8 +1200,6 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         $this->debug("ID: " . $rsp->{'borrowernumber'});
         $this->debug("Chrgs: " . $rsp->{'charges'});
 
-        $this->debug($rsp->{'fines'});
-
         foreach ($rsp->{'fines'}->{'fine'} as $fine) {
             $fineLst[] = [
                 'amount'     => 100 * $this->getField($fine->{'amount'}),

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1963,6 +1963,12 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 $this->dateConverter->convertToDisplayDateAndTime(
                     'Y-m-d H:i:s', $date
                 );
+        } elseif (preg_match("/^\d{4}-\d\d-\d\d \d\d:\d\d$/", $date) === 1) {
+            // YYYY-MM-DD HH:MM
+            return
+                $this->dateConverter->convertToDisplayDateAndTime(
+                    'Y-m-d H:i', $date
+                );
         } else {
             error_log("Unexpected date format: $date");
             return $date;

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1166,7 +1166,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                     'title'      => $row['title'],
                     'fine'       => $fineValue,
                     'balance'    => $row['balance'],
-                    'createdate' => $row['createdat'],
+                    'createdate' => $this->displayDate($row['createdat']),
                     'duedate'    => $this->displayDate($row['duedate']),
                     'id'         => isset($row['id']) ? $row['id'] : -1,
                 ];
@@ -1584,7 +1584,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                     = explode(" ", $this->getField($rsp->{'date_due'}));
                 $retVal['details'][$renewItem] = [
                     "success"  => true,
-                    "new_date" => $date,
+                    "new_date" => $this->displayDate($date),
                     "new_time" => $time,
                     "item_id"  => $renewItem,
                 ];


### PR DESCRIPTION
A number of places that dates are rendered for display in the KohaILSDI ILS Driver were hard coded to the "m/d/Y" format.  So I've switched these over to use the standard Date Converter to match the reset of VuFind.