### PR TITLE
Avoid Array to String Conversion in Aleph driver

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1076,7 +1076,7 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
                     ],
                     null, 'POST', null
                 );
-                $due = implode($xml->xpath('//new-due-date'));
+                $due = current($xml->xpath('//new-due-date'));
                 $result[$id] = [
                     'success' => true, 'new_date' => $this->parseDate($due)
                 ];

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1076,7 +1076,7 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
                     ],
                     null, 'POST', null
                 );
-                $due = current($xml->xpath('//new-due-date'));
+                $due = (string)current($xml->xpath('//new-due-date'));
                 $result[$id] = [
                     'success' => true, 'new_date' => $this->parseDate($due)
                 ];

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1076,7 +1076,7 @@ class Aleph extends AbstractBase implements \Zend\Log\LoggerAwareInterface,
                     ],
                     null, 'POST', null
                 );
-                $due = (string)$xml->xpath('//new-due-date');
+                $due = implode($xml->xpath('//new-due-date'));
                 $result[$id] = [
                     'success' => true, 'new_date' => $this->parseDate($due)
                 ];


### PR DESCRIPTION
The (string) conversion on an array throws an E_NOTICE exception. I would suggest using implode instead. What do you think @Witiko ?