### PR TITLE
Don't override login template in collection controller.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CollectionController.php
+++ b/module/VuFind/src/VuFind/Controller/CollectionController.php
@@ -87,7 +87,9 @@ class CollectionController extends AbstractRecord
         }
 
         $result = parent::showTab($tab, $ajax);
-        if (!$ajax && $result instanceof \Laminas\View\Model\ViewModel) {
+        if (!$ajax && $result instanceof \Laminas\View\Model\ViewModel
+            && $result->getTemplate() !== 'myresearch/login'
+        ) {
             $result->setTemplate('collection/view');
         }
         return $result;


### PR DESCRIPTION
This fixes a crash that occurs when a collection record is loaded with the ?login=true parameter. Note that there's currently nothing doing so, as far as I can tell, but some crawlers seem to be happy to try everything. 