### PR TITLE
Use GET instead of POST for limit control.

### DIFF
--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -1,6 +1,7 @@
 <?php $limitList = $this->params->getLimitList(); ?>
 <?php if (count($limitList) > 1): ?>
-  <form class="form-inline search-result-limit" action="<?=$this->currentPath() . $this->results->getUrlQuery()->setLimit(null)?>" method="post">
+  <form class="form-inline search-result-limit" action="<?=$this->currentPath() . $this->results->getUrlQuery()->setLimit(null)?>" method="get">
+    <?=$this->results->getUrlQuery()->asHiddenFields(['sort' => '/.*/']);?>
     <label for="limit"><?=$this->transEsc('Results per page')?></label>
     <select id="limit" name="limit" class="jumpMenu form-control">
       <?php foreach ($limitList as $limitVal => $limitData): ?>


### PR DESCRIPTION
- Creates cleaner browser history (no back button problems, etc.).