### PR TITLE
Add ability to filter sitemap results.

### DIFF
--- a/config/vufind/sitemap.ini
+++ b/config/vufind/sitemap.ini
@@ -53,6 +53,11 @@ index[] = "Solr,/Record/"
 ;    other limiting options and requires that the index has terms enabled.
 retrievalMode = search
 
+;  If you want to apply additional filtering to the records included in your
+;  sitemaps from the index plugin, you can specify Solr queries here. This option
+;  is ONLY supported when retrievalMode is set to search above.
+;extraFilters[] = "format:Book"
+
 ;  This settings controls whether different language versions are added to the
 ;    sitemap. Possible values:
 ;    empty or undefined - Language versions are not added

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index.php
@@ -67,6 +67,13 @@ class Index extends AbstractGeneratorPlugin
     protected $countPerPage;
 
     /**
+     * Search filters
+     *
+     * @var string[]
+     */
+    protected $filters;
+
+    /**
      * Constructor
      *
      * @param array                   $backendSettings Settings specifying which
@@ -74,15 +81,18 @@ class Index extends AbstractGeneratorPlugin
      * @param Index\AbstractIdFetcher $idFetcher       The helper object for
      * retrieving IDs
      * @param int                     $countPerPage    Page size for data retrieval
+     * @param string[]                $filters         Search filters
      */
     public function __construct(
         array $backendSettings,
         Index\AbstractIdFetcher $idFetcher,
-        int $countPerPage
+        int $countPerPage,
+        array $filters = []
     ) {
         $this->backendSettings = $backendSettings;
         $this->idFetcher = $idFetcher;
         $this->countPerPage = $countPerPage;
+        $this->filters = $filters;
     }
 
     /**
@@ -120,7 +130,8 @@ class Index extends AbstractGeneratorPlugin
                 $result = $this->idFetcher->getIdsFromBackend(
                     $current['id'],
                     $offset,
-                    $this->countPerPage
+                    $this->countPerPage,
+                    $this->filters
                 );
                 foreach ($result['ids'] as $item) {
                     $loc = htmlspecialchars($recordUrl . urlencode($item));

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
@@ -27,7 +27,6 @@
  */
 namespace VuFind\Sitemap\Plugin\Index;
 
-use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Service;
 
 /**
@@ -84,12 +83,14 @@ abstract class AbstractIdFetcher
      * @param string $backend       Search backend ID
      * @param string $currentOffset String representing progress through set
      * @param int    $countPerPage  Page size
+     * @param array  $filters      Filters to apply to the search
      *
      * @return array
      */
     abstract public function getIdsFromBackend(
         string $backend,
         string $currentOffset,
-        int $countPerPage
+        int $countPerPage,
+        array $filters = []
     ): array;
 }

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
@@ -91,6 +91,6 @@ abstract class AbstractIdFetcher
         string $backend,
         string $currentOffset,
         int $countPerPage,
-        array $filters = []
+        array $filters
     ): array;
 }

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/AbstractIdFetcher.php
@@ -83,7 +83,7 @@ abstract class AbstractIdFetcher
      * @param string $backend       Search backend ID
      * @param string $currentOffset String representing progress through set
      * @param int    $countPerPage  Page size
-     * @param array  $filters      Filters to apply to the search
+     * @param array  $filters       Filters to apply to the search
      *
      * @return array
      */

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
@@ -103,7 +103,7 @@ class CursorMarkIdFetcher extends AbstractIdFetcher
         string $backend,
         string $cursorMark,
         int $countPerPage,
