### PR TITLE
Fix loginIsHidden call in MultiBackend ILS driver

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1417,6 +1417,9 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         bool $stripPrefixes = true,
         bool $addPrefixes = true
     ) {
+        if (empty($params) && null === $source) {
+            return null;
+        }
         if (null === $source) {
             $source = $this->getSourceForMethod($method, $params);
         }


### PR DESCRIPTION
loginIsHidden has no parameters and in MultiBackend driver is called without source parameter (in __call method) which ends in 'No suitable backend driver found' ILS exception