### PR TITLE
Add explicit mount options to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   # Network configuration to forward ports.
   config.vm.network :forwarded_port, guest: 80, host: 4567
   config.vm.network :forwarded_port, guest: 8080, host: 4568
-  config.vm.synced_folder ".", "/vagrant", :mount_options => ['dmode=777','fmode=777']
+  config.vm.synced_folder ".", "/vagrant", :owner => 'ubuntu'
   
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure("2") do |config|
   # Network configuration to forward ports.
   config.vm.network :forwarded_port, guest: 80, host: 4567
   config.vm.network :forwarded_port, guest: 8080, host: 4568
+  config.vm.synced_folder ".", "/vagrant", :mount_options => ['dmode=777','fmode=777']
   
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the


### PR DESCRIPTION
Without the mount options Vagrant 2.2.0 fails to create the "vendor/" directory when when running `vagrant up` the first time. 

See also: https://vufind.org/jira/browse/VUFIND-1315