### PR TITLE
Catch exceptions when loading records from the cache.

### DIFF
--- a/module/VuFind/src/VuFind/Record/Cache.php
+++ b/module/VuFind/src/VuFind/Record/Cache.php
@@ -131,7 +131,15 @@ class Cache implements \Laminas\Log\LoggerAwareInterface
             "Cached record {$source}|{$id} "
             . ($record !== false ? 'found' : 'not found')
         );
-        return $record !== false ? [$this->getVuFindRecord($record)] : [];
+        try {
+            return $record !== false ? [$this->getVuFindRecord($record)] : [];
+        } catch (\Exception $e) {
+            $this->logError(
+                'Could not load record {$source}|{$id} from the record cache: '
+                . $e->getMessage()
+            );
+        }
+        return [];
     }
 
     /**
@@ -153,7 +161,15 @@ class Cache implements \Laminas\Log\LoggerAwareInterface
         $vufindRecords = [];
         $cachedRecords = $this->recordTable->findRecords($ids, $source);
         foreach ($cachedRecords as $cachedRecord) {
-            $vufindRecords[] = $this->getVuFindRecord($cachedRecord);
+            try {
+                $vufindRecords[] = $this->getVuFindRecord($cachedRecord);
+            } catch (\Exception $e) {
+                $this->logError(
+                    'Could not load record ' . $cachedRecord['source'] . '|'
+                    . $cachedRecord['record_id'] . ' from the record cache: '
+                    . $e->getMessage()
+                );
+            }
         }
 
         $extractIdCallback = function ($record) {


### PR DESCRIPTION
If there's a cached record that cannot be loaded (for any reason), it would have caused an uncaught exception. With this change any exception is logged but it won't stop execution.

While I encountered this with my test database, I'm not sure how the record got broken (might have been a manual tweak), so to test this I think it's necessary to break a serialized record in the database. 