### PR TITLE
Simplify facet label handling

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -120,6 +120,11 @@ labelSections[] = Advanced_Facets
 labelSections[] = FacetsTop
 labelSections[] = Facets
 
+; This setting lists configuration settings defining checkbox facets. If you use
+; a custom section to configure additional facets, be sure to add it to this list
+; so labels display correctly in history, the advanced search editor, etc.
+checkboxSections[] = CheckboxFacets
+
 ; Facet display settings
 [Results_Settings]
 ; By default, the side facets will only show 6 facets and then the "show more"

--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -108,6 +108,18 @@ SEARCHMODE = "Search Mode"
 ; above for more details.
 [FacetsTop]
 
+; This section controls where facet labels are retrieved from when facets are not
+; explicitly configured.
+[FacetLabels]
+; This setting lists configuration sections containing facet field => label
+; mappings. Later values will override earlier values. These mappings will be used
+; only when a label is not explicitly configured (i.e. through SideFacets settings).
+; If you customize your facet display, be sure to add any new facet configuration
+; sections to this list to ensure proper display in search history, etc.
+labelSections[] = Advanced_Facets
+labelSections[] = FacetsTop
+labelSections[] = Facets
+
 ; Facet display settings
 [Results_Settings]
 ; By default, the side facets will only show 6 facets and then the "show more"

--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -104,6 +104,11 @@ labelSections[] = Advanced_Facets
 labelSections[] = FacetsTop
 labelSections[] = Facets
 
+; This setting lists configuration settings defining checkbox facets. If you use
+; a custom section to configure additional facets, be sure to add it to this list
+; so labels display correctly in history, the advanced search editor, etc.
+checkboxSections[] = CheckboxFacets
+
 ; Checkbox facets are facets, which are getting displayed as checkboxes
 ; pcAvailability is a special facet. It's used to show all records found in
 ; PrimoCentral without checking the local availability against a holdingsfile.

--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -92,6 +92,18 @@ domain  = Source
 ; Top facets (not used by default)
 [FacetsTop]
 
+; This section controls where facet labels are retrieved from when facets are not
+; explicitly configured.
+[FacetLabels]
+; This setting lists configuration sections containing facet field => label
+; mappings. Later values will override earlier values. These mappings will be used
+; only when a label is not explicitly configured (i.e. through SideFacets settings).
+; If you customize your facet display, be sure to add any new facet configuration
+; sections to this list to ensure proper display in search history, etc.
+labelSections[] = Advanced_Facets
+labelSections[] = FacetsTop
+labelSections[] = Facets
+
 ; Checkbox facets are facets, which are getting displayed as checkboxes
 ; pcAvailability is a special facet. It's used to show all records found in
 ; PrimoCentral without checking the local availability against a holdingsfile.

--- a/config/vufind/Search2.ini
+++ b/config/vufind/Search2.ini
@@ -209,6 +209,7 @@ labelSections[] = HomePage_Facets
 labelSections[] = ResultsTop
 labelSections[] = Results
 labelSections[] = ExtraFacetLabels
+checkboxSections[] = CheckboxFacets
 
 [ExtraFacetLabels]
 long_lat = "Geographic Search"

--- a/config/vufind/Search2.ini
+++ b/config/vufind/Search2.ini
@@ -203,6 +203,13 @@ publishDate        = "adv_search_year"
 [ResultsTop]
 topic_facet        = "Suggested Topics"
 
+[FacetLabels]
+labelSections[] = Advanced_Facets
+labelSections[] = HomePage_Facets
+labelSections[] = ResultsTop
+labelSections[] = Results
+labelSections[] = ExtraFacetLabels
+
 [ExtraFacetLabels]
 long_lat = "Geographic Search"
 

--- a/config/vufind/Summon.ini
+++ b/config/vufind/Summon.ini
@@ -147,6 +147,19 @@ PublicationDate = "adv_search_year"  ; share year string w/advanced search page
 [FacetsTop]
 SubjectTerms = "Suggested Topics"
 
