### PR TITLE
Simplify/standardize search backend ID handling.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -60,6 +60,13 @@ abstract class Results
     protected $resultTotal = null;
 
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId;
+
+    /**
      * Override (only for use in very rare cases)
      *
      * @var int
@@ -401,6 +408,16 @@ abstract class Results
             $this->performAndProcessSearch();
         }
         return $this->errors;
+    }
+
+    /**
+     * Basic 'getter' of search backend identifier.
+     *
+     * @return string
+     */
+    public function getBackendId()
+    {
+        return $this->backendId;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/BrowZine/Results.php
+++ b/module/VuFind/src/VuFind/Search/BrowZine/Results.php
@@ -42,19 +42,11 @@ use VuFindSearch\Service as SearchService;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
-     * Constructor
+     * Search backend identifier.
      *
-     * @param \VuFind\Search\Base\Params $params        Object representing user
-     * search parameters.
-     * @param SearchService              $searchService Search service
-     * @param Loader                     $recordLoader  Record loader
+     * @var string
      */
-    public function __construct(\VuFind\Search\Base\Params $params,
-        SearchService $searchService, Loader $recordLoader
-    ) {
-        parent::__construct($params, $searchService, $recordLoader);
-        $this->backendId = 'BrowZine';
-    }
+    protected $backendId = 'BrowZine';
 
     /**
      * Returns the stored list of facets for the last search
@@ -83,7 +75,7 @@ class Results extends \VuFind\Search\Base\Results
         $limit  = $this->getParams()->getLimit();
         $offset = $this->getStartRecord() - 1;
         $collection = $this->getSearchService()->search(
-            'BrowZine', $query, $offset, $limit
+            $this->backendId, $query, $offset, $limit
         );
 
         $this->resultTotal = $collection->getTotal();

--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -39,6 +39,13 @@ namespace VuFind\Search\EDS;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'EDS';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -51,7 +58,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord() - 1;
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()->search(
-            'EDS', $query, $offset, $limit, $params
+            $this->backendId, $query, $offset, $limit, $params
         );
         if (null != $collection) {
             $this->responseFacets = $collection->getFacets();

--- a/module/VuFind/src/VuFind/Search/EIT/Results.php
+++ b/module/VuFind/src/VuFind/Search/EIT/Results.php
@@ -43,6 +43,13 @@ namespace VuFind\Search\EIT;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'EIT';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -55,7 +62,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord() - 1;
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()
-            ->search('EIT', $query, $offset, $limit, $params);
+            ->search($this->backendId, $query, $offset, $limit, $params);
 
         $this->resultTotal = $collection->getTotal();
         $this->results = $collection->getRecords();

--- a/module/VuFind/src/VuFind/Search/LibGuides/Results.php
+++ b/module/VuFind/src/VuFind/Search/LibGuides/Results.php
@@ -39,6 +39,13 @@ namespace VuFind\Search\LibGuides;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'LibGuides';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -50,7 +57,7 @@ class Results extends \VuFind\Search\Base\Results
         $limit  = $this->getParams()->getLimit();
         $offset = $this->getStartRecord() - 1;
         $collection = $this->getSearchService()->search(
-            'LibGuides', $query, $offset, $limit
+            $this->backendId, $query, $offset, $limit
         );
 
         $this->resultTotal = $collection->getTotal();

--- a/module/VuFind/src/VuFind/Search/Pazpar2/Results.php
+++ b/module/VuFind/src/VuFind/Search/Pazpar2/Results.php
@@ -39,6 +39,13 @@ namespace VuFind\Search\Pazpar2;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'Pazpar2';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -51,7 +58,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord() - 1;
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()
-            ->search('Pazpar2', $query, $offset, $limit, $params);
+            ->search($this->backendId, $query, $offset, $limit, $params);
 
         $this->resultTotal = $collection->getTotal();
         $this->results = $collection->getRecords();

--- a/module/VuFind/src/VuFind/Search/Primo/Results.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Results.php
@@ -39,6 +39,13 @@ namespace VuFind\Search\Primo;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'Primo';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -51,7 +58,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord() - 1;
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()->search(
-            'Primo', $query, $offset, $limit, $params
+            $this->backendId, $query, $offset, $limit, $params
         );
 
         $this->responseFacets = $collection->getFacets();

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -51,7 +51,7 @@ class Results extends \VuFind\Search\Base\Results
     protected $responseFacets = null;
 
     /**
-     * Search backend identifiers.
+     * Search backend identifier.
      *
      * @var string
      */

--- a/module/VuFind/src/VuFind/Search/SolrAuth/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuth/Results.php
@@ -42,17 +42,9 @@ use VuFindSearch\Service as SearchService;
 class Results extends \VuFind\Search\Solr\Results
 {
     /**
-     * Constructor
+     * Search backend identifier.
      *
-     * @param \VuFind\Search\Base\Params $params        Object representing user
-     * search parameters.
-     * @param SearchService              $searchService Search service
-     * @param Loader                     $recordLoader  Record loader
+     * @var string
      */
-    public function __construct(\VuFind\Search\Base\Params $params,
-        SearchService $searchService, Loader $recordLoader
-    ) {
-        parent::__construct($params, $searchService, $recordLoader);
-        $this->backendId = 'SolrAuth';
-    }
+    protected $backendId = 'SolrAuth';
 }

--- a/module/VuFind/src/VuFind/Search/SolrReserves/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrReserves/Results.php
@@ -44,17 +44,9 @@ use VuFindSearch\Service as SearchService;
 class Results extends \VuFind\Search\Solr\Results
 {
     /**
-     * Constructor
+     * Search backend identifier.
      *
-     * @param \VuFind\Search\Base\Params $params        Object representing user
-     * search parameters.
-     * @param SearchService              $searchService Search service
-     * @param Loader                     $recordLoader  Record loader
+     * @var string
      */
-    public function __construct(\VuFind\Search\Base\Params $params,
-        SearchService $searchService, Loader $recordLoader
-    ) {
-        parent::__construct($params, $searchService, $recordLoader);
-        $this->backendId = 'SolrReserves';
-    }
+    protected $backendId = 'SolrReserves';
 }

--- a/module/VuFind/src/VuFind/Search/SolrWeb/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrWeb/Results.php
@@ -42,17 +42,9 @@ use VuFindSearch\Service as SearchService;
 class Results extends \VuFind\Search\Solr\Results
 {
     /**
-     * Constructor
+     * Search backend identifier.
      *
-     * @param \VuFind\Search\Base\Params $params        Object representing user
-     * search parameters.
-     * @param SearchService              $searchService Search service
-     * @param Loader                     $recordLoader  Record loader
+     * @var string
      */
-    public function __construct(\VuFind\Search\Base\Params $params,
-        SearchService $searchService, Loader $recordLoader
-    ) {
-        parent::__construct($params, $searchService, $recordLoader);
-        $this->backendId = 'SolrWeb';
-    }
+    protected $backendId = 'SolrWeb';
 }

--- a/module/VuFind/src/VuFind/Search/Summon/Results.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Results.php
@@ -67,6 +67,13 @@ class Results extends \VuFind\Search\Base\Results
     protected $topicRecommendations = false;
 
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'Summon';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -79,7 +86,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord() - 1;
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()->search(
-            'Summon', $query, $offset, $limit, $params
+            $this->backendId, $query, $offset, $limit, $params
         );
 
         $this->responseFacets = $collection->getFacets();
@@ -368,7 +375,7 @@ class Results extends \VuFind\Search\Base\Results
         }
         $params = $params->getBackendParameters();
         $collection = $this->getSearchService()->search(
-            'Summon', $query, 0, 0, $params
+            $this->backendId, $query, 0, 0, $params
         );
 
         $facets = $collection->getFacets();

--- a/module/VuFind/src/VuFind/Search/WorldCat/Results.php
+++ b/module/VuFind/src/VuFind/Search/WorldCat/Results.php
@@ -39,6 +39,13 @@ namespace VuFind\Search\WorldCat;
 class Results extends \VuFind\Search\Base\Results
 {
     /**
+     * Search backend identifier.
+     *
+     * @var string
+     */
+    protected $backendId = 'WorldCat';
+
+    /**
      * Support method for performAndProcessSearch -- perform a search based on the
      * parameters passed to the object.
      *
@@ -51,7 +58,7 @@ class Results extends \VuFind\Search\Base\Results
         $offset = $this->getStartRecord();
         $params = $this->getParams()->getBackendParameters();
         $collection = $this->getSearchService()
-            ->search('WorldCat', $query, $offset, $limit, $params);
+            ->search($this->backendId, $query, $offset, $limit, $params);
 
         $this->resultTotal = $collection->getTotal();
         $this->results = $collection->getRecords();


### PR DESCRIPTION
There was some inconsistency in the code of the various search results classes; some had hard-coded search backend IDs, while others used a backendId property. This PR standardizes all results classes to use backendId for consistency (and also removes some unnecessary subclass constructors for simplicity and easier maintenance).