-        array $filters = []
+        array $filters
     ): array {
         // If the previous cursor mark matches the current one, we're finished!
         if ($cursorMark === $this->prevCursorMark) {

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
@@ -27,7 +27,6 @@
  */
 namespace VuFind\Sitemap\Plugin\Index;
 
-use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Backend\Solr\Response\Json\RecordCollectionFactory;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Query\Query;
@@ -96,13 +95,15 @@ class CursorMarkIdFetcher extends AbstractIdFetcher
      * @param string $backend      Search backend ID
      * @param string $cursorMark   String representing progress through set
      * @param int    $countPerPage Page size
+     * @param array  $filters      Filters to apply to the search
      *
      * @return array
      */
     public function getIdsFromBackend(
         string $backend,
         string $cursorMark,
-        int $countPerPage
+        int $countPerPage,
+        array $filters = []
     ): array {
         // If the previous cursor mark matches the current one, we're finished!
         if ($cursorMark === $this->prevCursorMark) {
@@ -125,6 +126,10 @@ class CursorMarkIdFetcher extends AbstractIdFetcher
                 'cursorMark' => $cursorMark
             ]
         );
+        // Apply filters:
+        foreach ($filters as $filter) {
+            $params->add('fq', $filter);
+        }
         $results = $this->searchService->getIds(
             $backend,
             new Query('*:*'),

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/TermsIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/TermsIdFetcher.php
@@ -81,7 +81,7 @@ class TermsIdFetcher extends AbstractIdFetcher
         string $backend,
         string $lastTerm,
         int $countPerPage,
-        array $filters = []
+        array $filters
     ): array {
         if (!empty($filters)) {
             throw new \Exception('extraFilters[] option incompatible with terms');

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/TermsIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/TermsIdFetcher.php
@@ -73,14 +73,19 @@ class TermsIdFetcher extends AbstractIdFetcher
      * @param string $backend      Search backend ID
      * @param string $lastTerm     String representing progress through set
      * @param int    $countPerPage Page size
+     * @param array  $filters      Filters to apply to the search
      *
      * @return array
      */
     public function getIdsFromBackend(
         string $backend,
         string $lastTerm,
-        int $countPerPage
+        int $countPerPage,
+        array $filters = []
     ): array {
+        if (!empty($filters)) {
+            throw new \Exception('extraFilters[] option incompatible with terms');
+        }
         $getKeyCommand = new GetUniqueKeyCommand($backend, []);
         $key = $this->searchService->invoke($getKeyCommand)->getResult();
         $termsCommand = new TermsCommand($backend, $key, $lastTerm, $countPerPage);

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/IndexFactory.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/IndexFactory.php
@@ -72,7 +72,8 @@ class IndexFactory implements FactoryInterface
         return new $requestedName(
             $this->getBackendSettings($sitemapConfig),
             $this->getIdFetcher($container, $retrievalMode),
-            $sitemapConfig->Sitemap->countPerPage ?? 10000
+            $sitemapConfig->Sitemap->countPerPage ?? 10000,
+            (array)($sitemapConfig->Sitemap->extraFilters ?? [])
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
@@ -142,6 +142,23 @@ class TermsIdFetcherTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that filters are unsupported.
+     *
+     * @return void
+     */
+    public function testFilters(): void
+    {
+        $this->expectExceptionMessage('extraFilters[] option incompatible with terms');
+        $fetcher = new TermsIdFetcher($this->getMockService());
+        $fetcher->getIdsFromBackend(
+            'foo',
+            0,
+            $this->countPerPage,
+            ['format:Book']
+        );
+    }
+
+    /**
      * Test the terms retrieval process.
      *
      * @return void
@@ -175,7 +192,8 @@ class TermsIdFetcherTest extends \PHPUnit\Framework\TestCase
             $fetcher->getIdsFromBackend(
                 'foo',
                 $fetcher->getInitialOffset(),
-                $this->countPerPage
+                $this->countPerPage,
+                []
             )
         );
         $this->assertEquals(
@@ -183,7 +201,8 @@ class TermsIdFetcherTest extends \PHPUnit\Framework\TestCase
             $fetcher->getIdsFromBackend(
                 'foo',
                 99,
-                $this->countPerPage
+                $this->countPerPage,
+                []
             )
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/IndexTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/IndexTest.php
@@ -48,7 +48,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyConfigs(): void
     {
-        $plugin = new Index([], $this->getMockIdFetcher(), 100);
+        $plugin = new Index([], $this->getMockIdFetcher(), 100, []);
         $this->assertEmpty(iterator_to_array($plugin->getUrls()));
     }
 
@@ -61,6 +61,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
     {
         $backendId = 'bar';
         $countPerPage = 2;
+        $fq = ['format:Book'];
         $fetcher = $this->getMockIdFetcher();
         $fetcher->expects($this->once())->method('getInitialOffset')
             ->will($this->returnValue('*'));
@@ -68,8 +69,8 @@ class IndexTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo($backendId));
         $fetcher->expects($this->exactly(2))->method('getIdsFromBackend')
             ->withConsecutive(
-                [$backendId, '*', $countPerPage],
-                [$backendId, 'offset', $countPerPage]
+                [$backendId, '*', $countPerPage, $fq],
+                [$backendId, 'offset', $countPerPage, $fq]
             )->willReturnOnConsecutiveCalls(
                 ['ids' => [1, 2], 'nextOffset' => 'offset'],
                 ['ids' => [3]]
@@ -77,7 +78,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         $config = [
             ['url' => 'http://foo/', 'id' => $backendId],
         ];
-        $plugin = new Index($config, $fetcher, $countPerPage);
+        $plugin = new Index($config, $fetcher, $countPerPage, $fq);
         $this->assertEquals(
             ['http://foo/1', 'http://foo/2', 'http://foo/3'],
             iterator_to_array($plugin->getUrls())


### PR DESCRIPTION
I just realized that for some reason, Villanova's Digital Library VuFind instance has custom filtering functionality built into its sitemap generator which was never contributed upstream. This PR addresses that shortcoming so that the feature will be available in future. While it might be possible to do more or less the same thing by event-hooking the getIds backend method, I think there's value in being able to specifically target sitemap generation with a configuration.

@EreMaijala, do you mind taking a look? I'd like to include this in 8.0 if possible.