### PR TITLE
Improve record tab hash handling

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -283,7 +283,7 @@ function applyRecordTabHash() {
   if (newTab.length <= 1 || newTab === '#tabnav') {
     $initiallyActiveTab.click();
   } else if (newTab.length > 1 && '#' + activeTab !== newTab) {
-    $('.' + newTab.substr(1) + ' a').click();
+    $('.record-tabs .' + newTab.substr(1) + ' a').click();
   }
 }
 


### PR DESCRIPTION
Fixes an issue where anchor links can trigger click on links inside elements with the same class name as the new hash