### PR TITLE
Use builddir instead of bare /tmp to make sure it's a directory and n…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -180,9 +180,10 @@
           </then>
         </if>
         <!-- unpack the archive into solr/vendor -->
-        <untar file="${srcdir}/downloads/solr-${solr_version}.tgz" todir="${tmp}" />
+        <mkdir dir="${builddir}/solr" />
+        <untar file="${srcdir}/downloads/solr-${solr_version}.tgz" todir="${builddir}/solr" />
         <delete dir="${srcdir}/solr/vendor" includeemptydirs="true" failonerror="false" />
-        <move file="${tmp}/solr-${solr_version}" tofile="${srcdir}/solr/vendor" />
+        <move file="${builddir}/solr/solr-${solr_version}" tofile="${srcdir}/solr/vendor" />
         <!-- make scripts executable -->
         <chmod mode="0755">
           <fileset dir="${srcdir}/solr/vendor/bin">


### PR DESCRIPTION
…ot a symlink that phing would choke on.

Phing seems to have a very strict check in the untar task that the destination must be a directory. In macOS /tmp is a symlink to /private/tmp which causes the script to fail. My proposal is to use a subdirectory of builddir instead, but any other real directory under /tmp would work too.