### PR TITLE
Add use command into generated sql

### DIFF
--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -454,13 +454,14 @@ class InstallController extends AbstractBase
             return [$create, $escape, $cuser, $grant];
         }
         // Default: MySQL:
-        $user = "CREATE USER '{$view->dbuser}'@'{$view->vufindhost}'"
+        $user = "CREATE USER '{$view->dbuser}'@'{$view->vufindhost}' "
             . "IDENTIFIED BY {$escapedPass}";
         $grant = "GRANT SELECT,INSERT,UPDATE,DELETE ON "
             . $view->dbname
             . ".* TO '{$view->dbuser}'@'{$view->vufindhost}' "
             . "WITH GRANT OPTION";
-        return [$create, $user, $grant, 'FLUSH PRIVILEGES'];
+        $use = "USE {$view->dbname}";
+        return [$create, $user, $grant, 'FLUSH PRIVILEGES', $use];
     }
 
     /**


### PR DESCRIPTION
When copying SQL from VuFind installer, there is need to add USE command manually. This PR should fix it.