### PR TITLE
Wraps &laquo/&raquo in aria-hidden="true" spans

### DIFF
--- a/themes/bootstrap3/templates/Helpers/pagination.phtml
+++ b/themes/bootstrap3/templates/Helpers/pagination.phtml
@@ -4,10 +4,10 @@
     <li<?php if (isset($this->previous)): ?>>
       <?php $newParams = $this->params; $newParams['page'] = $this->previous; ?>
       <a href="<?= $this->currentPath() . '?' . http_build_query($newParams); ?>">
-        &laquo; <?=$this->translate('Prev')?>
+        <span aria-hidden="true">&laquo;</span> <?=$this->translate('Prev')?>
       </a>
     <?php else: ?>
-       class="disabled"> <span>&laquo; <?=$this->translate('Prev')?></span>
+       class="disabled"> <span><span aria-hidden="true">&laquo;</span> <?=$this->translate('Prev')?></span>
     <?php endif; ?>
     </li>
 
@@ -53,7 +53,7 @@
         <?=$this->translate('Next')?> >
       </a>
     <?php else: ?>
-       class="disabled"> <span><?=$this->translate('Next')?> &raquo;</span>
+       class="disabled"> <span><?=$this->translate('Next')?> <span aria-hidden="true">&raquo;</span></span>
     <?php endif; ?>
     </li>
   </ul>

--- a/themes/bootstrap3/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap3/templates/alphabrowse/home.phtml
@@ -19,15 +19,15 @@
 <?php ob_start(); ?>
   <ul class="pager">
     <?php if (isset($this->prevpage)): ?>
-      <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->prevpage]]))?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
+      <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->prevpage]]))?>"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
     <?php else: ?>
-      <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
+      <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
     <?php endif; ?>
 
     <?php if (isset($this->nextpage)): ?>
-      <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->nextpage]]))?>"><?=$this->transEsc('Next')?> &raquo;</a></li>
+      <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => $baseQuery + ['page' => $this->nextpage]]))?>"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
     <?php else: ?>
-      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
+      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
     <?php endif; ?>
   </ul>
 <?php $pageLinks = ob_get_contents(); ?>

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -29,17 +29,17 @@
     <?php if ($this->scrollData['previousRecord']): ?>
       <?php if ($this->scrollData['firstRecord']): ?>
         <li>
-          <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('First')?></a>
+          <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('First')?></a>
         </li>
       <?php endif; ?>
       <li>
-        <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('Prev')?></a>
+        <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a>
       </li>
     <?php else: ?>
       <?php if ($this->scrollData['firstRecord']): ?>
-        <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('First')?></a></li>
+        <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('First')?></a></li>
       <?php endif; ?>
-      <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
+      <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
     <?php endif; ?>
     <?=$this->transEsc('of_num_results', [
       '%%position%%' => $this->localizedNumber($this->scrollData['currentPosition']),
@@ -47,17 +47,17 @@
     ]) ?>
     <?php if ($this->scrollData['nextRecord']): ?>
       <li>
-        <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> &raquo;</a>
+        <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a>
       </li>
       <?php if ($this->scrollData['lastRecord']): ?>
         <li>
-          <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> &raquo;</a>
+          <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> <span aria-hidden="true">&raquo;</span></a>
         </li>
       <?php endif; ?>
      <?php else: ?>
-      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
+      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php if ($this->scrollData['lastRecord']): ?>
-        <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> &raquo;</a></li>
+        <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php endif; ?>
     <?php endif; ?>
   </ul>

--- a/themes/bootstrap3/templates/collections/home.phtml
+++ b/themes/bootstrap3/templates/collections/home.phtml
@@ -15,14 +15,14 @@
   <form class="form-inline" method="GET" action="<?=$this->url('collections-home')?>">
     <ul class="pager">
       <?php if (isset($prevpage)): ?>
-        <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($prevpage)?><?=$this->escapeHtmlAttr($filterString)?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
+        <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($prevpage)?><?=$this->escapeHtmlAttr($filterString)?>"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
       <?php else: ?>
-        <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
+        <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
       <?php endif; ?>
       <?php if (isset($nextpage)): ?>
