### PR TITLE
League/Commonmark update to 1.6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "laminas/laminas-text": "2.8.1",
         "laminas/laminas-validator": "2.14.4",
         "laminas/laminas-view": "2.12.0",
-        "league/commonmark": "1.5.8",
+        "league/commonmark": "1.6.5",
         "lm-commons/lmc-rbac-mvc": "3.2.0",
         "matthiasmullie/minify": "1.3.66",
         "misd/linkify": "1.1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f883e8e381d0d7c30834b53d4547a08d",
+    "content-hash": "cb574152fe418cda61636cc17e8e8684",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -67,16 +67,16 @@
         },
         {
             "name": "bacon/bacon-qr-code",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "3e9d791b67d0a2912922b7b7c7312f4b37af41e4"
+                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/3e9d791b67d0a2912922b7b7c7312f4b37af41e4",
-                "reference": "3e9d791b67d0a2912922b7b7c7312f4b37af41e4",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
+                "reference": "f73543ac4e1def05f1a70bcd1525c8a157a1ad09",
                 "shasum": ""
             },
             "require": {
@@ -114,9 +114,9 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.3"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.4"
             },
-            "time": "2020-10-30T02:02:47+00:00"
+            "time": "2021-06-18T13:26:35+00:00"
         },
         {
             "name": "brick/varexporter",
@@ -1864,6 +1864,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:19:10+00:00"
         },
         {
@@ -2053,6 +2054,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:22:49+00:00"
         },
         {
@@ -2116,6 +2118,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:23:46+00:00"
         },
         {
@@ -3043,35 +3046,36 @@
         },
         {
             "name": "laminas/laminas-hydrator",
-            "version": "4.1.0",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-hydrator.git",
-                "reference": "fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f"
+                "reference": "e2749d6cda1dbbe730ba235a77323bf4f0b1f8f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f",
-                "reference": "fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f",
+                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/e2749d6cda1dbbe730ba235a77323bf4f0b1f8f2",
+                "reference": "e2749d6cda1dbbe730ba235a77323bf4f0b1f8f2",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-stdlib": "^3.3",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0",
+                "webmozart/assert": "^1.10"
             },
             "replace": {
                 "zendframework/zend-hydrator": "^3.0.2"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "laminas/laminas-eventmanager": "^3.2.1",
                 "laminas/laminas-modulemanager": "^2.8",
                 "laminas/laminas-serializer": "^2.9",
                 "laminas/laminas-servicemanager": "^3.3.2",
                 "phpunit/phpunit": "~9.3.0",
-                "psalm/plugin-phpunit": "^0.15.0",
-                "vimeo/psalm": "^4.2"
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8.1"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",
@@ -3114,7 +3118,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-12-16T21:35:39+00:00"
+            "time": "2021-06-29T11:04:20+00:00"
         },
         {
             "name": "laminas/laminas-i18n",
@@ -5015,16 +5019,16 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
+                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
+                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
                 "shasum": ""
             },
             "require": {
@@ -5073,20 +5077,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-25T21:54:58+00:00"
+            "time": "2021-06-24T12:49:22+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.8",
+            "version": "1.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf"
+                "reference": "44ffd8d3c4a9133e4bd0548622b09c55af39db5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
-                "reference": "08fa59b8e4e34ea8a773d55139ae9ac0e0aecbaf",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/44ffd8d3c4a9133e4bd0548622b09c55af39db5f",
+                "reference": "44ffd8d3c4a9133e4bd0548622b09c55af39db5f",
                 "shasum": ""
             },
             "require": {
@@ -5104,7 +5108,7 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan": "^0.12.90",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
@@ -5174,7 +5178,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T18:51:39+00:00"
+            "time": "2021-06-26T11:57:13+00:00"
         },
         {
             "name": "lm-commons/lmc-rbac-mvc",
@@ -7951,6 +7955,64 @@
             "time": "2021-04-19T16:34:45+00:00"
         },
         {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
             "name": "wikimedia/composer-merge-plugin",
             "version": "v2.0.1",
             "source": {
@@ -8681,16 +8743,16 @@
         },
         {
             "name": "instaclick/php-webdriver",
-            "version": "1.4.7",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/instaclick/php-webdriver.git",
-                "reference": "b5f330e900e9b3edfc18024a5ec8c07136075712"
+                "reference": "961b12178cb71f8667afaf2f66ab3e000e060e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/instaclick/php-webdriver/zipball/b5f330e900e9b3edfc18024a5ec8c07136075712",
-                "reference": "b5f330e900e9b3edfc18024a5ec8c07136075712",
+                "url": "https://api.github.com/repos/instaclick/php-webdriver/zipball/961b12178cb71f8667afaf2f66ab3e000e060e1c",
+                "reference": "961b12178cb71f8667afaf2f66ab3e000e060e1c",
                 "shasum": ""
             },
             "require": {
@@ -8738,9 +8800,9 @@
             ],
             "support": {
                 "issues": "https://github.com/instaclick/php-webdriver/issues",
-                "source": "https://github.com/instaclick/php-webdriver/tree/1.x"
+                "source": "https://github.com/instaclick/php-webdriver/tree/1.4.9"
             },
-            "time": "2019-09-25T09:05:11+00:00"
+            "time": "2021-06-28T22:23:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -12037,64 +12099,6 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
-            },
-            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],

