### PR TITLE
Avoid throwing exceptions when processing the results of a getMyFines…

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1359,11 +1359,7 @@ class MyResearchController extends AbstractBase
         foreach ($result as $row) {
             // Attempt to look up and inject title:
             try {
-                if (!isset($row['id']) || empty($row['id'])) {
-                    if (!isset($row['title'])) {
-                        $row['title'] = null;
-                    }
-                } else {
+                if (strlen($row['id'] ?? '') > 0) {
                     $source = $row['source'] ?? DEFAULT_SEARCH_BACKEND;
                     $row['driver'] = $this->serviceLocator
                         ->get('VuFind\Record\Loader')->load($row['id'], $source);
@@ -1372,9 +1368,11 @@ class MyResearchController extends AbstractBase
                     }
                 }
             } catch (\Exception $e) {
-                if (!isset($row['title'])) {
-                    $row['title'] = null;
-                }
+                // Ignore record loading exceptions...
+            }
+            // In case we skipped or failed record loading, make sure title is set.
+            if (!isset($row['title'])) {
+                $row['title'] = null;
             }
             $fines[] = $row;
         }

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1360,13 +1360,16 @@ class MyResearchController extends AbstractBase
             // Attempt to look up and inject title:
             try {
                 if (!isset($row['id']) || empty($row['id'])) {
-                    throw new \Exception();
-                }
-                $source = $row['source'] ?? DEFAULT_SEARCH_BACKEND;
-                $row['driver'] = $this->serviceLocator
-                    ->get('VuFind\Record\Loader')->load($row['id'], $source);
-                if (empty($row['title'])) {
-                    $row['title'] = $row['driver']->getShortTitle();
+                    if (!isset($row['title'])) {
+                        $row['title'] = null;
+                    }
+                } else {
+                    $source = $row['source'] ?? DEFAULT_SEARCH_BACKEND;
+                    $row['driver'] = $this->serviceLocator
+                        ->get('VuFind\Record\Loader')->load($row['id'], $source);
+                    if (empty($row['title'])) {
+                        $row['title'] = $row['driver']->getShortTitle();
+                    }
                 }
             } catch (\Exception $e) {
                 if (!isset($row['title'])) {


### PR DESCRIPTION
… call.

It's really annoying when debugging fine-related functionality and having debugger set to break on exceptions, and I think it's generally better to avoid throwing exceptions when there's no error involved.