### PR TITLE
Change MySQL session table data to mediumtext to make room for large …

### DIFF
--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -136,7 +136,7 @@ CREATE TABLE `search` (
 CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `session_id` varchar(128) DEFAULT NULL,
-  `data` text,
+  `data` mediumtext,
   `last_used` int(12) NOT NULL DEFAULT '0',
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),


### PR DESCRIPTION
…search objects and paging information.

Postgresql does not need changes since the text type is already long enough.