### PR TITLE
Refactor backend event targets and Solr error listeners

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -153,7 +153,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      * Create service
      *
      * @param ContainerInterface $sm      Service manager
-     * @param string             $name    Requested service name (unused)
+     * @param string             $name    Requested service name
      * @param array              $options Extra options (unused)
      *
      * @return Backend
@@ -170,6 +170,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
+        $backend->setIdentifier($name);
         $this->createListeners($backend);
         return $backend;
     }
@@ -285,9 +286,9 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
 
         // Attach error listeners for Solr 3.x and Solr 4.x (for backward
         // compatibility with VuFind 1.x instances).
-        $legacyErrorListener = new LegacyErrorListener($backend);
+        $legacyErrorListener = new LegacyErrorListener($backend->getIdentifier());
         $legacyErrorListener->attach($events);
-        $errorListener = new ErrorListener($backend);
+        $errorListener = new ErrorListener($backend->getIdentifier());
         $errorListener->attach($events);
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/AbstractErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/AbstractErrorListener.php
@@ -29,11 +29,7 @@
 namespace VuFind\Search\Solr;
 
 use Laminas\EventManager\EventInterface;
-
 use Laminas\EventManager\SharedEventManagerInterface;
-use SplObjectStorage;
-
-use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\Service;
 
 /**
@@ -57,45 +53,47 @@ abstract class AbstractErrorListener
     /**
      * Backends to listen for.
      *
-     * @var SplObjectStorage
+     * @var array
      */
     protected $backends;
 
     /**
      * Constructor.
      *
-     * @param string $backend Name of backend to listen for
+     * @param string $backend Identifier of backend to listen for
      *
      * @return void
      */
-    public function __construct(BackendInterface $backend)
+    public function __construct(string $backend)
     {
-        $this->backends = new SplObjectStorage();
+        $this->backends = [];
         $this->addBackend($backend);
     }
 
     /**
      * Add backend to listen for.
      *
-     * @param BackendInterface $backend Backend instance
+     * @param string $backend Identifier of backend to listen for
      *
      * @return void
      */
-    public function addBackend(BackendInterface $backend)
+    public function addBackend(string $backend)
     {
-        $this->backends->attach($backend);
+        if (!$this->listenForBackend($backend)) {
+            $this->backends[] = $backend;
+        }
     }
 
     /**
      * Return true if listeners listens for backend errors.
      *
-     * @param BackendInterface $backend Backend instance
+     * @param string $backend Backend identifier
      *
      * @return bool
      */
