### PR TITLE
Namespaced caches

### DIFF
--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -135,7 +135,7 @@ class Manager
 
         if (!isset($this->caches[$key])) {
             if (!isset($this->cacheSettings[$name])) {
-                throw new \Exception('Requested unknown cache: ' . $key);
+                throw new \Exception('Requested unknown cache: ' . $name);
             }
             // Special case for "no-cache" caches:
             if ($this->cacheSettings[$name] === false) {

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -122,7 +122,6 @@ class Manager
      * Retrieve the specified cache object.
      *
      * @param string      $name      Name of the requested cache.
-     *
      * @param string|null $namespace Optional namespace to use. Defaults to the
      *                               value of {@see $name}.
      *

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -4,7 +4,8 @@
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2007.
+ * Copyright (C) 2007 Villanova University 2007,
+ *               2018 Leipzig University Library <info@ub.uni-leipzig.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,11 +23,13 @@
  * @category VuFind
  * @package  Cache
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Sebastian Kehr <kehr@ub.uni-leipzig.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
 namespace VuFind\Cache;
 
+use Zend\Cache\Storage\StorageInterface;
 use Zend\Cache\StorageFactory;
 use Zend\Config\Config;
 
@@ -38,6 +41,7 @@ use Zend\Config\Config;
  * @category VuFind
  * @package  Cache
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Sebastian Kehr <kehr@ub.uni-leipzig.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
@@ -67,7 +71,7 @@ class Manager
     /**
      * Actual cache objects generated from settings.
      *
-     * @var array
+     * @var StorageInterface[]
      */
     protected $caches = [];
 
@@ -117,26 +121,34 @@ class Manager
     /**
      * Retrieve the specified cache object.
      *
-     * @param string $key Key identifying the requested cache.
+     * @param string      $name      Name of the requested cache.
      *
-     * @return object
+     * @param string|null $namespace Optional namespace to use. Defaults to the
+     *                               value of {@see $name}.
+     *
+     * @return StorageInterface
+     * @throws \Exception
      */
-    public function getCache($key)
+    public function getCache($name, $namespace = null)
     {
+        $namespace = $namespace ?? $name;
+        $key = "$name:$namespace";
+
         if (!isset($this->caches[$key])) {
-            if (!isset($this->cacheSettings[$key])) {
+            if (!isset($this->cacheSettings[$name])) {
                 throw new \Exception('Requested unknown cache: ' . $key);
             }
             // Special case for "no-cache" caches:
-            if ($this->cacheSettings[$key] === false) {
+            if ($this->cacheSettings[$name] === false) {
                 $this->caches[$key]
                     = new \VuFind\Cache\Storage\Adapter\NoCacheAdapter();
             } else {
-                $this->caches[$key] = StorageFactory::factory(
-                    $this->cacheSettings[$key]
-                );
+                $settings = $this->cacheSettings[$name];
+                $settings['adapter']['options']['namespace'] = $namespace;
+                $this->caches[$key] = StorageFactory::factory($settings);
             }
         }
+
         return $this->caches[$key];
     }
 

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) 2007 Villanova University 2007,
+ * Copyright (C) Villanova University 2007,
  *               2018 Leipzig University Library <info@ub.uni-leipzig.de>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -123,7 +123,7 @@ class Manager
      *
      * @param string      $name      Name of the requested cache.
      * @param string|null $namespace Optional namespace to use. Defaults to the
-     *                               value of {@see $name}.
+     * value of {@see $name}.
      *
      * @return StorageInterface
      * @throws \Exception


### PR DESCRIPTION
This pull request enables to create and use more than the statically defined caches (object, cover, config etc.) via namespacing as supported by all [zend-cache adapters](https://zendframework.github.io/zend-cache/storage/adapter/#basic-configuration-options).

Aside from having the potential to simplify the logic implemented in `VuFind\Cache\KeyGeneratorTrait` this will also allow to configure a namespace-specific TTL which should in turn simplify `VuFind\ILS\Driver\CacheTrait`.