### PR TITLE
Make it possible to return error messages for individual records in t…

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -484,16 +484,14 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
                 // Check for errors
                 if (!empty($record[0]['error'])) {
                     $current = $this->getItemStatusError($record);
+                } elseif ($locationSetting === 'group') {
+                    $current = $this->getItemStatusGroup(
+                       $record, $messages, $callnumberSetting
+                    );
                 } else {
-                    if ($locationSetting === 'group') {
-                        $current = $this->getItemStatusGroup(
-                            $record, $messages, $callnumberSetting
-                        );
-                    } else {
-                        $current = $this->getItemStatus(
-                            $record, $messages, $locationSetting, $callnumberSetting
-                        );
-                    }
+                    $current = $this->getItemStatus(
+                        $record, $messages, $locationSetting, $callnumberSetting
+                    );
                 }
                 // If a full status display has been requested, append the HTML:
                 if ($showFullStatus) {

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -398,17 +398,18 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
     /**
      * Support method for getItemStatuses() -- process a failed record.
      *
-     * @param array $record Information on items linked to a single bib record
+     * @param array  $record Information on items linked to a single bib record
+     * @param string $msg    Availability message
      *
      * @return array Summarized availability information
      */
-    protected function getItemStatusError($record)
+    protected function getItemStatusError($record, $msg = '')
     {
         return [
             'id' => $record[0]['id'],
             'error' => $this->translate($record[0]['error']),
             'availability' => false,
-            'availability_message' => '',
+            'availability_message' => $msg,
             'location' => false,
             'locationList' => [],
             'reserve' => false,
@@ -482,7 +483,8 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
             if (count($record)) {
                 // Check for errors
                 if (!empty($record[0]['error'])) {
-                    $current = $this->getItemStatusError($record);
+                    $current = $this
+                        ->getItemStatusError($record, $messages['unknown']);
                 } elseif ($locationSetting === 'group') {
                     $current = $this->getItemStatusGroup(
                         $record, $messages, $callnumberSetting

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -431,7 +431,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
         try {
             $results = $this->ils->getStatuses($ids);
         } catch (ILSException $e) {
-            // If the ILS fails, send an empty response instead of a fatal
+            // If the ILS fails, send an error response instead of a fatal
             // error; we don't want to confuse the end user unnecessarily.
             error_log($e->getMessage());
             foreach ($ids as $id) {

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -406,9 +406,9 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
     {
         return [
             'id' => $record[0]['id'],
-            'error' => $record[0]['error'],
+            'error' => $this->translate($record[0]['error']),
             'availability' => false,
-            'availability_message' => $record[0]['availability_message'] ?? '',
+            'availability_message' => '',
             'location' => false,
             'locationList' => [],
             'reserve' => false,
@@ -438,8 +438,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
                 $results[] = [
                     [
                         'id' => $id,
-                        'error' => 'An error has occurred',
-                        'availability_message' => 'status_unknown_message'
+                        'error' => 'An error has occurred'
                     ]
                 ];
             }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -486,7 +486,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
                     $current = $this->getItemStatusError($record);
                 } elseif ($locationSetting === 'group') {
                     $current = $this->getItemStatusGroup(
-                       $record, $messages, $callnumberSetting
+                        $record, $messages, $callnumberSetting
                     );
                 } else {
                     $current = $this->getItemStatus(

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -120,7 +120,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
 
         $filtered = [];
         foreach ($record as $current) {
-            if (!in_array($current['location'], $hideHoldings)) {
+            if (!in_array($current['location'] ?? null, $hideHoldings)) {
                 $filtered[] = $current;
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -198,8 +198,7 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
                 $items[] = [
                     [
                         'id' => $id,
-                        'error' => 'An error has occurred',
-                        'availability_message' => 'status_unknown_message'
+                        'error' => 'An error has occurred'
                     ]
                 ];
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -192,7 +192,17 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
     {
         $items = [];
         foreach ($ids as $id) {
-            $items[] = $this->getStatus($id);
+            try {
+                $items[] = $this->getStatus($id);
+            } catch (ILSException $e) {
+                $items[] = [
+                    [
+                        'id' => $id,
+                        'error' => 'An error has occurred',
+                        'availability_message' => 'status_unknown_message'
+                    ]
+                ];
+            }
         }
         return $items;
     }

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -123,7 +123,8 @@ function itemQueueAjax(id, el) {
   el.addClass('js-item-pending').removeClass('hidden');
   el.find('.callnumAndLocation').removeClass('hidden');
   el.find('.callnumAndLocation .ajax-availability').removeClass('hidden');
-}
+  el.find('.status').removeClass('hidden');
+ }
 
 function checkItemStatus(el) {
   var $item = $(el);

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -19,7 +19,7 @@ function displayItemStatus(result, $item) {
     && result.error.length > 0
   ) {
     $item.find('.callnumAndLocation').empty().addClass('text-danger').append(result.error);
-    $item.find('.callnumber,.hideIfDetailed,.location,.status').addClass('hidden');
+    $item.find('.callnumber,.hideIfDetailed,.location').addClass('hidden');
   } else if (typeof(result.full_status) != 'undefined'
     && result.full_status.length > 0
     && $item.find('.callnumAndLocation').length > 0

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -15,7 +15,12 @@ function displayItemStatus(result, $item) {
   $item.removeClass('js-item-pending');
   $item.find('.status').empty().append(result.availability_message);
   $item.find('.ajax-availability').removeClass('ajax-availability hidden');
-  if (typeof(result.full_status) != 'undefined'
+  if (typeof(result.error) != 'undefined'
+    && result.error.length > 0
+  ) {
+    $item.find('.callnumAndLocation').empty().addClass('text-danger').append(result.error);
+    $item.find('.callnumber,.hideIfDetailed,.location,.status').addClass('hidden');
+  } else if (typeof(result.full_status) != 'undefined'
     && result.full_status.length > 0
     && $item.find('.callnumAndLocation').length > 0
   ) {
@@ -115,7 +120,8 @@ function itemQueueAjax(id, el) {
   itemStatusEls[id] = el;
   itemStatusTimer = setTimeout(runItemAjaxForQueue, itemStatusDelay);
   el.addClass('js-item-pending').removeClass('hidden');
-  el.find('.status').removeClass('hidden');
+  el.find('.callnumAndLocation').removeClass('hidden');
+  el.find('.callnumAndLocation .ajax-availability').removeClass('hidden');
 }
 
 function checkItemStatus(el) {

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -124,7 +124,7 @@ function itemQueueAjax(id, el) {
   el.find('.callnumAndLocation').removeClass('hidden');
   el.find('.callnumAndLocation .ajax-availability').removeClass('hidden');
   el.find('.status').removeClass('hidden');
- }
+}
 
 function checkItemStatus(el) {
   var $item = $(el);

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -18,7 +18,12 @@ function displayItemStatus(result, $item) {
   if (typeof(result.error) != 'undefined'
     && result.error.length > 0
   ) {
-    $item.find('.callnumAndLocation').empty().addClass('text-danger').append(result.error);
+    // Only show error message if we also have a status indicator active:
+    if ($item.find('.status').length > 0) {
+      $item.find('.callnumAndLocation').empty().addClass('text-danger').append(result.error);
+    } else {
+      $item.find('.callnumAndLocation').addClass('hidden');
+    }
     $item.find('.callnumber,.hideIfDetailed,.location').addClass('hidden');
   } else if (typeof(result.full_status) != 'undefined'
     && result.full_status.length > 0


### PR DESCRIPTION
…he getStatuses ILS call.

Also displays the loading status properly. Now I'm not quite sure how the element with the .status class should be handled. It's only enabled if OpenURL is disabled, so it can't be used for the loading status, but it might be otherwise ok. The whole class structure etc. is a bit complicated, but anyway this tries to revert the important bits to how they are supposed to work as far as I can tell.

There's probably room for improvement here, but it would require template changes etc.