### PR TITLE
FeedbackForms: fix required/requireOne checkbox validator.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -776,7 +776,12 @@ class Form extends \Laminas\Form\Form implements
                         'options' => [
                             'callback' => function ($value, $context) use ($el) {
                                 return
-                                    !empty(array_intersect($el['options'], $value));
+                                    !empty(
+                                        array_intersect(
+                                            array_keys($el['options']),
+                                            $value
+                                        )
+                                    );
                             }
                          ]
                     ];
@@ -789,7 +794,7 @@ class Form extends \Laminas\Form\Form implements
                                 => $this->getValidationMessage('empty')
                             ],
                             'strict' => true,
-                            'token' => array_values($el['options'])
+                            'token' => array_keys($el['options'])
                         ]
                     ];
                 }

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -106,3 +106,47 @@ forms:
           - option-1
         label: checkbox
         requireOne: true
+
+  TestCheckboxWithAllOptionsRequired-2:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+          - label: Option 2
+            value: option-2
+        label: checkbox
+        required: true
+
+  TestCheckboxWithOneOptionRequired-2:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+          - label: Option 2
+            value: option-2
+        label: checkbox
+        requireOne: true
+
+  TestCheckboxWithOneOptionThatIsRequired-2:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+        label: checkbox
+        required: true
+
+  TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne-2:
+    fields:
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+        label: checkbox
+        requireOne: true

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -323,110 +323,143 @@ class FormTest extends \VuFindTest\Unit\TestCase
             ->will($this->returnValue($config));
 
         // Test checkbox with all options required
-        $form = new Form(
-            $mock,
-            $this->createMock(\Laminas\View\HelperPluginManager::class)
-        );
-        $form->setFormId('TestCheckboxWithAllOptionsRequired');
+        $ids = [
+            'TestCheckboxWithAllOptionsRequired',  // options with value
+            'TestCheckboxWithAllOptionsRequired-2' // options with label and value
+        ];
 
