### PR TITLE
Fix a PHP notice when a driver does not return callnumber_prefix.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -287,7 +287,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface
             }
             // Store call number/location info:
             $callNumbers[] = $this->formatCallNo(
-                $info['callnumber_prefix'],
+                $info['callnumber_prefix'] ?? '',
                 $info['callnumber']
             );
 


### PR DESCRIPTION
This usually remains hidden as it happens during an AJAX call and just produces an additional field in the JSON response.