### PR TITLE
Set default record page title.

### DIFF
--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -1,4 +1,9 @@
 <?php
+  // Set a default page title; this will usually be overridden when a tab is
+  // loaded, but it may be useful if there are no tabs, or when tabs are loaded
+  // via AJAX:
+  $this->headTitle($this->driver->getBreadcrumb());
+
   // Set up standard record scripts:
   $this->headScript()->appendFile("record.js");
   $this->headScript()->appendFile("check_save_statuses.js");


### PR DESCRIPTION
I opened this PR to resolve an issue reported on the vufind-general mailing list, in which the `<title>` tag is empty on the record page when `loadInitialTabWithAjax` is set to true.