### PR TITLE
Reset ChoiceAuth state when any exception occurs.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
@@ -162,7 +162,7 @@ class ChoiceAuth extends AbstractBase
     {
         try {
             return $this->proxyUserLoad($request, 'authenticate', func_get_args());
-        } catch (AuthException $e) {
+        } catch (\Exception $e) {
             // If an exception was thrown during login, we need to clear the
             // stored strategy to ensure that we display the full ChoiceAuth
             // form rather than the form for only the method that the user


### PR DESCRIPTION
E.g. the email authenticator may throw an exception other than AuthException.