### PR TITLE
Alma: Fix date and status display for the holds list.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -886,6 +886,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
                     'Y-m-dT', (string)$request->last_interest_date
                 ) : null;
             $available = (string)$request->request_status === 'On Hold Shelf';
+            $lastPickupDate = null;
             if ($available) {
                 $lastPickupDate = $request->expiry_date
                     ? $this->dateConverter->convertToDisplayDate(

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -881,11 +881,25 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
         );
         $holdList = [];
         foreach ($xml as $request) {
+            $lastInterestDate = $request->last_interest_date
+                ? $this->dateConverter->convertToDisplayDate(
+                    'Y-m-dT', (string)$request->last_interest_date
+                ) : null;
+            $available = (string)$request->request_status === 'On Hold Shelf';
+            if ($available) {
+                $lastPickupDate = $request->expiry_date
+                    ? $this->dateConverter->convertToDisplayDate(
+                        'Y-m-dT', (string)$request->expiry_date
+                    ) : null;
+            }
             $holdList[] = [
-                'create' => (string)$request->request_date,
-                'expire' => (string)$request->last_interest_date,
+                'create' => $this->dateConverter->convertToDisplayDate(
+                    'Y-m-dT', (string)$request->request_date
+                ),
+                'expire' => $lastInterestDate,
                 'id' => (string)$request->request_id,
-                'in_transit' => (string)$request->request_status !== 'On Hold Shelf',
+                'available' => $available,
+                'last_pickup_date' => $lastPickupDate,
                 'item_id' => (string)$request->mms_id,
                 'location' => (string)$request->pickup_location,
                 'processed' => $request->item_policy === 'InterlibraryLoan'


### PR DESCRIPTION
Accidentally merged original PR #1501. This is redoing it.

This adds date parsing to the holds list for Alma response. It also changes the way request status affects returned values: previously in_transit was set to true when the request status was not 'On Hold Shelf'. This was misleading since the item might as well still be on loan or not processed yet. Now the information is only used to determine if the item is ready for pickup. Additionally, last pickup date is displayed in this case.

As far as I can see there's no way to determine when a requested item is actually in transit, at least without further API calls. I also think similar changes should be done in getMyStorageRetrievalRequests and getMyILLRequests, but I can't currently verify those.