### PR TITLE
VuFind\Captcha\ImageFactory: Solve cache path problem

### DIFF
--- a/module/VuFind/src/VuFind/Captcha/ImageFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ImageFactory.php
@@ -98,8 +98,8 @@ class ImageFactory implements FactoryInterface
 
         return new $requestedName(
             new \Laminas\Captcha\Image($imageOptions),
-            ($container->get('ViewHelperManager')->get('url'))('home')
-                . 'cache/'
+            rtrim(($container->get('ViewHelperManager')->get('url'))('home'), '/')
+                . '/cache/'
         );
     }
 }

--- a/module/VuFind/src/VuFind/Captcha/ImageFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ImageFactory.php
@@ -99,7 +99,7 @@ class ImageFactory implements FactoryInterface
         return new $requestedName(
             new \Laminas\Captcha\Image($imageOptions),
             ($container->get('ViewHelperManager')->get('url'))('home')
-                . '/cache/'
+                . 'cache/'
         );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -44,10 +44,10 @@ namespace VuFindTest\Captcha;
 class ImageFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Helper function to execute a single test and manipulate the
-     * cache base path if necessary.
+     * Test that the factory behaves correctly.
      *
-     * @param string $homeUrl Home URL
+     * @param string $homeUrl       Home URL (returned by url helper)
+     * @param string $expectedCache Expected cache path
      *
      * @dataProvider factoryDataProvider
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -48,8 +48,10 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
      * cache base path if necessary.
      *
      * @param string $homeUrl Home URL
+     *
+     * @dataProvider factoryDataProvider
      */
-    protected function testFactoryHelper($homeUrl = null)
+    public function testFactory($homeUrl = null, $expectedCache = '/cache/')
     {
         // Set up mock services expected by factory:
         $options = new \Laminas\Cache\Storage\Adapter\FilesystemOptions();
@@ -98,26 +100,21 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
             'imgDir' => $options->getCacheDir()
         ];
         $this->assertEquals($expected, $result->constructorArgs[0]->getOptions());
-        $this->assertEquals('/cache/', $result->constructorArgs[1]);
+        $this->assertEquals($expectedCache, $result->constructorArgs[1]);
     }
 
     /**
-     * Test that the factory behaves correctly.
+     * Provide data for testFactory()
      *
      * @return void
      */
-    public function testFactory()
+    public function factoryDataProvider()
     {
-        $this->testFactoryHelper();
-    }
-
-    /**
-     * Test that the factory behaves correctly, if cache base path is "/".
-     *
-     * @return void
-     */
-    public function testFactory2()
-    {
-        $this->testFactoryHelper('/');
+        return [
+            'Empty base path' => [],
+            'Slash as base path' => ['/'],
+            'Directory with trailing slash' => ['/foo/', '/foo/cache/'],
+            'Directory without trailing slash' => ['/foo', '/foo/cache/'],
+        ];
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -48,14 +48,14 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
      *
      * @var string
      */
-    static protected $cacheBasePath;
+    protected static $cacheBasePath;
 
     /**
      * Getter for internal workaround variable regarding willReturn().
      *
      * @return string
      */
-    static public function getCacheBasePath()
+    public static function getCacheBasePath()
     {
         return self::$cacheBasePath;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -49,9 +49,11 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
      * @param string $homeUrl       Home URL (returned by url helper)
      * @param string $expectedCache Expected cache path
      *
+     * @return void
+     *
      * @dataProvider factoryDataProvider
      */
-    public function testFactory($homeUrl = null, $expectedCache = '/cache/')
+    public function testFactory($homeUrl = null, $expectedCache = '/cache/'): void
     {
         // Set up mock services expected by factory:
         $options = new \Laminas\Cache\Storage\Adapter\FilesystemOptions();
@@ -106,9 +108,9 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Provide data for testFactory()
      *
-     * @return void
+     * @return array
      */
-    public function factoryDataProvider()
+    public function factoryDataProvider(): array
     {
         return [
             'Empty base path' => [],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -44,23 +44,6 @@ namespace VuFindTest\Captcha;
 class ImageFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Internal workaround variable regarding willReturn().
-     *
-     * @var string
-     */
-    protected static $cacheBasePath;
-
-    /**
-     * Getter for internal workaround variable regarding willReturn().
-     *
-     * @return string
-     */
-    public static function getCacheBasePath()
-    {
-        return self::$cacheBasePath;
-    }
-
-    /**
      * Helper function to execute a single test and manipulate the
      * cache base path if necessary.
      *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -64,32 +64,30 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
      * Helper function to execute a single test and manipulate the
      * cache base path if necessary.
      *
-     * @param string $cacheBasePath
+     * @param string $homeUrl Home URL
      */
-    protected function testFactoryHelper($cacheBasePath=null)
+    protected function testFactoryHelper($homeUrl = null)
     {
         // Set up mock services expected by factory:
         $options = new \Laminas\Cache\Storage\Adapter\FilesystemOptions();
         $container = new \VuFindTest\Container\MockContainer($this);
         $storage = $container->get(\Laminas\Cache\Storage\StorageInterface::class);
-        $storage->expects($this->atLeast(1))->method('getOptions')
+        $storage->expects($this->once())->method('getOptions')
             ->will($this->returnValue($options));
         $cacheManager = $container->get(\VuFind\Cache\Manager::class);
-        $cacheManager->expects($this->atLeast(1))->method('getCache')
+        $cacheManager->expects($this->once())->method('getCache')
             ->with($this->equalTo('public'))
             ->will($this->returnValue($storage));
 
         $url = $container->get(\VuFind\View\Helper\Root\Url::class);
+        $url->expects($this->once())->method('__invoke')
+            ->with($this->equalTo('home'))
+            ->will($this->returnValue($homeUrl));
+
         $manager = $container->get('ViewHelperManager');
 
-        if ($cacheBasePath === null) {
-            $manager->expects($this->atLeast(1))->method('get')
-                ->with($this->equalTo('url'))->will($this->returnValue($url));
-        } else {
-            self::$cacheBasePath = $cacheBasePath;
-            $manager->expects($this->atLeast(1))->method('get')
-                ->with($this->equalTo('url'))->willReturn('VuFindTest\Captcha\ImageFactoryTest::getCacheBasePath');
-        }
+        $manager->expects($this->once())->method('get')
+            ->with($this->equalTo('url'))->will($this->returnValue($url));
 
         $factory = new \VuFind\Captcha\ImageFactory();
         $fakeImage = new class {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -72,7 +72,6 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($homeUrl));
 
         $manager = $container->get('ViewHelperManager');
-
         $manager->expects($this->once())->method('get')
             ->with($this->equalTo('url'))->will($this->returnValue($url));
 


### PR DESCRIPTION
Since the 'home' URL will usually only contain a `/`, adding another one at the beginning would result in `//` being generated, which would cause problems later.