### PR TITLE
schema.org publicationDate => datePublished

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-publicationDetails.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-publicationDetails.phtml
@@ -8,7 +8,7 @@
   <?php endif; ?>
   </span>
   <?php $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
-    <span property="publicationDate"><?=$this->escapeHtml($pubDate)?></span>
+    <span property="datePublished"><?=$this->escapeHtml($pubDate)?></span>
   <?php endif; ?>
   <br/>
 <?php endforeach; ?>


### PR DESCRIPTION
According to the google test tool, "publicationDate" is invalid.

https://search.google.com/structured-data/testing-tool?url=https%3A%2F%2Fvufind.org%2Fdemo%2FRecord%2F1068208

Use datePublished instead:
https://schema.org/datePublished