### PR TITLE
Make Piwik helper more robust.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -305,10 +305,14 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
      */
     protected function getRecordDriver()
     {
-        $viewModel = $this->getView()->plugin('view_model');
+        $view = $this->getView();
+        $viewModel = $view->plugin('view_model');
         $current = $viewModel->getCurrent();
         if (null === $current) {
-            return null;
+            $driver = $view->vars('driver');
+            if (is_a($driver, 'VuFind\RecordDriver\AbstractBase')) {
+                return $driver;
+            }
         }
         $children = $current->getChildren();
         if (isset($children[0])) {

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2014-2016.
+ * Copyright (C) The National Library of Finland 2014-2018.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -257,10 +257,11 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getSearchResults()
     {
         $viewModel = $this->getView()->plugin('view_model');
-        if ('layout/lightbox' === $viewModel->getCurrent()->getTemplate()) {
+        $current = $viewModel->getCurrent();
+        if (null === $current || 'layout/lightbox' === $current->getTemplate()) {
             return null;
         }
-        $children = $viewModel->getCurrent()->getChildren();
+        $children = $current->getChildren();
         if (isset($children[0])) {
             $template = $children[0]->getTemplate();
             if (!strstr($template, '/home') && !strstr($template, 'facet-list')) {
@@ -305,7 +306,11 @@ class Piwik extends \Zend\View\Helper\AbstractHelper
     protected function getRecordDriver()
     {
         $viewModel = $this->getView()->plugin('view_model');
-        $children = $viewModel->getCurrent()->getChildren();
+        $current = $viewModel->getCurrent();
+        if (null === $current) {
+            return null;
+        }
+        $children = $current->getChildren();
         if (isset($children[0])) {
             $driver = $children[0]->getVariable('driver');
             if (is_a($driver, 'VuFind\RecordDriver\AbstractBase')) {


### PR DESCRIPTION
Piwik helper was trying to access the result of ViewModel->getCurrent() without null checking (apart from getCombinedSearchResults, which already did). I encountered this while calling Record helper's renderTemplate() from an AjaxHandler.

Also make the helper try current view for a record driver if there's no current template in the ViewModel.