### PR TITLE
Don't add a title for the x in facet exclude link.

### DIFF
--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -12,7 +12,7 @@ function buildFacetNodes(data, currentPath, allowExclude, excludeTitle, counts)
         var excludeURL = currentPath + this.exclude;
         excludeURL.replace("'", "\\'");
         // Just to be safe
-        html += ' <a href="' + excludeURL + '" onclick="document.location.href=\'' + excludeURL + '\'; return false;" title="' + htmlEncode(excludeTitle) + '"><i class="fa fa-times" title="' + VuFind.translate('Selected') + '"></i></a>';
+        html += ' <a href="' + excludeURL + '" onclick="document.location.href=\'' + excludeURL + '\'; return false;" title="' + htmlEncode(excludeTitle) + '"><i class="fa fa-times"></i></a>';
       }
       html += '</span>';
     }


### PR DESCRIPTION
I've no idea why it was there and it was probably added by me, but in any case it leads to "Selected" being displayed as the title, which overrides the title of the a element and makes no sense.