### PR TITLE
FeedbackForms: require one checkbox option to be selected

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -47,16 +47,18 @@
 #
 #   fields (array) List of form elements with the following options:
 #
-#     name (string)      Element name
-#     label (string)     Element label (translation key)
-#     required (boolean) Is the element required?
-#     settings (array)   HTML attributes as key-value pairs, for example:
+#     name (string)        Element name
+#     label (string)       Element label (translation key)
+#     required (boolean)   Is the element required? (for checkbox elements this means that
+#                          all options have to be selected.)
+#     requireOne (boolean) Require at least one checkbox option to be selected.
+#     settings (array)     HTML attributes as key-value pairs, for example:
 #       - [class, "custom-css-class another-class"]
-#     type (string)      Element type (text|textarea|email|url|select|radio|checkbox|hidden)
+#     type (string)        Element type (text|textarea|email|url|select|radio|checkbox|hidden)
 #
-#     help (string)      Element help text (translation key) that is displayed before the element.
-#                        To include HTML formatting, use a translation key ending
-#                        in '_html' here, and define markup in the language files.
+#     help (string)        Element help text (translation key) that is displayed before the element.
+#                          To include HTML formatting, use a translation key ending
+#                          in '_html' here, and define markup in the language files.
 #
 #       or
 #

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -397,7 +397,8 @@ class Form extends \Laminas\Form\Form implements
     protected function getFormElementSettingFields()
     {
         return [
-            'required', 'help', 'value', 'inputType', 'group', 'placeholder'
+            'required', 'requireOne', 'help', 'value', 'inputType', 'group',
+            'placeholder'
         ];
     }
 
@@ -758,7 +759,10 @@ class Form extends \Laminas\Form\Form implements
         ];
 
         foreach ($this->getElements() as $el) {
-            $required = ($el['required'] ?? false) === true;
+            $required = $el['type'] === 'checkbox'
+               ? $el['required'] ?? $el['requireOne'] ?? false
+               : $el['required'] ?? false;
+
             $fieldValidators = [];
             if ($required) {
                 $fieldValidators[] = $validators['notEmpty'];

--- a/themes/bootstrap3/less/components/form.less
+++ b/themes/bootstrap3/less/components/form.less
@@ -17,6 +17,7 @@ form {
     }
     .form-group label.required::before,
     .form-group .radio-label.required::before,
+    .form-group .radio-label.require-one::before
     {
         content: '* ';
     }

--- a/themes/bootstrap3/scss/components/form.scss
+++ b/themes/bootstrap3/scss/components/form.scss
@@ -17,6 +17,7 @@ form {
     }
     .form-group label.required::before,
     .form-group .radio-label.required::before,
+    .form-group .radio-label.require-one::before
     {
         content: '* ';
     }

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -83,10 +83,14 @@
     <?php endif ?>
     <?php if ($el['type'] !== 'submit'): ?>
       <?php if ($el['label']): ?>
+        <?php
+          $required = $el['required'] ?? false;
+          $requireOne = !$required && ($el['requireOne'] ?? false);
+        ?>
         <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
-          <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=!empty($el['required']) ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
+          <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=$required ? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
         <?php else: ?>
-          <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=!empty($el['required']) ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
+          <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=!empty($required) ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
         <?php endif ?>
       <?php endif ?>
     <?php else: ?>

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -90,7 +90,7 @@
         <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
           <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=$required ? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
         <?php else: ?>
-          <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=!empty($required) ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
+          <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=$required ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
         <?php endif ?>
       <?php endif ?>
     <?php else: ?>


### PR DESCRIPTION
Currently enabling `required` setting for a checkbox element makes the validation require all options to be selected.

This PR adds `requireOne` setting, that loosens the validation by requiring that at least one (but not necessarily all) options is selected. 

The changes only affect the client-side/browser validation by leaving `require` attributes out from the option-elements. Backend validation still uses `Laminas\Validator\NotEmpty`, that only verifies that some options have been selected. 

