### PR TITLE
GeoFeatures - make maptab map responsive

### DIFF
--- a/themes/bootstrap3/templates/RecordTab/map.phtml
+++ b/themes/bootstrap3/templates/RecordTab/map.phtml
@@ -11,7 +11,7 @@
     json_encode($basemap)];
   $jsParams = implode(', ', $params);
   $jsLoad = "loadMapTab(" . $jsParams . ");"; ?>
-  <div id="wrap" style="width: 674px; height: 479px">
+  <div id="wrap" style="width: inherit; height: 479px">
     <div id="map-canvas" style="width: 100%; height: 100%"><div id="popup"></div></div>
     <?=$this->inlineScript(\Zend\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET');?>
   </div>


### PR DESCRIPTION
The Map Tab's map pane width was hard-coded to be 674px which was causing display issues as users resize their browser.  Changed this setting to inherit so that the map width dynamically resizes as the browser width changes. 