### PR TITLE
Avoid error in MultiBackend driver when a hold has no id field.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -757,11 +757,14 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
      */
     public function getPickUpLocations($patron = false, $holdDetails = null)
     {
-        $source = $this->getSource($patron['cat_username'] ?? $holdDetails['id']);
+        $source = $this->getSource(
+            $patron['cat_username'] ?? $holdDetails['id'] ?? $holdDetails['item_id']
+            ?? ''
+        );
         $driver = $this->getDriver($source);
         if ($driver) {
-            if ($holdDetails) {
-                if (!$this->driverSupportsSource($source, $holdDetails['id'])) {
+            if ($id = ($holdDetails['id'] ?? $holdDetails['item_id'] ?? '')) {
+                if (!$this->driverSupportsSource($source, $id)) {
                     // Return empty array since the sources don't match
                     return [];
                 }


### PR DESCRIPTION
Since the id field is not mandatory, use item_id as fallback and handle gracefully the situation where neither exists. The error can be reproduced by setting 

```
[Catalog]
idsInMyResearch = false
```
in Demo driver ini when MultiBackend is enabled and trying to edit holds.