### PR TITLE
Fix Language Menu for Records with Slashes

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Url.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Url.php
@@ -28,6 +28,7 @@
 namespace VuFind\View\Helper\Root;
 
 use Laminas\Http\PhpEnvironment\Request;
+use Laminas\Mvc\ModuleRouteListener;
 
 /**
  * Url view helper (extending core Laminas helper with additional functionality)
@@ -95,9 +96,21 @@ class Url extends \Laminas\View\Helper\Url
      */
     public function addQueryParameters($params, $reuseMatchedParams = true)
     {
-        $requestQuery = (null !== $this->request)
+        $requestQuery = ($this->request !== null)
             ? $this->request->getQuery()->toArray() : [];
         $options = ['query' => array_merge($requestQuery, $params)];
-        return $this->__invoke(null, [], $options, $reuseMatchedParams);
+
+        $params = [];
+
+        if ($reuseMatchedParams) {
+            $routeMatchParams = $this->routeMatch->getParams();
+
+            // Add case: VuFind Record ID escape
+            if (!isset($params['id']) && isset($routeMatchParams['id'])) {
+                $params['id'] = rawurlencode($routeMatchParams['id']);
+            }
+        }
+
+        return $this->__invoke(null, $params, $options);
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Url.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Url.php
@@ -28,7 +28,6 @@
 namespace VuFind\View\Helper\Root;
 
 use Laminas\Http\PhpEnvironment\Request;
-use Laminas\Mvc\ModuleRouteListener;
 
 /**
  * Url view helper (extending core Laminas helper with additional functionality)


### PR DESCRIPTION
Core Problem: Adding parameters and [invoking the URL helper](https://github.com/vufind-org/vufind/blob/master/module/VuFind/src/VuFind/View/Helper/Root/Url.php#L101) with `null` name and `[]` parameters causes the base URL to lose escaping.

Solution: escape id parameters for the path name. This solution feels a little too narrow but is a starting point for solving the issue.

Fixes [VUFIND-1392](https://vufind.org/jira/browse/VUFIND-1392)