### PR TITLE
FOLIO: add check for item level supression

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -441,7 +441,7 @@ class Folio extends AbstractAPI implements
             };
             for ($j = 0; $j < count($itemBody->items); $j++) {
                 $item = $itemBody->items[$j];
-                $supressed = isset($item->discoverySuppress) 
+                $supressed = isset($item->discoverySuppress)
                     ? $item->discoverySuppress : null;
                 if ($supressed == true) {
                     continue;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -441,9 +441,7 @@ class Folio extends AbstractAPI implements
             };
             for ($j = 0; $j < count($itemBody->items); $j++) {
                 $item = $itemBody->items[$j];
-                $supressed = isset($item->discoverySuppress)
-                    ? $item->discoverySuppress : null;
-                if ($supressed == true) {
+                if ($item->discoverySuppress ?? false) {
                     continue;
                 }
                 $items[] = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -441,6 +441,11 @@ class Folio extends AbstractAPI implements
             };
             for ($j = 0; $j < count($itemBody->items); $j++) {
                 $item = $itemBody->items[$j];
+                $supressed = isset($item->discoverySuppress) 
+                    ? $item->discoverySuppress : null;
+                if ($supressed == true) {
+                    continue;
+                }
                 $items[] = [
                     'id' => $bibId,
                     'item_id' => $itemBody->items[$j]->id,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -446,7 +446,7 @@ class Folio extends AbstractAPI implements
                 }
                 $items[] = [
                     'id' => $bibId,
-                    'item_id' => $itemBody->items[$j]->id,
+                    'item_id' => $item->id,
                     'holding_id' => $holding->id,
                     'number' => count($items) + 1,
                     'barcode' => $item->barcode ?? '',


### PR DESCRIPTION
In the response from `/item-storage/items` a key `discoverySupress` may exist. If that key exists and is set to true, do not include the supressed item in the array returned by getHoldings.

I originally had:
```
                if ((isset($item->discoverySuppress) ? $item->discoverySuppress : null) == true) {
                    continue;
                }
```
but this is the way I found that would make the linter happy.