### PR TITLE
Fix Redis session handler destroy return value

### DIFF
--- a/module/VuFind/src/VuFind/Session/Redis.php
+++ b/module/VuFind/src/VuFind/Session/Redis.php
@@ -121,7 +121,7 @@ class Redis extends AbstractBase
      *
      * @param string $sess_id The session ID to destroy
      *
-     * @return void
+     * @return bool
      */
     public function destroy($sess_id)
     {
@@ -130,9 +130,10 @@ class Redis extends AbstractBase
 
         // Perform Redis-specific cleanup
         if ($this->redisVersion >= 4) {
-            $this->getConnection()->unlink("vufind_sessions/{$sess_id}");
+            $return = $this->getConnection()->unlink("vufind_sessions/{$sess_id}");
         } else {
-            $this->getConnection()->del("vufind_sessions/{$sess_id}");
+            $return = $this->getConnection()->del("vufind_sessions/{$sess_id}");
         }
+        return ($return > 0) ? true : false;
     }
 }


### PR DESCRIPTION
This fixes warnings like these:

Warning: session_destroy(): Session callback expects true/false return value in /var/www/cpk/vendor/zendframework/zendframework/library/Zend/Session/SessionManager.php on line 171

Warning: session_destroy(): Session object destruction failed in /var/www/cpk/vendor/zendframework/zendframework/library/Zend/Session/SessionManager.php on line 171
