### PR TITLE
Add support for the SameSite cookie attribute. Default to 'Lax'.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -204,6 +204,10 @@ secure = false
 ; applications) on the same host, it is strongly recommended to give each a
 ; different session_name setting to avoid data contamination.
 session_name = VUFIND_SESSION
+; Set the SameSite attribute used for cookies. Default is Lax. See e.g.
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite for
+; more information
+;sameSite = "Lax"
 
 ; Please set the ILS that VuFind will interact with.
 ;

--- a/module/VuFind/src/VuFind/Cookie/CookieManager.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManager.php
@@ -5,6 +5,7 @@
  * PHP version 7
  *
  * Copyright (C) Villanova University 2015.
+ * Copyright (C) The National Library of Finland 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,6 +23,7 @@
  * @category VuFind
  * @package  Cookie
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -33,6 +35,7 @@ namespace VuFind\Cookie;
  * @category VuFind
  * @package  Cookie
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -74,6 +77,13 @@ class CookieManager
     protected $sessionName;
 
     /**
+     * Default SameSite attribute
+     *
+     * @var string
+     */
+    protected $sameSite;
+
+    /**
      * Constructor
      *
      * @param array  $cookies     Cookie array to manipulate (e.g. $_COOKIE)
@@ -83,9 +93,10 @@ class CookieManager
      * @param string $sessionName Session cookie name (if null defaults to PHP
      * settings)
      * @param bool   $httpOnly    Are cookies HTTP only? (default = true)
+     * @param string $sameSite    Default SameSite attribute (defaut = 'Lax')
      */
     public function __construct($cookies, $path = '/', $domain = null,
-        $secure = false, $sessionName = null, $httpOnly = true
+        $secure = false, $sessionName = null, $httpOnly = true, $sameSite = 'Lax'
     ) {
         $this->cookies = $cookies;
         $this->path = $path;
@@ -93,6 +104,7 @@ class CookieManager
         $this->secure = $secure;
         $this->httpOnly = $httpOnly;
         $this->sessionName = $sessionName;
+        $this->sameSite = $sameSite;
     }
 
     /**
@@ -156,16 +168,55 @@ class CookieManager
     }
 
     /**
+     * Get the cookie SameSite attribute.
+     *
+     * @return string
+     */
+    public function getSameSite()
+    {
+        return $this->sameSite;
+    }
+
+    /**
      * Support method for setGlobalCookie -- proxy PHP's setcookie() function
      * for compatibility with unit testing.
      *
+     * @param string $key      Name of cookie to set
+     * @param mixed  $value    Value to set
+     * @param int    $expire   Cookie expiration time
+     * @param string $path     Path
+     * @param string $domain   Domain
+     * @param bool   $secure   Whether the cookie is secure only
+     * @param bool   $httpOnly Whether the cookie should be "HTTP only"
+     * @param string $sameSite SameSite attribute to use (Lax, Strict or None)
+     *
      * @return bool
      */
-    public function proxySetCookie()
-    {
+    public function proxySetCookie($key, $value, $expire, $path, $domain, $secure,
+        $httpOnly, $sameSite
+    ) {
         // Special case: in CLI -- don't actually write headers!
-        return 'cli' === PHP_SAPI
-            ? true : call_user_func_array('setcookie', func_get_args());
+        if ('cli' === PHP_SAPI) {
+            return true;
+        }
+        if (PHP_VERSION_ID < 70300) {
+            return setcookie(
+                $key, $value, $expire, "$path; samesite=$sameSite", $domain, $secure,
+                $httpOnly
+            );
+        }
+        return setcookie(
+            $key,
+            $value,
+            [
+                'expires' => $expire,
+                'path' => $path,
+                'domain' => $domain,
+                'samesite' => $sameSite,
+                'secure' => $secure,
+                'httponly' => $httpOnly,
+            ]
+        );
     }
 
     /**
@@ -175,19 +226,24 @@ class CookieManager
      * @param mixed     $value    Value to set
      * @param int       $expire   Cookie expiration time
      * @param null|bool $httpOnly Whether the cookie should be "HTTP only"
+     * @param string    $sameSite SameSite attribute to use (Lax, Strict or None)
      *
      * @return bool
      */
-    public function setGlobalCookie($key, $value, $expire, $httpOnly = null)
-    {
+    public function setGlobalCookie($key, $value, $expire, $httpOnly = null,
+        $sameSite = null
+    ) {
         if (null === $httpOnly) {
             $httpOnly = $this->httpOnly;
+        }
+        if (null === $sameSite) {
+            $sameSite = $this->sameSite;
         }
         // Simple case: flat value.
         if (!is_array($value)) {
             return $this->proxySetCookie(
                 $key, $value, $expire, $this->path, $this->domain, $this->secure,
-                $httpOnly
+                $httpOnly, $sameSite
             );
         }
 
@@ -196,7 +252,7 @@ class CookieManager
         foreach ($value as $i => $curr) {
             $lastSuccess = $this->proxySetCookie(
                 $key . '[' . $i . ']', $curr, $expire,
-                $this->path, $this->domain, $this->secure, $httpOnly
+                $this->path, $this->domain, $this->secure, $httpOnly, $sameSite
             );
             if (!$lastSuccess) {
                 $success = false;
@@ -212,12 +268,16 @@ class CookieManager
      * @param mixed     $value    Value to set
      * @param int       $expire   Cookie expiration time
      * @param null|bool $httpOnly Whether the cookie should be "HTTP only"
+     * @param string    $sameSite SameSite attribute to use (Lax, Strict or None)
      *
      * @return bool
      */
-    public function set($key, $value, $expire = 0, $httpOnly = null)
-    {
-        if ($success = $this->setGlobalCookie($key, $value, $expire, $httpOnly)) {
+    public function set($key, $value, $expire = 0, $httpOnly = null,
+        $sameSite = null
+    ) {
+        $success = $this
+            ->setGlobalCookie($key, $value, $expire, $httpOnly, $sameSite);
+        if ($success) {
             $this->cookies[$key] = $value;
         }
         return $success;

--- a/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
@@ -5,6 +5,7 @@
  * PHP version 7
  *
  * Copyright (C) Villanova University 2018.
+ * Copyright (C) The National Library of Finland 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,6 +23,7 @@
  * @category VuFind
  * @package  Cookie
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -36,6 +38,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
  * @category VuFind
  * @package  Cookie
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -74,9 +77,10 @@ class CookieManagerFactory implements FactoryInterface
         $secure = $config->Cookies->only_secure ?? false;
         $httpOnly = $config->Cookies->http_only ?? true;
         $domain = $config->Cookies->domain ?? null;
-        $session_name = $config->Cookies->session_name ?? null;
+        $sessionName = $config->Cookies->session_name ?? null;
+        $sameSite = $config->Cookies->sameSite ?? 'Lax';
         return new $requestedName(
-            $_COOKIE, $path, $domain, $secure, $session_name, $httpOnly
+            $_COOKIE, $path, $domain, $secure, $sessionName, $httpOnly, $sameSite
         );
     }
 }


### PR DESCRIPTION
PHP versions < 7.3 need a hack to set the flag. Another possibility would be to manually craft the Set-Cookie header, but I opted for this since there are possible pitfalls in crafting the header properly.