### PR TITLE
SierraRest: Stop renewing access token on every request with global p…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1362,7 +1362,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $patron = false, $returnStatus = false
     ) {
         // Clear current access token if it's not specific to the given patron
-        if ($patron
+        if ($patron && $this->isPatronSpecificAccess()
             && $this->sessionCache->accessTokenPatron != $patron['cat_username']
         ) {
             $this->sessionCache->accessToken = null;


### PR DESCRIPTION
…atron data.

Follow-up for #1898. I had missed the this check for patron-specific access token. With global patron data there will never be one, and this caused the driver to renew the access token on every request for patron data.