### PR TITLE
KohaRest: Fix canceling holds.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -613,7 +613,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             }
             $holds[] = [
                 'id' => $entry['biblio_id'],
-                'item_id' => $entry['item_id'] ?? null,
+                'item_id' => $entry['hold_id'],
                 'requestId' => $entry['hold_id'],
                 'location' => $this->getLibraryName(
                     $entry['pickup_library_id'] ?? null
@@ -649,7 +649,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     public function getCancelHoldDetails($holdDetails)
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
-            : $holdDetails['requestId'] . '|' . $holdDetails['item_id'];
+            : $holdDetails['item_id'];
     }
 
     /**
@@ -669,8 +669,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $count = 0;
         $response = [];
 
-        foreach ($details as $detail) {
-            list($holdId, $itemId) = explode('|', $detail, 2);
+        foreach ($details as $holdId) {
             $result = $this->makeRequest(
                 [
                     'path' => ['v1', 'holds', $holdId],
@@ -679,14 +678,14 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 ]
             );
 
-            if (200 === $result['code']) {
-                $response[$itemId] = [
+            if (200 === $result['code'] || 204 === $result['code']) {
+                $response[$holdId] = [
                     'success' => true,
                     'status' => 'hold_cancel_success'
                 ];
                 ++$count;
             } else {
-                $response[$itemId] = [
+                $response[$holdId] = [
                     'success' => false,
                     'status' => 'hold_cancel_fail',
                     'sysMessage' => false


### PR DESCRIPTION
- Allow 204 as valid result code.
- Use item_id as the hold identifier when canceling holds. This allows the template to display failed cancels properly.