+; This section controls where facet labels are retrieved from when facets are not
+; explicitly configured.
+[FacetLabels]
+; This setting lists configuration sections containing facet field => label
+; mappings. Later values will override earlier values. These mappings will be used
+; only when a label is not explicitly configured (i.e. through SideFacets settings).
+; If you customize your facet display, be sure to add any new facet configuration
+; sections to this list to ensure proper display in search history, etc.
+labelSections[] = Advanced_Facets
+labelSections[] = HomePage_Facets
+labelSections[] = FacetsTop
+labelSections[] = Facets
+
 ; Facet display settings
 [Results_Settings]
 ; By default, the side facets will only show 6 facets and then the "show more"

--- a/config/vufind/Summon.ini
+++ b/config/vufind/Summon.ini
@@ -160,6 +160,11 @@ labelSections[] = HomePage_Facets
 labelSections[] = FacetsTop
 labelSections[] = Facets
 
+; This setting lists configuration settings defining checkbox facets. If you use
+; a custom section to configure additional facets, be sure to add it to this list
+; so labels display correctly in history, the advanced search editor, etc.
+checkboxSections[] = CheckboxFacets
+
 ; Facet display settings
 [Results_Settings]
 ; By default, the side facets will only show 6 facets and then the "show more"

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -37,6 +37,11 @@ labelSections[] = ResultsTop
 labelSections[] = Results
 labelSections[] = ExtraFacetLabels
 
+; This setting lists configuration settings defining checkbox facets. If you use
+; a custom section to configure additional facets, be sure to add it to this list
+; so labels display correctly in history, the advanced search editor, etc.
+checkboxSections[] = CheckboxFacets
+
 ; This section is used to specify labels for facets that may be applied by parts
 ; of VuFind other than the facet lists defined in this file (for example, the
 ; hierarchical browse of the BrowseController, or the Geographic Search).

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -23,6 +23,20 @@ publishDate        = "adv_search_year"  ; share year string w/advanced search pa
 [ResultsTop]
 topic_facet        = "Suggested Topics"
 
+; This section controls where facet labels are retrieved from when facets are not
+; explicitly configured.
+[FacetLabels]
+; This setting lists configuration sections containing facet field => label
+; mappings. Later values will override earlier values. These mappings will be used
+; only when a label is not explicitly configured (i.e. through SideFacets settings).
+; If you customize your facet display, be sure to add any new facet configuration
+; sections to this list to ensure proper display in search history, etc.
+labelSections[] = Advanced
+labelSections[] = HomePage
+labelSections[] = ResultsTop
+labelSections[] = Results
+labelSections[] = ExtraFacetLabels
+
 ; This section is used to specify labels for facets that may be applied by parts
 ; of VuFind other than the facet lists defined in this file (for example, the
 ; hierarchical browse of the BrowseController, or the Geographic Search).

--- a/config/vufind/reserves.ini
+++ b/config/vufind/reserves.ini
@@ -24,6 +24,10 @@ department_str   = "Department"
 instructor_str   = "Instructor"
 course_str       = "Course"
 
+[FacetLabels]
+labelSections[] = Facets
+checkboxSections[] = CheckboxFacets
+
 [Autocomplete]
 enabled = true
 

--- a/config/vufind/website.ini
+++ b/config/vufind/website.ini
@@ -25,6 +25,10 @@ category = "Category"
 linktype = "Link Type"
 subject = "Subject"
 
+[FacetLabels]
+labelSections[] = Facets
+checkboxSections[] = CheckboxFacets
+
 [Results_Settings]
 ; By default, how many values should we show for each facet? (-1 for no limit)
 facet_limit = 30

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -433,9 +433,6 @@ class AbstractSearch extends AbstractBase
             }
         }
 
-        // Activate facets so we get appropriate descriptions in the filter list:
-        $savedSearch->getParams()->activateAllFacets('Advanced');
-
         // Make the object available to the view:
         return $savedSearch;
     }
