### PR TITLE
Filter out empty arrays

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -464,9 +464,7 @@ class EDS extends DefaultRecord
             'BibRecord/BibRelationships/HasContributorRelationships/*/'
                 . 'PersonEntity/Name/NameFull'
         );
-        return array_unique(array_filter($authors, function ($a) {
-            return !empty($a);
-        }));
+        return array_unique(array_filter($authors));
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -460,12 +460,13 @@ class EDS extends DefaultRecord
      */
     public function getPrimaryAuthors()
     {
-        return array_unique(
-            $this->extractEbscoDataFromRecordInfo(
-                'BibRecord/BibRelationships/HasContributorRelationships/*/'
+        $authors = $this->extractEbscoDataFromRecordInfo(
+            'BibRecord/BibRelationships/HasContributorRelationships/*/'
                 . 'PersonEntity/Name/NameFull'
-            )
         );
+        return array_unique(array_filter($authors, function ($a) {
+            return !empty($a);
+        }));
     }
 
     /**


### PR DESCRIPTION
In the case the `extractEbscoDataFromRecordInfo` method returns an empty array, which is expected behavior (also associated with the `recurseIntoRecordInfo` method), `array_unique` blows up. With additional filtering, it works as expected.