### PR TITLE
Fix catalog login with MultiBackend.

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -368,18 +368,25 @@ function setupMultiILSLoginFields(loginMethods, idPrefix) {
   var searchPrefix = idPrefix ? '#' + idPrefix : '#';
   $(searchPrefix + 'target').change(function onChangeLoginTarget() {
     var target = $(this).val();
-    var $usernameGroup = $(searchPrefix + 'username').closest('.form-group');
+    var $username = $(searchPrefix + 'username');
+    var $usernameGroup = $username.closest('.form-group');
     var $password = $(searchPrefix + 'password');
     if (loginMethods[target] === 'email') {
+      $username.attr('type', 'email').attr('autocomplete', 'email');
       $usernameGroup.find('label.password-login').addClass('hidden');
       $usernameGroup.find('label.email-login').removeClass('hidden');
       $password.closest('.form-group').addClass('hidden');
       // Set password to a dummy value so that any checks for username+password work
       $password.val('****');
     } else {
+      $username.attr('type', 'text').attr('autocomplete', 'username');
       $usernameGroup.find('label.password-login').removeClass('hidden');
       $usernameGroup.find('label.email-login').addClass('hidden');
       $password.closest('.form-group').removeClass('hidden');
+      // Reset password from the dummy value in email login
+      if ($password.val() === '****') {
+        $password.val('');
+      }
     }
   }).change();
 }

--- a/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
@@ -31,12 +31,11 @@
     <div class="form-group">
       <?php if (null === $this->loginMethod || 'password' === $this->loginMethod): ?>
         <label class="control-label password-login" for="profile_cat_username"><?=$this->transEsc('Library Catalog Username')?>:</label>
-        <input id="profile_cat_username" type="text" name="cat_username" value="" class="form-control" autocomplete="username"/>
       <?php endif; ?>
       <?php if (null === $this->loginMethod || 'email' === $this->loginMethod): ?>
         <label class="control-label email-login<?php if (null === $this->loginMethod): ?> hidden<?php endif; ?>" for="profile_cat_username"><?=$this->transEsc('Email')?>:</label>
-        <input id="profile_cat_username" type="email" name="cat_username" value="" class="form-control" autocomplete="email"/>
       <?php endif; ?>
+      <input id="profile_cat_username" type="<?='email' === $this->loginMethod ? 'email' : 'text'?>" name="cat_username" value="" class="form-control" autocomplete="<?='email' === $this->loginMethod ? 'email' : 'username'?>"/>
     </div>
     <?php if (null === $this->loginMethod || 'password' === $this->loginMethod): ?>
       <div class="form-group">


### PR DESCRIPTION
PR #2039 caused cataloglogin.phtml to display two username fields with the MultiBackend driver. This fixes it and also adds resetting of the password field when selecting an ILS with username+password login after having one with email login selected.