@@ -731,7 +728,6 @@ class AbstractSearch extends AbstractBase
             $this->params()->fromQuery('facetop', 'AND') == 'OR'
         );
         $list = $facets[$facet]['data']['list'] ?? [];
-        $params->activateAllFacets();
         $facetLabel = $params->getFacetLabel($facet);
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -198,6 +198,16 @@ class Params
 
         // Make sure we have some sort of query object:
         $this->query = new Query();
+
+        // Set up facet label settings, to be used as fallbacks if specific facets
+        // are not already configured:
+        $config = $configLoader->get($options->getFacetsIni());
+        $sections = $config->FacetLabels->labelSections ?? ['ExtraFacetLabels'];
+        foreach ($sections as $section) {
+            foreach ($config->$section ?? [] as $field => $label) {
+                $this->extraFacetLabels[$field] = $label;
+            }
+        }
     }
 
     /**
@@ -1594,29 +1604,6 @@ class Params
 
         // Search terms, we need to expand keys
         $this->query = QueryAdapter::deminify($minified->t);
-    }
-
-    /**
-     * Load all available facet settings.  This is mainly useful for showing
-     * appropriate labels when an existing search has multiple filters associated
-     * with it.
-     *
-     * @param string $preferredSection Section to favor when loading settings;
-     * if multiple sections contain the same facet, this section's description
-     * will be favored.
-     *
-     * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function activateAllFacets($preferredSection = false)
-    {
-        // By default, there is only 1 set of facet settings, so this function isn't
-        // really necessary.  However, in the Search History screen, we need to
-        // use this for Solr-based Search Objects, so we need this dummy method to
-        // allow other types of Search Objects to co-exist with Solr-based ones.
-        // See the Solr Search Object for details of how this works if you need to
-        // implement context-sensitive facet settings in another module.
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -938,7 +938,7 @@ class Params
         // Extract the facet field name from the filter, then add the
         // relevant information to the array.
         list($fieldName) = explode(':', $filter);
-        $this->checkboxFacets[$fieldName][]
+        $this->checkboxFacets[$fieldName][$filter]
             = ['desc' => $desc, 'filter' => $filter];
     }
 

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -208,6 +208,12 @@ class Params
                 $this->extraFacetLabels[$field] = $label;
             }
         }
+
+        // Activate all relevant checkboxes, also important for labeling:
+        $checkboxSections = $config->FacetLabels->checkboxSections ?? [];
+        foreach ($checkboxSections as $checkboxSection) {
+            $this->initCheckboxFacets($checkboxSection);
+        }
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -939,14 +939,15 @@ class Params
     /**
      * Get a user-friendly string to describe the provided facet field.
      *
-     * @param string $field Facet field name.
-     * @param string $value Facet value.
+     * @param string $field   Facet field name.
+     * @param string $value   Facet value.
+     * @param string $default Default field name (null for default behavior).
      *
-     * @return string       Human-readable description of field.
+     * @return string         Human-readable description of field.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getFacetLabel($field, $value = null)
+    public function getFacetLabel($field, $value = null, $default = null)
     {
         if (!isset($this->facetConfig[$field])
             && !isset($this->extraFacetLabels[$field])
@@ -958,7 +959,8 @@ class Params
             return $this->facetConfig[$field];
         }
         return isset($this->extraFacetLabels[$field])
-            ? $this->extraFacetLabels[$field] : 'unrecognized_facet_label';
+            ? $this->extraFacetLabels[$field]
+            : ($default ?: 'unrecognized_facet_label');
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/EDS/Params.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Params.php
@@ -287,25 +287,23 @@ class Params extends \VuFind\Search\Base\Params
     /**
      * Get a user-friendly string to describe the provided facet field.
      *
-     * @param string $field Facet field name.
-     * @param string $value Facet value.
+     * @param string $field   Facet field name.
+     * @param string $value   Facet value.
+     * @param string $default Default field name (null for default behavior).
      *
-     * @return string       Human-readable description of field.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return string         Human-readable description of field.
      */
