### PR TITLE
Add support for help text on the hold update form.

### DIFF
--- a/config/vufind/Aleph.ini
+++ b/config/vufind/Aleph.ini
@@ -95,6 +95,11 @@ defaultRequiredDate = 0:1:0
 ; "pickUpLocation"
 extraHoldFields = comments:requiredByDate:pickUpLocation
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
 ; If you wish to cache translation results, uncomment type below and set it to the name of the
 ; \VuFind\Cache\Manager cache you would like to use for storing data ("object" is recommended).
 [Cache]

--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -73,7 +73,7 @@ updateFields = pickUpLocation
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
 ; HTML tags can be used, and everything needs to be properly escaped.
 ;updateHelpText[*] = "Hold update default help text used if not overridden."
-;updateHelpText[en] = "Hold update help text for British English localization."
+;updateHelpText[en-gb] = "Hold update help text for British English localization."
 
 ; The "NewUser" section defines some default values that are used when creating an account
 ; in Alma via its API. This is only relevant if you use the authentication method "AlmaDatabase"

--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -65,6 +65,16 @@ defaultPickUpLocation = ""
 ; available for pickup). The only supported value is "pickUpLocation".
 updateFields = pickUpLocation
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
+; Optional help texts that can be displayed on the hold update form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;updateHelpText[*] = "Hold update default help text used if not overridden."
+;updateHelpText[en] = "Hold update help text for British English localization."
+
 ; The "NewUser" section defines some default values that are used when creating an account
 ; in Alma via its API. This is only relevant if you use the authentication method "AlmaDatabase"
 ; in the "Authentication" section of the "config.ini" file.

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -140,13 +140,15 @@ defaultRequiredDate = 'driver:0:2:0'
 ; "pickUpLocation", "startDate" and "requiredByDate"
 extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate"
 
-; Optional help texts that can be displayed on the hold form. HTML allowed.
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, but everything needs to be properly escaped.
 helpText = "Help text for all languages."
 ;helpText[en-gb] = "Help text for English language."
 
-; Optional help texts that can be displayed on the hold update form. HTML allowed.
+; Optional help texts that can be displayed on the hold update form. Displayed as is;
+; HTML tags can be used, but everything needs to be properly escaped.
 updateHelpText = "Hold update help text for all languages."
-;updateHelpText[en-gb] = "Hold update help text for English language."
+;updateHelpText[en] = "Hold update help text for English language."
 
 ; Fields that can be updated for holds (unless the hold is already in transit or
 ; available for pickup). Supported values are "frozen", "frozenThrough" and

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -140,6 +140,14 @@ defaultRequiredDate = 'driver:0:2:0'
 ; "pickUpLocation", "startDate" and "requiredByDate"
 extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate"
 
+; Optional help texts that can be displayed on the hold form. HTML allowed.
+helpText = "Help text for all languages."
+;helpText[en-gb] = "Help text for English language."
+
+; Optional help texts that can be displayed on the hold update form. HTML allowed.
+updateHelpText = "Hold update help text for all languages."
+;updateHelpText[en-gb] = "Hold update help text for English language."
+
 ; Fields that can be updated for holds (unless the hold is already in transit or
 ; available for pickup). Supported values are "frozen", "frozenThrough" and
 ; "pickUpLocation"

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -148,7 +148,7 @@ extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
 ; HTML tags can be used, and everything needs to be properly escaped.
 ;updateHelpText[*] = "Hold update default help text used if not overridden."
-;updateHelpText[en] = "Hold update help text for British English localization."
+;updateHelpText[en-gb] = "Hold update help text for British English localization."
 
 ; Fields that can be updated for holds (unless the hold is already in transit or
 ; available for pickup). Supported values are "frozen", "frozenThrough" and

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -143,7 +143,7 @@ extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate
 ; Optional help texts that can be displayed on the hold form. Displayed as is;
 ; HTML tags can be used, but everything needs to be properly escaped.
 helpText = "Help text for all languages."
-;helpText[en-gb] = "Help text for English language."
+;helpText[en] = "Help text for English language."
 
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
 ; HTML tags can be used, but everything needs to be properly escaped.

