### PR TITLE
facets.js : Move the exclude link inside the badge

### DIFF
--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -36,20 +36,16 @@ function buildFacetNodes(data, currentPath, allowExclude, excludeTitle, counts)
         .html(
           this.count.toString().replace(/\B(?=(\d{3})+\b)/g, VuFind.translate('number_thousands_separator'))
         );
-
-        if (allowExclude) {
-            var excludeUrl = currentPath + this.exclude;
-            var $a = $('<a/>')
-                .addClass('exclude')
-                .attr('href', excludeUrl)
-                .attr('title', excludeTitle);
-            $('<i/>').addClass('fa fa-times').appendTo($a);
-            $badge.append($a);
-        }
-
-        $badge.appendTo($html);
-
-
+      if (allowExclude) {
+        var excludeUrl = currentPath + this.exclude;
+        var $a = $('<a/>')
+          .addClass('exclude')
+          .attr('href', excludeUrl)
+          .attr('title', excludeTitle);
+        $('<i/>').addClass('fa fa-times').appendTo($a);
+        $badge.append($a);
+      }
+      $badge.appendTo($html);
     }
 
     $html = $('<div/>').append($html);

--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -31,22 +31,25 @@ function buildFacetNodes(data, currentPath, allowExclude, excludeTitle, counts)
     $item.appendTo($html);
 
     if (!this.isApplied && counts) {
-      $('<span/>')
+      var $badge = $('<span/>')
         .addClass('badge')
         .html(
           this.count.toString().replace(/\B(?=(\d{3})+\b)/g, VuFind.translate('number_thousands_separator'))
-        )
-        .appendTo($html);
+        );
 
-      if (allowExclude) {
-        var excludeUrl = currentPath + this.exclude;
-        var $a = $('<a/>')
-          .addClass('exclude')
-          .attr('href', excludeUrl)
-          .attr('title', excludeTitle);
-        $('<i/>').addClass('fa fa-times').appendTo($a);
-        $a.appendTo($html);
-      }
+        if (allowExclude) {
+            var excludeUrl = currentPath + this.exclude;
+            var $a = $('<a/>')
+                .addClass('exclude')
+                .attr('href', excludeUrl)
+                .attr('title', excludeTitle);
+            $('<i/>').addClass('fa fa-times').appendTo($a);
+            $badge.append($a);
+        }
+
+        $badge.appendTo($html);
+
+
     }
 
     $html = $('<div/>').append($html);


### PR DESCRIPTION
In non-hierarchical facets, the exclude links are inside the <span class="badge>, as here : 
https://github.com/vufind-org/vufind/blob/master/themes/bootstrap3/templates/Recommend/TopFacets.phtml#L34

My suggestion would be to have the same behaviour in the hierarchical facets built by facets.js. Therefore : 
 * $a is appended to $badge
 * $badge is appended to $html

What do you think ?