### PR TITLE
    If a user accidentally mistypes their login credentials, they are…

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -616,6 +616,15 @@ class AbstractBase extends AbstractActionController
             return;
         }
 
+        // If the referer is the MyResearch/UserLogin action, it probably means
+        // that the user is repeatedly mistyping their password. We should
+        // ignore this and instead rely on any previously stored referer.
+        $myUserLogin = $this->getServerUrl('myresearch-userlogin');
+        $mulNorm = $this->normalizeUrlForComparison($myUserLogin);
+        if (0 === strpos($refererNorm, $mulNorm)) {
+            return;
+        }
+
         // If we got this far, we want to store the referer:
         $this->followup()->store([], $referer);
     }


### PR DESCRIPTION
… not returned to the

    page they were on after successfully logging in via ILS Autentication. There already
    exists a similar fix for when a non-logged-in user goes to MyResearch/Home (which
    initiates the login challenge page). This bug fix adds one for MyResearch/UserLogin,
    too, which is linked to in themes/bootstrap3/templates/header.phtml

    Note: Links to MyResearch/UserLogin can have parameters, e.g., UserLogin?method=ILS,
    which is why I perform a substring test here:

        if (0 === strpos($refererNorm, $mulNorm)) {

     instead of testing for equality:

        if ($refererNorm === $mulNorm) {