### PR TITLE
Fix for missing aria-hidden toggle on modal show

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -350,6 +350,7 @@ VuFind.register('lightbox', function Lightbox() {
       if (VuFind.lightbox.refreshOnClose) {
         VuFind.refreshPage();
       }
+      this.setAttribute('aria-hidden', true);
       _emit('VuFind.lightbox.closing');
     });
     _modal.on('hidden.bs.modal', function lightboxHidden() {
@@ -359,7 +360,7 @@ VuFind.register('lightbox', function Lightbox() {
 
     VuFind.modal = function modalShortcut(cmd) {
       if (cmd === 'show') {
-        _modal.modal($.extend({ show: true }, _modalParams));
+        _modal.modal($.extend({ show: true }, _modalParams)).attr('aria-hidden', false);
       } else {
         _modal.modal(cmd);
       }


### PR DESCRIPTION
Dear Chris, dear Damian
I've spent the morning trying to find the reason why the aria-hidden="true" isn't set to either "false" or removed when the modal is shown. If I am not mistaken, the entire issue should be handled by Bootstrap and the Bootstrap Accessibility Plugin (as correctly demoed here: http://paypal.github.io/bootstrap-accessibility-plugin/demo.html). (BS4 is apparently accessible without the plugin.) 

The plugin however isn't the problem, as I had suspected -- the underyling Bootstrap version is. The Demo uses BS v3.0.0 as its basis and our VF4 uses v3.3.7. I went backwards through all BS versions and BS 3.3.4. is the last one to contain the correct functionality (see lines 995 ff + 1029ff in bootstrap.js respectively). I've hacked the two lines into our bootstrap.min.js, which may not be state of the art but works for now. 