### PR TITLE
Use empty() instead of count() fixing a typo.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -362,7 +362,7 @@ class VoyagerRestful extends Voyager implements \VuFindHttp\HttpServiceAwareInte
             $valid_hold_statuses_array
                 = explode(':', $this->config['Holds']['valid_hold_statuses']);
 
-            if (count($valid_hold_statuses_array > 0)) {
+            if (!empty($valid_hold_statuses_array)) {
                 foreach ($statusArray as $status) {
                     if (!in_array($status, $valid_hold_statuses_array)) {
                         $is_holdable = false;


### PR DESCRIPTION
The comparison was misplaced.