### PR TITLE
Fix double colon in MARC links

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
@@ -643,6 +643,7 @@ trait MarcAdvancedTrait
     {
         // If set, use relationship information from subfield i
         if ($subfieldI = $field->getSubfield('i')) {
+            // VuFind will add a colon to the label, so prevent double colons:
             $data = rtrim(trim($subfieldI->getData(), ':'));
             if (!empty($data)) {
                 return $data;

--- a/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
@@ -643,7 +643,7 @@ trait MarcAdvancedTrait
     {
         // If set, use relationship information from subfield i
         if ($subfieldI = $field->getSubfield('i')) {
-            $data = trim($subfieldI->getData());
+            $data = rtrim(trim($subfieldI->getData(), ':'));
             if (!empty($data)) {
                 return $data;
             }


### PR DESCRIPTION
According to MARC standard documentation, when there is $i present, it should end with a colon:
https://www.loc.gov/marc/bibliographic/bd76x78x.html

In that case the colon character in MARC links generated in VuFind is doubled.

This patch fixes this and there is one colon for both cases consistantly.