### PR TITLE
Add contentinfo role & aria label for screen readers in feedback form

### DIFF
--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -73,7 +73,7 @@
       <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
         <div class="field-set" role="group"<?= !empty($el['label']) ? ' aria-labelledby="' . $this->escapeHtmlAttr($el['name']) . '"' : ''?>>
       <?php else: ?>
-        <div class="field-set" role="contentinfo" aria-label="<?=$this->escapeHtmlAttr($elementHelpPre) ?? ''?>">
+        <div class="field-set"<?= !empty($elementHelpPre) ? ' role="contentinfo" aria-label="' . $this->escapeHtmlAttr($elementHelpPre) . '"' : ''?>>
       <?php endif ?>
     <?php endif ?>
 

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -73,7 +73,7 @@
       <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
         <div class="field-set" role="group"<?= !empty($el['label']) ? ' aria-labelledby="' . $this->escapeHtmlAttr($el['name']) . '"' : ''?>>
       <?php else: ?>
-        <div class="field-set">
+        <div class="field-set" role="contentinfo" aria-label="<?=$this->escapeHtmlAttr($elementHelpPre) ?? ''?>">
       <?php endif ?>
     <?php endif ?>
 


### PR DESCRIPTION
When using a screen reader this enables them to inform the user of the possible help text when entering name/email field whichever comes first depending of the direction (up or down).