### PR TITLE
Alma: Handle 400 error for a non-existent account in patronLogin.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -737,12 +737,18 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
         ];
 
         // Check for patron in Alma
-        $response = $this->makeRequest(
+        [$response, $status] = $this->makeRequest(
             '/users/' . rawurlencode($patronId),
-            $getParams
+            $getParams,
+            [],
+            'GET',
+            null,
+            null,
+            [400],
+            true
         );
 
-        if ($response !== null) {
+        if ($status != 400 && $response !== null) {
             // We may already have some information, so just fill the gaps
             $patron['id'] = (string)$response->primary_id;
             $patron['cat_username'] = trim($username);


### PR DESCRIPTION
This is a possible fix for the issue reported on vufind-general list today.