### PR TITLE
Standardize user IP address retrieval.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1343,10 +1343,10 @@ url             = https://www.myendnoteweb.com/EndNoteWeb.html
 ;type = socks5
 ;type = socks5_hostname
 
-; If VuFind is running behind a proxy that uses X-Forwarded-For headers, you should
-; turn this setting on so that VuFind reports correct user IP addresses, and sets
-; permissions appropriately. If you are NOT behind a proxy, you should leave this
-; off to prevent spoofing.
+; If VuFind is running behind a proxy that uses X-Real-IP/X-Forwarded-For headers,
+; you should turn this setting on so that VuFind reports correct user IP
+; addresses, and sets permissions appropriately. If you are NOT behind a proxy, you
+; should leave this off to prevent spoofing.
 allow_forwarded_ips = false
 
 ; Default HTTP settings can be loaded here. These values will be passed to

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1343,6 +1343,12 @@ url             = https://www.myendnoteweb.com/EndNoteWeb.html
 ;type = socks5
 ;type = socks5_hostname
 
+; If VuFind is running behind a proxy that uses X-Forwarded-For headers, you should
+; turn this setting on so that VuFind reports correct user IP addresses, and sets
+; permissions appropriately. If you are NOT behind a proxy, you should leave this
+; off to prevent spoofing.
+allow_forwarded_ips = false
+
 ; Default HTTP settings can be loaded here. These values will be passed to
 ; the \Laminas\Http\Client's setOptions method.
 [Http]

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -397,6 +397,7 @@ $config = [
             'VuFind\Mailer\Mailer' => 'VuFind\Mailer\Factory',
             'VuFind\MetadataVocabulary\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Net\IpAddressUtils' => 'Laminas\ServiceManager\Factory\InvokableFactory',
+            'VuFind\Net\UserIpReader' => 'VuFind\Net\UserIpReaderFactory',
             'VuFind\OAI\Server' => 'VuFind\OAI\ServerFactory',
             'VuFind\OAI\Server\Auth' => 'VuFind\OAI\ServerFactory',
             'VuFind\QRCode\Loader' => 'VuFind\QRCode\LoaderFactory',

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -381,7 +381,11 @@ class LoggerFactory implements FactoryInterface
             $proxy->setProxyInitializer(null);
 
             // Now build the actual service:
-            $wrapped = new $requestedName();
+            $options = [
+                'vufind_ip_reader' =>
+                    $container->get(\VuFind\Net\UserIpReader::class)
+            ];
+            $wrapped = new $requestedName($options);
             $this->configureLogger($container, $wrapped);
         };
         $cfg = $container->get(\ProxyManager\Configuration::class);

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -381,11 +381,11 @@ class LoggerFactory implements FactoryInterface
             $proxy->setProxyInitializer(null);
 
             // Now build the actual service:
-            $options = [
+            $loggerOptions = [
                 'vufind_ip_reader' =>
                     $container->get(\VuFind\Net\UserIpReader::class)
             ];
-            $wrapped = new $requestedName($options);
+            $wrapped = new $requestedName($loggerOptions);
             $this->configureLogger($container, $wrapped);
         };
         $cfg = $container->get(\ProxyManager\Configuration::class);

--- a/module/VuFind/src/VuFind/Net/UserIpReader.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReader.php
@@ -27,6 +27,8 @@
  */
 namespace VuFind\Net;
 
+use Laminas\Stdlib\Parameters;
+
 /**
  * Service to retrieve user IP address.
  *
@@ -41,7 +43,7 @@ class UserIpReader
     /**
      * Server parameters
      *
-     * @var object
+     * @var Parameters
      */
     protected $server;
 
@@ -55,10 +57,11 @@ class UserIpReader
     /**
      * Constructor
      *
-     * @param object $server            Server parameters
-     * @param bool   $allowForwardedIps Should we respect the X-Forwarded-For header?
+     * @param Parameters $server            Server parameters
+     * @param bool       $allowForwardedIps Should we respect the X-Forwarded-For
+     * header?
      */
