### PR TITLE
Citations: smarter year cleanup

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
@@ -931,7 +931,8 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
     protected function getYear()
     {
         if (isset($this->details['pubDate'])) {
-            if (strlen($this->details['pubDate']) > 4) {
+            $numericDate = preg_replace('/\D/', '', $this->details['pubDate']);
+            if (strlen($numericDate) > 4) {
                 try {
                     return $this->dateConverter->convertFromDisplayDate(
                         'Y', $this->details['pubDate']
@@ -941,7 +942,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
                     return false;
                 }
             }
-            return preg_replace('/[^0-9]/', '', $this->details['pubDate']);
+            return $numericDate;
         }
         return false;
     }


### PR DESCRIPTION
Only use the date converter if there are more than four digits (rather than four CHARACTERS) in the incoming string.

Note: this fixes a problem where a WorldCat date with punctuation (e.g. `2018.`) got run through the date converter and misinterpreted as a month/day in the current year, resulting in citations showing the current year in place of the correct date. I suspect that this is an indication that using the date converter at all in the citation code is a bad idea, but this fix solves the immediate problem, and re-evaluating the use of the date converter requires more use cases to analyze. For now, I'm just moving forward with the simple part of the fix.

TODO:
- [x] Merge after Villanova librarian feedback/testing.