### PR TITLE
Feedbackforms: handle undefined reply-to address.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -183,7 +183,8 @@ class FeedbackController extends AbstractBase
                 $emailSubject,
                 $emailMessage,
                 null,
-                new Address($replyToEmail, $replyToName)
+                !empty($replyToEmail)
+                    ? new Address($replyToEmail, $replyToName) : null
             );
             return [true, null];
         } catch (MailException $e) {


### PR DESCRIPTION
`replyToEmail` can be undefined when not posted via the form and when profile email can not be used as a fallback (profile email not defined or user is not logged-in).  