### PR TITLE
Handle null response from Solr properly.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
@@ -85,6 +85,11 @@ class RecordCollection extends AbstractRecordCollection
      */
     public function __construct(array $response)
     {
+        if (array_key_exists('response', $response)
+            && null === $response['response']
+        ) {
+            unset($response['response']);
+        }
         $this->response = array_replace_recursive(static::$template, $response);
         $this->offset = $this->response['response']['start'];
         $this->rewind();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
@@ -66,6 +66,29 @@ class RecordCollectionTest extends TestCase
     }
 
     /**
+     * Test that the object returns appropriate defaults when given a null response
+     * element.
+     *
+     * @return void
+     */
+    public function testDefaultsWithNullResponse()
+    {
+        $coll = new RecordCollection(['response' => null]);
+        $this->assertEquals(
+            'VuFindSearch\Backend\Solr\Response\Json\Spellcheck',
+            get_class($coll->getSpellcheck())
+        );
+        $this->assertEquals(0, $coll->getTotal());
+        $this->assertEquals(
+            'VuFindSearch\Backend\Solr\Response\Json\Facets',
+            get_class($coll->getFacets())
+        );
+        $this->assertEquals([], $coll->getGroups());
+        $this->assertEquals([], $coll->getHighlighting());
+        $this->assertEquals(0, $coll->getOffset());
+    }
+
+    /**
      * Test that the object handles offsets properly.
      *
      * @return void


### PR DESCRIPTION
At least the similar handler in Solr 8.x can return null in the response element when no similar records are found.