### PR TITLE
Make abstract search command truly abstract; improve tests.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/MockSearchCommandTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/MockSearchCommandTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Trait for tests requiring mock search Command objects
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Feature;
+
+use VuFindSearch\Command\AbstractBase as Command;
+use VuFindSearch\ParamBag;
+
+/**
+ * Trait for tests requiring mock search Command objects
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait MockSearchCommandTrait
+{
+    /**
+     * Get a mock search command.
+     *
+     * @param ParamBag $params    Parameters for command to return
+     * @param mixed    $context   Context for command to return
+     * @param string   $backendId Backend ID for command
+     * @param mixed    $result    Result to return
+     *
+     * @return Command
+     */
+    protected function getMockSearchCommand(
+        ParamBag $params = null,
+        $context = null,
+        string $backendId = 'foo',
+        $result = null
+    ): Command {
+        $command = $this->getMockBuilder(Command::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        if ($params) {
+            $command->expects($this->any())->method('getSearchParameters')
+                ->will($this->returnValue($params));
+        }
+        if ($context) {
+            $command->expects($this->any())->method('getContext')
+                ->will($this->returnValue($context));
+        }
+        if ($result) {
+            $command->expects($this->any())->method('getResult')
+                ->will($this->returnValue($result));
+        }
+        $command->expects($this->any())->method('getTargetBackendName')
+            ->will($this->returnValue($backendId));
+        return $command;
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/OnCampusListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/OnCampusListenerTest.php
@@ -47,6 +47,8 @@ use VuFindSearch\Service;
  */
 class OnCampusListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
     /**
      * Backend.
      *
@@ -63,11 +65,11 @@ class OnCampusListenerTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockPreEvent(ParamBag $params): Event
     {
-        $command = new MockCommandForOnCampusListenerTest($params);
+        $command = $this->getMockSearchCommand($params);
         return new Event(
             Service::EVENT_PRE,
             $this->backend,
-            ['params' => $params, 'command' => $command]
+            compact('params', 'command')
         );
     }
 
@@ -253,13 +255,5 @@ class OnCampusListenerTest extends \PHPUnit\Framework\TestCase
 
         $onCampus   = $params->get('onCampus');
         $this->assertEquals([0 => false], $onCampus);
-    }
-}
-
-class MockCommandForOnCampusListenerTest extends \VuFindSearch\Command\AbstractBase
-{
-    public function __construct(ParamBag $params)
-    {
-        parent::__construct('foo', 'foo', $params);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -48,6 +48,8 @@ use VuFindSearch\Service;
  */
 class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
     /**
      * Sample configuration for ConditionalFilters.
      *
@@ -81,11 +83,11 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockPreEvent(ParamBag $params): Event
     {
-        $command = new MockCommandForConditionalFilterListenerTest($params);
+        $command = $this->getMockSearchCommand($params);
         return new Event(
             Service::EVENT_PRE,
             $this->backend,
-            ['params' => $params, 'command' => $command]
+            compact('params', 'command')
         );
     }
 
@@ -335,14 +337,5 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
             ],
             $fq
         );
-    }
-}
-
-class MockCommandForConditionalFilterListenerTest
-    extends \VuFindSearch\Command\AbstractBase
-{
-    public function __construct(ParamBag $params)
-    {
-        parent::__construct('foo', 'foo', $params);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/FilterFieldConversionListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/FilterFieldConversionListenerTest.php
@@ -45,6 +45,8 @@ use VuFindSearch\Service;
  */
 class FilterFieldConversionListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
     /**
      * Test attaching listener.
      *
@@ -88,7 +90,7 @@ class FilterFieldConversionListenerTest extends \PHPUnit\Framework\TestCase
 
         $backend = $this->getMockBuilder(\VuFindSearch\Backend\Solr\Backend::class)
             ->disableOriginalConstructor()->getMock();
-        $command = new MockCommandForFilterFieldConversionListenerTest($params);
+        $command = $this->getMockSearchCommand($params);
         $event = new Event(
             Service::EVENT_PRE,
             $backend,
@@ -106,14 +108,5 @@ class FilterFieldConversionListenerTest extends \PHPUnit\Framework\TestCase
             '(bar:value)',
         ];
         $this->assertEquals($expected, $fq);
-    }
-}
-
-class MockCommandForFilterFieldConversionListenerTest
-    extends \VuFindSearch\Command\AbstractBase
-{
-    public function __construct(ParamBag $params)
-    {
-        parent::__construct('foo', 'foo', $params);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HideFacetValueListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HideFacetValueListenerTest.php
@@ -45,6 +45,8 @@ use VuFindSearch\Backend\Solr\Response\Json\RecordCollection;
  */
 class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
     /**
      * Get a mock backend
      *
@@ -143,7 +145,7 @@ class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
         $listener = $this->getListener(['format' => ['Unknown']]);
         $result = $this->getMockResult();
         $facets = $result->getFacets()->getFieldFacets();
-        $command = new MockCommandForHideFacetValueTest($result);
+        $command = $this->getMockSearchCommand(null, 'search', 'Solr', $result);
         $params = ['backend' => 'Solr', 'context' => 'search', 'command' => $command];
         $event = new Event(null, $result, $params);
         $this->assertEquals(
@@ -167,7 +169,7 @@ class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
         $listener = $this->getListener([], ['format' => ['Book']]);
         $result = $this->getMockResult();
         $facets = $result->getFacets()->getFieldFacets();
-        $command = new MockCommandForHideFacetValueTest($result);
+        $command = $this->getMockSearchCommand(null, 'search', 'Solr', $result);
         $params = ['backend' => 'Solr', 'context' => 'search', 'command' => $command];
         $event = new Event(null, $result, $params);
         $this->assertEquals(
@@ -196,7 +198,7 @@ class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
         );
         $result = $this->getMockResult();
         $facets = $result->getFacets()->getFieldFacets();
-        $command = new MockCommandForHideFacetValueTest($result);
+        $command = $this->getMockSearchCommand(null, 'search', 'Solr', $result);
         $params = ['backend' => 'Solr', 'context' => 'search', 'command' => $command];
         $event = new Event(null, $result, $params);
         $this->assertEquals(
@@ -208,15 +210,5 @@ class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
             ['Book' => 124],
             $facets['format']->toArray()
         );
-    }
-}
-
-class MockCommandForHideFacetValueTest extends \VuFindSearch\Command\AbstractBase
-{
-    public function __construct(RecordCollection $result = null)
-    {
-        parent::__construct('Solr', 'search');
-        $this->executed = true;
-        $this->result = $result;
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
@@ -48,6 +48,7 @@ use VuFindSearch\Service;
  */
 class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
     use \VuFindTest\Feature\ReflectionTrait;
 
     /**
@@ -139,17 +140,17 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testStripFacetFields()
     {
-        $params   = new ParamBag(
+        $params = new ParamBag(
             [
                 'facet.field' => ['field_1', 'field_2', 'field_3'],
                 'shards' => [self::$shards['b'], self::$shards['c']],
             ]
         );
-        $command  = new MockCommandForMultiIndexListenerTest($params);
-        $event    = new Event(
+        $command = $this->getMockSearchCommand($params);
+        $event = new Event(
             Service::EVENT_PRE,
             $this->backend,
-            ['params' => $params, 'command' => $command]
+            compact('params', 'command')
         );
         $this->listener->onSearchPre($event);
 
@@ -170,7 +171,7 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
                 'shards' => [self::$shards['b'], self::$shards['c']],
             ]
         );
-        $command  = new MockCommandForMultiIndexListenerTest($params, 'retrieve');
+        $command  = $this->getMockSearchCommand($params, 'retrieve');
         $event    = new Event(
             Service::EVENT_PRE,
             $this->backend,
@@ -264,14 +265,5 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
             ['test' => ['QueryFields' => [], 'FilterQuery' => 'format:Book']],
             $specs
         );
-    }
-}
-
-class MockCommandForMultiIndexListenerTest
-    extends \VuFindSearch\Command\AbstractBase
-{
-    public function __construct(ParamBag $params, $context = 'foo')
-    {
-        parent::__construct('foo', $context, $params);
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -102,13 +102,16 @@ abstract class AbstractBase implements CommandInterface
     }
 
     /**
-     * Flag the command as executed and return it; useful as the final step in
-     * execute() implementations.
+     * Save a result, flag the command as executed, and return the command object;
+     * useful as the final step in execute() implementations.
+     *
+     * @param mixed $result Result of execution.
      *
      * @return CommandInterface
      */
-    protected function finalizeExecution(): CommandInterface
+    protected function finalizeExecution($result): CommandInterface
     {
+        $this->result = $result;
         $this->executed = true;
         return $this;
     }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -41,7 +41,7 @@ use VuFindSearch\ParamBag;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class AbstractBase implements CommandInterface
+abstract class AbstractBase implements CommandInterface
 {
     /**
      * Search backend identifier
@@ -109,7 +109,15 @@ class AbstractBase implements CommandInterface
      *
      * @return CommandInterface Command instance for method chaining
      */
-    public function execute(BackendInterface $backend): CommandInterface
+    abstract public function execute(BackendInterface $backend): CommandInterface;
+
+    /**
+     * Flag the command as executed and return it; useful as the final step in
+     * execute() implementations.
+     *
+     * @return CommandInterface
+     */
+    protected function finalizeExecution(): CommandInterface
     {
         $this->executed = true;
         return $this;

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -28,7 +28,6 @@
  */
 namespace VuFindSearch\Command;
 
-use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\Exception\LogicException;
 use VuFindSearch\ParamBag;
 
@@ -101,15 +100,6 @@ abstract class AbstractBase implements CommandInterface
     {
         return $this->backend;
     }
-
-    /**
-     * Execute command on backend.
-     *
-     * @param BackendInterface $backend Backend
-     *
-     * @return CommandInterface Command instance for method chaining
-     */
-    abstract public function execute(BackendInterface $backend): CommandInterface;
 
     /**
      * Flag the command as executed and return it; useful as the final step in

--- a/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
@@ -128,9 +128,8 @@ abstract class CallMethodCommand extends AbstractBase
         if ($this->addParamsToArgs) {
             $callArgs[] = $this->params;
         }
-        $this->result
-            = call_user_func([$backendInstance, $this->method], ...$callArgs);
-
-        return $this->finalizeExecution();
+        return $this->finalizeExecution(
+            call_user_func([$backendInstance, $this->method], ...$callArgs)
+        );
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
@@ -131,6 +131,6 @@ abstract class CallMethodCommand extends AbstractBase
         $this->result
             = call_user_func([$backendInstance, $this->method], ...$callArgs);
 
-        return parent::execute($backendInstance);
+        return $this->finalizeExecution();
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
@@ -126,9 +126,6 @@ class RandomCommand extends CallMethodCommand
             }
         }
 
-        $this->result = $response;
-
-        $this->executed = true;
-        return $this;
+        return $this->finalizeExecution($response);
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
@@ -96,9 +96,6 @@ class RetrieveBatchCommand extends CallMethodCommand
             }
         }
 
-        $this->result = $response;
-
-        $this->executed = true;
-        return $this;
+        return $this->finalizeExecution($response);
     }
 }


### PR DESCRIPTION
As @aleksip pointed out in #2036, the AbstractBase command was not actually abstract. I've refactored according to our conversation there. I also fixed several tests that were weirdly relying on command subclasses to use mocks instead, which seems significantly more appropriate.

Once this is approved, I'll go ahead and incorporate this work into #2036 and #2037.