### PR TITLE
Send lbreferer query param only if _currentUrl is set.

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -134,7 +134,10 @@ VuFind.register('lightbox', function Lightbox() {
       obj.url = parts[0].indexOf('?') < 0
         ? parts[0] + '?'
         : parts[0] + '&';
-      obj.url += 'layout=lightbox&lbreferer=' + encodeURIComponent(_currentUrl);
+      obj.url += 'layout=lightbox';
+      if (_currentUrl) {
+        obj.url += '&lbreferer=' + encodeURIComponent(_currentUrl);
+      }
       obj.url += parts.length < 2 ? '' : '#' + parts[1];
     }
     _xhr = $.ajax(obj);


### PR DESCRIPTION
Without the check the parameter is sent as lbreferer=false causing followup URL to be set to "false" in AbstractBase::setFollowupUrlToReferer(). This breaks followup processing for e.g. Shibboleth login from a ChoiceAuth lightbox.