### PR TITLE
Expose the ability to check ajax item status for a single search result.

### DIFF
--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -210,5 +210,5 @@ VuFind.register('itemStatuses', function ItemStatuses() {
     }
   }
 
-  return { init: init, check: checkItemStatuses };
+  return { init: init, check: checkItemStatuses, checkRecord: checkItemStatus };
 });


### PR DESCRIPTION
We need the ability to check item status directly for a single search result (when user selects source for deduplicated records from a drop-down that we display). Since the existing check (checkItemStatuses) expects a container that contains the record elements, it cannot be used for this purpose, and going via Hunt would be an extra roundtrip in any case.