-    public function getFacetLabel($field, $value = null)
+    public function getFacetLabel($field, $value = null, $default = null)
     {
-        //Also store Limiter/Search Mode IDs/Values in the config file
-        $facetId = $field;
+        // Also store Limiter/Search Mode IDs/Values in the config file
         if (substr($field, 0, 6) == 'LIMIT|') {
             $facetId = substr($field, 6);
-        }
-        if (substr($field, 0, 11) == 'SEARCHMODE|') {
+        } elseif (substr($field, 0, 11) == 'SEARCHMODE|') {
             $facetId = substr($field, 11);
+        } else {
+            $facetId = $field;
         }
-        return isset($this->facetConfig[$facetId])
-            ? $this->facetConfig[$facetId] : $facetId;
+        return parent::getFacetLabel($facetId, $value, $default ?: $facetId);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Primo/Params.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Params.php
@@ -99,22 +99,4 @@ class Params extends \VuFind\Search\Base\Params
         }
         return ucwords(str_replace('_', ' ', $str));
     }
-
-    /**
-     * Load all available facet settings.  This is mainly useful for showing
-     * appropriate labels when an existing search has multiple filters associated
-     * with it.
-     *
-     * @param string $preferredSection Section to favor when loading settings; if
-     * multiple sections contain the same facet, this section's description will
-     * be favored.
-     *
-     * @return void
-     */
-    public function activateAllFacets($preferredSection = false)
-    {
-        $this->initFacetList('Facets', 'Results_Settings');
-        $this->initFacetList('Advanced_Facets', 'Advanced_Facet_Settings');
-        $this->initCheckboxFacets();
-    }
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -103,9 +103,6 @@ class Params extends \VuFind\Search\Base\Params
         if (isset($config->LegacyFields)) {
             $this->facetAliases = $config->LegacyFields->toArray();
         }
-        if (isset($config->ExtraFacetLabels)) {
-            $this->extraFacetLabels = $config->ExtraFacetLabels->toArray();
-        }
         if (isset($config->Results_Settings->sorted_by_index)
             && count($config->Results_Settings->sorted_by_index) > 0
         ) {
@@ -305,44 +302,6 @@ class Params extends \VuFind\Search\Base\Params
         if (!$this->initFacetList('HomePage', 'HomePage_Settings')) {
             $this->initAdvancedFacets();
         }
-    }
-
-    /**
-     * Initialize facet settings for the standard search screen.
-     *
-     * @return void
-     */
-    public function initBasicFacets()
-    {
-        $this->initFacetList('ResultsTop', 'Results_Settings');
-        $this->initFacetList('Results', 'Results_Settings');
-    }
-
-    /**
-     * Load all available facet settings.  This is mainly useful for showing
-     * appropriate labels when an existing search has multiple filters associated
-     * with it.
-     *
-     * @param string $preferredSection Section to favor when loading settings; if
-     * multiple sections contain the same facet, this section's description will
-     * be favored.
-     *
-     * @return void
-     */
-    public function activateAllFacets($preferredSection = false)
-    {
-        // Based on preference, change the order of initialization to make sure
-        // that preferred facet labels come in last.
-        if ($preferredSection == 'Advanced') {
-            $this->initHomePageFacets();
-            $this->initBasicFacets();
-            $this->initAdvancedFacets();
-        } else {
-            $this->initHomePageFacets();
-            $this->initAdvancedFacets();
-            $this->initBasicFacets();
-        }
-        $this->initCheckboxFacets();
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Summon/Params.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Params.php
@@ -400,41 +400,4 @@ class Params extends \VuFind\Search\Base\Params
             $this->initAdvancedFacets();
         }
     }
