### PR TITLE
Display an error message if an activated library card doesn't work.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -192,6 +192,16 @@ class LibraryCardsController extends AbstractBase
         $cardID = $this->params()->fromQuery('cardID');
         $user->activateLibraryCard($cardID);
 
+        // Connect to the ILS and check that the credentials are correct:
+        $catalog = $this->getILS();
+        $patron = $catalog->patronLogin(
+            $user->cat_username, $user->getCatPassword()
+        );
+        if (!$patron) {
+            $this->flashMessenger()
+                ->addMessage('authentication_error_invalid', 'error');
+        }
+
         $this->setFollowupUrlToReferer();
         if ($url = $this->getFollowupUrl()) {
             $this->clearFollowupUrl();


### PR DESCRIPTION
While storedCatalogLogin would clean up invalid credentials, there was no message shown to the user, and this could have lead to confusion when the library card selection wouldn't stick.