### PR TITLE
Primo: Fix url-encoding of filters in search query.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -281,7 +281,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                         $facetOp = $values['facetOp'];
                         $values = $values['values'];
                     }
-                    array_map(
+                    $values = array_map(
                         function ($value) {
                             return urlencode(preg_replace('/,/', '+', $value));
                         },


### PR DESCRIPTION
There was an attempt at encoding the values properly, but the result was never used. This caused e.g. subjects with ampersands to not be encoded properly in the query string.