### PR TITLE
Run all tests on all PHP versions. Pin Composer version.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,11 @@ jobs:
         php-version: ['7.3', '7.4', '8.0']
         include:
           - php-version: 7.3
-            phing_tasks: "phpunitfast"
+            phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
           - php-version: 7.4
             phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
           - php-version: 8.0
-            phing_tasks: "phpunitfast"
+            phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
 
     steps:
       - name: Setup PHP
@@ -26,6 +26,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: intl, xsl
+          tools: composer:2.0.13
 
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
         php-version: ['7.3', '7.4', '8.0']
         include:
           - php-version: 7.3
-            phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
+            phing_tasks: "phpunitfast phpcs-console php-cs-fixer-dryrun phpstan-console"
           - php-version: 7.4
-            phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
+            phing_tasks: "phpunitfast phpcs-console php-cs-fixer-dryrun phpstan-console"
           - php-version: 8.0
             phing_tasks: "eslint jshint phpunitfast phpcs-console php-cs-fixer-dryrun checkLessToSass phpstan-console"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.3', '7.4', '8.0']
+        # We run most tests on all platforms, but we only run Javascript-related tests in 8.0,
+        # since the results should be the same on all platforms, so we don't need to repeat them.
         include:
           - php-version: 7.3
             phing_tasks: "phpunitfast phpcs-console php-cs-fixer-dryrun phpstan-console"


### PR DESCRIPTION
The composer version doesn't make difference at the moment, but I think it would be safer to use the known "good" version.