### PR TITLE
Add demo xsl to support multirecord OAI imports

### DIFF
--- a/harvest/oai.ini
+++ b/harvest/oai.ini
@@ -54,7 +54,7 @@
 ; work with this setting. However, it is possible to revise the XSLT to handle
 ; batches of records. Starting with VuFind 6.0, a demo .xsl for OJS that can handle
 ; combined records within a <collection> tag has been included as an example
-; and can be found at import/xsl/ojs-multirecord.xsl.
+; and can be found at $VUFIND_HOME/import/xsl/ojs-multirecord.xsl.
 ;
 ; combineRecordsTag may be used to supply a beginning and ending XML tag (if
 ; combinedRecords is set to true) which will be used to wrap the set of

--- a/harvest/oai.ini
+++ b/harvest/oai.ini
@@ -53,7 +53,10 @@
 ; types of metadata are designed to process one record at a time and will not
 ; work with this setting. However, it may be possible to revise the XSLT to handle
 ; batches of records, and such improvements would be welcomed as contributions to
-; future releases of VuFind.
+; future releases of VuFind. A demo xsl for OJS that can handle combined records
+; within a <collection></collection> tag has been included for your convenience
+; and can be found at import/xsl/ojs-multirecord.xsl. Feel free to experiment with
+; it and modify/extend it according to your needs.
 ;
 ; combineRecordsTag may be used to supply a beginning and ending XML tag (if
 ; combinedRecords is set to true) which will be used to wrap the set of

--- a/harvest/oai.ini
+++ b/harvest/oai.ini
@@ -49,14 +49,12 @@
 ; combined into a fewer number of files (this is determined by the OAI server's
 ; response chunk size). The default setting (false) will result in a new file being
 ; created for each record. Note that this function is primarily intended for
-; harvesting MARC records; many of the example XSLT transformations for other
+; harvesting MARC records; many of VuFind's example XSLT transformations for other
 ; types of metadata are designed to process one record at a time and will not
-; work with this setting. However, it may be possible to revise the XSLT to handle
-; batches of records, and such improvements would be welcomed as contributions to
-; future releases of VuFind. A demo xsl for OJS that can handle combined records
-; within a <collection></collection> tag has been included for your convenience
-; and can be found at import/xsl/ojs-multirecord.xsl. Feel free to experiment with
-; it and modify/extend it according to your needs.
+; work with this setting. However, it is possible to revise the XSLT to handle
+; batches of records. Starting with VuFind 6.0, a demo .xsl for OJS that can handle
+; combined records within a <collection> tag has been included as an example
+; and can be found at import/xsl/ojs-multirecord.xsl.
 ;
 ; combineRecordsTag may be used to supply a beginning and ending XML tag (if
 ; combinedRecords is set to true) which will be used to wrap the set of

--- a/import/ojs.properties
+++ b/import/ojs.properties
@@ -2,7 +2,8 @@
 [General]
 ; REQUIRED: Name of XSLT file to apply.  Path is relative to the import/xsl directory
 ; of the VuFind installation (or your local override directory).
-; If you merge your OJS records together inside a <collection> tag, you can use
+; If you merge your OJS records together inside a <collection> tag with the
+; combineRecords feature of the OAI-PMH harvest tool, you can use
 ; ojs-multirecord.xsl instead of ojs.xsl for faster indexing performance.
 xslt = ojs.xsl
 ;xslt = ojs-multirecord.xsl

--- a/import/ojs.properties
+++ b/import/ojs.properties
@@ -2,7 +2,10 @@
 [General]
 ; REQUIRED: Name of XSLT file to apply.  Path is relative to the import/xsl directory
 ; of the VuFind installation (or your local override directory).
+; If you merge your OJS records together inside a <collection> tag, you can use
+; ojs-multirecord.xsl instead of ojs.xsl for faster indexing performance.
 xslt = ojs.xsl
+;xslt = ojs-multirecord.xsl
 ; OPTIONAL: PHP function(s) to register for use within XSLT file.  You may repeat
 ; this line to register multiple PHP functions.
 ;php_function[] = str_replace

