### PR TITLE
Make empty searches skip authority recommendations

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/AuthorityRecommend.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorityRecommend.php
@@ -281,6 +281,11 @@ class AuthorityRecommend implements RecommendInterface
     {
         $this->results = $results;
 
+        // empty searches such as New Items will return blank
+        if ($this->lookfor == NULL) {
+            return;
+        }
+
         // function will return blank on Advanced Search
         if ($results->getParams()->getSearchType() == 'advanced') {
             return;


### PR DESCRIPTION
The `\VuFind\Recommend\AuthorityRecommend` recommendation module will produce useless recommendations for empty searches, where an empty search satisfies `$request->get('lookfor') == NULL)`. An example of an empty search is the New Item search. This pull request produces an empty array of recommendations for an empty search. The fix was backported from [KIC-MU/vufind](https://github.com/KIC-MU/vufind).