### PR TITLE
Fix multiple reply-to addresses in feedback emails.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -150,6 +150,9 @@ class FeedbackController extends AbstractBase
     ) {
         try {
             $mailer = $this->serviceLocator->get('VuFind\Mailer\Mailer');
+            if ($replyToEmail) {
+                $mailer->setFromAddressOverride('');
+            }
             $mailer->send(
                 new Address($recipientEmail, $recipientName),
                 new Address($senderEmail, $senderName),


### PR DESCRIPTION
This fixes a bug where feedback email message is sent with multiple reply-to
addresses when (1) sender email address was supplied via the feedback form and
(2) override_from is configured in config.ini > Mail.