### PR TITLE
Add support for multiple Form recipients.

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -33,9 +33,6 @@
 #     - name: Recipient 2
 #       email: recipient2@email
 #
-#   ...and updating the maximum number of recipients configured in
-#   config.ini > Feedback > max_recipient_cnt
-#
 #   response (string) Reponse after form submit (translation key)
 #   senderInfoRequired (boolean)  Require sender to fill out name and email fields
 #

--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -24,6 +24,18 @@
 #                    [Feedback] section)
 #     email (string) Recipient email address (default = recipient_email setting from
 #                    config.ini [Feedback] section)
+#
+#   Multiple recipients can be configured using a list:
+#
+#   recipient
+#     - name: Recipient 1
+#       email: recipient1@email
+#     - name: Recipient 2
+#       email: recipient2@email
+#
+#   ...and updating the maximum number of recipients configured in
+#   config.ini > Feedback > max_recipient_cnt
+#
 #   response (string) Reponse after form submit (translation key)
 #   senderInfoRequired (boolean)  Require sender to fill out name and email fields
 #

--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -27,7 +27,7 @@
 #
 #   Multiple recipients can be configured using a list:
 #
-#   recipient
+#   recipient:
 #     - name: Recipient 1
 #       email: recipient1@email
 #     - name: Recipient 2

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1702,6 +1702,10 @@ treeSearchLimit = 100
 ;sender_email      = "noreply@vufind.org"
 ;sender_name       = "VuFind Feedback"
 
+; Maximum number of recipients for a form. Use this to limit the amount of recipients
+; configured in FeedbackForms.yaml.
+max_recipient_cnt = 1
+
 ; Note: for additional details about stats (including additional notes on Google
 ; Analytics and Piwik), look at the wiki page:
 ;     https://vufind.org/wiki/configuration:usage_stats

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1702,10 +1702,6 @@ treeSearchLimit = 100
 ;sender_email      = "noreply@vufind.org"
 ;sender_name       = "VuFind Feedback"
 
-; Maximum number of recipients for a form. Use this to limit the amount of recipients
-; configured in FeedbackForms.yaml.
-max_recipient_cnt = 1
-
 ; Note: for additional details about stats (including additional notes on Google
 ; Analytics and Piwik), look at the wiki page:
 ;     https://vufind.org/wiki/configuration:usage_stats

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -94,14 +94,16 @@ class FeedbackController extends AbstractBase
             $user ? $user->email : null
         );
 
-        list($recipientName, $recipientEmail) = $form->getRecipient();
+        $recipients = $form->getRecipient();
 
         $emailSubject = $form->getEmailSubject($params->fromPost());
 
-        list($success, $errorMsg) = $this->sendEmail(
-            $recipientName, $recipientEmail, $senderName, $senderEmail,
-            $replyToName, $replyToEmail, $emailSubject, $emailMessage
-        );
+        foreach ($recipients as $recipient) {
+            list($success, $errorMsg) = $this->sendEmail(
+                $recipient['name'], $recipient['email'], $senderName, $senderEmail,
+                $replyToName, $replyToEmail, $emailSubject, $emailMessage
+            );
+        }
 
         $this->showResponse($view, $form, $success, $errorMsg);
 

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -98,14 +98,24 @@ class FeedbackController extends AbstractBase
 
         $emailSubject = $form->getEmailSubject($params->fromPost());
 
+        $sendSuccess = true;
         foreach ($recipients as $recipient) {
             list($success, $errorMsg) = $this->sendEmail(
                 $recipient['name'], $recipient['email'], $senderName, $senderEmail,
                 $replyToName, $replyToEmail, $emailSubject, $emailMessage
             );
+
+            $sendSuccess = $sendSuccess && $success;
+            if (!$success) {
+                $this->showResponse(
+                    $view, $form, false, $errorMsg
+                );
+            }
         }
 
