### PR TITLE
FOLIO: Access to Location Codes in ILS Driver

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -461,7 +461,7 @@ class Folio extends AbstractAPI implements
             ) as $location) {
                 $name = $location->discoveryDisplayName ?? $location->name;
                 $code = $location->code;
-                $locationMap[$location->id] = [$name, $code];
+                $locationMap[$location->id] = compact('name', 'code');
             }
         }
         $this->putCachedData($cacheKey, $locationMap);
@@ -478,11 +478,10 @@ class Folio extends AbstractAPI implements
     protected function getLocationData($locationId)
     {
         $locationMap = $this->getLocations();
-        $locationName = '';
-        $locationCode = '';
+        $name = '';
+        $code = '';
         if (array_key_exists($locationId, $locationMap)) {
-            $locationName = $locationMap[$locationId][0];
-            $locationCode = $locationMap[$locationId][1];
+            return $locationMap[$locationId];
         } else {
             // if key is not found in cache, the location could have
             // been added before the cache expired so check again
@@ -491,12 +490,12 @@ class Folio extends AbstractAPI implements
             );
             if ($locationResponse->isSuccess()) {
                 $location = json_decode($locationResponse->getBody());
-                $locationName = $location->discoveryDisplayName ?? $location->name;
-                $locationCode = $location->code;
+                $name = $location->discoveryDisplayName ?? $location->name;
+                $code = $location->code;
             }
         }
 
-        return [$locationName, $locationCode];
+        return compact('name', 'code');
     }
 
     /**
@@ -560,8 +559,8 @@ class Folio extends AbstractAPI implements
                 );
                 $locationId = $item->effectiveLocationId;
                 $locationData = $this->getLocationData($locationId);
-                $locationName = $locationData[0];
-                $locationCode = $locationData[1];
+                $locationName = $locationData['name'];
+                $locationCode = $locationData['code'];
                 $items[] = [
                     'id' => $bibId,
                     'item_id' => $item->id,


### PR DESCRIPTION
Fixes [issue #110](https://github.com/uchicago-library/vufind/issues/110).

**Changes in this request:**
- Add a new optional `location_code` key to the output of `getHolding` in the FOLIO ILS driver
- Change the name of the `getLocationName` method to `getLocationData` and alter the signature. Instead of returning a location name string, return an array with location name and code.
- Add location code to location caching.