### PR TITLE
Pass all form element data to the email template.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -358,11 +358,10 @@ class Form extends \Laminas\Form\Form implements
         $params = [];
         foreach ($this->getFormElementConfig() as $el) {
             $type = $el['type'];
-            $name = $el['name'];
             if ($type === 'submit') {
                 continue;
             }
-            $value = $requestParams[$name] ?? null;
+            $value = $requestParams[$el['name']] ?? null;
 
             if (in_array($type, ['radio', 'select'])) {
                 $value = $this->translate($value);
@@ -377,9 +376,10 @@ class Form extends \Laminas\Form\Form implements
                     ?? $this->vufindConfig['Site']['displayDateFormat'] ?? 'Y-m-d';
                 $value = date($format, strtotime($value));
             }
-
-            $label = isset($el['label']) ? $this->translate($el['label']) : null;
-            $params[] = ['type' => $type, 'value' => $value, 'label' => $label];
+            $el['value'] = $value;
+            $el['label'] = isset($el['label']) ? $this->translate($el['label'])
+                : null;
+            $params[] = $el;
         }
 
         return [$params, 'Email/form.phtml'];

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -376,10 +376,8 @@ class Form extends \Laminas\Form\Form implements
                     ?? $this->vufindConfig['Site']['displayDateFormat'] ?? 'Y-m-d';
                 $value = date($format, strtotime($value));
             }
-            $el['value'] = $value;
-            $el['label'] = isset($el['label']) ? $this->translate($el['label'])
-                : null;
-            $params[] = $el;
+            $label = isset($el['label']) ? $this->translate($el['label']) : null;
+            $params[] = $el + compact('value', 'label');
         }
 
         return [$params, 'Email/form.phtml'];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -183,9 +183,30 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 [
-                    ['type' => 'textarea', 'value' => 'x', 'label' => 'Comments'],
-                    ['type' => 'text', 'value' => 'y', 'label' => 'feedback_name'],
-                    ['type' => 'email', 'value' => 'z@foo.com', 'label' => 'feedback_email'],
+                    [
+                        'type' => 'textarea',
+                        'value' => 'x',
+                        'label' => 'Comments',
+                        'name' => 'message',
+                        'required' => true,
+                        'settings' => ['cols' => 50, 'rows' => 8],
+                    ],
+                    [
+                        'type' => 'text',
+                        'value' => 'y',
+                        'name' => 'name',
+                        'group' => '__sender__',
+                        'label' => 'feedback_name',
+                        'settings' => ['size' => 50],
+                    ],
+                    [
+                        'type' => 'email',
+                        'value' => 'z@foo.com',
+                        'name' => 'email',
+                        'group' => '__sender__',
+                        'label' => 'feedback_email',
+                        'settings' => ['size' => 50],
+                    ],
                 ],
                 'Email/form.phtml'
             ],


### PR DESCRIPTION
This makes it possible for the Email/form.phtml template to check field settings etc.

@demiankatz formatEmailMessage was filtering out all but the elements used by the default Email/form.phtml template. This is fine until you need to know more about the field in question, e.g. its name. Id' consider this a fix that I'd like to include in 8.0, but I'll leave the final decision to you.