### PR TITLE
Add hierarchical facet helper to search2 results

### DIFF
--- a/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
@@ -63,6 +63,9 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
         $solr->setSpellingProcessor(
             new \VuFind\Search\Solr\SpellingProcessor($config->Spelling ?? null)
         );
+        $solr->setHierarchicalFacetHelper(
+            $container->get(\VuFind\Search\Solr\HierarchicalFacetHelper::class)
+        );
         return $solr;
     }
 }


### PR DESCRIPTION
When a hierarchical facet is defined for Search2 index, the results page does end with exception after b87ce3c3c58a4f98ec4da7beb1a34a711600dd40

Should be fixed before release
