### PR TITLE
Standardise use of data-clear-account-cache attribute.

### DIFF
--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -31,7 +31,7 @@ VuFind.register('account', function Account() {
 
   // Clearing save forces AJAX update next page load
   var clearCache = function clearCache(name) {
-    if (typeof name === "undefined") {
+    if (typeof name === "undefined" || name === '') {
       for (var sub in _submodules) {
         if (_submodules.hasOwnProperty(sub)) {
           clearCache(sub);
@@ -122,11 +122,14 @@ VuFind.register('account', function Account() {
 
   var init = function init() {
     // Update information when certain actions are performed
-    $("[data-clear-account-cache]").submit(function dataClearCache() {
+    $("form[data-clear-account-cache]").submit(function dataClearCacheForm() {
       clearCache($(this).attr("data-clear-account-cache"));
     });
-    $("#library_card").change(function clearChangeLibraryCard() {
-      clearCache(/* all */);
+    $("a[data-clear-account-cache]").click(function dataClearCacheLink() {
+      clearCache($(this).attr("data-clear-account-cache"));
+    });
+    $("select[data-clear-account-cache]").change(function dataClearCacheSelect() {
+      clearCache($(this).attr("data-clear-account-cache"));
     });
   };
 

--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -1,6 +1,6 @@
 <?php if ($this->user): ?>
   <?php $cards = $this->user->getLibraryCards(); if ($cards->count() > 1): ?>
-    <form class="form-inline" action="<?=$this->url('librarycards-selectcard')?>" method="get">
+    <form class="form-inline" action="<?=$this->url('librarycards-selectcard')?>" method="get" data-clear-account-cache>
       <label for="library_card"><?=$this->transEsc('Library Card')?></label>
       <select id="library_card" name="cardID" class="jumpMenu form-control">
         <?php if (null === $this->user->cat_username): ?>


### PR DESCRIPTION
Removes the special case for library card selection and adds support for clearing all caches with an empty attribute also with links and select fields.