### PR TITLE
allow multipart messages in mails

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -328,6 +328,33 @@ class MailerTest extends \VuFindTest\Unit\TestCase
         $mailer = new Mailer($transport);
         $mailer->sendRecord('to@example.com', 'from@example.com', 'message', $driver, $view);
     }
+
+    /**
+     * Test sending an email using with text part and html part and multipart content type.
+     *
+     * @return void
+     * @throws \VuFind\Exception\Mail
+     */
+    public function testSendMimeMessageWithMultipartAlternativeContentType()
+    {
+        $this->html = '<!DOCTYPE html><head><title>html</title></head><body>html body part</body></html>';
+        $this->text = 'this is the text part';
+        $callback = function ($message) {
+            $fromString = $message->getFrom()->current()->toString();
+            return '<to@example.com>' == $message->getTo()->current()->toString()
+                && 'Sender TextName <from@example.com>' == $fromString
+                && 'subject' == $message->getSubject()
+                && 0 <= strpos($message->getBody()->getParts()[0]->getContent(), $this->html)
+                && 0 <= strpos($message->getBody()->getParts()[0]->getContent(), $this->text)
+                && 'multipart/alternative' == $message->getHeaders()->get('Content-Type')->getType();
+        };
+        $transport = $this->createMock('Zend\Mail\Transport\TransportInterface');
+        $transport->expects($this->once())->method('send')->with($this->callback($callback));
+        $address = new Address('from@example.com', 'Sender TextName');
+        $mailer = new Mailer($transport);
+        $body = $mailer->buildMultipartBody($this->text, $this->html);
+        $mailer->send('to@example.com', $address, 'subject', $body);
+    }
 }
 
 class MockEmailRenderer extends \Zend\View\Renderer\PhpRenderer


### PR DESCRIPTION
* introduce method for building multipart messages as option for creating html messages
* add method 'getNewBlankMessage' in mailer class to get message without content type in header
** necessary because initially set content type in 'getNewMessage' can not be overriden by Zend\Mail\Headers::addHeader() later in Zend\Mime\Message::setBody()
* add text content type only as fallback
* add test method for html message in Vufind MailerTest