### PR TITLE
Make it possible to use smaller expiration than 2 days for sessions.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
@@ -60,11 +60,18 @@ class AbstractExpireCommand extends Command
     protected $rowLabel = 'rows';
 
     /**
-     * Minimum (and default) legal age of rows to delete.
+     * Minimum legal age of rows to delete.
      *
      * @var int
      */
     protected $minAge = 2;
+
+    /**
+     * Default age of rows to delete. $minAge is used if $defaultAge is null.
+     *
+     * @var int|null
+     */
+    protected $defaultAge = null;
 
     /**
      * Table on which to expire rows
@@ -118,7 +125,7 @@ class AbstractExpireCommand extends Command
                 'age',
                 InputArgument::OPTIONAL,
                 "the age (in days) of {$this->rowLabel} to expire",
-                $this->minAge
+                $this->defaultAge ?? $this->minAge
             );
     }
 
@@ -153,7 +160,7 @@ class AbstractExpireCommand extends Command
         if ($daysOld < $this->minAge) {
             $output->writeln(
                 str_replace(
-                    '%%age%%', $this->minAge,
+                    '%%age%%', number_format($this->minAge, 1, '.', ''),
                     'Expiration age must be at least %%age%% days.'
                 )
             );

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommand.php
@@ -39,6 +39,20 @@ namespace VuFindConsole\Command\Util;
 class ExpireSessionsCommand extends AbstractExpireCommand
 {
     /**
+     * Minimum legal age of rows to delete.
+     *
+     * @var int
+     */
+    protected $minAge = 0.1;
+
+    /**
+     * Default age of rows to delete. $minAge is used $defaultAge is null.
+     *
+     * @var int
+     */
+    protected $defaultAge = 2;
+
+    /**
      * Help description for the command.
      *
      * @var string

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/AbstractExpireCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/AbstractExpireCommandTest.php
@@ -63,6 +63,20 @@ class AbstractExpireCommandTest extends \PHPUnit\Framework\TestCase
     protected $rowLabel = 'rows';
 
     /**
+     * Age parameter to use when testing illegal age input.
+     *
+     * @var int
+     */
+    protected $illegalAge = 1;
+
+    /**
+     * Expected minimum age in error message.
+     *
+     * @var int
+     */
+    protected $expectedMinAge = 2;
+
+    /**
      * Test an unsupported table class.
      *
      * @return void
@@ -91,9 +105,10 @@ class AbstractExpireCommandTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $command = new $this->targetClass($table, 'foo');
         $commandTester = new CommandTester($command);
-        $commandTester->execute(['age' => 1]);
+        $commandTester->execute(['age' => $this->illegalAge]);
+        $expectedMinAge = number_format($this->expectedMinAge, 1, '.', '');
         $this->assertEquals(
-            "Expiration age must be at least 2 days.\n",
+            "Expiration age must be at least $expectedMinAge days.\n",
             $commandTester->getDisplay()
         );
         $this->assertEquals(1, $commandTester->getStatusCode());

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/ExpireSessionsCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/ExpireSessionsCommandTest.php
@@ -60,4 +60,18 @@ class ExpireSessionsCommandTest extends AbstractExpireCommandTest
      * @var string
      */
     protected $rowLabel = 'sessions';
+
+    /**
+     * Age parameter to use when testing illegal age input.
+     *
+     * @var int
+     */
+    protected $illegalAge = 0.01;
+
+    /**
+     * Expected minimum age in error message.
+     *
+     * @var int
+     */
+    protected $expectedMinAge = 0.1;
 }


### PR DESCRIPTION
Allows defining a smaller minimum age than default for expire commands. Also makes sure that fractional values are printed with '.' as the decimal separator.

The output of the "Expiration age must be at least x days" is slightly changed to include one decimal also in the default case of 2. I don't find that an issue, but I can add logic to work around it if necessary. number_format is used because otherwise comma is used as the decimal separator in the error message with the Finnish locale.