### PR TITLE
Don't try to render an empty catalog login template resulting from IL…

### DIFF
--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -77,7 +77,7 @@
         ]
       )?>
     </table>
-  <?php elseif ('ils-none' !== $this->ils()->getOfflineMode()): ?>
+  <?php elseif ('ils-none' !== $this->ils()->getOfflineMode() && !empty($this->patronLoginView->getTemplate())): ?>
     <?=$this->partial($this->patronLoginView);?>
   <?php endif; ?>
 </div>


### PR DESCRIPTION
…S connection failure.

This is a bit ugly, but since catalogLogin creates an empty ViewModel if the ILS connection fails, we must not try to render it or the renderer will throw an exception.

Returning false or something from catalogLogin() and checking for that would probably be better, but I dared not do it without considerable digging into all the places that handle the result. Most seem to check for an array, but not all.