--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -141,14 +141,14 @@ defaultRequiredDate = 'driver:0:2:0'
 extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate"
 
 ; Optional help texts that can be displayed on the hold form. Displayed as is;
-; HTML tags can be used, but everything needs to be properly escaped.
-helpText = "Help text for all languages."
-;helpText[en] = "Help text for English language."
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
 
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
-; HTML tags can be used, but everything needs to be properly escaped.
-updateHelpText = "Hold update help text for all languages."
-;updateHelpText[en] = "Hold update help text for English language."
+; HTML tags can be used, and everything needs to be properly escaped.
+;updateHelpText[*] = "Hold update default help text used if not overridden."
+;updateHelpText[en] = "Hold update help text for British English localization."
 
 ; Fields that can be updated for holds (unless the hold is already in transit or
 ; available for pickup). Supported values are "frozen", "frozenThrough" and

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -118,3 +118,8 @@ extraHoldFields = requiredByDate:pickUpLocation
 ; cancellation reasons configured for your FOLIO instance, issue a GET request to
 ; /cancellation-reason-storage/cancellation-reasons
 cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
+
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."

--- a/config/vufind/HorizonXMLAPI.ini
+++ b/config/vufind/HorizonXMLAPI.ini
@@ -47,6 +47,11 @@ defaultRequiredDate = 0:1:0
 ; "pickUpLocation"
 extraHoldFields = pickUpLocation
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
 [Statuses]
 ; custom item statuses - A coma-separated list of value pairs. Supported values are
 ; available:1, available:0, reserve:N, reserve:Y, and duedate:0. duedate:0 is only

--- a/config/vufind/KohaILSDI.ini
+++ b/config/vufind/KohaILSDI.ini
@@ -77,6 +77,11 @@ defaultPickUpLocation = "MAIN"
 ; branchcodes for libraries avalaible as pickup locations
 pickupLocations[] = MAIN
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
 [Other]
 ; Locations for Always Available by Default
 ;availableLocations[] = REFERENCEAREA

--- a/config/vufind/KohaRest.ini
+++ b/config/vufind/KohaRest.ini
@@ -105,7 +105,7 @@ updateFields = frozen:frozenThrough:pickUpLocation
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
 ; HTML tags can be used, and everything needs to be properly escaped.
 ;updateHelpText[*] = "Hold update default help text used if not overridden."
-;updateHelpText[en] = "Hold update help text for British English localization."
+;updateHelpText[en-gb] = "Hold update help text for British English localization."
 
 ; This section controls article request behavior. To enable, uncomment (at minimum)
 ; the HMACKeys and extraFields settings below.
@@ -122,13 +122,10 @@ HMACKeys = item_id:holdings_id:StorageRetrievalRequest
 ; "item-issue" and "acceptTerms"
 extraFields = item-issue:acceptTerms:pickUpLocation
 
-; Optional help texts that can be displayed on the request form
-;helpText = "Help text for all languages."
-;helpText[en-gb] = "Help text for English language."
-
-; Optional label for the "acceptTerms" extra field
-acceptTermsText = "I accept the terms in any language."
-;acceptTermsText[en-gb] = "I accept the terms in English."
+; Optional help texts that can be displayed on the request form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Help text for all languages."
+;helpText[en-gb] = "Help text for British English localization."
 
 ; This section allows modification of the default mappings from item status codes to
 ; VuFind item statuses

--- a/config/vufind/KohaRest.ini
+++ b/config/vufind/KohaRest.ini
@@ -97,6 +97,16 @@ defaultPickUpLocation = ""
 ; "pickUpLocation"
 updateFields = frozen:frozenThrough:pickUpLocation
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
+; Optional help texts that can be displayed on the hold update form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;updateHelpText[*] = "Hold update default help text used if not overridden."
+;updateHelpText[en] = "Hold update help text for British English localization."
+
 ; This section controls article request behavior. To enable, uncomment (at minimum)
 ; the HMACKeys and extraFields settings below.
 [StorageRetrievalRequests]
