### PR TITLE
Use an items object to manage item statuses and request queue.

### DIFF
--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -35,6 +35,7 @@
   $this->showCheckboxes = $this->showCartControls || $this->showBulkOptions;
 
   // Load Javascript dependencies into header:
+  $this->headScript()->appendFile("vendor/hunt.min.js");
   $this->headScript()->appendFile("check_item_statuses.js");
   $this->headScript()->appendFile("check_save_statuses.js");
   $this->headScript()->appendFile("combined-search.js");


### PR DESCRIPTION
This makes ItemStatusHandler keep tab of all queued items and their states so that re-adding or re-requesting an item can be avoided.