### PR TITLE
Make sure to init theme just once.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -87,6 +87,13 @@ class Initializer
     protected $cookieManager;
 
     /**
+     * A static flag used to determine if the theme has been initialized
+     *
+     * @var bool
+     */
+    protected static $themeInitialized = false;
+
+    /**
      * Constructor
      *
      * @param Config   $config Configuration object containing these keys:
@@ -180,6 +187,12 @@ class Initializer
      */
     public function init()
     {
+        // Make sure to initialize the theme just once
+        if (self::$themeInitialized) {
+            return;
+        }
+        self::$themeInitialized = true;
+
         // Determine the current theme:
         $currentTheme = $this->pickTheme($this->event->getRequest());
 


### PR DESCRIPTION
Without this check both dispatch event and dispatch.error may try to initialize the theme, which causes the service manager to throw an exception and potentially mask the original error. This situation can be recreated e.g. by trying to call a non-existent method in an AjaxHandler (try e.g adding X to $this->getItemStatus() call in GetItemStatuses.php) where the following exception would be thrown:

    type: Zend\ServiceManager\Exception\ContainerModificationsNotAllowedException
    message: An  updated/new alias is not allowed, as the container does not allow  changes for services with existing instances; the following already  exist in the container: transEsc, translate

