### PR TITLE
Initialize search parameters from request in Recommend Ajax handler

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/Recommend.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/Recommend.php
@@ -99,7 +99,11 @@ class Recommend extends AbstractBase
         $module = $this->pluginManager->get($params->fromQuery('mod'));
         $module->setConfig($params->fromQuery('params'));
         $paramsObj = $this->results->getParams();
-        $module->init($paramsObj, new Parameters($params->fromQuery()));
+        $request = new Parameters($params->fromQuery());
+        // Initialize search parameters from Ajax request parameters in case the
+        // original request parameters were passed to the Ajax request.
+        $paramsObj->initFromRequest($request);
+        $module->init($paramsObj, $request);
         $module->process($this->results);
 
         // Render recommendations:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
@@ -104,12 +104,14 @@ class RecommendTest extends \VuFindTest\Unit\AjaxHandlerTest
             ->will($this->returnValue($mockPlugin));
         $this->container->set(PluginManager::class, $rm);
 
-        // Set up results plugin manager:
+        // Set up results and results plugin manager:
+        $results = $this->getMockResults();
+        $results->getParams()->expects($this->once())->method('initFromRequest');
         $resultsManager = $this->container
             ->createMock(ResultsManager::class, ['get']);
         $resultsManager->expects($this->once())->method('get')
             ->with($this->equalTo('Solr'))
-            ->will($this->returnValue($this->getMockResults()));
+            ->will($this->returnValue($results));
         $this->container->set(ResultsManager::class, $resultsManager);
 
         // Set up view helper and renderer:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
@@ -48,6 +48,44 @@ use VuFind\View\Helper\Root\Recommend as RecommendHelper;
 class RecommendTest extends \VuFindTest\Unit\AjaxHandlerTest
 {
     /**
+     * Get a mock params object.
+     *
+     * @param \VuFindSearch\Query\Query $query Query to include in container.
+     *
+     * @return \VuFind\Search\Solr\Params
+     */
+    protected function getMockParams($query = null)
+    {
+        if (null === $query) {
+            $query = new \VuFindSearch\Query\Query('foo', 'bar');
+        }
+        $params = $this->getMockBuilder(\VuFind\Search\Solr\Params::class)
+            ->disableOriginalConstructor()->getMock();
+        $params->expects($this->any())->method('getQuery')
+            ->will($this->returnValue($query));
+        return $params;
+    }
+
+    /**
+     * Get a mock results object.
+     *
+     * @param \VuFind\Search\Solr\Params $params Params to include in container.
+     *
+     * @return \VuFind\Search\Solr\Results
+     */
+    protected function getMockResults($params = null)
+    {
+        if (null === $params) {
+            $params = $this->getMockParams();
+        }
+        $results = $this->getMockBuilder(\VuFind\Search\Solr\Results::class)
+            ->disableOriginalConstructor()->getMock();
+        $results->expects($this->any())->method('getParams')
+            ->will($this->returnValue($params));
+        return $results;
+    }
+
+    /**
      * Test the AJAX handler's basic response.
      *
      * @return void
@@ -71,7 +109,7 @@ class RecommendTest extends \VuFindTest\Unit\AjaxHandlerTest
             ->createMock(ResultsManager::class, ['get']);
         $resultsManager->expects($this->once())->method('get')
             ->with($this->equalTo('Solr'))
-            ->will($this->returnValue($this->container->createMock(Results::class)));
+            ->will($this->returnValue($this->getMockResults()));
         $this->container->set(ResultsManager::class, $resultsManager);
 
         // Set up view helper and renderer:


### PR DESCRIPTION
It seems useful to initialize the search parameters here in case all request parameters from the original search request are passed to the Ajax handler. This way it is more likely that a recommendation module can use the passed objects in a similar fashion regardless whether it is a deferred call or not.