### PR TITLE
Fixes syntax error in HTTP header. Now correctly says "Content-type".

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -496,7 +496,7 @@ class DAIA extends AbstractBase implements
                 list($responseMediaType) = array_pad(
                     explode(
                         ';',
-                        $result->getHeaders()->get('ContentType')->getFieldValue(),
+                        $result->getHeaders()->get('Content-type')->getFieldValue(),
                         2
                     ),
                     2,


### PR DESCRIPTION
cf. https://tools.ietf.org/html/rfc2616#section-14.17

This had caused errors in DAIA response handling whenever a response type was configured in DAIA.ini