### PR TITLE
adapts getForUser in Tags Table

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Table/Tags.php
@@ -307,11 +307,7 @@ class Tags extends Gateway
             $select->group(['tag'])->order([new Expression('lower(tag)')]);
 
             $select->where->equalTo('ur.user_id', $userId)
-                ->equalTo('rt.user_id', $userId)
-                ->equalTo(
-                    'ur.list_id', 'rt.list_id',
-                    Predicate::TYPE_IDENTIFIER, Predicate::TYPE_IDENTIFIER
-                );
+                ->equalTo('rt.user_id', $userId);
 
             if (null !== $source) {
                 $select->where->equalTo('r.source', $source);


### PR DESCRIPTION
removes test for common list ID to ensure ALL tags for a user are returned.
Since Tags can be created in the record view without any connection to a user list, the current behaviour of `getForUser` seems somewhat counter intuitive in that it omits such "list free" tags.