### PR TITLE
Add ChromeDriver as headless driver option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,8 @@
         "phpmd/phpmd": "2.8.1",
         "phpunit/phpunit": "8.5.2",
         "sebastian/phpcpd": "4.1.0",
-        "squizlabs/php_codesniffer": "3.5.3"
+        "squizlabs/php_codesniffer": "3.5.3",
+        "dmore/chrome-mink-driver": "^2.7"
     },
     "extra": {
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e76f3bc2211b579b2c26d547e04d8b27",
+    "content-hash": "7b24bb187a5e9bd66dbc90fd10b0566e",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -5581,6 +5581,54 @@
             "time": "2019-11-06T16:40:04+00:00"
         },
         {
+            "name": "dmore/chrome-mink-driver",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/DMore/chrome-mink-driver.git",
+                "reference": "d66765fb7f448e8b2bca2b899308a4a6d8a69264"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/DMore%2Fchrome-mink-driver/repository/archive.zip?sha=d66765fb7f448e8b2bca2b899308a4a6d8a69264",
+                "reference": "d66765fb7f448e8b2bca2b899308a4a6d8a69264",
+                "shasum": ""
+            },
+            "require": {
+                "behat/mink": "^1.7",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "textalk/websocket": "^1.2.0"
+            },
+            "require-dev": {
+                "mink/driver-testsuite": "dev-master",
+                "phpunit/phpunit": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DMore\\ChromeDriver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dorian More",
+                    "email": "doriancmore@gmail.com"
+                }
+            ],
+            "description": "Mink driver for controlling chrome without selenium",
+            "time": "2019-03-30T09:22:58+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "v1.8.0",
             "source": {
@@ -8412,6 +8460,45 @@
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
             "time": "2020-01-04T13:00:46+00:00"
+        },
+        {
+            "name": "textalk/websocket",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Textalk/websocket-php.git",
+                "reference": "bfa18bb6bf523680c7803f6b04694fbbf2f67bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Textalk/websocket-php/zipball/bfa18bb6bf523680c7803f6b04694fbbf2f67bbf",
+                "reference": "bfa18bb6bf523680c7803f6b04694fbbf2f67bbf",
+                "shasum": ""
+            },
+            "require-dev": {
+                "cboden/ratchet": "0.3.*",
+                "phpunit/phpunit": "4.1.*",
+                "phpunit/phpunit-selenium": "1.3.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WebSocket\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fredrik Liljegren",
+                    "email": "fredrik.liljegren@textalk.se"
+                }
+            ],
+            "description": "WebSocket client and server",
+            "time": "2015-10-09T07:32:42+00:00"
         },
         {
             "name": "theseer/fdomdocument",

--- a/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
@@ -155,11 +155,11 @@ abstract class MinkTestCase extends DbTestCase
      */
     protected function getMinkDriver()
     {
-        $env = getenv('VUFIND_SELENIUM_BROWSER');
-        $browser = $env ? $env : 'headless';
-        if ($browser === 'headless') {
+        $driver = getenv('VUFIND_MINK_DRIVER') ?? 'selenium';
+        if ($driver === 'chrome') {
             return new ChromeDriver('http://localhost:9222', null, 'data:;');
         }
+        $browser = getenv('VUFIND_SELENIUM_BROWSER') ?? 'firefox';
         return new Selenium2Driver($browser);
     }
 

--- a/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
@@ -31,6 +31,7 @@ namespace VuFindTest\Unit;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\Element;
 use Behat\Mink\Session;
+use DMore\ChromeDriver\ChromeDriver;
 use VuFind\Config\Locator as ConfigLocator;
 use VuFind\Config\Writer as ConfigWriter;
 
@@ -155,7 +156,10 @@ abstract class MinkTestCase extends DbTestCase
     protected function getMinkDriver()
     {
         $env = getenv('VUFIND_SELENIUM_BROWSER');
-        $browser = $env ? $env : 'firefox';
+        $browser = $env ? $env : 'headless';
+        if ($browser === 'headless') {
+            return new ChromeDriver('http://localhost:9222', null, 'data:;');
+        }
         return new Selenium2Driver($browser);
     }
 


### PR DESCRIPTION
Chrome 80+ has a built-in remote debugging driver. It also has a headless feature.

To use, instead of running Selenium, run:
```
google-chrome --disable-gpu --headless --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --window-size="1366,768" --disable-extensions
```

More details on the driver at https://gitlab.com/DMore/chrome-mink-driver.