### PR TITLE
Update from Interop\Container to Psr\Container.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/DoiLookupFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DoiLookupFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetACSuggestionsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetACSuggestionsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetFacetDataFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetFacetDataFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetIlsStatusFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetIlsStatusFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCoverFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCoverFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory for GetRecordVersions AJAX handler.

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetVisDataFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetVisDataFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/KeepAliveFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/KeepAliveFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/RecommendFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/RecommendFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/SystemStatusFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/SystemStatusFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\AjaxHandler;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/ChoiceAuthFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuthFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/EmailFactory.php
+++ b/module/VuFind/src/VuFind/Auth/EmailFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/FacebookFactory.php
+++ b/module/VuFind/src/VuFind/Auth/FacebookFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Auth/ILSFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Auth/MultiAuthFactory.php
+++ b/module/VuFind/src/VuFind/Auth/MultiAuthFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Auth/ShibbolethFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ShibbolethFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Auth;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use VuFind\Auth\Shibboleth\MultiIdPConfigurationLoader;

--- a/module/VuFind/src/VuFind/Autocomplete/EdsFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/EdsFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Autocomplete;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Autocomplete/SolrFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Autocomplete;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Autocomplete/SuggesterFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SuggesterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Autocomplete;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Cache/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Cache/ManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Cache;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Captcha/FigletFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/FigletFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Captcha;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Captcha/ImageFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ImageFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Captcha;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Captcha/ReCaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ReCaptchaFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Captcha;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/CartFactory.php
+++ b/module/VuFind/src/VuFind/CartFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProviderFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProviderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/ChannelLoaderFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ChannelLoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/RandomFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/RandomFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ChannelProvider/RouterInitializer.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/RouterInitializer.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Initializer\InitializerInterface;
 
 /**

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ChannelProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Config/AccountCapabilitiesFactory.php
+++ b/module/VuFind/src/VuFind/Config/AccountCapabilitiesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Config;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Config/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Config;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Config\Config;
 use Laminas\Config\Reader\Ini as IniReader;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;

--- a/module/VuFind/src/VuFind/Config/PluginManagerFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Config;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Config/YamlReaderFactory.php
+++ b/module/VuFind/src/VuFind/Config/YamlReaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Config;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Connection/RelaisFactory.php
+++ b/module/VuFind/src/VuFind/Connection/RelaisFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Connection;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Connection/WorldCatUtilsFactory.php
+++ b/module/VuFind/src/VuFind/Connection/WorldCatUtilsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Connection;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Content/AbstractSyndeticsFactory.php
+++ b/module/VuFind/src/VuFind/Content/AbstractSyndeticsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Content/Covers/BooksiteFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BooksiteFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Covers;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Covers;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Covers/BuchhandelFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BuchhandelFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Covers;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Covers/ContentCafeFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/ContentCafeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Covers;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Covers/SyndeticsFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/SyndeticsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Covers;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Factory.php
+++ b/module/VuFind/src/VuFind/Content/Factory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihContentFactory.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihContentFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Content;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihServiceFactory.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihServiceFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Content;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
+++ b/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Content;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Content/Reviews/BooksiteFactory.php
+++ b/module/VuFind/src/VuFind/Content/Reviews/BooksiteFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Content\Reviews;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ContentBlock/BlockLoaderFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/BlockLoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ContentBlock;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ContentBlock/ChannelsFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/ChannelsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ContentBlock;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ContentBlock/FacetListFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/FacetListFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ContentBlock;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\ContentBlock;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/AbstractBaseWithConfigFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBaseWithConfigFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Controller/AjaxControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/CartControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/CartControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/IndexControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/IndexControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBaseFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBaseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/CaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/CaptchaFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/FlashMessengerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FlashMessengerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/FollowupFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FollowupFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/NewItemsFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/NewItemsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/PermissionFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/PermissionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/ReservesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ReservesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScrollerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScrollerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller\Plugin;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/QRCodeControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/QRCodeControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Controller/UpgradeControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
@@ -29,8 +29,8 @@
  */
 namespace VuFind\Cookie;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Cover/CachingProxyFactory.php
+++ b/module/VuFind/src/VuFind/Cover/CachingProxyFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Cover;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Cover/GeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Cover/GeneratorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Cover;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Cover/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/Cover/LoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Cover;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Cover/RouterFactory.php
+++ b/module/VuFind/src/VuFind/Cover/RouterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Cover;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Crypt/HMACFactory.php
+++ b/module/VuFind/src/VuFind/Crypt/HMACFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Crypt;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Db/AdapterFactory.php
+++ b/module/VuFind/src/VuFind/Db/AdapterFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Db;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Config\Config;
 use Laminas\Db\Adapter\Adapter;
 