-    public function __construct($server, $allowForwardedIps = false)
+    public function __construct(Parameters $server, $allowForwardedIps = false)
     {
         $this->server = $server;
         $this->allowForwardedIps = $allowForwardedIps;

--- a/module/VuFind/src/VuFind/Net/UserIpReader.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReader.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Service to retrieve user IP address.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2020.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Net
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+namespace VuFind\Net;
+
+/**
+ * Service to retrieve user IP address.
+ *
+ * @category VuFind
+ * @package  Net
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class UserIpReader
+{
+    /**
+     * Server parameters
+     *
+     * @var object
+     */
+    protected $server;
+
+    /**
+     * Should we respect the X-Forwarded-For header?
+     *
+     * @var bool
+     */
+    protected $allowForwardedIps;
+
+    /**
+     * Constructor
+     *
+     * @param object $server            Server parameters
+     * @param bool   $allowForwardedIps Should we respect the X-Forwarded-For header?
+     */
+    public function __construct($server, $allowForwardedIps = false)
+    {
+        $this->server = $server;
+        $this->allowForwardedIps = $allowForwardedIps;
+    }
+
+    /**
+     * Get the active user's IP address. Returns null if no address can be found.
+     *
+     * @return string
+     */
+    public function getUserIp()
+    {
+        $forwardedIp = $this->allowForwardedIps
+            ? $this->server->get('HTTP_X_FORWARDED_FOR') : null;
+        return $forwardedIp ?? $this->server->get('REMOTE_ADDR');
+    }
+}

--- a/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for instantiating UserIpReader.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2019.
+ * Copyright (C) Villanova University 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Authorization
+ * @package  Net
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
@@ -30,10 +30,10 @@ namespace VuFind\Role\PermissionProvider;
 use Interop\Container\ContainerInterface;
 
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for instantiating UserIpReader.
  *
  * @category VuFind
- * @package  Authorization
+ * @package  Net
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
@@ -62,10 +62,12 @@ class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
+        $config = $container->get(\VuFind\Config\PluginManager::class)
+            ->get('config');
+        $allowForwardedIps = $config->Proxy->allow_forwarded_ips ?? false;
         return new $requestedName(
-            $container->get('Request'),
-            $container->get(\VuFind\Net\IpAddressUtils::class),
-            $container->get(\VuFind\Net\UserIpReader::class),
+            $container->get('Request')->getServer(),
+            $allowForwardedIps
         );
     }
 }

--- a/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
@@ -25,7 +25,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-namespace VuFind\Role\PermissionProvider;
+namespace VuFind\Net;
 
 use Interop\Container\ContainerInterface;
 
