### PR TITLE
Refactor CallMethodCommand and add backend command argument accessors

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
@@ -92,7 +92,7 @@ class TermsIdFetcherTest extends \PHPUnit\Framework\TestCase
         return function ($command) use ($expectedCursorMark) {
             $this->assertEquals(
                 [$this->uniqueKey, $expectedCursorMark, $this->countPerPage],
-                $command->getArguments()
+                array_slice($command->getArguments(), 0, 3)
             );
             $this->assertInstanceOf(TermsCommand::class, $command);
             return true;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupDoiCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupDoiCommand.php
@@ -42,6 +42,13 @@ use VuFindSearch\Backend\BrowZine\Backend;
 class LookupDoiCommand extends \VuFindSearch\Command\CallMethodCommand
 {
     /**
+     * DOI to look up.
+     *
+     * @var string
+     */
+    protected $doi;
+
+    /**
      * Constructor
      *
      * @param string $backendId Search backend identifier
@@ -49,13 +56,31 @@ class LookupDoiCommand extends \VuFindSearch\Command\CallMethodCommand
      */
     public function __construct(string $backendId, string $doi)
     {
+        $this->doi = $doi;
         parent::__construct(
             $backendId,
             Backend::class,
-            'lookupDoi',
-            [$doi],
-            null,
-            false
+            'lookupDoi'
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [$this->getDoi()];
+    }
+
+    /**
+     * Return DOI to look up.
+     *
+     * @return string
+     */
+    public function getDoi(): string
+    {
+        return $this->doi;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupIssnsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Command/LookupIssnsCommand.php
@@ -42,6 +42,13 @@ use VuFindSearch\Backend\BrowZine\Backend;
 class LookupIssnsCommand extends \VuFindSearch\Command\CallMethodCommand
 {
     /**
+     * ISSNs to look up.
+     *
+     * @var string|string[]
+     */
+    protected $issns;
+
+    /**
      * Constructor
      *
      * @param string          $backendId Search backend identifier
@@ -49,13 +56,31 @@ class LookupIssnsCommand extends \VuFindSearch\Command\CallMethodCommand
      */
     public function __construct(string $backendId, $issns)
     {
+        $this->issns = $issns;
         parent::__construct(
             $backendId,
             Backend::class,
-            'lookupIssns',
-            [$issns],
-            null,
-            false
+            'lookupIssns'
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [$this->getIssns()];
+    }
+
+    /**
+     * Return ISSNs to look up.
+     *
+     * @return string|string[]
+     */
+    public function getIssns()
+    {
+        return $this->issns;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
@@ -44,6 +44,20 @@ use VuFindSearch\ParamBag;
 class AutocompleteCommand extends CallMethodCommand
 {
     /**
+     * Simple query string.
+     *
+     * @var string
+     */
+    protected $query;
+
+    /**
+     * Autocomplete type.
+     *
+     * @var string
+     */
+    protected $domain;
+
+    /**
      * Constructor.
      *
      * @param string    $backendId Search backend identifier
@@ -57,13 +71,46 @@ class AutocompleteCommand extends CallMethodCommand
         string $domain,
         ParamBag $params = null
     ) {
+        $this->query = $query;
+        $this->domain = $domain;
         parent::__construct(
             $backendId,
             Backend::class,
             'autocomplete',
-            [$query, $domain],
-            $params,
-            false
+            $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getQuery(),
+            $this->getDomain()
+        ];
+    }
+
+    /**
+     * Return simple query string.
+     *
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    /**
+     * Return autocomplete type.
+     *
+     * @return string
+     */
+    public function getDomain(): string
+    {
+        return $this->domain;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/GetInfoCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/GetInfoCommand.php
@@ -57,9 +57,17 @@ class GetInfoCommand extends CallMethodCommand
             $backendId,
             Backend::class,
             'getInfo',
-            [],
-            $params,
-            false
+            $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
@@ -31,7 +31,7 @@ namespace VuFindSearch\Backend\Solr\Command;
 
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Command\CommandInterface;
-use VuFindSearch\Command\QueryOffsetLimitTrait;
+use VuFindSearch\Command\Feature\QueryOffsetLimitTrait;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Query\AbstractQuery;
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
@@ -31,6 +31,7 @@ namespace VuFindSearch\Backend\Solr\Command;
 
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Command\CommandInterface;
+use VuFindSearch\Command\QueryOffsetLimitTrait;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Query\AbstractQuery;
 
@@ -46,6 +47,8 @@ use VuFindSearch\Query\AbstractQuery;
  */
 class RawJsonSearchCommand extends \VuFindSearch\Command\CallMethodCommand
 {
+    use QueryOffsetLimitTrait;
+
     /**
      * Constructor
      *
@@ -62,13 +65,30 @@ class RawJsonSearchCommand extends \VuFindSearch\Command\CallMethodCommand
         int $limit = 100,
         ParamBag $params = null
     ) {
+        $this->query = $query;
+        $this->offset = $offset;
+        $this->limit = $limit;
         parent::__construct(
             $backendId,
             Backend::class,
             'rawJsonSearch',
-            [$query, $offset, $limit],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getQuery(),
+            $this->getOffset(),
+            $this->getLimit(),
+            $this->getSearchParameters()
+        ];
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
@@ -44,6 +44,27 @@ use VuFindSearch\ParamBag;
 class WriteDocumentCommand extends \VuFindSearch\Command\CallMethodCommand
 {
     /**
+     * Document to write.
+     *
+     * @var DocumentInterface
+     */
+    protected $doc;
+
+    /**
+     * Timeout value.
+     *
+     * @var ?int
+     */
+    protected $timeout;
+
+    /**
+     * Handler to use.
+     *
+     * @var string
+     */
+    protected $handler;
+
+    /**
      * Constructor.
      *
      * @param string            $backendId Search backend identifier
@@ -59,12 +80,59 @@ class WriteDocumentCommand extends \VuFindSearch\Command\CallMethodCommand
         string $handler = 'update',
         ?ParamBag $params = null
     ) {
+        $this->doc = $doc;
+        $this->timeout = $timeout;
+        $this->handler = $handler;
         parent::__construct(
             $backendId,
             Backend::class,
             'writeDocument',
-            [$doc, $timeout, $handler],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getDocument(),
+            $this->getTimeout(),
+            $this->getHandler(),
+            $this->getSearchParameters()
+        ];
+    }
+
+    /**
+     * Return document to write.
+     *
+     * @return DocumentInterface
+     */
+    public function getDocument(): DocumentInterface
+    {
+        return $this->doc;
+    }
+
+    /**
+     * Return timeout value.
+     *
+     * @return int|null
+     */
+    public function getTimeout(): ?int
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Return handler to use.
+     *
+     * @return string
+     */
+    public function getHandler(): string
+    {
+        return $this->handler;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Command/GetHoldingsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Command/GetHoldingsCommand.php
@@ -28,7 +28,7 @@
  */
 namespace VuFindSearch\Backend\WorldCat\Command;
 
-use VuFindSearch\Command\RecordIdentifierTrait;
+use VuFindSearch\Command\Feature\RecordIdentifierTrait;
 
 /**
  * Command to fetch holdings from the WorldCat backend.

--- a/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
@@ -43,6 +43,41 @@ use VuFindSearch\ParamBag;
 class AlphabeticBrowseCommand extends CallMethodCommand
 {
     /**
+     * Name of index to search.
+     *
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * Starting point for browse results.
+     *
+     * @var string
+     */
+    protected $from;
+
+    /**
+     * Result page to return.
+     *
+     * @var int
+     */
+    protected $page;
+
+    /**
+     * Number of results to return on each page.
+     *
+     * @var int
+     */
+    protected $limit;
+
+    /**
+     * Delta to use when calculating page offset.
+     *
+     * @var int
+     */
+    protected $offsetDelta;
+
+    /**
      * Constructor.
      *
      * @param string    $backendId   Search backend identifier
@@ -63,13 +98,83 @@ class AlphabeticBrowseCommand extends CallMethodCommand
         ParamBag $params = null,
         int $offsetDelta = 0
     ) {
+        $this->source = $source;
+        $this->from = $from;
+        $this->page = $page;
+        $this->limit = $limit;
+        $this->offsetDelta = $offsetDelta;
         parent::__construct(
             $backendId,
             Backend::class, // we should define interface, if needed in more places
             'alphabeticBrowse',
-            [$source, $from, $page, $limit, $params, $offsetDelta],
-            $params,
-            false
+            $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getSource(),
+            $this->getFrom(),
+            $this->getPage(),
+            $this->getLimit(),
+            $this->getSearchParameters(),
+            $this->getOffsetDelta()
+        ];
+    }
+
+    /**
+     * Return name of index to search.
+     *
+     * @return string
+     */
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    /**
+     * Return starting point for browse results.
+     *
+     * @return string
+     */
+    public function getFrom(): string
+    {
+        return $this->from;
+    }
+
+    /**
+     * Return result page to return.
+     *
+     * @return int
+     */
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    /**
+     * Return number of results to return on each page.
+     *
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * Return delta to use when calculating page offset.
+     *
+     * @return int
+     */
+    public function getOffsetDelta(): int
+    {
+        return $this->offsetDelta;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/CallMethodCommand.php
@@ -58,41 +58,20 @@ abstract class CallMethodCommand extends AbstractBase
     protected $method;
 
     /**
-     * Search backend interface method arguments
-     *
-     * @var array
-     */
-    protected $args;
-
-    /**
-     * Should the search backend parameters be added as the last method argument?
-     *
-     * @var bool
-     */
-    protected $addParamsToArgs;
-
-    /**
      * CallMethodCommand constructor.
      *
-     * @param string    $backendId       Search backend identifier
-     * @param string    $interface       Search backend interface
-     * @param string    $method          Search backend interface method
-     * @param array     $args            Search backend interface method arguments,
-     *                                   excluding search backend parameters
-     * @param ?ParamBag $params          Search backend parameters
-     * @param bool      $addParamsToArgs Should the search backend parameters be
-     *                                   added as the last method argument?
-     * @param mixed     $context         Command context. Optional, if left out the
-     *                                   search interface method is used as the
-     *                                   context.
+     * @param string    $backendId Search backend identifier
+     * @param string    $interface Search backend interface
+     * @param string    $method    Search backend interface method
+     * @param ?ParamBag $params    Search backend parameters
+     * @param mixed     $context   Command context. Optional, if left out the search
+     * interface method is used as the context.
      */
     public function __construct(
         string $backendId,
         string $interface,
         string $method,
-        array $args,
         ?ParamBag $params = null,
-        bool $addParamsToArgs = true,
         $context = null
     ) {
         parent::__construct(
@@ -102,9 +81,14 @@ abstract class CallMethodCommand extends AbstractBase
         );
         $this->interface = $interface;
         $this->method = $method;
-        $this->args = $args;
-        $this->addParamsToArgs = $addParamsToArgs;
     }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    abstract public function getArguments(): array;
 
     /**
      * Execute command on backend.
@@ -123,22 +107,9 @@ abstract class CallMethodCommand extends AbstractBase
                 "$this->backendId does not support $this->method()"
             );
         }
-        $callArgs = $this->args;
-        if ($this->addParamsToArgs) {
-            $callArgs[] = $this->params;
-        }
+        $args = $this->getArguments();
         return $this->finalizeExecution(
-            call_user_func([$backend, $this->method], ...$callArgs)
+            call_user_func([$backend, $this->method], ...$args)
         );
-    }
-
-    /**
-     * Get function arguments.
-     *
-     * @return array
-     */
-    public function getArguments(): array
-    {
-        return $this->args;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/Feature/QueryOffsetLimitTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/Feature/QueryOffsetLimitTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Trait for commands with a record identifier argument.
+ * Trait for commands with search query, offset and limit arguments.
  *
  * PHP version 7
  *
@@ -26,10 +26,12 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-namespace VuFindSearch\Command;
+namespace VuFindSearch\Command\Feature;
+
+use VuFindSearch\Query\QueryInterface;
 
 /**
- * Trait for commands with a record identifier argument.
+ * Trait for commands with search query, offset and limit arguments.
  *
  * @category VuFind
  * @package  Search
@@ -37,22 +39,56 @@ namespace VuFindSearch\Command;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-trait RecordIdentifierTrait
+trait QueryOffsetLimitTrait
 {
     /**
-     * Record identifier.
+     * Search query.
      *
-     * @var string
+     * @var QueryInterface
      */
-    protected $id;
+    protected $query;
 
     /**
-     * Return record identifier.
+     * Search offset.
      *
-     * @return string
+     * @var int
      */
-    public function getRecordIdentifier(): string
+    protected $offset;
+
+    /**
+     * Search limit.
+     *
+     * @var int
+     */
+    protected $limit;
+
+    /**
+     * Return search query.
+     *
+     * @return QueryInterface
+     */
+    public function getQuery(): QueryInterface
     {
-        return $this->id;
+        return $this->query;
+    }
+
+    /**
+     * Return search offset.
+     *
+     * @return int
+     */
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    /**
+     * Return search limit.
+     *
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/Feature/RecordIdentifierTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/Feature/RecordIdentifierTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Trait for commands with search query, offset and limit arguments.
+ * Trait for commands with a record identifier argument.
  *
  * PHP version 7
  *
@@ -26,12 +26,10 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-namespace VuFindSearch\Command;
-
-use VuFindSearch\Query\QueryInterface;
+namespace VuFindSearch\Command\Feature;
 
 /**
- * Trait for commands with search query, offset and limit arguments.
+ * Trait for commands with a record identifier argument.
  *
  * @category VuFind
  * @package  Search
@@ -39,56 +37,22 @@ use VuFindSearch\Query\QueryInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-trait QueryOffsetLimitTrait
+trait RecordIdentifierTrait
 {
     /**
-     * Search query.
+     * Record identifier.
      *
-     * @var QueryInterface
+     * @var string
      */
-    protected $query;
+    protected $id;
 
     /**
-     * Search offset.
+     * Return record identifier.
      *
-     * @var int
+     * @return string
      */
-    protected $offset;
-
-    /**
-     * Search limit.
-     *
-     * @var int
-     */
-    protected $limit;
-
-    /**
-     * Return search query.
-     *
-     * @return QueryInterface
-     */
-    public function getQuery(): QueryInterface
+    public function getRecordIdentifier(): string
     {
-        return $this->query;
-    }
-
-    /**
-     * Return search offset.
-     *
-     * @return int
-     */
-    public function getOffset(): int
-    {
-        return $this->offset;
-    }
-
-    /**
-     * Return search limit.
-     *
-     * @return int
-     */
-    public function getLimit(): int
-    {
-        return $this->limit;
+        return $this->id;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
@@ -47,6 +47,8 @@ use VuFindSearch\Query\QueryInterface;
  */
 class GetIdsCommand extends CallMethodCommand
 {
+    use QueryOffsetLimitTrait;
+
     /**
      * GetIdsCommand constructor.
      *
@@ -63,15 +65,31 @@ class GetIdsCommand extends CallMethodCommand
         int $limit = 20,
         ?ParamBag $params = null
     ) {
+        $this->query = $query;
+        $this->offset = $offset;
+        $this->limit = $limit;
         parent::__construct(
             $backendId,
             GetIdsInterface::class,
             'getIds',
-            [$query, $offset, $limit],
             $params,
-            true,
             'getids'
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getQuery(),
+            $this->getOffset(),
+            $this->getLimit(),
+            $this->getSearchParameters()
+        ];
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
@@ -31,6 +31,7 @@
 namespace VuFindSearch\Command;
 
 use VuFindSearch\Backend\BackendInterface;
+use VuFindSearch\Command\Feature\QueryOffsetLimitTrait;
 use VuFindSearch\Feature\GetIdsInterface;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Query\QueryInterface;

--- a/module/VuFindSearch/src/VuFindSearch/Command/QueryOffsetLimitTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/QueryOffsetLimitTrait.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Command to fetch holdings from the WorldCat backend.
+ * Trait for commands with search query, offset and limit arguments.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2021.
+ * Copyright (C) The National Library of Finland 2021.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,50 +22,73 @@
  *
  * @category VuFind
  * @package  Search
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-namespace VuFindSearch\Backend\WorldCat\Command;
+namespace VuFindSearch\Command;
 
-use VuFindSearch\Command\RecordIdentifierTrait;
+use VuFindSearch\Query\QueryInterface;
 
 /**
- * Command to fetch holdings from the WorldCat backend.
+ * Trait for commands with search query, offset and limit arguments.
  *
  * @category VuFind
  * @package  Search
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class GetHoldingsCommand extends \VuFindSearch\Command\CallMethodCommand
+trait QueryOffsetLimitTrait
 {
-    use RecordIdentifierTrait;
+    /**
+     * Search query.
+     *
+     * @var QueryInterface
+     */
+    protected $query;
 
     /**
-     * Constructor
+     * Search offset.
      *
-     * @param string $backendId Search backend identifier
-     * @param string $id        WorldCat record identifier
+     * @var int
      */
-    public function __construct(string $backendId, string $id)
+    protected $offset;
+
+    /**
+     * Search limit.
+     *
+     * @var int
+     */
+    protected $limit;
+
+    /**
+     * Return search query.
+     *
+     * @return QueryInterface
+     */
+    public function getQuery(): QueryInterface
     {
-        $this->id = $id;
-        parent::__construct(
-            $backendId,
-            \VuFindSearch\Backend\WorldCat\Backend::class,
-            'getHoldings'
-        );
+        return $this->query;
     }
 
     /**
-     * Return search backend interface method arguments.
+     * Return search offset.
      *
-     * @return array
+     * @return int
      */
-    public function getArguments(): array
+    public function getOffset(): int
     {
-        return [$this->getRecordIdentifier()];
+        return $this->offset;
+    }
+
+    /**
+     * Return search limit.
+     *
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
@@ -48,6 +48,20 @@ use VuFindSearch\Query\QueryInterface;
 class RandomCommand extends CallMethodCommand
 {
     /**
+     * Search query.
+     *
+     * @var QueryInterface
+     */
+    protected $query;
+
+    /**
+     * Search limit.
+     *
+     * @var int
+     */
+    protected $limit;
+
+    /**
      * RandomCommand constructor.
      *
      * @param string         $backendId Search backend identifier
@@ -61,13 +75,28 @@ class RandomCommand extends CallMethodCommand
         int $limit,
         ?ParamBag $params = null
     ) {
+        $this->query = $query;
+        $this->limit = $limit;
         parent::__construct(
             $backendId,
             RandomInterface::class,
             'random',
-            [$query, $limit],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getQuery(),
+            $this->getLimit(),
+            $this->getSearchParameters()
+        ];
     }
 
     /**
@@ -87,8 +116,8 @@ class RandomCommand extends CallMethodCommand
 
         // Otherwise, we need to load them one at a time and aggregate them.
 
-        $query = $this->args[0];
-        $limit = $this->args[1];
+        $query = $this->getQuery();
+        $limit = $this->getLimit();
 
         // offset/limit of 0 - we don't need records, just count
         $results = $backend->search($query, 0, 0, $this->params);
@@ -127,5 +156,25 @@ class RandomCommand extends CallMethodCommand
         }
 
         return $this->finalizeExecution($response);
+    }
+
+    /**
+     * Return search query.
+     *
+     * @return QueryInterface
+     */
+    public function getQuery(): QueryInterface
+    {
+        return $this->query;
+    }
+
+    /**
+     * Return search limit.
+     *
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RecordIdentifierTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RecordIdentifierTrait.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Command to fetch holdings from the WorldCat backend.
+ * Trait for commands with a record identifier argument.
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2021.
+ * Copyright (C) The National Library of Finland 2021.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,50 +22,37 @@
  *
  * @category VuFind
  * @package  Search
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-namespace VuFindSearch\Backend\WorldCat\Command;
-
-use VuFindSearch\Command\RecordIdentifierTrait;
+namespace VuFindSearch\Command;
 
 /**
- * Command to fetch holdings from the WorldCat backend.
+ * Trait for commands with a record identifier argument.
  *
  * @category VuFind
  * @package  Search
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class GetHoldingsCommand extends \VuFindSearch\Command\CallMethodCommand
+trait RecordIdentifierTrait
 {
-    use RecordIdentifierTrait;
+    /**
+     * Record identifier.
+     *
+     * @var string
+     */
+    protected $id;
 
     /**
-     * Constructor
+     * Return record identifier.
      *
-     * @param string $backendId Search backend identifier
-     * @param string $id        WorldCat record identifier
+     * @return string
      */
-    public function __construct(string $backendId, string $id)
+    public function getRecordIdentifier(): string
     {
-        $this->id = $id;
-        parent::__construct(
-            $backendId,
-            \VuFindSearch\Backend\WorldCat\Backend::class,
-            'getHoldings'
-        );
-    }
-
-    /**
-     * Return search backend interface method arguments.
-     *
-     * @return array
-     */
-    public function getArguments(): array
-    {
-        return [$this->getRecordIdentifier()];
+        return $this->id;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
@@ -47,6 +47,13 @@ use VuFindSearch\ParamBag;
 class RetrieveBatchCommand extends CallMethodCommand
 {
     /**
+     * Record identifiers.
+     *
+     * @var array
+     */
+    protected $ids;
+
+    /**
      * RetrieveBatchCommand constructor.
      *
      * @param string    $backendId Search backend identifier
@@ -58,13 +65,26 @@ class RetrieveBatchCommand extends CallMethodCommand
         array $ids,
         ?ParamBag $params = null
     ) {
+        $this->ids = $ids;
         parent::__construct(
             $backendId,
             RetrieveBatchInterface::class,
             'retrieveBatch',
-            [$ids],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getRecordIdentifiers(),
+            $this->getSearchParameters()
+        ];
     }
 
     /**
@@ -84,10 +104,8 @@ class RetrieveBatchCommand extends CallMethodCommand
 
         // Otherwise, we need to load them one at a time and aggregate them.
 
-        $ids = $this->args[0];
-
         $response = false;
-        foreach ($ids as $id) {
+        foreach ($this->getRecordIdentifiers() as $id) {
             $next = $backend->retrieve($id, $this->params);
             if (!$response) {
                 $response = $next;
@@ -97,5 +115,15 @@ class RetrieveBatchCommand extends CallMethodCommand
         }
 
         return $this->finalizeExecution($response);
+    }
+
+    /**
+     * Return record identifiers.
+     *
+     * @return array
+     */
+    public function getRecordIdentifiers(): array
+    {
+        return $this->ids;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
@@ -31,6 +31,7 @@
 namespace VuFindSearch\Command;
 
 use VuFindSearch\Backend\BackendInterface;
+use VuFindSearch\Command\Feature\RecordIdentifierTrait;
 use VuFindSearch\ParamBag;
 
 /**

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
@@ -45,6 +45,8 @@ use VuFindSearch\ParamBag;
  */
 class RetrieveCommand extends CallMethodCommand
 {
+    use RecordIdentifierTrait;
+
     /**
      * RetrieveCommand constructor.
      *
@@ -57,12 +59,25 @@ class RetrieveCommand extends CallMethodCommand
         string $id,
         ?ParamBag $params = null
     ) {
+        $this->id = $id;
         parent::__construct(
             $backendId,
             BackendInterface::class,
             'retrieve',
-            [$id],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getRecordIdentifier(),
+            $this->getSearchParameters()
+        ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
@@ -46,6 +46,8 @@ use VuFindSearch\Query\QueryInterface;
  */
 class SearchCommand extends CallMethodCommand
 {
+    use QueryOffsetLimitTrait;
+
     /**
      * SearchCommand constructor.
      *
@@ -62,12 +64,29 @@ class SearchCommand extends CallMethodCommand
         int $limit = 20,
         ?ParamBag $params = null
     ) {
+        $this->query = $query;
+        $this->offset = $offset;
+        $this->limit = $limit;
         parent::__construct(
             $backendId,
             BackendInterface::class,
             'search',
-            [$query, $offset, $limit],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getQuery(),
+            $this->getOffset(),
+            $this->getLimit(),
+            $this->getSearchParameters()
+        ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
@@ -31,6 +31,7 @@
 namespace VuFindSearch\Command;
 
 use VuFindSearch\Backend\BackendInterface;
+use VuFindSearch\Command\Feature\QueryOffsetLimitTrait;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Query\QueryInterface;
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/SetRecordCollectionFactoryCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SetRecordCollectionFactoryCommand.php
@@ -43,6 +43,13 @@ use VuFindSearch\Response\RecordCollectionFactoryInterface;
 class SetRecordCollectionFactoryCommand extends CallMethodCommand
 {
     /**
+     * Factory to set.
+     *
+     * @var RecordCollectionFactoryInterface
+     */
+    protected $factory;
+
+    /**
      * Constructor.
      *
      * @param string                           $backendId Search backend identifier
@@ -52,13 +59,31 @@ class SetRecordCollectionFactoryCommand extends CallMethodCommand
         string $backendId,
         RecordCollectionFactoryInterface $factory
     ) {
+        $this->factory = $factory;
         parent::__construct(
             $backendId,
             AbstractBackend::class,
-            'setRecordCollectionFactory',
-            [$factory],
-            null,
-            false
+            'setRecordCollectionFactory'
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [$this->getFactory()];
+    }
+
+    /**
+     * Return factory to set.
+     *
+     * @return RecordCollectionFactoryInterface
+     */
+    public function getFactory(): RecordCollectionFactoryInterface
+    {
+        return $this->factory;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
@@ -45,11 +45,13 @@ use VuFindSearch\ParamBag;
  */
 class SimilarCommand extends CallMethodCommand
 {
+    use RecordIdentifierTrait;
+
     /**
      * SimilarCommand constructor.
      *
      * @param string    $backendId Search backend identifier
-     * @param string    $id        Id of record to compare with
+     * @param string    $id        Identifier of record to compare with
      * @param ?ParamBag $params    Search backend parameters
      */
     public function __construct(
@@ -57,12 +59,25 @@ class SimilarCommand extends CallMethodCommand
         string $id,
         ?ParamBag $params = null
     ) {
+        $this->id = $id;
         parent::__construct(
             $backendId,
             SimilarInterface::class,
             'similar',
-            [$id],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getRecordIdentifier(),
+            $this->getSearchParameters()
+        ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
@@ -30,6 +30,7 @@
  */
 namespace VuFindSearch\Command;
 
+use VuFindSearch\Command\Feature\RecordIdentifierTrait;
 use VuFindSearch\Feature\SimilarInterface;
 use VuFindSearch\ParamBag;
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
@@ -43,6 +43,27 @@ use VuFindSearch\ParamBag;
 class TermsCommand extends CallMethodCommand
 {
     /**
+     * Index field.
+     *
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * Starting term.
+     *
+     * @var string
+     */
+    protected $start;
+
+    /**
+     * Maximum number of terms.
+     *
+     * @var int
+     */
+    protected $limit;
+
+    /**
      * Constructor.
      *
      * @param string    $backendId Search backend identifier
@@ -58,12 +79,59 @@ class TermsCommand extends CallMethodCommand
         int $limit,
         ParamBag $params = null
     ) {
+        $this->field = $field;
+        $this->start = $start;
+        $this->limit = $limit;
         parent::__construct(
             $backendId,
             Backend::class, // we should define interface, if needed in more places
             'terms',
-            [$field, $start, $limit],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getField(),
+            $this->getStart(),
+            $this->getLimit(),
+            $this->getSearchParameters()
+        ];
+    }
+
+    /**
+     * Return index field.
+     *
+     * @return string
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    /**
+     * Return starting term.
+     *
+     * @return string
+     */
+    public function getStart(): string
+    {
+        return $this->start;
+    }
+
+    /**
+     * Return maximum number of terms.
+     *
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
@@ -30,6 +30,7 @@
 namespace VuFindSearch\Command;
 
 use VuFindSearch\Backend\BackendInterface;
+use VuFindSearch\Command\Feature\RecordIdentifierTrait;
 use VuFindSearch\Feature\WorkExpressionsInterface;
 use VuFindSearch\ParamBag;
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
@@ -45,11 +45,20 @@ use VuFindSearch\ParamBag;
  */
 class WorkExpressionsCommand extends CallMethodCommand
 {
+    use RecordIdentifierTrait;
+
+    /**
+     * Work identification keys.
+     *
+     * @var ?array
+     */
+    protected $workKeys;
+
     /**
      * WorkExpressionsCommand constructor.
      *
      * @param string    $backendId Search backend identifier
-     * @param string    $id        Id of record to compare with
+     * @param string    $id        Identifier of record to compare with
      * @param ?array    $workKeys  Work identification keys (optional; retrieved from
      *                             the record to compare with if not specified)
      * @param ?ParamBag $params    Search backend parameters
@@ -60,13 +69,28 @@ class WorkExpressionsCommand extends CallMethodCommand
         ?array $workKeys,
         ?ParamBag $params = null
     ) {
+        $this->id = $id;
+        $this->workKeys = $workKeys;
         parent::__construct(
             $backendId,
             WorkExpressionsInterface::class,
             'workExpressions',
-            [$id, $workKeys],
             $params
         );
+    }
+
+    /**
+     * Return search backend interface method arguments.
+     *
+     * @return array
+     */
+    public function getArguments(): array
+    {
+        return [
+            $this->getRecordIdentifier(),
+            $this->getWorkKeys(),
+            $this->getSearchParameters()
+        ];
     }
 
     /**
@@ -78,17 +102,27 @@ class WorkExpressionsCommand extends CallMethodCommand
      */
     public function execute(BackendInterface $backend): CommandInterface
     {
-        $id = $this->args[0];
-        $workKeys = $this->args[1];
+        $id = $this->getRecordIdentifier();
+        $workKeys = $this->getWorkKeys();
 
         if (empty($workKeys)) {
             $records = $backend->retrieve($id)->getRecords();
             if (!empty($records[0])) {
                 $fields = $records[0]->getRawData();
-                $this->args[1] = $fields['work_keys_str_mv'] ?? [];
+                $this->workKeys = $fields['work_keys_str_mv'] ?? [];
             }
         }
 
         return parent::execute($backend);
+    }
+
+    /**
+     * Return work identification keys.
+     *
+     * @return array|null
+     */
+    public function getWorkKeys(): ?array
+    {
+        return $this->workKeys;
     }
 }


### PR DESCRIPTION
I was refactoring Finna's listener code and realized that the new style events did not provide all the event parameters that the old ones did (e.g. `query`). So I am afraid that one more command refactoring was required... 😅 

However, I am quite happy with how this turned out. Now the concrete command classes have complete control over the arguments, and `$addParamsToArgs` is no longer required. Accessing an argument array by index is no longer required either, and everything seems much clearer, including the role of command classes.

The `getArguments()` construct allows for event listeners to change non-object arguments as well, as long as the command provides a setter method. I have only added getters for now, and setters can be added later if needed.