--- a/module/VuFind/src/VuFind/Db/Row/RowGatewayFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/RowGatewayFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Row;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Row/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Row;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Row/UserListFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserListFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Row;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Table/CaseSensitiveTagsFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/CaseSensitiveTagsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Table;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Table/GatewayFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/GatewayFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Table;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Table/ResourceFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Table;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Table/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Table;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Db\Table;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
+++ b/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
@@ -30,8 +30,8 @@
  */
 namespace VuFind\DigitalContent;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/DoiLinker/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/DoiLinker/BrowZineFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\DoiLinker;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/DoiLinker/UnpaywallFactory.php
+++ b/module/VuFind/src/VuFind/DoiLinker/UnpaywallFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\DoiLinker;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ExportFactory.php
+++ b/module/VuFind/src/VuFind/ExportFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Favorites;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/Form/FormFactory.php
+++ b/module/VuFind/src/VuFind/Form/FormFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Form;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/GeoFeatures/AbstractConfigFactory.php
+++ b/module/VuFind/src/VuFind/GeoFeatures/AbstractConfigFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\GeoFeatures;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBasedFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBasedFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Hierarchy\Driver;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Hierarchy Driver Factory Class

--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/SolrFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/SolrFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Hierarchy\TreeDataSource;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTreeFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTreeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Hierarchy\TreeRenderer;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Http/PhpEnvironment/RemoteAddressFactory.php
+++ b/module/VuFind/src/VuFind/Http/PhpEnvironment/RemoteAddressFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Http\PhpEnvironment;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\I18n\Translator;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/ILS/ConnectionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/AlmaFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AlmaFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/DriverWithDateConverterFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DriverWithDateConverterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/FolioFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/FolioFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRestFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRestFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackendFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackendFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/NoILSFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NoILSFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIAFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIAFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRestFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRestFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/SymphonyFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SymphonyFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestfulFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestfulFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/ILS/HoldSettingsFactory.php
+++ b/module/VuFind/src/VuFind/ILS/HoldSettingsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ILS/Logic/LogicFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/LogicFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ILS\Logic;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Log;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Config\Config;
 use Laminas\Log\Writer\WriterInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;

--- a/module/VuFind/src/VuFind/Mailer/Factory.php
+++ b/module/VuFind/src/VuFind/Mailer/Factory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Mailer;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Mail\Transport\InMemory;
 use Laminas\Mail\Transport\Smtp;
 use Laminas\Mail\Transport\SmtpOptions;

--- a/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Net;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/OAI/ServerFactory.php
+++ b/module/VuFind/src/VuFind/OAI/ServerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\OAI;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/QRCode/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/QRCode/LoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\QRCode;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Recommend/AuthorInfoFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorInfoFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/DPLATermsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/DPLATermsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/ExpandFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/ExpandFacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/MapSelectionFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/MapSelectionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/SideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacetsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/SwitchQueryFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/SwitchQueryFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Recommend;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Record/CacheFactory.php
+++ b/module/VuFind/src/VuFind/Record/CacheFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Record;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Record/FallbackLoader/SummonFactory.php
+++ b/module/VuFind/src/VuFind/Record/FallbackLoader/SummonFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Record\FallbackLoader;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Record/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/Record/LoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Record;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBaseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/RecordDriver/IlsAwareDelegatorFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/IlsAwareDelegatorFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/RecordDriver/NameBasedConfigFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/NameBasedConfigFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefaultFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefaultFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefaultWithoutSearchServiceFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefaultWithoutSearchServiceFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordDriver/SolrWebFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrWebFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordDriver/SummonFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SummonFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordDriver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/HoldingsILSFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsILSFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/MapFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/MapFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/PreviewFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/PreviewFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/TabManagerFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/TabManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/UserCommentsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/UserCommentsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/RecordTab/VersionsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/VersionsFactory.php
@@ -29,7 +29,7 @@
  */
 namespace VuFind\RecordTab;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory for building the Versions tab.

--- a/module/VuFind/src/VuFind/Related/BookplateFactory.php
+++ b/module/VuFind/src/VuFind/Related/BookplateFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Related;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/Related/SimilarFactory.php
+++ b/module/VuFind/src/VuFind/Related/SimilarFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Related;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Resolver/Driver/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/AbstractBaseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Resolver\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Resolver/Driver/DriverWithHttpClientFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/DriverWithHttpClientFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Resolver\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Resolver\Driver;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
+++ b/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Role;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/module/VuFind/src/VuFind/Role/PermissionDeniedManagerFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionDeniedManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Role/PermissionManagerFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role\PermissionProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role\PermissionProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role\PermissionProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role\PermissionProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/ShibbolethFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/ShibbolethFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Role\PermissionProvider;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/SMS/Factory.php
+++ b/module/VuFind/src/VuFind/SMS/Factory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\SMS;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/Search/BackendManagerFactory.php
+++ b/module/VuFind/src/VuFind/Search/BackendManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
+++ b/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Base;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/EDS/OptionsFactory.php
+++ b/module/VuFind/src/VuFind/Search/EDS/OptionsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\EDS;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\Config\Config;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\BrowZine\Backend;

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\EIT\Backend;

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\EDS\Backend;

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\LibGuides\Backend;

