### PR TITLE
Don't let the router normalize path.

### DIFF
--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -90,6 +90,10 @@ class Router
             $route['options']['query'] = $query;
         }
 
+        // Disable path normalization since it can unencode e.g. encoded slashes in
+        // record id's
+        $route['options']['normalize_path'] = false;
+
         // If collections are active and the record route was selected, we need
         // to check if the driver is actually a collection; if so, we should switch
         // routes.

--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -90,10 +90,6 @@ class Router
             $route['options']['query'] = $query;
         }
 
-        // Disable path normalization since it can unencode e.g. encoded slashes in
-        // record id's
-        $route['options']['normalize_path'] = false;
-
         // If collections are active and the record route was selected, we need
         // to check if the driver is actually a collection; if so, we should switch
         // routes.
@@ -148,8 +144,16 @@ class Router
         $routeBase = ($source == DEFAULT_SEARCH_BACKEND)
             ? 'record' : strtolower($source . 'record');
 
+        // Disable path normalization since it can unencode e.g. encoded slashes in
+        // record id's
+        $options = [
+            'normalize_path' => false
+        ];
+
         return [
-            'params' => $params, 'route' => $routeBase . $routeSuffix
+            'params' => $params,
+            'route' => $routeBase . $routeSuffix,
+            'options' => $options
         ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
@@ -54,7 +54,13 @@ class RouterTest extends TestCase
         $driver = $this->getDriver();
         $router = $this->getRouter();
         $this->assertEquals(
-            ['params' => ['id' => 'test'], 'route' => 'record'],
+            [
+                'params' => ['id' => 'test'],
+                'route' => 'record',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getRouteDetails($driver)
         );
     }
@@ -68,7 +74,13 @@ class RouterTest extends TestCase
     {
         $router = $this->getRouter();
         $this->assertEquals(
-            ['params' => ['id' => 'test'], 'route' => 'summonrecord'],
+            [
+                'params' => ['id' => 'test'],
+                'route' => 'summonrecord',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getRouteDetails('Summon|test')
         );
     }
@@ -82,7 +94,13 @@ class RouterTest extends TestCase
     {
         $router = $this->getRouter();
         $this->assertEquals(
-            ['params' => ['id' => 'test', 'tab' => 'foo'], 'route' => 'summonrecord'],
+            [
+                'params' => ['id' => 'test', 'tab' => 'foo'],
+                'route' => 'summonrecord',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getTabRouteDetails('Summon|test', 'foo')
         );
     }
@@ -96,8 +114,35 @@ class RouterTest extends TestCase
     {
         $router = $this->getRouter(['Collections' => ['collections' => true]]);
         $this->assertEquals(
-            ['params' => ['id' => 'test', 'tab' => 'foo'], 'route' => 'record', 'options' => ['query' => ['checkRoute' => 1]]],
+            [
+                'params' => ['id' => 'test', 'tab' => 'foo'],
+                'route' => 'record',
+                'options' => [
+                    'normalize_path' => false,
+                    'query' => ['checkRoute' => 1]
+                ]
+            ],
             $router->getTabRouteDetails('Solr|test', 'foo')
+        );
+    }
+
+    /**
+     * Test routing with source|id string including percent signs.
+     *
+     * @return void
+     */
+    public function testRoutingWithIDContainingPercent()
+    {
+        $router = $this->getRouter();
+        $this->assertEquals(
+            [
+                'params' => ['id' => 'test%2Fsub'],
+                'route' => 'record',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
+            $router->getRouteDetails('Solr|test%2Fsub')
         );
     }
 
@@ -110,7 +155,14 @@ class RouterTest extends TestCase
     {
         $router = $this->getRouter(['Collections' => ['collections' => true]]);
         $this->assertEquals(
-            ['params' => ['id' => 'test', 'tab' => 'foo'], 'route' => 'record', 'options' => ['query' => ['checkRoute' => 1]]],
+            [
+                'params' => ['id' => 'test', 'tab' => 'foo'],
+                'route' => 'record',
+                'options' => [
+                    'normalize_path' => false,
+                    'query' => ['checkRoute' => 1]
+                ]
+            ],
             $router->getTabRouteDetails('test', 'foo')
         );
     }
@@ -126,7 +178,13 @@ class RouterTest extends TestCase
         $driver->expects($this->once())->method('tryMethod')->with($this->equalTo('isCollection'))->will($this->returnValue(true));
         $router = $this->getRouter(['Collections' => ['collections' => true]]);
         $this->assertEquals(
-            ['params' => ['id' => 'test', 'tab' => 'foo'], 'route' => 'collection'],
+            [
+                'params' => ['id' => 'test', 'tab' => 'foo'],
+                'route' => 'collection',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getTabRouteDetails($driver, 'foo')
         );
     }
@@ -140,7 +198,13 @@ class RouterTest extends TestCase
     {
         $router = $this->getRouter();
         $this->assertEquals(
-            ['params' => ['id' => 'test'], 'route' => 'record'],
+            [
+                'params' => ['id' => 'test'],
+                'route' => 'record',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getRouteDetails('test')
         );
     }
@@ -155,7 +219,13 @@ class RouterTest extends TestCase
         $driver = $this->getDriver();
         $router = $this->getRouter();
         $this->assertEquals(
-            ['params' => ['id' => 'test'], 'route' => 'record-sms'],
+            [
+                'params' => ['id' => 'test'],
+                'route' => 'record-sms',
+                'options' => [
+                    'normalize_path' => false
+                ]
+            ],
             $router->getActionRouteDetails($driver, 'SMS')
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * RecordLink view helper Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2019.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\View\Helper\Root;
+
+use VuFind\Record\Router;
+use VuFind\View\Helper\Root\RecordLink;
+use Zend\Config\Config;
+
+/**
+ * RecordLink view helper Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RecordLinkTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test record URL creation.
+     *
+     * @return void
+     */
+    public function testRecordUrl()
+    {
+        $recordLink = $this->getRecordLink();
+        $this->assertEquals(
+            '/Record/foo',
+            $recordLink->getUrl('Solr|foo')
+        );
+
+        // Make sure any percent signs in record ID are properly URL-encoded
+        $this->assertEquals(
+            '/Record/foo%252fbar',
+            $recordLink->getUrl('Solr|foo%2fbar')
+        );
+        $this->assertEquals(
+            '/Record/foo%252fbar?checkRoute=1',
+            $recordLink->getTabUrl('Solr|foo%2fbar', null, ['checkRoute' => 1])
+        );
+    }
+
+    /**
+     * Get a RecordLink object ready for testing.
+     *
+     * @return Record
+     */
+    protected function getRecordLink()
+    {
+        $view = $this->getMockBuilder(\Zend\View\Renderer\PhpRenderer::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['plugin'])
+            ->getMock();
+        $view->expects($this->any())->method('plugin')
+            ->will($this->returnValue($this->getUrl()));
+
+        $recordLink = new RecordLink(new Router(new Config([])));
+        $recordLink->setView($view);
+        return $recordLink;
+    }
+
+    /**
+     * Get a URL helper.
+     *
+     * @return \Zend\View\Helper\Url
+     */
+    protected function getUrl()
+    {
+        $url = new \Zend\View\Helper\Url();
+
+        // Create router
+        $router = new \Zend\Router\Http\TreeRouteStack();
+        $router->setRequestUri(new \Zend\Uri\Http('http://localhost'));
+        $recordRoute = new \Zend\Router\Http\Segment(
+            '/Record/[:id[/[:tab]]]',
+            [
+                'controller' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                'action'     => '[a-zA-Z][a-zA-Z0-9_-]*',
+            ],
+            [
+                'controller' => 'Record',
+                'action'     => 'Home',
+            ]
+        );
+
+        $router->addRoute('record', $recordRoute);
+        $url->setRouter($router);
+
+        return $url;
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkTest.php
@@ -88,11 +88,16 @@ class RecordLinkTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a URL helper.
      *
-     * @return \Zend\View\Helper\Url
+     * @return \VuFind\View\Helper\Root\Url
      */
     protected function getUrl()
     {
-        $url = new \Zend\View\Helper\Url();
+        $request = $this->getMockBuilder(\Zend\Http\PhpEnvironment\Request::class)
+            ->setMethods(['getQuery'])->getMock();
+        $request->expects($this->any())->method('getQuery')
+            ->will($this->returnValue(new \Zend\StdLib\Parameters()));
+
+        $url = new \VuFind\View\Helper\Root\Url($request);
 
         // Create router
         $router = new \Zend\Router\Http\TreeRouteStack();


### PR DESCRIPTION
Path normalization would destroy any "overly encoded" characters in record identifiers, such as %2F.