### PR TITLE
KohaILSDI Fix to return all recieved serial issues

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1618,12 +1618,11 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             }
 
             $sql = "SELECT b.title, b.biblionumber,
-                       MAX(CONCAT(s.publisheddate, ' / ',s.serialseq))
+                       CONCAT(s.publisheddate, ' / ',s.serialseq)
                          AS 'date and enumeration'
                     FROM serial s
                     LEFT JOIN biblio b USING (biblionumber)
                     WHERE s.STATUS=2 and b.biblionumber = :id
-                    GROUP BY b.biblionumber
                     ORDER BY s.publisheddate DESC";
 
             $sqlStmt = $this->db->prepare($sql);


### PR DESCRIPTION
Fix in KohaILSDI getPurchaseHistory function in order to get as a result an array of ALL recieved issues of a serial.
This behavior better matches the function documentation and is consisntent with getPurchaseHistory results from other ILS drivers. In case one wants to limit the number of displayed issues, this should be ideally handled in the theme template.