--- a/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use LmcRbacMvc\Service\AuthorizationService;

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SerialsSolutions\Summon\Laminas as Connector;

--- a/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\Search\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\WorldCat\Backend;

--- a/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Favorites;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Search/HistoryFactory.php
+++ b/module/VuFind/src/VuFind/Search/HistoryFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/MemoryFactory.php
+++ b/module/VuFind/src/VuFind/Search/MemoryFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Options/OptionsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Options/OptionsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Options;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Options/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Search/Options/PluginFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Search\Options;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Search options plugin factory

--- a/module/VuFind/src/VuFind/Search/Params/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Params/ParamsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Params;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Params/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Search/Params/PluginFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Search\Params;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Search params plugin factory

--- a/module/VuFind/src/VuFind/Search/Results/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Search/Results/PluginFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Search\Results;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Search results plugin factory

--- a/module/VuFind/src/VuFind/Search/Results/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Results/ResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Results;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Search2;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Search/SearchRunnerFactory.php
+++ b/module/VuFind/src/VuFind/Search/SearchRunnerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\EventManager\EventManager;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/module/VuFind/src/VuFind/Search/SearchTabsHelperFactory.php
+++ b/module/VuFind/src/VuFind/Search/SearchTabsHelperFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Search/Solr/FacetCacheFactory.php
+++ b/module/VuFind/src/VuFind/Search/Solr/FacetCacheFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\Search\Solr;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Solr FacetCache Factory.

--- a/module/VuFind/src/VuFind/Search/Solr/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Solr/ParamsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Solr;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Search/Solr/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Solr/ResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Solr;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Search/Tags/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Tags/ResultsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Search\Tags;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFind/src/VuFind/Security/CspHeaderGeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGeneratorFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Security;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/DateConverterFactory.php
+++ b/module/VuFind/src/VuFind/Service/DateConverterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/HttpServiceFactory.php
+++ b/module/VuFind/src/VuFind/Service/HttpServiceFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/Service/MarkdownFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/ProxyConfigFactory.php
+++ b/module/VuFind/src/VuFind/Service/ProxyConfigFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/ReCaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Service/ReCaptchaFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Service/SearchServiceFactory.php
+++ b/module/VuFind/src/VuFind/Service/SearchServiceFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\EventManager\EventManager;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
+++ b/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Service;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ServiceManager/AbstractPluginFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/AbstractPluginFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\ServiceManager;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManagerFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\ServiceManager;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/ServiceManager/ServiceInitializer.php
+++ b/module/VuFind/src/VuFind/ServiceManager/ServiceInitializer.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\ServiceManager;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Initializer\InitializerInterface;
 
 /**

--- a/module/VuFind/src/VuFind/Session/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Session/AbstractBaseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Session;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Session/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Session/ManagerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Session;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Session/RedisFactory.php
+++ b/module/VuFind/src/VuFind/Session/RedisFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Session;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Session/SecureDelegatorFactory.php
+++ b/module/VuFind/src/VuFind/Session/SecureDelegatorFactory.php
@@ -29,7 +29,7 @@
  */
 namespace VuFind\Session;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 

--- a/module/VuFind/src/VuFind/Sitemap/GeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Sitemap/GeneratorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Sitemap;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/Solr/WriterFactory.php
+++ b/module/VuFind/src/VuFind/Solr/WriterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\Solr;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/TagsFactory.php
+++ b/module/VuFind/src/VuFind/TagsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/UrlShortener/DatabaseFactory.php
+++ b/module/VuFind/src/VuFind/UrlShortener/DatabaseFactory.php
@@ -28,7 +28,7 @@
 namespace VuFind\UrlShortener;
 
 use Exception;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory for local database-driven URL shortener.

--- a/module/VuFind/src/VuFind/UrlShortener/ServiceFactory.php
+++ b/module/VuFind/src/VuFind/UrlShortener/ServiceFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\UrlShortener;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory to construct the configured UrlShortener service.

