### PR TITLE
Make MarkdownFactory easier to extend

### DIFF
--- a/module/VuFind/src/VuFind/Service/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/Service/MarkdownFactory.php
@@ -23,6 +23,7 @@
  * @category VuFind
  * @package  VuFind\Service
  * @author   Josef Moravec <moravec@mzk.cz>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://knihovny.cz Main Page
  */
@@ -30,18 +31,21 @@ namespace VuFind\Service;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
+use Laminas\Config\Config;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\MarkdownConverter;
 
 /**
- * VuFind HTTP Service factory.
+ * VuFind Markdown Service factory.
  *
  * @category VuFind
  * @package  Service
  * @author   Josef Moravec <moravec@mzk.cz>
+ * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -91,8 +95,41 @@ class MarkdownFactory implements FactoryInterface
     ) {
         $markdownConfig = $container->get(\VuFind\Config\PluginManager::class)
             ->get('markdown');
+
+        $environment = $this->getEnvironment($markdownConfig);
+        $this->addExtensions($environment, $markdownConfig);
+
+        return new MarkdownConverter($environment);
+    }
+
+    /**
+     * Get Markdown environment.
+     *
+     * @param $markdownConfig Config VuFind Markdown config
+     *
+     * @return ConfigurableEnvironmentInterface
+     */
+    protected function getEnvironment(Config $markdownConfig):
+        ConfigurableEnvironmentInterface
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->mergeConfig($this->getEnvironmentConfig($markdownConfig));
+
+        return $environment;
+    }
+
+    /**
+     * Get Markdown environment config.
+     *
+     * @param $markdownConfig Config VuFind Markdown config
+     *
+     * @return array
+     */
+    protected function getEnvironmentConfig(Config $markdownConfig): array
+    {
         $mainConfig = $markdownConfig->Markdown;
-        $config = [
+
+        return [
             'html_input' => $mainConfig->html_input ?? 'strip',
             'allow_unsafe_links' => $mainConfig->allow_unsafe_links ?? false,
             'max_nesting_level' => $mainConfig->max_nesting_level ?? \PHP_INT_MAX,
@@ -115,8 +152,21 @@ class MarkdownFactory implements FactoryInterface
                 'soft_break' => $mainConfig->renderer['soft_break'] ?? "\n",
             ],
         ];
+    }
 
-        $environment = Environment::createCommonMarkEnvironment();
+    /**
+     * Add extensions to Markdown environment.
+     *
+     * @param $environment    ConfigurableEnvironmentInterface Markdown environment
+     * @param $markdownConfig Config                           VuFind Markdown config
+     *
+     * @return void
+     */
+    protected function addExtensions(
+        ConfigurableEnvironmentInterface $environment,
+        Config $markdownConfig
+    ): void {
+        $mainConfig = $markdownConfig->Markdown;
         $extensions = isset($mainConfig->extensions)
             ? array_map('trim', explode(',', $mainConfig->extensions))
             : self::$defaultExtensions;
@@ -137,11 +187,10 @@ class MarkdownFactory implements FactoryInterface
             }
             $environment->addExtension(new $extClass());
             if (isset($markdownConfig[$ext])) {
-                $config[self::$configKeys[$ext]] = $markdownConfig->$ext->toArray();
+                $environment->mergeConfig(
+                    [self::$configKeys[$ext] => $markdownConfig->$ext->toArray()]
+                );
             }
         }
-        $environment->mergeConfig($config);
-
-        return new MarkdownConverter($environment);
     }
 }


### PR DESCRIPTION
We have use cases where we need a differently configured Markdown environment. These changes should make the base service class easier to extend with a different environment, configuration or extensions.