### PR TITLE
Disconnect mailer when done processing scheduled searches.

### DIFF
--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -58,6 +58,13 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
     protected $transport;
 
     /**
+     * A clone of transport that can be used for a new connection
+     *
+     * @var TransportInterface
+     */
+    protected $initialTransport;
+
+    /**
      * The maximum number of email recipients allowed (0 = no limit)
      *
      * @var int
@@ -117,7 +124,13 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
         // If the transport has a disconnect method, call it:
         $transport = $this->getTransport();
         if (is_callable([$transport, 'disconnect'])) {
-            $transport->disconnect();
+            try {
+                $transport->disconnect();
+            } catch (\Exception $e) {
+                $this->setTransport($this->initialTransport);
+            }
+        } else {
+            $this->setTransport($this->initialTransport);
         }
         return $this;
     }
@@ -144,6 +157,7 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
     public function setTransport($transport)
     {
         $this->transport = $transport;
+        $this->initialTransport = clone $this->transport;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -58,7 +58,10 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
     protected $transport;
 
     /**
-     * A clone of transport that can be used for a new connection
+     * A clone of $transport above. This can be used to reset the connection state
+     * in case transport doesn't support the disconnect method or it throws an
+     * exception (this can happen if the connection is stale and the connector tries
+     * to issue a QUIT message for clean disconnect).
      *
      * @var TransportInterface
      */
@@ -121,7 +124,9 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
      */
     public function resetConnection()
     {
-        // If the transport has a disconnect method, call it:
+        // If the transport has a disconnect method, call it. Otherwise, and in case
+        // disconnect fails, revert to the transport instance clone made before a
+        // connection was made.
         $transport = $this->getTransport();
         if (is_callable([$transport, 'disconnect'])) {
             try {
@@ -157,6 +162,8 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
     public function setTransport($transport)
     {
         $this->transport = $transport;
+        // Store a clone of the given transport so that we can reset the connection
+        // as necessary.
         $this->initialTransport = clone $this->transport;
     }
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -238,6 +238,13 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
     {
         $this->output = $output;
         $this->processViewAlerts();
+        // Disconnect mailer to prevent exceptions from an attempt to gracefully
+        // close the connection on teardown
+        try {
+            $this->mailer->resetConnection();
+        } catch (\Exception $e) {
+            // Ignore exceptions
+        }
         return 0;
     }
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -240,11 +240,7 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
         $this->processViewAlerts();
         // Disconnect mailer to prevent exceptions from an attempt to gracefully
         // close the connection on teardown
-        try {
-            $this->mailer->resetConnection();
-        } catch (\Exception $e) {
-            // Ignore exceptions
-        }
+        $this->mailer->resetConnection();
         return 0;
     }
 


### PR DESCRIPTION
This avoids a potential exception from being thrown during destruction if the connection has been idle for too long.

This is the real issue I was mistakenly trying to fix in #1867.