### PR TITLE
Correct headings in Record View

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
@@ -34,7 +34,7 @@
   <?php endif; ?>
   <div class="media-body">
 
-    <h3 property="name"><?=$this->escapeHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection())?></h3>
+    <h1 property="name"><?=$this->escapeHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection())?></h1>
 
     <?php if(!empty($this->extraControls)): ?>
       <?=$this->extraControls['actionControls'] ?? ''?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -46,7 +46,7 @@
     </div>
   </div>
   <div class="media-body info-col">
-    <h3 property="name"><?=$this->driver->getTitle()?></h3>
+    <h1 property="name"><?=$this->driver->getTitle()?></h1>
 
     <table class="table table-striped">
       <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>


### PR DESCRIPTION
This aims at correcting the headings hierarchy in record view for accessibility. Developers should not that they would have to do the same for any custom record drivers, too.