### PR TITLE
Improve Solr error listener.

### DIFF
--- a/module/VuFind/src/VuFind/Search/SearchRunner.php
+++ b/module/VuFind/src/VuFind/Search/SearchRunner.php
@@ -31,6 +31,7 @@ use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Stdlib\Parameters;
 use VuFind\Search\Results\PluginManager as ResultsManager;
+use VuFind\Search\Solr\AbstractErrorListener as ErrorListener;
 
 /**
  * VuFind Search Runner
@@ -146,7 +147,7 @@ class SearchRunner
             // catch exceptions more reliably:
             $results->performAndProcessSearch();
         } catch (\VuFindSearch\Backend\Exception\BackendException $e) {
-            if ($e->hasTag('VuFind\Search\ParserError')) {
+            if ($e->hasTag(ErrorListener::TAG_PARSER_ERROR)) {
                 // We need to create and process an "empty results" object to
                 // ensure that recommendation modules and templates behave
                 // properly when displaying the error message.

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -27,9 +27,9 @@
  */
 namespace VuFind\Search\Solr;
 
+use VuFind\Search\Solr\AbstractErrorListener as ErrorListener;
 use VuFindSearch\Query\AbstractQuery;
 use VuFindSearch\Query\QueryGroup;
-use VuFind\Search\Solr\AbstractErrorListener as ErrorListener;
 
 /**
  * Solr Search Parameters

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -27,9 +27,9 @@
  */
 namespace VuFind\Search\Solr;
 
-use VuFindSearch\Backend\Solr\Response\Json\Spellcheck;
 use VuFindSearch\Query\AbstractQuery;
 use VuFindSearch\Query\QueryGroup;
+use VuFind\Search\Solr\AbstractErrorListener as ErrorListener;
 
 /**
  * Solr Search Parameters
@@ -172,7 +172,7 @@ class Results extends \VuFind\Search\Base\Results
                 ->search($this->backendId, $query, $offset, $limit, $params);
         } catch (\VuFindSearch\Backend\Exception\BackendException $e) {
             // If the query caused a parser error, see if we can clean it up:
-            if ($e->hasTag('VuFind\Search\ParserError')
+            if ($e->hasTag(ErrorListener::TAG_PARSER_ERROR)
                 && $newQuery = $this->fixBadQuery($query)
             ) {
                 // We need to get a fresh set of $params, since the previous one was

--- a/module/VuFind/src/VuFind/Search/Solr/V3/ErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/V3/ErrorListener.php
@@ -55,14 +55,14 @@ class ErrorListener extends AbstractErrorListener
     public function onSearchError(EventInterface $event)
     {
         $backend = $event->getParam('backend_instance');
-        if ($this->listenForBackend($backend)) {
+        if ($backend && $this->listenForBackend($backend)) {
             $error  = $event->getTarget();
             if ($error instanceof HttpErrorException) {
                 $reason = $error->getResponse()->getReasonPhrase();
                 if (stristr($reason, 'org.apache.lucene.queryParser.ParseException')
                     || stristr($reason, 'undefined field')
                 ) {
-                    $error->addTag('VuFind\Search\ParserError');
+                    $error->addTag(self::TAG_PARSER_ERROR);
                 }
             }
         }

--- a/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
@@ -64,7 +64,7 @@ class ErrorListener extends AbstractErrorListener
     public function onSearchError(EventInterface $event)
     {
         $backend = $event->getParam('backend_instance');
-        if ($this->listenForBackend($backend)) {
+        if ($backend && $this->listenForBackend($backend)) {
             $error = $event->getTarget();
             if ($error instanceof HttpErrorException) {
                 $response = $error->getResponse();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
@@ -29,13 +29,9 @@
 namespace VuFindTest\Search\Solr\V3;
 
 use Laminas\EventManager\Event;
-
 use Laminas\Http\Response;
-
 use PHPUnit\Framework\TestCase;
-
 use VuFind\Search\Solr\V3\ErrorListener;
-
 use VuFindSearch\Backend\Exception\HttpErrorException;
 
 /**
@@ -66,7 +62,7 @@ class ErrorListenerTest extends TestCase
         $event     = new Event(null, $exception, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
-        $this->assertTrue($exception->hasTag('VuFind\Search\ParserError'));
+        $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
     }
 
     /**
@@ -84,7 +80,7 @@ class ErrorListenerTest extends TestCase
         $event     = new Event(null, $exception, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
-        $this->assertTrue($exception->hasTag('VuFind\Search\ParserError'));
+        $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
     }
 
     /// Internal API

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
@@ -66,7 +66,7 @@ class ErrorListenerTest extends TestCase
         $event     = new Event(null, $exception, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
-        $this->assertTrue($exception->hasTag('VuFind\Search\ParserError'));
+        $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
     }
 
     /**
@@ -84,7 +84,7 @@ class ErrorListenerTest extends TestCase
         $event     = new Event(null, $exception, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
-        $this->assertTrue($exception->hasTag('VuFind\Search\ParserError'));
+        $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
     }
 
     /// Internal API


### PR DESCRIPTION
- Do not cause unexpected errors if the backend fails to initialize.
- Use constant for tag more consistently.