### PR TITLE
Replace pull request for VUFIND-1269 #1115

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -625,6 +625,7 @@ class Demo extends AbstractBase
         // Get basic status info:
         $status = $this->getSimulatedStatus($id, $patron);
 
+        $issue = 1;
         // Add notes and summary:
         foreach (array_keys($status) as $i) {
             $itemNum = $i + 1;
@@ -640,6 +641,10 @@ class Demo extends AbstractBase
             for ($j = 1; $j <= $summCount; $j++) {
                 $status[$i]['summary'][] = "Item $itemNum summary $j";
             }
+            $volume = intdiv($issue, 4) + 1;
+            $seriesIssue = $issue % 4;
+            $issue = $issue + 1;
+            $status[$i]['enumchron'] = "volume $volume, issue $seriesIssue";
         }
 
         // Send back final value:

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -807,6 +807,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             i.holdingbranch as HLDBRNCH, i.homebranch as HOMEBRANCH,
             i.reserves as RESERVES, i.itemcallnumber as CALLNO, i.barcode as BARCODE,
             i.copynumber as COPYNO, i.notforloan as NOTFORLOAN,
+	    i.enumchron AS ENUMCHRON,
             i.itemnotes as PUBLICNOTES, b.frameworkcode as DOCTYPE,
             t.frombranch as TRANSFERFROM, t.tobranch as TRANSFERTO,
             i.itemlost as ITEMLOST, i.itemlost_on AS LOSTON
@@ -980,6 +981,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                     ? 'Unknown' : $rowItem['BARCODE'],
                 'number'       => (null == $rowItem['COPYNO'])
                     ? '' : $rowItem['COPYNO'],
+		'enumchron     => (null == $rowitem['ENUMCHRON'])
+		    ? '' : $rowitem['ENUMCHRON'],
                 'requests_placed' => $reservesCount ? $reservesCount : 0,
                 'frameworkcode' => $rowItem['DOCTYPE'],
             ];

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -981,8 +981,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                     ? 'Unknown' : $rowItem['BARCODE'],
                 'number'       => (null == $rowItem['COPYNO'])
                     ? '' : $rowItem['COPYNO'],
-		'enumchron     => (null == $rowitem['ENUMCHRON'])
-		    ? '' : $rowitem['ENUMCHRON'],
+                'enumchron'    => $rowItem['ENUMCHRON'] ?? '',
                 'requests_placed' => $reservesCount ? $reservesCount : 0,
                 'frameworkcode' => $rowItem['DOCTYPE'],
             ];

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
@@ -64,12 +64,14 @@
           </span>
         <?php endif; ?>
       </div>
-
       <?php if (isset($holding['item_notes'])): ?>
         <div class="holding-notes">
           <div class="item-notes">
             <b><?=$this->transEsc("Item Notes")?>:</b>
             <ul>
+              <?php if ($holding['enumchron'] ?? false): ?>
+                <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>
+              <?php endif; ?>
               <?php foreach ($holding['item_notes'] as $item_note): ?>
                 <li><?=$this->escapeHtml($item_note) ?></li>
               <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
@@ -67,7 +67,7 @@
       <?php if (isset($holding['item_notes']) || isset($holding['enumchron'])): ?>
         <div class="holding-notes">
           <div class="item-notes">
-            <b><?=$this->transEsc("Item Notes")?>:</b> 
+            <b><?=$this->transEsc("Item Notes")?>:</b>
             <ul>
               <?php if ($holding['enumchron'] ?? false): ?>
                 <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
@@ -67,7 +67,7 @@
       <?php if (isset($holding['item_notes']) || isset($holding['enumchron'])): ?>
         <div class="holding-notes">
           <div class="item-notes">
-            <b><?=$this->transEsc("Item Notes")?>:</b>
+            <b><?=$this->transEsc("Item Notes")?>:</b> 
             <ul>
               <?php if ($holding['enumchron'] ?? false): ?>
                 <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
@@ -64,7 +64,7 @@
           </span>
         <?php endif; ?>
       </div>
-      <?php if (isset($holding['item_notes'])): ?>
+      <?php if (isset($holding['item_notes']) || isset($holding['enumchron'])): ?>
         <div class="holding-notes">
           <div class="item-notes">
             <b><?=$this->transEsc("Item Notes")?>:</b>
@@ -72,9 +72,11 @@
               <?php if ($holding['enumchron'] ?? false): ?>
                 <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>
               <?php endif; ?>
-              <?php foreach ($holding['item_notes'] as $item_note): ?>
-                <li><?=$this->escapeHtml($item_note) ?></li>
-              <?php endforeach; ?>
+              <?php if ($holding['item_notes'] ?? false): ?>
+                <?php foreach ($holding['item_notes'] as $item_note): ?>
+                  <li><?=$this->escapeHtml($item_note) ?></li>
+                <?php endforeach; ?>
+              <?php endif; ?>
             </ul>
           </div>
         </div>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
@@ -40,16 +40,18 @@
             <a class="<?=$check ? 'checkRequest' : ''?> placehold" <?php if (!empty($holding['linkLightbox'])): ?>data-lightbox <?php endif; ?>href="<?=$this->recordLink()->getRequestUrl($holding['link'])?>"><i class="fa fa-flag" aria-hidden="true"></i>&nbsp;<?=$this->transEsc($check ? "Check Recall" : "Recall This")?></a>
           <?php endif; ?>
         <?php endif; ?>
-        <?php if (isset($holding['item_notes'])): ?>
+        <?php if (isset($holding['item_notes']) || isset($holding['enumchron'])): ?>
           <div class="item-notes">
             <b><?=$this->transEsc("Item Notes")?>:</b>
             <ul>
               <?php if ($holding['enumchron'] ?? false): ?>
                 <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>
               <?php endif; ?>
-              <?php foreach ($holding['item_notes'] as $item_note): ?>
-                <li><?=$this->escapeHtml($item_note) ?></li>
-              <?php endforeach; ?>
+              <?php if ($holding['item_notes'] ?? false): ?>
+                <?php foreach ($holding['item_notes'] as $item_note): ?>
+                  <li><?=$this->escapeHtml($item_note) ?></li>
+                <?php endforeach; ?>
+              <?php endif; ?>
             </ul>
           </div>
         <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
@@ -44,6 +44,9 @@
           <div class="item-notes">
             <b><?=$this->transEsc("Item Notes")?>:</b>
             <ul>
+              <?php if ($holding['enumchron'] ?? false): ?>
+                <li class="enumchron"><?=$this->escapeHtml($holding['enumchron'])?></li>
+              <?php endif; ?>
               <?php foreach ($holding['item_notes'] as $item_note): ?>
                 <li><?=$this->escapeHtml($item_note) ?></li>
               <?php endforeach; ?>


### PR DESCRIPTION
A replacement pull request for https://github.com/vufind-org/vufind/pull/1115 as Github didn't seem to get on well with a rebase required to bring it up to date.

I've made a few changes to @KeckR's pull request. I've fixed the `enumchron` line in the `KohaILSDI` ILS driver and I've moved the logic for displaying it into the holdings sub-templates. I made a judgement call with the display location and set them to appear as the first note on an item - @demiankatz, @crhallberg does that make sense to yourselves?
