### PR TITLE
Feedbackform: add support for select element placeholder.

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -55,6 +55,9 @@
 #       label (string) Group label (translation key)
 #       options (array) List of select values (translation keys)
 #
+#     placeholder (string) Placeholder label (translation key). Used to instruct the user
+#       to make a selection from the options-list. Only select elements with 'options'
+#       are supported.
 #-----------------------------------------------------------------------------------
 
 forms:

--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -58,6 +58,11 @@
 #     placeholder (string) Placeholder label (translation key). Used to instruct or force
 #       (when combined with 'required' attribute) the user to make a selection from the
 #       options-list. Only select elements with 'options' are supported.
+#       For text, textarea, email and url elements, a placeholder text can be configured
+#       by adding a HTML-attribute via 'settings', for example:
+#       settings:
+#         - [placeholder, Please select...]
+#
 #-----------------------------------------------------------------------------------
 
 forms:

--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -55,9 +55,9 @@
 #       label (string) Group label (translation key)
 #       options (array) List of select values (translation keys)
 #
-#     placeholder (string) Placeholder label (translation key). Used to instruct the user
-#       to make a selection from the options-list. Only select elements with 'options'
-#       are supported.
+#     placeholder (string) Placeholder label (translation key). Used to instruct or force
+#       (when combined with 'required' attribute) the user to make a selection from the
+#       options-list. Only select elements with 'options' are supported.
 #-----------------------------------------------------------------------------------
 
 forms:

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -220,7 +220,8 @@ class Form extends \Zend\Form\Form implements
             $element = [];
 
             $required = ['type', 'name'];
