### PR TITLE
Fix fixPrimoFacetValue to not destroy UTF-8 strings

### DIFF
--- a/module/VuFind/src/VuFind/Search/Primo/Params.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Params.php
@@ -115,7 +115,11 @@ class Params extends \VuFind\Search\Base\Params
         if ($str == 'reference_entrys') {
             return 'Reference Entries';
         }
-        return ucwords(str_replace('_', ' ', $str));
+        return mb_convert_case(
+            preg_replace('/_/u', ' ', $str),
+            MB_CASE_TITLE,
+            'UTF-8'
+        );
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Unit tests for Primo Params.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFindTest\Search\Primo;
+
+use VuFind\Search\Primo\Params;
+use VuFindTest\Unit\TestCase;
+
+/**
+ * Unit tests for Primo Params.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class ParamsTest extends TestCase
+{
+    /**
+     * Test facet value normalization
+     *
+     * @return void
+     */
+    public function testFixPrimoFacetValue()
+    {
+        $optionsMock = $this->createMock(\VuFind\Search\Primo\Options::class);
+        $configMock = $this->createMock(\VuFind\Config\PluginManager::class);
+        $params = new \VuFind\Search\Primo\Params($optionsMock, $configMock);
+        $this->assertEquals(
+            'Foo Bar',
+            $params->fixPrimoFacetValue('foo bar')
+        );
+        $this->assertEquals(
+            'Foo Bar',
+            $params->fixPrimoFacetValue('foo_bar')
+        );
+        $this->assertEquals(
+            'Reference Entries',
+            $params->fixPrimoFacetValue('reference_entrys')
+        );
+        $this->assertEquals(
+            '维普资讯 (Chongqing)',
+            $params->fixPrimoFacetValue('维普资讯 (Chongqing)')
+        );
+    }
+}


### PR DESCRIPTION
fixPrimoFacetValue was actually destroying UTF-8 strings causing the HTML escaper to throw an exception.