### PR TITLE
Simplify unnecessary array_push call.

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -14,7 +14,7 @@ if (PHP_SAPI == 'cli' && APPLICATION_ENV !== 'testing') {
     $modules[] = 'VuFindConsole';
 }
 if (APPLICATION_ENV == 'development') {
-    array_push($modules, 'WhoopsErrorHandler');
+    $modules[] = 'WhoopsErrorHandler';
     $modules[] = 'VuFindDevTools';
 }
 if ($localModules = getenv('VUFIND_LOCAL_MODULES')) {


### PR DESCRIPTION
This is a truly trivial change, but it bothered me that we were updating the module array using two different methods in adjacent lines of code. There is no reason for this, and the simple `$modules[] =` assignment is slightly more efficient.