### PR TITLE
Make handling of missing locale settings more robust.

### DIFF
--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleSettings.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleSettings.php
@@ -170,7 +170,7 @@ class LocaleSettings
      */
     protected function parseDefaultLocale(Config $config): string
     {
-        $locale = $config->Site->language;
+        $locale = $config->Site->language ?? null;
         if (empty($locale)) {
             throw new \Exception('Default locale not configured!');
         }

--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleSettings.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleSettings.php
@@ -86,7 +86,8 @@ class LocaleSettings
      */
     public function __construct(Config $config)
     {
-        $this->enabledLocales = $config->Languages->toArray();
+        $this->enabledLocales = $config->Languages ? $config->Languages->toArray()
+            : [];
         $this->defaultLocale = $this->parseDefaultLocale($config);
         $this->fallbackLocales = $this->parseFallbackLocales($config);
         $this->rightToLeftLocales = $this->parseRightToLeftLocales($config);
@@ -170,6 +171,9 @@ class LocaleSettings
     protected function parseDefaultLocale(Config $config): string
     {
         $locale = $config->Site->language;
+        if (empty($locale)) {
+            throw new \Exception('Default locale not configured!');
+        }
         if (!array_key_exists($locale, $this->enabledLocales)) {
             throw new \Exception("Configured default locale '$locale' not enabled!");
         }


### PR DESCRIPTION
Throws a proper exception if language in [Site] is not defined or [Languages] section is missing.