### PR TITLE
makes MARC record field configurable

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1721,11 +1721,14 @@ jump_to_single_search_result = false
 ; punctuation, but this can be used when ISBD punctuation is absent (e.g. ", ").
 ;marcPublicationInfoSeparator = " "
 
-; If you have a custom index, you might want to change the field
-; where the full MARC record is supposed to be.
-; You can do that with this configuration setting.
+; If you have a custom index, you might want to change the field where the full
+; MARC record is supposed to be. The field will be checked and ignored, if it is
+; not a valid index field or does not exist in the record or index schema.
+; If you have multiple fields with MARC content, you may add all of them
+; by using a comma sepated list. The first field is the preferred one, if it does not
+; exist, the next ones are taken.
 ; (Default = "fullrecord")
-preferredMarcField = "fullrecord"
+preferredMarcFields = "fullrecord"
 
 ; When displaying publication information from 260/264, this can be set to true
 ; to make 264 information completely replace 260 information. Default is false,

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1721,6 +1721,12 @@ jump_to_single_search_result = false
 ; punctuation, but this can be used when ISBD punctuation is absent (e.g. ", ").
 ;marcPublicationInfoSeparator = " "
 
+; If you have a custom index, you might want to change the field
+; where the full MARC record is supposed to be.
+; You can do that with this configuration setting.
+; (Default = "fullrecord")
+preferredMarcField = "fullrecord"
+
 ; When displaying publication information from 260/264, this can be set to true
 ; to make 264 information completely replace 260 information. Default is false,
 ; which will display information from 260 AND 264 when both fields are populated.

--- a/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
@@ -58,12 +58,18 @@ trait MarcReaderTrait
     public function getMarcRecord()
     {
         if (null === $this->lazyMarcRecord) {
-            // Get preferred MARC field from config, if it is set and is existing:
-            $marcField = (isset($this->mainConfig->Record->preferredMarcField)
-                    && array_key_exists($this->mainConfig->Record->preferredMarcField, $this->fields))
-                ? $this->mainConfig->Record->preferredMarcField : 'fullrecord';
-
-            $marc = trim($this->fields[$marcField]);
+            // Get preferred MARC field from config, if it is set and is existing
+            $preferredMarcFields = $this->mainConfig->Record->preferredMarcFields ?? 'fullrecord';
+            $preferredMarcFieldArray = explode(',', $preferredMarcFields);
+            $preferredMarcField = 'fullrecord';
+            foreach ($preferredMarcFieldArray as $testField) {
+                if (array_key_exists($testField, $this->fields)) {
+                    $preferredMarcField = $testField;
+                    break;
+                }
+            }
+var_dump($preferredMarcField);
+            $marc = trim($this->fields[$preferredMarcField]);
 
             // check if we are dealing with MARCXML
             if (substr($marc, 0, 1) == '<') {

--- a/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
@@ -59,7 +59,8 @@ trait MarcReaderTrait
     {
         if (null === $this->lazyMarcRecord) {
             // Get preferred MARC field from config, if it is set and is existing
-            $preferredMarcFields = $this->mainConfig->Record->preferredMarcFields ?? 'fullrecord';
+            $preferredMarcFields = $this->mainConfig->Record->preferredMarcFields
+                ?? 'fullrecord';
             $preferredMarcFieldArray = explode(',', $preferredMarcFields);
             $preferredMarcField = 'fullrecord';
             foreach ($preferredMarcFieldArray as $testField) {

--- a/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
@@ -58,7 +58,12 @@ trait MarcReaderTrait
     public function getMarcRecord()
     {
         if (null === $this->lazyMarcRecord) {
-            $marc = trim($this->fields['fullrecord']);
+            // Get preferred MARC field from config, if it is set and is existing:
+            $marcField = (isset($this->mainConfig->Record->preferredMarcField)
+                    && array_key_exists($this->mainConfig->Record->preferredMarcField, $this->fields))
+                ? $this->mainConfig->Record->preferredMarcField : 'fullrecord';
+
+            $marc = trim($this->fields[$marcField]);
 
             // check if we are dealing with MARCXML
             if (substr($marc, 0, 1) == '<') {

--- a/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php
@@ -68,7 +68,7 @@ trait MarcReaderTrait
                     break;
                 }
             }
-var_dump($preferredMarcField);
+
             $marc = trim($this->fields[$preferredMarcField]);
 
             // check if we are dealing with MARCXML


### PR DESCRIPTION
We are using a central index provided by the Common Library Network in Germany for VuFind. The Common Library Network wants to introduce a new index field to hold the MARC records in MARCXML instead of raw binary MARC. But they do not want to import the content into the default field in VuFind (fullrecord), as there are very different clients using this index and such a change could cause problems with some of the other clients. That's why they want to introduce a new index field for that. VuFind could deal with MARCXML in the fullrecord field, but it can't easily use a different field to hold the full MARC record.

This PR makes the field with the full MARC record configurable by introducing a new configuration option in 'config.ini'. If this new option is not set, VuFind will keep fullrecord as the default field. I have implemented a check, if the field in the configuration really exists in the record; if not, VuFind will fallback to the default field. This should help avoiding any misconfiguration issues.

It would help us (and probably other VuFind users with the index by Common Library Network), if this PR could be merged into VuFind main and I would not expect it to break anything. But I would also understand, if this would be considered as too specific, though...