### PR TITLE
Treat invalid date errors from Solr as parser errors.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
@@ -102,6 +102,7 @@ class ErrorListener extends AbstractErrorListener
             $reason = $body->error->msg;
             if (stristr($reason, 'org.apache.solr.search.SyntaxError')
                 || stristr($reason, 'undefined field')
+                || stristr($reason, 'invalid date')
             ) {
                 $tags[] = self::TAG_PARSER_ERROR;
             }


### PR DESCRIPTION
Currently date parsing errors end up in a 400 Bad Request. This change allows Solr's date parsing errors to be considered query parsing errors. E.g. Bing bot seems to be sometimes double-encoding pluses in a query string resulting in something like this in the VuFind search query string: `lookfor=xyz&filter[]=first_indexed%3A"[NOW-3MONTHS%2FDAY%2BTO%2B*]"`