### PR TITLE
Fix undocumented behavior in MarcAdvancedTrait::getConsortialIDs

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php
@@ -901,6 +901,6 @@ trait MarcAdvancedTrait
      */
     public function getConsortialIDs()
     {
-        return $this->getFieldArray('035', 'a', true);
+        return $this->getFieldArray('035');
     }
 }


### PR DESCRIPTION
`MarcAdvancedTrait::getConsortialIDs` [calls `$this->getFieldArray('035', 'a', true);`](https://github.com/vufind-org/vufind/blob/dev/module/VuFind/src/VuFind/RecordDriver/MarcAdvancedTrait.php#L934), which has undocumented behavior, because `MarcReaderTrait::getFieldArray` [expects the second argument to be an array](https://github.com/vufind-org/vufind/blob/dev/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php#L104) and only [does the right thing by accident](https://github.com/vufind-org/vufind/blob/dev/module/VuFind/src/VuFind/RecordDriver/MarcReaderTrait.php#L115).