--- a/module/VuFind/src/VuFind/Validator/CsrfFactory.php
+++ b/module/VuFind/src/VuFind/Validator/CsrfFactory.php
@@ -29,8 +29,8 @@
  */
 namespace VuFind\Validator;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Bootstrap3;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilitiesFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilitiesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AddThisFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AddThisFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AuthFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AuthFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/CaptchaFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CaptchaFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/CartFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CartFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/CitationFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CitationFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ConfigFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ConfigFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ContentLoaderFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ContentLoaderFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/DateTimeFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DateTimeFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Mvc\I18n\Translator;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/module/VuFind/src/VuFind/View/Helper/Root/DoiFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DoiFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ExportFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ExportFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/FeedbackFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/FeedbackFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/FlashmessagesFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/FlashmessagesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/GeoCoordsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GeoCoordsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/HelpTextFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HelpTextFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/HistoryLabelFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HistoryLabelFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/IlsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/IlsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/JsTranslationsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/JsTranslationsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/KeepAliveFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/KeepAliveFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/MarkdownFactory.php
@@ -28,7 +28,7 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/MetadataFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/MetadataFactory.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrlFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
@@ -29,8 +29,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/PermissionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PermissionFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrlFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordLinkFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordLinkFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/RelaisFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RelaisFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/RelatedFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RelatedFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
@@ -28,7 +28,7 @@
 namespace VuFind\View\Helper\Root;
 
 use DateTime;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Feed\Writer\Feed;
 use Laminas\Feed\Writer\Writer as FeedWriter;
 use Laminas\View\Helper\AbstractHelper;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeedFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeedFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormatFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormatFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchBoxFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchBoxFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchMemoryFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchMemoryFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchOptionsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchOptionsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchParamsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchParamsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
@@ -28,8 +28,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrlFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlusFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlusFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SystemEmailFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SystemEmailFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserTagsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserTagsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFind\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\View\Helper\Root;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use VuFind\View\Helper\Root\RecordDataFormatter;
 use VuFind\View\Helper\Root\RecordDataFormatterFactory;
 

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindApi\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindApi/src/VuFindApi/Controller/Search2ApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/Search2ApiControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindApi\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindApi\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindApi/src/VuFindApi/Controller/WebApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/WebApiControllerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindApi\Controller;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatterFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatterFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindApi\Formatter;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Compile;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommand.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use VuFindConsole\Generator\GeneratorTools;
 
 /**

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractRouteCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractRouteCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Generate;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Harvest;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Import;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Import;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/AbstractCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/AbstractCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Language;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\ScheduledSearch;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrAndIlsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrAndIlsCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/ConsoleRunner.php
+++ b/module/VuFindConsole/src/VuFindConsole/ConsoleRunner.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindConsole;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 
 /**

--- a/module/VuFindConsole/src/VuFindConsole/ConsoleRunnerFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/ConsoleRunnerFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindConsole\Generator;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\FileGenerator;
 use Laminas\Code\Generator\MethodGenerator;
@@ -321,7 +321,7 @@ class GeneratorTools
                 );
                 $param1 = [
                     'name' => 'container',
-                    'type' => 'Interop\Container\ContainerInterface'
+                    'type' => 'Psr\Container\ContainerInterface'
                 ];
                 $param2 = [
                     'name' => 'requestedName',

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindConsole\Generator;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/DynamicRouteCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/DynamicRouteCommandTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFind\Route\RouteGenerator;
 use VuFindConsole\Command\Generate\DynamicRouteCommand;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendClassCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendClassCommandTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFindConsole\Command\Generate\ExtendClassCommand;
 use VuFindConsole\Generator\GeneratorTools;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/PluginCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/PluginCommandTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFindConsole\Command\Generate\PluginCommand;
 use VuFindConsole\Generator\GeneratorTools;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/RecordRouteCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/RecordRouteCommandTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFind\Route\RouteGenerator;
 use VuFindConsole\Command\Generate\RecordRouteCommand;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/StaticRouteCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/StaticRouteCommandTest.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTest\Command\Generate;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFind\Route\RouteGenerator;
 use VuFindConsole\Command\Generate\StaticRouteCommand;

--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindTheme;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Config\Config;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\RequestInterface as Request;
@@ -61,7 +61,7 @@ class Initializer
     /**
      * Top-level service container
      *
-     * @var \Interop\Container\ContainerInterface
+     * @var \Psr\Container\ContainerInterface
      */
     protected $serviceManager;
 

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoInjectorFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoInjectorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadThemeResourcesFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadThemeResourcesFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme\View\Helper;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLinkFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLinkFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme\View\Helper;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplateFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplateFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme\View\Helper;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme\View\Helper;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\Config\Config;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/TemplatePathFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/TemplatePathFactory.php
@@ -27,8 +27,8 @@
  */
 namespace VuFindTheme\View\Helper;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;


### PR DESCRIPTION
This PR moves VuFind away from deprecated interfaces. Unfortunately, much of it will not work until the next major release of laminas/service-manager, so I probably got a bit carried away working on it right now.

TODO
- [ ] Wait for release of laminas/service-manager 4.0
- [ ] Manually test generator changes
- [ ] Run full test suite