### PR TITLE
Use https for RefWorks by default.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1079,7 +1079,7 @@ replace_other_urls = true
 ; These settings affect RefWorks record exports.  They rarely need to be changed.
 [RefWorks]
 vendor          = VuFind
-url             = http://www.refworks.com
+url             = https://www.refworks.com
 
 ; These settings affect EndNote Web record exports.  They rarely need to be changed.
 [EndNoteWeb]

--- a/config/vufind/export.ini
+++ b/config/vufind/export.ini
@@ -41,7 +41,7 @@
 
 [RefWorks]
 requiredMethods[] = getTitle
-redirectUrl = "{config|RefWorks|url|http://www.refworks.com}/express/expressimport.asp?vendor={encodedConfig|RefWorks|vendor|VuFind}&filter=RefWorks%20Tagged%20Format&encoding=65001"
+redirectUrl = "{config|RefWorks|url|https://www.refworks.com}/express/expressimport.asp?vendor={encodedConfig|RefWorks|vendor|VuFind}&filter=RefWorks%20Tagged%20Format&encoding=65001"
 bulkExportType = post
 postField = ImportData
 


### PR DESCRIPTION
In addition to improved security this avoids a browser warning when using the POST export from a VuFind isntance accessed via https.