### PR TITLE
Null operator value fix in UrlQueryHelper

### DIFF
--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -145,9 +145,8 @@ class UrlQueryHelper
                         $this->urlParams['type' . $i][] = $inner->getHandler();
                         if (null !== ($op = $inner->getOperator())) {
                             // We want the op and lookfor parameters to align
-                            // with each other; let's backfill
-                            // empty op values if there
-                            // aren't enough in place already.
+                            // with each other; let's backfill empty op values
+                            // if there aren't enough in place already.
                             $expectedOps
                                 = count($this->urlParams['lookfor' . $i]) - 1;
                             while (

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -143,7 +143,14 @@ class UrlQueryHelper
                         }
                         $this->urlParams['lookfor' . $i][] = $inner->getString();
                         $this->urlParams['type' . $i][] = $inner->getHandler();
-                        $this->urlParams['op' . $i][] = $inner->getOperator() ?? '';
+                        $op = $inner->getOperator();
+                        if (!isset($op) 
+                            && !in_array('', $this->urlParams['op' . $i])
+                        ) {
+                            $this->urlParams['op' . $i][] = '';
+                        } else if (isset($op)) {
+                            $this->urlParams['op' . $i] = $op;
+                        }
                     }
                 }
             }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -149,7 +149,7 @@ class UrlQueryHelper
                         ) {
                             $this->urlParams['op' . $i][] = '';
                         } else if (isset($op)) {
-                            $this->urlParams['op' . $i] = $op;
+                            $this->urlParams['op' . $i][] = $op;
                         }
                     }
                 }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -129,6 +129,7 @@ class UrlQueryHelper
         }
         if ($this->queryObject instanceof QueryGroup) {
             $this->urlParams['join'] = $this->queryObject->getOperator();
+            $innerOperatorTmp = [];
             foreach ($this->queryObject->getQueries() as $i => $current) {
                 if ($current instanceof QueryGroup) {
                     $operator = $current->isNegated()
@@ -145,17 +146,20 @@ class UrlQueryHelper
                         $this->urlParams['type' . $i][] = $inner->getHandler();
                         $op = $inner->getOperator();
                         $key = 'op' . $i;
-                        if (!isset($this->urlParams[$key])) {
-                            $this->urlParams[$key] = [];
+                        if (!isset($innerOperatorTmp[$key])) {
+                            $innerOperatorTmp[$key] = [];
                         }
-                        if (!isset($op) 
-                            && !in_array('', $this->urlParams[$key])
-                        ) {
-                            $this->urlParams[$key][] = '';
+                        if (empty($op) && !in_array('', $innerOperatorTmp[$key])) {
+                            $innerOperatorTmp[$key][] = '';
                         } else if (isset($op)) {
-                            $this->urlParams[$key][] = $op;
+                            $innerOperatorTmp[$key][] = $op;
                         }
                     }
+                }
+            }
+            foreach ($innerOperatorTmp as $key => $value) {
+                if (!empty($value) && count($value) > 1 && in_array('', $value)) {
+                    $this->urlParams[$key] = $value;
                 }
             }
         } elseif ($this->queryObject instanceof Query) {

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -144,6 +144,7 @@ class UrlQueryHelper
                         $this->urlParams['lookfor' . $i][] = $inner->getString();
                         $this->urlParams['type' . $i][] = $inner->getHandler();
                         $op = $inner->getOperator();
+                        $this->urlParams['op' . $i] = [];
                         if (!isset($op) 
                             && !in_array('', $this->urlParams['op' . $i])
                         ) {

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -158,7 +158,10 @@ class UrlQueryHelper
                 }
             }
             foreach ($innerOperatorTmp as $key => $value) {
-                if (!empty($value) && count($value) > 1 && in_array('', $value)) {
+                if (!empty($value)) {
+                    if (in_array('', $value) && count($value) === 1) {
+                        continue;
+                    }
                     $this->urlParams[$key] = $value;
                 }
             }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -144,13 +144,16 @@ class UrlQueryHelper
                         $this->urlParams['lookfor' . $i][] = $inner->getString();
                         $this->urlParams['type' . $i][] = $inner->getHandler();
                         $op = $inner->getOperator();
-                        $this->urlParams['op' . $i] = [];
+                        $key = 'op' . $i;
+                        if (!isset($this->urlParams[$key])) {
+                            $this->urlParams[$key] = [];
+                        }
                         if (!isset($op) 
-                            && !in_array('', $this->urlParams['op' . $i])
+                            && !in_array('', $this->urlParams[$key])
                         ) {
-                            $this->urlParams['op' . $i][] = '';
+                            $this->urlParams[$key][] = '';
                         } else if (isset($op)) {
-                            $this->urlParams['op' . $i][] = $op;
+                            $this->urlParams[$key][] = $op;
                         }
                     }
                 }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -146,12 +146,12 @@ class UrlQueryHelper
                         if (null !== ($op = $inner->getOperator())) {
                             // We want the op and lookfor parameters to align
                             // with each other; let's backfill
-                            // empty op values if there 
+                            // empty op values if there
                             // aren't enough in place already.
-                            $expectedOps 
+                            $expectedOps
                                 = count($this->urlParams['lookfor' . $i]) - 1;
                             while (
-                                count($this->urlParams['op' . $i] ?? []) 
+                                count($this->urlParams['op' . $i] ?? [])
                                 < $expectedOps
                             ) {
                                 $this->urlParams['op' . $i][] = '';

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -151,7 +151,7 @@ class UrlQueryHelper
                         }
                         if (empty($op) && !in_array('', $innerOperatorTmp[$key])) {
                             $innerOperatorTmp[$key][] = '';
-                        } else if (isset($op)) {
+                        } elseif (isset($op)) {
                             $innerOperatorTmp[$key][] = $op;
                         }
                     }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -143,9 +143,7 @@ class UrlQueryHelper
                         }
                         $this->urlParams['lookfor' . $i][] = $inner->getString();
                         $this->urlParams['type' . $i][] = $inner->getHandler();
-                        if (null !== ($op = $inner->getOperator())) {
-                            $this->urlParams['op' . $i][] = $op;
-                        }
+                        $this->urlParams['op' . $i][] = $inner->getOperator() ?? '';
                     }
                 }
             }


### PR DESCRIPTION
At the moment URLQueryHelper is not regenerating a null 'op' parameter and its causing an issue when trying to sort with another option.

Here is an example:
Working:
https://mpkk.finna.fi/EDS/Search?sort=relevance&join=AND&bool0[]=AND&op0[]=&lookfor0[]="adelphi+papers"&type0[]=SO&op0[]=OR&lookfor0[]="adelphi+series"&type0[]=SO&op0[]=AND&lookfor0[]=&type0[]=AllFields&filter[]=EXPAND:fulltext&filter[]=SEARCHMODE:bool&daterange[]=PublicationDate&PublicationDatefrom=&PublicationDateto=&limit=50&dfApplied=1#

Not working:
https://mpkk.finna.fi/EDS/Search?limit=50&filter[]=EXPAND:"fulltext"&filter[]=SEARCHMODE:"bool"&dfApplied=1&join=AND&bool0[]=AND&lookfor0[]="adelphi+papers"&lookfor0[]="adelphi+series"&type0[]=SO&type0[]=SO&op0[]=OR&sort=date