### PR TITLE
Fix checking of metadata emptyness in cover router

### DIFF
--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -153,7 +153,7 @@ class Router implements \Laminas\Log\LoggerAwareInterface
                 ) {
                     $nextMetadata = $handler['handler']
                         ->getMetadata($handler['key'], $size, $ids);
-                    if ($nextMetadata !== false) {
+                    if (!empty($nextMetadata)) {
                         $nextMetadata['backlink_locations'] = $backlinkLocations;
                         $metadata = $nextMetadata;
                         break;


### PR DESCRIPTION
Cover handlers getMetadata always rerurn array, never boolean false