### PR TITLE
Use smarter defaults for retrieving facet configurations.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1714,13 +1714,15 @@ class Params
      *
      * @param string $facetList     Config section containing fields to activate
      * @param string $facetSettings Config section containing related settings
-     * @param string $cfgFile       Name of configuration to load
+     * @param string $cfgFile       Name of configuration to load (null to load
+     * default facets configuration).
      *
      * @return bool                 True if facets set, false if no settings found
      */
-    protected function initFacetList($facetList, $facetSettings, $cfgFile = 'facets')
+    protected function initFacetList($facetList, $facetSettings, $cfgFile = null)
     {
-        $config = $this->configLoader->get($cfgFile);
+        $config = $this->configLoader
+            ->get($cfgFile ?? $this->getOptions()->getFacetsIni());
         if (!isset($config->$facetList)) {
             return false;
         }
@@ -1753,14 +1755,16 @@ class Params
      * Initialize checkbox facet settings for the specified configuration sections.
      *
      * @param string $facetList Config section containing fields to activate
-     * @param string $cfgFile   Name of configuration to load
+     * @param string $cfgFile   Name of configuration to load (null to load
+     * default facets configuration).
      *
      * @return bool             True if facets set, false if no settings found
      */
     protected function initCheckboxFacets($facetList = 'CheckboxFacets',
-        $cfgFile = 'facets'
+        $cfgFile = null
     ) {
-        $config = $this->configLoader->get($cfgFile);
+        $config = $this->configLoader
+            ->get($cfgFile ?? $this->getOptions()->getFacetsIni());
         if (empty($config->$facetList)) {
             return false;
         }

--- a/module/VuFind/src/VuFind/Search/Primo/Params.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Params.php
@@ -113,8 +113,8 @@ class Params extends \VuFind\Search\Base\Params
      */
     public function activateAllFacets($preferredSection = false)
     {
-        $this->initFacetList('Facets', 'Results_Settings', 'Primo');
-        $this->initFacetList('Advanced_Facets', 'Advanced_Facet_Settings', 'Primo');
-        $this->initCheckboxFacets('CheckboxFacets', 'Primo');
+        $this->initFacetList('Facets', 'Results_Settings');
+        $this->initFacetList('Advanced_Facets', 'Advanced_Facet_Settings');
+        $this->initCheckboxFacets();
     }
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -271,13 +271,15 @@ class Params extends \VuFind\Search\Base\Params
      *
      * @param string $facetList     Config section containing fields to activate
      * @param string $facetSettings Config section containing related settings
-     * @param string $cfgFile       Name of configuration to load
+     * @param string $cfgFile       Name of configuration to load (null to load
+     * default facets configuration).
      *
      * @return bool                 True if facets set, false if no settings found
      */
-    protected function initFacetList($facetList, $facetSettings, $cfgFile = 'facets')
+    protected function initFacetList($facetList, $facetSettings, $cfgFile = null)
     {
-        $config = $this->configLoader->get($cfgFile);
+        $config = $this->configLoader
+            ->get($cfgFile ?? $this->getOptions()->getFacetsIni());
         $this->initFacetLimitsFromConfig($config->$facetSettings ?? null);
         return parent::initFacetList($facetList, $facetSettings, $cfgFile);
     }

--- a/module/VuFind/src/VuFind/Search/Summon/Params.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Params.php
@@ -355,13 +355,15 @@ class Params extends \VuFind\Search\Base\Params
      *
      * @param string $facetList     Config section containing fields to activate
      * @param string $facetSettings Config section containing related settings
-     * @param string $cfgFile       Name of configuration to load
+     * @param string $cfgFile       Name of configuration to load (null to load
+     * default facets configuration).
      *
      * @return bool                 True if facets set, false if no settings found
      */
-    protected function initFacetList($facetList, $facetSettings, $cfgFile = 'facets')
+    protected function initFacetList($facetList, $facetSettings, $cfgFile = null)
     {
-        $config = $this->configLoader->get($cfgFile);
+        $config = $this->configLoader
+            ->get($cfgFile ?? $this->getOptions()->getFacetsIni());
         // Special case -- when most settings are in Results_Settings, the limits
         // can be found in Facet_Settings.
         $limitSection = ($facetSettings === 'Results_Settings')
@@ -378,7 +380,7 @@ class Params extends \VuFind\Search\Base\Params
     public function initAdvancedFacets()
     {
         $success = $this
-            ->initFacetList('Advanced_Facets', 'Advanced_Facet_Settings', 'Summon');
+            ->initFacetList('Advanced_Facets', 'Advanced_Facet_Settings');
         // If no configuration was found, set up defaults instead:
         if (!$success) {
             $defaults = ['Language' => 'Language', 'ContentType' => 'Format'];
@@ -397,7 +399,7 @@ class Params extends \VuFind\Search\Base\Params
     {
         // Load Advanced settings if HomePage settings are missing (legacy support):
         $homeSuccess = $this
-            ->initFacetList('HomePage_Facets', 'HomePage_Facet_Settings', 'Summon');
+            ->initFacetList('HomePage_Facets', 'HomePage_Facet_Settings');
         if (!$homeSuccess) {
             $this->initAdvancedFacets();
         }
@@ -410,7 +412,7 @@ class Params extends \VuFind\Search\Base\Params
      */
     public function initBasicFacets()
     {
-        $this->initFacetList('Facets', 'Results_Settings', 'Summon');
+        $this->initFacetList('Facets', 'Results_Settings');
     }
 
     /**
@@ -437,6 +439,6 @@ class Params extends \VuFind\Search\Base\Params
             $this->initAdvancedFacets();
             $this->initBasicFacets();
         }
-        $this->initCheckboxFacets('CheckboxFacets', 'Summon');
+        $this->initCheckboxFacets();
     }
 }


### PR DESCRIPTION
- Pull the facet config from the options object so we don't have to rely on hard-coded config names in as many places.