### PR TITLE
Configurable top facet override of alphabetical sort for limits

### DIFF
--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -256,6 +256,14 @@ translated_facets[] = callnumber-first:CallNumberFirst
 ; These facets will be displayed on the Home Page when FacetList is turned on in
 ; the content setting of the [HomePage] section of searches.ini. If this section
 ; is omitted, the [Advanced] section will be used instead.
+
+; Override the alphabetical sorting for individual facets and display them at the
+; top of the limits on the advanced search page. As an example, this could be used
+; to display the most commonly searched languages above the rest. All following
+; limits display in the natural sorted order.
+;limit[language] = Icelandic,English,Spanish
+;limit[format] = CD,DVD
+
 [HomePage]
 callnumber-first = "Call Number"
 language         = Language

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -261,11 +261,11 @@ translated_facets[] = callnumber-first:CallNumberFirst
 ; top of the limits on the advanced search page. As an example, this could be used
 ; to display the most commonly searched languages above the rest. All following
 ; limits display in the natural sorted order.
-;limit[language] = Icelandic::English::Spanish
-;limit[format] = CD::DVD
+;limitOrderOverride[language] = Icelandic::English::Spanish
+;limitOrderOverride[format] = CD::DVD
 
-; Optional delimiter to use in the limit settings above. When enabled, limits must
-; be separated using the same character set here.
+; Optional delimiter to use in the limitOrderOverride settings above. When enabled,
+; limits must be separated using the same character set here.
 ;limitDelimiter = "::"
 
 [HomePage]

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -261,8 +261,12 @@ translated_facets[] = callnumber-first:CallNumberFirst
 ; top of the limits on the advanced search page. As an example, this could be used
 ; to display the most commonly searched languages above the rest. All following
 ; limits display in the natural sorted order.
-;limit[language] = Icelandic,English,Spanish
-;limit[format] = CD,DVD
+;limit[language] = Icelandic::English::Spanish
+;limit[format] = CD::DVD
+
+; Optional delimiter to use in the limit settings above. When enabled, limits must
+; be separated using the same character set here.
+;limitDelimiter = "::"
 
 [HomePage]
 callnumber-first = "Call Number"

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -982,4 +982,21 @@ abstract class Options implements TranslatorAwareInterface
         $this->autocompleteAutoSubmit = $searchSettings->Autocomplete->auto_submit
             ?? $this->autocompleteAutoSubmit;
     }
+
+    /**
+     * Get advanced search limits that override the natural sorting to
+     * display at the top.
+     *
+     * @param string $limit advanced search limit
+     *
+     * @return array
+     */
+    public function topLimits($limit)
+    {
+        $facetSettings = $this->configLoader->get($this->getFacetsIni());
+        $limits = $facetSettings->Advanced_Settings->limit;
+        $limitConf = $limits && $limits->get($limit) ?
+            preg_replace('/\s+/', '', $limits->get($limit)) : '';
+        return explode(',', $limitConf);
+    }
 }

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -995,8 +995,10 @@ abstract class Options implements TranslatorAwareInterface
     {
         $facetSettings = $this->configLoader->get($this->getFacetsIni());
         $limits = $facetSettings->Advanced_Settings->limit;
+        $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?
+            $facetSettings->Advanced_Settings->limitDelimiter : '::';
         $limitConf = $limits && $limits->get($limit) ?
             preg_replace('/\s+/', '', $limits->get($limit)) : '';
-        return explode(',', $limitConf);
+        return explode($delimiter, $limitConf);
     }
 }

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -994,9 +994,8 @@ abstract class Options implements TranslatorAwareInterface
     public function limitOrderOverride($limit)
     {
         $facetSettings = $this->configLoader->get($this->getFacetsIni());
-        $limits = $facetSettings->Advanced_Settings->limitOrderOverride;
-        $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?
-            $facetSettings->Advanced_Settings->limitDelimiter : '::';
+        $limits = $facetSettings->Advanced_Settings->limitOrderOverride ?? null;
+        $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?? '::';
         $limitConf = $limits ? $limits->get($limit) : '';
         return array_map('trim', explode($delimiter, $limitConf));
     }

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -997,8 +997,7 @@ abstract class Options implements TranslatorAwareInterface
         $limits = $facetSettings->Advanced_Settings->limitOrderOverride;
         $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?
             $facetSettings->Advanced_Settings->limitDelimiter : '::';
-        $limitConf = $limits && $limits->get($limit) ?
-            preg_replace('/\s+/', '', $limits->get($limit)) : '';
-        return explode($delimiter, $limitConf);
+        $limitConf = $limits ? $limits->get($limit) : '';
+        return array_map('trim', explode($delimiter, $limitConf));
     }
 }

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -991,10 +991,10 @@ abstract class Options implements TranslatorAwareInterface
      *
      * @return array
      */
