### PR TITLE
Fix KohaRest driver alias issue with LoggerAwareTrait.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -56,9 +56,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
 {
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
-    use \VuFind\Log\LoggerAwareTrait {
-        logError as error;
-    }
+    use \VuFind\Log\LoggerAwareTrait;
     use \VuFind\ILS\Driver\CacheTrait;
     use \VuFind\ILS\Driver\OAuth2TokenTrait;
 
@@ -1857,7 +1855,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 $statuses[] = 'Not Available';
             }
         } else {
-            $this->error(
+            $this->logError(
                 "Unable to determine status for item: " . print_r($item, true)
             );
         }


### PR DESCRIPTION
The problem was caused by both the driver and OAuth2TokenTrait using the same trait and ambiquity with the error alias.

This is quite trivial change, but requesting review just in case (the first one will suffice). 