### PR TITLE
Fix handling of nonce to not mess with HeadLink items.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -58,6 +58,19 @@ theme           = bootprint3
 ; Example: "development:off; production:js,css"
 ;asset_pipeline = "production:js"
 
+; File size limit for inlining of css @import resources in kilobytes when the asset
+; pipeline is enabled (see above) for css files. Set to 0 to disable inlining. Note
+; that you will need to delete any css files from local/cache/public directory for
+; changes to this setting to take effect.
+;
+; N.B. The default here is 0 for compatibility with the content security policy.
+; A suggested non-zero value is 5, which improves performance by avoiding http
+; requests for small images, but any non-zero value requires that data: URIs are
+; added as allowed for images in contentsecuritypolicy.ini e.g. with the following
+; line:
+; img-src[] = "data:"
+asset_pipeline_max_css_import_size = 0
+
 ; This is a comma-separated list of themes that may be accessed via the ?ui GET
 ; parameter.  Each entry has two parts: the value used on the URL followed by the
 ; actual theme name.  For example, http://library.myuniversity.edu/vufind?ui=theme1

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
@@ -88,6 +88,20 @@ trait ConcatTrait
     abstract protected function getMinifier();
 
     /**
+     * Add a content security policy nonce to the item
+     *
+     * @param stdClass $item Item
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function addNonce($item)
+    {
+        // Default implementation does nothing
+    }
+
+    /**
      * Set the file path of the link object
      *
      * @param stdClass $item Link element object
@@ -364,7 +378,7 @@ trait ConcatTrait
                 // files, which are stored in a theme-independent cache).
                 $path = $this->getConcatenatedFilePath($group);
                 $item = $this->setResourceFilePath($group['items'][0], $path);
-                $item->attributes['nonce'] = $this->cspNonce;
+                $this->addNonce($item);
                 $output[] = parent::itemToString(
                     $item, $indent, $escapeStart, $escapeEnd
                 );

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -105,7 +105,7 @@ class HeadLink extends \Laminas\View\Helper\HeadLink
             $url .= filemtime($details['path']);
             $item->href = $url;
         }
-        $item->attributes['nonce'] = $this->cspNonce;
+        $this->addNonce($item);
         return parent::itemToString($item);
     }
 

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -59,18 +59,28 @@ class HeadLink extends \Laminas\View\Helper\HeadLink
     protected $cspNonce;
 
     /**
+     * Maximum import size (for inlining of e.g. images) in kilobytes
+     *
+     * @var int|null
+     */
+    protected $maxImportSize;
+
+    /**
      * Constructor
      *
-     * @param ThemeInfo   $themeInfo Theme information service
-     * @param string|bool $plconfig  Config for current application environment
-     * @param string      $nonce     Nonce from nonce generator
+     * @param ThemeInfo   $themeInfo     Theme information service
+     * @param string|bool $plconfig      Config for current application environment
+     * @param string      $nonce         Nonce from nonce generator
+     * @param int         $maxImportSize Maximum imported (inlined) file size
      */
-    public function __construct(ThemeInfo $themeInfo, $plconfig = false, $nonce = '')
-    {
+    public function __construct(ThemeInfo $themeInfo, $plconfig = false, $nonce = '',
+        $maxImportSize = null
+    ) {
         parent::__construct();
         $this->themeInfo = $themeInfo;
         $this->usePipeline = $this->enabledInConfig($plconfig);
         $this->cspNonce = $nonce;
+        $this->maxImportSize = $maxImportSize;
         $this->itemKeys[] = 'nonce';
     }
 
@@ -244,6 +254,10 @@ class HeadLink extends \Laminas\View\Helper\HeadLink
      */
     protected function getMinifier()
     {
-        return new \VuFindTheme\Minify\CSS();
+        $minifier = new \VuFindTheme\Minify\CSS();
+        if (null !== $this->maxImportSize) {
+            $minifier->setMaxImportSize($this->maxImportSize);
+        }
+        return $minifier;
     }
 }

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
@@ -113,7 +113,7 @@ class HeadScript extends \Laminas\View\Helper\HeadScript
             }
         }
 
-        $item->attributes['nonce'] = $this->cspNonce;
+        $this->addNonce($item);
         return parent::itemToString($item, $indent, $escapeStart, $escapeEnd);
     }
 
@@ -215,5 +215,17 @@ class HeadScript extends \Laminas\View\Helper\HeadScript
             $data .= ';';
         }
         return $data;
+    }
+
+    /**
+     * Add a nonce to the item
+     *
+     * @param stdClass $item Item
+     *
+     * @return void
+     */
+    protected function addNonce($item)
+    {
+        $item->attributes['nonce'] = $this->cspNonce;
     }
 }

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
@@ -94,10 +94,12 @@ class PipelineInjectorFactory implements FactoryInterface
         $configManager = $container->get(\VuFind\Config\PluginManager::class);
         $nonceGenerator = $container->get(\VuFind\Security\NonceGenerator::class);
         $nonce = $nonceGenerator->getNonce();
+        $config = $configManager->get('config');
         return new $requestedName(
             $container->get(\VuFindTheme\ThemeInfo::class),
-            $this->getPipelineConfig($configManager->get('config')),
-            $nonce
+            $this->getPipelineConfig($config),
+            $nonce,
+            $config['Site']['asset_pipeline_max_css_import_size'] ?? null
         );
     }
 }


### PR DESCRIPTION
Since link elements don't support the nonce attribute, don't try to add it to them. Besides, the $item format didn't use 'attributes' element anyway.