### PR TITLE
Trigger print dialog only once

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -489,7 +489,7 @@ $(document).ready(function commonDocReady() {
   var url = window.location.href;
   if (url.indexOf('?print=') !== -1 || url.indexOf('&print=') !== -1) {
     $("link[media='print']").attr("media", "all");
-    $(document).ajaxStop(function triggerPrint() {
+    $(document).one('ajaxStop', function triggerPrint() {
       // Print dialogs cause problems during testing, so disable them
       // when the "test mode" cookie is set. This should never happen
       // under normal usage outside of the Phing startup process.


### PR DESCRIPTION
It the user closes the print dialog and stays on the page, and the keep-alive feature is enabled, the print dialog keeps popping up. With this change the print dialog is shown only once.