### PR TITLE
Koha ILSDI driver improvements

### DIFF
--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -32,6 +32,10 @@ dontValidatePasswords = false
 ;; I would also recommend you set 'holds_mode' to '"holds"', as this
 ;; driver does not handle recalls.
 
+; Whether to show sublocation in Holdings information from field location (default),
+; or from field permanent_location (set this to true for this option)
+showPermanentLocation = false
+
 ; This section controls hold behavior; note that you must also ensure that Holds are
 ; enabled in the [Catalog] section of config.ini in order to take advantage of these
 ; settings. Additional notes about some of these settings are available in the wiki:

--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -36,6 +36,9 @@ dontValidatePasswords = false
 ; or from field permanent_location (set this to true for this option)
 showPermanentLocation = false
 
+; Whethet to show home branch of an item or current holding branch
+showHomebranch = false
+
 ; This section controls hold behavior; note that you must also ensure that Holds are
 ; enabled in the [Catalog] section of config.ini in order to take advantage of these
 ; settings. Additional notes about some of these settings are available in the wiki:

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -970,7 +970,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 $branchSqlStmt->execute([':branch' => $branch]);
                 $row = $branchSqlStmt->fetch();
                 if ($row) {
-                    $loc = $row['BNAME'] . ' - ' - $loc;
+                    $loc = $row['BNAME'] . ' - ' . $loc;
                 }
             }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -837,7 +837,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 where datearrived IS NULL) as t USING (itemnumber)
             left join authorised_values as av
                 on i.$locationField = av.authorised_value
-            where i.biblionumber = :id AND av.category = :av_category
+            where i.biblionumber = :id
+                AND (av.category = :av_category OR av.category IS NULL)
             order by i.itemnumber DESC";
         $sqlReserves = "select count(*) as RESERVESCOUNT from reserves "
             . "WHERE biblionumber = :id AND found IS NULL";

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -153,6 +153,13 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
     protected $showPermanentLocation;
 
     /**
+     * Should we show homebranchinstead of holdingbranch
+     *
+     * @var boolean
+     */
+    protected $showHomebranch;
+
+    /**
      * Constructor
      *
      * @param \VuFind\Date\Converter $dateConverter Date converter object
@@ -208,6 +215,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
 
         $this->showPermanentLocation
             = $this->config['Catalog']['showPermanentLocation'] ?? false;
+
+        $this->showHomebranch = $this->config['Catalog']['showHomebranch'] ?? false;
 
         $this->debug("Config Summary:");
         $this->debug("DB Host: " . $this->host);
@@ -940,18 +949,19 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
 
             $duedate_formatted = $this->displayDate($duedate);
 
-            //Retrieving the full branch name
-            if ($rowItem['HLDBRNCH'] == null) {
-                if ($rowItem['HOMEBRANCH'] == null) {
-                    $loc = "Unknown";
-                } else {
-                    $loc = $rowItem['LOCATION'];
-                }
+            if ($rowItem['HLDBRNCH'] == null && $rowItem['HOMEBRANCH'] == null) {
+                $loc = "Unknown";
             } else {
                 $loc = $rowItem['LOCATION'];
             }
-            $branch = $rowItem['HLDBRNCH'] ?? $rowItem['HOMEBRANCH'] ?? '';
 
+            if ($this->showHomebranch) {
+                $branch = $rowItem['HOMEBRANCH'] ?? $rowItem['HLDBRNCH'] ?? '';
+            } else {
+                $branch = $rowItem['HLDBRNCH'] ?? $rowItem['HOMEBRANCH'] ?? '';
+            }
+
+            //Retrieving the full branch name
             if ($loc != "Unknown") {
                 $sqlBranch = "select branchname as BNAME
                               from branches

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -975,7 +975,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                 $branchSqlStmt->execute([':branch' => $rowItem["TRANSFERTO"]]);
                 $rowTo = $branchSqlStmt->fetch();
                 $transferto = $rowTo ? $rowTo["BNAME"] : $rowItem["TRANSFERTO"];
-                $status = "Na cest? z $transferfrom do $transferto";
+                $status = "In transit between library locations";
                 $available = false;
                 $onTransfer = true;
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -117,7 +117,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
     /**
      * Should validate passwords against Koha system?
      *
-     * @var boolean
+     * @var bool
      */
     protected $validatePasswords;
 
@@ -150,14 +150,14 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
     /**
      * Should we show permanent location (or current)
      *
-     * @var boolean
+     * @var bool
      */
     protected $showPermanentLocation;
 
     /**
      * Should we show homebranchinstead of holdingbranch
      *
-     * @var boolean
+     * @var bool
      */
     protected $showHomebranch;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -782,6 +782,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
         $this->debug("Code: " . $rsp->{'code'});
 
         if ($rsp->{'code'} != "") {
+            $this->debug("Error Message: " . $rsp->{'message'});
             return [
                 "success"    => false,
                 "sysMessage" => $this->getField($rsp->{'code'})
@@ -1395,6 +1396,7 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             ];
             return $profile;
         } else {
+            $this->debug("Error Message: " . $rsp->{'message'});
             return null;
         }
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -816,7 +816,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             i.enumchron AS ENUMCHRON,
             i.itemnotes as PUBLICNOTES, b.frameworkcode as DOCTYPE,
             t.frombranch as TRANSFERFROM, t.tobranch as TRANSFERTO,
-            i.itemlost as ITEMLOST, i.itemlost_on AS LOSTON
+            i.itemlost as ITEMLOST, i.itemlost_on AS LOSTON,
+            i.stocknumber as STOCKNUMBER
             from items i join biblio b on i.biblionumber = b.biblionumber
             left outer join
                 (SELECT itemnumber, frombranch, tobranch from branchtransfers
@@ -985,8 +986,8 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
                     ? '' : (string)$duedate_formatted,
                 'barcode'      => (null == $rowItem['BARCODE'])
                     ? 'Unknown' : $rowItem['BARCODE'],
-                'number'       => (null == $rowItem['COPYNO'])
-                    ? '' : $rowItem['COPYNO'],
+                'number'       =>
+                    $rowItem['COPYNO'] ?? $rowItem['STOCKNUMBER'] ?? '',
                 'enumchron'    => $rowItem['ENUMCHRON'] ?? null,
                 'requests_placed' => $reservesCount ? $reservesCount : 0,
                 'frameworkcode' => $rowItem['DOCTYPE'],

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -928,16 +928,17 @@ class KohaILSDI extends \VuFind\ILS\Driver\AbstractBase implements
             } else {
                 $loc = $rowItem['LOCATION'];
             }
+            $branch = $rowItem['HLDBRNCH'] ?? $rowItem['HOMEBRANCH'] ?? '';
 
             if ($loc != "Unknown") {
                 $sqlBranch = "select branchname as BNAME
                               from branches
                               where branchcode = :branch";
                 $branchSqlStmt = $this->db->prepare($sqlBranch);
-                $branchSqlStmt->execute([':branch' => $loc]);
+                $branchSqlStmt->execute([':branch' => $branch]);
                 $row = $branchSqlStmt->fetch();
                 if ($row) {
-                    $loc = $row['BNAME'];
+                    $loc = $row['BNAME'] . ' - ' - $loc;
                 }
             }
 


### PR DESCRIPTION
This patch:
- Adds stocknumber into getHolding result (if no copy number available, stocknumber is used)
- Fixes getting branch name for holdings
- Adds configuration to determine if location or permanent_location is shown 
- Adds configuration to determine if homebranch or holdingbranch is shown
- Fixes bug, when items without location field were not shown in UI
- Fixes "In transit..." status message
- Adds logging of error message from ILS-DI API