### PR TITLE
Use realpath when concatenating files.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
@@ -230,7 +230,10 @@ trait ConcatTrait
         }
         // Locate/create concatenated asset file
         $filename = md5($group['key']) . '.min.' . $this->getFileType();
-        $concatPath = $this->getResourceCacheDir() . $filename;
+        // Minifier uses realpath, so do that here too to make sure we're not
+        // pointing to a symlink. Otherwise the path converter won't find the correct
+        // shared directory part.
+        $concatPath = realpath($this->getResourceCacheDir()) . '/' . $filename;
         if (!file_exists($concatPath)) {
             $lockfile = "$concatPath.lock";
             $handle = fopen($lockfile, 'c+');

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
@@ -279,6 +279,7 @@ trait ConcatTrait
                 . $this->getResourceFilePath($item),
                 ThemeInfo::RETURN_ALL_DETAILS
             );
+            $details['path'] = realpath($details['path']);
             $data[] = $this->getMinifiedData($details, $concatPath);
         }
         // Separate each file's data with a new line so that e.g. a file


### PR DESCRIPTION
If you access VuFind via a symlink (with Apache pointing to a directory that's a symlink to the actual directory), minifier's path converter fails to detect the proper shared path since it uses realpath() on any path that it converts. This change makes sure that we use the actual paths as the source and target.