### PR TITLE
Voyager: Add a workaround for changed PDO signature in PHP 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "webfontkit/open-sans": "^1.0",
         "wikimedia/composer-merge-plugin": "2.0.1",
         "wikimedia/less.php": "3.1.0",
-        "yajra/laravel-pdo-via-oci8": "2.2.0"
+        "yajra/laravel-pdo-via-oci8": "2.2.0 || 3.0.0"
     },
     "require-dev": {
         "behat/mink": "1.8.1",

--- a/config/vufind/Voyager.ini
+++ b/config/vufind/Voyager.ini
@@ -29,6 +29,14 @@ login_field = LAST_NAME
 ; status 1 (active) or 4 (expired) are allowed.
 ;allowed_barcode_statuses = 1:4:5
 
+; Force OCI8 support. By default OCI8 is only supported on PHP 7, and you will
+; need to update the the yajra/laravel-pdo-via-oci8 package using the following
+; command before enabling it:
+;
+; php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
+;
+;forceOCI8Support = false
+
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -32,6 +32,14 @@ login_field = LAST_NAME
 ; This is the timeout value for making HTTP requests to the Voyager API.
 http_timeout = 30
 
+; Force OCI8 support. By default OCI8 is only supported on PHP 7, and you will
+; need to update the the yajra/laravel-pdo-via-oci8 package using the following
+; command before enabling it:
+;
+; php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
+;
+;forceOCI8Support = false
+
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -37,7 +37,6 @@ use PDOException;
 use VuFind\Date\DateException;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
-use Yajra\Pdo\Oci8;
 
 /**
  * Voyager ILS Driver
@@ -61,7 +60,7 @@ class Voyager extends AbstractBase
     /**
      * Lazily instantiated database connection. Use getDb() to access it.
      *
-     * @var Oci8
+     * @var \Yajra\Pdo\Oci8
      */
     protected $lazyDb;
 
@@ -187,7 +186,29 @@ class Voyager extends AbstractBase
                      ')' .
                    ')';
             try {
-                $this->lazyDb = new Oci8(
+                if ((!defined('PHP_MAJOR_VERSION ') || PHP_MAJOR_VERSION >= 8)
+                    && empty($this->config['Catalog']['forceOCI8Support'])
+                ) {
+                    $this->error(
+                        <<<EOT
+Voyager connection is only supported on PHP 7 by default. To enable support, you
+will need to manually update the yajra/laravel-pdo-via-oci8 package using the
+following command:
+
+php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
+
+Then force the Voyager driver to connect by adding the following setting to
+Voyager.ini or VoyagerRestful.ini:
+
+[Catalog]
+forceOCI8Support = true
+
+EOT
+                    );
+                    throw new ILSException('Unsupported PHP version');
+                }
+                // @phpstan-ignore-next-line
+                $this->lazyDb = new \Yajra\Pdo\Oci8(
                     "oci:dbname=$tns;charset=US7ASCII",
                     $this->config['Catalog']['user'],
                     $this->config['Catalog']['password']

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -37,6 +37,7 @@ use PDOException;
 use VuFind\Date\DateException;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
+use Yajra\Pdo\Oci8;
 
 /**
  * Voyager ILS Driver
@@ -60,7 +61,7 @@ class Voyager extends AbstractBase
     /**
      * Lazily instantiated database connection. Use getDb() to access it.
      *
-     * @var \Yajra\Pdo\Oci8
+     * @var Oci8
      */
     protected $lazyDb;
 
@@ -207,8 +208,7 @@ EOT
                     );
                     throw new ILSException('Unsupported PHP version');
                 }
-                // @phpstan-ignore-next-line
-                $this->lazyDb = new \Yajra\Pdo\Oci8(
+                $this->lazyDb = new Oci8(
                     "oci:dbname=$tns;charset=US7ASCII",
                     $this->config['Catalog']['user'],
                     $this->config['Catalog']['password']

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -187,7 +187,7 @@ class Voyager extends AbstractBase
                      ')' .
                    ')';
             try {
-                if ((!defined('PHP_MAJOR_VERSION ') || PHP_MAJOR_VERSION >= 8)
+                if ((!defined('PHP_MAJOR_VERSION') || PHP_MAJOR_VERSION >= 8)
                     && empty($this->config['Catalog']['forceOCI8Support'])
                 ) {
                     $this->error(

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,6 +1,10 @@
 parameters:
     paths:
         - %currentWorkingDirectory%/module
+    excludePaths:
+        analyse:
+              # Analysis would crash on PHP 8 due to a signature change in PDO
+            - %currentWorkingDirectory%/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
     tmpDir: %currentWorkingDirectory%/.phpstan_cache
     ignoreErrors:
         - '#Class VuFind\\Hierarchy\\Driver\\Hierarchy[a-zA-Z0-9]+ not found#'


### PR DESCRIPTION
The changed PDO method signature in PHP 8 makes the PHP 7 compatible Yajra\PDO\Oci class incompatible with PHP 8. This incompatibility makes phpstan crash during analysis on PHP 8, so Voyager.php has been excluded from analysis.

I no longer have access to Voyager to really test this, but at least the setting should be working.  