### PR TITLE
[Release 7.0] Account ajax fixes

### DIFF
--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -50,12 +50,16 @@ VuFind.register('account', function Account() {
     var accountStatus = ICON_LEVELS.NONE;
     for (var sub in _submodules) {
       if (Object.prototype.hasOwnProperty.call(_submodules, sub)) {
+        var status = _getStatus(sub);
+        if (status === INACTIVE) {
+          continue;
+        }
         var $element = $(_submodules[sub].selector);
-        if (!$element) {
+        if ($element.length === 0) {
+          // This could happen if the DOM is changed dynamically
           _statuses[sub] = INACTIVE;
           continue;
         }
-        var status = _getStatus(sub);
         if (status === MISSING) {
           $element.addClass('hidden');
         } else {

--- a/themes/bootstrap3/templates/librarycards/editcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/editcard.phtml
@@ -13,7 +13,7 @@
 
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
-<form class="form-edit-card" method="post" name="<?=empty($this->card->id) ? 'newCardForm' : 'editCardForm'?>" autocomplete="off">
+<form class="form-edit-card" method="post" name="<?=empty($this->card->id) ? 'newCardForm' : 'editCardForm'?>" autocomplete="off" data-clear-account-cache>
   <input type="hidden" name="id" value="<?=empty($this->card->id) ? 'NEW' : $this->card->id ?>"/>
   <div class="form-group">
     <label class="control-label" for="card_name"><?=$this->transEsc('Library Card Name'); ?>:</label>

--- a/themes/bootstrap3/templates/librarycards/home.phtml
+++ b/themes/bootstrap3/templates/librarycards/home.phtml
@@ -41,7 +41,7 @@
               <i class="fa fa-trash-o" aria-hidden="true"></i> <?=$this->transEsc('Delete')?>
             </a>
             <ul class="dropdown-menu">
-              <li><a href="<?=$this->url('librarycards-deletecard') ?>?cardID=<?=urlencode($record['id'])?>&amp;confirm=1"><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
+              <li><a href="<?=$this->url('librarycards-deletecard') ?>?cardID=<?=urlencode($record['id'])?>&amp;confirm=1" data-clear-account-cache><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
               <li><a href="#"><?=$this->transEsc('confirm_dialog_no')?></a></li>
             </ul>
           </div>


### PR DESCRIPTION
This fixes a couple of issues with account ajax.

The first issue with the element check only comes up when the `.fines-status` element is not available but something else is so that _render is called. With the bad check it would call render() method for fines without proper data, and since the render method checks for `if (status.value === 0)` the check is false and icon level becomes DANGER.