### PR TITLE
Permission comments improvements

### DIFF
--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -208,6 +208,10 @@ stitle = sort_title
 ; institution code and access level for the current user when retrieving Primo
 ; results. institutionCode is evaluated first, then onCampusRule, with
 ; defaultCode used only when no more specific rule is matched.
+; Please note, that these settings are only applied for certain keys, they are
+; not regulating the access to the module at all. If you are using onCampusRule,
+; be sure to allow access to the Primo module in permissions.ini seperately.
+; You need to have the permission 'access.PrimoModule' in permissions.ini for that.
 [Institutions]
 ; Simple example:
 onCampusRule['MYINSTITUTION'] = "primoOnCampus.MYINSTITUTION"

--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -212,6 +212,8 @@ stitle = sort_title
 ; not regulating the access to the module at all. If you are using onCampusRule,
 ; be sure to allow access to the Primo module in permissions.ini seperately.
 ; You need to have the permission 'access.PrimoModule' in permissions.ini for that.
+; See https://vufind.org/wiki/configuration:permission_options for further
+; information about permission settings related to Primo.
 [Institutions]
 ; Simple example:
 onCampusRule['MYINSTITUTION'] = "primoOnCampus.MYINSTITUTION"

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -83,6 +83,7 @@ role = loggedin
 permission = access.EITModule
 
 ; Default configuration for the Primo module (allow everyone by default).
+; Do not disable or comment out this configuration if you want to use the Primo module!
 [default.PrimoModule]
 role[] = guest
 role[] = loggedin

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -77,6 +77,8 @@
 ; access.SummonExtendedResults - Controls visibility of protected Summon results
 ; feature.Favorites - Controls access to the "save favorites" feature
 
+; See https://vufind.org/wiki/configuration:permission_options for further information.
+
 ; Default configuration for the EIT module; see EIT.ini for some notes on this.
 [default.EITModule]
 role = loggedin


### PR DESCRIPTION
I have added some comments to make the Institution section in Primo.ini a little bit more clear. The comment should explain, that a section for global access to the Primo module will still be required, even if setting for Institutions in Primo.ini are applicable. Maybe that helps avoiding falling into the same pithole as myself (as described on the mailinglist recently).
I guess the desciption in https://vufind.org/wiki/configuration:permission_options is clear enough, though. I have also added this link to the config files.