### PR TITLE
Adds missing sr-only text to exclude facets

### DIFF
--- a/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
@@ -57,7 +57,7 @@
 
   <?php if ($this->exclude && !$this->facet['isApplied']): ?>
     <?php $excludeURL = $this->urlBase . $this->url->addFacet($this->group, $this->facet['value'], 'NOT'); ?>
-    <a href="<?=$excludeURL ?>" data-lightbox-ignore title="<?=$this->transEsc('exclude_facet') ?>" class="exclude"><i class="fa fa-times" aria-hidden="true"></i></a>
+    <a href="<?=$excludeURL ?>" data-lightbox-ignore title="<?=$this->transEsc('exclude_facet') ?>" class="exclude"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
   <?php endif; ?>
 
 <?=$hasSubLinks ? '</div>' : '</a>'; ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
@@ -57,7 +57,7 @@
 
   <?php if ($this->exclude && !$this->facet['isApplied']): ?>
     <?php $excludeURL = $this->urlBase . $this->url->addFacet($this->group, $this->facet['value'], 'NOT'); ?>
-    <a href="<?=$excludeURL ?>" data-lightbox-ignore title="<?=$this->transEsc('exclude_facet') ?>" class="exclude"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
+    <a href="<?=$excludeURL ?>" data-lightbox-ignore class="exclude"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
   <?php endif; ?>
 
 <?=$hasSubLinks ? '</div>' : '</a>'; ?>

--- a/themes/bootstrap3/templates/Recommend/TopFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/TopFacets.phtml
@@ -33,7 +33,7 @@
            --></a>
               <span class="badge"><?=$this->localizedNumber($thisFacet['count']) ?></span>
               <?php if ($allowExclude): ?>
-                <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>" title="<?=$this->transEsc('exclude_facet')?>"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
+                <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
               <?php endif; ?>
             <?php endif; ?>
           </span>

--- a/themes/bootstrap3/templates/Recommend/TopFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/TopFacets.phtml
@@ -33,7 +33,7 @@
            --></a>
               <span class="badge"><?=$this->localizedNumber($thisFacet['count']) ?></span>
               <?php if ($allowExclude): ?>
-                <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>" title="<?=$this->transEsc('exclude_facet')?>"><i class="fa fa-times" aria-hidden="true"></i></a>
+                <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet($title, $thisFacet['value'], 'NOT')?>" title="<?=$this->transEsc('exclude_facet')?>"><i class="fa fa-times" aria-hidden="true"></i> <span class="sr-only"><?=$this->transEsc('exclude_facet') ?></span></a>
               <?php endif; ?>
             <?php endif; ?>
           </span>


### PR DESCRIPTION
The exclude switches in the side facets are not accessible since the icon is hidden, they appear as empty links to screen readers. I've added sr-only text.