-
-    /**
-     * Initialize facet settings for the standard search screen.
-     *
-     * @return void
-     */
-    public function initBasicFacets()
-    {
-        $this->initFacetList('Facets', 'Results_Settings');
-    }
-
-    /**
-     * Load all available facet settings.  This is mainly useful for showing
-     * appropriate labels when an existing search has multiple filters associated
-     * with it.
-     *
-     * @param string $preferredSection Section to favor when loading settings; if
-     * multiple sections contain the same facet, this section's description will
-     * be favored.
-     *
-     * @return void
-     */
-    public function activateAllFacets($preferredSection = false)
-    {
-        // Based on preference, change the order of initialization to make sure
-        // that preferred facet labels come in last.
-        if ($preferredSection == 'Advanced') {
-            $this->initHomePageFacets();
-            $this->initBasicFacets();
-            $this->initAdvancedFacets();
-        } else {
-            $this->initHomePageFacets();
-            $this->initAdvancedFacets();
-            $this->initBasicFacets();
-        }
-        $this->initCheckboxFacets();
-    }
 }

--- a/module/VuFind/src/VuFind/Search/Summon/Params.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Params.php
@@ -134,20 +134,18 @@ class Params extends \VuFind\Search\Base\Params
     /**
      * Get a user-friendly string to describe the provided facet field.
      *
-     * @param string $field Facet field name.
-     * @param string $value Facet value.
+     * @param string $field   Facet field name.
+     * @param string $value   Facet value.
+     * @param string $default Default field name (null for default behavior).
      *
-     * @return string       Human-readable description of field.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return string         Human-readable description of field.
      */
-    public function getFacetLabel($field, $value = null)
+    public function getFacetLabel($field, $value = null, $default = null)
     {
         // The default use of "Other" for undefined facets doesn't work well with
         // checkbox facets -- we'll use field names as the default within the Summon
         // search object.
-        return isset($this->facetConfig[$field])
-            ? $this->facetConfig[$field] : $field;
+        return parent::getFacetLabel($field, $value, $default ?: $field);
     }
 
     /**

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -114,7 +114,6 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch
         $results = $this->getResultsManager()->get($this->searchClassId);
         $options = $results->getOptions();
         $params = $results->getParams();
-        $params->activateAllFacets();
 
         $viewParams = [
             'config' => $config,

--- a/themes/bootstrap3/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap3/templates/search/advanced/ranges.phtml
@@ -1,5 +1,5 @@
 <?php if (isset($this->ranges) && !empty($this->ranges)): ?>
-  <?php $params = $this->searchParams($this->searchClassId); $params->activateAllFacets(); ?>
+  <?php $params = $this->searchParams($this->searchClassId); ?>
   <?php foreach ($this->ranges as $current): $escField = $this->escapeHtmlAttr($current['field']); ?>
     <?php $extraInputAttribs = ($current['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
     <fieldset class="range">

--- a/themes/bootstrap3/templates/search/history-table.phtml
+++ b/themes/bootstrap3/templates/search/history-table.phtml
@@ -18,7 +18,7 @@
         ?></a>
       </td>
       <td>
-        <?php $info->getParams()->activateAllFacets(); foreach ($info->getParams()->getFilterList(true) as $field => $filters): ?>
+        <?php foreach ($info->getParams()->getFilterList(true) as $field => $filters): ?>
           <?php foreach ($filters as $i => $filter): ?>
             <?php if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?>
             <strong><?=$this->transEsc($field)?></strong>: <?=$this->escapeHtml($filter['displayText'])?><br/>


### PR DESCRIPTION
This pull request replaces VuFind's somewhat confusing `activateAllFacets()` logic with a simpler configuration-based approach which tells the code where to find configurations that may be useful for displaying facet labels.

This causes two small behavioral changes from the current master code:

1.) When a facet value is included in multiple places, the order of the settings in the configuration will now determine which label is used (last section listed wins), as opposed to the logic/parameters of `activateAllFacets()` determining the preference.

2.) All checkbox facets are now activated by default. For most use cases this will not matter, but there are some edge cases where this will be problematic without the filtering logic added in #1283.