### PR TITLE
VuFind behind a reverse proxy

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -24,6 +24,9 @@ autoConfigure = true
 ; Base URL is normally auto-detected, but this setting is used when autodetection is
 ; not possible (i.e. during sitemap generation at the command line).
 url             = http://library.myuniversity.edu/vufind
+; Set to true if VuFind is behind a reverse proxy (typically Apache with mod_proxy),
+; make sure your reverse proxy set the necessary headers.
+reverse_proxy    = "1"
 email           = support@myuniversity.edu
 title           = "Library Catalog"
 ; This is the default theme for non-mobile devices (or all devices if mobile_theme

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -26,7 +26,7 @@ autoConfigure = true
 url             = http://library.myuniversity.edu/vufind
 ; Set to true if VuFind is behind a reverse proxy (typically Apache with mod_proxy),
 ; make sure your reverse proxy sets the necessary headers.
-reverse_proxy    = "1"
+;reverse_proxy    = true
 email           = support@myuniversity.edu
 title           = "Library Catalog"
 ; This is the default theme for non-mobile devices (or all devices if mobile_theme

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -25,7 +25,7 @@ autoConfigure = true
 ; not possible (i.e. during sitemap generation at the command line).
 url             = http://library.myuniversity.edu/vufind
 ; Set to true if VuFind is behind a reverse proxy (typically Apache with mod_proxy),
-; make sure your reverse proxy set the necessary headers.
+; make sure your reverse proxy sets the necessary headers.
 reverse_proxy    = "1"
 email           = support@myuniversity.edu
 title           = "Library Catalog"

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -459,6 +459,9 @@ class AbstractBase extends AbstractActionController
     public function getServerUrl($route = true)
     {
         $serverHelper = $this->getViewRenderer()->plugin('serverurl');
+        if ($this->getConfig()->Site->reverse_proxy) {
+            $serverHelper->setUseProxy(true);
+        }
         return $serverHelper(
             $route === true ? true : $this->url()->fromRoute($route)
         );

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -459,9 +459,6 @@ class AbstractBase extends AbstractActionController
     public function getServerUrl($route = true)
     {
         $serverHelper = $this->getViewRenderer()->plugin('serverurl');
-        if ($this->getConfig()->Site->reverse_proxy) {
-            $serverHelper->setUseProxy(true);
-        }
         return $serverHelper(
             $route === true ? true : $this->url()->fromRoute($route)
         );

--- a/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * ServerUrl helper factory. This uses the core Zend helper but configures it
+ * according to VuFind settings.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2019.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\View\Helper\Root;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+/**
+ * ServerUrl helper factory.
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class ServerUrlFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName,
+        array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory.');
+        }
+        $cfg = $container->get(\VuFind\Config\PluginManager::class)->get('config');
+        $helper = new $requestedName();
+        if ($cfg->Site->reverse_proxy ?? false) {
+            $helper->setUseProxy(true);
+        }
+        return $helper;
+    }
+}

--- a/themes/root/theme.config.php
+++ b/themes/root/theme.config.php
@@ -65,6 +65,7 @@ return [
             'VuFind\View\Helper\Root\Url' => 'VuFind\View\Helper\Root\UrlFactory',
             'VuFind\View\Helper\Root\UserList' => 'VuFind\View\Helper\Root\UserListFactory',
             'VuFind\View\Helper\Root\UserTags' => 'VuFind\View\Helper\Root\UserTagsFactory',
+            'Zend\View\Helper\ServerUrl' => 'VuFind\View\Helper\Root\ServerUrlFactory',
         ],
         'aliases' => [
             'accountCapabilities' => 'VuFind\View\Helper\Root\AccountCapabilities',


### PR DESCRIPTION
Add detection of the correct hostname if VuFind is behind a reverse proxy.
The reverse proxy need to serve X-Forwarded-* headers : https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers

TODO:
- [ ] Test