### PR TITLE
Add support for custom Google Analytics create options.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1961,6 +1961,13 @@ treeSearchLimit = 100
 ;[GoogleAnalytics]
 ;apiKey = "mykey"
 ;universal = false
+; Options to pass to the ga() function's create call; if omitted, defaults to
+; 'auto'. The example below can be uncommented to work around a common problem
+; with browsers complaining about problems with the samesite attribute. Note
+; that the value of this setting must be valid Javascript code, so be careful
+; about quoting and escaping.
+; Note: only supported when universal is set to true.
+;create_options_js = "{cookieFlags: 'max-age=7200;secure;samesite=none'}"
 
 ; The Piwik product has been renamed to Matomo, but for backward compatibility,
 ; the terminology has not yet been changed in VuFind. Uncomment this section and

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -62,8 +62,11 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
     /**
      * Constructor
      *
-     * @param string|bool $key       API key (false if disabled)
-     * @param bool|array  $universal Are we using Universal Analytics?
+     * @param string|bool $key     API key (false if disabled)
+     * @param bool|array  $options Configuration options (supported options:
+     * 'universal' and 'create_options_js'). If a boolean is provided instead of
+     * an array, that value is used as the 'universal' setting and no other options
+     * are set (for backward compatibility).
      */
     public function __construct($key, $options = [])
     {

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -53,15 +53,28 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
     protected $universal;
 
     /**
+     * Options to pass to the ga() create command.
+     *
+     * @var string
+     */
+    protected $createOptions;
+
+    /**
      * Constructor
      *
      * @param string|bool $key       API key (false if disabled)
-     * @param bool        $universal Are we using Universal Analytics?
+     * @param bool|array  $universal Are we using Universal Analytics?
      */
-    public function __construct($key, $universal = false)
+    public function __construct($key, $options = [])
     {
+        // The second constructor parameter used to be a boolean representing
+        // the "universal" setting, so convert to an array for back-compatibility:
+        if (!is_array($options)) {
+            $options = ['universal' => (bool)$options];
+        }
         $this->key = $key;
-        $this->universal = $universal;
+        $this->universal = $options['universal'] ?? false;
+        $this->createOptions = $options['create_options_js'] ?? "'auto'";
     }
 
     /**
@@ -83,7 +96,7 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
                 . 'm.parentNode.insertBefore(a,m)'
                 . "})(window,document,'script',"
                 . "'//www.google-analytics.com/analytics.js','ga');"
-                . "ga('create', '{$this->key}', 'auto');"
+                . "ga('create', '{$this->key}', {$this->createOptions});"
                 . "ga('send', 'pageview');";
         }
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
@@ -67,7 +67,11 @@ class GoogleAnalyticsFactory implements FactoryInterface
         $config = $container->get(\VuFind\Config\PluginManager::class)
             ->get('config');
         $key = $config->GoogleAnalytics->apiKey ?? false;
-        $universal = $config->GoogleAnalytics->universal ?? false;
-        return new $requestedName($key, $universal);
+        $options = [
+            'create_options_js' =>
+                $config->GoogleAnalytics->create_options_js ?? null,
+            'universal' => $config->GoogleAnalytics->universal ?? false,
+        ];
+        return new $requestedName($key, $options);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -47,7 +47,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testOldSetup()
+    public function testOldSetup(): void
     {
         $output = $this->renderGA('myfakekey', false);
         $this->assertTrue(false !== strstr($output, 'ga.js'));
@@ -60,7 +60,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNewSetup()
+    public function testNewSetup(): void
     {
         $output = $this->renderGA('myfakekey', true);
         $this->assertTrue(false !== strstr($output, 'analytics.js'));
@@ -69,11 +69,43 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test custom create options.
+     *
+     * @return void
+     */
+    public function testCustomCreateOptions(): void
+    {
+        $createJs = "{cookieFlags: 'max-age=7200;secure;samesite=none'}";
+        $options = [
+            'universal' => true,
+            'create_options_js' => $createJs
+        ];
+        $output = $this->renderGA('myfakekey', $options);
+        // Confirm that the custom JS appears in the output, and that the
+        // default 'auto' does not:
+        $this->assertTrue(false !== strstr($output, $createJs));
+        $this->assertFalse(strstr($output, "'auto'"));
+    }
+
+    /**
+     * Test default create options.
+     *
+     * @return void
+     */
+    public function testDefaultCreateOptions(): void
+    {
+        $output = $this->renderGA('myfakekey', true);
+        // Confirm that the default JS appears in the output:
+        $expectedJs = "ga('create', 'myfakekey', 'auto');";
+        $this->assertTrue(false !== strstr($output, $expectedJs));
+    }
+
+    /**
      * Test the helper (disabled mode)
      *
      * @return void
      */
-    public function testDisabled()
+    public function testDisabled(): void
     {
         $this->assertEquals('', $this->renderGA(false));
     }
@@ -81,14 +113,14 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
     /**
      * Render the GA code
      *
-     * @param string $key GA key (false for disabled)
-     * @param bool   $uni Universal mode?
+     * @param string     $key     GA key (false for disabled)
+     * @param array|bool $options Options for GA helper
      *
      * @return string
      */
-    protected function renderGA($key, $uni = false)
+    protected function renderGA(string $key, $options = []): string
     {
-        $helper = new GoogleAnalytics($key, $uni);
+        $helper = new GoogleAnalytics($key, $options);
         $helper->setView($this->getPhpRenderer());
         return (string)$helper();
     }


### PR DESCRIPTION
Because of Same-Site cookie changes, Google Analytics can cause browser warnings. The workaround is to add some custom options to the initialization. This PR adds a mechanism for setting these custom options.