### PR TITLE
Alma: Make request timeout configurable and set default to 30 seconds.

### DIFF
--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -3,6 +3,8 @@
 apiBaseUrl = "https://api-eu.hosted.exlibrisgroup.com/almaws/v1"
 ; An API key configured to allow access to Alma:
 apiKey = "your-key-here"
+; Timeout in seconds when making HTTP requests to the Alma APIs:
+http_timeout = 30
 ; Patron login method to use. The following options are available:
 ; vufind    Use VuFind's user database for authentication -- patrons are retrieved
 ;           from Alma without a password (default)

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -156,6 +156,10 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             // Set method
             $client->setMethod($method);
 
+            // Set timeout
+            $timeout = $this->config['Catalog']['http_timeout'] ?? 30;
+            $client->setOptions(['timeout' => $timeout]);
+
             // Set other GET parameters (apikey and other URL parameters are used
             // also with e.g. POST requests)
             $client->setParameterGet($paramsGet);


### PR DESCRIPTION
I've had trouble getting the sandboxes to respond in the default 10 seconds, and while it's possible to increase the default in config.ini, adding driver-level option just like with VoyagerRestful seemed sensible to me.