### PR TITLE
Fix bug in MapTabConfig defaultOptions array

### DIFF
--- a/module/VuFind/src/VuFind/GeoFeatures/MapTabConfig.php
+++ b/module/VuFind/src/VuFind/GeoFeatures/MapTabConfig.php
@@ -46,10 +46,10 @@ class MapTabConfig extends AbstractConfig
     protected function getDefaultOptions()
     {
         return [
-            'recordMap' => 'false',
-            'displayCoords' => 'false',
+            'recordMap' => false,
+            'displayCoords' => false,
             'mapLabels' => null,
-            'graticule' => 'false'
+            'graticule' => false
         ];
     }
 


### PR DESCRIPTION
Changed defaultOptions array to pass boolean values (false) rather than string values ('false').