### PR TITLE
Reduce logging severity of RecordMissing to debug.

### DIFF
--- a/module/VuFind/src/VuFind/Exception/SeverityLevelInterface.php
+++ b/module/VuFind/src/VuFind/Exception/SeverityLevelInterface.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Record Missing Exception
+ * Interface for exceptions to indicate the logging severity level.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2011.
+ * Copyright (C) The National Library of Finland 2021
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,41 +21,27 @@
  *
  * @category VuFind
  * @package  Exceptions
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
 namespace VuFind\Exception;
 
 /**
- * Record Missing Exception
+ * Interface for exceptions to indicate the logging severity level.
  *
  * @category VuFind
  * @package  Exceptions
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class RecordMissing extends \Exception implements HttpStatusInterface,
-    SeverityLevelInterface
+interface SeverityLevelInterface
 {
-    /**
-     * Get HTTP status associated with this exception.
-     *
-     * @return int
-     */
-    public function getHttpStatus()
-    {
-        return 404;
-    }
-
     /**
      * Get the logging severity level for this exception.
      *
      * @return int
      */
-    public function getSeverityLevel()
-    {
-        return \Laminas\Log\Logger::DEBUG;
-    }
+    public function getSeverityLevel();
 }

--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -132,6 +132,10 @@ class Logger extends BaseLogger
      */
     protected function getSeverityFromException($error)
     {
+        // If the exception provides the severity level, use it:
+        if ($error instanceof \VuFind\Exception\SeverityLevelInterface) {
+            return $error->getSeverityLevel();
+        }
         // Treat unexpected or 5xx errors as more severe than 4xx errors.
         if ($error instanceof \VuFind\Exception\HttpStatusInterface
             && in_array($error->getHttpStatus(), [403, 404])


### PR DESCRIPTION
This reduces logging in production environments where e.g. crawlers may cause a lot of hits on non-existent records.