### PR TITLE
Travis: Use Composer 1 until compatibility with 2 is fully resolved.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 before_script:
   - phpenv config-rm xdebug.ini
   - phpenv rehash
+  - composer selfupdate --1
   - composer install
   - npm install -g eslint@"<5.0.0"
   - npm install -g jshint@"2.9.6"


### PR DESCRIPTION
This PR gets the Travis build passing again by forcing use of Composer 1. For more on Composer 2 compatibility plans, see [VUFIND-1454](https://vufind.org/jira/browse/VUFIND-1454).