### PR TITLE
Add exclude and or-facet support to Primo. Expose exclude support.

### DIFF
--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -130,6 +130,10 @@ top_rows = 2
 top_cols = 3
 ; Do we want any facets to be collapsed by default?
 ;collapsedFacets = *
+; Should we show "exclude" links for some or all of the facets? Set to * for
+; all facets, use a comma-separated list to show for some of the facets, set
+; to false or omit to disable "exclude" links
+;exclude = *
 
 ; These settings affect the way the facets are displayed
 [Facet_Settings]

--- a/module/VuFind/src/VuFind/Recommend/AbstractFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/AbstractFacets.php
@@ -148,7 +148,7 @@ abstract class AbstractFacets implements RecommendInterface
         }
 
         // Which facets are ORed?
-        if (isset($config->Results_Settings->orFacets)) {
+        if (isset($config->$section->orFacets)) {
             $this->orFacets = ($config->$section->orFacets === '*')
                 ? $allFacets
                 : array_map('trim', explode(',', $config->$section->orFacets));

--- a/module/VuFind/src/VuFind/Search/Primo/Params.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Params.php
@@ -71,11 +71,7 @@ class Params extends \VuFind\Search\Base\Params
         $sort = $this->getSort();
         $finalSort = ($sort == 'relevance') ? null : $sort;
         $backendParams->set('sort', $finalSort);
-        $filterList = array_merge(
-            $this->getHiddenFilters(),
-            $this->filterList
-        );
-        $backendParams->set('filterList', $filterList);
+        $backendParams->set('filterList', $this->getFilterSettings());
 
         return $backendParams;
     }
@@ -115,5 +111,32 @@ class Params extends \VuFind\Search\Base\Params
             return 'Reference Entries';
         }
         return ucwords(str_replace('_', ' ', $str));
+    }
+
+    /**
+     * Return the current filters as an array
+     *
+     * @return array
+     */
+    public function getFilterSettings()
+    {
+        $result = [];
+        $filterList = array_merge(
+            $this->getHiddenFilters(),
+            $this->filterList
+        );
+        foreach ($filterList as $field => $filter) {
+            $facetOp = 'AND';
+            $prefix = substr($field, 0, 1);
+            if ('~' === $prefix || '-' === $prefix) {
+                $facetOp = '~' === $prefix ? 'OR' : 'NOT';
+                $field = substr($field, 1);
+            }
+            $result[$field] = [
+                'facetOp' => $facetOp,
+                'values' => $filter
+            ];
+        }
+        return $result;
     }
 }

--- a/module/VuFind/src/VuFind/Search/Primo/Results.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Results.php
@@ -100,7 +100,9 @@ class Results extends \VuFind\Search\Base\Results
                             'displayText' => $displayText,
                             'isApplied' =>
                                 $this->getParams()->hasFilter("$field:" . $value),
-                            'operator' => 'AND', 'count' => $count
+                            'operator' =>
+                                $this->getParams()->getFacetOperator($field),
+                            'count' => $count
                         ];
                     }
 


### PR DESCRIPTION
I left the orFacets configuration out since there's a silly issue with the Primo API: it will only return the included facet values in the facet list. I still need the support, though, to be able to map a single VuFind facet value to multiple values in a blended search. 

It would also be possible to retrieve the full facet list in another query, but if values from multiple OR-able facets are selected, the number of queries would also multiply. Some caching could alleviate the problem, but this gets complicated enough that I left it out for now.