### PR TITLE
Add a missing array level to error responses from MultiBackend::getSt…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -220,7 +220,9 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
                 } catch (ILSException $e) {
                     $statuses = array_map(
                         function ($id) {
-                            return ['id' => $id, 'error' => 'An error has occurred'];
+                            return [
+                                ['id' => $id, 'error' => 'An error has occurred']
+                            ];
                         },
                         $localIds
                     );


### PR DESCRIPTION
…atuses method.

There should have been one level per bib id and all the items under it. 