### PR TITLE
Make it possible to use email login also with any identifier in Alma.

### DIFF
--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -7,10 +7,18 @@ apiKey = "your-key-here"
 http_timeout = 30
 ; Patron login method to use. The following options are available:
 ; vufind    Use VuFind's user database for authentication -- patrons are retrieved
-;           from Alma without a password (default)
-; password  Use password authentication with Alma internal users
-; email     Username needs to be a valid email address for the user (an
-;           authentication link is sent by email)
+;           from Alma without a password (default). This is only useful when
+;           VuFind is set up to use AlmaDatabase authentication in config.ini. In any
+;           other setting it would allow login without proper password.
+; password  Use password authentication with Alma internal users. This method is
+;           supported with the normal ILS and MultiILS authentication methods in
+;           VuFind. Note that it will not work with external users in Alma since they
+;           don't have a password in Alma.
+; email     Username needs to be a valid email address or other unique identifier for
+;           the user. An authentication link is sent by email to user's preferred
+;           email address registered in Alma. This method can be used with both
+;           internal and external Alma users and it is supported with the normal ILS
+;           and MultiILS authentication methods in VuFind.
 ;loginMethod = vufind
 
 ; Translation prefix to use for codes coming from Alma. By default a prefix is not

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -644,33 +644,54 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
         $patron = [];
         $patronId = $username;
         if ('email' === $loginMethod) {
-            // Create parameters for API call
-            $getParams = [
-                'q' => 'email~' . $username
-            ];
-
-            // Try to find the user in Alma
-            $response = $this->makeRequest(
-                '/users/',
-                $getParams
+            // Try to find the user in Alma by an identifier
+            list($response, $status) = $this->makeRequest(
+                '/users/' . urlencode($username),
+                [
+                    'view' => 'full'
+                ],
+                [],
+                'GET',
+                null,
+                null,
+                [400],
+                true
             );
-
-            foreach (($response->user ?? []) as $user) {
-                if ((string)$user->status !== 'ACTIVE') {
-                    continue;
-                }
-                if ($patron) {
-                    // More than one match, cannot log in by email
-                    $this->debug(
-                        "Email $username matches more than one user, cannot login"
-                    );
-                    return null;
-                }
+            if (400 != $status) {
                 $patron = [
-                    'id' => (string)$user->primary_id,
+                    'id' => (string)$response->primary_id,
                     'cat_username' => trim($username),
-                    'email' => trim($username)
+                    'email' => $this->getPreferredEmail($response)
                 ];
+            } else {
+                // Try to find the user in Alma by unique email address
+                $getParams = [
+                    'q' => 'email~' . $username
+                ];
+
+                $response = $this->makeRequest(
+                    '/users/',
+                    $getParams
+                );
+
+                foreach (($response->user ?? []) as $user) {
+                    if ((string)$user->status !== 'ACTIVE') {
+                        continue;
+                    }
+                    if ($patron) {
+                        // More than one match, cannot log in by email
+                        $this->debug(
+                            "Email $username matches more than one user, cannot"
+                            . ' login'
+                        );
+                        return null;
+                    }
+                    $patron = [
+                        'id' => (string)$user->primary_id,
+                        'cat_username' => trim($username),
+                        'email' => trim($username)
+                    ];
+                }
             }
             if (!$patron) {
                 return null;


### PR DESCRIPTION
During testing it was discovered that users expected to be able to use e.g. an email address stored as the primary identifier in Alma. This change allows email login with email address or another identifier stored in an identifier field or email address field.