### PR TITLE
Open an external link instead of loading it into the lightbox

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -123,7 +123,7 @@ VuFind.register('lightbox', function Lightbox() {
       return;
     }
     // An external link should be just opened
-    if (obj.url.indexOf(window.location.hostname) == -1) {
+    if (obj.url.indexOf(window.location.hostname) === -1) {
       window.open(obj.url, "_blank").focus();
       return true;
     }

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -122,6 +122,11 @@ VuFind.register('lightbox', function Lightbox() {
     if (_xhr !== false) {
       return;
     }
+    // An external link should be just opened
+    if (obj.url.indexOf(window.location.hostname) == -1) {
+      window.open(obj.url, "_blank").focus();
+      return true;
+    }
     if (_originalUrl === false) {
       _originalUrl = obj.url;
     }


### PR DESCRIPTION
If there is an external Link for example on the help-pages, the lightbox script tries to load it into the lightbox causing a violation against the same-origin-policy and hence an error. Such links shoud be just opened. I'm not very into JavaScript so probably there is a better solution (eg. by unbinding an event). I pullrequest this to raise this issue.