### PR TITLE
SierraRest: Don't try to fetch items when there are no checkouts.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2620,6 +2620,9 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
     protected function getItemsWithBibsForTransactions(array $transactions,
         array $patron
     ): array {
+        if (!$transactions) {
+            return [];
+        }
         // Fetch items
         $itemIds = [];
         foreach ($transactions as $transaction) {


### PR DESCRIPTION
This fixes a PHP notice e.g. when trying to retrieve historic loans and there are none. Avoids an invalid API call as well.