### PR TITLE
Allow for Test Snooze Multipliers of less than 1

### DIFF
--- a/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/MinkTestCase.php
@@ -129,11 +129,11 @@ abstract class MinkTestCase extends DbTestCase
      */
     protected function snooze($secs = 1)
     {
-        $snoozeMultiplier = intval(getenv('VUFIND_SNOOZE_MULTIPLIER'));
-        if ($snoozeMultiplier < 1) {
+        $snoozeMultiplier = floatval(getenv('VUFIND_SNOOZE_MULTIPLIER'));
+        if ($snoozeMultiplier <= 0) {
             $snoozeMultiplier = 1;
         }
-        sleep($secs * $snoozeMultiplier);
+        usleep(1000000 * $secs * $snoozeMultiplier);
     }
 
     /**


### PR DESCRIPTION
Adjust the snooze behavior to allow for float options, allowing tests to be sped up with a fractional snooze multiplier. It also allows for casual timing testing (all tested interfaces are ready to go in 500ms).

```
phing -Dmink_driver="chrome" -Dsnooze_multiplier="0.5"
```