### PR TITLE
Allow multi-level indenting

### DIFF
--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -8,4 +8,9 @@
   <rule ref="PEAR">
     <exclude name="PEAR.Commenting.FunctionComment.ParamCommentAlignment" />
   </rule>
+  <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent">
+    <properties>
+      <property name="multilevel" value="true" />
+    </properties>
+  </rule>
 </ruleset>


### PR DESCRIPTION
@demiankatz This is just a suggestion, so feel free to close without merging if you don't think it is a good change.

Real life use case:

```php
$sources['type'] == 'sectors'
    ? $this->translator
    ->translate('moderation_alert_sectors')
    : $this->translator
    ->translate('moderation_alert_databases'),
```

Could be indented like this:

```php
$sources['type'] == 'sectors'
    ? $this->translator
        ->translate('moderation_alert_sectors')
    : $this->translator
        ->translate('moderation_alert_databases'),
```

The [related PHP_CodeSniffer documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#pearwhitespaceobjectoperatorindent) has another example.

I understand that the goal is to deviate from the PEAR coding standards as little as possible, but I am not sure if this is covered by them? It seems to be more of a default choice in the PHP_CodeSniffer sniff.