### PR TITLE
Alma resolver: Add support for displaying Unpaywall service.

### DIFF
--- a/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
@@ -109,9 +109,8 @@ class Alma extends AbstractBase
                     continue;
                 }
             }
-            $serviceType = $this->mapServiceType(
-                (string)$service->attributes()->service_type
-            );
+            $originalServiceType = (string)$service->attributes()->service_type;
+            $serviceType = $this->mapServiceType($originalServiceType);
             if (!$serviceType) {
                 continue;
             }
@@ -120,10 +119,18 @@ class Alma extends AbstractBase
                 $href = $this->getKeyWithId($service, 'url');
                 $access = '';
             } else {
-                $title = $this->getKeyWithId($service, 'package_public_name');
+                $title = $this->getKeyWithId($service, 'package_display_name');
+                if (!$title) {
+                    $title = $this->getKeyWithId($service, 'package_public_name');
+                }
                 $href = (string)$service->resolution_url;
-                $access = $this->getKeyWithId($service, 'Is_free')
-                    ? 'open' : 'limited';
+                if ('getOpenAccessFullText' === $originalServiceType
+                    || $this->getKeyWithId($service, 'Is_free')
+                ) {
+                    $access = 'open';
+                } else {
+                    $access = 'limited';
+                }
             }
             if ($coverage = $this->getKeyWithId($service, 'Availability')) {
                 $coverage = $this->cleanupText($coverage);
@@ -175,6 +182,7 @@ class Alma extends AbstractBase
     {
         $map = [
             'getFullTxt' => 'getFullTxt',
+            'getOpenAccessFullText' => 'getFullTxt',
             'getHolding' => 'getHolding',
             'GeneralElectronicService' => 'getWebService',
             'DB' => 'getFullTxt',

--- a/module/VuFind/tests/fixtures/resolver/response/alma.xml
+++ b/module/VuFind/tests/fixtures/resolver/response/alma.xml
@@ -52,6 +52,14 @@ Date: Mon, 19 Aug 2019 12:34:14 GMT
     </keys>
   </context_object>
   <context_services>
+    <context_service service_type="getOpenAccessFullText" context_service_id="1267096700006249">
+      <keys>
+        <key id="service_type_description">Open Access full text available at:</key>
+        <key id="package_display_name">Unpaywall</key>
+      </keys>
+      <resolution_url>https://na01.alma.exlibrisgroup.com/view/action/uresolver.do?operation=resolveService&amp;package_service_id=1</resolution_url>
+      <target_url>http://dro.dur.ac.uk/9845/1/9845.pdf</target_url>
+    </context_service>
     <context_service service_type="getFullTxt" context_service_id="5687861830000561">
       <keys>
         <key id="package_name">Ebook Central Perpetual and DDA Titles</key>
@@ -86,7 +94,7 @@ Date: Mon, 19 Aug 2019 12:34:14 GMT
     <context_service service_type="getFullTxt" context_service_id="5687861800000561">
       <keys>
         <key id="package_name">ebrary</key>
-        <key id="package_public_name">ebrary Academic Complete Subscription UKI Edition</key>
+        <key id="package_public_name">ebrary Academic Complete Subscription UKI</key>
         <key id="package_display_name">ebrary Academic Complete Subscription UKI Edition</key>
         <key id="package_internal_name">EBRARY_ACADEMIC_COMPLETE_SUBSCRIPTION_UKI_EDITION</key>
         <key id="interface_name">ebrary</key>
@@ -149,7 +157,6 @@ Date: Mon, 19 Aug 2019 12:34:14 GMT
       <keys>
         <key id="package_name">EBSCOhost</key>
         <key id="package_public_name">EBSCOhost Academic eBook Collection (North America)</key>
-        <key id="package_display_name">EBSCOhost Academic eBook Collection (North America)</key>
         <key id="package_internal_name">EBSCOHOST_EBOOKS_ACADEMIC_COLLECTION_NORTH_AMERICA</key>
         <key id="interface_name">EBSCOhost</key>
         <key id="package_pid">6178520000000561</key>

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
@@ -84,7 +84,16 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
         $result = $conn->parseLinks($conn->fetchLinks($openUrl));
 
         $testResult = [
-            0 => [
+            [
+                'title' => 'Unpaywall',
+                'coverage' => '',
+                'access' => 'open',
+                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do?operation=resolveService&package_service_id=1',
+                'notes' => '',
+                'authentication' => '',
+                'service_type' => 'getFullTxt',
+            ],
+            [
                 'title' => 'Ebook override',
                 'coverage' => 'Available from 2019',
                 'access' => 'limited',
@@ -93,7 +102,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getFullTxt',
             ],
-            1 => [
+            [
                 'title' => 'ebrary Academic Complete Subscription UKI Edition',
                 'coverage' => '',
                 'access' => 'limited',
@@ -102,7 +111,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getFullTxt',
             ],
-            2 => [
+            [
                 'title' => 'ebrary Science & Technology Subscription',
                 'coverage' => '',
                 'access' => 'limited',
@@ -111,7 +120,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getFullTxt',
             ],
-            3 => [
+            [
                 'title' => 'EBSCOhost Academic eBook Collection (North America)',
                 'coverage' => '',
                 'access' => 'open',
@@ -120,7 +129,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => 'collection level auth SERVICE LEVEL AUTHE NOTE',
                 'service_type' => 'getFullTxt',
             ],
-            4 => [
+            [
                 'title' => 'EBSCOhost eBook Community College Collection',
                 'coverage' => '',
                 'access' => 'limited',
@@ -129,7 +138,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getHolding',
             ],
-            5 => [
+            [
                 'title' => 'Elsevier ScienceDirect Books',
                 'coverage' => '',
                 'access' => 'limited',
@@ -138,7 +147,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getFullTxt',
             ],
-            6 => [
+            [
                 'title' => 'Request Assistance for this Resource!',
                 'coverage' => '',
                 'access' => '',
@@ -147,7 +156,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getWebService',
             ],
-            7 => [
+            [
                 'title' => 'ProQuest Safari Tech Books Online',
                 'coverage' => '',
                 'access' => 'limited',


### PR DESCRIPTION
Also includes any other getOpenAccessFullText type services and changes the default display title of packages to package_display_name with package_public_name as the fallback.

Looks like Unpaywall is a it special and only has a few fields. It also uses a new service type.