### PR TITLE
Remove empty lines at end of VufindAuth/Database.php

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Database.php
+++ b/module/VuFind/src/VuFind/Auth/Database.php
@@ -377,4 +377,3 @@ class Database extends AbstractBase
     }
 }
 ?>
-


### PR DESCRIPTION
When using authentication method 'Database', every response gets some leading characters which break rendering of cover images in our code (we call the authentication manager in our bootstrapping).