### PR TITLE
Reset filters button should work for advanced searches too.

### DIFF
--- a/themes/bootstrap3/templates/search/filters.phtml
+++ b/themes/bootstrap3/templates/search/filters.phtml
@@ -113,12 +113,10 @@
   ?>
   <?php // Normal view ?>
   <div class="active-filters hidden-xs">
-    <?php if ($advancedSearch): ?>
+    <?php if ($resetLink && $options->getRetainFilterSetting()): ?>
+      <a class="reset-filters-btn" href="<?=$resetLink?>"><?=$this->transEsc('reset_filters_button')?></a>
+    <?php elseif ($advancedSearch): ?>
       <p class="adv_search_filters"><?=$this->transEsc('adv_search_filters')?>:</p>
-    <?php else: ?>
-      <?php if ($resetLink && $options->getRetainFilterSetting()): ?>
-        <a class="reset-filters-btn" href="<?=$resetLink?>"><?=$this->transEsc('reset_filters_button')?></a>
-      <?php endif; ?>
     <?php endif; ?>
     <div class="filters">
       <?=$filters ?>


### PR DESCRIPTION
There used to be a special case for advanced search filters because the "retain current filters" checkbox could not be applied to them... but now that we have a "reset filters" button instead, I see no reason why we can't extend consistent functionality across all filters. Just opening this as a PR for comment before merging, in case I'm overlooking something.

TODO:
- [x] Run full test suite.