### PR TITLE
Bail out from selectCardAction if no card ID is given.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -191,6 +191,9 @@ class LibraryCardsController extends AbstractBase
         }
 
         $cardID = $this->params()->fromQuery('cardID');
+        if (null === $cardID) {
+            return $this->redirect()->toRoute('myresearch-home');
+        }
         $user->activateLibraryCard($cardID);
 
         // Connect to the ILS and check that the credentials are correct:


### PR DESCRIPTION
This is mainly to avoid eternal redirect if the user somehow ends up on the selectcard page without a something else as the referrring page. This can happen e.g. if the session has expired and login is needed. At least it happened to me in real life..