### PR TITLE
Use ILS cache trait with renamed method

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -51,7 +51,9 @@ use Zend\Log\LoggerAwareInterface as LoggerAwareInterface;
 class DAIA extends AbstractBase implements
     HttpServiceAwareInterface, LoggerAwareInterface
 {
-    use CacheTrait;
+    use CacheTrait {
+        getCacheKey as protected getBaseCacheKey;
+    }
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\Log\LoggerAwareTrait;
 
@@ -208,7 +210,7 @@ class DAIA extends AbstractBase implements
      */
     protected function getCacheKey($suffix = null)
     {
-        return parent::getCacheKey(md5($this->baseURL) . $suffix);
+        return $this->getBaseCacheKey(md5($this->baseUrl) . $suffix);
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -49,7 +49,9 @@ use Zend\Log\LoggerInterface;
 class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
     \VuFindHttp\HttpServiceAwareInterface, \Zend\Log\LoggerAwareInterface
 {
-    use CacheTrait;
+    use CacheTrait {
+        getCacheKey as protected getBaseCacheKey;
+    }
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\Log\LoggerAwareTrait;
 
@@ -324,7 +326,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
      */
     protected function getCacheKey($suffix = null)
     {
-        return \VuFind\ILS\Driver\AbstractBase::getCacheKey(
+        return $this->getBaseCacheKey(
             md5($this->ilsBaseUrl) . $suffix
         );
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -123,7 +123,7 @@ class PAIA extends DAIA
      */
     protected function getCacheKey($suffix = null)
     {
-        return \VuFind\ILS\Driver\AbstractBase::getCacheKey(
+        return $this->getBaseCacheKey(
             md5($this->baseUrl . $this->paiaURL) . $suffix
         );
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -50,7 +50,9 @@ use VuFind\Exception\ILS as ILSException;
  */
 class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInterface
 {
-    use CacheTrait;
+    use CacheTrait {
+        getCacheKey as protected getBaseCacheKey;
+    }
     use \VuFindHttp\HttpServiceAwareTrait;
 
     /**


### PR DESCRIPTION
Some ILS drivers using `VuFind\ILS\Driver\CacheTrait` still expected `VuFind\ILS\Driver\AbstractBase::getCacheKey()` to exist.

Instead the trait should be used having its `getCacheKey` method renamed.