### PR TITLE
debian: simplify JDK version requirements (depend on virtual package)

### DIFF
--- a/packages/DEBIAN/control
+++ b/packages/DEBIAN/control
@@ -4,7 +4,7 @@ Section: World Wide Web
 Priority: Optional
 Architecture: all
 Depends: apache2,
-         default-jdk | openjdk-11-jdk | openjdk-8-jdk,
+         default-jdk | java-compiler,
          libapache2-mod-php,
          mysql-server | virtual-mysql-server-core,
          php-pear,


### PR DESCRIPTION
As briefly discussed on https://vufind.org/jira/browse/VUFIND-1487, the JDK `Depends` entry for the VuFind package can be more generalized by making use of the virtual package `java-compiler`, which can be fulfilled by any version of the JDK.

There is a small downside to this change, which is the same as for PHP, that this does not limit VuFind to certain JDK versions. The upside being that there's less maintenance involved on the packaging side of VuFind.

I'm submitting this PR assuming that this is your desired behavior as upstream of VuFind (as it's the same case for PHP). But if you'd like to stick to limiting the versions I can see if we can have the same for PHP (the extra cost being making sure this file gets updated with any new supported versions).

Thanks