### PR TITLE
KohaRest: Use requestId instead of item_id in getCancelHoldDetails.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -659,7 +659,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     public function getCancelHoldDetails($holdDetails)
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
-            : $holdDetails['item_id'];
+            : $holdDetails['requestId'];
     }
 
     /**


### PR DESCRIPTION
While the fields initially get the same content, item_id is prefixed by MultiBackend driver.

It seems that there are two issues with the MultiBackend driver:
1.) It prefixes item_id in getMyHolds, but doesn't strip it in getHoldCancelDetails.
2.) It removes the prefix from the first field of an array with numeric keys.

The latter issue makes it so that the problem only manifests itself when you try to remove more than one hold at a time. I considered fixing MultiBackend, but item_id is used e.g. in VoyagerRestful, so I opted for this very safe change for now. I'll add a Jira issue so that these bugs don't get lost.