### PR TITLE
Process hierarchical facets for "similar" requests too.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
@@ -152,7 +152,7 @@ class HierarchicalFacetListener
         }
         $context = $event->getParam('context');
         if ($context == 'search' || $context == 'retrieve'
-            || $context == 'retrieveBatch'
+            || $context == 'retrieveBatch' || $context == 'similar'
         ) {
             $this->processHierarchicalFacets($event);
         }


### PR DESCRIPTION
Otherwise we don't get TranslatableString instances for the hierarchical fields.