### PR TITLE
Fix invalid leader handling in ISO2709 serialization, add tests

### DIFF
--- a/module/VuFind/src/VuFind/Marc/Serialization/Iso2709.php
+++ b/module/VuFind/src/VuFind/Marc/Serialization/Iso2709.php
@@ -167,7 +167,8 @@ class Iso2709 implements SerializationInterface
         }
         $directory .= self::END_OF_FIELD;
         $data .= self::END_OF_RECORD;
-        $dataStart = strlen($leader) + strlen($directory);
+        $leader = str_pad(substr($leader, 0, 24), 24);
+        $dataStart = 24 + strlen($directory);
         $recordLen = $dataStart + strlen($data);
         if ($recordLen > 99999) {
             return '';


### PR DESCRIPTION
If the leader was too short, the resulting record would have been invalid. Added tests bring coverage of VuFind\Marc to 100%.