### PR TITLE
Fix tideways support and make profiling work with command line tools.

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,13 +1,25 @@
 <?php
-// If the XHProf profiler is enabled, set it up now:
-$xhprof = getenv('VUFIND_PROFILER_XHPROF');
-if (!empty($xhprof)) {
-    if (extension_loaded('xhprof')) {
-        xhprof_enable();
-    } elseif (extension_loaded('tideways')) {
-        tideways_enable();
-    } else {
-        $xhprof = false;
+// If the profiler is enabled, set it up now:
+$vufindProfiler = getenv('VUFIND_PROFILER_XHPROF');
+if (!empty($vufindProfiler)) {
+    if (extension_loaded('tideways_xhprof')) {
+        tideways_xhprof_enable();
+
+        // Handle final profiling details, if necessary:
+        register_shutdown_function(function () use ($vufindProfiler) {
+            $xhprofData = tideways_xhprof_disable();
+            $xhprofRunId = uniqid();
+            $suffix = 'vufind';
+            $dir = ini_get('xhprof.output_dir');
+            if (empty($dir)) {
+                $dir = sys_get_temp_dir();
+            }
+            file_put_contents(
+                "$dir/$xhprofRunId.$suffix.xhprof", serialize($xhprofData)
+            );
+            $url = "$vufindProfiler?run=$xhprofRunId&source=$suffix";
+            echo "<a href='$url'>Profiler output</a>";
+        });
     }
 }
 
@@ -69,17 +81,3 @@ if (!class_exists('Zend\Loader\AutoloaderFactory')) {
 
 // Run the application!
 Zend\Mvc\Application::init(require 'config/application.config.php')->run();
-
-// Handle final profiling details, if necessary:
-if ($xhprof) {
-    $xhprofData = extension_loaded('xhprof') ? xhprof_disable() : tideways_disable();
-    $xhprofRunId = uniqid();
-    $suffix = 'vufind';
-    $dir = ini_get('xhprof.output_dir');
-    if (empty($dir)) {
-        $dir = sys_get_temp_dir();
-    }
-    file_put_contents("$dir/$xhprofRunId.$suffix.xhprof", serialize($xhprofData));
-    $url = "$xhprof?run=$xhprofRunId&source=$suffix";
-    echo "<a href='$url'>Profiler output</a>";
-}


### PR DESCRIPTION
Also remove obsolete xhprof support.

The tideways module has been renamed to tideways_xhprof. Profiling command line utilities didn't work because \Zend\Console\Response calls exit(), and the profile handling at the end of index.php wasn't called.