### PR TITLE
Add support for fetching summary holdings from Sierra when using the …

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -134,3 +134,6 @@ title_hold_bib_levels = a:b:m:d
 ;supplements = "867az"
 ; Holdings fields to include in indexes. Default is none.
 ;indexes = "868az"
+; Whether to sort items by enum/chron (v field) instead of order they are returned
+; from Sierra. Default is true.
+;sort_by_enum_chron = false

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -12,9 +12,12 @@ host = "https://sandbox.iii.com/iii/sierra-api"
 client_key = "something"
 ; Sierra API client secret
 client_secret = "very_secret"
-; Sierra API version available (defaults to highest one required for full
-; functionality in the driver)
-;api_version = 5
+; Sierra API version available. Functionality requiring a specific minimum version:
+;   5 (default):
+;     - last pickup date for holds
+;   5.1 (technically still v5 but added in a later revision):
+;     - summary holdings information (especially for serials)
+;api_version = 5.1
 ; Timeout for HTTP requests
 http_timeout = 30
 ; Redirect URL entered in Sierra for the patron-specific authentication (does not

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -120,3 +120,17 @@ title_hold_bib_levels = a:b:m:d
 [TransactionHistory]
 ; By default the loan history is disabled. Uncomment the following line to enable it.
 ;enabled = true
+
+; Both MARC field+subfields and Sierra field tags may be used to specify which fields
+; are included as textual information from holdings records. Note that Sierra does
+; not use MARC tags for all holdings information, and e.g. 'h' may cover several
+; fields of which only some are mapped to MARC fields.
+[Holdings]
+; Holdings fields to include in notes. Default is none.
+;notes = "n"
+; Holdings fields to include in summary. Default is "h".
+;summary = "863abiz:866az:h"
+; Holdings fields to include in supplements. Default is none.
+;supplements = "867az"
+; Holdings fields to include in indexes. Default is none.
+;indexes = "868az"

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -158,6 +158,13 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     protected $apiVersion = 5.1;
 
     /**
+     * Whether to sort items by enumchron. Default is true.
+     *
+     * @var array
+     */
+    protected $sortItemsByEnumChron;
+
+    /**
      * Constructor
      *
      * @param \VuFind\Date\Converter $dateConverter  Date converter object
@@ -241,6 +248,9 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         if (isset($this->config['Catalog']['api_version'])) {
             $this->apiVersion = $this->config['Catalog']['api_version'];
         }
+
+        $this->sortItemsByEnumChron
+            = $this->config['Holdings']['sort_by_enum_chron'] ?? true;
 
         // Init session cache for session-specific data
         $namespace = md5(
@@ -1957,7 +1967,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     protected function statusSortFunction($a, $b)
     {
         $result = strcmp($a['location'], $b['location']);
-        if ($result === 0) {
+        if ($result === 0 && $this->sortItemsByEnumChron) {
             $result = strnatcmp($b['number'] ?? '', $a['number'] ?? '');
         }
         if ($result === 0) {

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -151,11 +151,11 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
      * v5:
      *   - last pickup date for holds
      * v5.1 (technically still v5 but added in a later revision):
-     *   - holdings information (especially for serials)
+     *   - summary holdings information (especially for serials)
      *
      * @var int
      */
-    protected $apiVersion = 5.1;
+    protected $apiVersion = 5;
 
     /**
      * Whether to sort items by enumchron. Default is true.

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1957,7 +1957,10 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     protected function statusSortFunction($a, $b)
     {
         $result = strcmp($a['location'], $b['location']);
-        if ($result == 0) {
+        if ($result === 0) {
+            $result = strnatcmp($b['number'] ?? '', $a['number'] ?? '');
+        }
+        if ($result === 0) {
             $result = $a['sort'] - $b['sort'];
         }
         return $result;

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1878,7 +1878,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
                     $line = [];
                     foreach ($subfields as $subfield) {
                         if ($subfieldCodes
-                            && !strstr($subfieldCodes, $subfield['tag'])
+                            && false === strpos($subfieldCodes, $subfield['tag'])
                         ) {
                             continue;
                         }


### PR DESCRIPTION
…REST API.

Includes a fix for ordering of results.

Note that support for fetching the required information for the holdings records was only recently added to the v5 API, so I used a pseudo-version 5.1 to indicate support for it.