### PR TITLE
Fix handling of an empty hold updateFields setting.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -361,7 +361,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
             if (isset($functionConfig['extraHoldFields'])) {
                 $response['extraHoldFields'] = $functionConfig['extraHoldFields'];
             }
-            if (isset($functionConfig['updateFields'])) {
+            if (!empty($functionConfig['updateFields'])) {
                 $response['updateFields'] = array_map(
                     'trim',
                     explode(':', $functionConfig['updateFields'])


### PR DESCRIPTION
This avoids displaying of edit button and links when `updateFields = ""`.