### PR TITLE
Upgrade to League/CommonMark 1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "laminas/laminas-validator": "2.13.4",
         "laminas/laminas-view": "2.11.4",
         "laminas-commons/lmc-rbac-mvc": "3.0.1",
-        "league/commonmark": "1.4.3",
+        "league/commonmark": "1.5.4",
         "matthiasmullie/minify": "1.3.63",
         "misd/linkify": "1.1.4",
         "ocramius/proxy-manager": "2.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de3901e0772cf6c2165c5e40d1f9935e",
+    "content-hash": "cb066959aa28ca0433a6664405d1a7ff",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -3248,21 +3248,21 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.4.3",
+            "version": "1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "412639f7cfbc0b31ad2455b2fe965095f66ae505"
+                "reference": "21819c989e69bab07e933866ad30c7e3f32984ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/412639f7cfbc0b31ad2455b2fe965095f66ae505",
-                "reference": "412639f7cfbc0b31ad2455b2fe965095f66ae505",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/21819c989e69bab07e933866ad30c7e3f32984ba",
+                "reference": "21819c989e69bab07e933866ad30c7e3f32984ba",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "conflict": {
                 "scrutinizer/ocular": "1.7.*"
@@ -3276,7 +3276,7 @@
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
                 "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
             },
@@ -3284,11 +3284,6 @@
                 "bin/commonmark"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "League\\CommonMark\\": "src"
@@ -3344,7 +3339,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-04T22:15:21+00:00"
+            "time": "2020-08-18T01:19:12+00:00"
         },
         {
             "name": "matthiasmullie/minify",

--- a/config/vufind/markdown.ini
+++ b/config/vufind/markdown.ini
@@ -32,7 +32,7 @@
 
 ; Which extension you want to activate. List of extension names separated by comma.
 ; Available extensions as of league/commonmark version 1.4:
-; 	ExternalLink, HeadingPermalink, SmartPunct, TableOfContents
+;     ExternalLink, HeadingPermalink, SmartPunct, TableOfContents
 ; Some of them could have a configuration, see sections bellow
 ;extensions = ExternalLink,HeadingPermalink,SmartPunct,TableOfContents
 
@@ -48,7 +48,7 @@ internal_hosts[] = www.example.com
 [HeadingPermalink]
 ;html_class = heading-permalink
 ;id_prefix = user-content
-;inner_contents = '¶'
+;symbol = '¶'
 ;insert = before
 ;title = Permalink
 

--- a/config/vufind/markdown.ini
+++ b/config/vufind/markdown.ini
@@ -1,6 +1,6 @@
 ; This file could be used to define configuration of markdown to HTML converter.
 ; More detailed configuration documentation could be found here:
-; https://github.com/thephpleague/commonmark/blob/master/docs/1.0/configuration.md
+; https://github.com/thephpleague/commonmark/blob/latest/docs/1.5/configuration.md
 [Markdown]
 ; How to handle HTML input. Options are: strip, allow, escape. Defaults to strip
 ;html_input = allow
@@ -36,7 +36,7 @@
 ; Some of them could have a configuration, see sections bellow
 ;extensions = ExternalLink,HeadingPermalink,SmartPunct,TableOfContents
 
-; See https://commonmark.thephpleague.com/1.4/extensions/external-links/
+; See https://commonmark.thephpleague.com/1.5/extensions/external-links/
 [ExternalLink]
 ; This should be always set, if you want to use this extension. You can use regular
 ; expressions to match group of hosts
@@ -44,7 +44,7 @@ internal_hosts[] = www.example.com
 ;open_in_new_window = true
 ;html_class = external-link
 
-; See https://commonmark.thephpleague.com/1.4/extensions/heading-permalinks/
+; See https://commonmark.thephpleague.com/1.5/extensions/heading-permalinks/
 [HeadingPermalink]
 ;html_class = heading-permalink
 ;id_prefix = user-content
@@ -52,14 +52,14 @@ internal_hosts[] = www.example.com
 ;insert = before
 ;title = Permalink
 
-; See https://commonmark.thephpleague.com/1.4/extensions/smart-punctuation/
+; See https://commonmark.thephpleague.com/1.5/extensions/smart-punctuation/
 [SmartPunct]
 ;double_quote_opener = '“'
 ;double_quote_closer = '”'
 ;single_quote_opener = '‘'
 ;single_quote_closer = '’'
 
-; See https://commonmark.thephpleague.com/1.4/extensions/table-of-contents/
+; See https://commonmark.thephpleague.com/1.5/extensions/table-of-contents/
 [TableOfContents]
 ;html_class = table-of-contents
 ;position = top


### PR DESCRIPTION
There is a new minor version of the CommonMark Markdown processor, which includes at least one deprecation affecting VuFind's example configuration. This PR applies the updates and provides a space to review/discuss.