### PR TITLE
raise zend-mvc version to 2.7.13 (for VuFind 4.1 + PHP7.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "zendframework/zend-log": "2.9.2",
         "zendframework/zend-mail": "2.8.0",
         "zendframework/zend-modulemanager": "2.8.0",
-        "zendframework/zend-mvc": "2.7.12",
+        "zendframework/zend-mvc": "2.7.13",
         "zendframework/zend-paginator": "2.7.0",
         "zendframework/zend-serializer": "2.8.0",
         "zendframework/zend-servicemanager": "2.7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -3081,7 +3081,7 @@
         },
         {
             "name": "zendframework/zend-mvc",
-            "version": "2.7.12",
+            "version": "2.7.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-mvc.git",


### PR DESCRIPTION
this will increase compatibility for VuFind 4.1 with PHP 7.2, see also:
- https://github.com/zendframework/zend-mvc/releases/tag/release-2.7.13
- https://github.com/zendframework/zend-mvc/issues/266

