### PR TITLE
Translation tokens: remove need for %% wrapping

### DIFF
--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -174,6 +174,9 @@ trait TranslatorAwareTrait
         if (!empty($tokens)) {
             $in = $out = [];
             foreach ($tokens as $key => $value) {
+                if (substr($key, 0, 2) != '%%' || substr($key, -2) != '%%') {
+                    $key = '%%' . str_replace('%', '', $key) . '%%';
+                }
                 $in[] = $key;
                 $out[] = $value;
             }

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -60,6 +60,9 @@ var VuFind = (function VuFind() {
     if (replacements) {
       for (var key in replacements) {
         if (replacements.hasOwnProperty(key)) {
+          if (key.substr(0, 2) != "%%" || key.substr(key.length-2) != "%%") {
+            key = "%%" + key.replace(/%/g, "") + "%%";
+          }
           translation = translation.replace(key, replacements[key]);
         }
       }


### PR DESCRIPTION
Been doing a lot of theming lately and this finally bothered me enough to propose a change.

Right now to translate with tokens looks like

```php
$this->translate('something', ['%%words%%' => 'words', '%%page%%' => 6, '%%name%%' => $name]);
```

This PR removes the need for the `%%` but remains backwardly compatible:

```php
$this->translate('something', ['words' => 'words', 'page' => 6, 'name' => $name]);
```

- [ ] Decide if we're going this
- [ ] Decide if we should normalize all tokens to this (already done with regex but not pushed).