### PR TITLE
Change Vagrant default user to match updated box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   # Network configuration to forward ports.
   config.vm.network :forwarded_port, guest: 80, host: 4567
   config.vm.network :forwarded_port, guest: 8983, host: 4568
-  config.vm.synced_folder ".", "/vagrant", :owner => 'ubuntu'
+  config.vm.synced_folder ".", "/vagrant", :owner => 'vagrant'
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
@@ -55,8 +55,8 @@ Vagrant.configure("2") do |config|
 
     # Check out and set up VuFind.
     mkdir -p /vufindlocal/cache/cli /vufindlocal/config/vufind
-    chown -R ubuntu:ubuntu /vufindlocal
-    su - ubuntu -c 'cd /vagrant && composer install && php install.php --non-interactive --overridedir=/vufindlocal'
+    chown -R vagrant:vagrant /vufindlocal
+    su - vagrant -c 'cd /vagrant && composer install && php install.php --non-interactive --overridedir=/vufindlocal'
     ln -s /vufindlocal/httpd-vufind.conf /etc/apache2/conf-enabled/vufind.conf
     a2enmod rewrite
     systemctl restart apache2


### PR DESCRIPTION
This might be one of those problems due to the specific combination of macOS 10.15.7 / VirtualBox 6.1 / Vagrant 2.2.14 / ubuntu/focal64 I am using, but it looks like the recently updated Vagrant box has a different default user (`vagrant`).

This seems to cause some file and directory permission related problems. The `/vagrant/solr/vufind/logs` directory can not be created, and everything in the `/vagrant` directory is owned by `ubuntu:vagrant` and in `/vufindlocal` by `ubuntu:ubuntu`. So changing the user in `Vagrantfile` seemed to be the easiest way to get everything working.