### PR TITLE
Avoid PHP notices when extracting patron information and error messages.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -474,12 +474,19 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $zip = '';
         $city = '';
         if (!empty($result['names'])) {
-            $name = $result['names'][0];
-            list($lastname, $firstname) = explode(', ', $name, 2);
+            $nameParts = explode(', ', $result['names'][0], 2);
+            $lastname = $nameParts[0];
+            $firstname = $nameParts[1] ?? '';
         }
         if (!empty($result['addresses'][0]['lines'][1])) {
             $address = $result['addresses'][0]['lines'][0];
-            list($zip, $city) = explode(' ', $result['addresses'][0]['lines'][1], 2);
+            $postalParts = explode(' ', $result['addresses'][0]['lines'][1], 2);
+            if (isset($postalParts[1])) {
+                $zip = $postalParts[0];
+                $city = $postalParts[1];
+            } else {
+                $city = $postalParts[0];
+            }
         }
         $expirationDate = !empty($result['expirationDate'])
                 ? $this->dateConverter->convertToDisplayDate(
@@ -609,7 +616,9 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
                 $patron
             );
             if (!empty($result['code'])) {
-                $msg = $this->formatErrorMessage($result['description']);
+                $msg = $this->formatErrorMessage(
+                    $result['description'] ?? $result['name']
+                );
                 $finalResult['details'][$itemId] = [
                     'item_id' => $itemId,
                     'success' => false,
@@ -660,7 +669,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             'GET',
             $patron
         );
-        if (isset($result['code'])) {
+        if (!empty($result['code'])) {
             return [
                 'success' => false,
                 'status' => 146 === $result['code']
@@ -838,11 +847,13 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
 
         foreach ($details as $holdId) {
             $result = $this->makeRequest(
-                ['v3', 'patrons', 'holds', $holdId], [], 'DELETE', $patron
+                ['v5', 'patrons', 'holds', $holdId], [], 'DELETE', $patron
             );
 
             if (!empty($result['code'])) {
-                $msg = $this->formatErrorMessage($result['description']);
+                $msg = $this->formatErrorMessage(
+                    $result['description'] ?? $result['name']
+                );
                 $response[$holdId] = [
                     'item_id' => $holdId,
                     'success' => false,
@@ -907,7 +918,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             'GET',
             $patron
         );
-        if (isset($result['code'])) {
+        if (!empty($result['code'])) {
             // An error was returned
             $this->error(
                 "Request for pickup locations returned error code: {$result['code']}"
@@ -1060,7 +1071,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         );
 
         if (!empty($result['code'])) {
-            return $this->holdError($result['description']);
+            return $this->holdError($result['description'] ?? $result['name']);
         }
         return ['success' => true];
     }
@@ -1191,10 +1202,12 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             $patron
         );
 
-        if (isset($result['code']) && $result['code'] != 0) {
+        if (!empty($result['code'])) {
             return [
                 'success' => false,
-                'status' => $this->formatErrorMessage($result['description'])
+                'status' => $this->formatErrorMessage(
+                    $result['description'] ?? $result['name']
+                )
             ];
         }
         return ['success' => true, 'status' => 'change_password_ok'];


### PR DESCRIPTION
Error description in the Sierra REST API is optional, while name is not, so fall back to name if there's no description. Also use empty() instead if isset() to avoid considering code 0 an error.
Additionally, don't expect explode() to return more than one element.