--- a/import/xsl/ojs-multirecord.xsl
+++ b/import/xsl/ojs-multirecord.xsl
@@ -1,0 +1,138 @@
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:php="http://php.net/xsl"
+    xmlns:xlink="http://www.w3.org/2001/XMLSchema-instance">
+    <xsl:output method="xml" indent="yes" encoding="utf-8"/>
+    <xsl:param name="institution">My University</xsl:param>
+    <xsl:param name="collection">OJS</xsl:param>
+    <xsl:template match="/">
+        <xsl:if test="collection">
+            <collection>
+            <xsl:for-each select="collection">
+                <xsl:for-each select="oai_dc:dc">
+                    <xsl:apply-templates select="."/>
+                </xsl:for-each>
+            </xsl:for-each>
+            </collection>
+        </xsl:if>
+        <xsl:if test="oai_dc:dc">
+            <xsl:apply-templates/>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template match="oai_dc:dc">
+        <add>
+            <doc>
+                <!-- ID -->
+                <!-- Important: This relies on an <identifier> tag being injected by the OAI-PMH harvester. -->
+                <field name="id">
+                    <xsl:value-of select="identifier"/>
+                </field>
+
+                <!-- RECORDTYPE -->
+                <field name="recordtype">ojs</field>
+
+                <!-- FULLRECORD -->
+                <!-- disabled for now; records are so large that they cause memory problems!
+                <field name="fullrecord">
+                    <xsl:copy-of select="php:function('VuFind::xmlAsText', //oai_dc:dc)"/>
+                </field>
+                  -->
+
+                <!-- ALLFIELDS -->
+                <field name="allfields">
+                    <xsl:value-of select="normalize-space(string(oai_dc:dc))"/>
+                </field>
+
+                <!-- INSTITUTION -->
+                <field name="institution">
+                    <xsl:value-of select="$institution" />
+                </field>
+
+                <!-- COLLECTION -->
+                <field name="collection">
+                    <xsl:value-of select="$collection" />
+                </field>
+
+                <!-- LANGUAGE -->
+                <xsl:if test="dc:language">
+                    <xsl:for-each select="dc:language">
+                        <xsl:if test="string-length() > 0">
+                            <field name="language">
+                                <xsl:value-of select="php:function('VuFind::mapString', normalize-space(string(.)), 'language_map_iso639-1.properties')"/>
+                            </field>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:if>
+
+                <!-- FORMAT -->
+                <field name="format">Online</field>
+
+                <!-- AUTHOR -->
+                <xsl:if test="dc:creator">
+                    <xsl:for-each select="dc:creator">
+                        <xsl:if test="normalize-space()">
+                            <field name="author">
+                                <xsl:value-of select="normalize-space()"/>
+                            </field>
+                            <!-- use first author value for sorting -->
+                            <xsl:if test="position()=1">
+                                <field name="author_sort">
+                                    <xsl:value-of select="normalize-space()"/>
+                                </field>
+                            </xsl:if>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:if>
+
+                <!-- TITLE -->
+                <xsl:if test="dc:title[normalize-space()]">
+                    <field name="title">
+                        <xsl:value-of select="dc:title[normalize-space()]"/>
+                    </field>
+                    <field name="title_short">
+                        <xsl:value-of select="dc:title[normalize-space()]"/>
+                    </field>
+                    <field name="title_full">
+                        <xsl:value-of select="dc:title[normalize-space()]"/>
+                    </field>
+                    <field name="title_sort">
+                        <xsl:value-of select="php:function('VuFind::stripArticles', string(dc:title[normalize-space()]))"/>
+                    </field>
+                </xsl:if>
+                
+                <!-- DESCRIPTION -->
+                <xsl:if test="dc:description">
+                    <field name="description">
+                        <xsl:value-of select="dc:description" />
+                    </field>
+                </xsl:if>
+
+                <!-- PUBLISHER -->
+                <xsl:if test="dc:publisher[normalize-space()]">
+                    <field name="publisher">
+                        <xsl:value-of select="dc:publisher[normalize-space()]"/>
+                    </field>
+                </xsl:if>
+
+                <!-- PUBLISHDATE -->
+                <xsl:if test="dc:date">
+                    <field name="publishDate">
+                        <xsl:value-of select="substring(dc:date, 1, 4)"/>
+                    </field>
+                    <field name="publishDateSort">
+                        <xsl:value-of select="substring(dc:date, 1, 4)"/>
+                    </field>
+                </xsl:if>
+
+                <!-- URL -->
+                <xsl:if test="dc:identifier">
+                    <field name="url">
+                        <xsl:value-of select="dc:identifier[normalize-space()]"/>
+                    </field>
+                </xsl:if>
+            </doc>
+        </add>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This improvement adds an example ojs-multirecord.xsl that supports the handling of xml files containing many records.
The use of this xsl results in HUGE speedup during OAI import when compared to importing of several one-record xml files.