### PR TITLE
Always unset updateDetails unless the value is usable.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -134,15 +134,15 @@ class HoldsController extends AbstractBase
             }
 
             // Add update details if appropriate
-            if (empty($holdConfig['updateFields'])) {
-                if (isset($current['updateDetails'])) {
+            if (isset($current['updateDetails'])) {
+                if (empty($holdConfig['updateFields'])
+                    || '' === $current['updateDetails']
+                ) {
                     unset($current['updateDetails']);
+                } else {
+                    $view->updateForm = true;
+                    $this->holds()->rememberValidId($current['updateDetails']);
                 }
-            } elseif (isset($current['updateDetails'])
-                && '' !== $current['updateDetails']
-            ) {
-                $view->updateForm = true;
-                $this->holds()->rememberValidId($current['updateDetails']);
             }
 
             $driversNeeded[] = $current;


### PR DESCRIPTION
Previously an empty string would have been kept and used for the id in the list.