--- a/config/vufind/markdown.ini
+++ b/config/vufind/markdown.ini
@@ -36,7 +36,7 @@
 ;   HeadingPermalink, Mention, SmartPunct, Strikethrough, Table, TableOfContents,
 ;   TaskList.
 ; More about extensions: https://commonmark.thephpleague.com/1.6/extensions/overview/
-; Some of them could have a configuration, see sections bellow.
+; Some of them could have a configuration, see sections below.
 extensions = Autolink,DisallowedRawHtml,Strikethrough,Table,TaskList
 
 ; See https://commonmark.thephpleague.com/1.6/extensions/external-links/

--- a/config/vufind/markdown.ini
+++ b/config/vufind/markdown.ini
@@ -1,6 +1,6 @@
 ; This file could be used to define configuration of markdown to HTML converter.
 ; More detailed configuration documentation could be found here:
-; https://github.com/thephpleague/commonmark/blob/latest/docs/1.5/configuration.md
+; https://commonmark.thephpleague.com/1.6/configuration/
 [Markdown]
 ; How to handle HTML input. Options are: strip, allow, escape. Defaults to strip
 ;html_input = allow
@@ -31,17 +31,15 @@
 ;max_nesting_level = 10
 
 ; Which extension you want to activate. List of extension names separated by comma.
-; Available extensions as of league/commonmark version 1.5:
-;     Attributes, ExternalLink, Footnote, HeadingPermalink, Mention, SmartPunct,
-;     TableOfContents
-; More about extensions: https://commonmark.thephpleague.com/1.5/extensions/overview/
-; Some of them could have a configuration, see sections bellow. Available extensions
-; are: Attributes, Autolink, DisallowedRawHtml, ExternalLink, Footnote,
-; HeadingPermalink, Mention, SmartPunct, Strikethrough, Table, TableOfContents,
-; TaskList.
+; Available extensions as of league/commonmark version 1.6:
+;   Attributes, Autolink, DisallowedRawHtml, ExternalLink, Footnote,
+;   HeadingPermalink, Mention, SmartPunct, Strikethrough, Table, TableOfContents,
+;   TaskList.
+; More about extensions: https://commonmark.thephpleague.com/1.6/extensions/overview/
+; Some of them could have a configuration, see sections bellow.
 extensions = Autolink,DisallowedRawHtml,Strikethrough,Table,TaskList
 
-; See https://commonmark.thephpleague.com/1.5/extensions/external-links/
+; See https://commonmark.thephpleague.com/1.6/extensions/external-links/
 [ExternalLink]
 ; This should be always set, if you want to use this extension. You can use regular
 ; expressions to match group of hosts
@@ -52,7 +50,7 @@ internal_hosts[] = www.example.com
 ;noopener = external
 ;noreferrer = external
 
-; See https://commonmark.thephpleague.com/1.5/extensions/footnotes/
+; See https://commonmark.thephpleague.com/1.6/extensions/footnotes/
 [Footnote]
 ;backref_class = footnote-backref
 ;container_add_hr = true
@@ -62,7 +60,7 @@ internal_hosts[] = www.example.com
 ;footnote_class = footnote
 ;footnote_id_prefix = 'fn:'
 
-; See https://commonmark.thephpleague.com/1.5/extensions/heading-permalinks/
+; See https://commonmark.thephpleague.com/1.6/extensions/heading-permalinks/
 [HeadingPermalink]
 ; There is also 'slug_normalizer' options, which should be set to an object
 ; implementing League\CommonMark\Normalizer\TextNormalizerInterface
@@ -74,21 +72,21 @@ internal_hosts[] = www.example.com
 ;insert = before
 ;title = Permalink
 
-; See https://commonmark.thephpleague.com/1.5/extensions/mentions/
+; See https://commonmark.thephpleague.com/1.6/extensions/mentions/
 [Mention]
 ; This is an example of configuration, see more details in original documentation
 ;github_handle[symbol] = '@'
 ;github_handle[regex] = '/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)/'
 ;github_handle[generator] = 'https://github.com/%s'
 
-; See https://commonmark.thephpleague.com/1.5/extensions/smart-punctuation/
+; See https://commonmark.thephpleague.com/1.6/extensions/smart-punctuation/
 [SmartPunct]
 ;double_quote_opener = '“'
 ;double_quote_closer = '”'
 ;single_quote_opener = '‘'
 ;single_quote_closer = '’'
 
