### PR TITLE
Fix Csp helper's disablePolicy when CSP mode is "report_only".

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
@@ -72,12 +72,12 @@ class Csp extends \Laminas\View\Helper\AbstractHelper
             as $field
         ) {
             if ($cspHeaders = $headers->get($field)) {
-                if ($cspHeaders instanceof \ArrayIterator) {
-                    foreach ($cspHeaders as $header) {
-                        $headers->removeHeader($header);
-                    }
-                } else {
-                    $headers->removeHeader($cspHeaders);
+                // Make sure the result is iterable (an array cast doesn't work here
+                // as a single header may be castable as an array):
+                $headerArray = $cspHeaders instanceof \ArrayIterator
+                    ? $cspHeaders : [$cspHeaders];
+                foreach ($headerArray as $header) {
+                    $headers->removeHeader($header);
                 }
             }
         }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
@@ -72,8 +72,12 @@ class Csp extends \Laminas\View\Helper\AbstractHelper
             as $field
         ) {
             if ($cspHeaders = $headers->get($field)) {
-                foreach ((array)$cspHeaders as $header) {
-                    $headers->removeHeader($header);
+                if ($cspHeaders instanceof \ArrayIterator) {
+                    foreach ($cspHeaders as $header) {
+                        $headers->removeHeader($header);
+                    }
+                } else {
+                    $headers->removeHeader($cspHeaders);
                 }
             }
         }


### PR DESCRIPTION
Apparently the header may be castable as an array which breaks the foreach loop.

This seems to happen only when CSP is set to "report_only" mode, though I'm not quite sure why. In any case, this adds a couple more tests to make sure disablePolicy works in all modes.