### PR TITLE
Deprecate PHP-based LESS compiler.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CssBuilderCommand.php
@@ -27,7 +27,7 @@
  */
 namespace VuFindConsole\Command\Util;
 
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFindTheme\LessCompiler;
 
@@ -66,5 +66,24 @@ class CssBuilderCommand extends AbstractCssBuilderCommand
     protected function getCompiler(OutputInterface $output)
     {
         return new LessCompiler($output);
+    }
+
+    /**
+     * Run the command.
+     *
+     * @param InputInterface  $input  Input object
+     * @param OutputInterface $output Output object
+     *
+     * @return int 0 for success
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(
+            'WARNING: this tool is deprecated; please use "grunt less" for more'
+        );
+        $output->writeln(
+            'reliable results. See https://vufind.org/wiki/development:grunt' . "\n"
+        );
+        return parent::execute($input, $output);
     }
 }

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/CssBuilderCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/CssBuilderCommandTest.php
@@ -63,7 +63,10 @@ class CssBuilderCommandTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($compiler));
         $commandTester = new CommandTester($command);
         $commandTester->execute(['themes' => ['foo', 'bar', 'foo']]);
-        $this->assertEquals('', $commandTester->getDisplay());
+        $expectedOutput = 'WARNING: this tool is deprecated; please use "grunt less"'
+            . " for more\nreliable results. See "
+            . "https://vufind.org/wiki/development:grunt";
+        $this->assertEquals($expectedOutput, trim($commandTester->getDisplay()));
         $this->assertEquals(0, $commandTester->getStatusCode());
     }
 }


### PR DESCRIPTION
The PHP-based LESS compiler is less accurate than the Node-based one. We have maintained it for many years to avoid adding an additional development dependency, but it may be causing more problems than it is solving at this point. This PR adds a deprecation message to encourage users to switch to Grunt.

TODO:
- [x] Discuss whether this deprecation is appropriate, or whether we can/should improve the reliability of the PHP-based tool
- [x] Review wiki documentation about Grunt and LESS; update/clarify as needed
- [x] If we want to remove this after deprecation, we should add a note to [VUFIND-1474](https://vufind.org/jira/browse/VUFIND-1474)