### PR TITLE
Make it possible to call renderTemplate for optional templates.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
@@ -66,13 +66,12 @@ trait ClassBasedTemplateRendererTrait
      * (or null if $className is already the top level; used for recursion only).
      *
      * @return string
-     * @throws RuntimeException
      */
     protected function resolveClassTemplate($template, $className,
         ResolverInterface $resolver, $topClassName = null
     ) {
         // If the template resolves, return it:
-        $templateWithClass = sprintf($template, $this->getBriefClass($className));
+        $templateWithClass = $this->getTemplateWithClass($template, $className);
         if ($resolver->resolve($templateWithClass)) {
             return $templateWithClass;
         }
@@ -81,11 +80,7 @@ trait ClassBasedTemplateRendererTrait
         // template from a parent class:
         $parentClass = get_parent_class($className);
         if (empty($parentClass)) {
-            // No more parent classes left to try?  Throw an exception!
-            throw new RuntimeException(
-                'Cannot find ' . $templateWithClass . ' template for class: '
-                . ($topClassName ?? $className)
-            );
+            return '';
         }
 
         // Recurse until we find a template or run out of parents...
@@ -101,19 +96,34 @@ trait ClassBasedTemplateRendererTrait
      * @param string $template  Template path (with %s as class name placeholder)
      * @param string $className Name of class to apply to template.
      * @param array  $context   Context for rendering template
+     * @param bool   $throw     If true (default), an exception is thrown if the
+     * template is not found. Otherwise an empty string is returned.
      *
      * @return string
      * @throws RuntimeException
      */
-    protected function renderClassTemplate($template, $className, $context = [])
-    {
+    protected function renderClassTemplate($template, $className, $context = [],
+        $throw = true
+    ) {
         // Set up the needed context in the view:
         $view = $this->getView();
         $contextHelper = $view->plugin('context');
         $oldContext = $contextHelper($view)->apply($context);
 
         // Find and render the template:
-        $html = $view->render($this->getCachedClassTemplate($template, $className));
+        $classTemplate = $this->getCachedClassTemplate($template, $className);
+        if (!$classTemplate) {
+            if ($throw) {
+                throw new RuntimeException(
+                    'Cannot find '
+                    . $this->getTemplateWithClass($template, '[brief class name]')
+                    . " for class $className or any of its parent classes"
+                );
+            }
+            return '';
+        }
+
+        $html = $view->render($classTemplate);
 
         // Restore the original context before returning the result:
         $contextHelper($view)->restore($oldContext);
@@ -128,7 +138,6 @@ trait ClassBasedTemplateRendererTrait
      * @param string $className Name of class to apply to template.
      *
      * @return string
-     * @throws RuntimeException
      */
     protected function getCachedClassTemplate($template, $className)
     {
@@ -152,5 +161,18 @@ trait ClassBasedTemplateRendererTrait
     {
         $classParts = explode('\\', $className);
         return array_pop($classParts);
+    }
+
+    /**
+     * Helper to put the template path and class name together
+     *
+     * @param string $template  Template path (with %s as class name placeholder)
+     * @param string $className Class name to abbreviate
+     *
+     * @return string
+     */
+    protected function getTemplateWithClass(string $template, string $className
+    ): string {
+        return sprintf($template, $this->getBriefClass($className));
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ClassBasedTemplateRendererTrait.php
@@ -112,18 +112,15 @@ trait ClassBasedTemplateRendererTrait
 
         // Find and render the template:
         $classTemplate = $this->getCachedClassTemplate($template, $className);
-        if (!$classTemplate) {
-            if ($throw) {
-                throw new RuntimeException(
-                    'Cannot find '
-                    . $this->getTemplateWithClass($template, '[brief class name]')
-                    . " for class $className or any of its parent classes"
-                );
-            }
-            return '';
+        if (!$classTemplate && $throw) {
+            throw new RuntimeException(
+                'Cannot find '
+                . $this->getTemplateWithClass($template, '[brief class name]')
+                . " for class $className or any of its parent classes"
+            );
         }
 
-        $html = $view->render($classTemplate);
+        $html = $classTemplate ? $view->render($classTemplate) : '';
 
         // Restore the original context before returning the result:
         $contextHelper($view)->restore($oldContext);

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -99,15 +99,17 @@ class Record extends \Laminas\View\Helper\AbstractHelper
      * @param array  $context Variables needed for rendering template; these will
      * be temporarily added to the global view context, then reverted after the
      * template is rendered (default = record driver only).
+     * @param bool   $throw   If true (default), an exception is thrown if the
+     * template is not found. Otherwise an empty string is returned.
      *
      * @return string
      */
-    public function renderTemplate($name, $context = null)
+    public function renderTemplate($name, $context = null, $throw = true)
     {
         $template = 'RecordDriver/%s/' . $name;
         $className = get_class($this->driver);
         return $this->renderClassTemplate(
-            $template, $className, $context ?? ['driver' => $this->driver]
+            $template, $className, $context ?? ['driver' => $this->driver], $throw
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -61,7 +61,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
     public function testMissingTemplate()
     {
         $this->expectException(\Laminas\View\Exception\RuntimeException::class);
-        $this->expectExceptionMessage('Cannot find RecordDriver/AbstractBase/core.phtml template for class: VuFind\\RecordDriver\\SolrMarc');
+        $this->expectExceptionMessage('Cannot find RecordDriver/[brief class name]/core.phtml for class VuFind\\RecordDriver\\SolrMarc or any of its parent classes');
 
         $record = $this->getRecord($this->loadRecordFixture('testbug1.json'));
         $record->getView()->resolver()->expects($this->at(0))->method('resolve')
@@ -70,6 +70,21 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $record->getView()->expects($this->any())->method('render')
             ->will($this->throwException(new RuntimeException('boom')));
         $record->getCoreMetadata();
+    }
+
+    /**
+     * Test attempting to display a template that does not exist without throwing an
+     * exception.
+     *
+     * @return void
+     */
+    public function testMissingTemplateWithoutException()
+    {
+        $record = $this->getRecord($this->loadRecordFixture('testbug1.json'));
+        $this->assertEquals(
+            '',
+            $record->renderTemplate('foo', [], false)
+        );
     }
 
     /**


### PR DESCRIPTION
This allows renderTemplate to be called even if it's not certain that the given template exists.

We have some driver-specific templates that only need to be rendered if they exist, but the rendering is done by a template shared between all the drivers.