### PR TITLE
Alma: Check that the configured login method is valid.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -671,6 +671,9 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             if (400 === $status) {
                 return null;
             }
+        } elseif ('vufind' !== $loginMethod) {
+            $this->logError("Invalid login method configured: $loginMethod");
+            throw new ILSException('Invalid login method configured');
         }
 
         // Create parameters for API call


### PR DESCRIPTION
I just realized that if an invalid login method was configured, patronLogin might allow a user to log in without checking credentials. This change makes it sure that only the known login methods are processed.