### PR TITLE
Simplify alphabrowse linking.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
@@ -71,20 +71,10 @@ class AlphaBrowse extends \Zend\View\Helper\AbstractHelper
             return null;
         }
 
-        // Linking using bib ids is generally more reliable than doing searches for
-        // headings, but headings give shorter queries and don't look as strange.
-        if ($item['count'] < 5) {
-            $safeIds = array_map([$this, 'escapeForSolr'], $item['ids']);
-            $query = ['type' => 'ids', 'lookfor' => implode(' ', $safeIds)];
-            if ($item['count'] == 1) {
-                $query['jumpto'] = 1;
-            }
-        } else {
-            $query = [
-                'type' => ucwords($source) . 'Browse',
-                'lookfor' => $this->escapeForSolr($item['heading']),
-            ];
-        }
+        $query = [
+            'type' => ucwords($source) . 'Browse',
+            'lookfor' => $this->escapeForSolr($item['heading']),
+        ];
         return $this->url->__invoke('search-results', [], ['query' => $query]);
     }
 


### PR DESCRIPTION
The old ID-based method was based on lack of confidence and added unnecessary complexity.

See also conversation on https://github.com/vufind-org/vufind-browse-handler/pull/23