@@ -113,7 +123,7 @@ HMACKeys = item_id:holdings_id:StorageRetrievalRequest
 extraFields = item-issue:acceptTerms:pickUpLocation
 
 ; Optional help texts that can be displayed on the request form
-helpText = "Help text for all languages."
+;helpText = "Help text for all languages."
 ;helpText[en-gb] = "Help text for English language."
 
 ; Optional label for the "acceptTerms" extra field

--- a/config/vufind/Polaris.ini
+++ b/config/vufind/Polaris.ini
@@ -28,3 +28,8 @@ extraHoldFields = pickUpLocation
 ; provide a default option if others are not available. Must correspond with one of
 ; the Location IDs returned by getPickUpLocations()
 defaultPickUpLocation = "15"
+
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -123,6 +123,16 @@ title_hold_bib_levels = a:b:m:d
 ; available for pickup). Supported values are "frozen" and "pickUpLocation".
 ;updateFields = frozen:pickUpLocation
 
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
+; Optional help texts that can be displayed on the hold update form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;updateHelpText[*] = "Hold update default help text used if not overridden."
+;updateHelpText[en] = "Hold update help text for British English localization."
+
 ; This section allows modification of the default mapping from item status codes to
 ; VuFind item statuses
 [ItemStatusMappings]

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -131,7 +131,7 @@ title_hold_bib_levels = a:b:m:d
 ; Optional help texts that can be displayed on the hold update form. Displayed as is;
 ; HTML tags can be used, and everything needs to be properly escaped.
 ;updateHelpText[*] = "Hold update default help text used if not overridden."
-;updateHelpText[en] = "Hold update help text for British English localization."
+;updateHelpText[en-gb] = "Hold update help text for British English localization."
 
 ; This section allows modification of the default mapping from item status codes to
 ; VuFind item statuses

--- a/config/vufind/Symphony.ini
+++ b/config/vufind/Symphony.ini
@@ -87,3 +87,8 @@ extraHoldFields = comments:requiredByDate:pickUpLocation
 ; provide a default option if others are not available. Must correspond with one of
 ; the Location IDs returned by getPickUpLocations()
 ;defaultPickUpLocation = MAIN
+
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."

--- a/config/vufind/Unicorn.ini
+++ b/config/vufind/Unicorn.ini
@@ -43,7 +43,12 @@ defaultRequiredDate = 0:1:0
 ; place holds form. Supported values are "comments", "requiredByDate" and
 ; "pickUpLocation"
 extraHoldFields = requiredByDate:pickUpLocation:comments
-;
+
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
+
 ; The following are lists of Location Codes and Item Types
 ; for items that are NOT AVAILABLE even if they are NOT checked out.
 ; The values on the right side of "=" is the status message to display.

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -207,9 +207,10 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ; on it.
 ;checkLoans = true
 
-; Optional help texts that can be displayed on the hold form
-;helpText = "Help text for all languages."
-;helpText[en-gb] = "Help text for English language."
+; Optional help texts that can be displayed on the hold form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Default help text used if not overridden."
+;helpText[en-gb] = "Help text for British English localization."
 
 ; By default a request can be canceled even if the item is available for pickup.
 ; Uncomment this to disable canceling of available requests.

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -237,9 +237,10 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ; link. Use "0" to check all items via ajax. Default is 15.
 ;checkLimit = 0
 
