### PR TITLE
Fix shared reference problem when retrieving ID multiple times in a batch.

### DIFF
--- a/module/VuFind/src/VuFind/Record/Loader.php
+++ b/module/VuFind/src/VuFind/Record/Loader.php
@@ -309,8 +309,10 @@ class Loader implements \Laminas\Log\LoggerAwareInterface
                 $currentIds, $source, $tolerateBackendExceptions, $sourceParams
             );
             foreach ($records as $current) {
-                foreach ($list->getRecordPositions($current) as $position) {
-                    $retVal[$position] = $current;
+                foreach ($list->getRecordPositions($current) as $i => $position) {
+                    // If we have multiple positions, create a clone of the driver
+                    // for positions after 0, to avoid shared-reference problems:
+                    $retVal[$position] = $i == 0 ? $current : clone $current;
                 }
             }
         }


### PR DESCRIPTION
This fixes an unanticipated side effect of #1858: if a record ID appears multiple times in a batch, all of the entries in the resulting list are references to the same object. Subsequent manipulation of that object will then impact ALL positions of the list. This is particularly problematic for records where additional ILS details need to be added, since the correct details will not show up in the correct list positions.

TODO:
- [x] Confirm that this fixes the problem
- [x] Run full test suite