### PR TITLE
Folio: use service-points for pickup locations

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -607,13 +607,14 @@ class Folio extends AbstractAPI implements
      */
     public function getPickupLocations($patron)
     {
-        $response = $this->makeRequest('GET', '/locations');
+        $query = ['query' => 'pickupLocation=true'];
+        $response = $this->makeRequest('GET', '/service-points', $query);
         $json = json_decode($response->getBody());
         $locations = [];
-        foreach ($json->locations as $location) {
+        foreach ($json->servicepoints as $servicepoint) {
             $locations[] = [
-                'locationID' => $location->id,
-                'locationDisplay' => $location->name
+                'locationID' => $servicepoint->id,
+                'locationDisplay' => $servicepoint->discoveryDisplayName
             ];
         }
         return $locations;

--- a/module/VuFind/tests/fixtures/folio/responses/check-invalid-token.json
+++ b/module/VuFind/tests/fixtures/folio/responses/check-invalid-token.json
@@ -1,5 +1,5 @@
 [
   { "status": 400 },
   { "headers": { "X-Okapi-Token": "x-okapi-token-after-invalid" } },
-  { "body": "{ \"locations\": [] }" }
+  { "body": "{ \"servicepoints\": [] }" }
 ]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -182,7 +182,7 @@ class FolioTest extends \VuFindTest\Unit\TestCase
         // Request new token
         $this->assertEquals('/authn/login', $this->testRequestLog[1]['path']);
         // Move to method call
-        $this->assertEquals('/locations', $this->testRequestLog[2]['path']);
+        $this->assertEquals('/service-points', $this->testRequestLog[2]['path']);
         // - Passed correct token
         $this->assertEquals(
             'x-okapi-token-after-invalid', // from fixtures: check-invalid-token.json


### PR DESCRIPTION
Uses `service-points endpoint` instead of `locations` to determine pickup location. Locations is for shelving locations: https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/locations.json

For service points, filter so pickupLocation = true. See:
https://github.com/folio-org/mod-inventory-storage/blob/master/ramls/servicepoint.json