### PR TITLE
replace-table-summaries-w-captions

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
@@ -44,7 +44,8 @@
       $fields = $formatter->getData($driver, $formatter->getDefaults('collection-info'));
     ?>
     <? if (!empty($fields)): ?>
-      <table id="collectionInfo" class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
+      <table id="collectionInfo" class="table table-striped">
+        <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>
         <? foreach ($fields as $key => $current): ?>
           <tr><th><?=$this->transEsc($key)?>:</th><td><?=$current['value']?></td></tr>
         <? endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-record.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-record.phtml
@@ -6,7 +6,8 @@
   $fields = $formatter->getData($driver, $formatter->getDefaults('collection-record'));
 ?>
 <? if (!empty($fields)): ?>
-  <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
+  <table class="table table-striped">
+    <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>
     <? foreach ($fields as $key => $current): ?>
       <tr><th><?=$this->transEsc($key)?>:</th><td><?=$current['value']?></td></tr>
     <? endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
@@ -56,7 +56,8 @@
       $coreFields = $formatter->getData($driver, $formatter->getDefaults('core'));
     ?>
     <? if (!empty($coreFields)): ?>
-      <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
+      <table class="table table-striped">
+        <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>
         <? foreach ($coreFields as $key => $current): ?>
           <tr><th><?=$this->transEsc($key)?>:</th><td><?=$current['value']?></td></tr>
         <? endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -48,7 +48,8 @@
   <div class="media-body info-col">
     <h3 property="name"><?=$this->driver->getTitle()?></h3>
 
-    <table class="table table-striped" summary="<?=$this->transEsc('Bibliographic Details')?>">
+    <table class="table table-striped">
+      <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>
       <? foreach ($items as $key => $item): ?>
         <? if (!empty($item['Data'])): ?>
         <tr>

--- a/themes/bootstrap3/templates/RecordTab/description.phtml
+++ b/themes/bootstrap3/templates/RecordTab/description.phtml
@@ -5,7 +5,8 @@
     $formatter = $this->recordDataFormatter();
     $mainFields = $formatter->getData($driver, $formatter->getDefaults('description'));
 ?>
-<table class="table table-striped" summary="<?=$this->transEsc('Description')?>">
+<table class="table table-striped">
+  <caption class="sr-only"><?=$this->transEsc('Description')?></caption>
   <? if (!empty($mainFields)): ?>
     <? foreach ($mainFields as $key => $current): ?>
       <tr><th><?=$this->transEsc($key)?>:</th><td><?=$current['value']?></td></tr>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -60,7 +60,8 @@
     <?=$locationText?>
   <? endif; ?>
 </h3>
-<table class="table table-striped" summary="<?=$this->transEsc('holdings_details_from', ['%%location%%' => $this->transEsc($holding['location'])]) ?>">
+<table class="table table-striped">
+  <caption class="sr-only"><?=$this->transEsc('holdings_details_from', ['%%location%%' => $this->transEsc($holding['location'])]) ?></caption>
   <? $callNos = $this->tab->getUniqueCallNumbers($holding['items']); if (!empty($callNos)): ?>
   <tr>
     <th><?=$this->transEsc("Call Number")?>: </th>

--- a/themes/bootstrap3/templates/librarycards/home.phtml
+++ b/themes/bootstrap3/templates/librarycards/home.phtml
@@ -13,7 +13,8 @@
   <? if ($this->libraryCards->count() == 0): ?>
     <div><?=$this->transEsc('You do not have any library cards')?></div>
   <? else: ?>
-    <table class="table table-striped" summary="<?=$this->transEsc('Library Cards')?>">
+    <table class="table table-striped">
+      <caption class="sr-only"><?=$this->transEsc('Library Cards')?></caption>
     <tr>
       <th><?=$this->transEsc('Library Card Name')?></th>
       <? if ($this->multipleTargets): ?>

--- a/themes/bootstrap3/templates/myresearch/fines.phtml
+++ b/themes/bootstrap3/templates/myresearch/fines.phtml
@@ -14,7 +14,8 @@
   <? if (empty($this->fines)): ?>
     <?=$this->transEsc('You do not have any fines')?>
   <? else: ?>
-    <table class="table table-striped" summary="<?=$this->transEsc('Your Fines')?>">
+    <table class="table table-striped">
+      <caption class="sr-only"><?=$this->transEsc('Your Fines')?></caption>
     <tr>
       <th><?=$this->transEsc('Title')?></th>
       <th><?=$this->transEsc('Checked Out')?></th>


### PR DESCRIPTION
* replaces table summaries with captions (sr-only) to avoid 
validation warning 'table summary not supported in html5'