### PR TITLE
Add GetItemStatuses::renderFullStatus()

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -454,6 +454,26 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
     }
 
     /**
+     * Render full item status.
+     *
+     * @param array $record Record
+     * @param array $values Additional values for the template
+     *
+     * @return string
+     */
+    protected function renderFullStatus($record, array $values = [])
+    {
+        $values = array_merge(
+            [
+                'statusItems' => $record,
+                'callnumberHandler' => $this->getCallnumberHandler()
+            ],
+            $values
+        );
+        return $this->renderer->render('ajax/status-full.phtml', $values);
+    }
+
+    /**
      * Handle a request.
      *
      * @param Params $params Parameter helper from controller
@@ -535,13 +555,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
                 // If a full status display has been requested and no errors were
                 // encountered, append the HTML:
                 if ($showFullStatus && empty($record[0]['error'])) {
-                    $current['full_status'] = $this->renderer->render(
-                        'ajax/status-full.phtml',
-                        [
-                            'statusItems' => $record,
-                            'callnumberHandler' => $this->getCallnumberHandler()
-                        ]
-                    );
+                    $current['full_status'] = $this->renderFullStatus($record);
                 }
                 $current['record_number'] = array_search($current['id'], $ids);
                 $statuses[] = $current;


### PR DESCRIPTION
Moves the template render call to a separate overridable method, so that a subclass can process and add more values for the template (or even use a different template).