### PR TITLE
Add timestamps to image links.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
@@ -199,7 +199,7 @@ class ThemeInfo
      * if boolean false, return containing theme name; if self::RETURN_ALL_DETAILS,
      * return an array containing both values (keyed with 'path' and 'theme').
      *
-     * @return string
+     * @return string|array|null
      */
     public function findContainingTheme($relativePath, $returnType = false)
     {

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
@@ -66,13 +66,19 @@ class ImageLink extends \Zend\View\Helper\AbstractHelper
     {
         // Normalize href to account for themes:
         $relPath = 'images/' . $image;
-        $currentTheme = $this->themeInfo->findContainingTheme($relPath);
+        $details = $this->themeInfo->findContainingTheme(
+            $relPath, \VuFindTheme\ThemeInfo::RETURN_ALL_DETAILS
+        );
 
-        if (null === $currentTheme) {
+        if (null === $details) {
             return null;
         }
 
         $urlHelper = $this->getView()->plugin('url');
-        return $urlHelper('home') . "themes/$currentTheme/" . $relPath;
+        $url = $urlHelper('home') . "themes/{$details['theme']}/" . $relPath;
+        $url .= strstr($url, '?') ? '&_=' : '?_=';
+        $url .= filemtime($details['path']);
+
+        return $url;
     }
 }


### PR DESCRIPTION
Add timestamps to static image urls like is already done for js and css files so that images can be cached without risk of missing any updates.