-    public function listenForBackend(BackendInterface $backend)
+    public function listenForBackend(string $backend)
     {
-        return $this->backends->contains($backend);
+        return in_array($backend, $this->backends);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/V3/ErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/V3/ErrorListener.php
@@ -54,9 +54,9 @@ class ErrorListener extends AbstractErrorListener
      */
     public function onSearchError(EventInterface $event)
     {
-        $backend = $event->getParam('backend_instance');
-        if ($backend && $this->listenForBackend($backend)) {
-            $error  = $event->getTarget();
+        $command = $event->getParam('command');
+        if ($this->listenForBackend($command->getTargetIdentifier())) {
+            $error = $event->getParam('error');
             if ($error instanceof HttpErrorException) {
                 $reason = $error->getResponse()->getReasonPhrase();
                 if (stristr($reason, 'org.apache.lucene.queryParser.ParseException')

--- a/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/V4/ErrorListener.php
@@ -63,9 +63,9 @@ class ErrorListener extends AbstractErrorListener
      */
     public function onSearchError(EventInterface $event)
     {
-        $backend = $event->getParam('backend_instance');
-        if ($backend && $this->listenForBackend($backend)) {
-            $error = $event->getTarget();
+        $command = $event->getParam('command');
+        if ($this->listenForBackend($command->getTargetIdentifier())) {
+            $error = $event->getParam('error');
             if ($error instanceof HttpErrorException) {
                 $response = $error->getResponse();
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
@@ -46,6 +46,7 @@ use VuFindSearch\Backend\Exception\HttpErrorException;
 class ErrorListenerTest extends TestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\MockSearchCommandTrait;
 
     /**
      * Detect parser error response.
@@ -55,11 +56,15 @@ class ErrorListenerTest extends TestCase
     public function testDetectParseError()
     {
         $response = $this->createResponse('solr3-parse-error');
-        $backend  = $this->getMockForAbstractClass('VuFindSearch\Backend\BackendInterface');
+        $backend  = 'foo';
 
+        $command   = $this->getMockSearchCommand();
         $exception = HttpErrorException::createFromResponse($response);
-        $params    = ['backend_instance' => $backend];
-        $event     = new Event(null, $exception, $params);
+        $params    = [
+            'command'   => $command,
+            'error'     => $exception
+        ];
+        $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
         $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
@@ -73,11 +78,15 @@ class ErrorListenerTest extends TestCase
     public function testDetectUndefinedFieldError()
     {
         $response = $this->createResponse('solr3-undefined-field-error');
-        $backend  = $this->getMockForAbstractClass('VuFindSearch\Backend\BackendInterface');
+        $backend  = 'foo';
 
+        $command   = $this->getMockSearchCommand();
         $exception = HttpErrorException::createFromResponse($response);
-        $params    = ['backend_instance' => $backend];
-        $event     = new Event(null, $exception, $params);
+        $params    = [
+            'command'   => $command,
+            'error'     => $exception
+        ];
+        $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
         $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
@@ -50,6 +50,7 @@ use VuFindSearch\Backend\Exception\HttpErrorException;
 class ErrorListenerTest extends TestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\MockSearchCommandTrait;
 
     /**
      * Detect parser error response.
@@ -59,11 +60,15 @@ class ErrorListenerTest extends TestCase
     public function testDetectParseError()
     {
         $response  = $this->createResponse('solr4-parse-error');
-        $backend   = $this->getMockForAbstractClass('VuFindSearch\Backend\BackendInterface');
+        $backend   = 'foo';
 
+        $command   = $this->getMockSearchCommand();
         $exception = HttpErrorException::createFromResponse($response);
-        $params    = ['backend_instance' => $backend];
-        $event     = new Event(null, $exception, $params);
+        $params    = [
+            'command'   => $command,
+            'error'     => $exception
+        ];
+        $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
         $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));
@@ -77,11 +82,15 @@ class ErrorListenerTest extends TestCase
     public function testDetectUndefinedFieldError()
     {
         $response = $this->createResponse('solr4-undefined-field-error');
-        $backend  = $this->getMockForAbstractClass('VuFindSearch\Backend\BackendInterface');
+        $backend  = 'foo';
 
+        $command   = $this->getMockSearchCommand();
         $exception = HttpErrorException::createFromResponse($response);
-        $params    = ['backend_instance' => $backend];
-        $event     = new Event(null, $exception, $params);
+        $params    = [
+            'command'   => $command,
+            'error'     => $exception
+        ];
+        $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
         $listener->onSearchError($event);
         $this->assertTrue($exception->hasTag(ErrorListener::TAG_PARSER_ERROR));

--- a/module/VuFindSearch/src/VuFindSearch/Service.php
+++ b/module/VuFindSearch/src/VuFindSearch/Service.php
@@ -112,14 +112,15 @@ class Service
 
         $backendInstance = $this->resolve($command->getTargetIdentifier(), $args);
 
-        $this->triggerPre($command, $args);
+        $this->triggerPre($this, $args);
         try {
             $command->execute($backendInstance);
         } catch (BackendException $e) {
-            $this->triggerError($e, $args);
+            $args['error'] = $e;
+            $this->triggerError($this, $args);
             throw $e;
         }
-        $this->triggerPost($command, $args);
+        $this->triggerPost($this, $args);
 
         return $command;
     }
@@ -326,6 +327,7 @@ class Service
         try {
             $response = $command->execute($backendInstance)->getResult();
         } catch (BackendException $e) {
+            $args['error'] = $e;
             $this->triggerError($e, $args);
             throw $e;
         }
@@ -380,20 +382,21 @@ class Service
     /**
      * Trigger the error event.
      *
-     * @param BackendException $exception Error exception
-     * @param array            $args      Event arguments
+     * @param mixed $target Service instance, or error exception for deprecated
+     *                      legacy events
+     * @param array $args   Event arguments
      *
      * @return void
      */
-    public function triggerError(BackendException $exception, $args)
+    public function triggerError($target, $args)
     {
-        $this->getEventManager()->trigger(self::EVENT_ERROR, $exception, $args);
+        $this->getEventManager()->trigger(self::EVENT_ERROR, $target, $args);
     }
 
     /**
      * Trigger the pre event.
      *
-     * @param mixed $target Command object, or backend instance for deprecated
+     * @param mixed $target Service instance, or backend instance for deprecated
      *                      legacy events
      * @param array $args   Event arguments
      *
@@ -407,7 +410,7 @@ class Service
     /**
      * Trigger the post event.
      *
-     * @param mixed $target Command object, or backend response for deprecated
+     * @param mixed $target Service instance, or backend response for deprecated
      *                      legacy events
      * @param array $args   Event arguments
      *


### PR DESCRIPTION
Here is a PR changing all backend event targets to the `Service` instance, as discussed in #2092. 

I changed the target of error events as well for consistency. This is a new breaking change if someone has subclassed one of the Solr error listener classes. I considered it to be relatively small breakage, but I can also refactor the PR to keep the error event target unchanged.

The refactoring of Solr error listeners and related tests highlighted that there is still refactoring to do on the other listeners to replace actual backend instances with backend identifiers. But I believe that this can be done after the 8.0 release.

Interestingly, it looks like backend identifiers are only set in `BackendManager::get()` and are `null` in freshly created backend instances. I might be missing something important, but it seems odd and even undesired that a backend instance can be created without an identifier, especially when it would be easy to set in the constructor? So this could be another refactoring task for the future.