-        <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($nextpage)?><?=$this->escapeHtmlAttr($filterString)?>"><?=$this->transEsc('Next')?> &raquo;</a></li>
+        <li><a href="<?=$this->url('collections-home')?>?from=<?=urlencode($from)?>&amp;page=<?=urlencode($nextpage)?><?=$this->escapeHtmlAttr($filterString)?>"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php else: ?>
-        <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
+        <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php endif; ?>
       <input type="submit" class="btn btn-default" value="<?=$this->transEsc('Jump to')?>" />
       <input type="text" name="from" value="<?=$this->escapeHtmlAttr($from)?>" class="form-control" />

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -23,17 +23,17 @@
     <?php if ($this->scrollData['previousRecord']): ?>
       <?php if ($this->scrollData['firstRecord']): ?>
         <li>
-          <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('First')?></a>
+          <a href="<?=$this->recordLink()->getUrl($this->scrollData['firstRecord'])?>" title="<?=$this->transEsc('First Search Result')?>" rel="nofollow"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('First')?></a>
         </li>
       <?php endif; ?>
       <li>
-        <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow">&laquo; <?=$this->transEsc('Prev')?></a>
+        <a href="<?=$this->recordLink()->getUrl($this->scrollData['previousRecord'])?>" title="<?=$this->transEsc('Previous Search Result')?>" rel="nofollow"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a>
       </li>
     <?php else: ?>
       <?php if ($this->scrollData['firstRecord']): ?>
-        <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('First')?></a></li>
+        <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('First')?></a></li>
       <?php endif; ?>
-      <li class="disabled"><a href="#">&laquo; <?=$this->transEsc('Prev')?></a></li>
+      <li class="disabled"><a href="#"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
     <?php endif; ?>
     <?=$this->transEsc('of_num_results', [
       '%%position%%' => $this->localizedNumber($this->scrollData['currentPosition']),
@@ -41,17 +41,17 @@
     ]) ?>
     <?php if ($this->scrollData['nextRecord']): ?>
       <li>
-        <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> &raquo;</a>
+        <a href="<?=$this->recordLink()->getUrl($this->scrollData['nextRecord'])?>" title="<?=$this->transEsc('Next Search Result')?>" rel="nofollow"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a>
       </li>
       <?php if ($this->scrollData['lastRecord']): ?>
         <li>
-          <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> &raquo;</a>
+          <a href="<?=$this->recordLink()->getUrl($this->scrollData['lastRecord'])?>" title="<?=$this->transEsc('Last Search Result')?>" rel="nofollow"><?=$this->transEsc('Last')?> <span aria-hidden="true">&raquo;</span></a>
         </li>
       <?php endif; ?>
      <?php else: ?>
-      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> &raquo;</a></li>
+      <li class="disabled"><a href="#"><?=$this->transEsc('Next')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php if ($this->scrollData['lastRecord']): ?>
-        <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> &raquo;</a></li>
+        <li class="disabled"><a href="#"><?=$this->transEsc('Last')?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php endif; ?>
     <?php endif; ?>
   </ul>

--- a/themes/bootstrap3/templates/search/pagination.phtml
+++ b/themes/bootstrap3/templates/search/pagination.phtml
@@ -4,7 +4,7 @@
       <?php if (!isset($this->options['disableFirst']) || !$this->options['disableFirst']): ?>
         <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage(1)?>">[1]</a></li>
       <?php endif; ?>
-      <li><a class="page-prev" href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->previous)?>">&laquo; <?=$this->transEsc('Prev')?></a></li>
+      <li><a class="page-prev" href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->previous)?>"><span aria-hidden="true">&laquo;</span> <?=$this->transEsc('Prev')?></a></li>
     <?php endif; ?>
 
     <?php if (count($this->pagesInRange) > 1): ?>
@@ -18,7 +18,7 @@
     <?php endif; ?>
 
     <?php if (isset($this->next)): ?>
-      <li><a class="page-next" href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->next)?>"><?=$this->transEsc('Next');?> &raquo;</a></li>
+      <li><a class="page-next" href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->next)?>"><?=$this->transEsc('Next');?> <span aria-hidden="true">&raquo;</span></a></li>
       <?php if (!isset($this->options['disableLast']) || !$this->options['disableLast']): ?>
         <li><a href="<?=$this->currentPath() . $this->results->getUrlQuery()->setPage($this->pageCount)?>">[<?=$this->pageCount?>]</a></li>
       <?php endif; ?>


### PR DESCRIPTION
My screen reader reads the "french" quotes used in the paginators and next/previous navigation bars as the respective french opening/closing quotes, which is misleading. Hence the suggestion of wrapping them in <span aria-hidden="true">