### PR TITLE
show profile menu (incl. toggler) for editing favorite lists in account

### DIFF
--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -10,6 +10,13 @@
 
 <?=$this->flashmessages()?>
 
+<?php if ($this->auth()->isLoggedIn() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
+  <div class="<?=$this->layoutClass('mainbody')?>">
+  <a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" aria-label="<?=$this->transEsc('sidebar_expand')?>">
+      <?=$this->transEsc('Your Account') ?>
+  </a>
+<?php endif; ?>
+
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-list" method="post" name="<?=empty($this->list->id) ? 'newList' : 'editListForm'?>">
@@ -52,3 +59,9 @@
     <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>"/>
   </div>
 </form>
+<?php if ($this->auth()->isLoggedIn() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
+  </div>
+  <div class="<?=$this->layoutClass('sidebar')?>" id="myresearch-sidebar">
+      <?=$this->context($this)->renderInContext("myresearch/menu.phtml", ['active' => 'editlist/NEW'])?>
+  </div>
+<?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -94,7 +94,7 @@
         <span class="badge"><?=$list->cnt ?></span>
       </a>
     <?php endforeach; ?>
-    <a href="<?=$this->url('editList', ['id' => 'NEW'])?>">
+    <a href="<?=$this->url('editList', ['id' => 'NEW'])?>"<?=$this->active == 'editlist/NEW' ? ' class="active"' : ''?>>
       <i class="fa fa-fw fa-plus" aria-hidden="true"></i> <?=$this->transEsc('Create a List') ?>
     </a>
   </div>


### PR DESCRIPTION
Displaying profile menu (and toggler) while editing / create new favorite list coming from account features. Account behavior feels more consistently.

Editing / create new favorite lists in lightbox still works fine.

Co-authored-by: Robert Lange <robert.lange@uni-leipzig.de>