### PR TITLE
Change id fields of high-frequency tables to 64-bit integers.

### DIFF
--- a/module/VuFind/sql/migrations/pgsql/6.1/002-modify-id-columns.sql
+++ b/module/VuFind/sql/migrations/pgsql/6.1/002-modify-id-columns.sql
@@ -1,0 +1,20 @@
+--
+-- Modifications to table `search`
+--
+
+ALTER TABLE "search"
+  ALTER COLUMN id SET DATA TYPE bigint;
+
+--
+-- Modifications to table `session`
+--
+
+ALTER TABLE "session"
+  ALTER COLUMN id SET DATA TYPE bigint;
+
+--
+-- Modifications to table `external_session`
+--
+
+ALTER TABLE "external_session"
+  ALTER COLUMN id SET DATA TYPE bigint;

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -112,7 +112,7 @@ CREATE TABLE `resource_tags` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `search` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL DEFAULT '0',
   `session_id` varchar(128) DEFAULT NULL,
   `folder_id` int(11) DEFAULT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE `search` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `session` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `session_id` varchar(128) DEFAULT NULL,
   `data` mediumtext,
   `last_used` int(12) NOT NULL DEFAULT '0',
@@ -153,7 +153,7 @@ CREATE TABLE `session` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `external_session` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `session_id` varchar(128) NOT NULL,
   `external_session_id` varchar(255) NOT NULL,
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -69,7 +69,7 @@ CREATE INDEX resource_tags_list_id_idx ON resource_tags (list_id);
 DROP TABLE IF EXISTS "search";
 
 CREATE TABLE search (
-id SERIAL,
+id BIGSERIAL,
 user_id int NOT NULL DEFAULT '0',
 session_id varchar(128),
 folder_id int DEFAULT NULL,
@@ -202,7 +202,7 @@ CREATE INDEX user_resource_list_id_idx ON user_resource (list_id);
 DROP TABLE IF EXISTS "session";
 
 CREATE TABLE session (
-id SERIAL,
+id BIGSERIAL,
 session_id varchar(128),
 data text,
 last_used int NOT NULL default 0,
@@ -219,7 +219,7 @@ CREATE INDEX last_used_idx on session(last_used);
 DROP TABLE IF EXISTS "external_session";
 
 CREATE TABLE external_session (
-id SERIAL,
+id BIGSERIAL,
 session_id varchar(128) NOT NULL,
 external_session_id varchar(255) NOT NULL,
 created timestamp NOT NULL default '1970-01-01 00:00:00',


### PR DESCRIPTION
We had a system down event due to reaching maximum for 32-bit integer fields. This proposal switches the tables with most frequent adds to 64-bit id fields.