### PR TITLE
phpcs exclude patterns fix

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Config.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Config.php
@@ -48,9 +48,9 @@ class Config extends \Zend\View\Helper\AbstractHelper
     protected $configLoader;
 
     /**
-     * Constructor
+     * Config constructor.
      *
-     * @param Helper $helper Capabilities helper
+     * @param PluginManager $configLoader Configuration loader
      */
     public function __construct(PluginManager $configLoader)
     {

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset name="VuFind Coding Standards" namespace="VuFind\PHPCS">
   <description>Coding standards for VuFind.</description>
   <file>../module</file>
-  <exclude-pattern>*/config/*</exclude-pattern>
+  <exclude-pattern>module/[^/]+/config/*</exclude-pattern>
   <exclude-pattern>*/tests/*</exclude-pattern>
   <arg name="extensions" value="php"/>
   <rule ref="PEAR">

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -3,7 +3,7 @@
   <description>Coding standards for VuFind.</description>
   <file>../module</file>
   <exclude-pattern>module/[^/]+/config/*</exclude-pattern>
-  <exclude-pattern>*/tests/*</exclude-pattern>
+  <exclude-pattern>module/[^/]+/tests/*</exclude-pattern>
   <arg name="extensions" value="php"/>
   <rule ref="PEAR">
     <exclude name="PEAR.Commenting.FunctionComment.ParamCommentAlignment" />


### PR DESCRIPTION
As already mentioned in #1141 the exclude patterns currently specified in `tests/phpcs.xml` are too greedy: for example `module/VuFind/src/VuFind/View/Helper/Root/Config.php` and all files residing under `/module/VuFind/src/VuFind/Config/` won't be checked/fixed by phpcs/phpcbf.

This pull request should fix that.
