### PR TITLE
Rename CommandInterface method

### DIFF
--- a/module/VuFind/src/VuFind/Search/BackendManager.php
+++ b/module/VuFind/src/VuFind/Search/BackendManager.php
@@ -142,7 +142,7 @@ class BackendManager
      */
     public function onResolve(EventInterface $e)
     {
-        $name = $e->getParam('command')->getTargetBackendName();
+        $name = $e->getParam('command')->getTargetIdentifier();
         if ($name && $this->has($name)) {
             return $this->get($name);
         }

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -145,7 +145,7 @@ class DeduplicationListener
     public function onSearchPre(EventInterface $event)
     {
         $command = $event->getParam('command');
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             $params = $command->getSearchParameters();
             $context = $command->getContext();
             $contexts = ['search', 'similar', 'getids', 'workExpressions'];
@@ -194,7 +194,7 @@ class DeduplicationListener
         // Inject deduplication details into record objects:
         $command = $event->getParam('command');
 
-        if ($command->getTargetBackendName() !== $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() !== $this->backend->getIdentifier()) {
             return $event;
         }
         $context = $command->getContext();

--- a/module/VuFind/src/VuFind/Search/Solr/HideFacetValueListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HideFacetValueListener.php
@@ -111,7 +111,7 @@ class HideFacetValueListener
     {
         $command = $event->getParam('command');
 
-        if ($command->getTargetBackendName() !== $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() !== $this->backend->getIdentifier()) {
             return $event;
         }
         $context = $command->getContext();

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
@@ -177,7 +177,7 @@ class HierarchicalFacetListener
     {
         $command = $event->getParam('command');
 
-        if ($command->getTargetBackendName() !== $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() !== $this->backend->getIdentifier()) {
             return $event;
         }
         $context = $command->getContext();

--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -114,7 +114,7 @@ class InjectHighlightingListener
         if ($command->getContext() != 'search') {
             return $event;
         }
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             if ($params = $command->getSearchParameters()) {
                 // Set highlighting parameters unless explicitly disabled:
                 $hl = $params->get('hl');
@@ -149,7 +149,7 @@ class InjectHighlightingListener
         }
 
         // Inject highlighting details into record objects:
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             $result = $command->getResult();
             $hlDetails = $result->getHighlighting();
             foreach ($result->getRecords() as $record) {

--- a/module/VuFind/src/VuFind/Search/Solr/InjectSpellingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectSpellingListener.php
@@ -117,7 +117,7 @@ class InjectSpellingListener
         if ($command->getContext() !== 'search') {
             return $event;
         }
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             if ($params = $command->getSearchParameters()) {
                 // Set spelling parameters when enabled:
                 $sc = $params->get('spellcheck');
@@ -163,7 +163,7 @@ class InjectSpellingListener
         }
 
         // Merge spelling details from extra dictionaries:
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             $result = $command->getResult();
             $params = $command->getSearchParameters();
             $spellcheckQuery = $params->get('spellcheck.q');

--- a/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/MultiIndexListener.php
@@ -121,7 +121,7 @@ class MultiIndexListener
     public function onSearchPre(EventInterface $event)
     {
         $command = $event->getParam('command');
-        if ($command->getTargetBackendName() === $this->backend->getIdentifier()) {
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
             $params = $command->getSearchParameters();
             $allShardsContexts = ['retrieve', 'retrieveBatch'];
             if (in_array($command->getContext(), $allShardsContexts)) {

--- a/module/VuFind/src/VuFindTest/Feature/MockSearchCommandTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/MockSearchCommandTrait.php
@@ -73,7 +73,7 @@ trait MockSearchCommandTrait
             $command->expects($this->any())->method('getResult')
                 ->will($this->returnValue($result));
         }
-        $command->expects($this->any())->method('getTargetBackendName')
+        $command->expects($this->any())->method('getTargetIdentifier')
             ->will($this->returnValue($backendId));
         return $command;
     }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -92,11 +92,11 @@ abstract class AbstractBase implements CommandInterface
     }
 
     /**
-     * Return name of target backend.
+     * Return target backend identifier.
      *
      * @return string
      */
-    public function getTargetBackendName(): string
+    public function getTargetBackendIdentifier(): string
     {
         return $this->backend;
     }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -96,7 +96,7 @@ abstract class AbstractBase implements CommandInterface
      *
      * @return string
      */
-    public function getTargetBackendIdentifier(): string
+    public function getTargetIdentifier(): string
     {
         return $this->backend;
     }

--- a/module/VuFindSearch/src/VuFindSearch/Command/CommandInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CommandInterface.php
@@ -47,11 +47,11 @@ use VuFindSearch\ParamBag;
 interface CommandInterface
 {
     /**
-     * Return name of target backend.
+     * Return target backend identifier.
      *
      * @return string
      */
-    public function getTargetBackendName(): string;
+    public function getTargetBackendIdentifier(): string;
 
     /**
      * Execute command on backend.

--- a/module/VuFindSearch/src/VuFindSearch/Command/CommandInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CommandInterface.php
@@ -51,7 +51,7 @@ interface CommandInterface
      *
      * @return string
      */
-    public function getTargetBackendIdentifier(): string;
+    public function getTargetIdentifier(): string;
 
     /**
      * Execute command on backend.

--- a/module/VuFindSearch/src/VuFindSearch/Service.php
+++ b/module/VuFindSearch/src/VuFindSearch/Service.php
@@ -110,7 +110,8 @@ class Service
         // All other legacy event parameters are accessible via the command object.
         $args = ['command' => $command];
 
-        $backendInstance = $this->resolve($command->getTargetBackendName(), $args);
+        $backendInstance
+            = $this->resolve($command->getTargetBackendIdentifier(), $args);
 
         $this->triggerPre($command, $args);
         try {
@@ -311,7 +312,7 @@ class Service
      */
     protected function legacyInvoke(CommandInterface $command, array $args = [])
     {
-        $backend = $command->getTargetBackendName();
+        $backend = $command->getTargetBackendIdentifier();
         $params = $command->getSearchParameters();
         $context = $command->getContext();
         $args = array_merge(

--- a/module/VuFindSearch/src/VuFindSearch/Service.php
+++ b/module/VuFindSearch/src/VuFindSearch/Service.php
@@ -110,8 +110,7 @@ class Service
         // All other legacy event parameters are accessible via the command object.
         $args = ['command' => $command];
 
-        $backendInstance
-            = $this->resolve($command->getTargetBackendIdentifier(), $args);
+        $backendInstance = $this->resolve($command->getTargetIdentifier(), $args);
 
         $this->triggerPre($command, $args);
         try {
@@ -312,7 +311,7 @@ class Service
      */
     protected function legacyInvoke(CommandInterface $command, array $args = [])
     {
-        $backend = $command->getTargetBackendIdentifier();
+        $backend = $command->getTargetIdentifier();
         $params = $command->getSearchParameters();
         $context = $command->getContext();
         $args = array_merge(
@@ -363,7 +362,7 @@ class Service
                     ? $args['command']->getContext()
                     : ($args['context'] ?? 'null');
                 $backend = isset($args['command'])
-                    ? $args['command']->getTargetBackendName()
+                    ? $args['command']->getTargetIdentifier()
                     : ($args['backend'] ?? $backend);
                 throw new Exception\RuntimeException(
                     sprintf(


### PR DESCRIPTION
To better match the method names in `BackendInterface`.

In addition to being more consistent, and hopefully making code easier to understand, makes the command method name less backend specific, which can be nice if we want to use the command pattern in other places too.