### PR TITLE
Let the router use the default record route if a record driver cannot…

### DIFF
--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -103,9 +103,15 @@ class Router
             ) {
                 if (!is_object($driver)) {
                     list($source, $id) = $this->extractSourceAndId($driver);
-                    $driver = $this->loader->load($id, $source);
+                    try {
+                        $driver = $this->loader->load($id, $source);
+                    } catch (\Exception $e) {
+                        // Ignore exceptions here so that we don't crash when
+                        // creating a link to record that does not exist
+                    }
                 }
-                if (true === $driver->tryMethod('isCollection')) {
+                if (is_object($driver) && true === $driver->tryMethod('isCollection')
+                ) {
                     $route['route'] = 'collection';
                 }
             }


### PR DESCRIPTION
… be loaded.

Currently an exception is thrown if a record cannot be loaded when determining the link action. This can happen e.g. with the hierarchy support or any other links between records. With this change the default record route is used if the target record cannot be loaded without aborting the processing of e.g. search results.