-; Optional help texts that can be displayed on the call slip form
-;helpText = "Help text for all languages."
-;helpText[en-gb] = "Help text for English language."
+; Optional help texts that can be displayed on the request form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Help text for all languages."
+;helpText[en-gb] = "Help text for British English localization."
 
 ; Colon-separated list of call slip statuses (see CALL_SLIP_STATUS_TYPE table in
 ; Voyager's database) that control whether a call slip is displayed. Only slips
@@ -267,9 +268,10 @@ disableAvailabilityCheckForRequestGroups = "15:19:21:32"
 ; e.g. 0:1:0 will set a "not required after" date of 1 month from the current date
 ;defaultRequiredDate = 0:1:0
 
-; Optional help texts that can be displayed on the ILL form
-;helpText = "ILL Help text for all languages."
-;helpText[en-gb] = "ILL Help text for English language."
+; Optional help texts that can be displayed on the request form. Displayed as is;
+; HTML tags can be used, and everything needs to be properly escaped.
+;helpText[*] = "Help text for all languages."
+;helpText[en-gb] = "Help text for British English localization."
 
 ; This section lists the valid patron id prefixes for UB (ILL in VuFind) requests,
 ; and maps them to the their Voyager UB library IDs. Any patron of another library

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -257,6 +257,7 @@ class HoldsController extends AbstractBase
                 'gatheredDetails' => $gatheredDetails,
                 'pickupLocations' => $pickupLocationInfo['pickupLocations'],
                 'conflictingPickupLocations' => $pickupLocationInfo['differences'],
+                'helpText' => $holdConfig['updateHelpText'],
             ]
         );
 

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -257,7 +257,7 @@ class HoldsController extends AbstractBase
                 'gatheredDetails' => $gatheredDetails,
                 'pickupLocations' => $pickupLocationInfo['pickupLocations'],
                 'conflictingPickupLocations' => $pickupLocationInfo['differences'],
-                'helpText' => $holdConfig['updateHelpText'],
+                'helpTextHtml' => $holdConfig['updateHelpText'],
             ]
         );
 

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -227,7 +227,8 @@ trait HoldsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
-        $helpText = $checkHolds['helpText'] ?? null;
+        // helpText is only for for backward compatibility:
+        $helpText = $helpTextHtml = $checkHolds['helpText'];
 
         $view = $this->createViewModel(
             compact(
@@ -241,7 +242,8 @@ trait HoldsTrait
                 'requestGroups',
                 'defaultRequestGroup',
                 'requestGroupNeeded',
-                'helpText'
+                'helpText',
+                'helpTextHtml'
             )
         );
         $view->setTemplate('record/hold');

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -227,7 +227,7 @@ trait HoldsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
-        // helpText is only for for backward compatibility:
+        // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkHolds['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -153,7 +153,7 @@ trait ILLRequestsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
-        // helpText is only for for backward compatibility:
+        // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -154,7 +154,7 @@ trait ILLRequestsTrait
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
         // helpText is only for for backward compatibility:
