### PR TITLE
Checkbox validators

### DIFF
--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -28,10 +28,10 @@
 namespace VuFind\Form;
 
 use Laminas\InputFilter\InputFilter;
-use Laminas\Validator\EmailAddress;
-use Laminas\Validator\NotEmpty;
-use Laminas\Validator\Identical;
 use Laminas\Validator\Callback;
+use Laminas\Validator\EmailAddress;
+use Laminas\Validator\Identical;
+use Laminas\Validator\NotEmpty;
 use Laminas\View\HelperPluginManager;
 use VuFind\Config\YamlReader;
 
@@ -781,7 +781,7 @@ class Form extends \Laminas\Form\Form implements
                             }
                          ]
                     ];
-                } else if ($required) {
+                } elseif ($required) {
                     $fieldValidators[] = [
                         'name' => Identical::class,
                         'options' => [

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -762,9 +762,8 @@ class Form extends \Laminas\Form\Form implements
 
         foreach ($this->getElements() as $el) {
             $isCheckbox = $el['type'] === 'checkbox';
-            $required = $el['required']
-                ?? ($isCheckbox && ($el['requireOne'] ?? false));
             $requireOne = $isCheckbox && ($el['requireOne'] ?? false);
+            $required = $el['required'] ?? $requireOne;
 
             $fieldValidators = [];
             if ($required || $requireOne) {

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -88,3 +88,21 @@ forms:
           - option-2
         label: checkbox
         requireOne: true
+
+  TestCheckboxWithOneOptionThatIsRequired:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - option-1
+        label: checkbox
+        required: true
+
+  TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - option-1
+        label: checkbox
+        requireOne: true

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -68,3 +68,23 @@ forms:
           - option-1
           - option-2
         label: checkbox2
+
+  TestCheckboxWithAllOptionsRequired:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - option-1
+          - option-2
+        label: checkbox
+        required: true
+
+  TestCheckboxWithOneOptionRequired:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - option-1
+          - option-2
+        label: checkbox
+        requireOne: true

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -304,7 +304,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
             ['option-1' => 'option-1', 'option-2' => 'option-2'],
             $el['options']
         );
-
     }
 
     /**
@@ -322,7 +321,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
         $mock->expects($this->any())->method('get')
             ->with($this->equalTo('FeedbackForms.yaml'))
             ->will($this->returnValue($config));
-
 
         // Test checkbox with all options required
         $form = new Form(
@@ -350,7 +348,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
         // Both required options and one invalid
         $form->setData(['checkbox' => ['option-1', 'option-2', 'invalid-option']]);
         $this->assertFalse($form->isValid());
-
 
         // Test checkbox with one required option
         $form = new Form(
@@ -383,7 +380,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
         $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
         $this->assertTrue($form->isValid());
 
-
         // Test checkbox with a single options that is required
         $form = new Form(
             $mock,
@@ -406,7 +402,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
         // One OK and one invalid option
         $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
         $this->assertFalse($form->isValid());
-
 
         // Test checkbox with a single options that is required,
         // configured with requireOne

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -304,5 +304,83 @@ class FormTest extends \VuFindTest\Unit\TestCase
             ['option-1' => 'option-1', 'option-2' => 'option-2'],
             $el['options']
         );
+
+    }
+
+    /**
+     * Test checkbox element validators.
+     *
+     * @return void
+     */
+    public function testCheckboxValidators()
+    {
+        $config = Yaml::parse($this->getFixture('configs/feedbackforms/test.yaml'));
+        $mock = $this->getMockBuilder(\VuFind\Config\YamlReader::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
+        $mock->expects($this->any())->method('get')
+            ->with($this->equalTo('FeedbackForms.yaml'))
+            ->will($this->returnValue($config));
+
+
+        // Test checkbox with all options required
+        $form = new Form(
+            $mock,
+            $this->createMock(\Laminas\View\HelperPluginManager::class)
+        );
+        $form->setFormId('TestCheckboxWithAllOptionsRequired');
+
+        // No options
+        $form->setData(['checkbox' => []]);
+        $this->assertFalse($form->isValid());
+
+        // One OK option, another missing
+        $form->setData(['checkbox' => ['option-1']]);
+        $this->assertFalse($form->isValid());
+
+        // One OK option, another invalid
+        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+        // Both required options
+        $form->setData(['checkbox' => ['option-1', 'option-2']]);
+        $this->assertTrue($form->isValid());
+
+        // Both required options and one invalid
+        $form->setData(['checkbox' => ['option-1', 'option-2', 'invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+
+        // Test checkbox with one required option
+        $form = new Form(
+            $mock,
+            $this->createMock(\Laminas\View\HelperPluginManager::class)
+        );
+        $form->setFormId('TestCheckboxWithOneOptionRequired');
+
+        // No options
+        $form->setData(['checkbox' => []]);
+        $this->assertFalse($form->isValid());
+
+        // One invalid option
+        $form->setData(['checkbox' => ['invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+        // One OK option
+        $form->setData(['checkbox' => ['option-1']]);
+        $this->assertTrue($form->isValid());
+
+        // One OK options
+        $form->setData(['checkbox' => ['option-2']]);
+        $this->assertTrue($form->isValid());
+
+        // Both options OK
+        $form->setData(['checkbox' => ['option-1', 'option-2']]);
+        $this->assertTrue($form->isValid());
+
+        // One OK and one invalid option
+        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+        $this->assertTrue($form->isValid());
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -382,5 +382,56 @@ class FormTest extends \VuFindTest\Unit\TestCase
         // One OK and one invalid option
         $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
         $this->assertTrue($form->isValid());
+
+
+        // Test checkbox with a single options that is required
+        $form = new Form(
+            $mock,
+            $this->createMock(\Laminas\View\HelperPluginManager::class)
+        );
+        $form->setFormId('TestCheckboxWithOneOptionThatIsRequired');
+
+        // No options
+        $form->setData(['checkbox' => []]);
+        $this->assertFalse($form->isValid());
+
+        // One invalid option
+        $form->setData(['checkbox' => ['invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+        // One OK option
+        $form->setData(['checkbox' => ['option-1']]);
+        $this->assertTrue($form->isValid());
+
+        // One OK and one invalid option
+        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+
+        // Test checkbox with a single options that is required,
+        // configured with requireOne
+        $form = new Form(
+            $mock,
+            $this->createMock(\Laminas\View\HelperPluginManager::class)
+        );
+        $form->setFormId(
+            'TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne'
+        );
+
+        // No options
+        $form->setData(['checkbox' => []]);
+        $this->assertFalse($form->isValid());
+
+        // One invalid option
+        $form->setData(['checkbox' => ['invalid-option']]);
+        $this->assertFalse($form->isValid());
+
+        // One OK option
+        $form->setData(['checkbox' => ['option-1']]);
+        $this->assertTrue($form->isValid());
+
+        // One OK and one invalid option
+        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+        $this->assertTrue($form->isValid());
     }
 }

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -85,10 +85,10 @@
       <?php if ($el['label']): ?>
         <?php
           $required = $el['required'] ?? false;
-          $requireOne = !$required && ($el['requireOne'] ?? false);
+          $requireOne = $el['requireOne'] ?? false;
         ?>
         <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
-          <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=$required ? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
+          <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=$required && !$requireOne? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
         <?php else: ?>
           <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=$required ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
         <?php endif ?>


### PR DESCRIPTION
Continued from https://github.com/vufind-org/vufind/pull/1811

Improve server-side validation of  checkbox elements:
- when `required` setting is true, posted options are validated with `\Laminas\Validator\Identical`. The validation fails if any of the configured options are missing or if not configured options are posted.
- when `requireOne` setting is true, posted option(s) are compared to the configured options using a custom callback (`InArray`can't be used here, since it doesn't work when the needle is an array).

Both cases are also validated with `notEmpty`.