### PR TITLE
Make Form class non-shared.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -522,6 +522,9 @@ $config = [
             'VuFind\YamlReader' => 'VuFind\Config\YamlReader',
             'Laminas\Validator\Csrf' => 'VuFind\Validator\Csrf',
         ],
+        'shared' => [
+            'VuFind\Form\Form' => false,
+        ],
     ],
     'translator' => [],
     'translator_plugins' => [


### PR DESCRIPTION
This makes it possible to create multiple independent Form objects.

Without this change creating and modifying a second object would affect the first one, and e.g. creating two forms with different id's side by side would lead to a complete mess.