### PR TITLE
Cache results of class based template resolution.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -38,8 +38,10 @@ use VuFind\Exception\ILS as ILSException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Auth extends AbstractClassBasedTemplateRenderer
+class Auth extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Authentication manager
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Captcha.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Captcha.php
@@ -38,8 +38,10 @@ namespace VuFind\View\Helper\Root;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Captcha extends AbstractClassBasedTemplateRenderer
+class Captcha extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Captcha services
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
@@ -1,10 +1,14 @@
 <?php
 /**
- * Trait for helpers that render a template based on a class name.
+ * Trait for view helpers that render a template based on a class name.
+ *
+ * Note: This trait is for view helpers only. It expects $this->getView() method to
+ * be available.
  *
  * PHP version 7
  *
  * Copyright (C) Villanova University 2018.
+ * Copyright (C) The National Library of Finland 2020.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,6 +26,7 @@
  * @category VuFind
  * @package  View_Helpers
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -31,11 +36,12 @@ use Laminas\View\Exception\RuntimeException;
 use Laminas\View\Resolver\ResolverInterface;
 
 /**
- * Trait for helpers that render a template based on a class name.
+ * Trait for view helpers that render a template based on a class name.
  *
  * @category VuFind
  * @package  View_Helpers
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */

--- a/module/VuFind/src/VuFind/View/Helper/Root/ContentBlock.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ContentBlock.php
@@ -36,8 +36,10 @@ namespace VuFind\View\Helper\Root;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ContentBlock extends AbstractClassBasedTemplateRenderer
+class ContentBlock extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Render the output of a ContentBlock plugin.
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Recommend.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Recommend.php
@@ -38,8 +38,10 @@ use VuFind\Recommend\RecommendInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Recommend extends AbstractClassBasedTemplateRenderer
+class Recommend extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Render the output of a recommendation module.
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -38,8 +38,10 @@ use VuFind\Cover\Router as CoverRouter;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Record extends AbstractClassBasedTemplateRenderer
+class Record extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Context view helper
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Related.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Related.php
@@ -40,8 +40,10 @@ use VuFind\Search\Options\PluginManager as OptionsManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Related extends AbstractClassBasedTemplateRenderer
+class Related extends \Laminas\View\Helper\AbstractHelper
 {
+    use ClassBasedTemplateRendererTrait;
+
     /**
      * Config manager
      *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -82,7 +82,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('RecordDriver/SolrMarc/collection-record.phtml'))
             ->will($this->returnValue(false));
         $this->setSuccessTemplate(
-            $record, 'RecordDriver/SolrDefault/collection-record.phtml', 'success', 1, 3
+            $record, 'RecordDriver/SolrDefault/collection-record.phtml', 'success', 1, 2
         );
         $this->assertEquals('success', $record->getCollectionBriefRecord());
     }
@@ -196,7 +196,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $record->getView()->resolver()->expects($this->at(0))->method('resolve')
             ->will($this->returnValue(false));
         $this->setSuccessTemplate(
-            $record, 'RecordDriver/AbstractBase/list-entry.phtml', 'success', 1, 3
+            $record, 'RecordDriver/AbstractBase/list-entry.phtml', 'success', 1, 2
         );
         $this->assertEquals('success', $record->getListEntry(null, $user));
     }


### PR DESCRIPTION
This has the potential to avoid a lot of repeated resolution requests e.g. when rendering search results.

TODO:
- [x] Edit changelog when merging to document BC breaks (replacement of AbstractClassBasedTemplateRenderer with ClassBasedTemplateRendererTrait, plus reworking of resolveClassTemplate method).
- [x] Run full test suite