### PR TITLE
Do not require MVC event to initialize theme.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -122,7 +122,7 @@ class Initializer
         $this->config = $config;
 
         if ($eventOrContainer instanceof MvcEvent) {
-            $this->event = $event;
+            $this->event = $eventOrContainer;
             $this->serviceManager = $this->event->getApplication()
                 ->getServiceManager();
         } elseif ($eventOrContainer instanceof ContainerInterface) {

--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -27,6 +27,7 @@
  */
 namespace VuFindTheme;
 
+use Interop\Container\ContainerInterface;
 use Laminas\Config\Config;
 use Laminas\Console\Console;
 use Laminas\Mvc\MvcEvent;
@@ -96,7 +97,8 @@ class Initializer
     /**
      * Constructor
      *
-     * @param Config   $config Configuration object containing these keys:
+     * @param Config                      $config           Configuration object
+     * containing these keys:
      * <ul>
      *   <li>theme - the name of the default theme for non-mobile devices</li>
      *   <li>mobile_theme - the name of the default theme for mobile devices
@@ -111,16 +113,26 @@ class Initializer
      *   <li>generator - a Generator value to display in the HTML header
      * (optional)</li>
      * </ul>
-     * @param MvcEvent $event  Laminas MVC Event object
+     * @param MvcEvent|ContainerInterface $eventOrContainer Laminas MVC Event object
+     * OR service container object
      */
-    public function __construct(Config $config, MvcEvent $event)
+    public function __construct(Config $config, $eventOrContainer)
     {
         // Store parameters:
         $this->config = $config;
-        $this->event = $event;
 
-        // Grab the service manager for convenience:
-        $this->serviceManager = $this->event->getApplication()->getServiceManager();
+        if ($eventOrContainer instanceof MvcEvent) {
+            $this->event = $event;
+            $this->serviceManager = $this->event->getApplication()
+                ->getServiceManager();
+        } elseif ($eventOrContainer instanceof ContainerInterface) {
+            $this->event = null;
+            $this->serviceManager = $eventOrContainer;
+        } else {
+            throw new \Exception(
+                'Illegal type for $eventOrContainer: ' . get_class($eventOrContainer)
+            );
+        }
 
         // Get the cookie manager from the service manager:
         $this->cookieManager = $this->serviceManager
@@ -150,7 +162,9 @@ class Initializer
         self::$themeInitialized = true;
 
         // Determine the current theme:
-        $currentTheme = $this->pickTheme($this->event->getRequest());
+        $currentTheme = $this->pickTheme(
+            isset($this->event) ? $this->event->getRequest() : null
+        );
 
         // Determine theme options:
         $this->sendThemeOptionsToView();
@@ -178,11 +192,12 @@ class Initializer
     /**
      * Support method for init() -- figure out which theme option is active.
      *
-     * @param Request $request Request object (for obtaining user parameters).
+     * @param Request $request Request object (for obtaining user parameters);
+     * set to null if no request context is available.
      *
      * @return string
      */
-    protected function pickTheme(Request $request)
+    protected function pickTheme(?Request $request)
     {
         // Load standard configuration options:
         $standardTheme = $this->config->theme;
@@ -193,12 +208,14 @@ class Initializer
             ? $this->config->mobile_theme : false;
 
         // Find out if the user has a saved preference in the POST, URL or cookies:
-        $selectedUI = $request->getPost()->get(
-            'ui', $request->getQuery()->get(
-                'ui', isset($request->getCookie()->ui)
-                ? $request->getCookie()->ui : null
-            )
-        );
+        if (isset($request)) {
+            $selectedUI = $request->getPost()->get(
+                'ui', $request->getQuery()->get(
+                    'ui', isset($request->getCookie()->ui)
+                    ? $request->getCookie()->ui : null
+                )
+            );
+        }
         if (empty($selectedUI)) {
             $selectedUI = ($mobileTheme && $this->mobile->detect())
                 ? 'mobile' : 'standard';


### PR DESCRIPTION
Allows console commands to utilize themes without Laminas-MVC.

TODO
- [x] Run full test suite
- [x] Note BC breaks in changelog