### PR TITLE
KohaRest: Take public notes for items from the correct field.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1705,8 +1705,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     $result['data']['hold_queue_length']]
                 )
             ];
-            if (!empty($item['itemnotes'])) {
-                $entry['item_notes'] = [$item['itemnotes']];
+            if (!empty($item['public_notes'])) {
+                $entry['item_notes'] = [$item['public_notes']];
             }
 
             if ($patron && $this->itemHoldAllowed($item)) {


### PR DESCRIPTION
I had missed the fact that the itemnotes internal field is now translated to public_notes in the Koha REST API.