### PR TITLE
Fix JDK8 compatibility in WorkKeys generation.

### DIFF
--- a/import/index_java/src/org/vufind/index/WorkKeys.java
+++ b/import/index_java/src/org/vufind/index/WorkKeys.java
@@ -125,7 +125,7 @@ public class WorkKeys
     ) {
         String normalized = transliterator != null ? transliterator.transliterate(s)
             : Normalizer.normalize(s, Normalizer.Form.NFKC);
-        if (!includeRegEx.isBlank()) {
+        if (!includeRegEx.chars().allMatch(Character::isWhitespace)) {
             StringBuilder result = new StringBuilder();
             Matcher m = Pattern.compile(includeRegEx).matcher(normalized);
             while (m.find()) {
@@ -133,7 +133,7 @@ public class WorkKeys
             }
             normalized = result.toString();
         }
-        if (!excludeRegEx.isBlank()) {
+        if (!excludeRegEx.chars().allMatch(Character::isWhitespace)) {
             normalized = normalized.replaceAll(excludeRegEx, "");
         }
         int length = normalized.length();


### PR DESCRIPTION
I was just testing VuFind's compatibility with JDK8 and discovered that we introduced a compatibility break recently through use of the isBlank() method in the work key generator. I believe that this PR switches to a more backward-compatible method, but I haven't had time to test extensively yet.

TODO
- [x] Test