### PR TITLE
Alma: Ignore OpenURL services that are filtered out.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -829,13 +829,14 @@ class DefaultRecord extends AbstractBase
         // of databases if they do not cover the exact date provided!
         unset($params['rft.date']);
 
-        // If we're working with the SFX resolver, we should add a
+        // If we're working with the SFX or Alma resolver, we should add a
         // special parameter to ensure that electronic holdings links
         // are shown even though no specific date or issue is specified:
-        if (isset($this->mainConfig->OpenURL->resolver)
-            && strtolower($this->mainConfig->OpenURL->resolver) == 'sfx'
-        ) {
+        $resolver = strtolower($this->mainConfig->OpenURL->resolver ?? '');
+        if ('sfx' === $resolver) {
             $params['sfx.ignore_date_threshold'] = 1;
+        } elseif ('alma' === $resolver) {
+            $params['u.ignore_date_coverage'] = 'true';
         }
         return $params;
     }

--- a/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
@@ -95,6 +95,10 @@ class Alma extends AbstractBase
         }
 
         foreach ($xml->context_services->children() as $service) {
+            $filtered = $this->getKeyWithId($service, 'Filtered');
+            if ('true' === $filtered) {
+                continue;
+            }
             $serviceType = $this->mapServiceType(
                 (string)$service->attributes()->service_type
             );

--- a/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
@@ -46,6 +46,13 @@ class Alma extends AbstractBase
     protected $httpClient;
 
     /**
+     * List of filter reasons that are ignored (displayed regardless of filtering)
+     *
+     * @var array
+     */
+    protected $ignoredFilterReasons = ['Date Filter'];
+
+    /**
      * Constructor
      *
      * @param string            $baseUrl    Base URL for link resolver
@@ -97,7 +104,10 @@ class Alma extends AbstractBase
         foreach ($xml->context_services->children() as $service) {
             $filtered = $this->getKeyWithId($service, 'Filtered');
             if ('true' === $filtered) {
-                continue;
+                $reason = $this->getKeyWithId($service, 'Filter reason');
+                if (!in_array($reason, $this->ignoredFilterReasons)) {
+                    continue;
+                }
             }
             $serviceType = $this->mapServiceType(
                 (string)$service->attributes()->service_type

--- a/module/VuFind/tests/fixtures/resolver/response/alma.xml
+++ b/module/VuFind/tests/fixtures/resolver/response/alma.xml
@@ -274,7 +274,8 @@ Date: Mon, 19 Aug 2019 12:34:14 GMT
         <key id="is_closly_related">false</key>
         <key id="license_exist">false</key>
         <key id="crossref_enabled">no</key>
-        <key id="Filtered">false</key>
+        <key id="Filtered">true</key>
+        <key id="Filter reason">Date Filter</key>
         <key id="preferred_link">false</key>
       </keys>
       <resolution_url>https://na01.alma.exlibrisgroup.com/view/action/uresolver.do?operation=resolveService&amp;package_service_id=5687861810000561&amp;institutionId=561&amp;customerId=550</resolution_url>

--- a/module/VuFind/tests/fixtures/resolver/response/alma.xml
+++ b/module/VuFind/tests/fixtures/resolver/response/alma.xml
@@ -274,11 +274,44 @@ Date: Mon, 19 Aug 2019 12:34:14 GMT
         <key id="is_closly_related">false</key>
         <key id="license_exist">false</key>
         <key id="crossref_enabled">no</key>
-        <key id="Filtered">true</key>
-        <key id="Filter reason">Available for - No group for the incoming ip and AF line for the portfolio/service/package exists</key>
+        <key id="Filtered">false</key>
         <key id="preferred_link">false</key>
       </keys>
       <resolution_url>https://na01.alma.exlibrisgroup.com/view/action/uresolver.do?operation=resolveService&amp;package_service_id=5687861810000561&amp;institutionId=561&amp;customerId=550</resolution_url>
+    </context_service>
+    <context_service service_type="getFullTxt" context_service_id="971788650005972">
+      <keys>
+        <key id="package_name">Elsevier ScienceDirect</key>
+        <key id="package_public_name">Elsevier SD FREEDOM COLLECTION</key>
+        <key id="package_display_name">Elsevier SD FREEDOM COLLECTION</key>
+        <key id="package_internal_name">ELSEVIER_SD_FREEDOM_COLLECTION</key>
+        <key id="interface_name">Elsevier ScienceDirect</key>
+        <key id="db_id">.~1,8P~,AAOAW,ACRLP,AGUBO,AIKHN,BLXMC,EO8,EO9,EP2,EP3,G-Q,OAUVE,Q38,SDF</key>
+        <key id="package_pid">6139351080005972</key>
+        <key id="service_type_description">Full text available via</key>
+        <key id="character_set">iso-8859-1</key>
+        <key id="Is_free">0</key>
+        <key id="portfolio_PID">5344797220005972</key>
+        <key id="cz_link_id">531000000000042994</key>
+        <key id="electronic_material_type">JOURNAL</key>
+        <key id="Availability">Available from 1995 volume: 22 issue: 1.&lt;br></key>
+        <key id="static_url">true</key>
+        <key id="parser_program">ELSEVIER::SCIENCE_DIRECT</key>
+        <key id="parse_parameters">host=https://www.sciencedirect.com/science/&amp; prefsite = sd &amp; shib= &amp; u_shib=&amp;uis=03064549</key>
+        <key id="Authentication_note"/>
+        <key id="public_note"/>
+        <key id="proxy_enabled">true</key>
+        <key id="proxy_selected">ÅA Proxy</key>
+        <key id="related_title">@TITLE (@RelationType)</key>
+        <key id="is_related_service">false</key>
+        <key id="is_closly_related">false</key>
+        <key id="license_exist">false</key>
+        <key id="crossref_enabled">yes</key>
+        <key id="Filtered">true</key>
+        <key id="Filter reason">Available for - the ip groups are not part of the service AF groups</key>
+        <key id="preferred_link">true</key>
+      </keys>
+      <resolution_url>https://na01.alma.exlibrisgroup.com/view/action/uresolver.do?operation=resolveService&amp;package_service_id=971788650005972&amp;institutionId=561&amp;customerId=550</resolution_url>
     </context_service>
   </context_services>
   <performance_counters>


### PR DESCRIPTION
Turns out filtered entries don't show up in the service menu but are included in the XML response with Filtered=true.