### PR TITLE
Enable to set $profile['home_library'] with values of ILS

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -443,7 +443,9 @@ class MyResearchController extends AbstractBase
             $catalog = $this->getILS();
             $this->addAccountBlocksToFlashMessenger($catalog, $patron);
             $profile = $catalog->getMyProfile($patron);
-            $profile['home_library'] = $user->home_library;
+            if (!empty($user->home_library)) {
+                $profile['home_library'] = $user->home_library;
+            }
             $view->profile = $profile;
             try {
                 $view->pickup = $catalog->getPickUpLocations($patron);


### PR DESCRIPTION
@demiankatz Hitherto value of $profile['home_library'] is only filled by the $user object at profileAction() of MyResearchController class and overwrites every parameter delivery by the $patron. In reality, we have few cases that information about home library of the user is provided by ILS. Therefore we like to integrate the possibility to take this information from the $patron here. Thanks in advance! 