### PR TITLE
Fix encoding of ampersands in linkify.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -652,7 +652,7 @@ class Demo extends AbstractBase
             $status[$i]['item_notes'] = [];
             for ($j = 1; $j <= $noteCount; $j++) {
                 $status[$i]['holdings_notes'][] = "Item $itemNum holdings note $j"
-                    . ($j === 1 ? ' https://vufind.org#sample_link' : '');
+                    . ($j === 1 ? ' https://vufind.org/?f=1&b=2#sample_link' : '');
                 $status[$i]['item_notes'][] = "Item $itemNum note $j";
             }
             $summCount = rand(1, 3);

--- a/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
@@ -43,7 +43,7 @@ class Linkify extends AbstractHelper
     /**
      * Linkify a string
      *
-     * @param string $str String to linkify
+     * @param string $str String to linkify (must be HTML-escaped)
      *
      * @return string
      */

--- a/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
@@ -51,13 +51,13 @@ class Linkify extends AbstractHelper
     {
         $linkify = new \Misd\Linkify\Linkify();
         $proxyUrl = $this->getView()->plugin('proxyUrl');
-        $escapeHtml = $this->getView()->plugin('escapeHtml');
         $escapeHtmlAttr = $this->getView()->plugin('escapeHtmlAttr');
-        $callback = function ($url, $caption, $isEmail) use ($proxyUrl, $escapeHtml,
+        $callback = function ($url, $caption, $isEmail) use ($proxyUrl,
             $escapeHtmlAttr
         ) {
+            $url = html_entity_decode($url);
             return '<a href="' . $escapeHtmlAttr($proxyUrl($url)) . '">'
-                . $escapeHtml($caption) . '</a>';
+                . "$caption</a>";
         };
         return $linkify->process($str, ['callback' => $callback]);
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Linkify Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2019.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\View\Helper\Root;
+
+use VuFind\View\Helper\Root\Linkify;
+use VuFind\View\Helper\Root\ProxyUrl;
+use Zend\View\Helper\EscapeHtml;
+use Zend\View\Helper\EscapeHtmlAttr;
+
+/**
+ * Linkify Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class LinkifyTest extends \VuFindTest\Unit\ViewHelperTestCase
+{
+    /**
+     * Get view helper to test.
+     *
+     * @return Linkify
+     */
+    protected function getHelper()
+    {
+        $view = $this->getPhpRenderer(
+            [
+                'proxyUrl' => new ProxyUrl(),
+                'escapeHtmlAttr' => new EscapeHtmlAttr(),
+            ]
+        );
+        $linkify = new Linkify();
+        $linkify->setView($view);
+        return $linkify;
+    }
+
+    /**
+     * Run a simple test.
+     *
+     * @param string $text     Raw input text
+     * @param string $expected Expected output HTML
+     *
+     * @return void
+     */
+    protected function linkify($text, $expected)
+    {
+        $escaper = new EscapeHtml();
+        // The linkify helper expects HTML-escaped input, because we can't
+        // escape unlinked text after the fact without messing up the links:
+        $html = $escaper->__invoke($text);
+        $this->assertEquals($expected, $this->getHelper()->__invoke($html));
+    }
+    /**
+     * Test linkification of HTTP URL.
+     *
+     * @return void
+     */
+    public function testHttpLink()
+    {
+        $text = 'This has http://vufind.org in the middle of it';
+        $expected = 'This has '
+            . '<a href="http&#x3A;&#x2F;&#x2F;vufind.org">http://vufind.org</a>'
+            . ' in the middle of it';
+        $this->linkify($text, $expected);
+    }
+
+    /**
+     * Test linkification of HTTPS URL.
+     *
+     * @return void
+     */
+    public function testHttpsLink()
+    {
+        $text = "This has https://vufind.org in the middle of it";
+        $expected = 'This has '
+            . '<a href="https&#x3A;&#x2F;&#x2F;vufind.org">https://vufind.org</a>'
+            . ' in the middle of it';
+        $this->linkify($text, $expected);
+    }
+
+    /**
+     * Test linkification of complex URL with parameters and hash.
+     *
+     * @return void
+     */
+    public function testComplexLink()
+    {
+        $text = "This has https://vufind.org?foo=1&bar=2#xyzzy in the middle of it";
+        $expected = 'This has '
+            . '<a href="https&#x3A;&#x2F;&#x2F;vufind.org'
+            . '&#x3F;foo&#x3D;1&amp;bar&#x3D;2&#x23;xyzzy">'
+            . 'https://vufind.org?foo=1&amp;bar=2#xyzzy</a> in the middle of it';
+        $this->linkify($text, $expected);
+    }
+
+    /**
+     * Test linkification of multiple URLs.
+     *
+     * @return void
+     */
+    public function testMultipleLinks()
+    {
+        $text = "This has https://vufind.org and http://vufind.org in it";
+        $expected = 'This has '
+            . '<a href="https&#x3A;&#x2F;&#x2F;vufind.org">https://vufind.org</a>'
+            . ' and '
+            . '<a href="http&#x3A;&#x2F;&#x2F;vufind.org">http://vufind.org</a>'
+            . ' in it';
+        $this->linkify($text, $expected);
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
@@ -77,6 +77,7 @@ class LinkifyTest extends \VuFindTest\Unit\ViewHelperTestCase
         $html = $escaper->__invoke($text);
         $this->assertEquals($expected, $this->getHelper()->__invoke($html));
     }
+
     /**
      * Test linkification of HTTP URL.
      *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
@@ -72,8 +72,9 @@ class LinkifyTest extends \VuFindTest\Unit\ViewHelperTestCase
     protected function linkify($text, $expected)
     {
         $escaper = new EscapeHtml();
-        // The linkify helper expects HTML-escaped input, because we can't
-        // escape unlinked text after the fact without messing up the links:
+        // The linkify helper expects HTML-escaped input, because after linkify
+        // has been applied, we can no longer escape unlinked portions of the text
+        // without messing up the link HTML:
         $html = $escaper->__invoke($text);
         $this->assertEquals($expected, $this->getHelper()->__invoke($html));
     }


### PR DESCRIPTION
This corrects a mistake I made when creating the linkifier. Since it creates HTML, it must be given a pre-escaped string. If there's something to linkify, it must be decoded before escaping as an HTML attribute. Since caption is already encoded, there's no need to re-encode it.