### PR TITLE
EZproxy ticket authentication improvements.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1121,7 +1121,6 @@ replace_other_urls = true
 ; authentication requests in VuFind:
 ;disable_ticket_auth_logging = true
 
-
 ; These settings affect RefWorks record exports.  They rarely need to be changed.
 [RefWorks]
 vendor          = VuFind

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1114,6 +1114,14 @@ replace_other_urls = true
 ; replace SHA512 with SHA1 also in EZproxy's configuration file.
 ;secret_hash_method = "SHA512"
 
+; Uncomment the following line to disable relaying of user name to EZproxy on ticket
+; authentication:
+;anonymous_ticket = true
+; Uncomment the following line to disable logging of successful ticket
+; authentication requests in VuFind:
+;disable_ticket_auth_logging = true
+
+
 ; These settings affect RefWorks record exports.  They rarely need to be changed.
 [RefWorks]
 vendor          = VuFind


### PR DESCRIPTION
- Make it possible for non-logged in users to get access to EZproxy e.g. based on IP address.
- Make it possible to disable passing of user's username to EZproxy with the ticket.
- Add logging of successful login requests.

Logging of authentication somewhere is important for resolution of potential misuse cases, but the settings allow for the information to be kept safe on VuFind side.