### PR TITLE
Eliminate use of VUFIND_PHPUNIT_RUNNING constant.

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -5,7 +5,7 @@ $modules = [
     'Zend\Router', 'ZfcRbac',
     'VuFindTheme', 'VuFindSearch', 'VuFind', 'VuFindAdmin', 'VuFindApi'
 ];
-if (PHP_SAPI == 'cli' && !defined('VUFIND_PHPUNIT_RUNNING')) {
+if (PHP_SAPI == 'cli' && APPLICATION_ENV !== 'testing') {
     $modules[] = 'Zend\Mvc\Console';
     $modules[] = 'VuFindConsole';
 }
@@ -52,7 +52,7 @@ if (!is_dir($cacheDir)) {
 }
 
 // Enable caching unless in dev mode or running tests:
-$useCache = APPLICATION_ENV != 'development' && !defined('VUFIND_PHPUNIT_RUNNING');
+$useCache = APPLICATION_ENV != 'development' && APPLICATION_ENV != 'testing';
 
 // Build configuration:
 return [

--- a/module/VuFind/src/VuFind/Cookie/CookieManager.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManager.php
@@ -163,8 +163,8 @@ class CookieManager
      */
     public function proxySetCookie()
     {
-        // Special case: in test suite or CLI -- don't actually write headers!
-        return defined('VUFIND_PHPUNIT_RUNNING') || 'cli' === PHP_SAPI
+        // Special case: in CLI -- don't actually write headers!
+        return 'cli' === PHP_SAPI
             ? true : call_user_func_array('setcookie', func_get_args());
     }
 

--- a/module/VuFind/tests/bootstrap.php
+++ b/module/VuFind/tests/bootstrap.php
@@ -1,8 +1,5 @@
 <?php
 
-// Set flag that we're in test mode
-define('VUFIND_PHPUNIT_RUNNING', 1);
-
 // Set path to this module
 define('VUFIND_PHPUNIT_MODULE_PATH', __DIR__);
 


### PR DESCRIPTION
- Relying on APPLICATION_ENV is simpler.