### PR TITLE
KohaRest: Request all results when endpoint uses paging

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -638,7 +638,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'path' => 'v1/holds',
                 'query' => [
                     'patron_id' => $patron['id'],
-                    '_match' => 'exact'
+                    '_match' => 'exact',
+                    '_per_page' => -1
                 ]
             ]
         );
@@ -1972,7 +1973,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $cacheKey = 'libraries';
         $libraries = $this->getCachedData($cacheKey);
         if (null === $libraries) {
-            $result = $this->makeRequest('v1/libraries');
+            $result = $this->makeRequest('v1/libraries?_per_page=-1');
             $libraries = [];
             foreach ($result['data'] as $library) {
                 $libraries[$library['library_id']] = $library;


### PR DESCRIPTION
I had not taken into account that the endpoints that allow paging have a default page size in Koha. By default it's 20, so chances were some records would have been left out.