### PR TITLE
Multibackend getholding fix

### DIFF
--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -36,11 +36,6 @@ extraHoldFields = comments:requiredByDate:pickUpLocation
 ; 3) a value within the Location IDs returned by getPickUpLocations()
 defaultPickUpLocation = ""
 
-; Max. no. of items displayed in the holdings tab. A paginator is used when there are
-; more holdings to display.
-itemLimit = "10"
-
-
 ; The "NewUser" section defines some default values that are used when creating an account
 ; in Alma via its API. This is only relevant if you use the authentication method "AlmaDatabase"
 ; in the "Authentication" section of the "config.ini" file.
@@ -92,9 +87,13 @@ purgeDate =
 secret = YOUR_WEBHOOK_SECRET_FROM_ALMA
 
 [Holdings]
+; Max. no. of items displayed in the holdings tab. A paginator is used when there are
+; more holdings to display.
+itemLimit = "10"
 ; The digital delivery URL for your Alma instance. Replace at least SOMETHING and
 ; INSTITUTION with correct values.
 ;digitalDeliveryUrl = "https://SOMETHING.alma.exlibrisgroup.com/view/delivery/INSTITUTION/%%id%%"
 ; Inventory types to display from Alma. A colon-separated list. Supported values
 ; are "physical", "electronic" and "digital". By default all are displayed.
 ;inventoryTypes = "physical:electronic"
+

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -15,8 +15,8 @@ ILLRequests = true
 ; email     Username is an email address
 ;loginMethod = email
 
-; Holds and holds-logic-related configuration options.
-[Holds]
+; Holdings configuration options.
+[Holdings]
 ; Max. no. of items displayed in the holdings tab. A paginator is used when there are
 ; more holdings to display. (Default = no limit)
 ;itemLimit = "10"

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1014,12 +1014,18 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      */
     public function getHolding($id, $patron = null, $options = [])
     {
-        // Get pagination options for holdings tab
-        $holdsConfig
-            = $this->checkCapability('getConfig', ['Holds', compact('id')])
-            ? $this->driver->getConfig('Holds', compact('id')) : null;
-        $itemLimit = !empty($holdsConfig['itemLimit'])
-            ? $holdsConfig['itemLimit'] : null;
+        // Get pagination options for holdings tab:
+        $params = compact('id', 'patron');
+        $config = $this->checkCapability('getConfig', ['Holdings', $params])
+            ? $this->getDriver()->getConfig('Holdings', $params) : [];
+        if (empty($config['itemLimit'])) {
+            // Use itemLimit in Holds as fallback for backward compatibility:
+            $config
+                = $this->checkCapability('getConfig', ['Holds', $params])
+                ? $this->getDriver()->getConfig('Holds', $params) : [];
+        }
+        $itemLimit = !empty($config['itemLimit']) ? $config['itemLimit'] : null;
+
         $page = $this->request ? $this->request->getQuery('page', 1) : 1;
         $offset = ($itemLimit && is_numeric($itemLimit))
             ? ($page * $itemLimit) - $itemLimit

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1016,8 +1016,8 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     {
         // Get pagination options for holdings tab
         $holdsConfig
-            = $this->checkCapability('getConfig', ['Holds', compact('patron')])
-            ? $this->driver->getConfig('Holds') : null;
+            = $this->checkCapability('getConfig', ['Holds', compact('id')])
+            ? $this->driver->getConfig('Holds', compact('id')) : null;
         $itemLimit = !empty($holdsConfig['itemLimit'])
             ? $holdsConfig['itemLimit'] : null;
         $page = $this->request ? $this->request->getQuery('page', 1) : 1;

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1283,9 +1283,9 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             // Set default value for "itemLimit" in Alma driver
             if ($function === 'Holdings') {
                 // Use itemLimit in Holds as fallback for backward compatibility
-                $functionConfig['itemLimit'] = $functionConfig['itemLimit']
+                $functionConfig['itemLimit'] = ($functionConfig['itemLimit']
                     ?? $this->config['Holds']['itemLimit']
-                    ?? 10;
+                    ?? 10) ?: 10;
             }
         } elseif ('getMyTransactions' === $function) {
             $functionConfig = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1281,10 +1281,11 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             $functionConfig = $this->config[$function];
 
             // Set default value for "itemLimit" in Alma driver
-            if ($function === 'Holds') {
+            if ($function === 'Holdings') {
+                // Use itemLimit in Holds as fallback for backward compatibility
                 $functionConfig['itemLimit'] = $functionConfig['itemLimit']
-                    ?? 10
-                    ?: 10;
+                    ?? $this->config['Holds']['itemLimit']
+                    ?? 10;
             }
         } elseif ('getMyTransactions' === $function) {
             $functionConfig = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -2306,7 +2306,11 @@ class Demo extends AbstractBase
                 'extraHoldFields' =>
                     'comments:requestGroup:pickUpLocation:requiredByDate',
                 'defaultRequiredDate' => 'driver:0:2:0',
-                'itemLimit' => $this->config['Holds']['itemLimit'] ?? null,
+            ];
+        }
+        if ($function == 'Holdings') {
+            return [
+                'itemLimit' => $this->config['Holdings']['itemLimit'] ?? null,
             ];
         }
         if ($function == 'StorageRetrievalRequests'

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -268,7 +268,8 @@ class MultiBackend extends AbstractBase implements \Zend\Log\LoggerAwareInterfac
             }
             $holdings = $driver->getHolding(
                 $this->getLocalId($id),
-                $this->stripIdPrefixes($patron, $source)
+                $this->stripIdPrefixes($patron, $source),
+                $options
             );
             return $this->addIdPrefixes($holdings, $source);
         }


### PR DESCRIPTION
Patron is not really relevant when checking config of the backend for the bib record, record id is and needs to be passed also to getConfig for proper routing.

By the way, it seems to me that using Holds configuration instead of Holdings configuration for paging of holdings is bound to cause confusion. Could we change that? @betullam?