### PR TITLE
Improve PHPUnit tests 

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -147,6 +147,8 @@ class AccountActionsTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that changing email is disabled by default.
      *
+     * @depends testChangePassword
+     *
      * @return void
      */
     public function testChangeEmailDisabledByDefault()
@@ -169,6 +171,8 @@ class AccountActionsTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test changing an email.
+     *
+     * @depends testChangePassword
      *
      * @return void
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -164,6 +164,8 @@ class AccountMenuTest extends \VuFindTest\Unit\MinkTestCase
      * Test that the menu is absent when enableAjax is false and enableDropdown
      * is false.
      *
+     * @depends testMenuOffAjaxNoDropdown
+     *
      * @return void
      */
     public function testMenuOffNoAjaxNoDropdown()
@@ -192,6 +194,8 @@ class AccountMenuTest extends \VuFindTest\Unit\MinkTestCase
      * Test that the menu is absent when enableAjax is false and enableDropdown
      * is true.
      *
+     * @depends testMenuOffAjaxNoDropdown
+     *
      * @return void
      */
     public function testMenuOffNoAjaxDropdown()
@@ -218,6 +222,8 @@ class AccountMenuTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that the menu is absent when enableAjax is true and enableDropdown
      * is true.
+     *
+     * @depends testMenuOffAjaxNoDropdown
      *
      * @return void
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -178,6 +178,8 @@ class BulkTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that the save control works.
      *
+     * @depends testBulkEmail
+     *
      * @return void
      */
     public function testBulkSave()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -579,6 +579,8 @@ class CartTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that the save control works.
      *
+     * @depends testCartEmail
+     *
      * @return void
      */
     public function testCartSave()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -168,6 +168,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
      * Test adding a record to favorites (from the record page) using an existing
      * account that is not yet logged in.
      *
+     * @depends testAddRecordToFavoritesNewAccount
+     *
      * @return void
      */
     public function testAddRecordToFavoritesLogin()
@@ -217,6 +219,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test adding a record to favorites (from the record page) using an existing
      * account that is already logged in.
+     *
+     * @depends testAddRecordToFavoritesNewAccount
      *
      * @return void
      */
@@ -309,6 +313,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
      * Test adding a record to favorites (from the search results) using an existing
      * account that is not yet logged in.
      *
+     * @depends testAddSearchItemToFavoritesNewAccount
+     *
      * @return void
      */
     public function testAddSearchItemToFavoritesLogin()
@@ -356,6 +362,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test adding a record to favorites (from the search results) using an existing
      * account that is already logged in.
+     *
+     * @depends testAddSearchItemToFavoritesNewAccount
      *
      * @return void
      */
@@ -448,6 +456,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that the email control works.
      *
+     * @depends testAddRecordToFavoritesNewAccount
+     *
      * @return void
      */
     public function testBulkEmail()
@@ -478,6 +488,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test that the export control works.
+     *
+     * @depends testAddRecordToFavoritesNewAccount
      *
      * @return void
      */
@@ -511,6 +523,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that the print control works.
      *
+     * @depends testAddRecordToFavoritesNewAccount
+     *
      * @return void
      */
     public function testBulkPrint()
@@ -538,6 +552,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test that it is possible to email a public list.
+     *
+     * @depends testAddRecordToFavoritesNewAccount
      *
      * @return void
      */
@@ -585,6 +601,8 @@ class FavoritesTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test that the bulk delete control works.
+     *
+     * @depends testAddRecordToFavoritesNewAccount
      *
      * @return void
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -284,6 +284,8 @@ class IlsActionsTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test canceling a hold.
      *
+     * @depends testPlaceHold
+     *
      * @return void
      */
     public function testCancelHold()
@@ -351,6 +353,8 @@ class IlsActionsTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test ILL requests.
      *
+     * @depends testPlaceHold
+     *
      * @return void
      */
     public function testIllRequest()
@@ -386,6 +390,8 @@ class IlsActionsTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test storage retrieval requests.
+     *
+     * @depends testPlaceHold
      *
      * @return void
      */
@@ -423,6 +429,8 @@ class IlsActionsTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test user profile action.
      *
+     * @depends testPlaceHold
+     *
      * @return void
      */
     public function testProfile()
@@ -454,6 +462,8 @@ class IlsActionsTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test renewal action.
+     *
+     * @depends testPlaceHold
      *
      * @return void
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
@@ -137,6 +137,8 @@ class ListViewsTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that we can save a favorite from accordion mode.
      *
+     * @depends testFavoritesInTabMode
+     *
      * @return void
      */
     public function testFavoritesInAccordionMode()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -92,6 +92,8 @@ class SavedSearchesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test search history.
      *
+     * @depends testSaveSearch
+     *
      * @return void
      */
     public function testSearchHistory()
@@ -142,6 +144,7 @@ class SavedSearchesTest extends \VuFindTest\Unit\MinkTestCase
     /**
      * Test that user A cannot delete user B's favorites.
      *
+     * @depends testSaveSearch
      * @retryCallback removeUsername2
      *
      * @return void
@@ -191,6 +194,8 @@ class SavedSearchesTest extends \VuFindTest\Unit\MinkTestCase
 
     /**
      * Test that notification settings work correctly.
+     *
+     * @depends testSaveSearch
      *
      * @return void
      */


### PR DESCRIPTION
Add `@depends` annotation to skip tests doomed to fail by earlier tests.