### PR TITLE
Add a constraint to record tab route parameter.

### DIFF
--- a/module/VuFind/src/VuFind/Route/RouteGenerator.php
+++ b/module/VuFind/src/VuFind/Route/RouteGenerator.php
@@ -132,6 +132,7 @@ class RouteGenerator
                 'constraints' => [
                     'controller' => '[a-zA-Z][a-zA-Z0-9_-]*',
                     'action'     => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'tab'        => '[a-zA-Z][a-zA-Z0-9_-]*',
                 ],
                 'defaults' => [
                     'controller' => $controller,

--- a/module/VuFind/src/VuFind/View/Helper/Root/Url.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Url.php
@@ -104,6 +104,8 @@ class Url extends \Laminas\View\Helper\Url
             'query' => array_merge($requestQuery, $params),
             'normalize_path' => false, // fix for VUFIND-1392
         ];
-        return ($this)(null, [], $options, $reuseMatchedParams);
+        // If we don't have a route match, direct any url's to default route:
+        $routeName = $this->routeMatch ? null : 'default';
+        return ($this)($routeName, [], $options, $reuseMatchedParams);
     }
 }


### PR DESCRIPTION
Also make sure that the url helper can handle a case where there's no proper route match (the url doesn't match the default route either).

The url helper issue would come up with e.g. /Record/id/* where the tab doesn't match the constraint and the url doesn't match the default route.