### PR TITLE
Always set $VUFIND_HOME to an absolute path.

### DIFF
--- a/harvest/batch-delete.sh
+++ b/harvest/batch-delete.sh
@@ -6,7 +6,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ "$VUFIND_HOME" = /.. ]; then
+  if [ "$VUFIND_HOME" = /.. ]
+  then
     exit 1
   fi
 fi

--- a/harvest/batch-delete.sh
+++ b/harvest/batch-delete.sh
@@ -3,8 +3,12 @@
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]
 then
-  echo "Please set the VUFIND_HOME environment variable."
-  exit 1
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
 
 SKIP_OPTIMIZE=0

--- a/harvest/batch-delete.sh
+++ b/harvest/batch-delete.sh
@@ -6,7 +6,7 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ "$VUFIND_HOME" = /.. ]; then
     exit 1
   fi
 fi

--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -6,7 +6,7 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ "$VUFIND_HOME" = /.. ]; then
     exit 1
   fi
 fi

--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -3,8 +3,12 @@
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]
 then
-  echo "Please set the VUFIND_HOME environment variable."
-  exit 1
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
 
 # Find harvest directory for future use

--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -6,7 +6,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ "$VUFIND_HOME" = /.. ]; then
+  if [ "$VUFIND_HOME" = /.. ]
+  then
     exit 1
   fi
 fi

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -6,7 +6,7 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ "$VUFIND_HOME" = /.. ]; then
     exit 1
   fi
 fi

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -3,8 +3,12 @@
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]
 then
-  echo "Please set the VUFIND_HOME environment variable."
-  exit 1
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
 
 # Find harvest directory for future use

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -6,7 +6,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ "$VUFIND_HOME" = /.. ]; then
+  if [ "$VUFIND_HOME" = /.. ]
+  then
     exit 1
   fi
 fi

--- a/harvest/batch-import-xsl.sh
+++ b/harvest/batch-import-xsl.sh
@@ -3,9 +3,14 @@
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]
 then
-  echo "Please set the VUFIND_HOME environment variable."
-  exit 1
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
+
 
 SKIP_OPTIMIZE=0
 

--- a/harvest/batch-import-xsl.sh
+++ b/harvest/batch-import-xsl.sh
@@ -6,7 +6,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ "$VUFIND_HOME" = /.. ]; then
+  if [ "$VUFIND_HOME" = /.. ]
+  then
     exit 1
   fi
 fi

--- a/harvest/batch-import-xsl.sh
+++ b/harvest/batch-import-xsl.sh
@@ -6,7 +6,7 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/..
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ "$VUFIND_HOME" = /.. ]; then
     exit 1
   fi
 fi

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -12,6 +12,20 @@ then
   exit $E_BADARGS
 fi
 
+##################################################
+# Set VUFIND_HOME
+##################################################
+if [ -z "$VUFIND_HOME" ]
+then
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
+fi
+
+
 # Always use the standard authority mappings; if the user specified an override
 # file, add that to the setting.
 if [ -f "$VUFIND_LOCAL_DIR/import/marc_auth.properties" ]

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -20,7 +20,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ -z "$VUFIND_HOME" ]
+  then
     exit 1
   fi
 fi

--- a/import-marc.sh
+++ b/import-marc.sh
@@ -67,7 +67,10 @@ if [ -z "$VUFIND_HOME" ]
 then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
-  export VUFIND_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+  export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
 
 if [ -z "$VUFIND_LOCAL_DIR" ]

--- a/import-marc.sh
+++ b/import-marc.sh
@@ -68,7 +68,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   export VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ -z "$VUFIND_HOME" ]
+  then
     exit 1
   fi
 fi

--- a/import/bin/import.sh
+++ b/import/bin/import.sh
@@ -50,7 +50,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/../..
-  if [ "$VUFIND_HOME" = /../.. ]; then
+  if [ "$VUFIND_HOME" = /../.. ]
+  then
     exit 1
   fi
 fi

--- a/import/bin/import.sh
+++ b/import/bin/import.sh
@@ -43,17 +43,25 @@ fi
 
 
 ##################################################
+# Set VUFIND_HOME
+##################################################
+if [ -z "$VUFIND_HOME" ]
+then
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/../..
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
+fi
+
+
+##################################################
 # Set SOLR_HOME
 ##################################################
 if [ -z "$SOLR_HOME" ]
 then
-  if [ -z "$VUFIND_HOME" ]
-  then
-    echo "You need to set the VUFIND_HOME environmental variable before running this script."
-    exit 1
-  else
-    SOLR_HOME="$VUFIND_HOME/solr"
-  fi
+  SOLR_HOME="$VUFIND_HOME/solr"
 fi
 
 

--- a/import/bin/import.sh
+++ b/import/bin/import.sh
@@ -50,7 +50,7 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"/../..
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ "$VUFIND_HOME" = /../.. ]; then
     exit 1
   fi
 fi

--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -10,10 +10,20 @@ else
   JAVA="java"
 fi
 
+
+##################################################
+# Set VUFIND_HOME
+##################################################
 if [ -z "$VUFIND_HOME" ]
 then
-  VUFIND_HOME=`dirname $0`
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
+
 
 if [ -z "$SOLR_HOME" ]
 then

--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -19,7 +19,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ -z "$VUFIND_HOME" ]
+  then
     exit 1
   fi
 fi

--- a/solr.sh
+++ b/solr.sh
@@ -45,7 +45,8 @@ then
   # set VUFIND_HOME to the absolute path of the directory containing this script
   # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
   VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
-  if [ -z "$VUFIND_HOME" ]; then
+  if [ -z "$VUFIND_HOME" ]
+  then
     exit 1
   fi
 fi

--- a/solr.sh
+++ b/solr.sh
@@ -42,8 +42,14 @@ usage()
 # Set VUFIND_HOME
 if [ -z "$VUFIND_HOME" ]
 then
-  VUFIND_HOME=$(dirname "$0")
+  # set VUFIND_HOME to the absolute path of the directory containing this script
+  # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+  VUFIND_HOME="$(cd "$(dirname "$0")" && pwd -P)"
+  if [ -z "$VUFIND_HOME" ]; then
+    exit 1
+  fi
 fi
+
 
 if [ -z "$SOLR_HOME" ]
 then


### PR DESCRIPTION
When `index-alphabetic-browse.sh` is invoked as `./index-alphabetic-browse.sh` from the `/usr/local/vufind/` working directory, and the `VUFIND_HOME` environmental variable is unset, `VUFIND_HOME` is set to the relative path `.`. Since `index-alphabetic-browse.sh` changes the working directory to `import`, `$CLASSPATH` points to non-existent files, and the script fails with a `java.lang.NoClassDefFoundError: org/apache/lucene/search/Query` exception.

This PR proposes using `readlink(1)` from GNU coreutils to always resolve `$VUFIND_HOME` to an absolute path, thereby solving the above issue.