### PR TITLE
Simplify and improve Bootstrapper

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -190,23 +190,6 @@ class Bootstrapper
     }
 
     /**
-     * Set up headTitle view helper -- we always want to set, not append, titles.
-     *
-     * @return void
-     */
-    protected function initHeadTitle(): void
-    {
-        $callback = function ($event) {
-            $helperManager = $this->container->get('ViewHelperManager');
-            $headTitle = $helperManager->get('headtitle');
-            $headTitle->setDefaultAttachOrder(
-                \Laminas\View\Helper\Placeholder\Container\AbstractContainer::SET
-            );
-        };
-        $this->events->attach('dispatch', $callback);
-    }
-
-    /**
      * Support method for initLanguage(): process HTTP_ACCEPT_LANGUAGE value.
      * Returns browser-requested language string or null if none found.
      *

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -92,7 +92,7 @@ class Bootstrapper
      *
      * @return void
      */
-    public function bootstrap()
+    public function bootstrap(): void
     {
         // automatically call all methods starting with "init":
         $methods = get_class_methods($this);
@@ -108,7 +108,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initTestMode()
+    protected function initTestMode(): void
     {
         // If we're in test mode (as determined by the config.ini property installed
         // by the build.xml startup process), set a cookie so the front-end code can
@@ -125,7 +125,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initSystemStatus()
+    protected function initSystemStatus(): void
     {
         // If the system is unavailable and we're not in the console, forward to the
         // unavailable page.
@@ -146,7 +146,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initLocaleAndTimeZone()
+    protected function initLocaleAndTimeZone(): void
     {
         // Try to set the locale to UTF-8, but fail back to the exact string from
         // the config file if this doesn't work -- different systems may vary in
@@ -167,7 +167,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initContext()
+    protected function initContext(): void
     {
         $callback = function ($event) {
             if (PHP_SAPI !== 'cli') {
@@ -194,7 +194,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initHeadTitle()
+    protected function initHeadTitle(): void
     {
         $callback = function ($event) {
             $helperManager = $this->container->get('ViewHelperManager');
@@ -208,16 +208,16 @@ class Bootstrapper
 
     /**
      * Support method for initLanguage(): process HTTP_ACCEPT_LANGUAGE value.
-     * Returns browser-requested language string or false if none found.
+     * Returns browser-requested language string or null if none found.
      *
-     * @return string|bool
+     * @return ?string
      */
-    public function detectBrowserLanguage()
+    public function detectBrowserLanguage(): ?string
     {
         if (isset($this->config->Site->browserDetectLanguage)
             && false == $this->config->Site->browserDetectLanguage
         ) {
-            return false;
+            return null;
         }
 
         // break up string into pieces (languages and q factors)
@@ -228,7 +228,7 @@ class Bootstrapper
         );
 
         if (!count($langParse[1])) {
-            return false;
+            return null;
         }
 
         // create a list like "en" => 0.8
@@ -261,7 +261,7 @@ class Bootstrapper
             }
         }
 
-        return false;
+        return null;
     }
 
     /**
@@ -269,7 +269,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initLanguage()
+    protected function initLanguage(): void
     {
         // Language not supported in CLI mode:
         if (PHP_SAPI == 'cli') {
@@ -292,7 +292,7 @@ class Bootstrapper
             } elseif (!empty($request->getCookie()->language)) {
                 $language = $request->getCookie()->language;
             } else {
-                $language = (false !== $validBrowserLanguage)
+                $language = (null !== $validBrowserLanguage)
                     ? $validBrowserLanguage : $config->Site->language;
             }
 
@@ -341,7 +341,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initTheme()
+    protected function initTheme(): void
     {
         // Attach remaining theme configuration to the dispatch event at high
         // priority (TODO: use priority constant once defined by framework):
@@ -359,7 +359,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initExceptionBasedHttpStatuses()
+    protected function initExceptionBasedHttpStatuses(): void
     {
         // HTTP statuses not needed in console mode:
         if (PHP_SAPI == 'cli') {
@@ -385,7 +385,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initSearch()
+    protected function initSearch(): void
     {
         $bm = $this->container->get(\VuFind\Search\BackendManager::class);
         $events = $this->container->get('SharedEventManager');
@@ -397,7 +397,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initErrorLogging()
+    protected function initErrorLogging(): void
     {
         $callback = function ($event) {
             if ($this->container->has(\VuFind\Log\Logger::class)) {
@@ -424,7 +424,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initRenderErrorEvent()
+    protected function initRenderErrorEvent(): void
     {
         // When a render.error is triggered, as a high priority, set a flag in the
         // layout that can be used to suppress actions in the layout templates that
@@ -442,7 +442,7 @@ class Bootstrapper
      *
      * @return void
      */
-    protected function initContentSecurityPolicy()
+    protected function initContentSecurityPolicy(): void
     {
         if (PHP_SAPI === 'cli') {
             return;

--- a/module/VuFind/src/VuFind/View/Helper/Root/HeadTitleFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HeadTitleFactory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * HeadTitle helper factory.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\View\Helper\Root;
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\View\Helper\Placeholder\Container\AbstractContainer;
+
+/**
+ * HeadTitle helper factory.
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class HeadTitleFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName,
+        array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory.');
+        }
+        $helper = new $requestedName();
+        // In VuFind, we always want to set, not append, titles:
+        $helper->setDefaultAttachOrder(AbstractContainer::SET);
+        return $helper;
+    }
+}

--- a/themes/root/theme.config.php
+++ b/themes/root/theme.config.php
@@ -3,6 +3,7 @@ return [
     'extends' => false,
     'helpers' => [
         'factories' => [
+            'Laminas\View\Helper\HeadTitle' => 'VuFind\View\Helper\Root\HeadTitleFactory',
             'VuFind\View\Helper\Root\AccountCapabilities' => 'VuFind\View\Helper\Root\AccountCapabilitiesFactory',
             'VuFind\View\Helper\Root\AddEllipsis' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFind\View\Helper\Root\AddThis' => 'VuFind\View\Helper\Root\AddThisFactory',


### PR DESCRIPTION
This PR works on simplifying VuFind's bootstrapper, and moving functionality to more granular places where possible.

TODO
- [x] Simplify config/container initialization
- [x] Add typehints
- [x] Refactor initHeadTitle() to factory
- [x] Run full test suite