### PR TITLE
Fix full facet list when nothing was returned.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -730,7 +730,7 @@ class AbstractSearch extends AbstractBase
             [$facet], false, $limit, $sort, $page,
             $this->params()->fromQuery('facetop', 'AND') == 'OR'
         );
-        $list = $facets[$facet]['data']['list'];
+        $list = $facets[$facet]['data']['list'] ?? [];
         $params->activateAllFacets();
         $facetLabel = $params->getFacetLabel($facet);
 
@@ -743,7 +743,7 @@ class AbstractSearch extends AbstractBase
                 'operator' => $this->params()->fromQuery('facetop', 'AND'),
                 'page' => $page,
                 'results' => $results,
-                'anotherPage' => $facets[$facet]['more'],
+                'anotherPage' => $facets[$facet]['more'] ?? '',
                 'sort' => $sort,
                 'sortOptions' => $facetSortOptions,
                 'baseUriExtra' => $this->params()->fromQuery('baseUriExtra'),


### PR DESCRIPTION
Although I don't know how a link that results in no facets was acquired in the first place, this was logged in production. Easy to reproduce with a handcrafted link like:
/Search/FacetList?lookfor=something&type=AllFields&facet=unknown_str_mv&facetop=OR&facetexclude=0