### PR TITLE
Make dates optional and escape values when editing a hold.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -344,11 +344,19 @@ class HoldsController extends AbstractBase
                 $pickupLocations
             );
         }
-        $dateValidationResults = $this->holds()->validateDates(
-            $gatheredDetails['startDate'] ?? null,
-            $gatheredDetails['requiredBy'] ?? null,
-            $holdConfig['updateFields']
-        );
+        $dateValidationResults = [
+            'errors' => []
+        ];
+        // The dates are not required unless one of them is set, so check that first:
+        if (!empty($gatheredDetails['startDate'])
+            || !empty($gatheredDetails['requiredBy'])
+        ) {
+            $dateValidationResults = $this->holds()->validateDates(
+                $gatheredDetails['startDate'] ?? null,
+                $gatheredDetails['requiredBy'] ?? null,
+                $holdConfig['updateFields']
+            );
+        }
         if (in_array('frozenThrough', $holdConfig['updateFields'])) {
             $frozenThroughValidationResults = $this->holds()->validateFrozenThrough(
                 $gatheredDetails['frozenThrough'] ?? null,

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -30,7 +30,7 @@
     <?php if (in_array('frozenThrough', $this->fields)): ?>
       <div class="form-group hold-frozen-through">
         <label for="frozen_through" class="control-label"><?=$this->transEsc('hold_edit_frozen_through')?>:</label>
-        <input id="frozen_through" type="text" name="gatheredDetails[frozenThrough]" value="<?=$this->gatheredDetails['frozenThrough'] ?? ''?>" size="10" class="form-control"/>
+        <input id="frozen_through" type="text" name="gatheredDetails[frozenThrough]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['frozenThrough'] ?? '')?>" size="10" class="form-control"/>
         (<?=$this->dateTime()->getDisplayDateFormat()?>)
       </div>
     <?php endif; ?>
@@ -39,15 +39,15 @@
   <?php if (in_array('startDate', $this->fields)): ?>
     <div class="form-group hold-start-date">
       <label for="start_date" class="control-label"><?=$this->transEsc('hold_start_date')?>:</label>
-      <input id="start_date" type="text" name="gatheredDetails[startDate]" value="<?=$this->gatheredDetails['startDate'] ?? ''?>" size="10" class="form-control"/>
-      (<?=$this->dateTime()->getDisplayDateFormat()?>)
+      <input id="start_date" type="text" name="gatheredDetails[startDate]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['startDate'] ?? '')?>" size="10" class="form-control"/>
+        (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
 
   <?php if (in_array("requiredByDate", $this->fields)): ?>
     <div class="form-group hold-required-by">
       <label for="required_by_date" class="control-label"><?=$this->transEsc('hold_required_by')?>:</label>
-      <input id="required_by_date" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : ''?>" size="10" class="form-control"/>
+      <input id="required_by_date" type="text" name="gatheredDetails[requiredBy]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['requiredBy'] ?? '')?>" size="10" class="form-control"/>
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>


### PR DESCRIPTION
If both start date and required by date are editable, the validation would required both to be set (that'd be right if we were placing a hold). Skip validation if neither is set to keep the values optional. Also, user-entered values should be escaped.