### PR TITLE
Bug fix: Use COPY_NUMBER instead of ITEM_SEQUENCE_NUMBER to determine "Copy Number"

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -634,6 +634,7 @@ EOT;
             "BIB_ITEM.BIB_ID", "MFHD_ITEM.MFHD_ID",
             "ITEM_BARCODE.ITEM_BARCODE", "ITEM.ITEM_ID",
             "ITEM.ON_RESERVE", "ITEM.ITEM_SEQUENCE_NUMBER",
+            "ITEM.COPY_NUMBER",
             "ITEM.RECALLS_PLACED", "ITEM.HOLDS_PLACED",
             "ITEM_STATUS_TYPE.ITEM_STATUS_DESC as status",
             "MFHD_DATA.RECORD_SEGMENT", "MFHD_ITEM.ITEM_ENUM",
@@ -764,9 +765,11 @@ EOT;
         $data = [];
 
         foreach ($sqlRows as $row) {
-            // Determine Copy Number (always use sequence number; append volume
-            // when available)
-            $number = $row['ITEM_SEQUENCE_NUMBER'];
+            // Determine Copy Number (append volume when available)
+            $number = '';
+            if (isset($row['COPY_NUMBER'])) {
+                $number = $row['COPY_NUMBER'];
+            }
             if (isset($row['ITEM_ENUM'])) {
                 $number .= ' (' . utf8_encode($row['ITEM_ENUM']) . ')';
             }


### PR DESCRIPTION
I'm not sure why ITEM_SEQUENCE_NUMBER is being used to "determine copy number." ITEM_SEQUENCE_NUMBER should continue to be used for sorting, however.