### PR TITLE
Bug fix: StatusRankings does not work. Rankings are only compared to …

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -244,8 +244,10 @@ class Voyager extends AbstractBase
         $status = $statusArray[0];
         $rank = $this->getStatusRanking($status);
         for ($x = 1; $x < count($statusArray); $x++) {
-            if ($this->getStatusRanking($statusArray[$x]) < $rank) {
+            $thisRank = $this->getStatusRanking($statusArray[$x]);
+            if ($thisRank < $rank) {
                 $status = $statusArray[$x];
+                $rank = $thisRank;
             }
         }
 


### PR DESCRIPTION
…the first status ranking.

This method needs to choose the minimum status ranking among *all* statuses.