-        // No options
-        $form->setData(['checkbox' => []]);
-        $this->assertFalse($form->isValid());
+        foreach ($ids as $id) {
+            $form = new Form(
+                $mock,
+                $this->createMock(\Laminas\View\HelperPluginManager::class)
+            );
+            $form->setFormId($id);
 
-        // One OK option, another missing
-        $form->setData(['checkbox' => ['option-1']]);
-        $this->assertFalse($form->isValid());
+            // No options
+            $form->setData(['checkbox' => []]);
+            $this->assertFalse($form->isValid());
 
-        // One OK option, another invalid
-        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // One OK option, another missing
+            $form->setData(['checkbox' => ['option-1']]);
+            $this->assertFalse($form->isValid());
 
-        // Both required options
-        $form->setData(['checkbox' => ['option-1', 'option-2']]);
-        $this->assertTrue($form->isValid());
+            // One OK option, another invalid
+            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $this->assertFalse($form->isValid());
 
-        // Both required options and one invalid
-        $form->setData(['checkbox' => ['option-1', 'option-2', 'invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // Both required options
+            $form->setData(['checkbox' => ['option-1', 'option-2']]);
+            $this->assertTrue($form->isValid());
+
+            // Both required options and one invalid
+            $form->setData(['checkbox' => ['option-1', 'option-2', 'invalid-option']]);
+            $this->assertFalse($form->isValid());
+        }
+
 
         // Test checkbox with one required option
-        $form = new Form(
-            $mock,
-            $this->createMock(\Laminas\View\HelperPluginManager::class)
-        );
-        $form->setFormId('TestCheckboxWithOneOptionRequired');
+        $ids = [
+            'TestCheckboxWithOneOptionRequired',  // options with value
+            'TestCheckboxWithOneOptionRequired-2' // options with label and value
+        ];
 
-        // No options
-        $form->setData(['checkbox' => []]);
-        $this->assertFalse($form->isValid());
+        foreach ($ids as $id) {
+            $form = new Form(
+                $mock,
+                $this->createMock(\Laminas\View\HelperPluginManager::class)
+            );
+            $form->setFormId($id);
 
-        // One invalid option
-        $form->setData(['checkbox' => ['invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // No options
+            $form->setData(['checkbox' => []]);
+            $this->assertFalse($form->isValid());
 
-        // One OK option
-        $form->setData(['checkbox' => ['option-1']]);
-        $this->assertTrue($form->isValid());
+            // One invalid option
+            $form->setData(['checkbox' => ['invalid-option']]);
+            $this->assertFalse($form->isValid());
 
-        // One OK options
-        $form->setData(['checkbox' => ['option-2']]);
-        $this->assertTrue($form->isValid());
+            // One OK option
+            $form->setData(['checkbox' => ['option-1']]);
+            $this->assertTrue($form->isValid());
 
-        // Both options OK
-        $form->setData(['checkbox' => ['option-1', 'option-2']]);
-        $this->assertTrue($form->isValid());
+            // One OK options
+            $form->setData(['checkbox' => ['option-2']]);
+            $this->assertTrue($form->isValid());
 
-        // One OK and one invalid option
-        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
-        $this->assertTrue($form->isValid());
+            // Both options OK
+            $form->setData(['checkbox' => ['option-1', 'option-2']]);
+            $this->assertTrue($form->isValid());
+
+            // One OK and one invalid option
+            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $this->assertTrue($form->isValid());
+        }
+
 
         // Test checkbox with a single options that is required
-        $form = new Form(
-            $mock,
-            $this->createMock(\Laminas\View\HelperPluginManager::class)
-        );
-        $form->setFormId('TestCheckboxWithOneOptionThatIsRequired');
+        $ids = [
+            // options with value
+            'TestCheckboxWithOneOptionThatIsRequired',
+            // options with label and value
+            'TestCheckboxWithOneOptionThatIsRequired-2'
+        ];
 
-        // No options
-        $form->setData(['checkbox' => []]);
-        $this->assertFalse($form->isValid());
+        foreach ($ids as $id) {
+            $form = new Form(
+                $mock,
+                $this->createMock(\Laminas\View\HelperPluginManager::class)
+            );
+            $form->setFormId($id);
 
-        // One invalid option
-        $form->setData(['checkbox' => ['invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // No options
+            $form->setData(['checkbox' => []]);
+            $this->assertFalse($form->isValid());
 
-        // One OK option
-        $form->setData(['checkbox' => ['option-1']]);
-        $this->assertTrue($form->isValid());
+            // One invalid option
+            $form->setData(['checkbox' => ['invalid-option']]);
+            $this->assertFalse($form->isValid());
 
-        // One OK and one invalid option
-        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // One OK option
+            $form->setData(['checkbox' => ['option-1']]);
+            $this->assertTrue($form->isValid());
+
+            // One OK and one invalid option
+            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $this->assertFalse($form->isValid());
+        }
+
 
         // Test checkbox with a single options that is required,
         // configured with requireOne
-        $form = new Form(
-            $mock,
-            $this->createMock(\Laminas\View\HelperPluginManager::class)
-        );
-        $form->setFormId(
-            'TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne'
-        );
+        $ids = [
+            // options with value
+            'TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne',
+            // options with label and value
+            'TestCheckboxWithOneOptionThatIsRequiredConfiguredWithRequireOne-2',
+        ];
 
-        // No options
-        $form->setData(['checkbox' => []]);
-        $this->assertFalse($form->isValid());
+        foreach ($ids as $id) {
+            $form = new Form(
+                $mock,
+                $this->createMock(\Laminas\View\HelperPluginManager::class)
+            );
+            $form->setFormId($id);
 
-        // One invalid option
-        $form->setData(['checkbox' => ['invalid-option']]);
-        $this->assertFalse($form->isValid());
+            // No options
+            $form->setData(['checkbox' => []]);
+            $this->assertFalse($form->isValid());
 
-        // One OK option
-        $form->setData(['checkbox' => ['option-1']]);
-        $this->assertTrue($form->isValid());
+            // One invalid option
+            $form->setData(['checkbox' => ['invalid-option']]);
+            $this->assertFalse($form->isValid());
 
-        // One OK and one invalid option
-        $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
-        $this->assertTrue($form->isValid());
+            // One OK option
+            $form->setData(['checkbox' => ['option-1']]);
+            $this->assertTrue($form->isValid());
+
+            // One OK and one invalid option
+            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $this->assertTrue($form->isValid());
+        }
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -356,7 +356,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
             $this->assertFalse($form->isValid());
         }
 
-
         // Test checkbox with one required option
         $ids = [
             'TestCheckboxWithOneOptionRequired',  // options with value
@@ -395,7 +394,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
             $this->assertTrue($form->isValid());
         }
 
-
         // Test checkbox with a single options that is required
         $ids = [
             // options with value
@@ -427,7 +425,6 @@ class FormTest extends \VuFindTest\Unit\TestCase
             $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
             $this->assertFalse($form->isValid());
         }
-
 
         // Test checkbox with a single options that is required,
         // configured with requireOne


### PR DESCRIPTION
Currently validating required checkbox options fails if the options are configured with label and value, for example:
```
 options:
   - label: Option 1
     value: option-1
   - label: Option 2
     value: option-2
```
 $el['options'] is an key-value list with `value` as the key. This PR fixes the validation to use keys.