### PR TITLE
FeedbackForm: translate placeholder text also when configured via 'settings'

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -67,8 +67,8 @@
 #     placeholder (string) Placeholder label (translation key). Used to instruct or force
 #       (when combined with 'required' attribute) the user to make a selection from the
 #       options-list. Only select elements with 'options' are supported.
-#       For text, textarea, email and url elements, a placeholder text can be configured
-#       by adding a HTML-attribute via 'settings', for example:
+#       For text, textarea, email and url elements, a placeholder text (translation key)
+#       can be configured by adding a HTML-attribute via 'settings', for example:
 #       settings:
 #         - [placeholder, Please select...]
 #

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -291,7 +291,12 @@ class Form extends \Zend\Form\Form implements
             $settings = [];
             if (isset($el['settings'])) {
                 foreach ($el['settings'] as list($settingId, $settingVal)) {
-                    $settings[trim($settingId)] = trim($settingVal);
+                    $settingId = trim($settingId);
+                    $settingVal = trim($settingVal);
+                    if ($settingId === 'placeholder') {
+                        $settingVal = $this->translate($settingVal);
+                    }
+                    $settings[$settingId] = $settingVal;
                 }
                 $element['settings'] = $settings;
             }


### PR DESCRIPTION
This PR translates form element placeholder text also when it is configured via `settings`. Currently the placeholder is translated only when configured with `placeholder` attribute (that can be used only with `select` elements).