@@ -38,7 +38,7 @@ use Interop\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class UserIpReaderFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
@@ -69,8 +69,9 @@ class Ezb extends AbstractBase
     /**
      * Constructor
      *
-     * @param string               $baseUrl    Base URL for link resolver
-     * @param \Laminas\Http\Client $httpClient HTTP client
+     * @param string               $baseUrl      Base URL for link resolver
+     * @param \Laminas\Http\Client $httpClient   HTTP client
+     * @param UserIpReader         $userIpReader User IP address reader
      */
     public function __construct($baseUrl, \Laminas\Http\Client $httpClient,
         UserIpReader $userIpReader = null

--- a/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
@@ -157,11 +157,11 @@ class Ezb extends AbstractBase
 
         foreach ($tmp as $current) {
             $tmp2 = explode('=', $current, 2);
-            $parsed[$tmp2[0]] = $tmp2[1];
+            $parsed[$tmp2[0]] = $tmp2[1] ?? null;
         }
 
         // Downgrade 1.0 to 0.1
-        if ($parsed['ctx_ver'] == 'Z39.88-2004') {
+        if ($parsed['ctx_ver'] ?? null == 'Z39.88-2004') {
             $openURL = $this->downgradeOpenUrl($parsed);
         }
 

--- a/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Ezb.php
@@ -38,6 +38,7 @@ namespace VuFind\Resolver\Driver;
 
 use DOMDocument;
 use DOMXpath;
+use VuFind\Net\UserIpReader;
 
 /**
  * EZB Link Resolver Driver
@@ -59,15 +60,24 @@ class Ezb extends AbstractBase
     protected $httpClient;
 
     /**
+     * User IP address reader
+     *
+     * @var UserIpReader
+     */
+    protected $userIpReader;
+
+    /**
      * Constructor
      *
      * @param string               $baseUrl    Base URL for link resolver
      * @param \Laminas\Http\Client $httpClient HTTP client
      */
-    public function __construct($baseUrl, \Laminas\Http\Client $httpClient)
-    {
+    public function __construct($baseUrl, \Laminas\Http\Client $httpClient,
+        UserIpReader $userIpReader = null
+    ) {
         parent::__construct($baseUrl);
         $this->httpClient = $httpClient;
+        $this->userIpReader = $userIpReader;
     }
 
     /**
@@ -156,7 +166,10 @@ class Ezb extends AbstractBase
 
         // make the request IP-based to allow automatic
         // indication on institution level
-        $openURL .= '&pid=client_ip%3D' . $_SERVER['REMOTE_ADDR'];
+        $ipAddr = $this->userIpReader !== null
+            ? $this->userIpReader->getUserIp()
+            : $_SERVER['REMOTE_ADDR'];
+        $openURL .= '&pid=client_ip%3D' . urlencode($ipAddr);
 
         // Make the call to the EZB and load results
         $url = $this->baseUrl . '?' . $openURL;

--- a/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for EZB resolver driver.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2019.
+ * Copyright (C) Villanova University 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -20,25 +20,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Authorization
+ * @package  Resolver_Drivers
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-namespace VuFind\Role\PermissionProvider;
+namespace VuFind\Resolver\Driver;
 
 use Interop\Container\ContainerInterface;
 
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for EZB resolver driver.
  *
  * @category VuFind
- * @package  Authorization
+ * @package  Resolver_Drivers
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class EzbFactory extends DriverWithHttpClientFactory
 {
     /**
      * Create an object
@@ -53,19 +53,11 @@ class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
      * @throws ContainerException if any other error occurs
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null
     ) {
-        if (!empty($options)) {
-            throw new \Exception('Unexpected options passed to factory.');
-        }
-        return new $requestedName(
-            $container->get('Request'),
-            $container->get(\VuFind\Net\IpAddressUtils::class),
-            $container->get(\VuFind\Net\UserIpReader::class),
-        );
+        $options = [$container->get(\VuFind\Net\UserIpReader::class)];
+        return parent::__invoke($container, $requestedName, $options);
     }
 }

--- a/module/VuFind/src/VuFind/Resolver/Driver/PluginManager.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/PluginManager.php
@@ -66,7 +66,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         Alma::class => DriverWithHttpClientFactory::class,
         Threesixtylink::class => DriverWithHttpClientFactory::class,
         Demo::class => InvokableFactory::class,
-        Ezb::class => DriverWithHttpClientFactory::class,
+        Ezb::class => EzbFactory::class,
         Sfx::class => DriverWithHttpClientFactory::class,
         Redi::class => DriverWithHttpClientFactory::class,
         Generic::class => AbstractBaseFactory::class,

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRange.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRange.php
@@ -93,13 +93,14 @@ class IpRange implements PermissionProviderInterface
      */
     public function getPermissions($options)
     {
-        if (PHP_SAPI == 'cli') {
-            return [];
-        }
         // Check if any regex matches....
-        $ipAddr = $this->userIpReader !== null
-            ? $this->userIpReader->getUserIp()
-            : $this->request->getServer()->get('REMOTE_ADDR');
+        if ($this->userIpReader !== null) {
+            $ipAddr = $this->userIpReader->getUserIp();
+        } elseif (PHP_SAPI == 'cli') {
+            $ipAddr = null;
+        } else {
+            $ipAddr = $this->request->getServer()->get('REMOTE_ADDR');
+        }
         if ($this->ipAddressUtils->isInRange($ipAddr, (array)$options)) {
             // Match? Grant to all users (guest or logged in).
             return ['guest', 'loggedin'];

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRange.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRange.php
@@ -32,6 +32,7 @@ namespace VuFind\Role\PermissionProvider;
 
 use Laminas\Stdlib\RequestInterface;
 use VuFind\Net\IpAddressUtils;
+use VuFind\Net\UserIpReader;
 
 /**
  * IpRange permission provider for VuFind.
@@ -61,15 +62,25 @@ class IpRange implements PermissionProviderInterface
     protected $ipAddressUtils;
 
     /**
+     * User IP address reader
+     *
+     * @var UserIpReader
+     */
+    protected $userIpReader;
+
+    /**
      * Constructor
      *
-     * @param RequestInterface $request Request object
-     * @param IpAddressUtils   $ipUtils IpAddressUtils object
+     * @param RequestInterface $request      Request object
+     * @param IpAddressUtils   $ipUtils      IpAddressUtils object
+     * @param UserIpReader     $userIpReader User IP address reader
      */
-    public function __construct(RequestInterface $request, IpAddressUtils $ipUtils)
-    {
+    public function __construct(RequestInterface $request, IpAddressUtils $ipUtils,
+        UserIpReader $userIpReader = null
+    ) {
         $this->request = $request;
         $this->ipAddressUtils = $ipUtils;
+        $this->userIpReader = $userIpReader;
     }
 
     /**
@@ -86,9 +97,10 @@ class IpRange implements PermissionProviderInterface
             return [];
         }
         // Check if any regex matches....
-        $ip = $this->request->getServer()->get('HTTP_X_FORWARDED_FOR')
-            ?? $this->request->getServer()->get('REMOTE_ADDR');
-        if ($this->ipAddressUtils->isInRange($ip, (array)$options)) {
+        $ipAddr = $this->userIpReader !== null
+            ? $this->userIpReader->getUserIp()
+            : $this->request->getServer()->get('REMOTE_ADDR');
+        if ($this->ipAddressUtils->isInRange($ipAddr, (array)$options)) {
             // Match? Grant to all users (guest or logged in).
             return ['guest', 'loggedin'];
         }

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
@@ -65,7 +65,7 @@ class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
         return new $requestedName(
             $container->get('Request'),
             $container->get(\VuFind\Net\IpAddressUtils::class),
-            $container->get(\VuFind\Net\UserIpReader::class),
+            $container->get(\VuFind\Net\UserIpReader::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegEx.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegEx.php
@@ -28,6 +28,7 @@
 namespace VuFind\Role\PermissionProvider;
 
 use Laminas\Http\PhpEnvironment\Request;
+use VuFind\Net\UserIpReader;
 
 /**
  * IpRegEx permission provider for VuFind.
@@ -48,13 +49,22 @@ class IpRegEx implements PermissionProviderInterface
     protected $request;
 
     /**
+     * User IP address reader
+     *
+     * @var UserIpReader
+     */
+    protected $userIpReader;
+
+    /**
      * Constructor
      *
-     * @param Request $request Request object
+     * @param Request      $request      Request object
+     * @param UserIpReader $userIpReader User IP address reader
      */
-    public function __construct(Request $request)
+    public function __construct(Request $request, UserIpReader $userIpReader = null)
     {
         $this->request = $request;
+        $this->userIpReader = $userIpReader;
     }
 
     /**
@@ -68,10 +78,11 @@ class IpRegEx implements PermissionProviderInterface
     public function getPermissions($options)
     {
         // Check if any regex matches....
-        $ip = $this->request->getServer()->get('HTTP_X_FORWARDED_FOR')
-            ?? $this->request->getServer()->get('REMOTE_ADDR');
+        $ipAddr = $this->userIpReader !== null
+            ? $this->userIpReader->getUserIp()
+            : $this->request->getServer()->get('REMOTE_ADDR');
         foreach ((array)$options as $current) {
-            if (preg_match($current, $ip)) {
+            if (preg_match($current, $ipAddr)) {
                 // Match? Grant to all users (guest or logged in).
                 return ['guest', 'loggedin'];
             }

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegEx.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegEx.php
@@ -78,9 +78,13 @@ class IpRegEx implements PermissionProviderInterface
     public function getPermissions($options)
     {
         // Check if any regex matches....
-        $ipAddr = $this->userIpReader !== null
-            ? $this->userIpReader->getUserIp()
-            : $this->request->getServer()->get('REMOTE_ADDR');
+        if ($this->userIpReader !== null) {
+            $ipAddr = $this->userIpReader->getUserIp();
+        } elseif (PHP_SAPI == 'cli') {
+            $ipAddr = null;
+        } else {
+            $ipAddr = $this->request->getServer()->get('REMOTE_ADDR');
+        }
         foreach ((array)$options as $current) {
             if (preg_match($current, $ipAddr)) {
                 // Match? Grant to all users (guest or logged in).

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for instantiating IpRegEx permission provider.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2019.
+ * Copyright (C) Villanova University 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -30,7 +30,7 @@ namespace VuFind\Role\PermissionProvider;
 use Interop\Container\ContainerInterface;
 
 /**
- * Factory for instantiating IpRange permission provider.
+ * Factory for instantiating IpRegEx permission provider.
  *
  * @category VuFind
  * @package  Authorization
@@ -38,7 +38,7 @@ use Interop\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class IpRegExFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object
@@ -64,8 +64,7 @@ class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
         }
         return new $requestedName(
             $container->get('Request'),
-            $container->get(\VuFind\Net\IpAddressUtils::class),
-            $container->get(\VuFind\Net\UserIpReader::class),
+            $container->get(\VuFind\Net\UserIpReader::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/PluginManager.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/PluginManager.php
@@ -60,7 +60,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      */
     protected $factories = [
         IpRange::class => IpRangeFactory::class,
-        IpRegEx::class => InjectRequestFactory::class,
+        IpRegEx::class => IpRegExFactory::class,
         Role::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
         ServerParam::class => InjectRequestFactory::class,
         Shibboleth::class => ShibbolethFactory::class,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * UserIpReader Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2020.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Net;
+
+use Laminas\Stdlib\Parameters;
+use VuFind\Net\UserIpReader;
+
+/**
+ * UserIpReader Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class UserIpReaderTest extends \VuFindTest\Unit\TestCase
+{
+    /**
+     * Test X-Real-IP; it should take priority over all other settings when
+     * forwarding is allowed.
+     *
+     * @return void
+     */
+    public function testXRealIp()
+    {
+        $params = new Parameters(
+            [
+                'HTTP_X_REAL_IP' => '1.2.3.4',
+                'HTTP_X_FORWARDED_FOR' => '5.6.7.8',
+                'REMOTE_ADDR' => '127.0.0.1',
+            ]
+        );
+        // Test appropriate behavior with forwarding enabled:
+        $reader1 = new UserIpReader($params, true);
+        $this->assertEquals('1.2.3.4', $reader1->getUserIp());
+        // Test appropriate behavior with forwarding disabled:
+        $reader2 = new UserIpReader($params, false);
+        $this->assertEquals('127.0.0.1', $reader2->getUserIp());
+    }
+
+    /**
+     * Test X-Forwarded-For (single value); it should take priority over REMOTE_ADDR
+     * when forwarding is allowed.
+     *
+     * @return void
+     */
+    public function testXForwardedForSingle()
+    {
+        $params = new Parameters(
+            [
+                'HTTP_X_FORWARDED_FOR' => '5.6.7.8',
+                'REMOTE_ADDR' => '127.0.0.1',
+            ]
+        );
+        // Test appropriate behavior with forwarding enabled:
+        $reader1 = new UserIpReader($params, true);
+        $this->assertEquals('5.6.7.8', $reader1->getUserIp());
+        // Test appropriate behavior with forwarding disabled:
+        $reader2 = new UserIpReader($params, false);
+        $this->assertEquals('127.0.0.1', $reader2->getUserIp());
+    }
+
+    /**
+     * Test X-Forwarded-For (multi-value); the leftmost IP should take priority over
+     * REMOTE_ADDR when forwarding is allowed.
+     *
+     * @return void
+     */
+    public function testXForwardedForMultiValued()
+    {
+        $params = new Parameters(
+            [
+                'HTTP_X_FORWARDED_FOR' => '5.6.7.8, 9.10.11.12',
+                'REMOTE_ADDR' => '127.0.0.1',
+            ]
+        );
+        // Test appropriate behavior with forwarding enabled:
+        $reader1 = new UserIpReader($params, true);
+        $this->assertEquals('5.6.7.8', $reader1->getUserIp());
+        // Test appropriate behavior with forwarding disabled:
+        $reader2 = new UserIpReader($params, false);
+        $this->assertEquals('127.0.0.1', $reader2->getUserIp());
+    }
+
+    /**
+     * Test what happens when only REMOTE_ADDR is provided.
+     *
+     * @return void
+     */
+    public function testXForwardedForSimple()
+    {
+        $params = new Parameters(
+            [
+                'REMOTE_ADDR' => '127.0.0.1',
+            ]
+        );
+        // Test appropriate behavior with forwarding enabled:
+        $reader1 = new UserIpReader($params, true);
+        $this->assertEquals('127.0.0.1', $reader1->getUserIp());
+        // Test appropriate behavior with forwarding disabled:
+        $reader2 = new UserIpReader($params, false);
+        $this->assertEquals('127.0.0.1', $reader2->getUserIp());
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRangeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRangeTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * IpRange ServerParam Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2020.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Role\PermissionProvider;
+
+use VuFind\Net\IpAddressUtils;
+use VuFind\Role\PermissionProvider\IpRange;
+
+/**
+ * IpRange ServerParam Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class IpRangeTest extends \VuFindTest\Unit\TestCase
+{
+    /**
+     * Get a permission provider with the specified IP assigned.
+     *
+     * @param string         $ipAddr IP address to send to provider.
+     * @param IpAddressUtils $utils  IP address utils to use
+     *
+     * @return IpRegEx
+     */
+    protected function getPermissionProvider($ipAddr, IpAddressUtils $utils)
+    {
+        $mockRequestClass = $this->getMockClass(
+            \Laminas\Http\PhpEnvironment\Request::class
+        );
+        $mockIpReader = $this->getMockBuilder(\VuFind\Net\UserIpReader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockIpReader->expects($this->once())->method('getUserIp')
+            ->will($this->returnValue($ipAddr));
+        return new IpRange(new $mockRequestClass, $utils, $mockIpReader);
+    }
+
+    /**
+     * Test a matching range.
+     *
+     * @return void
+     */
+    public function testMatchingRange()
+    {
+        // In this example, we'll pass the IP address as the options to the provider.
+        // Note that we're not actually testing the range checking itself, because
+        // we're mocking out the IpAddressUtils; we're just confirming that the parts
+        // fit together correctly.
+        $ipAddr = '123.124.125.126';
+        $utils = $this->getMockBuilder(IpAddressUtils::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $utils->expects($this->once())->method('isInRange')
+            ->with($this->equalTo($ipAddr), $this->equalTo([$ipAddr]))
+            ->will($this->returnValue(true));
+        $provider = $this->getPermissionProvider($ipAddr, $utils);
+        $this->assertEquals(
+            ['guest', 'loggedin'], $provider->getPermissions($ipAddr)
+        );
+    }
+
+    /**
+     * Test an array of non-matching ranges.
+     *
+     * @return void
+     */
+    public function testNonMatchingRegExArray()
+    {
+        // In this example, we'll pass the IP address as the options to the provider.
+        // Note that we're not actually testing the range checking itself, because
+        // we're mocking out the IpAddressUtils; we're just confirming that the parts
+        // fit together correctly.
+        $ipAddr = '123.124.125.126';
+        $options = [
+            '1.2.3.4-1.2.3.7',
+            '2.3.4.5',
+        ];
+        $utils = $this->getMockBuilder(IpAddressUtils::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $utils->expects($this->once())->method('isInRange')
+            ->with($this->equalTo($ipAddr), $this->equalTo($options))
+            ->will($this->returnValue(false));
+        $provider = $this->getPermissionProvider($ipAddr, $utils);
+        $this->assertEquals([], $provider->getPermissions($options));
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2010.
+ * Copyright (C) Villanova University 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  * @category VuFind
  * @package  Tests
  * @author   Demian Katz <demian.katz@villanova.edu>
- * @author   Bernd Oberknapp <bo@ub.uni-freiburg.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
@@ -36,7 +35,6 @@ use VuFind\Role\PermissionProvider\IpRegEx;
  * @category VuFind
  * @package  Tests
  * @author   Demian Katz <demian.katz@villanova.edu>
- * @author   Bernd Oberknapp <bo@ub.uni-freiburg.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * IpRegEx ServerParam Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Bernd Oberknapp <bo@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Role\PermissionProvider;
+
+use VuFind\Role\PermissionProvider\IpRegEx;
+
+/**
+ * IpRegEx ServerParam Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Bernd Oberknapp <bo@ub.uni-freiburg.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class IpRegExTest extends \VuFindTest\Unit\TestCase
+{
+    /**
+     * Get a permission provider with the specified IP assigned.
+     *
+     * @return IpRegEx
+     */
+    protected function getPermissionProvider($ip)
+    {
+        $mockRequestClass = $this->getMockClass(
+            \Laminas\Http\PhpEnvironment\Request::class
+        );
+        $mockIpReader = $this->getMockBuilder(\VuFind\Net\UserIpReader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockIpReader->expects($this->once())->method('getUserIp')
+            ->will($this->returnValue($ip));
+        return new IpRegEx(new $mockRequestClass, $mockIpReader);
+    }
+
+    /**
+     * Test a matching regular expression.
+     *
+     * @return void
+     */
+    public function testMatchingRegEx()
+    {
+        $regEx = '/123\.124\..*/';
+        $provider = $this->getPermissionProvider('123.124.125.126');
+        $this->assertEquals(
+            ['guest', 'loggedin'], $provider->getPermissions($regEx)
+        );
+    }
+
+    /**
+     * Test an array of non-matching regular expressions.
+     *
+     * @return void
+     */
+    public function testNonMatchingRegExArray()
+    {
+        $regEx = [
+            '/123\.124\..*/',
+            '/125\.126\..*/',
+        ];
+        $provider = $this->getPermissionProvider('129.124.125.126');
+        $this->assertEquals([], $provider->getPermissions($regEx));
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
@@ -45,9 +45,11 @@ class IpRegExTest extends \VuFindTest\Unit\TestCase
     /**
      * Get a permission provider with the specified IP assigned.
      *
+     * @param string $ipAddr IP address to send to provider.
+     *
      * @return IpRegEx
      */
-    protected function getPermissionProvider($ip)
+    protected function getPermissionProvider($ipAddr)
     {
         $mockRequestClass = $this->getMockClass(
             \Laminas\Http\PhpEnvironment\Request::class
@@ -56,7 +58,7 @@ class IpRegExTest extends \VuFindTest\Unit\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $mockIpReader->expects($this->once())->method('getUserIp')
-            ->will($this->returnValue($ip));
+            ->will($this->returnValue($ipAddr));
         return new IpRegEx(new $mockRequestClass, $mockIpReader);
     }
 


### PR DESCRIPTION
This PR makes it possible to respect end-user IP addresses through a proxy in a secure way. It is designed with backward compatibility in mind. The code can be simplified if we accept some backward compatibility breaks; this will be done in release 8.0 (see [VUFIND-1410](https://vufind.org/jira/browse/VUFIND-1410)).

TODO
- [x] Add X-Real-IP support
- [x] Test everything
  - [x] Logger integration
  - [x] IpRange integration
  - [x] IpRegEx integration
  - [x] EZB integration
  - [x] Write appropriate unit test(s)
