### PR TITLE
Indicate that ContainerExceptions must also be Throwable.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
@@ -56,7 +56,7 @@ class AbstractIlsAndUserActionFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
@@ -56,7 +56,7 @@ class AbstractRelaisActionFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
@@ -56,7 +56,7 @@ class CommentRecordFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
@@ -56,7 +56,7 @@ class DeleteRecordCommentFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/DoiLookupFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DoiLookupFactory.php
@@ -55,7 +55,7 @@ class DoiLookupFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetACSuggestionsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetACSuggestionsFactory.php
@@ -56,7 +56,7 @@ class GetACSuggestionsFactory implements
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetFacetDataFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetFacetDataFactory.php
@@ -55,7 +55,7 @@ class GetFacetDataFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetIlsStatusFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetIlsStatusFactory.php
@@ -55,7 +55,7 @@ class GetIlsStatusFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
@@ -56,7 +56,7 @@ class GetItemStatusesFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
@@ -56,7 +56,7 @@ class GetRecordCommentsAsHTMLFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCoverFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCoverFactory.php
@@ -56,7 +56,7 @@ class GetRecordCoverFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
@@ -56,7 +56,7 @@ class GetRecordDetailsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
@@ -56,7 +56,7 @@ class GetRecordTagsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
@@ -53,7 +53,7 @@ class GetRecordVersionsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
@@ -56,7 +56,7 @@ class GetResolverLinksFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
@@ -56,7 +56,7 @@ class GetSaveStatusesFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
@@ -56,7 +56,7 @@ class GetSideFacetsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
@@ -56,7 +56,7 @@ class GetUserFinesFactory extends AbstractIlsAndUserActionFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/GetVisDataFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetVisDataFactory.php
@@ -55,7 +55,7 @@ class GetVisDataFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/KeepAliveFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/KeepAliveFactory.php
@@ -55,7 +55,7 @@ class KeepAliveFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/RecommendFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/RecommendFactory.php
@@ -57,7 +57,7 @@ class RecommendFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/SystemStatusFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/SystemStatusFactory.php
@@ -55,7 +55,7 @@ class SystemStatusFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
@@ -55,7 +55,7 @@ class TagRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Auth/ChoiceAuthFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuthFactory.php
@@ -55,7 +55,7 @@ class ChoiceAuthFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
@@ -56,7 +56,7 @@ class EmailAuthenticatorFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/EmailFactory.php
+++ b/module/VuFind/src/VuFind/Auth/EmailFactory.php
@@ -55,7 +55,7 @@ class EmailFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/FacebookFactory.php
+++ b/module/VuFind/src/VuFind/Auth/FacebookFactory.php
@@ -55,7 +55,7 @@ class FacebookFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
@@ -56,7 +56,7 @@ class ILSAuthenticatorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/ILSFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSFactory.php
@@ -55,7 +55,7 @@ class ILSFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ManagerFactory.php
@@ -56,7 +56,7 @@ class ManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/MultiAuthFactory.php
+++ b/module/VuFind/src/VuFind/Auth/MultiAuthFactory.php
@@ -55,7 +55,7 @@ class MultiAuthFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Auth/ShibbolethFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ShibbolethFactory.php
@@ -59,7 +59,7 @@ class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Autocomplete/EdsFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/EdsFactory.php
@@ -57,7 +57,7 @@ class EdsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Autocomplete/SolrFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrFactory.php
@@ -57,7 +57,7 @@ class SolrFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Autocomplete/SuggesterFactory.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SuggesterFactory.php
@@ -55,7 +55,7 @@ class SuggesterFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Cache/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Cache/ManagerFactory.php
@@ -56,7 +56,7 @@ class ManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Captcha/FigletFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/FigletFactory.php
@@ -56,7 +56,7 @@ class FigletFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Captcha/ImageFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ImageFactory.php
@@ -56,7 +56,7 @@ class ImageFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Captcha/ReCaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ReCaptchaFactory.php
@@ -57,7 +57,7 @@ class ReCaptchaFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProviderFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProviderFactory.php
@@ -56,7 +56,7 @@ class AbstractILSChannelProviderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
@@ -56,7 +56,7 @@ class AlphaBrowseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/ChannelLoaderFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ChannelLoaderFactory.php
@@ -57,7 +57,7 @@ class ChannelLoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
@@ -56,7 +56,7 @@ class FacetsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
@@ -56,7 +56,7 @@ class ListItemsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/RandomFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/RandomFactory.php
@@ -56,7 +56,7 @@ class RandomFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
@@ -56,7 +56,7 @@ class SimilarItemsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Config/AccountCapabilitiesFactory.php
+++ b/module/VuFind/src/VuFind/Config/AccountCapabilitiesFactory.php
@@ -56,7 +56,7 @@ class AccountCapabilitiesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Config/PluginManagerFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginManagerFactory.php
@@ -56,7 +56,7 @@ class PluginManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Config/YamlReaderFactory.php
+++ b/module/VuFind/src/VuFind/Config/YamlReaderFactory.php
@@ -56,7 +56,7 @@ class YamlReaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Connection/RelaisFactory.php
+++ b/module/VuFind/src/VuFind/Connection/RelaisFactory.php
@@ -56,7 +56,7 @@ class RelaisFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Connection/WorldCatUtilsFactory.php
+++ b/module/VuFind/src/VuFind/Connection/WorldCatUtilsFactory.php
@@ -56,7 +56,7 @@ class WorldCatUtilsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Content/AbstractSyndeticsFactory.php
+++ b/module/VuFind/src/VuFind/Content/AbstractSyndeticsFactory.php
@@ -56,7 +56,7 @@ class AbstractSyndeticsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Content/Covers/BooksiteFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BooksiteFactory.php
@@ -55,7 +55,7 @@ class BooksiteFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
@@ -55,7 +55,7 @@ class BrowZineFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/Covers/BuchhandelFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BuchhandelFactory.php
@@ -55,7 +55,7 @@ class BuchhandelFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/Covers/ContentCafeFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/ContentCafeFactory.php
@@ -55,7 +55,7 @@ class ContentCafeFactory implements \Laminas\ServiceManager\Factory\FactoryInter
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/Covers/SyndeticsFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/SyndeticsFactory.php
@@ -55,7 +55,7 @@ class SyndeticsFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/Factory.php
+++ b/module/VuFind/src/VuFind/Content/Factory.php
@@ -87,7 +87,7 @@ class Factory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
+++ b/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
@@ -58,7 +58,7 @@ class PageLocatorFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Content/Reviews/BooksiteFactory.php
+++ b/module/VuFind/src/VuFind/Content/Reviews/BooksiteFactory.php
@@ -55,7 +55,7 @@ class BooksiteFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ContentBlock/BlockLoaderFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/BlockLoaderFactory.php
@@ -56,7 +56,7 @@ class BlockLoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ContentBlock/ChannelsFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/ChannelsFactory.php
@@ -56,7 +56,7 @@ class ChannelsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ContentBlock/FacetListFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/FacetListFactory.php
@@ -56,7 +56,7 @@ class FacetListFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
@@ -57,7 +57,7 @@ class TemplateBasedFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
@@ -96,7 +96,7 @@ class AbstractBaseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/AbstractBaseWithConfigFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBaseWithConfigFactory.php
@@ -55,7 +55,7 @@ class AbstractBaseWithConfigFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/AjaxControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxControllerFactory.php
@@ -56,7 +56,7 @@ class AjaxControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/CartControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/CartControllerFactory.php
@@ -55,7 +55,7 @@ class CartControllerFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
@@ -55,7 +55,7 @@ class ChannelsControllerFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
@@ -56,7 +56,7 @@ class CoverControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/IndexControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/IndexControllerFactory.php
@@ -56,7 +56,7 @@ class IndexControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBaseFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBaseFactory.php
@@ -56,7 +56,7 @@ class AbstractRequestBaseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/CaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/CaptchaFactory.php
@@ -58,7 +58,7 @@ class CaptchaFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
@@ -56,7 +56,7 @@ class FavoritesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/FlashMessengerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FlashMessengerFactory.php
@@ -56,7 +56,7 @@ class FlashMessengerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/FollowupFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FollowupFactory.php
@@ -56,7 +56,7 @@ class FollowupFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/NewItemsFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/NewItemsFactory.php
@@ -56,7 +56,7 @@ class NewItemsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/PermissionFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/PermissionFactory.php
@@ -56,7 +56,7 @@ class PermissionFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/ReservesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ReservesFactory.php
@@ -56,7 +56,7 @@ class ReservesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScrollerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScrollerFactory.php
@@ -56,7 +56,7 @@ class ResultScrollerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/QRCodeControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/QRCodeControllerFactory.php
@@ -56,7 +56,7 @@ class QRCodeControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Controller/UpgradeControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeControllerFactory.php
@@ -55,7 +55,7 @@ class UpgradeControllerFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManagerFactory.php
@@ -59,7 +59,7 @@ class CookieManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Cover/CachingProxyFactory.php
+++ b/module/VuFind/src/VuFind/Cover/CachingProxyFactory.php
@@ -56,7 +56,7 @@ class CachingProxyFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Cover/GeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Cover/GeneratorFactory.php
@@ -56,7 +56,7 @@ class GeneratorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Cover/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/Cover/LoaderFactory.php
@@ -56,7 +56,7 @@ class LoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Cover/RouterFactory.php
+++ b/module/VuFind/src/VuFind/Cover/RouterFactory.php
@@ -56,7 +56,7 @@ class RouterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Crypt/HMACFactory.php
+++ b/module/VuFind/src/VuFind/Crypt/HMACFactory.php
@@ -56,7 +56,7 @@ class HMACFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/AdapterFactory.php
+++ b/module/VuFind/src/VuFind/Db/AdapterFactory.php
@@ -78,7 +78,7 @@ class AdapterFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Row/RowGatewayFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/RowGatewayFactory.php
@@ -55,7 +55,7 @@ class RowGatewayFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Row/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserFactory.php
@@ -62,7 +62,7 @@ class UserFactory extends RowGatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Row/UserListFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserListFactory.php
@@ -55,7 +55,7 @@ class UserListFactory extends RowGatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Table/CaseSensitiveTagsFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/CaseSensitiveTagsFactory.php
@@ -55,7 +55,7 @@ class CaseSensitiveTagsFactory extends GatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Table/GatewayFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/GatewayFactory.php
@@ -71,7 +71,7 @@ class GatewayFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Table/ResourceFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceFactory.php
@@ -55,7 +55,7 @@ class ResourceFactory extends GatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Table/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserFactory.php
@@ -55,7 +55,7 @@ class UserFactory extends GatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
@@ -55,7 +55,7 @@ class UserListFactory extends GatewayFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
+++ b/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
@@ -61,7 +61,7 @@ class OverdriveConnectorFactory implements
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(
         ContainerInterface $container, $requestedName,

--- a/module/VuFind/src/VuFind/DoiLinker/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/DoiLinker/BrowZineFactory.php
@@ -55,7 +55,7 @@ class BrowZineFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/DoiLinker/UnpaywallFactory.php
+++ b/module/VuFind/src/VuFind/DoiLinker/UnpaywallFactory.php
@@ -55,7 +55,7 @@ class UnpaywallFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/ExportFactory.php
+++ b/module/VuFind/src/VuFind/ExportFactory.php
@@ -56,7 +56,7 @@ class ExportFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Form/FormFactory.php
+++ b/module/VuFind/src/VuFind/Form/FormFactory.php
@@ -56,7 +56,7 @@ class FormFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/GeoFeatures/AbstractConfigFactory.php
+++ b/module/VuFind/src/VuFind/GeoFeatures/AbstractConfigFactory.php
@@ -59,7 +59,7 @@ class AbstractConfigFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/SolrFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/SolrFactory.php
@@ -62,7 +62,7 @@ class SolrFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTreeFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTreeFactory.php
@@ -55,7 +55,7 @@ class JSTreeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Http/PhpEnvironment/RemoteAddressFactory.php
+++ b/module/VuFind/src/VuFind/Http/PhpEnvironment/RemoteAddressFactory.php
@@ -57,7 +57,7 @@ class RemoteAddressFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
@@ -65,7 +65,7 @@ class LocaleDetectorFactory implements DelegatorFactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(
         ContainerInterface $container,

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
@@ -59,7 +59,7 @@ class TranslatorFactory extends \Laminas\Mvc\I18n\TranslatorFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/ILS/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/ILS/ConnectionFactory.php
@@ -56,7 +56,7 @@ class ConnectionFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
@@ -55,7 +55,7 @@ class AlephFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/AlmaFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AlmaFactory.php
@@ -56,7 +56,7 @@ class AlmaFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      *     creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(
         ContainerInterface $container,

--- a/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
@@ -55,7 +55,7 @@ class DemoFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/DriverWithDateConverterFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DriverWithDateConverterFactory.php
@@ -56,7 +56,7 @@ class DriverWithDateConverterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/FolioFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/FolioFactory.php
@@ -55,7 +55,7 @@ class FolioFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRestFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRestFactory.php
@@ -55,7 +55,7 @@ class KohaRestFactory extends \VuFind\ILS\Driver\DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackendFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackendFactory.php
@@ -56,7 +56,7 @@ class MultiBackendFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/NoILSFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NoILSFactory.php
@@ -56,7 +56,7 @@ class NoILSFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIAFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIAFactory.php
@@ -55,7 +55,7 @@ class PAIAFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRestFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRestFactory.php
@@ -55,7 +55,7 @@ class SierraRestFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/SymphonyFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SymphonyFactory.php
@@ -56,7 +56,7 @@ class SymphonyFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestfulFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestfulFactory.php
@@ -55,7 +55,7 @@ class VoyagerRestfulFactory extends DriverWithDateConverterFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/HoldSettingsFactory.php
+++ b/module/VuFind/src/VuFind/ILS/HoldSettingsFactory.php
@@ -56,7 +56,7 @@ class HoldSettingsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ILS/Logic/LogicFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/LogicFactory.php
@@ -56,7 +56,7 @@ class LogicFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -409,7 +409,7 @@ class LoggerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Mailer/Factory.php
+++ b/module/VuFind/src/VuFind/Mailer/Factory.php
@@ -105,7 +105,7 @@ class Factory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
+++ b/module/VuFind/src/VuFind/Net/UserIpReaderFactory.php
@@ -55,7 +55,7 @@ class UserIpReaderFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/OAI/ServerFactory.php
+++ b/module/VuFind/src/VuFind/OAI/ServerFactory.php
@@ -56,7 +56,7 @@ class ServerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/QRCode/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/QRCode/LoaderFactory.php
@@ -56,7 +56,7 @@ class LoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Recommend/AuthorInfoFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorInfoFactory.php
@@ -57,7 +57,7 @@ class AuthorInfoFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
@@ -56,7 +56,7 @@ class CollectionSideFacetsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/DPLATermsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/DPLATermsFactory.php
@@ -55,7 +55,7 @@ class DPLATermsFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
@@ -56,7 +56,7 @@ class EuropeanaResultsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/ExpandFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/ExpandFacetsFactory.php
@@ -55,7 +55,7 @@ class ExpandFacetsFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
@@ -56,7 +56,7 @@ class FavoriteFacetsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
@@ -58,7 +58,7 @@ class InjectConfigManagerFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
@@ -58,7 +58,7 @@ class InjectResultsManagerFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
@@ -58,7 +58,7 @@ class InjectSearchRunnerFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/MapSelectionFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/MapSelectionFactory.php
@@ -55,7 +55,7 @@ class MapSelectionFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
@@ -56,7 +56,7 @@ class RandomRecommendFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/SideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacetsFactory.php
@@ -55,7 +55,7 @@ class SideFacetsFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/SwitchQueryFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/SwitchQueryFactory.php
@@ -55,7 +55,7 @@ class SwitchQueryFactory implements \Laminas\ServiceManager\Factory\FactoryInter
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
@@ -56,7 +56,7 @@ class WorldCatIdentitiesFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Record/CacheFactory.php
+++ b/module/VuFind/src/VuFind/Record/CacheFactory.php
@@ -56,7 +56,7 @@ class CacheFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Record/FallbackLoader/SummonFactory.php
+++ b/module/VuFind/src/VuFind/Record/FallbackLoader/SummonFactory.php
@@ -56,7 +56,7 @@ class SummonFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Record/LoaderFactory.php
+++ b/module/VuFind/src/VuFind/Record/LoaderFactory.php
@@ -56,7 +56,7 @@ class LoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBaseFactory.php
@@ -56,7 +56,7 @@ class AbstractBaseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/NameBasedConfigFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/NameBasedConfigFactory.php
@@ -55,7 +55,7 @@ class NameBasedConfigFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefaultFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefaultFactory.php
@@ -55,7 +55,7 @@ class SolrDefaultFactory extends SolrDefaultWithoutSearchServiceFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefaultWithoutSearchServiceFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefaultWithoutSearchServiceFactory.php
@@ -55,7 +55,7 @@ class SolrDefaultWithoutSearchServiceFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
@@ -57,7 +57,7 @@ class SolrOverdriveFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/SolrWebFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrWebFactory.php
@@ -55,7 +55,7 @@ class SolrWebFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordDriver/SummonFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SummonFactory.php
@@ -55,7 +55,7 @@ class SummonFactory extends NameBasedConfigFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
@@ -66,7 +66,7 @@ abstract class AbstractContentFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
@@ -56,7 +56,7 @@ class CollectionHierarchyTreeFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
@@ -56,7 +56,7 @@ class CollectionListFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
@@ -56,7 +56,7 @@ class ComponentPartsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
@@ -56,7 +56,7 @@ class HierarchyTreeFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/HoldingsILSFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsILSFactory.php
@@ -55,7 +55,7 @@ class HoldingsILSFactory implements \Laminas\ServiceManager\Factory\FactoryInter
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
@@ -56,7 +56,7 @@ class HoldingsWorldCatFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/MapFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/MapFactory.php
@@ -55,7 +55,7 @@ class MapFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/PreviewFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/PreviewFactory.php
@@ -55,7 +55,7 @@ class PreviewFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
@@ -56,7 +56,7 @@ class SimilarItemsCarouselFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/TabManagerFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/TabManagerFactory.php
@@ -55,7 +55,7 @@ class TabManagerFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/UserCommentsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/UserCommentsFactory.php
@@ -55,7 +55,7 @@ class UserCommentsFactory implements \Laminas\ServiceManager\Factory\FactoryInte
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/RecordTab/VersionsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/VersionsFactory.php
@@ -55,7 +55,7 @@ class VersionsFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Related/SimilarFactory.php
+++ b/module/VuFind/src/VuFind/Related/SimilarFactory.php
@@ -56,7 +56,7 @@ class SimilarFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Resolver/Driver/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/AbstractBaseFactory.php
@@ -56,7 +56,7 @@ class AbstractBaseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Resolver/Driver/DriverWithHttpClientFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/DriverWithHttpClientFactory.php
@@ -55,7 +55,7 @@ class DriverWithHttpClientFactory extends AbstractBaseFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/EzbFactory.php
@@ -55,7 +55,7 @@ class EzbFactory extends DriverWithHttpClientFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Role/PermissionDeniedManagerFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionDeniedManagerFactory.php
@@ -56,7 +56,7 @@ class PermissionDeniedManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Role/PermissionManagerFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionManagerFactory.php
@@ -56,7 +56,7 @@ class PermissionManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
@@ -58,7 +58,7 @@ class InjectAuthorizationServiceFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
@@ -56,7 +56,7 @@ class InjectRequestFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRangeFactory.php
@@ -55,7 +55,7 @@ class IpRangeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/IpRegExFactory.php
@@ -55,7 +55,7 @@ class IpRegExFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/ShibbolethFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/ShibbolethFactory.php
@@ -55,7 +55,7 @@ class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/Search/BackendManagerFactory.php
+++ b/module/VuFind/src/VuFind/Search/BackendManagerFactory.php
@@ -56,7 +56,7 @@ class BackendManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
+++ b/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
@@ -72,7 +72,7 @@ class FacetCacheFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/EDS/OptionsFactory.php
+++ b/module/VuFind/src/VuFind/Search/EDS/OptionsFactory.php
@@ -55,7 +55,7 @@ class OptionsFactory extends \VuFind\Search\Options\OptionsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
@@ -55,7 +55,7 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/HistoryFactory.php
+++ b/module/VuFind/src/VuFind/Search/HistoryFactory.php
@@ -56,7 +56,7 @@ class HistoryFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/MemoryFactory.php
+++ b/module/VuFind/src/VuFind/Search/MemoryFactory.php
@@ -57,7 +57,7 @@ class MemoryFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Options/OptionsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Options/OptionsFactory.php
@@ -56,7 +56,7 @@ class OptionsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Params/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Params/ParamsFactory.php
@@ -56,7 +56,7 @@ class ParamsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Results/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Results/ResultsFactory.php
@@ -57,7 +57,7 @@ class ResultsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Search2/ResultsFactory.php
@@ -55,7 +55,7 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/SearchRunnerFactory.php
+++ b/module/VuFind/src/VuFind/Search/SearchRunnerFactory.php
@@ -57,7 +57,7 @@ class SearchRunnerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/SearchTabsHelperFactory.php
+++ b/module/VuFind/src/VuFind/Search/SearchTabsHelperFactory.php
@@ -56,7 +56,7 @@ class SearchTabsHelperFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Solr/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Solr/ParamsFactory.php
@@ -55,7 +55,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Solr/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Solr/ResultsFactory.php
@@ -55,7 +55,7 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Search/Tags/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Tags/ResultsFactory.php
@@ -55,7 +55,7 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Security/CspHeaderGeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGeneratorFactory.php
@@ -57,7 +57,7 @@ class CspHeaderGeneratorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/DateConverterFactory.php
+++ b/module/VuFind/src/VuFind/Service/DateConverterFactory.php
@@ -56,7 +56,7 @@ class DateConverterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/HttpServiceFactory.php
+++ b/module/VuFind/src/VuFind/Service/HttpServiceFactory.php
@@ -56,7 +56,7 @@ class HttpServiceFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/Service/MarkdownFactory.php
@@ -74,7 +74,7 @@ class MarkdownFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(
         ContainerInterface $container, $requestedName, array $options = null

--- a/module/VuFind/src/VuFind/Service/ProxyConfigFactory.php
+++ b/module/VuFind/src/VuFind/Service/ProxyConfigFactory.php
@@ -56,7 +56,7 @@ class ProxyConfigFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/ReCaptchaFactory.php
+++ b/module/VuFind/src/VuFind/Service/ReCaptchaFactory.php
@@ -57,7 +57,7 @@ class ReCaptchaFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/SearchServiceFactory.php
+++ b/module/VuFind/src/VuFind/Service/SearchServiceFactory.php
@@ -57,7 +57,7 @@ class SearchServiceFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
+++ b/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
@@ -56,7 +56,7 @@ class ServiceWithConfigIniFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManagerFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/AbstractPluginManagerFactory.php
@@ -72,7 +72,7 @@ class AbstractPluginManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Session/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Session/AbstractBaseFactory.php
@@ -58,7 +58,7 @@ class AbstractBaseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Session/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Session/ManagerFactory.php
@@ -133,7 +133,7 @@ class ManagerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Session/RedisFactory.php
+++ b/module/VuFind/src/VuFind/Session/RedisFactory.php
@@ -58,7 +58,7 @@ class RedisFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Sitemap/GeneratorFactory.php
+++ b/module/VuFind/src/VuFind/Sitemap/GeneratorFactory.php
@@ -56,7 +56,7 @@ class GeneratorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPagesFactory.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPagesFactory.php
@@ -56,7 +56,7 @@ class ContentPagesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Solr/WriterFactory.php
+++ b/module/VuFind/src/VuFind/Solr/WriterFactory.php
@@ -56,7 +56,7 @@ class WriterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/TagsFactory.php
+++ b/module/VuFind/src/VuFind/TagsFactory.php
@@ -56,7 +56,7 @@ class TagsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/Validator/CsrfFactory.php
+++ b/module/VuFind/src/VuFind/Validator/CsrfFactory.php
@@ -61,7 +61,7 @@ class CsrfFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
@@ -56,7 +56,7 @@ class LayoutClassFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilitiesFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilitiesFactory.php
@@ -56,7 +56,7 @@ class AccountCapabilitiesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/AddThisFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AddThisFactory.php
@@ -56,7 +56,7 @@ class AddThisFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
@@ -56,7 +56,7 @@ class AlphaBrowseFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/AuthFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AuthFactory.php
@@ -56,7 +56,7 @@ class AuthFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/CaptchaFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CaptchaFactory.php
@@ -58,7 +58,7 @@ class CaptchaFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/CartFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CartFactory.php
@@ -56,7 +56,7 @@ class CartFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/CitationFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CitationFactory.php
@@ -56,7 +56,7 @@ class CitationFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ConfigFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ConfigFactory.php
@@ -56,7 +56,7 @@ class ConfigFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ContentLoaderFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ContentLoaderFactory.php
@@ -56,7 +56,7 @@ class ContentLoaderFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/DateTimeFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DateTimeFactory.php
@@ -56,7 +56,7 @@ class DateTimeFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
@@ -57,7 +57,7 @@ class DisplayLanguageOptionFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/DoiFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DoiFactory.php
@@ -56,7 +56,7 @@ class DoiFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ExportFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ExportFactory.php
@@ -56,7 +56,7 @@ class ExportFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/FeedbackFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/FeedbackFactory.php
@@ -56,7 +56,7 @@ class FeedbackFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/FlashmessagesFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/FlashmessagesFactory.php
@@ -56,7 +56,7 @@ class FlashmessagesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/GeoCoordsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GeoCoordsFactory.php
@@ -56,7 +56,7 @@ class GeoCoordsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
@@ -56,7 +56,7 @@ class GoogleAnalyticsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/HeadTitleFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HeadTitleFactory.php
@@ -57,7 +57,7 @@ class HeadTitleFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/HelpTextFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HelpTextFactory.php
@@ -57,7 +57,7 @@ class HelpTextFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/HistoryLabelFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HistoryLabelFactory.php
@@ -56,7 +56,7 @@ class HistoryLabelFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/IlsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/IlsFactory.php
@@ -56,7 +56,7 @@ class IlsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/JsTranslationsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/JsTranslationsFactory.php
@@ -56,7 +56,7 @@ class JsTranslationsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/KeepAliveFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/KeepAliveFactory.php
@@ -56,7 +56,7 @@ class KeepAliveFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrlFactory.php
@@ -56,7 +56,7 @@ class OpenUrlFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
@@ -59,7 +59,7 @@ class OverdriveFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(
         ContainerInterface $container, $requestedName,

--- a/module/VuFind/src/VuFind/View/Helper/Root/PermissionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PermissionFactory.php
@@ -56,7 +56,7 @@ class PermissionFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
@@ -56,7 +56,7 @@ class PiwikFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrlFactory.php
@@ -56,7 +56,7 @@ class ProxyUrlFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -58,7 +58,7 @@ class RecordDataFormatterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordFactory.php
@@ -56,7 +56,7 @@ class RecordFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordLinkFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordLinkFactory.php
@@ -56,7 +56,7 @@ class RecordLinkFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/RelaisFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RelaisFactory.php
@@ -56,7 +56,7 @@ class RelaisFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/RelatedFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RelatedFactory.php
@@ -56,7 +56,7 @@ class RelatedFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeedFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeedFactory.php
@@ -56,7 +56,7 @@ class ResultFeedFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormatFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SafeMoneyFormatFactory.php
@@ -56,7 +56,7 @@ class SafeMoneyFormatFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchBoxFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchBoxFactory.php
@@ -56,7 +56,7 @@ class SearchBoxFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchMemoryFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchMemoryFactory.php
@@ -56,7 +56,7 @@ class SearchMemoryFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchOptionsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchOptionsFactory.php
@@ -56,7 +56,7 @@ class SearchOptionsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchParamsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchParamsFactory.php
@@ -56,7 +56,7 @@ class SearchParamsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabsFactory.php
@@ -56,7 +56,7 @@ class SearchTabsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ServerUrlFactory.php
@@ -57,7 +57,7 @@ class ServerUrlFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrlFactory.php
@@ -56,7 +56,7 @@ class ShortenUrlFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlusFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SyndeticsPlusFactory.php
@@ -56,7 +56,7 @@ class SyndeticsPlusFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/SystemEmailFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SystemEmailFactory.php
@@ -56,7 +56,7 @@ class SystemEmailFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
@@ -57,7 +57,7 @@ class UrlFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
@@ -56,7 +56,7 @@ class UserListFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserTagsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserTagsFactory.php
@@ -56,7 +56,7 @@ class UserTagsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
@@ -56,7 +56,7 @@ class ApiControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindApi/src/VuFindApi/Controller/Search2ApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/Search2ApiControllerFactory.php
@@ -56,7 +56,7 @@ class Search2ApiControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiControllerFactory.php
@@ -56,7 +56,7 @@ class SearchApiControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindApi/src/VuFindApi/Controller/WebApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/WebApiControllerFactory.php
@@ -56,7 +56,7 @@ class WebApiControllerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatterFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatterFactory.php
@@ -63,7 +63,7 @@ class RecordFormatterFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommandFactory.php
@@ -56,7 +56,7 @@ class ThemeCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractCommandFactory.php
@@ -56,7 +56,7 @@ class AbstractCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractContainerAwareCommandFactory.php
@@ -55,7 +55,7 @@ class AbstractContainerAwareCommandFactory extends AbstractCommandFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractRouteCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/AbstractRouteCommandFactory.php
@@ -57,7 +57,7 @@ class AbstractRouteCommandFactory extends AbstractCommandFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommandFactory.php
@@ -55,7 +55,7 @@ class NonTabRecordActionCommandFactory extends AbstractCommandFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommandFactory.php
@@ -55,7 +55,7 @@ class ThemeCommandFactory extends AbstractCommandFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommandFactory.php
@@ -55,7 +55,7 @@ class ThemeMixinCommandFactory extends AbstractCommandFactory
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommandFactory.php
@@ -79,7 +79,7 @@ class HarvestOaiCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommandFactory.php
@@ -56,7 +56,7 @@ class ImportXslCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommandFactory.php
@@ -56,7 +56,7 @@ class WebCrawlCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/AbstractCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/AbstractCommandFactory.php
@@ -58,7 +58,7 @@ class AbstractCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommandFactory.php
@@ -56,7 +56,7 @@ class NotifyCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrAndIlsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrAndIlsCommandFactory.php
@@ -56,7 +56,7 @@ class AbstractSolrAndIlsCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractSolrCommandFactory.php
@@ -56,7 +56,7 @@ class AbstractSolrCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommandFactory.php
@@ -56,7 +56,7 @@ class CleanUpRecordCacheCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommandFactory.php
@@ -56,7 +56,7 @@ class CreateHierarchyTreesCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommandFactory.php
@@ -56,7 +56,7 @@ class CssBuilderCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommandFactory.php
@@ -56,7 +56,7 @@ class ExpireAuthHashesCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommandFactory.php
@@ -56,7 +56,7 @@ class ExpireExternalSessionsCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommandFactory.php
@@ -56,7 +56,7 @@ class ExpireSearchesCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommandFactory.php
@@ -56,7 +56,7 @@ class ExpireSessionsCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommandFactory.php
@@ -56,7 +56,7 @@ class ScssBuilderCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommandFactory.php
@@ -56,7 +56,7 @@ class SitemapCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
@@ -56,7 +56,7 @@ class SwitchDbHashCommandFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/ConsoleRunnerFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/ConsoleRunnerFactory.php
@@ -56,7 +56,7 @@ class ConsoleRunnerFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
@@ -56,7 +56,7 @@ class GeneratorToolsFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
@@ -56,7 +56,7 @@ class ThemeInfoFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoInjectorFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoInjectorFactory.php
@@ -56,7 +56,7 @@ class ThemeInfoInjectorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadThemeResourcesFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadThemeResourcesFactory.php
@@ -56,7 +56,7 @@ class HeadThemeResourcesFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLinkFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLinkFactory.php
@@ -56,7 +56,7 @@ class ImageLinkFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplateFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplateFactory.php
@@ -56,7 +56,7 @@ class ParentTemplateFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/PipelineInjectorFactory.php
@@ -86,7 +86,7 @@ class PipelineInjectorFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/TemplatePathFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/TemplatePathFactory.php
@@ -56,7 +56,7 @@ class TemplatePathFactory implements FactoryInterface
      * @throws ServiceNotFoundException if unable to resolve the service.
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
-     * @throws ContainerException if any other error occurs
+     * @throws ContainerException&\Throwable if any other error occurs
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null


### PR DESCRIPTION
This is a minor documentation improvement intended to reduce Psalm warnings (see #1764).