-    public function topLimits($limit)
+    public function limitOrderOverride($limit)
     {
         $facetSettings = $this->configLoader->get($this->getFacetsIni());
-        $limits = $facetSettings->Advanced_Settings->limit;
+        $limits = $facetSettings->Advanced_Settings->limitOrderOverride;
         $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?
             $facetSettings->Advanced_Settings->limitDelimiter : '::';
         $limitConf = $limits && $limits->get($limit) ?

--- a/module/VuFind/src/VuFind/View/Helper/Root/Config.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Config.php
@@ -88,20 +88,4 @@ class Config extends \Laminas\View\Helper\AbstractHelper
     {
         return $this->get('config')->Content->ajaxcovers ?? false;
     }
-
-    /**
-     * Get advanced search limits that override the natural sorting to
-     * display at the top.
-     *
-     * @param string $limit advanced search limit
-     *
-     * @return array
-     */
-    public function topLimits($limit)
-    {
-        $limits = $this->get('facets')->Advanced_Settings->limit;
-        $limitConf = $limits && $limits->get($limit) ?
-            preg_replace('/\s+/', '', $limits->get($limit)) : '';
-        return explode(',', $limitConf);
-    }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Config.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Config.php
@@ -88,4 +88,20 @@ class Config extends \Laminas\View\Helper\AbstractHelper
     {
         return $this->get('config')->Content->ajaxcovers ?? false;
     }
+
+    /**
+     * Get advanced search limits that override the natural sorting to
+     * display at the top.
+     *
+     * @param string $limit advanced search limit
+     *
+     * @return array
+     */
+    public function topLimits($limit)
+    {
+        $limits = $this->get('facets')->Advanced_Settings->limit;
+        $limitConf = $limits && $limits->get($limit) ?
+            preg_replace('/\s+/', '', $limits->get($limit)) : '';
+        return explode(',', $limitConf);
+    }
 }

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -16,16 +16,34 @@
               <?php endforeach; ?>
             <?php else: ?>
               <?php
-              // Sort the current facet list alphabetically; we'll use this data
+              // Sort the current facet list alphabetically and filter items to
+              // the top if they appear in the config; we'll use this data
               // along with the foreach below to display facet options in the
               // correct order.
+              $conf = $this->config()->topLimits($field);
               $sorted = [];
+              $filtered = [];
               foreach ($list['list'] as $i => $value) {
                 if (!empty($value['displayText'])) {
-                  $sorted[$i] = $value['displayText'];
+                  if (in_array($value['displayText'], $conf)) {
+                    $filtered[$i] = $value['displayText'];
+                  } else {
+                    $sorted[$i] = $value['displayText'];
+                  }
                 }
               }
               natcasesort($sorted);
+
+              // Order filtered items according to how they appear in the config.
+              $filterKeys = array_flip($conf);
+              uasort($filtered, function ($a, $b) use ($filterKeys) {
+                return $filterKeys[$a] > $filterKeys[$b] ? 1 : -1;
+              });
+
+              // Combine filtered and sorted arrays so that the items in the config
+              // appear in order at the top and all other items appear afterwards
+              // sorted by natcasesort.
+              $sorted = $filtered + $sorted;
               ?>
               <?php foreach ($sorted as $i => $display): ?>
                 <?php $value = $list['list'][$i]; ?>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -20,7 +20,7 @@
               // the top if they appear in the config; we'll use this data
               // along with the foreach below to display facet options in the
               // correct order.
-              $conf = $this->options->topLimits($field);
+              $conf = $this->options->limitOrderOverride($field);
               $sorted = [];
               $filtered = [];
               foreach ($list['list'] as $i => $value) {

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -37,7 +37,7 @@
               // Order filtered items according to how they appear in the config.
               $filterKeys = array_flip($conf);
               uasort($filtered, function ($a, $b) use ($filterKeys) {
-                return $filterKeys[$a] > $filterKeys[$b] ? 1 : -1;
+                return $filterKeys[$a] <=> $filterKeys[$b];
               });
 
               // Combine filtered and sorted arrays so that the items in the config

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -20,7 +20,7 @@
               // the top if they appear in the config; we'll use this data
               // along with the foreach below to display facet options in the
               // correct order.
-              $conf = $this->config()->topLimits($field);
+              $conf = $this->options->topLimits($field);
               $sorted = [];
               $filtered = [];
               foreach ($list['list'] as $i => $value) {


### PR DESCRIPTION
# Problem

We need to display our top 8 most frequently used languages at the top of the advanced search limit box. 

![image](https://user-images.githubusercontent.com/7826429/101832578-46915a80-3afd-11eb-8139-85a91e124f0b.png)

In order to achieve this, this pull request allows facets to be configured with an override that will place them at the top of the advanced search limit box (See Language in the image above). This implementation allows the static display order to be determined by the configuration. All facets not included in the config are displayed in their natural alphabetical sort order following the static ones from the config. This only works with regular facets, it does not work with hierarchical facets.