### PR TITLE
Set phpstan memory limit to 2G.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -108,10 +108,10 @@
 
   <!-- Phpstan -->
   <target name="phpstan-checkstyle">
-    <exec command="${srcdir}/vendor/bin/phpstan --configuration=${srcdir}/tests/phpstan.neon --error-format=checkstyle analyse &gt; ${builddir}/reports/phpstan-checkstyle.xml" escape="false" passthru="true" checkreturn="true" />
+    <exec command="${srcdir}/vendor/bin/phpstan --configuration=${srcdir}/tests/phpstan.neon --memory-limit=2G --error-format=checkstyle analyse &gt; ${builddir}/reports/phpstan-checkstyle.xml" escape="false" passthru="true" checkreturn="true" />
   </target>
   <target name="phpstan-console">
-    <exec command="${srcdir}/vendor/bin/phpstan --configuration=${srcdir}/tests/phpstan.neon analyse" escape="false" passthru="true" checkreturn="true" />
+    <exec command="${srcdir}/vendor/bin/phpstan --configuration=${srcdir}/tests/phpstan.neon --memory-limit=2G analyse" escape="false" passthru="true" checkreturn="true" />
   </target>
 
   <!-- php-cs-fixer (first task applies fixes, second task simply checks if they are needed) -->


### PR DESCRIPTION
This will avoid running out of memory when PHP's default is too small.

For reference, our branch with our custom module ran out of memory with Travis' 1G limit.