### PR TITLE
SierraRest: Use REST API v5 by default.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -262,7 +262,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             $this->apiVersion = $this->config['Catalog']['api_version'];
             // Default to API v5 unless a lower compatibility level is needed.
             if ($this->apiVersion < 5) {
-                $this->apiBase = 'v' . substr($this->apiVersion, 0, 1);
+                $this->apiBase = 'v' . floor($this->apiVersion);
             }
         }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2016-2019.
+ * Copyright (C) The National Library of Finland 2016-2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -153,9 +153,22 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
      * v5.1 (technically still v5 but added in a later revision):
      *   - summary holdings information (especially for serials)
      *
+     * Note that API version 3 is deprecated in Sierra 5.1 and will be removed later
+     * on (reported March 2020).
+     *
      * @var int
      */
     protected $apiVersion = 5;
+
+    /**
+     * API base path
+     *
+     * This is the default API level used even if apiVersion is higher so that any
+     * changes in existing methods don't cause trouble.
+     *
+     * @var string
+     */
+    protected $apiBase = 'v5';
 
     /**
      * Whether to sort items by enumchron. Default is true.
@@ -247,6 +260,10 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
 
         if (isset($this->config['Catalog']['api_version'])) {
             $this->apiVersion = $this->config['Catalog']['api_version'];
+            // Default to API v5 unless a lower compatibility level is needed.
+            if ($this->apiVersion < 5) {
+                $this->apiBase = 'v' . substr($this->apiVersion, 0, 1);
+            }
         }
 
         $this->sortItemsByEnumChron
@@ -397,7 +414,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         // which verifies the PIN code).
 
         $result = $this->makeRequest(
-            ['v3', 'info', 'token'],
+            [$this->apiBase, 'info', 'token'],
             [],
             'GET',
             ['cat_username' => $username, 'cat_password' => $password]
@@ -411,7 +428,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $patronId = $result['patronId'];
 
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patronId],
+            [$this->apiBase, 'patrons', $patronId],
             ['fields' => 'names,emails'],
             'GET',
             ['cat_username' => $username, 'cat_password' => $password]
@@ -479,7 +496,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     public function getMyProfile($patron)
     {
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id']],
+            [$this->apiBase, 'patrons', $patron['id']],
             [
                 'fields' => 'names,emails,phones,addresses,expirationDate'
             ],
@@ -546,7 +563,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $offset = isset($params['page']) ? ($params['page'] - 1) * $pageSize : 0;
 
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id'], 'checkouts'],
+            [$this->apiBase, 'patrons', $patron['id'], 'checkouts'],
             [
                 'limit' => $pageSize,
                 'offset' => $offset,
@@ -584,7 +601,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             }
             // Fetch item information
             $item = $this->makeRequest(
-                ['v3', 'items', $transaction['item_id']],
+                [$this->apiBase, 'items', $transaction['item_id']],
                 ['fields' => 'bibIds,varFields'],
                 'GET',
                 $patron
@@ -644,7 +661,9 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         foreach ($renewDetails['details'] as $details) {
             list($checkoutId, $itemId) = explode('|', $details);
             $result = $this->makeRequest(
-                ['v3', 'patrons', 'checkouts', $checkoutId, 'renewal'], [], 'POST',
+                [$this->apiBase, 'patrons', 'checkouts', $checkoutId, 'renewal'],
+                [],
+                'POST',
                 $patron
             );
             if (!empty($result['code'])) {
@@ -690,7 +709,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $sortOrder = isset($params['sort']) && 'checkout asc' === $params['sort']
             ? 'asc' : 'desc';
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id'], 'checkouts', 'history'],
+            [$this->apiBase, 'patrons', $patron['id'], 'checkouts', 'history'],
             [
                 'limit' => $pageSize,
                 'offset' => $offset,
@@ -720,7 +739,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             ];
             // Fetch item information
             $item = $this->makeRequest(
-                ['v3', 'items', $transaction['item_id']],
+                [$this->apiBase, 'items', $transaction['item_id']],
                 ['fields' => 'bibIds,varFields'],
                 'GET',
                 $patron
@@ -769,7 +788,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             $fields .= ',pickupByDate';
         }
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id'], 'holds'],
+            [$this->apiBase, 'patrons', $patron['id'], 'holds'],
             [
                 'limit' => 10000,
                 'fields' => $fields
@@ -791,7 +810,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
                 $itemId = $this->extractId($entry['record']);
                 // Fetch bib ID from item
                 $item = $this->makeRequest(
-                    ['v3', 'items', $itemId],
+                    [$this->apiBase, 'items', $itemId],
                     ['fields' => 'bibIds,varFields'],
                     'GET',
                     $patron
@@ -1098,7 +1117,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         }
 
         $result = $this->makeRequest(
-            [$comment ? 'v4' : 'v3', 'patrons', $patron['id'], 'holds', 'requests'],
+            [$this->apiBase, 'patrons', $patron['id'], 'holds', 'requests'],
             json_encode($request),
             'POST',
             $patron
@@ -1124,7 +1143,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     public function getMyFines($patron)
     {
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id'], 'fines'],
+            [$this->apiBase, 'patrons', $patron['id'], 'fines'],
             [
                 'fields' => 'item,assessedDate,description,chargeType,itemCharge'
                     . ',processingFee,billingFee,paidAmount'
@@ -1165,7 +1184,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
                 $itemId = $this->extractId($entry['item']);
                 // Fetch bib ID from item
                 $item = $this->makeRequest(
-                    ['v3', 'items', $itemId],
+                    [$this->apiBase, 'items', $itemId],
                     ['fields' => 'bibIds'],
                     'GET',
                     $patron
@@ -1230,7 +1249,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $request = ['pin' => $newPIN];
 
         $result = $this->makeRequest(
-            ['v3', 'patrons', $patron['id']],
+            [$this->apiBase, 'patrons', $patron['id']],
             json_encode($request),
             'PUT',
             $patron
@@ -1692,7 +1711,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $result = null;
         while (null === $result || $limit === $result['total']) {
             $result = $this->makeRequest(
-                ['v3', 'items'],
+                [$this->apiBase, 'items'],
                 [
                     'bibIds' => $this->extractBibId($id),
                     'deleted' => 'false',
@@ -2136,7 +2155,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $blockReason = $this->getCachedData($cacheId);
         if (null === $blockReason) {
             $result = $this->makeRequest(
-                ['v3', 'patrons', $patronId],
+                [$this->apiBase, 'patrons', $patronId],
                 ['fields' => 'blockInfo'],
                 'GET',
                 $patron
@@ -2246,7 +2265,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     protected function getBibRecord($id, $fields, $patron = false)
     {
         return $this->makeRequest(
-            ['v3', 'bibs', $this->extractBibId($id)],
+            [$this->apiBase, 'bibs', $this->extractBibId($id)],
             ['fields' => $fields],
             'GET',
             $patron


### PR DESCRIPTION
v3 is deprecated and will be removed in a future release.