### PR TITLE
KohaRest: Split GetItemStatusCodes into smaller sub-methods.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -183,6 +183,23 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     protected $itemStatusMappings = [];
 
     /**
+     * Item status mapping methods used when the item status mappings above don't
+     * contain a direct mapping.
+     *
+     * @var array
+     */
+    protected $itemStatusMappingMethods = [
+        'Item::CheckedOut' => 'getStatusCodeItemCheckedOut',
+        'Item::Lost' => 'getStatusCodeItemLost',
+        'Item::NotForLoan' => 'getStatusCodeItemNotForLoan',
+        'Item::NotForLoanForcing' => 'getStatusCodeItemNotForLoan',
+        'Item::Transfer' => 'getStatusCodeItemTransfer',
+        'Item::Held' => 'getStatusCodeItemHeld',
+        'Item::Waiting' => 'getStatusCodeItemWaiting',
+        'ItemType::NotForLoan' => 'getStatusCodeItemNotForLoan',
+    ];
+
+    /**
      * Whether to display home library instead of holding library
      *
      * @var bool
@@ -1750,9 +1767,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 }
 
                 // Check for a mapping method for the unavailability reason:
-                $methodName = 'getStatusCode'
-                    . preg_replace('/[^a-zA-Z0-9_]/', '', $code);
-                if (method_exists($this, $methodName)) {
+                if ($methodName = ($this->itemStatusMappingMethods[$code] ?? '')) {
                     $statuses[]
                         = call_user_func([$this, $methodName], $code, $data, $item);
                 } else {

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1862,20 +1862,6 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     }
 
     /**
-     * Get item status code for NorForLoanForcing status
-     *
-     * @param string $code Status code
-     * @param array  $data Status data
-     * @param array  $item Item
-     *
-     * @return string
-     */
-    protected function getStatusCodeItemNotForLoanForcing($code, $data, $item)
-    {
-        return $this->getStatusCodeItemNotForLoan($code, $data, $item);
-    }
-
-    /**
      * Get item status code for Transfer status
      *
      * @param string $code Status code
@@ -1925,20 +1911,6 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     protected function getStatusCodeItemWaiting($code, $data, $item)
     {
         return 'On Holdshelf';
-    }
-
-    /**
-     * Get item type status code for NotForLoan status
-     *
-     * @param string $code Status code
-     * @param array  $data Status data
-     * @param array  $item Item
-     *
-     * @return string
-     */
-    protected function getStatusCodeItemTypeNotForLoan($code, $data, $item)
-    {
-        return $this->getStatusCodeItemNotForLoan($code, $data, $item);
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1750,7 +1750,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 }
 
                 // Check for a mapping method for the unavailability reason:
-                $methodName = 'GetStatusCode'
+                $methodName = 'getStatusCode'
                     . preg_replace('/[^a-zA-Z0-9_]/', '', $code);
                 if (method_exists($this, $methodName)) {
                     $statuses[]

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1742,67 +1742,27 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         if ($item['availability']['available']) {
             $statuses[] = 'On Shelf';
         } elseif (isset($item['availability']['unavailabilities'])) {
-            foreach ($item['availability']['unavailabilities'] as $key => $reason) {
-                if (isset($this->itemStatusMappings[$key])) {
-                    $statuses[] = $this->itemStatusMappings[$key];
+            foreach ($item['availability']['unavailabilities'] as $code => $data) {
+                // If we have a direct mapping, use it:
+                if (isset($this->itemStatusMappings[$code])) {
+                    $statuses[] = $this->itemStatusMappings[$code];
                     continue;
                 }
-                $parts = explode('::', $key, 2);
-                $statusType = $parts[0];
-                $status = $parts[1] ?? '';
 
-                if ('Item' === $statusType || 'ItemType' === $statusType) {
-                    switch ($status) {
-                    case 'CheckedOut':
-                        $overdue = false;
-                        if (!empty($reason['due_date'])) {
-                            $duedate = $this->dateConverter->convert(
-                                'Y-m-d',
-                                'U',
-                                $reason['due_date']
-                            );
-                            $overdue = $duedate < time();
+                // Check for a mapping method for the unavailability reason:
+                $methodName = 'GetStatusCode'
+                    . preg_replace('/[^a-zA-Z0-9_]/', '', $code);
+                if (method_exists($this, $methodName)) {
+                    $statuses[]
+                        = call_user_func([$this, $methodName], $code, $data, $item);
+                } else {
+                    if (!empty($data['code'])) {
+                        $statuses[] = $data['code'];
+                    } else {
+                        $parts = explode('::', $code, 2);
+                        if (isset($parts[1])) {
+                            $statuses[] = $parts[1];
                         }
-                        $statuses[] = $overdue ? 'Overdue' : 'Charged';
-                        break;
-                    case 'Lost':
-                        $statuses[] = 'Lost--Library Applied';
-                        break;
-                    case 'NotForLoan':
-                    case 'NotForLoanForcing':
-                        // NotForLoan is special: status has a library-specific
-                        // status number. Allow mapping of different status numbers
-                        // separately (e.g. Item::NotForLoan with status number 4
-                        // is mapped with key Item::NotForLoan4):
-                        $statusKey = $key . ($reason['status'] ?? '-');
-                        // Replace ':' in status key if used as status since ':' is
-                        // the namespace separator in translatable strings:
-                        $statuses[] = $this->itemStatusMappings[$statusKey]
-                            ?? $reason['code'] ?? str_replace(':', '_', $statusKey);
-                        break;
-                    case 'Transfer':
-                        $onHold = false;
-                        if (!empty($item['availability']['notes'])) {
-                            foreach (array_keys($item['availability']['notes'])
-                                as $noteKey
-                            ) {
-                                if ('Item::Held' === $noteKey) {
-                                    $onHold = true;
-                                    break;
-                                }
-                            }
-                        }
-                        $statuses[] = $onHold ? 'In Transit On Hold' : 'In Transit';
-                        break;
-                    case 'Held':
-                        $statuses[] = 'On Hold';
-                        break;
-                    case 'Waiting':
-                        $statuses[] = 'On Holdshelf';
-                        break;
-                    default:
-                        $statuses[] = !empty($reason['code'])
-                            ? $reason['code'] : $status;
                     }
                 }
             }
@@ -1819,6 +1779,151 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             $statuses[] = 'No information available';
         }
         return array_unique($statuses);
+    }
+
+    /**
+     * Get item status code for CheckedOut status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemCheckedOut($code, $data, $item)
+    {
+        $overdue = false;
+        if (!empty($data['due_date'])) {
+            $duedate = $this->dateConverter->convert(
+                'Y-m-d',
+                'U',
+                $data['due_date']
+            );
+            $overdue = $duedate < time();
+        }
+        return $overdue ? 'Overdue' : 'Charged';
+    }
+
+    /**
+     * Get item status code for Lost status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemLost($code, $data, $item)
+    {
+        return 'Lost--Library Applied';
+    }
+
+    /**
+     * Get item status code for NotForLoan status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemNotForLoan($code, $data, $item)
+    {
+        // NotForLoan is special: status has a library-specific
+        // status number. Allow mapping of different status numbers
+        // separately (e.g. Item::NotForLoan with status number 4
+        // is mapped with key Item::NotForLoan4):
+        $statusKey = $code . ($data['status'] ?? '-');
+        // Replace ':' in status key if used as status since ':' is
+        // the namespace separator in translatable strings:
+        return $this->itemStatusMappings[$statusKey]
+            ?? $data['code'] ?? str_replace(':', '_', $statusKey);
+    }
+
+    /**
+     * Get item status code for NorForLoanForcing status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     */
+    protected function getStatusCodeItemNotForLoanForcing($code, $data, $item)
+    {
+        return $this->getStatusCodeItemNotForLoan($code, $data, $item);
+    }
+
+    /**
+     * Get item status code for Transfer status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemTransfer($code, $data, $item)
+    {
+        $onHold = array_key_exists(
+            'Item::Held',
+            $item['availability']['notes'] ?? []
+        );
+        return $onHold ? 'In Transit On Hold' : 'In Transit';
+    }
+
+    /**
+     * Get item status code for Held status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemHeld($code, $data, $item)
+    {
+        return 'On Hold';
+    }
+
+    /**
+     * Get item status code for Waiting status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function getStatusCodeItemWaiting($code, $data, $item)
+    {
+        return 'On Holdshelf';
+    }
+
+    /**
+     * Get item type status code for NotForLoan status
+     *
+     * @param string $code Status code
+     * @param array  $data Status data
+     * @param array  $item Item
+     *
+     * @return string
+     */
+    protected function getStatusCodeItemTypeNotForLoan($code, $data, $item)
+    {
+        return $this->getStatusCodeItemNotForLoan($code, $data, $item);
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -180,22 +180,23 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @var array
      */
-    protected $itemStatusMappings = [];
+    protected $itemStatusMappings = [
+        'Item::Held' => 'On Hold',
+        'Item::Lost' => 'Lost--Library Applied',
+        'Item::Waiting' => 'On Holdshelf',
+    ];
 
     /**
-     * Item status mapping methods used when the item status mappings above don't
-     * contain a direct mapping.
+     * Item status mapping methods used when the item status mappings above
+     * (or in the configuration file) don't contain a direct mapping.
      *
      * @var array
      */
     protected $itemStatusMappingMethods = [
         'Item::CheckedOut' => 'getStatusCodeItemCheckedOut',
-        'Item::Lost' => 'getStatusCodeItemLost',
         'Item::NotForLoan' => 'getStatusCodeItemNotForLoan',
         'Item::NotForLoanForcing' => 'getStatusCodeItemNotForLoan',
         'Item::Transfer' => 'getStatusCodeItemTransfer',
-        'Item::Held' => 'getStatusCodeItemHeld',
-        'Item::Waiting' => 'getStatusCodeItemWaiting',
         'ItemType::NotForLoan' => 'getStatusCodeItemNotForLoan',
     ];
 
@@ -1822,22 +1823,6 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     }
 
     /**
-     * Get item status code for Lost status
-     *
-     * @param string $code Status code
-     * @param array  $data Status data
-     * @param array  $item Item
-     *
-     * @return string
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    protected function getStatusCodeItemLost($code, $data, $item)
-    {
-        return 'Lost--Library Applied';
-    }
-
-    /**
      * Get item status code for NotForLoan status
      *
      * @param string $code Status code
@@ -1879,38 +1864,6 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             $item['availability']['notes'] ?? []
         );
         return $onHold ? 'In Transit On Hold' : 'In Transit';
-    }
-
-    /**
-     * Get item status code for Held status
-     *
-     * @param string $code Status code
-     * @param array  $data Status data
-     * @param array  $item Item
-     *
-     * @return string
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    protected function getStatusCodeItemHeld($code, $data, $item)
-    {
-        return 'On Hold';
-    }
-
-    /**
-     * Get item status code for Waiting status
-     *
-     * @param string $code Status code
-     * @param array  $data Status data
-     * @param array  $item Item
-     *
-     * @return string
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    protected function getStatusCodeItemWaiting($code, $data, $item)
-    {
-        return 'On Holdshelf';
     }
 
     /**


### PR DESCRIPTION
Follow-up from #1730. I'm not quite convinced that this is easier to read, but at least it allows for easier overriding of specific cases if needed.