### PR TITLE
Add apostrophe to removed characters for autocomplete

### DIFF
--- a/module/VuFind/src/VuFind/Autocomplete/Solr.php
+++ b/module/VuFind/src/VuFind/Autocomplete/Solr.php
@@ -172,7 +172,7 @@ class Solr implements AutocompleteInterface
     protected function mungeQuery($query)
     {
         // Modify the query so it makes a nice, truncated autocomplete query:
-        $forbidden = [':', '(', ')', '*', '+', '"'];
+        $forbidden = [':', '(', ')', '*', '+', '"', "'"];
         $query = str_replace($forbidden, " ", $query);
         if (substr($query, -1) != " ") {
             $query .= "*";


### PR DESCRIPTION
Searching `d'alember` on https://vufind.org/demo/ doesn't give any completion suggestions. Although `alember` yield results. 

The combination of apostrophe and wildcard seems to make problems : 
https://vufind.org/demo/Search/Results?lookfor=d%27alember*&type=Author&limit=20

To get at least suggestions, I propose to add the apostrophe to the removed characters. What do you think ?