### PR TITLE
Consistent variable names and code style for backend commands

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupDoiCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupDoiCommand.php
@@ -44,13 +44,13 @@ class LookupDoiCommand extends \VuFindSearch\Command\CallMethodCommand
     /**
      * Constructor
      *
-     * @param string $backend Search backend identifier
-     * @param string $doi     DOI to look up
+     * @param string $backendId Search backend identifier
+     * @param string $doi       DOI to look up
      */
-    public function __construct(string $backend, string $doi)
+    public function __construct(string $backendId, string $doi)
     {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'lookupDoi',
             [$doi],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupIssnsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupIssnsCommand.php
@@ -44,13 +44,13 @@ class LookupIssnsCommand extends \VuFindSearch\Command\CallMethodCommand
     /**
      * Constructor
      *
-     * @param string          $backend Search backend identifier
-     * @param string|string[] $issns   ISSNs to look up
+     * @param string          $backendId Search backend identifier
+     * @param string|string[] $issns     ISSNs to look up
      */
-    public function __construct(string $backend, $issns)
+    public function __construct(string $backendId, $issns)
     {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'lookupIssns',
             [$issns],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
@@ -46,19 +46,19 @@ class AutocompleteCommand extends CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param string    $query   Simple query string
-     * @param string    $domain  Autocomplete type (e.g. 'rawqueries' or 'holdings')
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $query     Simple query string
+     * @param string    $domain    Autocomplete type, e.g. 'rawqueries' or 'holdings'
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $query,
         string $domain,
         ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'autocomplete',
             [$query, $domain],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/GetInfoCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/GetInfoCommand.php
@@ -46,15 +46,15 @@ class GetInfoCommand extends CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend = 'EDS',
+        string $backendId = 'EDS',
         ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'getInfo',
             [],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
@@ -49,21 +49,21 @@ class RawJsonSearchCommand extends \VuFindSearch\Command\CallMethodCommand
     /**
      * Constructor
      *
-     * @param string        $backend Search backend identifier
-     * @param AbstractQuery $query   Search query string
-     * @param int           $offset  Search offset
-     * @param int           $limit   Search limit
-     * @param ?ParamBag     $params  Search backend parameters
+     * @param string        $backendId Search backend identifier
+     * @param AbstractQuery $query     Search query string
+     * @param int           $offset    Search offset
+     * @param int           $limit     Search limit
+     * @param ?ParamBag     $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         AbstractQuery $query,
         int $offset = 0,
         int $limit = 100,
         ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'rawJsonSearch',
             [$query, $offset, $limit],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
@@ -46,21 +46,21 @@ class WriteDocumentCommand extends \VuFindSearch\Command\CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string            $backend Search backend identifier
-     * @param DocumentInterface $doc     Document to write
-     * @param ?int              $timeout Timeout value (null for default)
-     * @param string            $handler Handler to use
-     * @param ?ParamBag         $params  Search backend parameters
+     * @param string            $backendId Search backend identifier
+     * @param DocumentInterface $doc       Document to write
+     * @param ?int              $timeout   Timeout value (null for default)
+     * @param string            $handler   Handler to use
+     * @param ?ParamBag         $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         DocumentInterface $doc,
         int $timeout = null,
         string $handler = 'update',
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class,
             'writeDocument',
             [$doc, $timeout, $handler],

--- a/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Command/GetHoldingsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Command/GetHoldingsCommand.php
@@ -42,13 +42,13 @@ class GetHoldingsCommand extends \VuFindSearch\Command\CallMethodCommand
     /**
      * Constructor
      *
-     * @param string $backend Search backend identifier
-     * @param string $id      WorldCat record ID
+     * @param string $backendId Search backend identifier
+     * @param string $id        WorldCat record ID
      */
-    public function __construct(string $backend, string $id)
+    public function __construct(string $backendId, string $id)
     {
         parent::__construct(
-            $backend,
+            $backendId,
             \VuFindSearch\Backend\WorldCat\Backend::class,
             'getHoldings',
             [$id],

--- a/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AbstractBase.php
@@ -49,7 +49,7 @@ abstract class AbstractBase implements CommandInterface
      *
      * @var string
      */
-    protected $backend;
+    protected $backendId;
 
     /**
      * Command context
@@ -82,13 +82,16 @@ abstract class AbstractBase implements CommandInterface
     /**
      * Constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param mixed     $context Command context
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param mixed     $context   Command context
+     * @param ?ParamBag $params    Search backend parameters
      */
-    public function __construct(string $backend, $context, ?ParamBag $params = null)
-    {
-        $this->backend = $backend;
+    public function __construct(
+        string $backendId,
+        $context,
+        ?ParamBag $params = null
+    ) {
+        $this->backendId = $backendId;
         $this->context = $context;
         $this->params = $params ?: new ParamBag();
     }
@@ -100,7 +103,7 @@ abstract class AbstractBase implements CommandInterface
      */
     public function getTargetIdentifier(): string
     {
-        return $this->backend;
+        return $this->backendId;
     }
 
     /**
@@ -121,16 +124,16 @@ abstract class AbstractBase implements CommandInterface
     /**
      * Validate that the provided backend matches the expected target identifier.
      *
-     * @param BackendInterface $backendInstance Backend instance
+     * @param BackendInterface $backend Backend instance
      *
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      */
-    protected function validateBackend(BackendInterface $backendInstance): void
+    protected function validateBackend(BackendInterface $backend): void
     {
-        if (($backend = $backendInstance->getIdentifier()) !== $this->backend) {
+        if (($backendId = $backend->getIdentifier()) !== $this->backendId) {
             throw new RuntimeException(
-                "Expected backend instance $this->backend instead of $backend"
+                "Expected backend instance $this->backendId instead of $backendId"
             );
         }
     }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
@@ -45,26 +45,26 @@ class AlphabeticBrowseCommand extends CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string   $backend     Search backend identifier
-     * @param string   $source      Name of index to search
-     * @param string   $from        Starting point for browse results
-     * @param int      $page        Result page to return (starts at 0)
-     * @param int      $limit       Number of results to return on each page
-     * @param ParamBag $params      Additional parameters
-     * @param int      $offsetDelta Delta to use when calculating page
+     * @param string    $backendId   Search backend identifier
+     * @param string    $source      Name of index to search
+     * @param string    $from        Starting point for browse results
+     * @param int       $page        Result page to return (starts at 0)
+     * @param int       $limit       Number of results to return on each page
+     * @param ?ParamBag $params      Additional parameters
+     * @param int       $offsetDelta Delta to use when calculating page
      * offset (useful for showing a few results above the highlighted row)
      */
     public function __construct(
-        string $backend,
-        $source,
-        $from,
-        $page,
-        $limit = 20,
-        $params = null,
-        $offsetDelta = 0
+        string $backendId,
+        string $source,
+        string $from,
+        int $page,
+        int $limit = 20,
+        ParamBag $params = null,
+        int $offsetDelta = 0
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class, // we should define interface, if needed in more places
             'alphabeticBrowse',
             [$source, $from, $page, $limit, $params, $offsetDelta],

--- a/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
@@ -74,7 +74,7 @@ abstract class CallMethodCommand extends AbstractBase
     /**
      * CallMethodCommand constructor.
      *
-     * @param string    $backend         Search backend identifier
+     * @param string    $backendId       Search backend identifier
      * @param string    $interface       Search backend interface
      * @param string    $method          Search backend interface method
      * @param array     $args            Search backend interface method arguments,
@@ -87,7 +87,7 @@ abstract class CallMethodCommand extends AbstractBase
      *                                   context.
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $interface,
         string $method,
         array $args,
@@ -95,7 +95,11 @@ abstract class CallMethodCommand extends AbstractBase
         bool $addParamsToArgs = true,
         $context = null
     ) {
-        parent::__construct($backend, $context ?: $method, $params);
+        parent::__construct(
+            $backendId,
+            $context ?: $method,
+            $params
+        );
         $this->interface = $interface;
         $this->method = $method;
         $this->args = $args;
@@ -105,18 +109,18 @@ abstract class CallMethodCommand extends AbstractBase
     /**
      * Execute command on backend.
      *
-     * @param BackendInterface $backendInstance Backend instance
+     * @param BackendInterface $backend Backend
      *
-     * @return CommandInterface
+     * @return CommandInterface Command instance for method chaining
      */
-    public function execute(BackendInterface $backendInstance): CommandInterface
+    public function execute(BackendInterface $backend): CommandInterface
     {
-        $this->validateBackend($backendInstance);
-        if (!($backendInstance instanceof $this->interface)
+        $this->validateBackend($backend);
+        if (!($backend instanceof $this->interface)
             || !method_exists($this->interface, $this->method)
         ) {
             throw new BackendException(
-                "$this->backend does not support $this->method()"
+                "$this->backendId does not support $this->method()"
             );
         }
         $callArgs = $this->args;
@@ -124,7 +128,7 @@ abstract class CallMethodCommand extends AbstractBase
             $callArgs[] = $this->params;
         }
         return $this->finalizeExecution(
-            call_user_func([$backendInstance, $this->method], ...$callArgs)
+            call_user_func([$backend, $this->method], ...$callArgs)
         );
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
@@ -50,21 +50,21 @@ class GetIdsCommand extends CallMethodCommand
     /**
      * GetIdsCommand constructor.
      *
-     * @param string         $backend Search backend identifier
-     * @param QueryInterface $query   Search query
-     * @param int            $offset  Search offset
-     * @param int            $limit   Search limit
-     * @param ?ParamBag      $params  Search backend parameters
+     * @param string         $backendId Search backend identifier
+     * @param QueryInterface $query     Search query
+     * @param int            $offset    Search offset
+     * @param int            $limit     Search limit
+     * @param ?ParamBag      $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         QueryInterface $query,
         int $offset = 0,
         int $limit = 20,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             GetIdsInterface::class,
             'getIds',
             [$query, $offset, $limit],
@@ -77,16 +77,16 @@ class GetIdsCommand extends CallMethodCommand
     /**
      * Execute command on backend.
      *
-     * @param BackendInterface $backendInstance Backend instance
+     * @param BackendInterface $backend Backend
      *
      * @return CommandInterface Command instance for method chaining
      */
-    public function execute(BackendInterface $backendInstance): CommandInterface
+    public function execute(BackendInterface $backend): CommandInterface
     {
-        if (!($backendInstance instanceof GetIdsInterface)) {
+        if (!($backend instanceof GetIdsInterface)) {
             $this->interface = BackendInterface::class;
             $this->method = 'search';
         }
-        return parent::execute($backendInstance);
+        return parent::execute($backend);
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetLuceneHelperCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetLuceneHelperCommand.php
@@ -45,11 +45,11 @@ class GetLuceneHelperCommand extends \VuFindSearch\Command\AbstractBase
     /**
      * Constructor.
      *
-     * @param string $backend Search backend identifier
+     * @param string $backendId Search backend identifier
      */
-    public function __construct(string $backend)
+    public function __construct(string $backendId)
     {
-        parent::__construct($backend, []);
+        parent::__construct($backendId, []);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetQueryBuilderCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetQueryBuilderCommand.php
@@ -44,11 +44,11 @@ class GetQueryBuilderCommand extends AbstractBase
     /**
      * Constructor.
      *
-     * @param string $backend Search backend identifier
+     * @param string $backendId Search backend identifier
      */
-    public function __construct(string $backend)
+    public function __construct(string $backendId)
     {
-        parent::__construct($backend, []);
+        parent::__construct($backendId, []);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
@@ -49,17 +49,17 @@ class RetrieveBatchCommand extends CallMethodCommand
     /**
      * RetrieveBatchCommand constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param array     $ids     Record identifiers
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param array     $ids       Record identifiers
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         array $ids,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             RetrieveBatchInterface::class,
             'retrieveBatch',
             [$ids],
@@ -70,16 +70,16 @@ class RetrieveBatchCommand extends CallMethodCommand
     /**
      * Execute command on backend.
      *
-     * @param BackendInterface $backendInstance Backend instance
+     * @param BackendInterface $backend Backend
      *
      * @return CommandInterface Command instance for method chaining
      */
-    public function execute(BackendInterface $backendInstance): CommandInterface
+    public function execute(BackendInterface $backend): CommandInterface
     {
         // If the backend implements the RetrieveBatchInterface, we can load
         // all the records at once.
-        if ($backendInstance instanceof RetrieveBatchInterface) {
-            return parent::execute($backendInstance);
+        if ($backend instanceof RetrieveBatchInterface) {
+            return parent::execute($backend);
         }
 
         // Otherwise, we need to load them one at a time and aggregate them.
@@ -88,7 +88,7 @@ class RetrieveBatchCommand extends CallMethodCommand
 
         $response = false;
         foreach ($ids as $id) {
-            $next = $backendInstance->retrieve($id, $this->params);
+            $next = $backend->retrieve($id, $this->params);
             if (!$response) {
                 $response = $next;
             } elseif ($record = $next->first()) {

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
@@ -48,17 +48,17 @@ class RetrieveCommand extends CallMethodCommand
     /**
      * RetrieveCommand constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param string    $id      Record identifier
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Record identifier
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $id,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             BackendInterface::class,
             'retrieve',
             [$id],

--- a/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
@@ -49,21 +49,21 @@ class SearchCommand extends CallMethodCommand
     /**
      * SearchCommand constructor.
      *
-     * @param string         $backend Search backend identifier
-     * @param QueryInterface $query   Search query
-     * @param int            $offset  Search offset
-     * @param int            $limit   Search limit
-     * @param ?ParamBag      $params  Search backend parameters
+     * @param string         $backendId Search backend identifier
+     * @param QueryInterface $query     Search query
+     * @param int            $offset    Search offset
+     * @param int            $limit     Search limit
+     * @param ?ParamBag      $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         QueryInterface $query,
         int $offset = 0,
         int $limit = 20,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             BackendInterface::class,
             'search',
             [$query, $offset, $limit],

--- a/module/VuFindSearch/src/VuFindSearch/Command/SetRecordCollectionFactoryCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SetRecordCollectionFactoryCommand.php
@@ -45,15 +45,15 @@ class SetRecordCollectionFactoryCommand extends CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string                           $backend Search backend identifier
-     * @param RecordCollectionFactoryInterface $factory Factory to set
+     * @param string                           $backendId Search backend identifier
+     * @param RecordCollectionFactoryInterface $factory   Factory to set
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         RecordCollectionFactoryInterface $factory
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             AbstractBackend::class,
             'setRecordCollectionFactory',
             [$factory],

--- a/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
@@ -48,17 +48,17 @@ class SimilarCommand extends CallMethodCommand
     /**
      * SimilarCommand constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param string    $id      Id of record to compare with
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Id of record to compare with
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $id,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             SimilarInterface::class,
             'similar',
             [$id],

--- a/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
@@ -45,21 +45,21 @@ class TermsCommand extends CallMethodCommand
     /**
      * Constructor.
      *
-     * @param string    $backend Search backend identifier
-     * @param string    $field   Index field
-     * @param string    $start   Starting term (blank for beginning of list)
-     * @param int       $limit   Maximum number of terms
-     * @param ?ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $field     Index field
+     * @param string    $start     Starting term (blank for beginning of list)
+     * @param int       $limit     Maximum number of terms
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $field,
         string $start,
         int $limit,
         ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             Backend::class, // we should define interface, if needed in more places
             'terms',
             [$field, $start, $limit],

--- a/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
@@ -48,20 +48,20 @@ class WorkExpressionsCommand extends CallMethodCommand
     /**
      * WorkExpressionsCommand constructor.
      *
-     * @param string    $backend  Search backend identifier
-     * @param string    $id       Id of record to compare with
-     * @param ?array    $workKeys Work identification keys (optional; retrieved from
-     *                            the record to compare with if not specified)
-     * @param ?ParamBag $params   Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Id of record to compare with
+     * @param ?array    $workKeys  Work identification keys (optional; retrieved from
+     *                             the record to compare with if not specified)
+     * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
-        string $backend,
+        string $backendId,
         string $id,
         ?array $workKeys,
         ?ParamBag $params = null
     ) {
         parent::__construct(
-            $backend,
+            $backendId,
             WorkExpressionsInterface::class,
             'workExpressions',
             [$id, $workKeys],
@@ -72,23 +72,23 @@ class WorkExpressionsCommand extends CallMethodCommand
     /**
      * Execute command on backend.
      *
-     * @param BackendInterface $backendInstance Backend instance
+     * @param BackendInterface $backend Backend
      *
      * @return CommandInterface Command instance for method chaining
      */
-    public function execute(BackendInterface $backendInstance): CommandInterface
+    public function execute(BackendInterface $backend): CommandInterface
     {
         $id = $this->args[0];
         $workKeys = $this->args[1];
 
         if (empty($workKeys)) {
-            $records = $backendInstance->retrieve($id)->getRecords();
+            $records = $backend->retrieve($id)->getRecords();
             if (!empty($records[0])) {
                 $fields = $records[0]->getRawData();
                 $this->args[1] = $fields['work_keys_str_mv'] ?? [];
             }
         }
 
-        return parent::execute($backendInstance);
+        return parent::execute($backend);
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Service.php
+++ b/module/VuFindSearch/src/VuFindSearch/Service.php
@@ -85,7 +85,7 @@ class Service
     /**
      * Constructor.
      *
-     * @param EventManagerInterface $events Event manager (optional)
+     * @param ?EventManagerInterface $events Event manager (optional)
      *
      * @return void
      */
@@ -110,11 +110,11 @@ class Service
         // All other legacy event parameters are accessible via the command object.
         $args = ['command' => $command];
 
-        $backendInstance = $this->resolve($command->getTargetIdentifier(), $args);
+        $backend = $this->resolve($command->getTargetIdentifier(), $args);
 
         $this->triggerPre($this, $args);
         try {
-            $command->execute($backendInstance);
+            $command->execute($backend);
         } catch (BackendException $e) {
             $args['error'] = $e;
             $this->triggerError($this, $args);
@@ -128,24 +128,24 @@ class Service
     /**
      * Perform a search and return a wrapped response.
      *
-     * @param string              $backend Search backend identifier
-     * @param Query\AbstractQuery $query   Search query
-     * @param int                 $offset  Search offset
-     * @param int                 $limit   Search limit
-     * @param ParamBag            $params  Search backend parameters
+     * @param string              $backendId Search backend identifier
+     * @param Query\AbstractQuery $query     Search query
+     * @param int                 $offset    Search offset
+     * @param int                 $limit     Search limit
+     * @param ?ParamBag           $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(SearchCommand $command) instead
      */
     public function search(
-        $backend,
+        string $backendId,
         Query\AbstractQuery $query,
-        $offset = 0,
-        $limit = 20,
+        int $offset = 0,
+        int $limit = 20,
         ParamBag $params = null
     ) {
-        $command = new SearchCommand($backend, $query, $offset, $limit, $params);
+        $command = new SearchCommand($backendId, $query, $offset, $limit, $params);
         return $this->legacyInvoke(
             $command,
             ['query' => $query, 'offset' => $offset, 'limit' => $limit]
@@ -155,24 +155,24 @@ class Service
     /**
      * Perform a search that returns record IDs and return a wrapped response.
      *
-     * @param string              $backend Search backend identifier
-     * @param Query\AbstractQuery $query   Search query
-     * @param int                 $offset  Search offset
-     * @param int                 $limit   Search limit
-     * @param ParamBag            $params  Search backend parameters
+     * @param string              $backendId Search backend identifier
+     * @param Query\AbstractQuery $query     Search query
+     * @param int                 $offset    Search offset
+     * @param int                 $limit     Search limit
+     * @param ?ParamBag           $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(GetIdsCommand $command) instead
      */
     public function getIds(
-        $backend,
+        string $backendId,
         Query\AbstractQuery $query,
-        $offset = 0,
-        $limit = 20,
+        int $offset = 0,
+        int $limit = 20,
         ParamBag $params = null
     ) {
-        $command = new GetIdsCommand($backend, $query, $offset, $limit, $params);
+        $command = new GetIdsCommand($backendId, $query, $offset, $limit, $params);
         return $this->legacyInvoke(
             $command,
             ['query' => $query, 'offset' => $offset, 'limit' => $limit]
@@ -182,92 +182,105 @@ class Service
     /**
      * Retrieve a single record.
      *
-     * @param string   $backend Search backend identifier
-     * @param string   $id      Record identifier
-     * @param ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Record identifier
+     * @param ?ParamBag $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(RetrieveCommand $command) instead
      */
-    public function retrieve($backend, $id, ParamBag $params = null)
-    {
-        $command = new RetrieveCommand($backend, $id, $params);
+    public function retrieve(
+        string $backendId,
+        string $id,
+        ParamBag $params = null
+    ) {
+        $command = new RetrieveCommand($backendId, $id, $params);
         return $this->legacyInvoke($command, ['id' => $id]);
     }
 
     /**
      * Retrieve a batch of records.
      *
-     * @param string   $backend Search backend identifier
-     * @param array    $ids     Record identifier
-     * @param ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param array     $ids       Record identifier
+     * @param ?ParamBag $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(RetrieveBatchCommand $command) instead
      */
-    public function retrieveBatch($backend, $ids, ParamBag $params = null)
-    {
-        $command = new RetrieveBatchCommand($backend, $ids, $params);
+    public function retrieveBatch(
+        string $backendId,
+        array $ids,
+        ParamBag $params = null
+    ) {
+        $command = new RetrieveBatchCommand($backendId, $ids, $params);
         return $this->legacyInvoke($command, ['ids' => $ids]);
     }
 
     /**
      * Retrieve a random batch of records.
      *
-     * @param string              $backend Search backend identifier
-     * @param Query\AbstractQuery $query   Search query
-     * @param int                 $limit   Search limit
-     * @param ParamBag            $params  Search backend parameters
+     * @param string              $backendId Search backend identifier
+     * @param Query\AbstractQuery $query     Search query
+     * @param int                 $limit     Search limit
+     * @param ?ParamBag           $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(RandomCommand $command) instead
      */
-    public function random($backend, $query, $limit = 20, $params = null)
-    {
-        $command = new RandomCommand($backend, $query, $limit, $params);
+    public function random(
+        string $backendId,
+        Query\AbstractQuery $query,
+        int $limit = 20,
+        ParamBag $params = null
+    ) {
+        $command = new RandomCommand($backendId, $query, $limit, $params);
         return $this->legacyInvoke($command, ['query' => $query, 'limit' => $limit]);
     }
 
     /**
      * Return similar records.
      *
-     * @param string   $backend Search backend identifier
-     * @param string   $id      Id of record to compare with
-     * @param ParamBag $params  Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Id of record to compare with
+     * @param ?ParamBag $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(SimilarCommand $command) instead
      */
-    public function similar($backend, $id, ParamBag $params = null)
-    {
-        $command = new SimilarCommand($backend, $id, $params);
+    public function similar(
+        string $backendId,
+        string $id,
+        ParamBag $params = null
+    ) {
+        $command = new SimilarCommand($backendId, $id, $params);
         return $this->legacyInvoke($command, ['id' => $id]);
     }
 
     /**
      * Return records for work expressions.
      *
-     * @param string   $backend  Search backend identifier
-     * @param string   $id       Id of record to compare with
-     * @param array    $workKeys Work identification keys (optional; retrieved from
-     * the record to compare with if not specified)
-     * @param ParamBag $params   Search backend parameters
+     * @param string    $backendId Search backend identifier
+     * @param string    $id        Id of record to compare with
+     * @param ?array    $workKeys  Work identification keys (optional; retrieved
+     *                             from the record to compare with if not specified)
+     * @param ?ParamBag $params    Search backend parameters
      *
      * @return RecordCollectionInterface
      *
      * @deprecated Use Service::invoke(WorkExpressionsCommand $command) instead
      */
     public function workExpressions(
-        $backend,
-        $id,
-        $workKeys = null,
+        string $backendId,
+        string $id,
+        array $workKeys = null,
         ParamBag $params = null
     ) {
-        $command = new WorkExpressionsCommand($backend, $id, $workKeys, $params);
+        $command = new WorkExpressionsCommand($backendId, $id, $workKeys, $params);
         return $this->legacyInvoke($command, ['id' => $id, 'workKeys' => $workKeys]);
     }
 
@@ -312,20 +325,21 @@ class Service
      */
     protected function legacyInvoke(CommandInterface $command, array $args = [])
     {
-        $backend = $command->getTargetIdentifier();
+        $backendId = $command->getTargetIdentifier();
         $params = $command->getSearchParameters();
         $context = $command->getContext();
         $args = array_merge(
-            compact('backend', 'params', 'context', 'command'),
+            ['backend' => $backendId],
+            compact('params', 'context', 'command'),
             $args
         );
 
-        $backendInstance = $this->resolve($backend, $args);
-        $args['backend_instance'] = $backendInstance;
+        $backend = $this->resolve($backendId, $args);
+        $args['backend_instance'] = $backend;
 
-        $this->triggerPre($backendInstance, $args);
+        $this->triggerPre($backend, $args);
         try {
-            $response = $command->execute($backendInstance)->getResult();
+            $response = $command->execute($backend)->getResult();
         } catch (BackendException $e) {
             $args['error'] = $e;
             $this->triggerError($e, $args);
@@ -339,16 +353,16 @@ class Service
     /**
      * Resolve a backend.
      *
-     * @param string            $backend Backend name
-     * @param array|ArrayAccess $args    Service function arguments
+     * @param string            $backendId Backend name
+     * @param array|ArrayAccess $args      Service function arguments
      *
      * @return BackendInterface
      *
      * @throws Exception\RuntimeException Unable to resolve backend
      */
-    protected function resolve($backend, $args)
+    protected function resolve($backendId, $args)
     {
-        if (!isset($this->backends[$backend])) {
+        if (!isset($this->backends[$backendId])) {
             $response = $this->getEventManager()->triggerUntil(
                 function ($o) {
                     return $o instanceof BackendInterface;
@@ -363,20 +377,20 @@ class Service
                 $context = isset($args['command'])
                     ? $args['command']->getContext()
                     : ($args['context'] ?? 'null');
-                $backend = isset($args['command'])
+                $backendId = isset($args['command'])
                     ? $args['command']->getTargetIdentifier()
-                    : ($args['backend'] ?? $backend);
+                    : ($args['backend'] ?? $backendId);
                 throw new Exception\RuntimeException(
                     sprintf(
                         'Unable to resolve backend: %s, %s',
                         $context,
-                        $backend
+                        $backendId
                     )
                 );
             }
-            $this->backends[$backend] = $response->last();
+            $this->backends[$backendId] = $response->last();
         }
-        return $this->backends[$backend];
+        return $this->backends[$backendId];
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/SearchServiceTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/SearchServiceTest.php
@@ -781,7 +781,7 @@ class SearchServiceMock extends \VuFindSearch\Service
      *
      * @return Service
      */
-    protected function resolve($backend, $args)
+    protected function resolve($backendId, $args)
     {
         return $this->backend;
     }


### PR DESCRIPTION
This PR attempts to make all backend instances `$backend` and all backend identifiers `$backendId`.

This touches a lot of files, but I think consistent variable names would improve the developer experience.

Additionally there are some other small improvements like added parameter types.