### PR TITLE
Use window.location.href as fallback for form action.

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -327,7 +327,7 @@ VuFind.register('lightbox', function Lightbox() {
     _lightboxTitle = submit.data('lightbox-title') || $(form).data('lightbox-title') || false;
     // Get Lightbox content
     ajax({
-      url: $(form).attr('action') || _currentUrl,
+      url: $(form).attr('action') || _currentUrl || window.location.href,
       method: $(form).attr('method') || 'GET',
       data: data
     }).done(function recaptchaReset() {


### PR DESCRIPTION
- Lightbox didn't work on forms that don't have an action attribute. _currentUrl is not yet set at the moment the initial request is made, so we need to use the current page URL like the form would have used if submitted normally.
- Extracted from #1956.

TODO
- [x] Run full test suite.