-        $helpText = $helpTextHtml = $checkHolds['helpText'];
+        $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(
             compact(

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -132,10 +132,11 @@ trait ILLRequestsTrait
         }
 
         // Find and format the default required date:
-        $defaultRequired = $this->ILLRequests()
+        $defaultRequiredDate = $this->ILLRequests()
             ->getDefaultRequiredDate($checkRequests);
-        $defaultRequired = $this->serviceLocator->get(\VuFind\Date\Converter::class)
-            ->convertToDisplayDate("U", $defaultRequired);
+        $defaultRequiredDate
+            = $this->serviceLocator->get(\VuFind\Date\Converter::class)
+            ->convertToDisplayDate("U", $defaultRequiredDate);
 
         // Get pickup libraries
         $pickupLibraries = $catalog->getILLPickUpLibraries(
@@ -150,18 +151,22 @@ trait ILLRequestsTrait
         $pickupLocations = $catalog->getPickUpLocations($patron, $gatheredDetails);
 
         $config = $this->getConfig();
-        $allowHomeLibrary = $config->Account->set_home_library ?? true;
+        $homeLibrary = ($config->Account->set_home_library ?? true)
+            ? $this->getUser()->home_library : '';
+        // helpText is only for for backward compatibility:
+        $helpText = $helpTextHtml = $checkHolds['helpText'];
+
         $view = $this->createViewModel(
-            [
-                'gatheredDetails' => $gatheredDetails,
-                'pickupLibraries' => $pickupLibraries,
-                'pickupLocations' => $pickupLocations,
-                'homeLibrary' => $allowHomeLibrary
-                    ? $this->getUser()->home_library : '',
-                'extraFields' => $extraFields,
-                'defaultRequiredDate' => $defaultRequired,
-                'helpText' => $checkRequests['helpText'] ?? null
-            ]
+            compact(
+                'gatheredDetails',
+                'pickupLibraries',
+                'pickupLocations',
+                'homeLibrary',
+                'extraFields',
+                'defaultRequiredDate',
+                'helpText',
+                'helpTextHtml'
+            )
         );
         $view->setTemplate('record/illrequest');
         return $view;

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -157,7 +157,6 @@ trait StorageRetrievalRequestsTrait
                 'defaultPickup',
                 'homeLibrary',
                 'extraFields',
-                'defaultStartDate',
                 'defaultRequiredDate',
                 'helpText',
                 'helpTextHtml'

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -147,7 +147,7 @@ trait StorageRetrievalRequestsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
-        // helpText is only for for backward compatibility:
+        // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -148,7 +148,7 @@ trait StorageRetrievalRequestsTrait
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';
         // helpText is only for for backward compatibility:
-        $helpText = $helpTextHtml = $checkHolds['helpText'];
+        $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(
             compact(

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -132,10 +132,11 @@ trait StorageRetrievalRequestsTrait
         }
 
         // Find and format the default required date:
-        $defaultRequired = $this->storageRetrievalRequests()
+        $defaultRequiredDate = $this->storageRetrievalRequests()
             ->getDefaultRequiredDate($checkRequests);
-        $defaultRequired = $this->serviceLocator->get(\VuFind\Date\Converter::class)
-            ->convertToDisplayDate("U", $defaultRequired);
+        $defaultRequiredDate
+            = $this->serviceLocator->get(\VuFind\Date\Converter::class)
+            ->convertToDisplayDate("U", $defaultRequiredDate);
         try {
             $defaultPickup
                 = $catalog->getDefaultPickUpLocation($patron, $gatheredDetails);
@@ -144,18 +145,23 @@ trait StorageRetrievalRequestsTrait
         }
 
         $config = $this->getConfig();
-        $allowHomeLibrary = $config->Account->set_home_library ?? true;
+        $homeLibrary = ($config->Account->set_home_library ?? true)
+            ? $this->getUser()->home_library : '';
+        // helpText is only for for backward compatibility:
+        $helpText = $helpTextHtml = $checkHolds['helpText'];
+
         $view = $this->createViewModel(
-            [
-                'gatheredDetails' => $gatheredDetails,
-                'pickup' => $pickup,
-                'defaultPickup' => $defaultPickup,
-                'homeLibrary' => $allowHomeLibrary
-                    ? $this->getUser()->home_library : '',
-                'extraFields' => $extraFields,
-                'defaultRequiredDate' => $defaultRequired,
-                'helpText' => $checkRequests['helpText'] ?? null
-            ]
+            compact(
+                'gatheredDetails',
+                'pickup',
+                'defaultPickup',
+                'homeLibrary',
+                'extraFields',
+                'defaultStartDate',
+                'defaultRequiredDate',
+                'helpText',
+                'helpTextHtml'
+            )
         );
         $view->setTemplate('record/storageretrievalrequest');
         return $view;

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -367,11 +367,10 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                     explode(':', $functionConfig['updateFields'])
                 );
             }
-            if (isset($functionConfig['helpText'])) {
-                $response['helpText'] = $this->getHelpText(
-                    $functionConfig['helpText']
-                );
-            }
+            $response['helpText']
+                = $this->getHelpText($functionConfig['helpText'] ?? '');
+            $response['updateHelpText']
+                = $this->getHelpText($functionConfig['updateHelpText'] ?? '');
             if (isset($functionConfig['consortium'])) {
                 $response['consortium'] = $functionConfig['consortium'];
             }

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -726,7 +726,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     {
         if (is_array($helpText)) {
             $lang = $this->getTranslatorLocale();
-            return $helpText[$lang] ?? '';
+            return $helpText[$lang] ?? $helpText['*'] ?? '';
         }
         return $helpText;
     }

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -486,11 +486,8 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
             if (isset($functionConfig['extraFields'])) {
                 $response['extraFields'] = $functionConfig['extraFields'];
             }
-            if (isset($functionConfig['helpText'])) {
-                $response['helpText'] = $this->getHelpText(
-                    $functionConfig['helpText']
-                );
-            }
+            $response['helpText']
+                = $this->getHelpText($functionConfig['helpText'] ?? '');
         }
         return $response;
     }
