### PR TITLE
Reset authentication state on logout.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -403,6 +403,9 @@ class Manager implements \LmcRbacMvc\Identity\IdentityProviderInterface
         // necessary.
         $url = $this->getAuth()->logout($url);
 
+        // Reset authentication state
+        $this->getAuth()->resetState();
+
         // Clear out the cached user object and session entry.
         $this->currentUser = false;
         unset($this->session->userId);


### PR DESCRIPTION
This probably has no effect in real life unless the followup after logout is short-circuited. However, if one would shortcut the redirect and go directly back to login screen, at least ChoiceAuth would get confused.