### PR TITLE
Add filtering of invalid request parameters.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -439,6 +439,7 @@ $config = [
             'VuFind\ServiceManager\ServiceInitializer',
         ],
         'aliases' => [
+            'Request' => 'VuFind\Http\PhpEnvironment\Request',
             'VuFind\AccountCapabilities' => 'VuFind\Config\AccountCapabilities',
             'VuFind\AuthManager' => 'VuFind\Auth\Manager',
             'VuFind\AuthPluginManager' => 'VuFind\Auth\PluginManager',
@@ -499,7 +500,6 @@ $config = [
             'VuFind\WorldCatUtils' => 'VuFind\Connection\WorldCatUtils',
             'VuFind\YamlReader' => 'VuFind\Config\YamlReader',
             'Zend\Validator\Csrf' => 'VuFind\Validator\Csrf',
-            'Request' => 'VuFind\Http\PhpEnvironment\Request',
         ],
     ],
     'translator' => [],

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -383,6 +383,7 @@ $config = [
             'VuFind\Hierarchy\TreeDataFormatter\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Hierarchy\TreeDataSource\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Hierarchy\TreeRenderer\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
+            'VuFind\Http\PhpEnvironment\Request' => 'Zend\ServiceManager\Factory\InvokableFactory',
             'VuFind\ILS\Connection' => 'VuFind\ILS\ConnectionFactory',
             'VuFind\ILS\Driver\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\ILS\Logic\Holds' => 'VuFind\ILS\Logic\LogicFactory',
@@ -430,6 +431,9 @@ $config = [
             'Zend\Db\Adapter\Adapter' => 'VuFind\Db\AdapterFactory',
             'Zend\Mvc\I18n\Translator' => 'VuFind\I18n\Translator\TranslatorFactory',
             'Zend\Session\SessionManager' => 'VuFind\Session\ManagerFactory',
+        ],
+        'delegators' => [
+            'VuFind\Http\PhpEnvironment\Request' => [ \Zend\Mvc\Console\Service\ConsoleRequestDelegatorFactory::class ],
         ],
         'initializers' => [
             'VuFind\ServiceManager\ServiceInitializer',
@@ -495,6 +499,7 @@ $config = [
             'VuFind\WorldCatUtils' => 'VuFind\Connection\WorldCatUtils',
             'VuFind\YamlReader' => 'VuFind\Config\YamlReader',
             'Zend\Validator\Csrf' => 'VuFind\Validator\Csrf',
+            'Request' => 'VuFind\Http\PhpEnvironment\Request',
         ],
     ],
     'translator' => [],

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -30,6 +30,7 @@ namespace VuFind\Controller;
 
 use VuFind\Exception\Auth as AuthException;
 use VuFind\Exception\ILS as ILSException;
+use VuFind\Http\PhpEnvironment\Request as HttpRequest;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Mvc\MvcEvent;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -128,6 +129,20 @@ class AbstractBase extends AbstractActionController
     public function setAccessPermission($ap)
     {
         $this->accessPermission = empty($ap) ? false : $ap;
+    }
+
+    /**
+     * Get request object
+     *
+     * @return HttpRequest
+     */
+    public function getRequest()
+    {
+        if (!$this->request) {
+            $this->request = new HttpRequest();
+        }
+
+        return $this->request;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
+++ b/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  OAI_Server
+ * @package  HTTP
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
@@ -31,7 +31,7 @@ namespace VuFind\Http\PhpEnvironment;
  * HTTP Request class
  *
  * @category VuFind
- * @package  OAI_Server
+ * @package  HTTP
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki

--- a/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
+++ b/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * HTTP Request class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2019.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  OAI_Server
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\Http\PhpEnvironment;
+
+/**
+ * HTTP Request class
+ *
+ * @category VuFind
+ * @package  OAI_Server
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Request extends \Zend\Http\PhpEnvironment\Request
+{
+    /**
+     * Return the parameter container responsible for query parameters or a single
+     * query parameter
+     *
+     * @param string|null $name    Parameter name to retrieve, or null to get the
+     * whole container.
+     * @param mixed|null  $default Default value to use when the parameter is
+     * missing.
+     *
+     * @return \Zend\Stdlib\ParametersInterface|mixed
+     */
+    public function getQuery($name = null, $default = null)
+    {
+        return $this->cleanup(parent::getQuery($name, $default));
+    }
+
+    /**
+     * Return the parameter container responsible for post parameters or a single
+     * post parameter.
+     *
+     * @param string|null $name    Parameter name to retrieve, or null to get the
+     * whole container.
+     * @param mixed|null  $default Default value to use when the parameter is
+     * missing.
+     *
+     * @return \Zend\Stdlib\ParametersInterface|mixed
+     */
+    public function getPost($name = null, $default = null)
+    {
+        return $this->cleanup(parent::getPost($name, $default));
+    }
+
+    /**
+     * Return the parameter container responsible for server parameters or a single
+     * parameter value.
+     *
+     * @param string|null $name    Parameter name to retrieve, or null to get the
+     * whole container.
+     * @param mixed|null  $default Default value to use when the parameter is
+     * missing.
+     *
+     * @see    http://www.faqs.org/rfcs/rfc3875.html
+     * @return \Zend\Stdlib\ParametersInterface|mixed
+     */
+    public function getServer($name = null, $default = null)
+    {
+        return $this->cleanup(parent::getServer($name, $default));
+    }
+
+    /**
+     * Clean up a parameter
+     *
+     * @param \Zend\Stdlib\ParametersInterface|mixed $param Parameter
+     *
+     * @return \Zend\Stdlib\ParametersInterface|mixed
+     */
+    protected function cleanup($param)
+    {
+        if (is_array($param) || $param instanceof \Zend\Stdlib\ParametersInterface) {
+            foreach ($param as $key => &$value) {
+                if (is_array($value)) {
+                    $value = $this->cleanup($value);
+                } elseif (!$this->isValid($key) || !$this->isValid($value)) {
+                    unset($param[$key]);
+                }
+            }
+            return $param;
+        }
+
+        if (is_string($param) && !$this->isValid($param)) {
+            return '';
+        }
+
+        return $param;
+    }
+
+    /**
+     * Check if a string is a valid parameter
+     *
+     * @param string $str String to check
+     *
+     * @return bool
+     */
+    protected function isValid($str)
+    {
+        // Check if the string is UTF-8
+        if (is_string($str) && $str !== '' && !preg_match('/^./su', $str)) {
+            return false;
+        }
+        if (strpos($str, "\x00") !== false) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Not quite sure if the delegator thing is right, I just mimicked it from Zend\Mvc\Console's config provider and it seems to work..

Examples of invalid search parameters:
- lookfor=test%00
- lookfor=test%C0%A7%C0

TODO
- [x] Run full test suite
- [x] Add note to changelog when merging