### PR TITLE
Add last_login and auth_method to user table.

### DIFF
--- a/module/VuFind/sql/migrations/pgsql/5.0/002-modify-user-columns.sql
+++ b/module/VuFind/sql/migrations/pgsql/5.0/002-modify-user-columns.sql
@@ -1,0 +1,7 @@
+--
+-- Modifications to table `user`
+--
+
+ALTER TABLE "user"
+  ADD COLUMN last_login timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+  ADD COLUMN auth_method varchar(50) DEFAULT NULL;

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -198,6 +198,8 @@ CREATE TABLE `user` (
   `home_library` varchar(100) NOT NULL DEFAULT '',
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `verify_hash` varchar(42) NOT NULL DEFAULT '',
+  `last_login` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
+  `auth_method` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   UNIQUE KEY `cat_id` (`cat_id`)

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -123,6 +123,8 @@ major varchar(100) NOT NULL DEFAULT '',
 home_library varchar(100) NOT NULL DEFAULT '',
 created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
 verify_hash varchar(42) NOT NULL DEFAULT '',
+last_login timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+auth_method varchar(50) DEFAULT NULL,
 PRIMARY KEY (id),
 UNIQUE (username),
 UNIQUE (cat_id)


### PR DESCRIPTION
last_login is important for the ability to verify when the user has agreed to the terms of use (see the GDPR thread in vufind-tech) and if inactive users need to be automatically expired. auth_method is useful for troubleshooting and if it's necessary to disable cross-method logins, plus there might be a need to expire users after different periods of inactivity according to their authentication method. 