### PR TITLE
KohaRest: Check that item_id is set before sending it to Koha.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -922,6 +922,11 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             ];
         }
 
+        // Check if we have an item id:
+        if (empty($data['item_id'])) {
+            return false;
+        }
+
         $result = $this->makeRequest(
             [
                 'path' => [


### PR DESCRIPTION
It might not be if it's missing from HMACKeys.