### PR TITLE
FOLIO: Add callnumber_prefix to the output of getHolding.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -499,6 +499,24 @@ class Folio extends AbstractAPI implements
     }
 
     /**
+     * Choose a call number and callnumber prefix.
+     *
+     * @param string $hCallNumP Holding-level call number prefix
+     * @param string $hCallNum  Holding-level call number
+     * @param string $iCallNumP Item-level call number prefix
+     * @param string $iCallNum  Item-level call number
+     *
+     * @return array with call number and call number prefix.
+     */
+    protected function chooseCallNumber($hCallNumP, $hCallNum, $iCallNumP, $iCallNum)
+    {
+        if (empty($iCallNum)) {
+            return ['prefix' => $hCallNumP, 'callnumber' => $hCallNum];
+        }
+        return ['prefix' => $iCallNumP, 'callnumber' => $iCallNum];
+    }
+
+    /**
      * This method queries the ILS for holding information.
      *
      * @param string $bibId   Bib-level id
@@ -565,6 +583,12 @@ class Folio extends AbstractAPI implements
                 $locationCode = $locationData['code'];
                 $itemCallNumber = $item->itemLevelCallNumber ?? '';
                 $itemCallNumberPrefix = $item->itemLevelCallNumberPrefix ?? '';
+                $callNumberData = $this->chooseCallNumber(
+                    $holdingCallNumberPrefix,
+                    $holdingCallNumber,
+                    $itemCallNumberPrefix,
+                    $itemCallNumber
+                );
                 $items[] = [
                     'id' => $bibId,
                     'item_id' => $item->id,
@@ -579,10 +603,8 @@ class Folio extends AbstractAPI implements
                     'issues' => $holdingsStatements,
                     'supplements' => $holdingsSupplements,
                     'indexes' => $holdingsIndexes,
-                    'callnumber' => $itemCallNumber
-                        ? $itemCallNumber : $holdingCallNumber,
-                    'callnumber_prefix' => $itemCallNumberPrefix
-                        ? $itemCallNumberPrefix : $holdingCallNumberPrefix,
+                    'callnumber' => $callNumberData['callnumber'],
+                    'callnumber_prefix' => $callNumberData['prefix'],
                     'location' => $locationName,
                     'location_code' => $locationCode,
                     'reserve' => 'TODO',

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -511,9 +511,9 @@ class Folio extends AbstractAPI implements
     protected function chooseCallNumber($hCallNumP, $hCallNum, $iCallNumP, $iCallNum)
     {
         if (empty($iCallNum)) {
-            return ['prefix' => $hCallNumP, 'callnumber' => $hCallNum];
+            return ['callnumber_prefix' => $hCallNumP, 'callnumber' => $hCallNum];
         }
-        return ['prefix' => $iCallNumP, 'callnumber' => $iCallNum];
+        return ['callnumber_prefix' => $iCallNumP, 'callnumber' => $iCallNum];
     }
 
     /**
@@ -581,15 +581,13 @@ class Folio extends AbstractAPI implements
                 $locationData = $this->getLocationData($locationId);
                 $locationName = $locationData['name'];
                 $locationCode = $locationData['code'];
-                $itemCallNumber = $item->itemLevelCallNumber ?? '';
-                $itemCallNumberPrefix = $item->itemLevelCallNumberPrefix ?? '';
                 $callNumberData = $this->chooseCallNumber(
                     $holdingCallNumberPrefix,
                     $holdingCallNumber,
-                    $itemCallNumberPrefix,
-                    $itemCallNumber
+                    $item->itemLevelCallNumberPrefix ?? '',
+                    $item->itemLevelCallNumber ?? ''
                 );
-                $items[] = [
+                $items[] = $callNumberData + [
                     'id' => $bibId,
                     'item_id' => $item->id,
                     'holding_id' => $holding->id,
@@ -603,8 +601,6 @@ class Folio extends AbstractAPI implements
                     'issues' => $holdingsStatements,
                     'supplements' => $holdingsSupplements,
                     'indexes' => $holdingsIndexes,
-                    'callnumber' => $callNumberData['callnumber'],
-                    'callnumber_prefix' => $callNumberData['prefix'],
                     'location' => $locationName,
                     'location_code' => $locationCode,
                     'reserve' => 'TODO',

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -551,6 +551,8 @@ class Folio extends AbstractAPI implements
                 $textFormatter,
                 $holding->holdingsStatementsForIndexes ?? []
             );
+            $holdingCallNumber = $holding->callNumber ?? '';
+            $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
             foreach ($this->getPagedResults(
                 'items', '/item-storage/items', $query
             ) as $item) {
@@ -561,8 +563,6 @@ class Folio extends AbstractAPI implements
                 $locationData = $this->getLocationData($locationId);
                 $locationName = $locationData['name'];
                 $locationCode = $locationData['code'];
-                $holdingCallNumber = $holding->callNumber ?? '';
-                $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
                 $itemCallNumber = $item->itemLevelCallNumber ?? '';
                 $itemCallNumberPrefix = $item->itemLevelCallNumberPrefix ?? '';
                 $items[] = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -561,6 +561,10 @@ class Folio extends AbstractAPI implements
                 $locationData = $this->getLocationData($locationId);
                 $locationName = $locationData['name'];
                 $locationCode = $locationData['code'];
+                $holdingCallNumber = $holding->callNumber ?? '';
+                $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
+                $itemCallNumber = $item->itemLevelCallNumber ?? '';
+                $itemCallNumberPrefix = $item->itemLevelCallNumberPrefix ?? '';
                 $items[] = [
                     'id' => $bibId,
                     'item_id' => $item->id,
@@ -575,8 +579,10 @@ class Folio extends AbstractAPI implements
                     'issues' => $holdingsStatements,
                     'supplements' => $holdingsSupplements,
                     'indexes' => $holdingsIndexes,
-                    'callnumber' => $holding->callNumber ?? '',
-                    'callnumber_prefix' => $holding->callNumberPrefix ?? '',
+                    'callnumber' => $itemCallNumber
+                        ? $itemCallNumber : $holdingCallNumber,
+                    'callnumber_prefix' => $itemCallNumberPrefix
+                        ? $itemCallNumberPrefix : $holdingCallNumberPrefix,
                     'location' => $locationName,
                     'location_code' => $locationCode,
                     'reserve' => 'TODO',

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -576,6 +576,7 @@ class Folio extends AbstractAPI implements
                     'supplements' => $holdingsSupplements,
                     'indexes' => $holdingsIndexes,
                     'callnumber' => $holding->callNumber ?? '',
+                    'callnumber_prefix' => $holding->callNumberPrefix ?? '',
                     'location' => $locationName,
                     'location_code' => $locationCode,
                     'reserve' => 'TODO',


### PR DESCRIPTION
We use call number prefixes for some of the stuff we do behind the scenes. We also display them in some cases. I'm hoping this will be an acceptable tweak to the driver though I don't see this attribute in the ILS driver API documentation. Let me know what you think.