### PR TITLE
Folio: Fix parameters of getNewItems method.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1475,7 +1475,7 @@ class Folio extends AbstractAPI implements
      * in more recent code, it receives one of the KEYS from getFunds(). See getFunds
      * for additional notes.
      */
-    public function getNewItems($page = 1, $limit, $daysOld = 30, $fundID = null)
+    public function getNewItems($page, $limit, $daysOld, $fundID = null)
     {
         return [];
     }


### PR DESCRIPTION
This fixes "Required parameter $limit follows optional parameter $page" error with PHP 8.

With this fix, all tests pass with PHP 8.0.2.