### PR TITLE
Guard against circular references when building record hierarchy from…

### DIFF
--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
@@ -195,6 +195,10 @@ class Solr extends AbstractBase
             $parents = isset($current->hierarchy_parent_id)
                 ? $current->hierarchy_parent_id : [];
             foreach ($parents as $parentId) {
+                if ($current->id === $parentId) {
+                    // Ignore circular reference
+                    continue;
+                }
                 if (!isset($map[$parentId])) {
                     $map[$parentId] = [$current];
                 } else {


### PR DESCRIPTION
… Solr.

This happened in real life, so it's worth checking. Otherwise leads to exhausting of memory or nesting limit.