### PR TITLE
Adjust timeouts in tool configurations.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -202,8 +202,9 @@
     <if>
       <not><equals arg1="${existing_solr_version}" arg2="${solr_version}" /></not>
       <then>
-        <!-- make sure we don't run out of memory during installation: -->
+        <!-- make sure we don't run out of memory or time during installation: -->
         <php expression="ini_set('memory_limit', '1G');" />
+        <php expression="ini_set('default_socket_timeout', '600');" />
 
         <!-- download from Apache if not already present in the downloads cache -->
         <if>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "config": {
         "platform": {
             "php": "7.2"
-        }
+        },
+        "process-timeout": 0
     },
     "require": {
         "php": ">=7.2",


### PR DESCRIPTION
Reduces the chance of problems caused by slow Solr download during "composer install"