### PR TITLE
Aleph: Fix for pagination of historic loans

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1124,11 +1124,12 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
 
         // with full details and paging
         $pageSize = $params['limit'] ?? 50;
+        $itemsNoKey = $history ? 'no_loans' : 'noItems';
         $alephParams += [
             'view' => 'full',
             'startPos' => isset($params['page'])
                 ? ($params['page'] - 1) * $pageSize : 0,
-            'noItems' => $pageSize,
+            $itemsNoKey => $pageSize,
         ];
 
         $xml = $this->doRestDLFRequest(


### PR DESCRIPTION
According to the [docs](https://developers.exlibrisgroup.com/aleph/apis/aleph-restful-apis/loans/), the parameter for getting just a chunk of historic loans should be **no_loans** instead of **noItems**, which is used for regular loans. In my case, it really works this way. It is a rather annoying inconsistency.