### PR TITLE
Use more appropriate currency icon.

### DIFF
--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -43,7 +43,11 @@
   <?php endif; ?>
   <?php if ($ilsOnline && $this->ils()->checkCapability('getMyFines', $capabilityParams)): ?>
     <a href="<?=$this->url('myresearch-fines')?>" class="flex<?=$this->active == 'fines' ? ' active' : ''?>">
-      <span class="flex-col"><i class="fa fa-fw fa-usd" aria-hidden="true"></i>&nbsp;<?=$this->transEsc('Fines')?></span>
+      <?php
+        // Use a "fines" icon based on the configured default currency symbol:
+        $currency = strtolower($this->config()->get('config')->Site->defaultCurrency ?? 'usd');
+      ?>
+      <span class="flex-col"><i class="fa fa-fw fa-<?=$this->escapeHtmlAttr($currency)?>" aria-hidden="true"></i>&nbsp;<?=$this->transEsc('Fines')?></span>
       <span class="fines-status status hidden"><i class="fa fa-spin fa-spinner" aria-hidden="true"></i></span>
     </a>
   <?php endif; ?>


### PR DESCRIPTION
Previously, the Fines icon was always a dollar sign. This uses an icon based on the configured default currency. FontAwesome seems to support most currency codes, and if an invalid code is provided, there will simply be no icon displayed.