### PR TITLE
Rename Form class method

### DIFF
--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -228,7 +228,7 @@ class Form extends \Laminas\Form\Form implements
      *
      * @return array
      */
-    public function getElements(): array
+    public function getFormElementConfig(): array
     {
         return $this->formElementConfig;
     }
@@ -356,7 +356,7 @@ class Form extends \Laminas\Form\Form implements
     public function formatEmailMessage(array $requestParams = [])
     {
         $params = [];
-        foreach ($this->getElements() as $el) {
+        foreach ($this->getFormElementConfig() as $el) {
             $type = $el['type'];
             $name = $el['name'];
             if ($type === 'submit') {
@@ -415,12 +415,8 @@ class Form extends \Laminas\Form\Form implements
             ]
         ];
 
-        // Get instantiated element objects by calling parent class method since the
-        // overridden method in this class does not return them.
-        // TODO: Refactor to avoid having to do this.
-        $elementObjects = parent::getElements();
-
-        foreach ($this->getElements() as $el) {
+        $elementObjects = $this->getElements();
+        foreach ($this->getFormElementConfig() as $el) {
             $isCheckbox = $el['type'] === 'checkbox';
             $requireOne = $isCheckbox && ($el['requireOne'] ?? false);
             $required = $el['required'] ?? $requireOne;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -60,7 +60,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($form->isEnabled());
         $this->assertTrue($form->useCaptcha());
         $this->assertFalse($form->showOnlyForLoggedUsers());
-        $this->assertEquals([], $form->getElements());
+        $this->assertEquals([], $form->getFormElementConfig());
         $this->assertEquals(
             [['email' => null, 'name' => null]],
             $form->getRecipient()
@@ -165,7 +165,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'label' => 'Send',
                 ],
             ],
-            $form->getElements()
+            $form->getFormElementConfig()
         );
 
         $this->assertEquals(
@@ -280,7 +280,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             return null;
         };
 
-        $elements = $form->getElements();
+        $elements = $form->getFormElementConfig();
 
         // Select element optionGroup: options with labels and values
         $el = $getElement('select', $elements);

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -34,7 +34,7 @@
   <?php endif ?>
 
   <?php $currentGroup = null; ?>
-  <?php foreach($form->getElements() as $el): ?>
+  <?php foreach($form->getFormElementConfig() as $el): ?>
     <?php
     $formElement = $form->get($el['name']);
 


### PR DESCRIPTION
I don't know why the parent class method was originally overridden, perhaps not even intentionally, but it looks like renaming the method did not require much changes in the codebase.

It is a breaking change though, so in that sense it is good to get it in now.