### PR TITLE
Fix for a null variable situation in Piwik helper

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -321,6 +321,7 @@ class Piwik extends \Laminas\View\Helper\AbstractHelper
             if (is_a($driver, 'VuFind\RecordDriver\AbstractBase')) {
                 return $driver;
             }
+            return null;
         }
         $children = $current->getChildren();
         if (isset($children[0])) {


### PR DESCRIPTION
We want to track deferred recommendations using Piwik, and came across this situation where `$current` may be `null`, causing an exception.