### PR TITLE
Fix replaceTerm() word boundary bug.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -227,9 +227,8 @@ class Query extends AbstractQuery
         // try again with a less restricted regular expression.
         // TODO: identify a test case where this fallback is actually needed; it
         // may not actually serve a useful purpose.
-        $before = $this->queryString;
         $this->queryString = preg_replace("/\b$from\b/i", $to, $queryString);
-        if ($before === $this->queryString) {
+        if ($queryString === $this->queryString) {
             $this->queryString = preg_replace("/$from/i", $to, $queryString);
         }
     }

--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -93,7 +93,15 @@ class Query extends AbstractQuery
      */
     protected function normalizeText($text)
     {
-        return strtolower($this->stripDiacritics($text));
+        // The input to normalizeText may be a Solr query with Boolean operators
+        // in it; we want to be careful not to turn this into something invalid.
+        $stripped = $this->stripDiacritics($text);
+        $booleans = ['AND', 'OR', 'NOT'];
+        $words = [];
+        foreach (preg_split('/\s+/', $stripped) as $word) {
+            $words[] = in_array($word, $booleans) ? $word : strtolower($word);
+        }
+        return implode(' ', $words);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -223,18 +223,15 @@ class Query extends AbstractQuery
         $queryString = $normalize
             ? $this->getNormalizedString() : $this->queryString;
 
-        // If our "from" pattern contains non-word characters, we can't use word
-        // boundaries for matching.  We want to try to use word boundaries when
-        // possible, however, to avoid the replacement from affecting unexpected
-        // parts of the search query.
-        if (!preg_match('/.*[^\w].*/', $from)) {
-            $pattern = "/\b$from\b/i";
-        } else {
-            $pattern = "/$from/i";
+        // Try to match within word boundaries; if that fails to change anything,
+        // try again with a less restricted regular expression.
+        // TODO: identify a test case where this fallback is actually needed; it
+        // may not actually serve a useful purpose.
+        $before = $this->queryString;
+        $this->queryString = preg_replace("/\b$from\b/i", $to, $queryString);
+        if ($before === $this->queryString) {
+            $this->queryString = preg_replace("/$from/i", $to, $queryString);
         }
-
-        // Perform the replacement:
-        $this->queryString = preg_replace($pattern, $to, $queryString);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -232,9 +232,8 @@ class Query extends AbstractQuery
             ? $this->getNormalizedString() : $this->queryString;
 
         // Try to match within word boundaries; if that fails to change anything,
-        // try again with a less restricted regular expression.
-        // TODO: identify a test case where this fallback is actually needed; it
-        // may not actually serve a useful purpose.
+        // try again with a less restricted regular expression. The fallback is
+        // needed when $from contains punctuation characters such as commas.
         $this->queryString = preg_replace("/\b$from\b/i", $to, $queryString);
         if ($queryString === $this->queryString) {
             $this->queryString = preg_replace("/$from/i", $to, $queryString);

--- a/module/VuFindSearch/src/VuFindSearch/Query/Query.php
+++ b/module/VuFindSearch/src/VuFindSearch/Query/Query.php
@@ -231,9 +231,10 @@ class Query extends AbstractQuery
         $queryString = $normalize
             ? $this->getNormalizedString() : $this->queryString;
 
-        // Try to match within word boundaries; if that fails to change anything,
-        // try again with a less restricted regular expression. The fallback is
-        // needed when $from contains punctuation characters such as commas.
+        // Try to match within word boundaries to prevent the replacement from
+        // affecting unexpected parts of the search query; if that fails to change
+        // anything, try again with a less restricted regular expression. The fall-
+        // back is needed when $from contains punctuation characters such as commas.
         $this->queryString = preg_replace("/\b$from\b/i", $to, $queryString);
         if ($queryString === $this->queryString) {
             $this->queryString = preg_replace("/$from/i", $to, $queryString);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
@@ -89,6 +89,19 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test replacing a term containing punctuation; this exercises a special case
+     * in the code.
+     *
+     * @return void
+     */
+    public function testReplacePunctuatedTerm()
+    {
+        $q = new Query('this, that');
+        $q->replaceTerm('this,', 'the other,');
+        $this->assertEquals('the other, that', $q->getString());
+    }
+
+    /**
      * Test multiple replacements -- this simulates the scenario discussed in the
      * VUFIND-1423 JIRA ticket.
      *

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
@@ -82,6 +82,28 @@ class QueryTest extends TestCase
         $q = new Query('test query we<(ird and/or');
         $q->replaceTerm('and', 'not');
         $this->assertEquals('test query we<(ird not/or', $q->getString());
+
+        $q = new Query('th\bbbt');
+        $q->replaceTerm('th\bbbt', 'that');
+        $this->assertEquals('that', $q->getString());
+    }
+
+    /**
+     * Test multiple replacements -- this simulates the scenario discussed in the
+     * VUFIND-1423 JIRA ticket.
+     *
+     * @return void
+     */
+    public function testMultipleReplacements()
+    {
+        $q = new Query("color code");
+        $q->replaceTerm('color code', '((color code) OR (color codes))', true);
+        $this->assertEquals('((color code) OR (color codes))', $q->getString());
+        $q->replaceTerm('color code', '((color code) OR (color coded))');
+        $this->assertEquals(
+            '((((color code) OR (color coded))) OR (color codes))',
+            $q->getString()
+        );
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
@@ -99,7 +99,7 @@ class QueryTest extends TestCase
         $q = new Query("color code");
         $q->replaceTerm('color code', '((color code) OR (color codes))', true);
         $this->assertEquals('((color code) OR (color codes))', $q->getString());
-        $q->replaceTerm('color code', '((color code) OR (color coded))');
+        $q->replaceTerm('color code', '((color code) OR (color coded))', true);
         $this->assertEquals(
             '((((color code) OR (color coded))) OR (color codes))',
             $q->getString()


### PR DESCRIPTION
TODO:
- [x] Figure out how to correctly deal with Boolean operators in query
- [x] Determine whether the fallback clause is needed at all; eliminate if not, add useful test case if so
- [x] Run full test suite
- [x] Resolve [VUFIND-1423](https://vufind.org/jira/browse/VUFIND-1423) when merging.