### PR TITLE
Correction of wrong parameter types in exception handling

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -954,7 +954,7 @@ class PAIA extends DAIA
             case 'access_denied':
                 throw new AuthException(
                     $array['error_description'] ?? $array['error'],
-                    (int) $array['code'] ?? 0
+                    (int)$array['code'] ?? 0
                 );
 
                 // invalid_grant     401     The access token was missing, invalid
@@ -966,7 +966,7 @@ class PAIA extends DAIA
             case 'insufficient_scope':
                 throw new ForbiddenException(
                     $array['error_description'] ?? $array['error'],
-                    (int) $array['code'] ?? 0
+                    (int)$array['code'] ?? 0
                 );
 
                 // not_found     404     Unknown request URL or unknown patron.
@@ -1013,7 +1013,7 @@ class PAIA extends DAIA
             default:
                 throw new ILSException(
                     $array['error_description'] ?? $array['error'],
-                    (int) $array['code'] ?? 0
+                    (int)$array['code'] ?? 0
                 );
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -954,7 +954,7 @@ class PAIA extends DAIA
             case 'access_denied':
                 throw new AuthException(
                     $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? 0
+                    (int) $array['code'] ?? 0
                 );
 
                 // invalid_grant     401     The access token was missing, invalid
@@ -966,7 +966,7 @@ class PAIA extends DAIA
             case 'insufficient_scope':
                 throw new ForbiddenException(
                     $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? 0
+                    (int) $array['code'] ?? 0
                 );
 
                 // not_found     404     Unknown request URL or unknown patron.
@@ -1013,7 +1013,7 @@ class PAIA extends DAIA
             default:
                 throw new ILSException(
                     $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? 0
+                    (int) $array['code'] ?? 0
                 );
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -954,7 +954,7 @@ class PAIA extends DAIA
             case 'access_denied':
                 throw new AuthException(
                     $array['error_description'] ?? $array['error'],
-                    (int)$array['code'] ?? 0
+                    (int)($array['code'] ?? 0)
                 );
 
                 // invalid_grant     401     The access token was missing, invalid
@@ -966,7 +966,7 @@ class PAIA extends DAIA
             case 'insufficient_scope':
                 throw new ForbiddenException(
                     $array['error_description'] ?? $array['error'],
-                    (int)$array['code'] ?? 0
+                    (int)($array['code'] ?? 0)
                 );
 
                 // not_found     404     Unknown request URL or unknown patron.
@@ -1013,7 +1013,7 @@ class PAIA extends DAIA
             default:
                 throw new ILSException(
                     $array['error_description'] ?? $array['error'],
-                    (int)$array['code'] ?? 0
+                    (int)($array['code'] ?? 0)
                 );
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -953,8 +953,8 @@ class PAIA extends DAIA
                 //                          access token
             case 'access_denied':
                 throw new AuthException(
-                    $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error']
+                    . ', ' . $array['code'] ?? ''
                 );
 
                 // invalid_grant     401     The access token was missing, invalid
@@ -965,8 +965,8 @@ class PAIA extends DAIA
                 //                              it lacks permission for the request
             case 'insufficient_scope':
                 throw new ForbiddenException(
-                    $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error']
+                    . ', ' . $array['code'] ?? ''
                 );
 
                 // not_found     404     Unknown request URL or unknown patron.
@@ -1012,8 +1012,8 @@ class PAIA extends DAIA
 
             default:
                 throw new ILSException(
-                    $array['error_description'] ?? $array['error'],
-                    $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error']
+                    . ', ' . $array['code'] ?? ''
                 );
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -953,8 +953,8 @@ class PAIA extends DAIA
                 //                          access token
             case 'access_denied':
                 throw new AuthException(
-                    $array['error_description'] ?? $array['error']
-                    . ', ' . $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error'],
+                    $array['code'] ?? 0
                 );
 
                 // invalid_grant     401     The access token was missing, invalid
@@ -965,8 +965,8 @@ class PAIA extends DAIA
                 //                              it lacks permission for the request
             case 'insufficient_scope':
                 throw new ForbiddenException(
-                    $array['error_description'] ?? $array['error']
-                    . ', ' . $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error'],
+                    $array['code'] ?? 0
                 );
 
                 // not_found     404     Unknown request URL or unknown patron.
@@ -1012,8 +1012,8 @@ class PAIA extends DAIA
 
             default:
                 throw new ILSException(
-                    $array['error_description'] ?? $array['error']
-                    . ', ' . $array['code'] ?? ''
+                    $array['error_description'] ?? $array['error'],
+                    $array['code'] ?? 0
                 );
             }
         }


### PR DESCRIPTION
In three cases an exception is thrown by using two parameters while the exception object accepts only one. This causes an internal server error when one of these exceptions is thrown.