### PR TITLE
Add ability to use own (local) identifiers for getting covers

### DIFF
--- a/config/vufind/obalkyknih.ini
+++ b/config/vufind/obalkyknih.ini
@@ -21,6 +21,8 @@
 [ObalkyKnih]
 base_url[] = https://cache.obalkyknih.cz
 base_url[] = https://cache2.obalkyknih.cz
+; Library identifier - so called sigla, it needs to be set when you want to use own identifiers
+;sigla = 'AAA001'
 
 ; This is needed to 'authenticate' your catalog to ObalkyKnih service. You also have
 ; to register on obalkyknih.cz and add this url to your configuration

--- a/module/VuFind/src/VuFind/Content/AbstractCover.php
+++ b/module/VuFind/src/VuFind/Content/AbstractCover.php
@@ -81,6 +81,13 @@ abstract class AbstractCover
     protected $supportsNbn = false;
 
     /**
+     * Does this plugin support getting cover by local id?
+     *
+     * @var bool
+     */
+    protected $supportsRecordid = false;
+
+    /**
      * Are we allowed to cache images from this source?
      *
      * @var bool
@@ -137,7 +144,8 @@ abstract class AbstractCover
             || ($this->supportsIsmn && isset($ids['ismn']))
             || ($this->supportsOclc && isset($ids['oclc']))
             || ($this->supportsUpc && isset($ids['upc']))
-            || ($this->supportsNbn && isset($ids['nbn']));
+            || ($this->supportsNbn && isset($ids['nbn']))
+            || ($this->supportsRecordid && isset($ids['recordid']));
     }
 
     /**

--- a/module/VuFind/src/VuFind/Content/Covers/ObalkyKnih.php
+++ b/module/VuFind/src/VuFind/Content/Covers/ObalkyKnih.php
@@ -63,6 +63,7 @@ class ObalkyKnih extends \VuFind\Content\AbstractCover
         $this->supportsOclc = true;
         $this->supportsUpc = true;
         $this->supportsNbn = true;
+        $this->supportsRecordid = true;
         $this->cacheAllowed = false;
         $this->directUrls = true;
         $this->mandatoryBacklinkLocations = ['core'];


### PR DESCRIPTION
ObalkyKnih.cz could serve covers also for records without any standard identifier -  in that case the identifier is in format "SIGLA-recordid" where is sigla is library identifier used in Czech Republic and recordid is record identifier in local library system