### PR TITLE
Make holdings retrieval preserve any custom array elements.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1056,13 +1056,23 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
         $holdings = $this->__call('getHolding', [$id, $patron, $finalOptions]);
 
         // Return all the necessary details:
-        return [
-            'total' => $holdings['total'] ?? count($holdings),
-            'holdings' => $holdings['holdings'] ?? $holdings,
-            'electronic_holdings' => $holdings['electronic_holdings'] ?? [],
-            'page' => $finalOptions['page'],
-            'itemLimit' => $finalOptions['itemLimit'],
-        ];
+        if (!isset($holdings['holdings'])) {
+            $holdings = [
+                'total' => count($holdings),
+                'holdings' => $holdings,
+                'electronic_holdings' => [],
+            ];
+        } else {
+            if (!isset($holdings['total'])) {
+                $holdings['total'] = count($holdings['holdings']);
+            }
+            if (!isset($holdings['electronic_holdings'])) {
+                $holdings['electronic_holdings'] = [];
+            }
+        }
+        $holdings['page'] = $finalOptions['page'];
+        $holdings['itemLimit'] = $finalOptions['itemLimit'];
+        return $holdings;
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -175,10 +175,11 @@ class Holds
      *
      * @param string $id  A Bib ID
      * @param array  $ids A list of Source Records (if catalog is for a consortium)
+     * @param array  $options Optional options to pass on to getHolding()
      *
      * @return array A sorted results set
      */
-    public function getHoldings($id, $ids = null)
+    public function getHoldings($id, $ids = null, $options = [])
     {
         if (!$this->catalog) {
             return [];

--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -173,8 +173,9 @@ class Holds
      * Public method for getting item holdings from the catalog and selecting which
      * holding method to call
      *
-     * @param string $id  A Bib ID
-     * @param array  $ids A list of Source Records (if catalog is for a consortium)
+     * @param string $id      A Bib ID
+     * @param array  $ids     A list of Source Records (if catalog is for a
+     * consortium)
      * @param array  $options Optional options to pass on to getHolding()
      *
      * @return array A sorted results set


### PR DESCRIPTION
This makes the Holds::getHoldings method and Connection::getHolding method pass any custom array elements through. I'm using the functionality with a revised multi-step holdings retrieval for Alma (to be introduced later, our main commit https://github.com/NatLibFi/NDL-VuFind2/commit/1cff2e124851778d2a4af96292905a33d40abfb6). Should make no functional difference at the moment. Sorry about the messy diff for Holds.php. It's mostly the indentation change due to early return.