### PR TITLE
Add patron to getCancelHoldDetails. Use in MultiBackend.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1195,7 +1195,7 @@ class MyResearchController extends AbstractBase
         foreach ($result as $current) {
             // Add cancel details if appropriate:
             $current = $this->holds()->addCancelDetails(
-                $catalog, $current, $cancelStatus
+                $catalog, $current, $cancelStatus, $patron
             );
             if ($cancelStatus && $cancelStatus['function'] != "getCancelHoldLink"
                 && isset($current['cancel_details'])

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -46,10 +46,11 @@ class Holds extends AbstractRequestBase
      * getMyHolds() method
      * @param array                  $cancelStatus Cancel settings from ILS driver's
      * checkFunction() method
+     * @param array                  $patron       ILS patron
      *
      * @return array $ilsDetails with cancellation info added
      */
-    public function addCancelDetails($catalog, $ilsDetails, $cancelStatus)
+    public function addCancelDetails($catalog, $ilsDetails, $cancelStatus, $patron)
     {
         // Generate Form Details for cancelling Holds if Cancelling Holds
         // is enabled
@@ -57,7 +58,7 @@ class Holds extends AbstractRequestBase
             if ($cancelStatus['function'] == "getCancelHoldLink") {
                 // Build OPAC URL
                 $ilsDetails['cancel_link']
-                    = $catalog->getCancelHoldLink($ilsDetails);
+                    = $catalog->getCancelHoldLink($ilsDetails, $patron);
             } elseif (isset($ilsDetails['cancel_details'])) {
                 // The ILS driver provided cancel details up front. If the
                 // details are an empty string (flagging lack of support), we
@@ -71,7 +72,8 @@ class Holds extends AbstractRequestBase
             } else {
                 // Default case: ILS supports cancel but we need to look up
                 // details:
-                $cancelDetails = $catalog->getCancelHoldDetails($ilsDetails);
+                $cancelDetails
+                    = $catalog->getCancelHoldDetails($ilsDetails, $patron);
                 if ($cancelDetails !== '') {
                     $ilsDetails['cancel_details'] = $cancelDetails;
                     $this->rememberValidId($ilsDetails['cancel_details']);

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -50,8 +50,9 @@ class Holds extends AbstractRequestBase
      *
      * @return array $ilsDetails with cancellation info added
      */
-    public function addCancelDetails($catalog, $ilsDetails, $cancelStatus, $patron)
-    {
+    public function addCancelDetails($catalog, $ilsDetails, $cancelStatus,
+        $patron = []
+    ) {
         // Generate Form Details for cancelling Holds if Cancelling Holds
         // is enabled
         if ($cancelStatus) {

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1306,7 +1306,7 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         if ($holdDetails['delete']) {
             return $holdDetails['item_id'];

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1299,11 +1299,14 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
     /**
      * Get Cancel Hold Details
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         if ($holdDetails['delete']) {
             return $holdDetails['item_id'];

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1005,12 +1005,14 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
     /**
      * Get details of a single hold request.
      *
-     * @param array $holdDetails One of the item arrays returned by the
-     *                           getMyHolds method
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string            The Alma request ID
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1012,7 +1012,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -1599,13 +1599,17 @@ class Demo extends AbstractBase
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $hold   An array of hold data
+     * @param array $patron Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($hold, $patron)
     {
-        return $holdDetails['reqnum'];
+        return empty($hold['available']) && empty($hold['in_transit'])
+            ? $hold['reqnum'] : '';
     }
 
     /**
@@ -1663,13 +1667,16 @@ class Demo extends AbstractBase
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $details An array of item data
+     * @param array $request An array of request data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($request, $patron)
     {
-        return $details['reqnum'];
+        return $request['reqnum'];
     }
 
     /**
@@ -2259,13 +2266,16 @@ class Demo extends AbstractBase
     /**
      * Get Cancel ILL Request Details
      *
-     * @param array $details An array of item data
+     * @param array $request An array of request data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelILLRequestDetails($details)
+    public function getCancelILLRequestDetails($request, $patron)
     {
-        return $details['reqnum'];
+        return $request['reqnum'];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -1606,7 +1606,7 @@ class Demo extends AbstractBase
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($hold, $patron)
+    public function getCancelHoldDetails($hold, $patron = [])
     {
         return empty($hold['available']) && empty($hold['in_transit'])
             ? $hold['reqnum'] : '';

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1099,7 +1099,7 @@ class Folio extends AbstractAPI implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($hold, $patron)
+    public function getCancelHoldDetails($hold, $patron = [])
     {
         return $hold['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1092,12 +1092,14 @@ class Folio extends AbstractAPI implements
     /**
      * Get FOLIO hold IDs for use in cancelHolds.
      *
-     * @param array $hold An single request
-     * array from getMyHolds
+     * @param array $hold   A single hold array from getMyHolds
+     * @param array $patron Patron information from patronLogin
      *
      * @return string request ID for this request
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($hold)
+    public function getCancelHoldDetails($hold, $patron)
     {
         return $hold['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
@@ -916,7 +916,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         $cancelDetails = $holdDetails['id'] . "|" . $holdDetails['item_id'];
         return $cancelDetails;

--- a/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
@@ -909,11 +909,14 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         $cancelDetails = $holdDetails['id'] . "|" . $holdDetails['item_id'];
         return $cancelDetails;

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1276,11 +1276,14 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
      * an item ID. This function returns the item id as a string. This
      * value is then used by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['reserve_id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -1283,7 +1283,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['reserve_id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -776,11 +776,14 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      * Get required data for canceling a hold. This value is used by relayed to the
      * cancelHolds function when the user attempts to cancel a hold.
      *
-     * @param array $holdDetails An array of hold data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
             : $holdDetails['requestId'];

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -783,7 +783,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
             : $holdDetails['requestId'];

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1178,10 +1178,13 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      * Get Cancel Storage Retrieval Request (article request) Details
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($details, $patron)
     {
         return $details['item_id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -943,21 +943,23 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      * as form data in Hold.php. This value is then extracted by the CancelHolds
      * function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $hold   A single hold array from getMyHolds
+     * @param array $patron Patron information from patronLogin
      *
      * @return string Data for use in a form field
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($hold, $patron)
     {
-        $source = $this->getSource(
-            $holdDetails['id'] ?? $holdDetails['item_id'] ?? ''
-        );
+        $source = $this->getSource($patron['cat_username']);
         $driver = $this->getDriver($source);
         if ($driver) {
-            $holdDetails = $this->stripIdPrefixes(
-                $holdDetails, $source, ['id', 'item_id', 'cat_username']
+            $hold = $this->stripIdPrefixes(
+                $hold, $source, ['id', 'item_id', 'cat_username']
             );
-            return $driver->getCancelHoldDetails($holdDetails);
+            return $driver->getCancelHoldDetails(
+                $hold,
+                $this->stripIdPrefixes($patron, $source)
+            );
         }
         throw new ILSException('No suitable backend driver found');
     }
@@ -1028,22 +1030,25 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      * as form data. This value is then extracted by the
      * CancelStorageRetrievalRequests function.
      *
-     * @param array $details An array of item data
+     * @param array $request An array of request data
+     * @param array $patron  Patron information
      *
      * @return string Data for use in a form field
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($request, $patron)
     {
-        $source = $this->getSource($details['id'] ?? '');
+        $source = $this->getSource($patron['cat_username']);
         $driver = $this->getDriver($source);
         if ($driver
             && $this->methodSupported(
                 $driver, 'getCancelStorageRetrievalRequestDetails',
-                compact('details')
+                compact('request', 'patron')
             )
         ) {
-            $details = $this->stripIdPrefixes($details, $source);
-            return $driver->getCancelStorageRetrievalRequestDetails($details);
+            return $driver->getCancelStorageRetrievalRequestDetails(
+                $this->stripIdPrefixes($request, $source),
+                $this->stripIdPrefixes($patron, $source)
+            );
         }
         throw new ILSException('No suitable backend driver found');
     }
@@ -1206,7 +1211,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      * data in $cancelDetails['details'] is determined by
      * getCancelILLRequestDetails().
      *
-     * @param array $cancelDetails An array of item and patron data
+     * @param array $cancelDetails An array of request and patron data
      *
      * @return array               An array of data on each request including
      * whether or not it was successful and a system message (if available)
@@ -1235,21 +1240,23 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      * submitted as form data. This value is then extracted by the CancelILLRequests
      * function.
      *
-     * @param array $details An array of item data
+     * @param array $request An array of request data
+     * @param array $patron  The patron array from patronLogin
      *
      * @return string Data for use in a form field
      */
-    public function getCancelILLRequestDetails($details)
+    public function getCancelILLRequestDetails($request, $patron)
     {
-        $source = $this->getSource($details['id'] ?? $details['item_id'] ?? '');
+        $source = $this->getSource($patron['cat_username']);
         $driver = $this->getDriver($source);
         if ($driver
             && $this->methodSupported(
-                $driver, 'getCancelILLRequestDetails', compact('details')
+                $driver, 'getCancelILLRequestDetails', compact('request', 'patron')
             )
         ) {
             return $driver->getCancelILLRequestDetails(
-                $this->stripIdPrefixes($details, $source)
+                $this->stripIdPrefixes($request, $source),
+                $this->stripIdPrefixes($patron, $source)
             );
         }
         throw new ILSException('No suitable backend driver found');

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -948,9 +948,11 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      *
      * @return string Data for use in a form field
      */
-    public function getCancelHoldDetails($hold, $patron)
+    public function getCancelHoldDetails($hold, $patron = [])
     {
-        $source = $this->getSource($patron['cat_username']);
+        $source = $this->getSource(
+            $patron['cat_username'] ?? $hold['id'] ?? $hold['item_id'] ?? ''
+        );
         $driver = $this->getDriver($source);
         if ($driver) {
             $hold = $this->stripIdPrefixes(

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -478,10 +478,13 @@ class PAIA extends DAIA
      * value is then extracted by the CancelHolds function.
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($details, $patron)
     {
         // Not yet implemented
         return '';
@@ -601,10 +604,13 @@ class PAIA extends DAIA
      * Get Cancel ILL Request Details
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelILLRequestDetails($details)
+    public function getCancelILLRequestDetails($details, $patron)
     {
         // Not yet implemented
         return '';

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -403,18 +403,20 @@ class PAIA extends DAIA
      * cancelling each hold item. (optional, but required if you
      * implement cancelHolds). Not supported prior to VuFind 1.2
      *
-     * @param array $checkOutDetails One of the individual item arrays returned by
-     *                               the getMyHolds method
+     * @param array $hold   A single hold array from getMyHolds
+     * @param array $patron Patron information from patronLogin
      *
      * @return string  A string to use as the input form value for cancelling
      *                 each hold item; you can pass any data that is needed
      *                 by your ILS to identify the hold – the output of this
      *                 method will be used as part of the input to the
      *                 cancelHolds method.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($checkOutDetails)
+    public function getCancelHoldDetails($hold, $patron)
     {
-        return $checkOutDetails['cancel_details'];
+        return $hold['cancel_details'];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -414,7 +414,7 @@ class PAIA extends DAIA
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($hold, $patron)
+    public function getCancelHoldDetails($hold, $patron = [])
     {
         return $hold['cancel_details'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
@@ -832,12 +832,15 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
     /**
      * Get Cancel Hold Details
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field (just request id is all Polaris
      * needs)
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
@@ -840,7 +840,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -847,7 +847,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
             : $holdDetails['requestId'];

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -840,11 +840,14 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
      * Get required data for canceling a hold. This value is used by relayed to the
      * cancelHolds function when the user attempts to cancel a hold.
      *
-     * @param array $holdDetails An array of hold data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['available'] || $holdDetails['in_transit'] ? ''
             : $holdDetails['requestId'];

--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1394,7 +1394,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1387,11 +1387,14 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
      *
      * Supplies the form details required to cancel a hold
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string  Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['reqnum'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -683,11 +683,14 @@ class Unicorn extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $holdDetails['item_id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -690,7 +690,7 @@ class Unicorn extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $holdDetails['item_id'];
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
@@ -1605,13 +1605,14 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         // TODO: implement me.
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
@@ -1612,7 +1612,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         // TODO: implement me.
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2106,11 +2106,14 @@ EOT;
      * separated by a pipe, which is then submitted as form data in Hold.php. This
      * value is then extracted by the CancelHolds function.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         if (!$this->allowCancelingAvailableRequests && $holdDetails['available']) {
             return '';

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2607,10 +2607,13 @@ EOT;
      * value is then extracted by the CancelStorageRetrievalRequests function.
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($details, $patron)
     {
         $details
             = ($details['institution_dbkey'] ?? '')
@@ -3209,10 +3212,13 @@ EOT;
      * submitted as form data and extracted by the CancelILLRequests function.
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelILLRequestDetails($details)
+    public function getCancelILLRequestDetails($details, $patron)
     {
         $details = ($details['institution_dbkey'] ?? '')
             . '|' . $details['item_id']

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -2113,7 +2113,7 @@ EOT;
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         if (!$this->allowCancelingAvailableRequests && $holdDetails['available']) {
             return '';

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -1581,11 +1581,14 @@ class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      * value is then extracted by the CancelHolds function.  item id is used as the
      * array key in the response.
      *
-     * @param array $holdDetails An array of item data
+     * @param array $holdDetails A single hold array from getMyHolds
+     * @param array $patron      Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
         return $this->getCancelRequestDetails($holdDetails);
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -1619,10 +1619,13 @@ class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      * The item id is used as the key in the return value.
      *
      * @param array $details An array of item data
+     * @param array $patron  Patron information from patronLogin
      *
      * @return string Data for use in a form field
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelStorageRetrievalRequestDetails($details)
+    public function getCancelStorageRetrievalRequestDetails($details, $patron)
     {
         return $this->getCancelRequestDetails($details);
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -1588,7 +1588,7 @@ class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
         return $this->getCancelRequestDetails($holdDetails);
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -114,7 +114,6 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     protected function submitCatalogLoginForm(Element $page, string $username,
         string $password
     ): void {
-
         $this->findCss($page, '#profile_cat_username')->setValue($username);
         $this->findCss($page, '#profile_cat_password')->setValue($password);
         $this->clickCss($page, 'input.btn.btn-primary');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -76,7 +76,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function getConfigIniOverrides()
+    public function getConfigIniOverrides(): array
     {
         return [
             'Catalog' => [
@@ -93,9 +93,9 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @param string $id ID of record to access.
      *
-     * @return \Behat\Mink\Element\Element
+     * @return Element
      */
-    protected function gotoRecordById($id = 'testsample1')
+    protected function gotoRecordById(string $id = 'testsample1'): Element
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Record/' . urlencode($id));
@@ -111,8 +111,10 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function submitCatalogLoginForm(Element $page, $username, $password)
-    {
+    protected function submitCatalogLoginForm(Element $page, string $username,
+        string $password
+    ): void {
+
         $this->findCss($page, '#profile_cat_username')->setValue($username);
         $this->findCss($page, '#profile_cat_password')->setValue($password);
         $this->clickCss($page, 'input.btn.btn-primary');
@@ -126,7 +128,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function placeHoldAndGoToHoldsScreen($page)
+    protected function placeHoldAndGoToHoldsScreen(Element $page): void
     {
         // Open the "place hold" dialog
         $this->clickCss($page, 'a.placehold');
@@ -157,7 +159,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function placeIllRequestAndGoToIllScreen($page)
+    protected function placeIllRequestAndGoToIllScreen(Element $page): void
     {
         // Open the "place hold" dialog
         $this->snooze();
@@ -192,8 +194,9 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function placeStorageRetrievalRequestAndGoToSRRScreen($page)
-    {
+    protected function placeStorageRetrievalRequestAndGoToSRRScreen(
+        Element $page
+    ): void {
         // Open the "place hold" dialog
         $this->snooze();
         $this->clickCss($page, 'a.placeStorageRetrievalRequest');
@@ -224,7 +227,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testPlaceHold()
+    public function testPlaceHold(): void
     {
         $this->changeConfigs(
             [
@@ -252,6 +255,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test valid patron login
         $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
+        $this->snooze(1);
 
         // Create the hold and go to the holds screen:
         $this->placeHoldAndGoToHoldsScreen($page);
@@ -264,7 +268,8 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         );
         $this->assertTrue(false !== strstr($page->getContent(), 'Campus B'));
 
-        // Confirm that no cancel button appears, since it is not configured:
+        // Confirm that no cancel buttons appear, since they are not configured:
+        $this->assertNull($page->find('css', '#cancelSelected'));
         $this->assertNull($page->find('css', '#cancelAll'));
     }
 
@@ -276,7 +281,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function clickButtonGroupLink($page, $text)
+    protected function clickButtonGroupLink(Element $page, string $text): void
     {
         $link = $this->findCss($page, '.btn-group.open')->findLink($text);
         $this->assertTrue(is_object($link));
@@ -284,42 +289,21 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Test canceling a hold.
+     * Test canceling a request.
      *
-     * @depends testPlaceHold
+     * @param Element $page Page element.
+     * @param string  $type Request type being tested.
      *
      * @return void
      */
-    public function testCancelHold()
+    protected function cancelProcedure(Element $page, string $type): void
     {
-        // Turn on "cancel holds" in addition to normal defaults:
-        $config = $this->getConfigIniOverrides();
-        $config['Catalog']['cancel_holds_enabled'] = 1;
-        $this->changeConfigs(
-            [
-                'config' => $config,
-                'Demo' => $this->getDemoIniOverrides(),
-            ]
-        );
-
-        // Log in the user on the record page:
-        $page = $this->gotoRecordById();
-        $element = $this->findCss($page, '.alert.alert-info a');
-        $this->assertEquals('Login for hold and recall information', $element->getText());
-        $element->click();
-        $this->snooze();
-        $this->fillInLoginForm($page, 'username1', 'test', false);
-        $this->submitLoginForm($page, false);
-
-        // Place the hold:
-        $this->placeHoldAndGoToHoldsScreen($page);
-
         // Test empty selection
         $this->clickCss($page, '#cancelSelected');
         $this->clickButtonGroupLink($page, 'Yes');
         $this->snooze();
         $this->assertEquals(
-            'No holds were selected',
+            'No ' . $type . ' were selected',
             $this->findCss($page, '.alert.alert-danger')->getText()
         );
 
@@ -353,24 +337,14 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Test ILL requests.
+     * Routine to place an ILL request
      *
-     * @depends testPlaceHold
+     * @param Element $page Page element.
      *
      * @return void
      */
-    public function testIllRequest()
+    protected function illRequestProcedure(Element $page): void
     {
-        // Turn on "cancel holds" in addition to normal defaults:
-        $this->changeConfigs(
-            [
-                'config' => $this->getConfigIniOverrides(),
-                'Demo' => $this->getDemoIniOverrides(),
-            ]
-        );
-
-        // Log in the user on the record page:
-        $page = $this->gotoRecordById();
         $element = $this->findCss($page, '.alert.alert-info a');
         $this->assertEquals('Login for hold and recall information', $element->getText());
         $element->click();
@@ -378,7 +352,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLoginForm($page, 'username1', 'test', false);
         $this->submitLoginForm($page, false);
 
-        // Place the hold:
+        // Place the request:
         $this->placeIllRequestAndGoToIllScreen($page);
 
         // Verify the request is correct:
@@ -391,18 +365,48 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Test storage retrieval requests.
+     * Routine to place a storage retrieval request
+     *
+     * @param Element $page Page element.
+     *
+     * @return void
+     */
+    protected function storageRetrievalRequestProcedure(Element $page): void
+    {
+        $element = $this->findCss($page, '.alert.alert-info a');
+        $this->assertEquals('Login for hold and recall information', $element->getText());
+        $element->click();
+        $this->snooze();
+        $this->fillInLoginForm($page, 'username1', 'test', false);
+        $this->submitLoginForm($page, false);
+
+        // Place the request:
+        $this->placeStorageRetrievalRequestAndGoToSRRScreen($page);
+
+        // Verify the request is correct:
+        $this->assertEquals(
+            'Journal of rational emotive therapy :'
+            . ' the journal of the Institute for Rational-Emotive Therapy.',
+            $this->findCss($page, 'a.title')->getText()
+        );
+        $this->assertTrue(false !== strstr($page->getContent(), 'Campus C'));
+    }
+
+    /**
+     * Test canceling a hold.
      *
      * @depends testPlaceHold
      *
      * @return void
      */
-    public function testStorageRetrievalRequest()
+    public function testCancelHold(): void
     {
         // Turn on "cancel holds" in addition to normal defaults:
+        $config = $this->getConfigIniOverrides();
+        $config['Catalog']['cancel_holds_enabled'] = 1;
         $this->changeConfigs(
             [
-                'config' => $this->getConfigIniOverrides(),
+                'config' => $config,
                 'Demo' => $this->getDemoIniOverrides(),
             ]
         );
@@ -417,15 +421,114 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->submitLoginForm($page, false);
 
         // Place the hold:
-        $this->placeStorageRetrievalRequestAndGoToSRRScreen($page);
+        $this->placeHoldAndGoToHoldsScreen($page);
 
-        // Verify the request is correct:
-        $this->assertEquals(
-            'Journal of rational emotive therapy :'
-            . ' the journal of the Institute for Rational-Emotive Therapy.',
-            $this->findCss($page, 'a.title')->getText()
+        // Test canceling the hold:
+        $this->cancelProcedure($page, 'holds');
+    }
+
+    /**
+     * Test ILL requests.
+     *
+     * @depends testPlaceHold
+     *
+     * @return void
+     */
+    public function testIllRequest(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => $this->getConfigIniOverrides(),
+                'Demo' => $this->getDemoIniOverrides(),
+            ]
         );
-        $this->assertTrue(false !== strstr($page->getContent(), 'Campus C'));
+
+        // Log in the user on the record page:
+        $page = $this->gotoRecordById();
+        $this->illRequestProcedure($page);
+
+        // Confirm that no cancel buttons appear, since they are not configured:
+        $this->assertNull($page->find('css', '#cancelSelected'));
+        $this->assertNull($page->find('css', '#cancelAll'));
+    }
+
+    /**
+     * Test canceling an ILL request.
+     *
+     * @depends testPlaceHold
+     *
+     * @return void
+     */
+    public function testCancelIllRequest(): void
+    {
+        // Turn on "cancel ILL requests" in addition to normal defaults:
+        $config = $this->getConfigIniOverrides();
+        $config['Catalog']['cancel_ill_requests_enabled'] = 1;
+        $this->changeConfigs(
+            [
+                'config' => $config,
+                'Demo' => $this->getDemoIniOverrides(),
+            ]
+        );
+
+        // Log in the user on the record page:
+        $page = $this->gotoRecordById();
+        $this->illRequestProcedure($page);
+
+        // Test canceling the request:
+        $this->cancelProcedure($page, 'interlibrary loan requests');
+    }
+
+    /**
+     * Test storage retrieval requests.
+     *
+     * @depends testPlaceHold
+     *
+     * @return void
+     */
+    public function testStorageRetrievalRequest(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => $this->getConfigIniOverrides(),
+                'Demo' => $this->getDemoIniOverrides(),
+            ]
+        );
+
+        // Log in the user on the record page:
+        $page = $this->gotoRecordById();
+        $this->storageRetrievalRequestProcedure($page);
+
+        // Confirm that no cancel buttons appear, since they are not configured:
+        $this->assertNull($page->find('css', '#cancelSelected'));
+        $this->assertNull($page->find('css', '#cancelAll'));
+    }
+
+    /**
+     * Test canceling storage retrieval requests.
+     *
+     * @depends testPlaceHold
+     *
+     * @return void
+     */
+    public function testCancelStorageRetrievalRequest(): void
+    {
+        // Turn on "cancel storage requests" in addition to normal defaults:
+        $config = $this->getConfigIniOverrides();
+        $config['Catalog']['cancel_storage_retrieval_requests_enabled'] = 1;
+        $this->changeConfigs(
+            [
+                'config' => $config,
+                'Demo' => $this->getDemoIniOverrides(),
+            ]
+        );
+
+        // Log in the user on the record page:
+        $page = $this->gotoRecordById();
+        $this->storageRetrievalRequestProcedure($page);
+
+        // Test canceling the request:
+        $this->cancelProcedure($page, 'storage retrieval requests');
     }
 
     /**
@@ -435,7 +538,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testProfile()
+    public function testProfile(): void
     {
         $this->changeConfigs(
             [
@@ -469,7 +572,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testRenewal()
+    public function testRenewal(): void
     {
         $this->changeConfigs(
             [
@@ -515,7 +618,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testHoldsAll()
+    public function testHoldsAll(): void
     {
         $config = $this->getConfigIniOverrides();
         $config['Catalog']['holds_mode'] = 'all';
@@ -569,7 +672,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function removeUsername2()
+    protected function removeUsername2(): void
     {
         static::removeUsers(['username2']);
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -1657,19 +1657,23 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         );
 
         $result = $driver->getCancelHoldDetails(
-            ['id' => 'd1.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'd1')
         );
         $this->assertEquals($expected, $result);
 
         $result = $driver->getCancelHoldDetails(
-            ['id' => 'd2.1', 'item_id' => 2]
+            ['id' => 'd2.1', 'item_id' => 2],
+            $this->getPatron('user', 'd2')
+
         );
         $this->assertEquals($expected, $result);
 
         $this->expectException('VuFind\Exception\ILS');
         $this->expectExceptionMessage('No suitable backend driver found');
         $result = $driver->getCancelHoldDetails(
-            ['id' => 'invalid.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'invalid')
         );
     }
 
@@ -1811,19 +1815,22 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         );
 
         $result = $driver->getCancelStorageRetrievalRequestDetails(
-            ['id' => 'd1.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'd1')
         );
         $this->assertEquals($expected, $result);
 
         $result = $driver->getCancelStorageRetrievalRequestDetails(
-            ['id' => 'd2.1', 'item_id' => 2]
+            ['id' => 'd2.1', 'item_id' => 2],
+            $this->getPatron('user', 'd2')
         );
         $this->assertEquals($expected, $result);
 
         $this->expectException('VuFind\Exception\ILS');
         $this->expectExceptionMessage('No suitable backend driver found');
         $result = $driver->getCancelStorageRetrievalRequestDetails(
-            ['id' => 'invalid.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'invalid')
         );
     }
 
@@ -2148,19 +2155,22 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         );
 
         $result = $driver->getCancelILLRequestDetails(
-            ['id' => 'd1.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'd1')
         );
         $this->assertEquals($expected, $result);
 
         $result = $driver->getCancelILLRequestDetails(
-            ['id' => 'd2.1', 'item_id' => 2]
+            ['id' => 'd2.1', 'item_id' => 2],
+            $this->getPatron('user', 'd2')
         );
         $this->assertEquals($expected, $result);
 
         $this->expectException('VuFind\Exception\ILS');
         $this->expectExceptionMessage('No suitable backend driver found');
         $result = $driver->getCancelILLRequestDetails(
-            ['id' => 'invalid.1', 'item_id' => 2]
+            ['id' => 'd1.1', 'item_id' => 2],
+            $this->getPatron('user', 'invalid')
         );
     }
 
@@ -2633,15 +2643,15 @@ trait ILSMockTrait
     {
     }
 
-    public function getCancelHoldDetails($holdDetails)
+    public function getCancelHoldDetails($holdDetails, $patron)
     {
     }
 
-    public function getCancelILLRequestDetails($holdDetails)
+    public function getCancelILLRequestDetails($holdDetails, $patron)
     {
     }
 
-    public function getCancelStorageRetrievalRequestDetails($holdDetails)
+    public function getCancelStorageRetrievalRequestDetails($holdDetails, $patron)
     {
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -1649,7 +1649,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $expected = ['1', '2'];
         $driver = $this->initSimpleMethodTest(
             $this->once(),
-            $this->once(),
+            $this->exactly(2),
             'getCancelHoldDetails',
             [['id' => '1', 'item_id' => '2']],
             $expected,
@@ -1665,6 +1665,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->getCancelHoldDetails(
             ['id' => 'd2.1', 'item_id' => 2],
             $this->getPatron('user', 'd2')
+
+        );
+        $this->assertEquals($expected, $result);
+
+        $result = $driver->getCancelHoldDetails(
+            ['id' => 'd2.1', 'item_id' => 2]
 
         );
         $this->assertEquals($expected, $result);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -2643,7 +2643,7 @@ trait ILSMockTrait
     {
     }
 
-    public function getCancelHoldDetails($holdDetails, $patron)
+    public function getCancelHoldDetails($holdDetails, $patron = [])
     {
     }
 


### PR DESCRIPTION
This unifies the getCancel*Details methods and makes things easier with the MultiBackend driver.
Also fixes issues with Demo+MultiBackend where the record id may be anything and not related to the patron.

I encountered this while working on #1956.

TODO
- [x] Run full test suite
- [x] Document possible BC breaks
- [x] Update ILS driver wiki page