### PR TITLE
Simplify/standardize I18n configuration.

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -2,8 +2,9 @@
 
 // Set up modules:
 $modules = [
-    'Laminas\Form', 'Laminas\Router', 'LmcRbacMvc', 'SlmLocale', 'VuFindTheme',
-    'VuFindSearch', 'VuFind', 'VuFindAdmin', 'VuFindApi'
+    'Laminas\Form', 'Laminas\Router', 'LmcRbacMvc', 'Laminas\I18n',
+    'Laminas\Mvc\I18n', 'SlmLocale', 'VuFindTheme', 'VuFindSearch', 'VuFind',
+    'VuFindAdmin', 'VuFindApi'
 ];
 if (!extension_loaded('intl')) {
     // Disable SlmLocale module if intl extension is missing:

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -441,10 +441,12 @@ $config = [
             'VuFindSearch\Service' => 'VuFind\Service\SearchServiceFactory',
             'Laminas\Db\Adapter\Adapter' => 'VuFind\Db\AdapterFactory',
             'Laminas\Http\PhpEnvironment\RemoteAddress' => 'VuFind\Http\PhpEnvironment\RemoteAddressFactory',
-            'Laminas\Mvc\I18n\Translator' => 'VuFind\I18n\Translator\TranslatorFactory',
             'Laminas\Session\SessionManager' => 'VuFind\Session\ManagerFactory',
         ],
         'delegators' => [
+            'Laminas\I18n\Translator\TranslatorInterface' => [
+                'VuFind\I18n\Translator\TranslatorFactory',
+            ],
             'SlmLocale\Locale\Detector' => [
                 'VuFind\I18n\Locale\LocaleDetectorFactory',
             ],
@@ -517,6 +519,14 @@ $config = [
         ],
     ],
     'translator' => [],
+    'translator_plugins' => [
+        'factories' => [
+            'VuFind\I18n\Translator\Loader\ExtendedIni' => 'VuFind\I18n\Translator\Loader\ExtendedIniFactory',
+        ],
+        'aliases' => [
+            'ExtendedIni' => 'VuFind\I18n\Translator\Loader\ExtendedIni'
+        ],
+    ],
     'view_helpers' => [
         'initializers' => [
             'VuFind\ServiceManager\ServiceInitializer',

--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
@@ -35,7 +35,6 @@ use Laminas\EventManager\EventInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
-use SlmLocale\Locale\Detector;
 use SlmLocale\LocaleEvent;
 use SlmLocale\Strategy\CookieStrategy;
 use SlmLocale\Strategy\QueryStrategy;

--- a/module/VuFind/src/VuFind/I18n/Translator/LanguageInitializerTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/LanguageInitializerTrait.php
@@ -27,7 +27,7 @@
  */
 namespace VuFind\I18n\Translator;
 
-use Laminas\Mvc\I18n\Translator;
+use Laminas\I18n\Translator\TranslatorInterface;
 use VuFind\I18n\Locale\LocaleSettings;
 
 /**
@@ -68,14 +68,14 @@ trait LanguageInitializerTrait
     /**
      * Configure a translator to support the requested language.
      *
-     * @param Translator     $translator Translator
-     * @param LocaleSettings $settings   Locale settings
-     * @param string         $language   Language to set up
+     * @param TranslatorInterface $translator Translator
+     * @param LocaleSettings      $settings   Locale settings
+     * @param string              $language   Language to set up
      *
      * @return void
      */
     protected function addLanguageToTranslator(
-        Translator $translator, LocaleSettings $settings, string $language
+        TranslatorInterface $translator, LocaleSettings $settings, string $language
     ): void {
         // Don't double-initialize languages:
         if ($settings->isLocaleInitialized($language)) {

--- a/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIniFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIniFactory.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * DisplayLanguageOption helper factory.
+ * ExtendedIni Loader Factory
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2018.
+ * Copyright (C) Villanova University 2021.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -20,30 +20,29 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  View_Helpers
+ * @package  Translator
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     https://vufind.org Main Site
  */
-namespace VuFind\View\Helper\Root;
+namespace VuFind\I18n\Translator\Loader;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Laminas\Mvc\I18n\Translator;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
-use Laminas\ServiceManager\Factory\FactoryInterface;
+use VuFind\I18n\Locale\LocaleSettings;
 
 /**
- * DisplayLanguageOption helper factory.
+ * ExtendedIni Loader Factory
  *
  * @category VuFind
- * @package  View_Helpers
+ * @package  Translator
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     https://vufind.org Main Site
  */
-class DisplayLanguageOptionFactory implements FactoryInterface
+class ExtendedIniFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object
@@ -58,13 +57,20 @@ class DisplayLanguageOptionFactory implements FactoryInterface
      * @throws ServiceNotCreatedException if an exception is raised when
      * creating a service.
      * @throws ContainerException&\Throwable if any other error occurs
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __invoke(ContainerInterface $container, $requestedName,
         array $options = null
     ) {
         if (!empty($options)) {
-            throw new \Exception('Unexpected options sent to factory.');
+            throw new \Exception('Unexpected options passed to factory.');
         }
-        return new $requestedName($container->get(Translator::class));
+        $pathStack = [
+            APPLICATION_PATH . '/languages',
+            LOCAL_OVERRIDE_DIR . '/languages'
+        ];
+        $settings = $container->get(LocaleSettings::class);
+        return new $requestedName($pathStack, $settings->getFallbackLocales());
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOption.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOption.php
@@ -55,18 +55,6 @@ class DisplayLanguageOption extends \Laminas\View\Helper\AbstractHelper
     public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
-        try {
-            $this->translator->addTranslationFile(
-                'ExtendedIni', null, 'default', 'native'
-            );
-            $this->translator->setLocale('native');
-        } catch (\Laminas\Mvc\I18n\Exception\BadMethodCallException $e) {
-            if (!extension_loaded('intl')) {
-                error_log(
-                    'Translation broken due to missing PHP intl extension.'
-                );
-            }
-        }
     }
 
     /**
@@ -78,6 +66,8 @@ class DisplayLanguageOption extends \Laminas\View\Helper\AbstractHelper
      */
     public function __invoke($str)
     {
-        return $this->view->escapeHtml($this->translator->translate($str));
+        return $this->view->escapeHtml(
+            $this->translator->translate($str, 'default', 'native')
+        );
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOptionFactory.php
@@ -65,6 +65,9 @@ class DisplayLanguageOptionFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        return new $requestedName($container->get(Translator::class));
+        $translator = $container->get(Translator::class);
+        // Add a special locale used just for this plugin:
+        $translator->addTranslationFile('ExtendedIni', null, 'default', 'native');
+        return new $requestedName($translator);
     }
 }


### PR DESCRIPTION
This pull request extracts more useful ideas from #1232:

- It loads standard Laminas\I18n configurations, exposing some additional view helpers and filters
- It makes the translator factory more granular (e.g. by giving the ExtendedIni loader its own separate factory), and applies VuFind customizations through a delegator rather than a subclass
- Configuration now applies customizations directly to the lower-level Translator object instead of the MVC-specific proxy
- It simplifies some unnecessary complexities in the DisplayLanguageOption view helper and its factory
- It relies on SlmLocale to set up the translator locale instead of setting it explicitly in VuFind-land code

Note one minor annoyance which I don't particularly like: the standard Laminas `translate` view helper has a different interface than VuFind's `translate` view helper. VuFind's configuration should override the Laminas helper with the VuFind version, but due to the existence of some differently-cased aliases, it might be possible to access the wrong helper and become confused. I'm not sure if it's worth any effort to eliminate this possibility, but it's at least something we should be aware of in the future.

TODO:
- [x] Run full test suite.
- [x] Add note to changelog when merging.