### PR TITLE
Avoid PHP error if Alma API response doesn't contain an error message.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -226,7 +226,8 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             }
             $returnValue = $xml;
         } else {
-            $almaErrorMsg = $xml->errorList->error[0]->errorMessage;
+            $almaErrorMsg = $xml->errorList->error[0]->errorMessage
+                ?? '[could not parse error message]';
             error_log(
                 '[ALMA] ' . $almaErrorMsg . ' | Call to: ' . $client->getUri() .
                 '. GET params: ' . var_export($paramsGet, true) . '. POST params: ' .


### PR DESCRIPTION
This can happen at least if the API key is valid but not properly routing to the Alma instance.