### PR TITLE
Make EDS connector not override HTTP client's adapter.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
@@ -79,7 +79,6 @@ class Connector extends Base implements LoggerAwareInterface
             [
                 'timeout' => $settings['timeout'] ?? 120,
                 'sslverifypeer' => false,
-
             ]
         );
     }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
@@ -53,22 +53,6 @@ class Connector extends Base implements LoggerAwareInterface
     protected $client;
 
     /**
-     * Print a message if debug is enabled.
-     *
-     * @param string $msg Message to print
-     *
-     * @return void
-     */
-    protected function debugPrint($msg)
-    {
-        if ($this->logger) {
-            $this->logger->debug("$msg\n");
-        } else {
-            parent::debugPrint($msg);
-        }
-    }
-
-    /**
      * Constructor
      *
      * Sets up the EDS API Client
@@ -85,18 +69,19 @@ class Connector extends Base implements LoggerAwareInterface
     public function __construct($settings = [], $client = null)
     {
         parent::__construct($settings);
-        $this->client = is_object($client) ? $client : new HttpClient();
-        $this->client->setOptions(['timeout' => $settings['timeout'] ?? 120]);
-        $adapter = new CurlAdapter();
-        $adapter->setOptions(
+        if ($client) {
+            $this->client = $client;
+        } else {
+            $this->client = new HttpClient();
+            $this->client->setAdapter(new CurlAdapter());
+        }
+        $this->client->setOptions(
             [
-                'curloptions' => [
-                    CURLOPT_SSL_VERIFYPEER => false,
-                    CURLOPT_FOLLOWLOCATION => true,
-                ]
+                'timeout' => $settings['timeout'] ?? 120,
+                'sslverifypeer' => false,
+
             ]
         );
-        $this->client->setAdapter($adapter);
     }
 
     /**
@@ -141,5 +126,21 @@ class Connector extends Base implements LoggerAwareInterface
             throw new ApiException($decodedError ? $decodedError : $error);
         }
         return $result->getBody();
+    }
+
+    /**
+     * Print a message if debug is enabled.
+     *
+     * @param string $msg Message to print
+     *
+     * @return void
+     */
+    protected function debugPrint($msg)
+    {
+        if ($this->logger) {
+            $this->logger->debug("$msg\n");
+        } else {
+            parent::debugPrint($msg);
+        }
     }
 }


### PR DESCRIPTION
Currently the connector forces curl adapter and sets curl-specific options, but there appears to be nothing actually requiring curl. This change switches to standard options. The Laminas HTTP client handles location redirects as well, so there should be no need for that. 

I've tested this with the default adapter and curl adapter, and everything seems to still work.