### PR TITLE
Make QRCode loader validate params and handle errors better.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/QRCode/LoaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/QRCode/LoaderTest.php
@@ -80,6 +80,19 @@ class LoaderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that requesting a too small image returns the fail image.
+     *
+     * @return void
+     */
+    public function testDefaultLoadingForTooSmallImage()
+    {
+        $loader = $this->getLoader();
+        $loader->loadQRCode('foofoofoofoofoofoofoofoofoofoofoofoo', ['size' => 1]);
+        $this->assertEquals('image/gif', $loader->getContentType());
+        $this->assertEquals('483', strlen($loader->getImage()));
+    }
+
+    /**
      * Get a loader object to test.
      *
      * @param array      $config Configuration


### PR DESCRIPTION
This allows e.g. /QRCode/Show?text=something&level=L&size=FOO&margin=4 to return the "QRCode not available" image instead of failing with an exception.