### PR TITLE
corrects logic for first and last name detection for space seperated …

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -1378,12 +1378,8 @@ class PAIA extends DAIA
             $lastname = $nameArr[0];
         } else {
             $nameArr = explode(' ', $username);
-            $firstname = '';
             $lastname = array_pop($nameArr);
-            foreach ($nameArr as $value) {
-                $firstname .= ' ' . $value;
-            }
-            $firstname = trim($firstname);
+            $firstname = trim(implode(' ', $nameArr));
         }
 
         // TODO: implement parsing of user details according to types set

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -1378,13 +1378,12 @@ class PAIA extends DAIA
             $lastname = $nameArr[0];
         } else {
             $nameArr = explode(' ', $username);
-            $firstname = $nameArr[0];
-            $lastname = '';
-            array_shift($nameArr);
+            $firstname = '';
+            $lastname = array_pop($nameArr);
             foreach ($nameArr as $value) {
-                $lastname .= ' ' . $value;
+                $firstname .= ' ' . $value;
             }
-            $lastname = trim($lastname);
+            $firstname = trim($firstname);
         }
 
         // TODO: implement parsing of user details according to types set

--- a/module/VuFind/tests/fixtures/paia/response/patron.json
+++ b/module/VuFind/tests/fixtures/paia/response/patron.json
@@ -11,7 +11,7 @@ X-Accepted-OAuth-Scopes: read_patron
 Content-Type: application/json; charset=UTF-8
 
 {
-  "name": " Nobody Nothing",
+  "name": " Susan Q. Nothing",
   "expires": "9999-12-31",
   "email": "nobody@vufind.org",
   "status": 0,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
@@ -305,7 +305,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
     ];
 
     protected $profileTestResult = [
-        'firstname' => "Nobody",
+        'firstname' => "Susan Q.",
         'lastname' => "Nothing",
         'address1' => "No street at all 8, D-21073 Hamburg",
         'address2' => null,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
@@ -61,12 +61,12 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
 
     protected $patron = [
         'id' => '08301001001',
-        'firstname' => 'Nobody',
+        'firstname' => 'Susan Q.',
         'lastname' => 'Nothing',
         'email' => 'nobody@vufind.org',
         'major' => null,
         'college' => null,
-        'name' => ' Nobody Nothing',
+        'name' => ' Susan Q. Nothing',
         'expires' => '9999-12-31',
         'status' => 0,
         'address' => 'No street at all 8, D-21073 Hamburg',


### PR DESCRIPTION
…names from PAIA

We have noticed, that the PAIA driver handles space seperated names wrong, if someone has more than one first name. I have changed the logic, so that only the last part of the name is taken as the last name, while everything before that is handled as the first name. I know, that this is not 100% accurate, but I guess it's better than the treatment right now.