### PR TITLE
Catch exception on HTTP request

### DIFF
--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -166,6 +166,7 @@ class ObalkyKnihService implements \VuFindHttp\HttpServiceAwareInterface,
         try {
             $response = $client->send();
         } catch (\Exception $e) {
+            $this->logError('Unexpected ' . get_class($e) . ': ' . $e->getMessage());
             return null;
         }
         return $response->isSuccess() ? json_decode($response->getBody())[0] : null;

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -163,7 +163,11 @@ class ObalkyKnihService implements \VuFindHttp\HttpServiceAwareInterface,
         $url = $this->apiUrl . "?";
         $url .= http_build_query([$param => json_encode([$query])]);
         $client = $this->getHttpClient($url);
-        $response = $client->send();
+        try {
+            $response = $client->send();
+        } catch (\Exception $e) {
+            return null;
+        }
         return $response->isSuccess() ? json_decode($response->getBody())[0] : null;
     }
 }


### PR DESCRIPTION
We faced an exception with "Unable to enable crypto" on connection to obalkyknih.cz, than we assume we can't get a cover and so just return null