### PR TITLE
return null if lc call number is empty

### DIFF
--- a/import/index_java/src/org/vufind/index/CallNumberTools.java
+++ b/import/index_java/src/org/vufind/index/CallNumberTools.java
@@ -274,13 +274,12 @@ public class CallNumberTools
             }
         }
 
+        // if the call number is empty, return null to indicate there is no LC number
         if (firstCall.length() == 0) {
-            // if the call number is empty, return null to indicate there is no LC number
             return null;
-        } else {
-            // If we made it this far, did not find a valid LC number, so use what we have:
-            return new LCCallNumber(firstCall).getShelfKey();
         }
+        // If we made it this far, did not find a valid LC number, so use what we have:
+        return new LCCallNumber(firstCall).getShelfKey();
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/CallNumberTools.java
+++ b/import/index_java/src/org/vufind/index/CallNumberTools.java
@@ -274,8 +274,13 @@ public class CallNumberTools
             }
         }
 
-        // If we made it this far, did not find a valid LC number, so use what we have:
-        return new LCCallNumber(firstCall).getShelfKey();
+        if (firstCall.length() == 0) {
+            // if the call number is empty, return null to indicate there is no LC number
+            return null;
+        } else {
+            // If we made it this far, did not find a valid LC number, so use what we have:
+            return new LCCallNumber(firstCall).getShelfKey();
+        }
     }
 
     /**


### PR DESCRIPTION
Returns null for lc call number instead of an empty string in the case where there is no lc call. This is to address this issue from the listserv: https://sourceforge.net/p/vufind/mailman/message/37117867/