### PR TITLE
Alma: Fix a silly mistake when creating TranslatableString instances.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1814,7 +1814,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
         }
         $value = ($this->config['Catalog']['translationPrefix'] ?? '')
             . (string)$element;
-        $desc = (string)($element->attributes()->desc ?? $value);
+        $desc = (string)($element->attributes()->desc ?? $element);
         return new \VuFind\I18n\TranslatableString($value, $desc);
     }
 
@@ -1831,7 +1831,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             return null;
         }
         $value = 'status_' . strtolower((string)$element);
-        $desc = (string)($element->attributes()->desc ?? $value);
+        $desc = (string)($element->attributes()->desc ?? $element);
         return new \VuFind\I18n\TranslatableString($value, $desc);
     }
 


### PR DESCRIPTION
Don't use the prefixed translation key as the default description..