### PR TITLE
enable overriding scss variables from bootstrap accessibility plugin

### DIFF
--- a/themes/bootstrap3/scss/vendor/bootstrap-accessibility/partials/_variables.scss
+++ b/themes/bootstrap3/scss/vendor/bootstrap-accessibility/partials/_variables.scss
@@ -1,21 +1,21 @@
 //Set the variables for use in stylesheet
 
 // Colors
-$black: 		#000;
-$green-dark: 	#2d4821;
-$blue-dark: 	#214c62;
-$red-dark: 		#6c4a00;
-$red: 			#d2322d;
-$yellow: 		#f9f1c6;
+$black: 		#000 !default;
+$green-dark: 	#2d4821 !default;
+$blue-dark: 	#214c62 !default;
+$red-dark: 		#6c4a00 !default;
+$red: 			#d2322d !default;
+$yellow: 		#f9f1c6 !default;
 
 // Outline
-$outline-default-style: 	dotted;
-$outline-default-color: 	$black;
+$outline-default-style: 	dotted !default;
+$outline-default-color: 	$black !default;
 
 // Alerts Colors
-$alert-success-color: 			$green-dark;
-$alert-info-color: 				$blue-dark;
-$alert-warning-color: 			$red-dark;
-$alert-warning-bkg: 			$yellow;
-$alert-danger-color: 			$red;
-$alert-danger-hover: 			darken($red, 10%);
+$alert-success-color: 			$green-dark !default;
+$alert-info-color: 				$blue-dark !default;
+$alert-warning-color: 			$red-dark !default;
+$alert-warning-bkg: 			$yellow !default;
+$alert-danger-color: 			$red !default;
+$alert-danger-hover: 			darken($red, 10%) !default;


### PR DESCRIPTION
Setting the bootstrap accessibility plugin scss variables to '!default' enables global overriding of them from other files like compiled.scss

Why as PR?
* bootstrap accessibility itself does not seemed to be maintained any more
* we coudn't override the default plugin styles without changing something within the bootstrap3/scss/vendor folder. because a clean VuFind is our base layer we coudn't edit there.

Further question:
* Can we backport the change to 5.1? And if yes, shall I create an additional PR?