### PR TITLE
Make EBSCO URLs configurable; fix for HTTPS compatibility.

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -48,6 +48,12 @@ timeout = 120
 ; limits that do not affect the POST-based API.
 search_http_method = POST
 
+; This is the URL of the EDS API endpoint:
+api_url = "https://eds-api.ebscohost.com/edsapi/rest"
+
+; This is the URL of the EBSCO authorization endpoint:
+auth_url = "https://eds-api.ebscohost.com/authservice/rest"
+
 ; The following two sections can be used to associate specific recommendations
 ; modules with specific search types defined in the [Basic_Searches] section
 ; below.  For all the details on how these sections work, see the comments above

--- a/config/vufind/EIT.ini
+++ b/config/vufind/EIT.ini
@@ -1,7 +1,7 @@
 ; This section contains global settings affecting search behavior.
 [General]
 ; EBSCO offers searching via the EBSCOhost API. See the API
-; documentation (http://support.ebsco.com/eit/ws.php) for more information.
+; documentation (https://support.ebsco.com/eit/ws.php) for more information.
 ; "prof" is your profile ID; "pwd" is the password associated with that profile;
 ; "dbs" is a comma-separated list of three-character codes for EBSCO databases
 ; to which your institution subscribes and for which access is available via the
@@ -18,6 +18,9 @@
 prof = prof.prof.prof
 pwd = password
 dbs = aph,reh,ehh,etc
+
+; This is the EIT API base URL:
+base_url = "https://eit.ebscohost.com/Services/SearchService.asmx/Search"
 
 ; This setting controls the default sort order of search results; the selected
 ; option should be one of the options present in the [Sorting] section below.

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -119,7 +119,8 @@ class EITBackendFactory implements FactoryInterface
     {
         $prof = $this->config->General->prof ?? null;
         $pwd = $this->config->General->pwd ?? null;
-        $base = "http://eit.ebscohost.com/Services/SearchService.asmx/Search";
+        $base = $this->config->General->base_url
+            ?? 'https://eit.ebscohost.com/Services/SearchService.asmx/Search';
         $dbs = $this->config->General->dbs ?? null;
         $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
             ->createClient();

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -141,6 +141,12 @@ class EdsBackendFactory implements FactoryInterface
             'search_http_method' => $this->edsConfig->General->search_http_method
                 ?? 'POST'
         ];
+        if (isset($this->edsConfig->General->api_url)) {
+            $options['api_url'] = $this->edsConfig->General->api_url;
+        }
+        if (isset($this->edsConfig->General->auth_url)) {
+            $options['auth_url'] = $this->edsConfig->General->auth_url;
+        }
         // Build HTTP client:
         $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
             ->createClient();

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -51,7 +51,7 @@ abstract class Base
      *
      * @var string
      */
-    protected $edsApiHost = 'http://eds-api.ebscohost.com/edsapi/rest';
+    protected $edsApiHost = 'https://eds-api.ebscohost.com/edsapi/rest';
 
     /**
      * Auth host
@@ -106,6 +106,12 @@ abstract class Base
         if (is_array($settings)) {
             foreach ($settings as $key => $value) {
                 switch ($key) {
+                case 'api_url':
+                    $this->edsApiHost = $value;
+                    break;
+                case 'auth_url':
+                    $this->authHost = $value;
+                    break;
                 case 'debug':
                     $this->debug = $value;
                     break;


### PR DESCRIPTION
EBSCO will be shutting down HTTP URLs soon; this PR makes all URLs configurable and switches to HTTPS by default. I am targeting this against release-7.1 instead of dev so that we can get the change released more quickly, so users can more easily get up to date before service is potentially disrupted.