### PR TITLE
SolrPrefix autocomplete

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -542,6 +542,10 @@ sort = "last_indexed desc"
 ;       call numbers using the custom CallNumber search handler.
 ; Tag
 ;       Provide suggestions from the local database of tags.
+; SolrPrefix:[Autocomplete field]:[Display field]
+;       Perform a search against autocomplete field with edge-n gram tokenizer,
+;       each word in query is handled as a prefix. Display field must be copied
+;       from autocomplete field and be stored and indexed or with docValues.
 ;
 ; You can build your own autocomplete modules if you wish.  See the developer's
 ; guide here:

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -578,6 +578,7 @@ CallNumber = "SolrCN"
 ISN = "Solr:ISN:isbn,issn"
 Coordinate = "None"
 tag = "Tag"
+;Title = "SolrPrefix:title_autocomplete:title"
 
 ; When snippets are enabled, this section can be used to display captions based on
 ; the Solr fields from which the snippets were obtained.  Keys are the names of Solr

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -578,7 +578,7 @@ CallNumber = "SolrCN"
 ISN = "Solr:ISN:isbn,issn"
 Coordinate = "None"
 tag = "Tag"
-;Title = "SolrPrefix:title_autocomplete:title"
+;Title = "SolrPrefix:title_autocomplete:title_sort"
 
 ; When snippets are enabled, this section can be used to display captions based on
 ; the Solr fields from which the snippets were obtained.  Keys are the names of Solr

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -552,7 +552,11 @@ sort = "last_indexed desc"
 ;       field, preferably single-valued, for display purposes, because display
 ;       of values by this option relies on faceting -- be sure to choose an
 ;       appropriate field type, such as a simple _str field, to ensure correct
-;       display.
+;       display. For example, to switch title suggestions to use the edge n-gram
+;       method, you could index titles into a new dynamic title_autocomplete
+;       field, then change the Title configuration in [Autocomplete_Types] to:
+;       "SolrPrefix:title_autocomplete:title_sort" (note the use of title_sort
+;       for display, because it is a string field and thus suitable for faceting).
 ;
 ; You can build your own autocomplete modules if you wish.  See the developer's
 ; guide here:
@@ -578,7 +582,6 @@ CallNumber = "SolrCN"
 ISN = "Solr:ISN:isbn,issn"
 Coordinate = "None"
 tag = "Tag"
-;Title = "SolrPrefix:title_autocomplete:title_sort"
 
 ; When snippets are enabled, this section can be used to display captions based on
 ; the Solr fields from which the snippets were obtained.  Keys are the names of Solr

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -543,9 +543,16 @@ sort = "last_indexed desc"
 ; Tag
 ;       Provide suggestions from the local database of tags.
 ; SolrPrefix:[Autocomplete field]:[Display field]
-;       Perform a search against autocomplete field with edge-n gram tokenizer,
-;       each word in query is handled as a prefix. Display field must be copied
-;       from autocomplete field and be stored and indexed or with docValues.
+;       Perform a search against [Autocomplete field] using the edge n-gram
+;       tokenizer. Each word in the user's query is handled as a prefix. Values
+;       from [Display field] will be displayed for matching records. It is
+;       recommended that you index values for this handler into fields of type
+;       "text_autocomplete" (which are available using the dynamic field suffix
+;       *_autocomplete). These values should also be copied into a separate
+;       field, preferably single-valued, for display purposes, because display
+;       of values by this option relies on faceting -- be sure to choose an
+;       appropriate field type, such as a simple _str field, to ensure correct
+;       display.
 ;
 ; You can build your own autocomplete modules if you wish.  See the developer's
 ; guide here:

--- a/module/VuFind/src/VuFind/Autocomplete/PluginManager.php
+++ b/module/VuFind/src/VuFind/Autocomplete/PluginManager.php
@@ -56,6 +56,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'solrcn' => SolrCN::class,
         'solrreserves' => SolrReserves::class,
         'tag' => Tag::class,
