### PR TITLE
Fix double-init of record comment delete links.

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -138,11 +138,6 @@ function registerTabEvents() {
   registerAjaxCommentRecord();
   // Render recaptcha
   recaptchaOnLoad();
-  // Delete links
-  $('.delete').click(function commentTabDeleteClick() {
-    deleteRecordComment(this, $('.hiddenId').val(), $('.hiddenSource').val(), this.id.substr(13));
-    return false;
-  });
 
   setUpCheckRequest();
 


### PR DESCRIPTION
Delete links are already initialized in registerAjaxCommentRecord just above.