### PR TITLE
Convert paths in css files using a naïve mechanism that disregards sy…

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/Minify/PathConverter.php
+++ b/module/VuFindTheme/src/VuFindTheme/Minify/PathConverter.php
@@ -53,4 +53,38 @@ class PathConverter extends \MatthiasMullie\PathConverter\Converter
 
         return $path;
     }
+
+    /**
+     * Convert paths relative to the themes directory.
+     *
+     * Takes advantage of the fact that we know the themes directory will be
+     * '../themes' relative to the cache directory. This allows path resolution to
+     * work regardless of whether there are symlinked directories or other
+     * differences between the actual file system path and the path used to access
+     * the theme files.
+     *
+     * @param string $path The relative path that needs to be converted
+     *
+     * @return string The new relative path
+     */
+    public function convert($path)
+    {
+        $path = $this->from . '/' . $path;
+        $path = preg_replace('/.*?\/themes\//', '../themes/', $path);
+
+        // Remove .. parts in the middle of the resulting path:
+        $parts = explode('/', $path);
+        $result = [];
+        $last = '';
+        foreach ($parts as $part) {
+            if ('' !== $last && '..' !== $last && '..' === $part) {
+                array_pop($result);
+                continue;
+            }
+            $last = $part;
+            $result[] = $part;
+        }
+
+        return implode('/', $result);
+    }
 }


### PR DESCRIPTION
…mlinks etc.

This should allow the CSS minification to work with all kinds of combinations of symlinked directories since it doesn't rely on converting paths using their common parts.

TODO
- [X] Verify that this works properly in all cases. I'm going to implement this locally to make sure there are no more edge cases failing.