-        $this->showResponse($view, $form, $success, $errorMsg);
+        if ($sendSuccess) {
+            $this->showResponse($view, $form, true);
+        }
 
         return $view;
     }

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -515,24 +515,31 @@ class Form extends \Zend\Form\Form implements
     }
 
     /**
-     * Return form recipient.
+     * Return form recipient(s).
      *
-     * @return array with name, email or null if not configured
+     * @return array of reciepients, each consisting of an array with
+     * name, email or null if not configured
      */
     public function getRecipient()
     {
-        $recipient = $this->formConfig['recipient'] ?? null;
+        $recipient = $this->formConfig['recipient'] ?? [null];
+        $recipients = isset($recipient['email']) || isset($recipient['name'])
+            ? [$recipient] : $recipient;
 
-        $recipientEmail = $recipient['email']
-            ?? $this->defaultFormConfig['recipient_email'] ?? null;
+        $cnt = $this->defaultFormConfig['max_recipient_cnt'] ?? null;
+        if ($cnt !== null) {
+            $recipients = array_slice($recipients, 0, max(1, (int)$cnt));
+        }
 
-        $recipientName = $recipient['name']
-            ?? $this->defaultFormConfig['recipient_name'] ?? null;
+        foreach ($recipients as &$recipient) {
+            $recipient['email'] = $recipient['email']
+                ?? $this->defaultFormConfig['recipient_email'] ?? null;
 
-        return [
-            $recipientName,
-            $recipientEmail,
-        ];
+            $recipient['name'] = $recipient['name']
+                ?? $this->defaultFormConfig['recipient_name'] ?? null;
+        }
+
+        return $recipients;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -526,11 +526,6 @@ class Form extends \Zend\Form\Form implements
         $recipients = isset($recipient['email']) || isset($recipient['name'])
             ? [$recipient] : $recipient;
 
-        $cnt = $this->defaultFormConfig['max_recipient_cnt'] ?? null;
-        if ($cnt !== null) {
-            $recipients = array_slice($recipients, 0, max(1, (int)$cnt));
-        }
-
         foreach ($recipients as &$recipient) {
             $recipient['email'] = $recipient['email']
                 ?? $this->defaultFormConfig['recipient_email'] ?? null;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -53,7 +53,9 @@ class FormTest extends \VuFindTest\Unit\TestCase
         $this->assertTrue($form->useCaptcha());
         $this->assertFalse($form->showOnlyForLoggedUsers());
         $this->assertEquals([], $form->getElements());
-        $this->assertEquals([null, null], $form->getRecipient());
+        $this->assertEquals(
+            [['email' => null, 'name' => null]], $form->getRecipient()
+        );
         $this->assertNull($form->getTitle());
         $this->assertNull($form->getHelp());
         $this->assertEquals('VuFind Feedback', $form->getEmailSubject([]));
@@ -79,7 +81,9 @@ class FormTest extends \VuFindTest\Unit\TestCase
             'email_subject' => 'subject',
         ];
         $form = new Form(new YamlReader(), $defaults);
-        $this->assertEquals(['me', 'me@example.com'], $form->getRecipient());
+        $this->assertEquals(
+            [['name' => 'me', 'email' => 'me@example.com']], $form->getRecipient()
+        );
         $this->assertEquals('subject', $form->getEmailSubject([]));
     }
 
@@ -140,7 +144,9 @@ class FormTest extends \VuFindTest\Unit\TestCase
             ],
             $form->getElements()
         );
-        $this->assertEquals([null, null], $form->getRecipient());
+        $this->assertEquals(
+            [['email' => null, 'name' => null]], $form->getRecipient()
+        );
         $this->assertEquals('Send us your feedback!', $form->getTitle());
         $this->assertNull($form->getHelp());
         $this->assertEquals('VuFind Feedback', $form->getEmailSubject([]));


### PR DESCRIPTION
This PR adds support for configuring multiple recipients that each should receive submitted form responses.

For backward compatibility, a single recipient with `email` and `name` is still supported.
Maximum number of recipients can be limited globally using `max_recipient_cnt` in config.ini > Feedback, which defaults to 1.