### PR TITLE
Don't set cookies or cookie options when running in CLI.

### DIFF
--- a/module/VuFind/src/VuFind/Cookie/CookieManager.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManager.php
@@ -163,8 +163,8 @@ class CookieManager
      */
     public function proxySetCookie()
     {
-        // Special case: in test suite -- don't actually write headers!
-        return defined('VUFIND_PHPUNIT_RUNNING')
+        // Special case: in test suite or CLI -- don't actually write headers!
+        return defined('VUFIND_PHPUNIT_RUNNING') || 'cli' === PHP_SAPI
             ? true : call_user_func_array('setcookie', func_get_args());
     }
 

--- a/module/VuFind/src/VuFind/Session/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Session/ManagerFactory.php
@@ -54,11 +54,12 @@ class ManagerFactory implements FactoryInterface
     protected function getOptions(ContainerInterface $container)
     {
         $cookieManager = $container->get('VuFind\Cookie\CookieManager');
-        $options = [
+        // Set options only if we are not running from CLI
+        $options = 'cli' !== PHP_SAPI ? [
             'cookie_httponly' => $cookieManager->isHttpOnly(),
             'cookie_path' => $cookieManager->getPath(),
             'cookie_secure' => $cookieManager->isSecure()
-        ];
+        ] : [];
 
         $domain = $cookieManager->getDomain();
         if (!empty($domain)) {


### PR DESCRIPTION
Otherwise Zend\Session\Config\SessionConfig::setStorageOption() throws an exception when it tries to call ini_set with session-specific settings. This would have happened at least when creating a \Zend\Session\Container.

We have command-line utils that call ILS drivers, and the problem popped up when a driver that uses session storage was initialized under PHP 7.2.