### PR TITLE
Fix for tab15 missing index

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -155,7 +155,7 @@ class AlephTranslator
             echo "tab15 is null!<br>";
         }
         $findme = $tab15["tab15"] . "|" . $isc . "|" . $ipsc;
-        $result = $this->table15[$findme];
+        $result = $this->table15[$findme] ?? null;
         if ($result == null) {
             $findme = $tab15["tab15"] . "||" . $ipsc;
             $result = $this->table15[$findme];


### PR DESCRIPTION
In a bit more strict environment (tested on php 7.4+), missing index often causes problems. It helps to set the value explicitly.