### PR TITLE
DEB package: allow compatibility with more Java packages.

### DIFF
--- a/packages/DEBIAN/control
+++ b/packages/DEBIAN/control
@@ -4,7 +4,7 @@ Section: World Wide Web
 Priority: Optional
 Architecture: all
 Depends: apache2,
-         default-jdk,
+         default-jdk | openjdk-11-jdk | openjdk-8-jdk,
          libapache2-mod-php,
          mysql-server | virtual-mysql-server-core,
          php-pear,


### PR DESCRIPTION
As currently written, the VuFind DEB package will force installation of the default JDK, even if a different JDK is already installed; this PR is an attempt to avoid duplicate JDK installation if it is not actually necessary.

TODO
- Build and test the package on a fresh VM; scenarios:
  - [x] Installation on clean system still works
  - [x] Installation with pre-existing JDK 8 still works, and does not install a duplicate JDK