### PR TITLE
Explicitly initialize OpenURL embedding in ajax-loaded record tabs.

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -161,6 +161,10 @@ function registerTabEvents() {
   handleAjaxTabLinks();
 
   VuFind.lightbox.bind('.tab-pane.active');
+
+  if (typeof VuFind.openurl !== 'undefined') {
+    VuFind.openurl.init($('.tab-pane.active'));
+  }
 }
 
 function removeHashFromLocation() {


### PR DESCRIPTION
This should fix any timing issues with binding to OpenURL elements as reported in https://github.com/vufind-org/vufind/pull/1581#issuecomment-758250727.