### PR TITLE
Overdrive: use class constants instead of strings.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/OverdriveController.php
+++ b/module/VuFind/src/VuFind/Controller/OverdriveController.php
@@ -98,7 +98,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
                 foreach ($checkoutResults->data as $checkout) {
                     $mycheckout['checkout'] = $checkout;
                     $mycheckout['record']
-                        = $this->serviceLocator->get('VuFind\Record\Loader')
+                        = $this->serviceLocator->get(\VuFind\Record\Loader::class)
                         ->load(strtolower($checkout->reserveId));
                     $checkouts[] = $mycheckout;
                 }
@@ -117,7 +117,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
                 foreach ($holdsResults->data as $hold) {
                     $myhold['hold'] = $hold;
                     $myhold['record']
-                        = $this->serviceLocator->get('VuFind\Record\Loader')
+                        = $this->serviceLocator->get(\VuFind\Record\Loader::class)
                         ->load(strtolower($hold->reserveId));
                     $holds[] = $myhold;
                 }
@@ -195,7 +195,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
 
         $this->debug("ODRC od_id=$od_id rec_id=$rec_id action=$action");
         //load the Record Driver.  Should be a SolrOverdrive  driver.
-        $driver = $this->serviceLocator->get('VuFind\Record\Loader')->load(
+        $driver = $this->serviceLocator->get(\VuFind\Record\Loader::class)->load(
             $rec_id
         );
 

--- a/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
+++ b/module/VuFind/src/VuFind/DigitalContent/OverdriveConnectorFactory.php
@@ -71,17 +71,16 @@ class OverdriveConnectorFactory implements
             throw new \Exception('Unexpected options sent to factory!');
         }
 
-        $config = $container->get('VuFind\Config\PluginManager')->get('config');
-        $odConfig = $container->get('VuFind\Config\PluginManager')->get(
-            'Overdrive'
-        );
-        $auth = $container->get('VuFind\Auth\ILSAuthenticator');
+        $configManager = $container->get(\VuFind\Config\PluginManager::class);
+        $config = $configManager->get('config');
+        $odConfig = $configManager->get('Overdrive');
+        $auth = $container->get(\VuFind\Auth\ILSAuthenticator::class);
         $sessionContainer = null;
 
         if (PHP_SAPI !== 'cli') {
             $sessionContainer = new \Laminas\Session\Container(
                 'DigitalContent\OverdriveController',
-                $container->get('Laminas\Session\SessionManager')
+                $container->get(\Laminas\Session\SessionManager::class)
             );
         }
         $connector = new $requestedName(
@@ -90,7 +89,7 @@ class OverdriveConnectorFactory implements
 
         // Populate cache storage
         $connector->setCacheStorage(
-            $container->get('VuFind\Cache\Manager')->getCache(
+            $container->get(\VuFind\Cache\Manager::class)->getCache(
                 'object', "Overdrive"
             )
         );

--- a/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrOverdriveFactory.php
@@ -32,6 +32,7 @@ use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use VuFind\DigitalContent\OverdriveConnector;
 
 /**
  * Factory for Overdrive record drivers.
@@ -65,9 +66,10 @@ class SolrOverdriveFactory
         if ($options !== null) {
             throw new \Exception('Unexpected options sent to factory!');
         }
-        $config = $container->get('VuFind\Config\PluginManager')->get('config');
-        $odConfig = $container->get('VuFind\Config\PluginManager')->get('Overdrive');
-        $connector = $container->get('VuFind\DigitalContent\OverdriveConnector');
+        $configManager = $container->get(\VuFind\Config\PluginManager::class);
+        $config = $configManager->get('config');
+        $odConfig = $configManager->get('Overdrive');
+        $connector = $container->get(OverdriveConnector::class);
         return new $requestedName($config, $odConfig, $connector);
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OverdriveFactory.php
@@ -69,7 +69,7 @@ class OverdriveFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         // Only load the connector if we need to show
-        $config = $container->get('VuFind\Config\PluginManager')->get(
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get(
             'Overdrive'
         );
         $connector = null;
@@ -77,7 +77,7 @@ class OverdriveFactory implements FactoryInterface
         $showAdmin = $config->Overdrive->showOverdriveAdminMenu;
         if ($showAdmin || $showMyContent != "never") {
             $connector = $container->get(
-                'VuFind\DigitalContent\OverdriveConnector'
+                \VuFind\DigitalContent\OverdriveConnector::class
             );
         }
         return new $requestedName($connector);

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/OverdriveController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/OverdriveController.php
@@ -68,7 +68,7 @@ class OverdriveController extends AbstractAdmin
     public function homeAction()
     {
         $connector  = $this->serviceLocator
-            ->get('VuFind\DigitalContent\OverdriveConnector');
+            ->get(\VuFind\DigitalContent\OverdriveConnector::class);
 
         $view = $this->createViewModel();
         $view->setTemplate('admin/overdrive/home');


### PR DESCRIPTION
These should be trivial changes to modernize the code and improve static analysis.