### PR TITLE
Add getBuildings() method to retrieve building field.

### DIFF
--- a/config/vufind/SearchApiRecordFields.yaml
+++ b/config/vufind/SearchApiRecordFields.yaml
@@ -44,6 +44,12 @@ bibliographyNotes:
   type: array
   items:
     type: string
+buildings:
+  vufind.method: getBuildings
+  description: Buildings where the record is held
+  type: array
+  items:
+    type: string
 callNumbers:
   vufind.method: getCallNumbers
   description: Call numbers

--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -563,6 +563,16 @@ class DefaultRecord extends AbstractBase
     }
 
     /**
+     * Get the buildings containing the record.
+     *
+     * @return array
+     */
+    public function getBuildings()
+    {
+        return (array)($this->fields['building'] ?? []);
+    }
+
+    /**
      * Get an array of all ISBNs associated with the record (may be empty).
      *
      * @return array

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -101,7 +101,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
     {
         // "Mock out" tag functionality to avoid database access:
         $methods = [
-            'getBuilding', 'getDeduplicatedAuthors', 'getContainerTitle', 'getTags'
+            'getBuildings', 'getDeduplicatedAuthors', 'getContainerTitle', 'getTags'
         ];
         $record = $this->getMockBuilder(\VuFind\RecordDriver\SolrDefault::class)
             ->setMethods($methods)
@@ -110,8 +110,8 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue([]));
         // Force a return value of zero so we can test this edge case value (even
         // though in the context of "building"/"container title" it makes no sense):
-        $record->expects($this->any())->method('getBuilding')
-            ->will($this->returnValue(0));
+        $record->expects($this->any())->method('getBuildings')
+            ->will($this->returnValue(['0']));
         $record->expects($this->any())->method('getContainerTitle')
             ->will($this->returnValue('0'));
         // Expect only one call to getDeduplicatedAuthors to confirm that caching
@@ -208,7 +208,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
         $formatter = $this->getFormatter();
         $spec = $formatter->getDefaults('core');
         $spec['Building'] = [
-            'dataMethod' => 'getBuilding', 'pos' => 0, 'context' => ['foo' => 1],
+            'dataMethod' => 'getBuildings', 'pos' => 0, 'context' => ['foo' => 1],
             'translationTextDomain' => 'prefix_',
         ];
         $spec['MultiTest'] = [

--- a/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
+++ b/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
@@ -118,7 +118,7 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
                 'DedupData' => [['id' => 'bar']],
                 'fullrecord' => 'xyzzy',
                 'spelling' => 's',
-                'Building' => ['foo', new TranslatableString('bar', 'xyzzy')],
+                'Buildings' => ['foo', new TranslatableString('bar', 'xyzzy')],
                 'AllSubjectHeadings' => [['heading' => 'subject']],
                 'DeduplicatedAuthors' => [
                     'primary' => ['Ms. A' => ['role' => ['Editor']]],
@@ -149,7 +149,7 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
         );
         $expectedRaw = $driver->getRawData();
         unset($expectedRaw['spelling']);
-        $expectedRaw['Building'] = [
+        $expectedRaw['Buildings'] = [
             'foo', ['value' => 'bar', 'translated' => 'xyzzy']
         ];
         $expected = [

--- a/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
+++ b/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
@@ -63,7 +63,7 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
             ],
             'fullRecord' => ['vufind.method' => 'Formatter::getFullRecord'],
             'rawData' => ['vufind.method' => 'Formatter::getRawData'],
-            'buildings' => ['vufind.method' => 'getBuilding'],
+            'buildings' => ['vufind.method' => 'getBuildings'],
             'recordPage' => ['vufind.method' => 'Formatter::getRecordPage'],
             'subjectsExtended' => [
                 'vufind.method' => 'Formatter::getExtendedSubjectHeadings'


### PR DESCRIPTION
For some reason, we never added a record driver method to retrieve the building field from Solr; however, some code existed which assumed the existence of such a method. This PR creates the method and normalizes references to it into a plural form.