### PR TITLE
KohaRest: Update patron validation request path.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -407,7 +407,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
 
         $result = $this->makeRequest(
             [
-                'path' => 'v1/contrib/kohasuomi/patrons/validation',
+                'path' => 'v1/contrib/kohasuomi/auth/patrons/validation',
                 'json' => ['userid' => $username, 'password' => $password],
                 'method' => 'POST',
                 'errors' => true,


### PR DESCRIPTION
Old path is deprecated, and new path is included in REST plugin versions considered more stable and secure, so there's no need for back-compatibility.