### PR TITLE
FOLIO: use date converter for requiredBy formatting in placeHold

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1035,8 +1035,8 @@ class Folio extends AbstractAPI implements
     {
         $default_request = $this->config['Holds']['default_request'] ?? 'Hold';
         try {
-            $requiredBy = date_create_from_format(
-                'm-d-Y',
+            $requiredBy = $this->dateConverter->convertFromDisplayDate(
+                'Y-m-d',
                 $holdDetails['requiredBy']
             );
         } catch (Exception $e) {
@@ -1049,7 +1049,7 @@ class Folio extends AbstractAPI implements
             'requesterId' => $holdDetails['patron']['id'],
             'requestDate' => date('c'),
             'fulfilmentPreference' => 'Hold Shelf',
-            'requestExpirationDate' => date_format($requiredBy, 'Y-m-d'),
+            'requestExpirationDate' => $requiredBy,
             'pickupServicePointId' => $holdDetails['pickUpLocation']
         ];
         $response = $this->makeRequest(


### PR DESCRIPTION
@EreMaijala pointed out that FOLIO was not using the date converter in placeHold(), which I think would make the code a bit more reliable and consistent with other drivers. This PR is an attempt to standardize the date formatting, but I have not had an opportunity to test it. I am hoping that @ihardy and/or @mis306lu might have time to take a look. Please let me know what you think!