-            $optional = ['required', 'help','value', 'inputType', 'group'];
+            $optional
+                = ['required', 'help','value', 'inputType', 'group', 'placeholder'];
             foreach (array_merge($required, $optional) as $field
             ) {
                 if (!isset($el[$field])) {
@@ -254,12 +255,21 @@ class Form extends \Zend\Form\Form implements
                 if (isset($el['options'])) {
                     $options = [];
                     if ($elementType === 'select'
-                        && $placeholder = $element['settings']['placeholder'] ?? null
+                        && $placeholder = $element['placeholder'] ?? null
                     ) {
-                        $options[''] = $this->translate($placeholder);
+                        $options[] = [
+                            'value' => '',
+                            'label' => $this->translate($placeholder),
+                            'attributes' => [
+                                'selected' => 'selected', 'disabled' => 'disabled'
+                            ]
+                        ];
                     }
                     foreach ($el['options'] as $option) {
-                        $options[$option] = $this->translate($option);
+                        $options[] = [
+                            'value' => $option,
+                            'label' => $this->translate($option)
+                        ];
                     }
                     $element['options'] = $options;
                 } elseif (isset($el['optionGroups'])) {

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -216,7 +216,7 @@ class Form extends \Zend\Form\Form implements
         $configuredElements[] = $senderName;
         $configuredElements[] = $senderEmail;
 
-        foreach ($configuredElements as $el) {
+        foreach ($configuredElements as &$el) {
             $element = [];
 
             $required = ['type', 'name'];
@@ -238,6 +238,14 @@ class Form extends \Zend\Form\Form implements
 
             $element['label'] = $this->translate($el['label'] ?? null);
 
+            $settings = [];
+            if (isset($el['settings'])) {
+                foreach ($el['settings'] as list($settingId, $settingVal)) {
+                    $settings[trim($settingId)] = trim($settingVal);
+                }
+                $element['settings'] = $settings;
+            }
+
             $elementType = $element['type'];
             if (in_array($elementType, ['checkbox', 'radio', 'select'])) {
                 if (empty($el['options']) && empty($el['optionGroups'])) {
@@ -245,6 +253,11 @@ class Form extends \Zend\Form\Form implements
                 }
                 if (isset($el['options'])) {
                     $options = [];
+                    if ($elementType === 'select'
+                        && $placeholder = $element['settings']['placeholder'] ?? null
+                    ) {
+                        $options[''] = $this->translate($placeholder);
+                    }
                     foreach ($el['options'] as $option) {
                         $options[$option] = $this->translate($option);
                     }
@@ -264,14 +277,6 @@ class Form extends \Zend\Form\Form implements
                     }
                     $element['optionGroups'] = $groups;
                 }
-            }
-
-            $settings = [];
-            if (isset($el['settings'])) {
-                foreach ($el['settings'] as list($settingId, $settingVal)) {
-                    $settings[trim($settingId)] = trim($settingVal);
-                }
-                $element['settings'] = $settings;
             }
 
             if (in_array($elementType, ['text', 'url', 'email'])

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -246,12 +246,12 @@ class Form extends \Zend\Form\Form implements
                 }
                 if (isset($el['options'])) {
                     $options = [];
-                    $placeholder
-                        = $elementType === 'select'
-                        ? ($element['placeholder'] ?? null)
-                        : null;
+                    $isSelect = $elementType === 'select';
+                    $placeholder = $element['placeholder'] ?? null;
 
-                    if ($placeholder) {
+                    if ($isSelect && $placeholder) {
+                        // Add placeholder option (without value) for
+                        // select element.
                         $options[] = [
                             'value' => '',
                             'label' => $this->translate($placeholder),
@@ -261,7 +261,7 @@ class Form extends \Zend\Form\Form implements
                         ];
                     }
                     foreach ($el['options'] as $option) {
-                        if ($placeholder) {
+                        if ($isSelect) {
                             $options[] = [
                                 'value' => $option,
                                 'label' => $this->translate($option)

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -216,7 +216,7 @@ class Form extends \Zend\Form\Form implements
         $configuredElements[] = $senderName;
         $configuredElements[] = $senderEmail;
 
-        foreach ($configuredElements as &$el) {
+        foreach ($configuredElements as $el) {
             $element = [];
 
             $required = ['type', 'name'];

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -246,9 +246,12 @@ class Form extends \Zend\Form\Form implements
                 }
                 if (isset($el['options'])) {
                     $options = [];
-                    if ($elementType === 'select'
-                        && $placeholder = $element['placeholder'] ?? null
-                    ) {
+                    $placeholder
+                        = $elementType === 'select'
+                        ? ($element['placeholder'] ?? null)
+                        : null;
+
+                    if ($placeholder) {
                         $options[] = [
                             'value' => '',
                             'label' => $this->translate($placeholder),
@@ -258,10 +261,14 @@ class Form extends \Zend\Form\Form implements
                         ];
                     }
                     foreach ($el['options'] as $option) {
-                        $options[] = [
-                            'value' => $option,
-                            'label' => $this->translate($option)
-                        ];
+                        if ($placeholder) {
+                            $options[] = [
+                                'value' => $option,
+                                'label' => $this->translate($option)
+                            ];
+                        } else {
+                            $options[$option] = $this->translate($option);
+                        }
                     }
                     $element['options'] = $options;
                 } elseif (isset($el['optionGroups'])) {

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -239,14 +239,6 @@ class Form extends \Zend\Form\Form implements
 
             $element['label'] = $this->translate($el['label'] ?? null);
 
-            $settings = [];
-            if (isset($el['settings'])) {
-                foreach ($el['settings'] as list($settingId, $settingVal)) {
-                    $settings[trim($settingId)] = trim($settingVal);
-                }
-                $element['settings'] = $settings;
-            }
-
             $elementType = $element['type'];
             if (in_array($elementType, ['checkbox', 'radio', 'select'])) {
                 if (empty($el['options']) && empty($el['optionGroups'])) {
@@ -287,6 +279,14 @@ class Form extends \Zend\Form\Form implements
                     }
                     $element['optionGroups'] = $groups;
                 }
+            }
+
+            $settings = [];
+            if (isset($el['settings'])) {
+                foreach ($el['settings'] as list($settingId, $settingVal)) {
+                    $settings[trim($settingId)] = trim($settingVal);
+                }
+                $element['settings'] = $settings;
             }
 
             if (in_array($elementType, ['text', 'url', 'email'])


### PR DESCRIPTION
This adds a new configuration option 'placeholder' for select-elements. When defined, an option without value is added to the beginning of the options-list. If combined with the 'required' attribute, the browser does not accept the placeholder element as a proper selection (due to the empty value-attribute) and prevents the form from being submitted.

As far as I know, the same logic can not be used with optionGroups and therefore 'placeholder' is only implemented for select elements with 'options'.