@@ -576,11 +573,8 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
             if (isset($functionConfig['extraFields'])) {
                 $response['extraFields'] = $functionConfig['extraFields'];
             }
-            if (isset($functionConfig['helpText'])) {
-                $response['helpText'] = $this->getHelpText(
-                    $functionConfig['helpText']
-                );
-            }
+            $response['helpText']
+                = $this->getHelpText($functionConfig['helpText']);
         }
         return $response;
     }

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -8,8 +8,8 @@
     . '<li class="active">' . $this->transEsc('hold_edit_title') . '</li>';
 ?>
 <h2><?=$this->transEsc('hold_edit_title')?></h2>
-<?php if ($this->helpText): ?>
-  <p class="helptext"><?=$this->helpText // Intentionally left unescaped?></p>
+<?php if ($this->helpTextHtml): ?>
+  <p class="helptext"><?=$this->helpTextHtml?></p>
 <?php endif; ?>
 
 <form action="<?=$this->url('holds-edit')?>" class="form-edit-holds" method="post" name="editHolds">

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -8,6 +8,9 @@
     . '<li class="active">' . $this->transEsc('hold_edit_title') . '</li>';
 ?>
 <h2><?=$this->transEsc('hold_edit_title')?></h2>
+<?php if ($this->helpText): ?>
+  <p class="helptext"><?=$this->helpText // Intentionally left unescaped?></p>
+<?php endif; ?>
 
 <form action="<?=$this->url('holds-edit')?>" class="form-edit-holds" method="post" name="editHolds">
   <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>">

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -9,7 +9,7 @@
 ?>
 <h2><?=$this->transEsc('request_place_text')?></h2>
 <?php if ($this->helpText): ?>
-<p class="helptext"><?=$this->helpText?></p>
+  <p class="helptext"><?=$this->helpText // Intentionally left unescaped?></p>
 <?php endif; ?>
 
 <form class="form-record-hold" method="post" name="placeHold" data-clear-account-cache="holds">

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -8,8 +8,8 @@
         . '<li class="active">' . $this->transEsc('request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('request_place_text')?></h2>
-<?php if ($this->helpText): ?>
-  <p class="helptext"><?=$this->helpText // Intentionally left unescaped?></p>
+<?php if ($this->helpTextHtml): ?>
+  <p class="helptext"><?=$this->helpTextHtml?></p>
 <?php endif; ?>
 
 <form class="form-record-hold" method="post" name="placeHold" data-clear-account-cache="holds">

--- a/themes/bootstrap3/templates/record/illrequest.phtml
+++ b/themes/bootstrap3/templates/record/illrequest.phtml
@@ -8,8 +8,8 @@
         . '<li class="active">' . $this->transEsc('ill_request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('ill_request_place_text')?></h2>
-<?php if ($this->helpText): ?>
-  <p class="help-block"><?=$this->helpText?></p>
+<?php if ($this->helpTextHtml): ?>
+  <p class="help-block"><?=$this->helpTextHtml?></p>
 <?php endif; ?>
 
 <form id="ILLRequestForm" name="placeILLRequest" class="form-ill-retrieval-request" method="post" data-clear-account-cache="illRequests">

--- a/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
@@ -8,8 +8,8 @@
         . '<li class="active">' . $this->transEsc('storage_retrieval_request_place_text') . '</li>';
 ?>
 <h2><?=$this->transEsc('storage_retrieval_request_place_text')?></h2>
-<?php if ($this->helpText): ?>
-<p class="helptext"><?=$this->helpText?></p>
+<?php if ($this->helpTextHtml): ?>
+<p class="helptext"><?=$this->helpTextHtml?></p>
 <?php endif; ?>
 
 <form name="placeStorageRetrievalRequest" class="form-storage-retrieval-request" method="post" data-clear-account-cache="storageRetrievalRequests">


### PR DESCRIPTION
This is just like the help text that is displayed on the hold form.

I just realized that while the helpText setting has been universally supported for a long time, it's not in the default config files. @demiankatz Do you think it should be added?

TODO:
- [x] Update wiki
- [x] Decide whether to include the help texts in all the ILS sample configs.