### PR TITLE
FOLIO: Modify notes field and add item_notes, issues, supplements and indexes

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -482,7 +482,8 @@ class Folio extends AbstractAPI implements
             $itemResponse = $this->makeRequest('GET', '/item-storage/items', $query);
             $itemBody = json_decode($itemResponse->getBody());
             $notesFormatter = function ($note) {
-                return !$note->staffOnly && $note->note ? $note->note : '';
+                return !($note->staffOnly ?? false)
+                    && !empty($note->note) ? $note->note : '';
             };
             $textFormatter = function ($supplement) {
                 $format = '%s %s';
@@ -491,7 +492,9 @@ class Folio extends AbstractAPI implements
                 $statement = trim(sprintf($format, $supStat, $supNote));
                 return $statement ?? '';
             };
-            $holdingNotes = array_map($notesFormatter, $holding->notes ?? []);
+            $holdingNotes = array_filter(
+                array_map($notesFormatter, $holding->notes ?? [])
+            );
             $hasHoldingNotes = !empty(implode($holdingNotes));
             $holdingsStatements = array_map(
                 $textFormatter,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -488,19 +488,27 @@ class Folio extends AbstractAPI implements
                 $format = '%s %s';
                 $supStat = $supplement->statement;
                 $supNote = $supplement->note;
-                $statement = sprintf($format, $supStat, $supNote);
+                $statement = trim(sprintf($format, $supStat, $supNote));
                 return $statement ?? '';
             };
             $holdingNotes = array_map($notesFormatter, $holding->notes ?? []);
             $hasHoldingNotes = !empty(implode($holdingNotes));
-            $holdingsStatements = $holding->holdingsStatements;
-            $holdingsSupplements = $holding->holdingsStatementsForSupplements;
-            $holdingsIndexes = $holding->holdingsStatementsForIndexes;
-            $issues = array_map($textFormatter, $holdingsStatements ?? []);
-            $supplements = array_map($textFormatter, $holdingsSupplements ?? []);
-            $indexes = array_map($textFormatter, $holdingsIndexes ?? []);
+            $holdingsStatements = array_map(
+                $textFormatter,
+                $holding->holdingsStatements ?? []
+            );
+            $holdingsSupplements = array_map(
+                $textFormatter,
+                $holding->holdingsStatementsForSupplements ?? []
+            );
+            $holdingsIndexes = array_map(
+                $textFormatter,
+                $holding->holdingsStatementsForIndexes ?? []
+            );
             foreach ($itemBody->items as $item) {
-                $itemNotes = array_map($notesFormatter, $item->notes ?? []);
+                $itemNotes = array_filter(
+                    array_map($notesFormatter, $item->notes ?? [])
+                );
                 $items[] = [
                     'id' => $bibId,
                     'item_id' => $item->id,
@@ -512,9 +520,9 @@ class Folio extends AbstractAPI implements
                     'is_holdable' => $this->isHoldable($locationName),
                     'holdings_notes'=> $hasHoldingNotes ? $holdingNotes : null,
                     'item_notes' => !empty(implode($itemNotes)) ? $itemNotes : null,
-                    'issues' => $issues,
-                    'supplements' => $supplements,
-                    'indexes' => $indexes,
+                    'issues' => $holdingsStatements,
+                    'supplements' => $holdingsSupplements,
+                    'indexes' => $holdingsIndexes,
                     'callnumber' => $holding->callNumber ?? '',
                     'location' => $locationName,
                     'reserve' => 'TODO',


### PR DESCRIPTION
**Changes in this request**:
- Updates the `noteFormatter` to only return notes that are public.
- Eliminates the deprecated `notes` field that was returning item notes and replaces it with the more descriptive `holdings_notes` field.
- Adds return values for `item_notes`, `issues`, `supplements` and `indexes`.