### PR TITLE
Add support for including browser's user agent in the feedback email.

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -12,7 +12,8 @@
 #   useCaptcha (boolean) Should the form use Captcha validation? Requires the "feedback"
 #                        option to be turned on in the config.ini [Captcha] form setting.
 #                        (default = true, if Captcha turned on for feedback overall).
-#   reportReferrer (boolean) Should the form report the page from which it was invoked?
+#   reportReferrer (boolean) Should the form report the page from which it was invoked
+#   reportUserAgent (boolean) Should the form report the browser's user agent string
 #   title (string) Form title (translation key)
 #   onlyForLoggedUsers (boolean) Require the user to be logged in to see the form
 #                                (default = false)
@@ -124,6 +125,7 @@ forms:
     enabled: true
     useCaptcha: true
     reportReferrer: false
+    reportUserAgent: true
     #emailFrom:
     #  name: Your Library - Site Feedback
     #recipient:

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -64,9 +64,11 @@ class FeedbackController extends AbstractBase
 
         $form = $this->serviceLocator->get($this->formClass);
         $params = [];
-        if ($refererHeader = $this->getRequest()->getHeader('Referer')
-        ) {
+        if ($refererHeader = $this->getRequest()->getHeader('Referer')) {
             $params['referrer'] = $refererHeader->getFieldValue();
+        }
+        if ($userAgentHeader = $this->getRequest()->getHeader('User-Agent')) {
+            $params['userAgent'] = $userAgentHeader->getFieldValue();
         }
         $form->setFormId($formId, $params);
 

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -204,6 +204,16 @@ class Form extends \Laminas\Form\Form implements
     }
 
     /**
+     * Check if the form should report browser's user agent
+     *
+     * @return bool
+     */
+    public function reportUserAgent()
+    {
+        return (bool)($this->formConfig['reportUserAgent'] ?? false);
+    }
+
+    /**
      * Check if form is available only for logged users.
      *
      * @return bool
@@ -670,7 +680,18 @@ class Form extends \Laminas\Form\Form implements
             }
         }
 
-        $elements[]= [
+        if ($this->reportUserAgent()) {
+            if ($userAgent = ($params['userAgent'] ?? false)) {
+                $elements[] = [
+                    'type' => 'hidden',
+                    'name' => 'useragent',
+                    'settings' => ['value' => $userAgent],
+                    'label' => $this->translate('User Agent'),
+                ];
+            }
+        }
+
+        $elements[] = [
             'type' => 'submit',
             'name' => 'submit',
             'label' => $this->translate('Send')
@@ -694,6 +715,7 @@ class Form extends \Laminas\Form\Form implements
             'onlyForLoggedUsers',
             'recipient',
             'reportReferrer',
+            'reportUserAgent',
             'response',
             'senderEmailRequired',
             'senderInfoRequired',


### PR DESCRIPTION
This includes a translatable string 'User Agent', but I've left out the translations as I'm not sure if it's worth translating, and without a translation this could be included in 8.0. :) If you feel that the translation is needed, this can wait until after 8.0.