### PR TITLE
Address Lodash Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "grunt": "^1.0.0",
     "grunt-contrib-less": "1.3.0",
-    "grunt-less-to-sass": "0.0.10",
+    "grunt-less-to-sass": "crhallberg/grunt-less-to-sass#lodash-fix",
     "grunt-sass": "^1.0.0",
     "jit-grunt": "^0.9.1",
     "node-sass": "^4.11.0"


### PR DESCRIPTION
Switch less2sass to branch to solve vulnerability.
- Original repo is 5 years out of date, may be dead.
- PR made. If accepted, switch this back.