### PR TITLE
Fix Alma driver to cast Simple XML values to string.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1732,7 +1732,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
         }
         $value = ($this->config['Catalog']['translationPrefix'] ?? '')
             . (string)$element;
-        $desc = $element->attributes()->desc ?? $value;
+        $desc = (string)($element->attributes()->desc ?? $value);
         return new \VuFind\I18n\TranslatableString($value, $desc);
     }
 


### PR DESCRIPTION
I forgot to add the string cast, and while everything currently works, I think it's better to just cast the elements to strings.