### PR TITLE
Catch the exception of unsuccessful hold cancel

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1199,8 +1199,10 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
                     ], null, "DELETE"
                 );
             } catch (AlephRestfulException $e) {
-                $statuses[$id]
-                    = ['success' => false, 'status' => 'cancel_hold_failed'];
+                $statuses[$id] = [
+                    'success' => false, 'status' => 'cancel_hold_failed',
+                    'sysMessage' => $e->getMessage(),
+                ];
             }
             if (isset($result)) {
                 $count++;

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1194,8 +1194,8 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
             try {
                 $result = $this->doRestDLFRequest(
                     [
-                        'patron', $patronId, 'circulationActions', 'requests', 'holds',
-                        $id
+                        'patron', $patronId, 'circulationActions', 'requests',
+                         'holds', $id
                     ], null, "DELETE"
                 );
             } catch (AlephRestfulException $e) {

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1191,23 +1191,18 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
         $count = 0;
         $statuses = [];
         foreach ($details['details'] as $id) {
-            $result = $this->doRestDLFRequest(
-                [
-                    'patron', $patronId, 'circulationActions', 'requests', 'holds',
-                    $id
-                ], null, "DELETE"
-            );
-            $reply_code = $result->{'reply-code'};
-            if ($reply_code != "0000") {
-                $message = $result->{'del-pat-hold'}->{'note'};
-                if ($message == null) {
-                    $message = $result->{'reply-text'};
-                }
-                $statuses[$id] = [
-                    'success' => false, 'status' => 'cancel_hold_failed',
-                    'sysMessage' => (string)$message
-                ];
-            } else {
+            try {
+                $result = $this->doRestDLFRequest(
+                    [
+                        'patron', $patronId, 'circulationActions', 'requests', 'holds',
+                        $id
+                    ], null, "DELETE"
+                );
+            } catch (AlephRestfulException $e) {
+                $statuses[$id]
+                    = ['success' => false, 'status' => 'cancel_hold_failed'];
+            }
+            if (isset($result)) {
                 $count++;
                 $statuses[$id]
                     = ['success' => true, 'status' => 'cancel_hold_ok'];


### PR DESCRIPTION
There was a logic duplication in the `cancelHolds` method and `doRestDLFRequest`. Inside the `doRestDLFRequest`, if the request fails and the response code is `0000` then `AlephRestfulException` is thrown. This means the repeated check of the response code in `cancelHolds` is never triggered. This way the exception should be gracefully solved.

I made it as small as possible because editing the `doRestDLFRequest` directly would affect a lot of things and because errors of this type are typically thrown during holds cancellation.

Note: Aleph uses a special daemon for harvesting pending requests. For a good user experience, it has a really short delay. After the harvest, it is quite possible a user has the hold list still enriched with the `cancelForm`. If she submits it after the harvest, the error is thrown because the request became non-cancellable in the meantime.