### PR TITLE
Bug fix: AJAX facet calls must support all UrlQueryHelper features

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetFacetData.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetFacetData.php
@@ -112,7 +112,9 @@ class GetFacetData extends AbstractBase
         } else {
             // Set appropriate query suppression / extra field behavior:
             $queryHelper = $results->getUrlQuery();
-            $queryHelper->setSuppressQuery((bool)($request['querySuppressed'] ?? false));
+            $queryHelper->setSuppressQuery(
+                (bool)($request['querySuppressed'] ?? false)
+            );
             $extraFields = array_filter(explode(',', $request['extraFields'] ?? ''));
             foreach ($extraFields as $field) {
                 if (isset($request[$field])) {

--- a/module/VuFind/src/VuFind/AjaxHandler/GetFacetData.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetFacetData.php
@@ -93,25 +93,37 @@ class GetFacetData extends AbstractBase
     {
         $this->disableSessionWrites();  // avoid session write timing bug
 
-        $facet = $params->fromQuery('facetName');
-        $sort = $params->fromQuery('facetSort');
-        $operator = $params->fromQuery('facetOperator');
-        $backend = $params->fromQuery('source', DEFAULT_SEARCH_BACKEND);
+        // Allow both GET and POST variables:
+        $request = $params->fromQuery() + $params->fromPost();
+
+        $facet = $request['facetName'] ?? null;
+        $sort = $request['facetSort'] ?? null;
+        $operator = $request['facetOperator'] ?? null;
+        $backend = $request['source'] ?? DEFAULT_SEARCH_BACKEND;
 
         $results = $this->resultsManager->get($backend);
         $paramsObj = $results->getParams();
         $paramsObj->addFacet($facet, null, $operator === 'OR');
-        $paramsObj->initFromRequest(new Parameters($params->fromQuery()));
+        $paramsObj->initFromRequest(new Parameters($request));
 
         $facets = $results->getFullFieldFacets([$facet], false, -1, 'count');
         if (empty($facets[$facet]['data']['list'])) {
             $facets = [];
         } else {
+            // Set appropriate query suppression / extra field behavior:
+            $queryHelper = $results->getUrlQuery();
+            $queryHelper->setSuppressQuery((bool)($request['querySuppressed'] ?? false));
+            $extraFields = array_filter(explode(',', $request['extraFields'] ?? ''));
+            foreach ($extraFields as $field) {
+                if (isset($request[$field])) {
+                    $queryHelper->setDefaultParameter($field, $request[$field]);
+                }
+            }
+
             $facetList = $facets[$facet]['data']['list'];
             $this->facetHelper->sortFacetList($facetList, $sort);
-            $facets = $this->facetHelper->buildFacetArray(
-                $facet, $facetList, $results->getUrlQuery(), false
-            );
+            $facets = $this->facetHelper
+                ->buildFacetArray($facet, $facetList, $queryHelper, false);
         }
         return $this->formatResponse(compact('facets'));
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
@@ -132,6 +132,16 @@ class GetSideFacets extends \VuFind\AjaxHandler\AbstractBase
             return $this->formatResponse('', self::STATUS_HTTP_ERROR);
         }
 
+        // Set appropriate query suppression / extra field behavior:
+        $queryHelper = $results->getUrlQuery();
+        $queryHelper->setSuppressQuery((bool)($request['querySuppressed'] ?? false));
+        $extraFields = array_filter(explode(',', $request['extraFields'] ?? ''));
+        foreach ($extraFields as $field) {
+            if (isset($request[$field])) {
+                $queryHelper->setDefaultParameter($field, $request[$field]);
+            }
+        }
+
         $recommend = $results->getRecommendations($configLocation)[0] ?? null;
         if (null === $recommend) {
             return $this->formatResponse(

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -200,7 +200,8 @@ class UrlQueryHelper
     public function setDefaultParameter($name, $value, $forceOverride = true)
     {
         // Add the new default to the configuration, and apply it to the query
-        // if no existing value has already been set in this position.
+        // if no existing value has already been set in this position (or if an
+        // override has been forced).
         $this->config['defaults'][$name] = $value;
         if (!isset($this->urlParams[$name]) || $forceOverride) {
             $this->urlParams[$name] = $value;

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -189,17 +189,20 @@ class UrlQueryHelper
      * Set the default value of a parameter, and add that parameter to the object
      * if it is not already defined.
      *
-     * @param string $name  Name of parameter
-     * @param string $value Value of parameter
+     * @param string $name          Name of parameter
+     * @param string $value         Value of parameter
+     * @param bool   $forceOverride Force an override of the existing value, even if
+     * it was set in the incoming $urlParams in the constructor (defaults to true for
+     * backward compatibility)
      *
      * @return UrlQueryHelper
      */
-    public function setDefaultParameter($name, $value)
+    public function setDefaultParameter($name, $value, $forceOverride = true)
     {
         // Add the new default to the configuration, and apply it to the query
         // if no existing value has already been set in this position.
         $this->config['defaults'][$name] = $value;
-        if (!isset($this->urlParams[$name])) {
+        if (!isset($this->urlParams[$name]) || $forceOverride) {
             $this->urlParams[$name] = $value;
         }
         return $this;

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -186,7 +186,8 @@ class UrlQueryHelper
     }
 
     /**
-     * Add a parameter to the object.
+     * Set the default value of a parameter, and add that parameter to the object
+     * if it is not already defined.
      *
      * @param string $name  Name of parameter
      * @param string $value Value of parameter
@@ -195,8 +196,24 @@ class UrlQueryHelper
      */
     public function setDefaultParameter($name, $value)
     {
-        $this->urlParams[$name] = $value;
+        // Add the new default to the configuration, and apply it to the query
+        // if no existing value has already been set in this position.
+        $this->config['defaults'][$name] = $value;
+        if (!isset($this->urlParams[$name])) {
+            $this->urlParams[$name] = $value;
+        }
         return $this;
+    }
+
+    /**
+     * Get an array of field names with configured defaults; this is a useful way
+     * to identify custom query parameters added through setDefaultParameter().
+     *
+     * @return array
+     */
+    public function getParamsWithConfiguredDefaults()
+    {
+        return array_keys($this->config['defaults'] ?? []);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -91,13 +91,18 @@ class UrlQueryHelperTest extends TestCase
         // default does NOT override the existing value.
         $this->assertEquals(
             '?foo=bar&lookfor=search',
-            $helper->setDefaultParameter('foo', 'baz')->getParams(false)
+            $helper->setDefaultParameter('foo', 'baz', false)->getParams(false)
         );
         // Now let's add a default parameter that was NOT part of the incoming
         // request... we DO want this to get added to the query:
         $this->assertEquals(
             '?foo=bar&lookfor=search&xyzzy=true',
-            $helper->setDefaultParameter('xyzzy', 'true')->getParams(false)
+            $helper->setDefaultParameter('xyzzy', 'true', false)->getParams(false)
+        );
+        // Finally, let's force an override of an existing parameter:
+        $this->assertEquals(
+            '?foo=baz&lookfor=search&xyzzy=true',
+            $helper->setDefaultParameter('foo', 'baz', true)->getParams(false)
         );
 
         // Confirm that we can look up a list of configured parameters:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -45,15 +45,27 @@ use VuFindTest\Unit\TestCase as TestCase;
 class UrlQueryHelperTest extends TestCase
 {
     /**
+     * Get a preconfigured helper.
+     *
+     * @param array $request Request parameters
+     * @param Query $query   Query object
+     *
+     * @return UrlQueryHelper
+     */
+    protected function getHelper($request = ['foo' => 'bar'], $query = null)
+    {
+        return new UrlQueryHelper($request, $query ?? new Query('search'));
+    }
+
+    /**
      * Test the basic functionality of the helper.
      *
      * @return void
      */
-    public function testBasicFunctionality()
+    public function testBasicGetters()
     {
         // Test basic getters
-        $query = new Query('search');
-        $helper = new UrlQueryHelper(['foo' => 'bar'], $query);
+        $helper = $this->getHelper();
         $this->assertEquals('?foo=bar&amp;lookfor=search', $helper->getParams());
         $this->assertEquals('?foo=bar&amp;lookfor=search', (string)$helper);
         $this->assertEquals(
@@ -63,56 +75,109 @@ class UrlQueryHelperTest extends TestCase
             '<input type="hidden" name="foo" value="bar" />',
             $helper->asHiddenFields(['lookfor' => '/.*/'])
         );
+    }
 
-        // Test setDefaultParameters and disabling escaping
+    /**
+     * Test the behavior of setDefaultParameters
+     *
+     * @return void
+     */
+    public function testSetDefaultParameters()
+    {
+        $helper = $this->getHelper();
+
+        // Test setDefaultParameters and disabling escaping. Note that, because
+        // the "foo" parameter is already set in the original request, adding a
+        // default does NOT override the existing value.
         $this->assertEquals(
-            '?foo=baz&lookfor=search',
+            '?foo=bar&lookfor=search',
             $helper->setDefaultParameter('foo', 'baz')->getParams(false)
         );
-        // Confirm that we can look up a list of configured parameters:
-        $this->assertEquals(['foo'], $helper->getParamsWithConfiguredDefaults);
+        // Now let's add a default parameter that was NOT part of the incoming
+        // request... we DO want this to get added to the query:
+        $this->assertEquals(
+            '?foo=bar&lookfor=search&xyzzy=true',
+            $helper->setDefaultParameter('xyzzy', 'true')->getParams(false)
+        );
 
-        // Test query suppression
+        // Confirm that we can look up a list of configured parameters:
+        $this->assertEquals(
+            ['foo', 'xyzzy'], $helper->getParamsWithConfiguredDefaults()
+        );
+    }
+
+    /**
+     * Test query suppression.
+     *
+     * @return void
+     */
+    public function testQuerySuppression()
+    {
+        $helper = $this->getHelper();
         $this->assertEquals(false, $helper->isQuerySuppressed());
         $helper->setSuppressQuery(true);
         $this->assertEquals(true, $helper->isQuerySuppressed());
-        $this->assertEquals('?foo=baz', $helper->getParams());
+        $this->assertEquals('?foo=bar', $helper->getParams());
         $helper->setSuppressQuery(false);
         $this->assertEquals(false, $helper->isQuerySuppressed());
-        $this->assertEquals('?foo=baz&lookfor=search', $helper->getParams(false));
+        $this->assertEquals('?foo=bar&lookfor=search', $helper->getParams(false));
+    }
 
-        // Test replacing query terms
+    /**
+     * Test replacing query terms
+     *
+     * @return void
+     */
+    public function testReplacingQueryTerms()
+    {
+        $helper = $this->getHelper();
         $this->assertEquals(
-            '?foo=baz&amp;lookfor=srch',
+            '?foo=bar&amp;lookfor=srch',
             $helper->replaceTerm('search', 'srch')->getParams()
         );
         $this->assertEquals(
-            '?foo=baz&amp;lookfor=srch',
+            '?foo=bar&amp;lookfor=srch',
             $helper->setSearchTerms('srch')->getParams()
         );
+    }
 
-        // Test adding/removing facets and filters
+    /**
+     * Test adding/removing facets and filters
+     *
+     * @return void
+     */
+    public function testFacetsAndFilters()
+    {
+        $helper = $this->getHelper();
         $faceted = $helper->addFacet('f', '1')->addFilter('f:2');
         $this->assertEquals(
-            '?foo=baz&lookfor=search&filter%5B%5D=f%3A%221%22&filter%5B%5D=f%3A2',
+            '?foo=bar&lookfor=search&filter%5B%5D=f%3A%221%22&filter%5B%5D=f%3A2',
             $faceted->getParams(false)
         );
         $this->assertEquals(
-            '?foo=baz&lookfor=search&filter%5B%5D=f%3A%221%22',
+            '?foo=bar&lookfor=search&filter%5B%5D=f%3A%221%22',
             $faceted->removeFacet('f', '2')->getParams(false)
         );
         $this->assertEquals(
-            '?foo=baz&lookfor=search&filter%5B%5D=f%3A2',
+            '?foo=bar&lookfor=search&filter%5B%5D=f%3A2',
             $faceted->removeFilter('f:1')->getParams(false)
         );
         $this->assertEquals(
-            '?foo=baz&lookfor=search',
+            '?foo=bar&lookfor=search',
             $faceted->removeAllFilters()->getParams(false)
         );
+    }
 
-        // Test stacking setters
+    /**
+     * Test stacking setters
+     *
+     * @return void
+     */
+    public function testStackingSetters()
+    {
+        $helper = $this->getHelper();
         $this->assertEquals(
-            '?foo=baz&sort=title&view=grid&lookfor=search&type=x&limit=50&page=3',
+            '?foo=bar&sort=title&view=grid&lookfor=search&type=x&limit=50&page=3',
             $helper->setSort('title')->setViewParam('grid')->setHandler('x')
                 ->setLimit(50)->setPage(3)->getParams(false)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -69,6 +69,8 @@ class UrlQueryHelperTest extends TestCase
             '?foo=baz&lookfor=search',
             $helper->setDefaultParameter('foo', 'baz')->getParams(false)
         );
+        // Confirm that we can look up a list of configured parameters:
+        $this->assertEquals(['foo'], $helper->getParamsWithConfiguredDefaults);
 
         // Test query suppression
         $this->assertEquals(false, $helper->isQuerySuppressed());

--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -106,25 +106,23 @@ function initFacetTree(treeNode, inSidebar)
   }
   treeNode.data('loaded', true);
 
-  var source = treeNode.data('source');
-  var facet = treeNode.data('facet');
-  var operator = treeNode.data('operator');
-  var sort = treeNode.data('sort');
-  var query = window.location.href.split('?')[1];
-
   if (inSidebar) {
     treeNode.prepend('<li class="list-group-item"><i class="fa fa-spinner fa-spin" aria-hidden="true"></i></li>');
   } else {
     treeNode.prepend('<div><i class="fa fa-spinner fa-spin" aria-hidden="true"></i><div>');
   }
-  $.getJSON(VuFind.path + '/AJAX/JSON?' + query,
-    {
-      method: "getFacetData",
-      source: source,
-      facetName: facet,
-      facetSort: sort,
-      facetOperator: operator
-    },
+  var request = {
+    method: "getFacetData",
+    source: treeNode.data('source'),
+    facetName: treeNode.data('facet'),
+    facetSort: treeNode.data('sort'),
+    facetOperator: treeNode.data('operator'),
+    query: treeNode.data('query'),
+    querySuppressed: treeNode.data('querySuppressed'),
+    extraFields: treeNode.data('extraFields')
+  };
+  $.getJSON(VuFind.path + '/AJAX/JSON?' + request.query,
+    request,
     function getFacetData(response/*, textStatus*/) {
       buildFacetTree(treeNode, response.data.facets, inSidebar);
     }

--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -178,18 +178,18 @@ VuFind.register('sideFacets', function SideFacets() {
     if (facetList.length === 0) {
       return;
     }
-    var urlParts = window.location.href.split('?');
-    var query = urlParts.length > 1 ? urlParts[1] : '';
     var request = {
       method: 'getSideFacets',
       searchClassId: $container.data('searchClassId'),
       location: $container.data('location'),
       configIndex: $container.data('configIndex'),
-      query: query,
+      query: $container.data('query'),
+      querySuppressed: $container.data('querySuppressed'),
+      extraFields: $container.data('extraFields'),
       enabledFacets: facetList
     };
     $container.find('.facet-load-indicator').removeClass('hidden');
-    $.getJSON(VuFind.path + '/AJAX/JSON?' + query, request)
+    $.getJSON(VuFind.path + '/AJAX/JSON?' + request.query, request)
       .done(function onGetSideFacetsDone(response) {
         $.each(response.data.facets, function initFacet(facet, facetData) {
           var containerSelector = typeof facetData.checkboxCount !== 'undefined'

--- a/themes/bootstrap3/templates/Recommend/SideFacets/facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/facet.phtml
@@ -29,7 +29,8 @@
         'allowExclude' => $this->recommend->excludeAllowed($facet),
         'title' => $facet,
         'sortOptions' => $hierarchicalFacetSortOptions[$facet] ?? $hierarchicalFacetSortOptions['*'] ?? null,
-        'collapsedFacets' => $this->collapsedFacets
+        'collapsedFacets' => $this->collapsedFacets,
+        'results' => $this->results
       ]
     ); ?>
     <noscript>

--- a/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
@@ -1,4 +1,18 @@
-<?php $this->headScript()->appendFile('vendor/jsTree/jstree.min.js'); ?>
+<?php
+  $this->headScript()->appendFile('vendor/jsTree/jstree.min.js');
+
+  // We need to pass the current URL query to the Javascript; we use substr() to
+  // strip off the leading ? character. The "suppress query" option is used for
+  // special search types like course reserves / new items. The AJAX handler needs
+  // the real Solr query in order to process facets correctly, so we need to
+  // unsuppress it here.
+  $querySuppressed = $this->results->getUrlQuery()->isQuerySuppressed();
+  $urlQuery = substr($this->results->getUrlQuery()->setSuppressQuery(false)->getParams(false), 1);
+  $this->results->getUrlQuery()->setSuppressQuery($querySuppressed); // restore original config
+  // We also need to inform the helper about any special parameters used in place
+  // of the suppressed query:
+  $extraUrlFields = $this->results->getUrlQuery()->getParamsWithConfiguredDefaults();
+?>
 <?php if (!in_array($this->title, $this->collapsedFacets)): ?>
   <?php
     $script = <<<JS
@@ -25,5 +39,8 @@ JS;
     data-exclude="<?=$this->allowExclude?>"
     data-operator="<?=$this->recommend->getFacetOperator($this->title)?>"
     data-exclude-title="<?=$this->transEsc('exclude_facet')?>"
-    data-sort="<?=isset($this->sortOptions) ? $this->sortOptions : ''?>">
+    data-sort="<?=isset($this->sortOptions) ? $this->sortOptions : ''?>"
+    data-query="<?=$this->escapeHtmlAttr($urlQuery)?>"
+    data-query-suppressed="<?=$querySuppressed ? '1' : '0' ?>"
+    data-extra-fields="<?=$this->escapeHtml(implode(',', $extraUrlFields))?>">
 </li>

--- a/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
@@ -30,7 +30,20 @@
 ?>
 <?php if ($results->getResultTotal() > 0): ?>
   <h2><?=$this->transEsc($this->slot('side-facet-caption')->get('Narrow Search')) ?></h2>
-  <div class="side-facets-container-ajax" data-search-class-id="<?=$this->escapeHtmlAttr($this->searchClassId) ?>" data-location="<?=$this->escapeHtmlAttr($this->location) ?>" data-config-index="<?=$this->escapeHtmlAttr($this->configIndex) ?>">
+  <?php
+    // We need to pass the current URL query to the Javascript; we use substr() to
+    // strip off the leading ? character. The "suppress query" option is used for
+    // special search types like course reserves / new items. The AJAX handler needs
+    // the real Solr query in order to process facets correctly, so we need to
+    // unsuppress it here.
+    $querySuppressed = $results->getUrlQuery()->isQuerySuppressed();
+    $urlQuery = substr($results->getUrlQuery()->setSuppressQuery(false)->getParams(false), 1);
+    $results->getUrlQuery()->setSuppressQuery($querySuppressed); // restore original config
+    // We also need to inform the helper about any special parameters used in place
+    // of the suppressed query:
+    $extraUrlFields = $results->getUrlQuery()->getParamsWithConfiguredDefaults();
+  ?>
+  <div class="side-facets-container-ajax" data-search-class-id="<?=$this->escapeHtmlAttr($this->searchClassId) ?>" data-location="<?=$this->escapeHtmlAttr($this->location) ?>" data-config-index="<?=$this->escapeHtmlAttr($this->configIndex)?>" data-query="<?=$this->escapeHtmlAttr($urlQuery)?>" data-query-suppressed="<?=$querySuppressed ? '1' : '0' ?>" data-extra-fields="<?=$this->escapeHtml(implode(',', $extraUrlFields))?>">
 <?php endif; ?>
 <?php $checkboxFilters = $this->recommend->getCheckboxFacetSet(); ?>
 <?php $checkboxesShown = false; ?>


### PR DESCRIPTION
TODO
- [x] Test thoroughly
- [x] Investigate whether similar changes are needed for other facet-related AJAX calls (e.g. get tree)

