### PR TITLE
Prevent result list from jumping to the top (due to link href "#")

### DIFF
--- a/themes/bootstrap3/js/cart.js
+++ b/themes/bootstrap3/js/cart.js
@@ -204,7 +204,8 @@ VuFind.register('cart', function Cart() {
         var currentId = $this.data('cart-id');
         var currentSource = $this.data('cart-source');
         $this.find('.correct').removeClass('correct hidden');
-        $this.find('.cart-add').click(function cartAddClick() {
+        $this.find('.cart-add').click(function cartAddClick(e) {
+          e.preventDefault();
           if (addItem(currentId, currentSource)) {
             $this.find('.cart-add').addClass('hidden');
             $this.find('.cart-remove').removeClass('hidden');
@@ -215,7 +216,8 @@ VuFind.register('cart', function Cart() {
             }, 5000);
           }
         });
-        $this.find('.cart-remove').click(function cartRemoveClick() {
+        $this.find('.cart-remove').click(function cartRemoveClick(e) {
+          e.preventDefault();
           removeItem(currentId, currentSource);
           $this.find('.cart-add').removeClass('hidden');
           $this.find('.cart-remove').addClass('hidden');

--- a/themes/bootstrap3/templates/record/cart-buttons.phtml
+++ b/themes/bootstrap3/templates/record/cart-buttons.phtml
@@ -2,11 +2,11 @@
 <?php if ($cart->isActive()): ?>
   <?php $cartId = $this->source . '|' . $this->id; ?>
   <span class="btn-bookbag-toggle" data-cart-id="<?=$this->escapeHtmlAttr($this->id)?>" data-cart-source="<?=$this->escapeHtmlAttr($this->source)?>">
-    <a class="cart-add hidden<?php if(!$cart->contains($cartId)): ?> correct<?php endif ?>">
+    <a href="#" class="cart-add hidden<?php if(!$cart->contains($cartId)): ?> correct<?php endif ?>">
       <i class="cart-link-icon fa fa-plus" title="<?=$this->transEsc('Add to Book Bag') ?>"></i><!--
    --><span class="cart-link-label"><?=$this->transEsc('Add to Book Bag') ?></span><!--
  --></a>
-    <a class="cart-remove hidden<?php if($cart->contains($cartId)): ?> correct<?php endif ?>">
+    <a href="#" class="cart-remove hidden<?php if($cart->contains($cartId)): ?> correct<?php endif ?>">
       <i class="cart-link-icon fa fa-minus-circle" title="<?=$this->transEsc('Remove from Book Bag') ?>"></i><!--
    --><span class="cart-link-label"><?=$this->transEsc('Remove from Book Bag') ?></span>
     </a>


### PR DESCRIPTION
Without my fix, the result list always jumps to the top because the links href to "#" (same page). With my fix, adding/removing to/from cart still works but there is not link being followed. 