### PR TITLE
Improve specificity/encoding of EDS internal links.

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -199,6 +199,7 @@ translated_facets[] = SourceType
 AllFields           = "All Fields"
 TI                  = Title
 AU                  = Author
+SU                  = Subject
 
 ; This section defines which search options will be included on the advanced
 ; search screen.  All the notes above [Basic_Searches] also apply here.

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -579,9 +579,9 @@ class EDS extends DefaultRecord
                 if (in_array($group, $allowed_searchlink_groups)) {
                     $type = strtoupper($group);
                     $link_xml = '/<searchLink fieldCode="([^\"]*)" '
-                        . 'term="%22([^\"]*)%22">/';
-                    $link_html
-                        = "<a href=\"../EDS/Search?lookfor=$2&amp;type={$type}\">";
+                        . 'term="(%22[^\"]*%22)">/';
+                    $link_html = '<a href="../EDS/Search?lookfor=$2&amp;type='
+                        . urlencode($type) . '">';
                     $data = preg_replace($link_xml, $link_html, $data);
                     $data = str_replace('</searchLink>', '</a>', $data);
                 }


### PR DESCRIPTION
The EDS record driver creates internal links for authors and subjects. It did not previously put quotes around these searches, leading to very large and non-specific result sets. This PR adds quotes and ensures URL encoding of the search type parameter (which should not be necessary, but is done for consistency). Note that due to inconsistencies in the formatting of metadata in the EDS database, there are still some unavoidable problems with these searches (e.g. some authors are in "First Last" format and others in "Last, First" format -- they will not be collocated in these searches).