### PR TITLE
KohaRest: Check also for 'errors' element in response.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1567,7 +1567,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         // valid JSON that the caller can handle
         $decodedResult = json_decode($result, true);
         if (empty($request['errors']) && !$response->isSuccess()
-            && (null === $decodedResult || !empty($decodedResult['error']))
+            && (null === $decodedResult || !empty($decodedResult['error'])
+            || !empty($decodedResult['errors']))
         ) {
             $params = $method == 'GET'
                 ? $client->getRequest()->getQuery()->toString()


### PR DESCRIPTION
Looks like a low-level error such as 500 results in 'errors' element instead of 'error'.