+        'solrprefix' => SolrPrefix::class,
         // for legacy 1.x compatibility
         'noautocomplete' => 'None',
         'oclcidentitiesautocomplete' => 'OCLCIdentities',
@@ -82,6 +83,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         SolrCN::class => SolrFactory::class,
         SolrReserves::class => SolrFactory::class,
         Tag::class => InvokableFactory::class,
+        SolrPrefix::class => SolrFactory::class,
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Solr Autocomplete Module
+ * Solr Prefix Autocomplete Module
  *
  * PHP version 7
  *

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -77,6 +77,13 @@ class SolrPrefix implements AutocompleteInterface
     protected $facetField;
 
     /**
+     * Facet limit, can be overridden in subclasses
+     *
+     * @var int
+     */
+    protected $limit = 10;
+
+    /**
      * Constructor
      *
      * @param \VuFind\Search\Results\PluginManager $results Results plugin manager
@@ -110,7 +117,7 @@ class SolrPrefix implements AutocompleteInterface
             $params->setBasicSearch($rawQuery);
             $params->addFacet($this->facetField);
             $params->setLimit(0);
-            $params->setFacetLimit(10);
+            $params->setFacetLimit($this->limit);
             $this->searchObject->getResults();
             $facets = $this->searchObject->getFacetList();
             if (isset($facets[$this->facetField]['list'])) {

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Solr Autocomplete Module
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * @category VuFind2
+ * @package  Autocomplete
+ * @author   Vaclav Rosecky <vaclav.rosecky@mzk.cz>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:autosuggesters Wiki
+ */
+namespace VuFind\Autocomplete;
+
+/**
+ * Solr autocomplete module with prefix queries using edge N-gram filter
+ *
+ * This class provides suggestions by using the local Solr index.
+ *
+ * @category VuFind2
+ * @package  Autocomplete
+ * @author   Vaclav Rosecky <vaclav.rosecky@mzk.cz>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:autosuggesters Wiki
+ */
+class SolrPrefix implements AutocompleteInterface
+{
+    /**
+     * Results manager
+     *
+     * @var \VuFind\Search\Results\PluginManager
+     */
+    protected $resultsManager;
+
+    /**
+     * Search object
+     *
+     * @var \VuFind\Search\Solr\Results
+     */
+    protected $searchObject;
+
+    /**
+     * Search class id
+     *
+     * @var string
+     */
+    protected $searchClassId = 'Solr';
+
+    /**
+     * Autocomplete field
+     *
+     * @var string
+     */
+    protected $autocompleteField;
+
+    /**
+     * Facet field
+     *
+     * @var string
+     */
+    protected $facetField;
+
+    /**
+     * Constructor
+     *
+     * @param \VuFind\Search\Results\PluginManager $results Results plugin manager
+     */
+    public function __construct(\VuFind\Search\Results\PluginManager $results)
+    {
+        $this->resultsManager = $results;
+    }
+
+    /**
+     * Get suggestions
+     *
+     * This method returns an array of strings matching the user's query for
+     * display in the autocomplete box.
+     *
+     * @param string $query The user query
+     *
+     * @return array        The suggestions for the provided query
+     */
+    public function getSuggestions($query)
+    {
+        if (!is_object($this->searchObject)) {
+            throw new \Exception('Please set configuration first.');
+        }
+
+        $results = [];
+        try {
+            $params = $this->searchObject->getParams();
+            $rawQuery = $this->autocompleteField . ':(' .
+                $this->mungeQuery($query) . ')';
+            $params->setBasicSearch($rawQuery);
+            $params->addFacet($this->facetField);
+            $params->setLimit(0);
+            $params->setFacetLimit(10);
+            $this->searchObject->getResults();
+            $facets = $this->searchObject->getFacetList();
+            if (isset($facets[$this->facetField]['list'])) {
+                foreach ($facets[$this->facetField]['list'] as $filter) {
+                    $results[] = $filter['value'];
+                }
+            }
+        } catch (\Exception $e) {
+            // Ignore errors -- just return empty results if we must.
+        }
+        return array_unique($results);
+    }
+
+    /**
+     * Process the user query to make it suitable for a Solr query.
+     *
+     * @param string $query Incoming user query
+     *
+     * @return string       Processed query
+     */
+    protected function mungeQuery($query)
+    {
+        $forbidden = [':', '(', ')', '*', '+', '"'];
+        return str_replace($forbidden, " ", $query);
+    }
+
+    /**
+     * Set configuration
+     *
+     * Set parameters that affect the behavior of the autocomplete handler.
+     * These values normally come from the search configuration file.
+     *
+     * @param string $params Parameters to set
+     *
+     * @return void
+     */
+    public function setConfig($params)
+    {
+        list($this->autocompleteField, $this->facetField) = explode(':', $params, 2);
+        $this->initSearchObject();
+    }
+
+    /**
+     * Initialize the search object used for finding recommendations.
+     *
+     * @return void
+     */
+    protected function initSearchObject()
+    {
+        // Build a new search object:
+        $this->searchObject = $this->resultsManager->get($this->searchClassId);
+        $this->searchObject->getOptions()->spellcheckEnabled(false);
+        $this->searchObject->getOptions()->disableHighlighting();
+    }
+}

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -18,9 +18,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
- * @category VuFind2
+ * @category VuFind
  * @package  Autocomplete
  * @author   Vaclav Rosecky <vaclav.rosecky@mzk.cz>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