-; See https://commonmark.thephpleague.com/1.5/extensions/table-of-contents/
+; See https://commonmark.thephpleague.com/1.6/extensions/table-of-contents/
 [TableOfContents]
 ;html_class = table-of-contents
 ;position = top

--- a/config/vufind/markdown.ini
+++ b/config/vufind/markdown.ini
@@ -35,8 +35,11 @@
 ;     Attributes, ExternalLink, Footnote, HeadingPermalink, Mention, SmartPunct,
 ;     TableOfContents
 ; More about extensions: https://commonmark.thephpleague.com/1.5/extensions/overview/
-; Some of them could have a configuration, see sections bellow
-;extensions = Attributes,ExternalLink,Footnote,HeadingPermalink,Mention,SmartPunct,TableOfContents
+; Some of them could have a configuration, see sections bellow. Available extensions
+; are: Attributes, Autolink, DisallowedRawHtml, ExternalLink, Footnote,
+; HeadingPermalink, Mention, SmartPunct, Strikethrough, Table, TableOfContents,
+; TaskList.
+extensions = Autolink,DisallowedRawHtml,Strikethrough,Table,TaskList
 
 ; See https://commonmark.thephpleague.com/1.5/extensions/external-links/
 [ExternalLink]

--- a/module/VuFind/src/VuFind/Service/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/Service/MarkdownFactory.php
@@ -34,7 +34,6 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use League\CommonMark\Environment;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\MarkdownConverter;
 
 /**
@@ -107,7 +106,6 @@ class MarkdownFactory implements FactoryInterface
         ];
 
         $environment = Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new GithubFlavoredMarkdownExtension());
         $extensions = isset($mainConfig->extensions)
             ? array_map('trim', explode(',', $mainConfig->extensions)) : [];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
@@ -121,15 +121,24 @@ class MarkdownFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $config = [
             'Markdown' => [
-                'extensions' => 'Attributes,ExternalLink',
+                'extensions' => 'Attributes,ExternalLink,Table',
             ],
         ];
-
         $expectedExtensions = [
             'League\CommonMark\Extension\CommonMarkCoreExtension',
-            'League\CommonMark\Extension\GithubFlavoredMarkdownExtension',
             'League\CommonMark\Extension\Attributes\AttributesExtension',
-            'League\CommonMark\Extension\ExternalLink\ExternalLinkExtension'
+            'League\CommonMark\Extension\ExternalLink\ExternalLinkExtension',
+            'League\CommonMark\Extension\Table\TableExtension',
+        ];
+        $result = $this->getMarkdownEnvironmentExtensions($config);
+        $result = array_map(function ($extension) {
+            return get_class($extension);
+        }, $result);
+        $this->assertEquals($expectedExtensions, $result);
+
+        $config = [];
+        $expectedExtensions = [
+            'League\CommonMark\Extension\CommonMarkCoreExtension',
         ];
         $result = $this->getMarkdownEnvironmentExtensions($config);
         $result = array_map(function ($extension) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
@@ -54,12 +54,14 @@ class MarkdownFactoryTest extends \PHPUnit\Framework\TestCase
         $defaultEnvironment = [
             'html_input' => 'strip',
             'allow_unsafe_links' => false,
-            'enable_em' => true,
-            'enable_strong' => true,
-            'use_asterisk' => true,
-            'use_underscore' => true,
-            'unordered_list_markers' => ['-', '*', '+'],
-            'max_nesting_level' => \INF,
+            'max_nesting_level' => \PHP_INT_MAX,
+            'commonmark' => [
+                'enable_em' => true,
+                'enable_strong' => true,
+                'use_asterisk' => true,
+                'use_underscore' => true,
+                'unordered_list_markers' => ['-', '*', '+'],
+            ],
             'renderer' => [
                 'block_separator' => "\n",
                 'inner_separator' => "\n",
@@ -87,12 +89,14 @@ class MarkdownFactoryTest extends \PHPUnit\Framework\TestCase
         $customEnvironment = [
             'html_input' => 'escape',
             'allow_unsafe_links' => true,
-            'enable_em' => false,
-            'enable_strong' => false,
-            'use_asterisk' => false,
-            'use_underscore' => false,
-            'unordered_list_markers' => [';', '^'],
             'max_nesting_level' => 10,
+            'commonmark' => [
+                'enable_em' => false,
+                'enable_strong' => false,
+                'use_asterisk' => false,
+                'use_underscore' => false,
+                'unordered_list_markers' => [';', '^'],
+            ],
             'renderer' => [
                 'block_separator' => "\r\n",
                 'inner_separator' => "\r\n",


### PR DESCRIPTION
This PR updates league/commonmark dependency to version 1.6.5, updates MarkdownFactory according to https://commonmark.thephpleague.com/1.6/upgrading/ and refactors setting of extensions to be more flexible by removing hardcoded GithubFlavoredMarkdownExtension, but make the parts of github extension a default set.