### PR TITLE
Focus to element after closing modal

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -466,7 +466,8 @@ VuFind.register('lightbox', function Lightbox() {
       });
     });
   }
-
+  // Element which to focus after modal is closed
+  var beforeOpenElement;
   function reset() {
     _html(VuFind.translate('loading') + '...');
     _originalUrl = false;
@@ -481,6 +482,10 @@ VuFind.register('lightbox', function Lightbox() {
       if (VuFind.lightbox.refreshOnClose) {
         VuFind.refreshPage();
       } else {
+        if (beforeOpenElement) {
+          beforeOpenElement.focus();
+          beforeOpenElement = null;
+        }
         unbindFocus();
         this.setAttribute('aria-hidden', true);
         _emit('VuFind.lightbox.closing');
@@ -496,8 +501,8 @@ VuFind.register('lightbox', function Lightbox() {
 
     VuFind.modal = function modalShortcut(cmd) {
       if (cmd === 'show') {
+        beforeOpenElement = document.activeElement;
         _modal.modal($.extend({ show: true }, _modalParams)).attr('aria-hidden', false);
-
         // Set keyboard focus
         setFocusToFirstNode();
       } else {


### PR DESCRIPTION
Small accessibility adjustment, where the user is returned to its previous element when the lightbox modal is closed.