@@ -33,11 +33,11 @@ namespace VuFind\Autocomplete;
  *
  * This class provides suggestions by using the local Solr index.
  *
- * @category VuFind2
+ * @category VuFind
  * @package  Autocomplete
  * @author   Vaclav Rosecky <vaclav.rosecky@mzk.cz>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     http://vufind.org/wiki/vufind2:autosuggesters Wiki
+ * @link     https://vufind.org/wiki/development:plugins:autosuggesters Wiki
  */
 class SolrPrefix implements AutocompleteInterface
 {

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -118,6 +118,9 @@ class SolrPrefix implements AutocompleteInterface
             $params->addFacet($this->facetField);
             $params->setLimit(0);
             $params->setFacetLimit($this->limit);
+            $options = $params->getOptions();
+            $options->disableHighlighting();
+            $options->spellcheckEnabled(false);
             $this->searchObject->getResults();
             $facets = $this->searchObject->getFacetList();
             if (isset($facets[$this->facetField]['list'])) {

--- a/solr/vufind/biblio/conf/schema.xml
+++ b/solr/vufind/biblio/conf/schema.xml
@@ -95,6 +95,18 @@
         <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
+    <!-- Field for SolrPrefix autocomplete -->
+    <fieldType name="text_autocomplete" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+      </analyzer>
+    </fieldType>
     <fieldType name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true" />
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
@@ -232,6 +244,7 @@
    <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
    <dynamicField name="*_geo" type="geo" indexed="true" stored="true" multiValued="false" />
    <dynamicField name="*_geo_mv" type="geo" indexed="true" stored="true" multiValued="true" />
+   <dynamicField name="*_autocomplete" type="text_autocomplete" indexed="true" stored="true" multiValued="true"/>
  </fields>
  <uniqueKey>id</uniqueKey>
  <!-- CopyFields for Spelling -->

--- a/solr/vufind/biblio/conf/schema.xml
+++ b/solr/vufind/biblio/conf/schema.xml
@@ -244,7 +244,7 @@
    <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
    <dynamicField name="*_geo" type="geo" indexed="true" stored="true" multiValued="false" />
    <dynamicField name="*_geo_mv" type="geo" indexed="true" stored="true" multiValued="true" />
-   <dynamicField name="*_autocomplete" type="text_autocomplete" indexed="true" stored="true" multiValued="true"/>
+   <dynamicField name="*_autocomplete" type="text_autocomplete" indexed="true" stored="true" multiValued="false"/>
  </fields>
  <uniqueKey>id</uniqueKey>
  <!-- CopyFields for Spelling -->


### PR DESCRIPTION
SolrPrefix autocomplete using edge n-gram tokenizer in Solr for prefix queries, eg. each term in query is considered as a prefix. Best works for single valued fields.
