### PR TITLE
Emit VuFind.lightbox.login event even if processing is short-circuite…

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -222,7 +222,9 @@ VuFind.register('lightbox', function Lightbox() {
    */
   _constrainLink = function constrainLink(event) {
     if (typeof $(this).data('lightboxIgnore') != 'undefined'
-      || typeof this.attributes.href === 'undefined' || this.attributes.href.value.charAt(0) === '#'
+      || typeof this.attributes.href === 'undefined'
+      || this.attributes.href.value.charAt(0) === '#'
+      || this.href.match(/^[a-zA-Z]+\:[^\/]/) // ignore resource identifiers (mailto:, tel:, etc.)
     ) {
       return true;
     }
@@ -351,6 +353,7 @@ VuFind.register('lightbox', function Lightbox() {
       if (VuFind.lightbox.refreshOnClose) {
         VuFind.refreshPage();
       }
+      this.setAttribute('aria-hidden', true);
       _emit('VuFind.lightbox.closing');
     });
     _modal.on('hidden.bs.modal', function lightboxHidden() {
@@ -360,7 +363,7 @@ VuFind.register('lightbox', function Lightbox() {
 
     VuFind.modal = function modalShortcut(cmd) {
       if (cmd === 'show') {
-        _modal.modal($.extend({ show: true }, _modalParams));
+        _modal.modal($.extend({ show: true }, _modalParams)).attr('aria-hidden', false);
       } else {
         _modal.modal(cmd);
       }


### PR DESCRIPTION
…d with 205 response.

I just realised that the previous change that made the 205 response more prevalent on login caused the VuFind.lightbox.login event to not be emitted at all. This caused breakage in our local code. This PR will move the 205 handling to happen after the event handling is done.