### PR TITLE
Add option to set accepted HTTP codes (other than 2xx) for NCIP driver

### DIFF
--- a/config/vufind/XCNCIP2.ini
+++ b/config/vufind/XCNCIP2.ini
@@ -65,3 +65,8 @@ consortium  = false
 ; to 'ILSMessages'
 ;translationDomain = "ILSMessages"
 
+; Accepted HTTP status codes other than 2xx, which could be accepted as correct
+; response. Some NCIP servers could return some 4xx codes similar to REST API
+; (like 404 Not found) altogether with correct XML in response body.
+;otherAcceptedHttpStatusCodes[] = "400,404"
+

--- a/module/VuFind/tests/fixtures/xcncip2/response/RenewItemResponse404.xml
+++ b/module/VuFind/tests/fixtures/xcncip2/response/RenewItemResponse404.xml
@@ -1,0 +1,11 @@
+HTTP/1.1 400 Bad Request
+Content-Type: application/xml
+Date: Wed, 18 Mar 2015 11:49:40 GMT
+
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<NCIPMessage xmlns="http://www.niso.org/2008/ncip">
+    <Problem>
+        <ProblemType>Item Not Renewable</ProblemType>
+        <ProblemDetail>No active registration.</ProblemDetail>
+    </Problem>
+</NCIPMessage>

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
@@ -60,911 +60,677 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
      *
      * @var array[]
      */
-    protected $transactionsTests = [
-        [
-            'file' => [
-                'lookupUserResponse.xml',
-                'LookupItem.xml',
-            ],
-            'result' => [
+    protected $transactionsTests
+        = [
+            [
+                'file' => [
+                    'lookupUserResponse.xml', 'LookupItem.xml',
+                ], 'result' => [
                 [
                     'id' => 'MZK01000847602-MZK50000847602000090',
                     'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-19-2014',
+                    'patronAgencyId' => 'Test agency', 'duedate' => '11-19-2014',
                     'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
-                    'item_id' => '104',
-                    'renewable' => false,
-                ],
-                [
+                    'item_id' => '104', 'renewable' => false,
+                ], [
                     'id' => 'KN3183000000046386',
                     'item_agency_id' => 'Agency from lookup item',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-26-2014',
+                    'patronAgencyId' => 'Test agency', 'duedate' => '11-26-2014',
                     'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
-                    'item_id' => '105',
-                    'renewable' => true,
+                    'item_id' => '105', 'renewable' => true,
                 ],
             ],
-        ],
-        [
-            'file' => [
-                'LookupUserResponseWithoutNamespacePrefix.xml',
-            ],
-            'result' => [
-                [
-                    'id' => 'MZK01000847602-MZK50000847602000090',
-                    'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-19-2014',
-                    'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
-                    'item_id' => '104',
-                    'renewable' => true,
+            ], [
+                'file' => [
+                    'LookupUserResponseWithoutNamespacePrefix.xml',
+                ], 'result' => [
+                    [
+                        'id' => 'MZK01000847602-MZK50000847602000090',
+                        'item_agency_id' => 'My Agency',
+                        'patronAgencyId' => 'Test agency', 'duedate' => '11-19-2014',
+                        'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
+                        'item_id' => '104', 'renewable' => true,
+                    ], [
+                        'id' => 'MZK01000000456-MZK50000000456000440',
+                        'item_agency_id' => 'My Agency',
+                        'patronAgencyId' => 'Test agency', 'duedate' => '11-26-2014',
+                        'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
+                        'item_id' => '105', 'renewable' => true,
+                    ],
                 ],
-                [
-                    'id' => 'MZK01000000456-MZK50000000456000440',
-                    'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-26-2014',
-                    'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
-                    'item_id' => '105',
-                    'renewable' => true,
-                ],
-            ],
-        ],
-        [
-            'file' => [
-                'LookupUserResponseWithoutNamespaceDefinition.xml',
-            ],
-            'result' => [
-                [
-                    'id' => 'MZK01000847602-MZK50000847602000090',
-                    'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-19-2014',
-                    'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
-                    'item_id' => '104',
-                    'renewable' => true,
-                ],
-                [
-                    'id' => 'MZK01000000456-MZK50000000456000440',
-                    'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-26-2014',
-                    'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
-                    'item_id' => '105',
-                    'renewable' => true,
+            ], [
+                'file' => [
+                    'LookupUserResponseWithoutNamespaceDefinition.xml',
+                ], 'result' => [
+                    [
+                        'id' => 'MZK01000847602-MZK50000847602000090',
+                        'item_agency_id' => 'My Agency',
+                        'patronAgencyId' => 'Test agency', 'duedate' => '11-19-2014',
+                        'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
+                        'item_id' => '104', 'renewable' => true,
+                    ], [
+                        'id' => 'MZK01000000456-MZK50000000456000440',
+                        'item_agency_id' => 'My Agency',
+                        'patronAgencyId' => 'Test agency', 'duedate' => '11-26-2014',
+                        'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
+                        'item_id' => '105', 'renewable' => true,
+                    ],
                 ],
             ],
-        ],
-    ];
+        ];
 
-    protected $notRenewableTransactionsTests = [
-        [
-            'file' => [
-                'lookupUserResponse.xml',
-                'LookupItem.xml',
-            ],
-            'result' => [
+    protected $notRenewableTransactionsTests
+        = [
+            [
+                'file' => [
+                    'lookupUserResponse.xml', 'LookupItem.xml',
+                ], 'result' => [
                 [
                     'id' => 'MZK01000847602-MZK50000847602000090',
                     'item_agency_id' => 'My Agency',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-19-2014',
+                    'patronAgencyId' => 'Test agency', 'duedate' => '11-19-2014',
                     'title' => 'Jahrbücher der Deutschen Malakozoologischen Gesellschaft ...',
-                    'item_id' => '104',
-                    'renewable' => false,
-                ],
-                [
+                    'item_id' => '104', 'renewable' => false,
+                ], [
                     'id' => 'KN3183000000046386',
                     'item_agency_id' => 'Agency from lookup item',
-                    'patronAgencyId' => 'Test agency',
-                    'duedate' => '11-26-2014',
+                    'patronAgencyId' => 'Test agency', 'duedate' => '11-26-2014',
                     'title' => 'Anna Nahowská a císař František Josef : zápisky / Friedrich Saathen ; z něm. přel. Ivana Víz',
-                    'item_id' => '105',
-                    'renewable' => false,
+                    'item_id' => '105', 'renewable' => false,
                 ],
             ],
-        ],
-    ];
+            ],
+        ];
 
     /**
      * Test definition for testGetMyFines
      *
      * @var array[]
      */
-    protected $finesTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [
+    protected $finesTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [
                 [
-                    'id' => '8071750247',
-                    'duedate' => '',
-                    'amount' => 25,
-                    'balance' => 25,
-                    'checkout' => '',
-                    'fine' => 'Service Charge',
+                    'id' => '8071750247', 'duedate' => '', 'amount' => 25,
+                    'balance' => 25, 'checkout' => '', 'fine' => 'Service Charge',
                     'createdate' => '11-14-2014',
                 ],
             ],
-        ],
-        [
-            'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
-            'result' => [
-                [
-                    'id' => '',
-                    'duedate' => '',
-                    'amount' => 25,
-                    'balance' => 25,
-                    'checkout' => '',
-                    'fine' => 'Service Charge',
-                    'createdate' => '11-14-2014',
+            ], [
+                'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
+                'result' => [
+                    [
+                        'id' => '', 'duedate' => '', 'amount' => 25, 'balance' => 25,
+                        'checkout' => '', 'fine' => 'Service Charge',
+                        'createdate' => '11-14-2014',
+                    ],
                 ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testPatronLogin
      *
      * @var array[]
      */
-    protected $loginTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [
-                'id' => '700',
-                'patronAgencyId' => 'MZK',
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'email' => 'test@mzk.cz',
-                'major' => null,
-                'college' => null,
-                'firstname' => 'John',
-                'lastname' => 'Smith',
+    protected $loginTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [
+                'id' => '700', 'patronAgencyId' => 'MZK',
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'email' => 'test@mzk.cz', 'major' => null, 'college' => null,
+                'firstname' => 'John', 'lastname' => 'Smith',
             ],
-        ],
-        [
-            'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
-            'result' => [
-                'id' => '700',
-                'patronAgencyId' => 'MZK',
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'email' => 'test@mzk.cz',
-                'major' => null,
-                'college' => null,
-                'firstname' => 'John',
-                'lastname' => 'Smith',
+            ], [
+                'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
+                'result' => [
+                    'id' => '700', 'patronAgencyId' => 'MZK',
+                    'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                    'email' => 'test@mzk.cz', 'major' => null, 'college' => null,
+                    'firstname' => 'John', 'lastname' => 'Smith',
+                ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testGetMyHolds
      *
      * @var array[]
      */
-    protected $holdsTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [
+    protected $holdsTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [
                 [
                     'id' => '111',
                     'title' => 'Ahoj, Blanko! : dívčí román / Eva Bernardinová',
                     'item_id' => 'MZK01000353880-MZK50000353880000040',
-                    'create' => '10-10-2014',
-                    'expire' => null,
-                    'position' => null,
+                    'create' => '10-10-2014', 'expire' => null, 'position' => null,
                     'requestId' => null,
                     'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
+                    'item_agency_id' => null, 'canceled' => false,
                     'available' => false,
 
-                ],
-                [
+                ], [
                     'id' => '112',
                     'title' => 'Aktiv revizních techniků elektrických zařízení',
                     'item_id' => 'MZK01000065021-MZK50000065021000010',
-                    'create' => '10-23-2014',
-                    'expire' => null,
-                    'position' => null,
+                    'create' => '10-23-2014', 'expire' => null, 'position' => null,
                     'requestId' => null,
                     'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
+                    'item_agency_id' => null, 'canceled' => false,
                     'available' => false,
                 ],
             ],
-        ],
-        [
-            'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
-            'result' => [
-                [
-                    'id' => '111',
-                    'title' => 'Ahoj, Blanko! : dívčí román / Eva Bernardinová',
-                    'item_id' => 'MZK01000353880-MZK50000353880000040',
-                    'create' => '10-10-2014',
-                    'expire' => null,
-                    'position' => null,
-                    'requestId' => null,
-                    'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
-                    'available' => false,
+            ], [
+                'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
+                'result' => [
+                    [
+                        'id' => '111',
+                        'title' => 'Ahoj, Blanko! : dívčí román / Eva Bernardinová',
+                        'item_id' => 'MZK01000353880-MZK50000353880000040',
+                        'create' => '10-10-2014', 'expire' => null,
+                        'position' => null, 'requestId' => null,
+                        'location' => 'Loan Department - Ground floor',
+                        'item_agency_id' => null, 'canceled' => false,
+                        'available' => false,
 
-                ],
-                [
-                    'id' => '112',
-                    'title' => 'Aktiv revizních techniků elektrických zařízení',
-                    'item_id' => 'MZK01000065021-MZK50000065021000010',
-                    'create' => '10-23-2014',
-                    'expire' => null,
-                    'position' => null,
-                    'requestId' => null,
-                    'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
-                    'available' => false,
+                    ], [
+                        'id' => '112',
+                        'title' => 'Aktiv revizních techniků elektrických zařízení',
+                        'item_id' => 'MZK01000065021-MZK50000065021000010',
+                        'create' => '10-23-2014', 'expire' => null,
+                        'position' => null, 'requestId' => null,
+                        'location' => 'Loan Department - Ground floor',
+                        'item_agency_id' => null, 'canceled' => false,
+                        'available' => false,
+                    ],
                 ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testGetMyProfile
      *
      * @var array[]
      */
-    protected $profileTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [
-                'firstname' => 'John',
-                'lastname' => 'Smith',
-                'address1' => 'Trvalá ulice 123, Big City, 12345',
-                'address2' => '',
-                'zip' => '',
-                'phone' => '',
-                'group' => '',
+    protected $profileTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [
+                'firstname' => 'John', 'lastname' => 'Smith',
+                'address1' => 'Trvalá ulice 123, Big City, 12345', 'address2' => '',
+                'zip' => '', 'phone' => '', 'group' => '',
                 'expiration_date' => '12-30-2099',
             ],
-        ],
-        [
-            'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
-            'result' => [
-                'firstname' => 'John',
-                'lastname' => 'Smith',
-                'address1' => 'Trvalá ulice 123, Big City, 12345',
-                'address2' => '',
-                'zip' => '',
-                'phone' => '',
-                'group' => '',
-                'expiration_date' => '12-30-2099',
+            ], [
+                'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
+                'result' => [
+                    'firstname' => 'John', 'lastname' => 'Smith',
+                    'address1' => 'Trvalá ulice 123, Big City, 12345',
+                    'address2' => '', 'zip' => '', 'phone' => '', 'group' => '',
+                    'expiration_date' => '12-30-2099',
+                ],
+            ], [
+                'file' => 'lookupUserResponseStructuredAddress.xml', 'result' => [
+                    'firstname' => 'John', 'lastname' => 'Smith',
+                    'address1' => 'Trvalá ulice 123', 'address2' => '12345 Big City',
+                    'zip' => '', 'phone' => '', 'group' => '',
+                    'expiration_date' => '12-30-2099',
+                ],
+            ], [
+                'file' => 'lookupUserResponseStructuredAddressDetail.xml',
+                'result' => [
+                    'firstname' => 'John', 'lastname' => 'Smith',
+                    'address1' => 'Trvalá ulice 123', 'address2' => 'Big City',
+                    'zip' => '12345', 'phone' => '', 'group' => '',
+                    'expiration_date' => '12-30-2099',
+                ],
+            ], [
+                'file' => 'lookupUserResponseUnstructuredName.xml', 'result' => [
+                    'firstname' => '', 'lastname' => 'John Smith Jr.',
+                    'address1' => 'Trvalá ulice 123', 'address2' => '12345 Big City',
+                    'zip' => '', 'phone' => '', 'group' => '',
+                    'expiration_date' => '12-30-2099'
+                ],
             ],
-        ],
-        [
-            'file' => 'lookupUserResponseStructuredAddress.xml',
-            'result' => [
-                'firstname' => 'John',
-                'lastname' => 'Smith',
-                'address1' => 'Trvalá ulice 123',
-                'address2' => '12345 Big City',
-                'zip' => '',
-                'phone' => '',
-                'group' => '',
-                'expiration_date' => '12-30-2099',
-            ],
-        ],
-        [
-            'file' => 'lookupUserResponseStructuredAddressDetail.xml',
-            'result' => [
-                'firstname' => 'John',
-                'lastname' => 'Smith',
-                'address1' => 'Trvalá ulice 123',
-                'address2' => 'Big City',
-                'zip' => '12345',
-                'phone' => '',
-                'group' => '',
-                'expiration_date' => '12-30-2099',
-            ],
-        ],
-        [
-            'file' => 'lookupUserResponseUnstructuredName.xml',
-            'result' => [
-                'firstname' => '',
-                'lastname' => 'John Smith Jr.',
-                'address1' => 'Trvalá ulice 123',
-                'address2' => '12345 Big City',
-                'zip' => '',
-                'phone' => '',
-                'group' => '',
-                'expiration_date' => '12-30-2099'
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testGetMyStorageRetrievalRequests
      *
      * @var array[]
      */
-    protected $storageRetrievalTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [
+    protected $storageRetrievalTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [
                 [
                     'id' => '155',
                     'title' => 'Listen and play : with magicians! : 3. ročník / Věra Štiková ; [ilustrace Andrea Schindlerová]',
-                    'create' => '11-09-2014',
-                    'expire' => null,
-                    'position' => null,
+                    'create' => '11-09-2014', 'expire' => null, 'position' => null,
                     'requestId' => null,
                     'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
+                    'item_agency_id' => null, 'canceled' => false,
                     'item_id' => 'MZK01001333770-MZK50001370317000020',
                     'available' => false,
                 ],
             ],
-        ],
-        [
-            'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
-            'result' => [
-                [
-                    'id' => '155',
-                    'title' => 'Listen and play : with magicians! : 3. ročník / Věra Štiková ; [ilustrace Andrea Schindlerová]',
-                    'create' => '11-09-2014',
-                    'expire' => null,
-                    'position' => null,
-                    'requestId' => null,
-                    'location' => 'Loan Department - Ground floor',
-                    'item_agency_id' => null,
-                    'canceled' => false,
-                    'item_id' => 'MZK01001333770-MZK50001370317000020',
-                    'available' => false,
+            ], [
+                'file' => 'LookupUserResponseWithoutNamespacePrefix.xml',
+                'result' => [
+                    [
+                        'id' => '155',
+                        'title' => 'Listen and play : with magicians! : 3. ročník / Věra Štiková ; [ilustrace Andrea Schindlerová]',
+                        'create' => '11-09-2014', 'expire' => null,
+                        'position' => null, 'requestId' => null,
+                        'location' => 'Loan Department - Ground floor',
+                        'item_agency_id' => null, 'canceled' => false,
+                        'item_id' => 'MZK01001333770-MZK50001370317000020',
+                        'available' => false,
+                    ],
                 ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testGetStatuses
      *
      * @var array[]
      */
-    protected $statusesTests = [
-        [
-            'file' => 'lookupItemSet.xml',
-            'result' => [
+    protected $statusesTests
+        = [
+            [
+                'file' => 'lookupItemSet.xml', 'result' => [
                 'MZK01000000421' => [
                     [
-                        'status' => 'Available on shelf',
-                        'location' => null,
-                        'callnumber' => '621.3 ANG',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000421',
+                        'status' => 'Available on shelf', 'location' => null,
+                        'callnumber' => '621.3 ANG', 'availability' => true,
+                        'reserve' => 'N', 'id' => 'MZK01000000421',
                     ],
-                ],
-                'MZK01000062021' => [
+                ], 'MZK01000062021' => [
                     [
-                        'status' => 'Available On Shelf',
-                        'location' => null,
-                        'callnumber' => 'PK-0083.568',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000062021',
+                        'status' => 'Available On Shelf', 'location' => null,
+                        'callnumber' => 'PK-0083.568', 'availability' => true,
+                        'reserve' => 'N', 'id' => 'MZK01000062021',
                     ],
-                ],
-                'MZK01000000425' => [
+                ], 'MZK01000000425' => [
                     [
                         'status' => 'Available On Shelf',
                         'location' => 'Some holding location',
-                        'callnumber' => '2-0997.767,2',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000425',
-                    ],
-                    [
+                        'callnumber' => '2-0997.767,2', 'availability' => true,
+                        'reserve' => 'N', 'id' => 'MZK01000000425',
+                    ], [
                         'status' => 'Circulation Status Undefined',
-                        'location' => 'Some holding location',
-                        'callnumber' => null,
-                        'availability' => false,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000425',
-                        'use_unknown_message' => true,
+                        'location' => 'Some holding location', 'callnumber' => null,
+                        'availability' => false, 'reserve' => 'N',
+                        'id' => 'MZK01000000425', 'use_unknown_message' => true,
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'lookupItemSetWithoutNamespacePrefix.xml',
-            'result' => [
-                'MZK01000000421' => [
-                    [
-                        'status' => 'Available on shelf',
-                        'location' => null,
-                        'callnumber' => '621.3 ANG',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000421',
-                    ],
-                ],
-                'MZK01000062021' => [
-                    [
-                        'status' => 'Available On Shelf',
-                        'location' => null,
-                        'callnumber' => 'PK-0083.568',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000062021',
-                    ],
-                ],
-                'MZK01000000425' => [
-                    [
-                        'status' => 'Available On Shelf',
-                        'location' => 'Some holding location',
-                        'callnumber' => '2-0997.767,2',
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000425',
-                    ],
-                    [
-                        'status' => 'Available On Shelf',
-                        'location' => 'Some holding location',
-                        'callnumber' => null,
-                        'availability' => true,
-                        'reserve' => 'N',
-                        'id' => 'MZK01000000425',
+            ], [
+                'file' => 'lookupItemSetWithoutNamespacePrefix.xml', 'result' => [
+                    'MZK01000000421' => [
+                        [
+                            'status' => 'Available on shelf', 'location' => null,
+                            'callnumber' => '621.3 ANG', 'availability' => true,
+                            'reserve' => 'N', 'id' => 'MZK01000000421',
+                        ],
+                    ], 'MZK01000062021' => [
+                        [
+                            'status' => 'Available On Shelf', 'location' => null,
+                            'callnumber' => 'PK-0083.568', 'availability' => true,
+                            'reserve' => 'N', 'id' => 'MZK01000062021',
+                        ],
+                    ], 'MZK01000000425' => [
+                        [
+                            'status' => 'Available On Shelf',
+                            'location' => 'Some holding location',
+                            'callnumber' => '2-0997.767,2', 'availability' => true,
+                            'reserve' => 'N', 'id' => 'MZK01000000425',
+                        ], [
+                            'status' => 'Available On Shelf',
+                            'location' => 'Some holding location',
+                            'callnumber' => null, 'availability' => true,
+                            'reserve' => 'N', 'id' => 'MZK01000000425',
+                        ],
                     ],
                 ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testGetHolding
      *
      * @var array[]
      */
-    protected $holdingTests = [
-        [
-            'file' => 'lookupItemSet.xml',
-            'result' => [
+    protected $holdingTests
+        = [
+            [
+                'file' => 'lookupItemSet.xml', 'result' => [
                 [
-                    'status' => 'Available on shelf',
-                    'location' => null,
-                    'callnumber' => '621.3 ANG',
-                    'availability' => true,
-                    'reserve' => 'N',
-                    'id' => '123456',
+                    'status' => 'Available on shelf', 'location' => null,
+                    'callnumber' => '621.3 ANG', 'availability' => true,
+                    'reserve' => 'N', 'id' => '123456',
                     'item_id' => 'MZK01000000421-MZK50000000421000010',
-                    'bib_id' => 'MZK01000000421',
-                    'duedate' => '',
-                    'volume' => '',
-                    'number' => '',
-                    'is_holdable' => false,
-                    'addLink' => false,
+                    'bib_id' => 'MZK01000000421', 'duedate' => '', 'volume' => '',
+                    'number' => '', 'is_holdable' => false, 'addLink' => false,
                     'storageRetrievalRequest' => 'auto',
-                    'addStorageRetrievalRequestLink' => 'true',
-                    'eresource' => '',
-                    'item_agency_id' => 'My university',
-                    'holdtype' => 'Hold',
+                    'addStorageRetrievalRequestLink' => 'true', 'eresource' => '',
+                    'item_agency_id' => 'My university', 'holdtype' => 'Hold',
                     'barcode' => 'MZK01000000421-MZK50000000421000010',
-                ],
-                [
-                    'status' => 'Available On Shelf',
-                    'location' => null,
-                    'callnumber' => 'PK-0083.568',
-                    'availability' => true,
-                    'reserve' => 'N',
-                    'id' => '123456',
-                    'bib_id' => 'MZK01000062021',
+                ], [
+                    'status' => 'Available On Shelf', 'location' => null,
+                    'callnumber' => 'PK-0083.568', 'availability' => true,
+                    'reserve' => 'N', 'id' => '123456', 'bib_id' => 'MZK01000062021',
                     'item_id' => 'MZK01000062021-MZK50000062021000010',
-                    'item_agency_id' => 'Test agency',
-                    'duedate' => '12-08-2019',
-                    'volume' => '',
-                    'number' => '',
-                    'barcode' => 'Unknown barcode',
-                    'is_holdable' => true,
-                    'addLink' => true,
-                    'holdtype' => 'Hold',
+                    'item_agency_id' => 'Test agency', 'duedate' => '12-08-2019',
+                    'volume' => '', 'number' => '', 'barcode' => 'Unknown barcode',
+                    'is_holdable' => true, 'addLink' => true, 'holdtype' => 'Hold',
                     'storageRetrievalRequest' => 'auto',
-                    'addStorageRetrievalRequestLink' => 'true',
-                    'eresource' => '',
-                ],
-                [
+                    'addStorageRetrievalRequestLink' => 'true', 'eresource' => '',
+                ], [
                     'status' => 'Available On Shelf',
                     'location' => 'Some holding location',
-                    'callnumber' => '2-0997.767,2',
-                    'availability' => true,
-                    'reserve' => 'N',
-                    'id' => '123456',
+                    'callnumber' => '2-0997.767,2', 'availability' => true,
+                    'reserve' => 'N', 'id' => '123456',
                     'item_id' => 'MZK01000000425-MZK50000000425000020',
-                    'bib_id' => 'MZK01000000425',
-                    'item_agency_id' => 'Test agency',
-                    'duedate' => '',
-                    'volume' => '',
-                    'number' => '',
-                    'barcode' => 'Unknown barcode',
-                    'is_holdable' => true,
-                    'addLink' => true,
-                    'holdtype' => 'Hold',
+                    'bib_id' => 'MZK01000000425', 'item_agency_id' => 'Test agency',
+                    'duedate' => '', 'volume' => '', 'number' => '',
+                    'barcode' => 'Unknown barcode', 'is_holdable' => true,
+                    'addLink' => true, 'holdtype' => 'Hold',
                     'storageRetrievalRequest' => 'auto',
-                    'addStorageRetrievalRequestLink' => 'true',
-                    'eresource' => '',
+                    'addStorageRetrievalRequestLink' => 'true', 'eresource' => '',
                     'collection_desc' => 'Some holding sublocation',
-                ],
-                [
+                ], [
                     'status' => 'Circulation Status Undefined',
-                    'location' => 'Some holding location',
-                    'callnumber' => '',
-                    'availability' => false,
-                    'reserve' => 'N',
-                    'id' => '123456',
+                    'location' => 'Some holding location', 'callnumber' => '',
+                    'availability' => false, 'reserve' => 'N', 'id' => '123456',
                     'use_unknown_message' => true,
                     'item_id' => 'MZK01000000425-MZK50000000425000030',
-                    'bib_id' => 'MZK01000000425',
-                    'item_agency_id' => 'Test agency',
-                    'duedate' => '09-14-2020',
-                    'volume' => '',
-                    'number' => '',
-                    'barcode' => 'Unknown barcode',
-                    'is_holdable' => false,
-                    'addLink' => false,
-                    'holdtype' => 'Recall',
+                    'bib_id' => 'MZK01000000425', 'item_agency_id' => 'Test agency',
+                    'duedate' => '09-14-2020', 'volume' => '', 'number' => '',
+                    'barcode' => 'Unknown barcode', 'is_holdable' => false,
+                    'addLink' => false, 'holdtype' => 'Recall',
                     'storageRetrievalRequest' => 'auto',
-                    'addStorageRetrievalRequestLink' => 'true',
-                    'eresource' => '',
+                    'addStorageRetrievalRequestLink' => 'true', 'eresource' => '',
                     'collection_desc' => 'Some holding sublocation',
                 ],
             ],
-        ],
-    ];
+            ],
+        ];
 
     /**
      * Test definition for testPlaceHold
      *
      * @var array[]
      */
-    protected $placeHoldTests = [
-        [
-            'file' => 'RequestItemResponseAcceptedWithItemId.xml',
-            'result' => [
-                'success' => true,
-                'sysMessage' => 'Request Successful.'
+    protected $placeHoldTests
+        = [
+            [
+                'file' => 'RequestItemResponseAcceptedWithItemId.xml', 'result' => [
+                'success' => true, 'sysMessage' => 'Request Successful.'
             ],
-        ],
-        [
-            'file' => 'RequestItemResponseAcceptedWithRequestId.xml',
-            'result' => [
-                'success' => true,
-                'sysMessage' => 'Request Successful.'
+            ], [
+                'file' => 'RequestItemResponseAcceptedWithRequestId.xml',
+                'result' => [
+                    'success' => true, 'sysMessage' => 'Request Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDenied.xml', 'result' => [
+                    'success' => false, 'sysMessage' => 'Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
+                'result' => [
+                    'success' => false, 'sysMessage' => 'Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
+                'result' => [
+                    'success' => false, 'sysMessage' => 'Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedEmpty.xml', 'result' => [
+                    'success' => false, 'sysMessage' => 'Request Not Successful.'
+                ],
             ],
-        ],
-        [
-            'file' => 'RequestItemResponseDenied.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedEmpty.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Request Not Successful.'
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testPlaceStorageRetrievalRequest
      *
      * @var array[]
      */
-    protected $placeStorageRetrievalRequestTests = [
-        [
-            'file' => 'RequestItemResponseAcceptedWithItemId.xml',
-            'result' => [
+    protected $placeStorageRetrievalRequestTests
+        = [
+            [
+                'file' => 'RequestItemResponseAcceptedWithItemId.xml', 'result' => [
                 'success' => true,
                 'sysMessage' => 'Storage Retrieval Request Successful.'
             ],
-        ],
-        [
-            'file' => 'RequestItemResponseAcceptedWithRequestId.xml',
-            'result' => [
-                'success' => true,
-                'sysMessage' => 'Storage Retrieval Request Successful.'
+            ], [
+                'file' => 'RequestItemResponseAcceptedWithRequestId.xml',
+                'result' => [
+                    'success' => true,
+                    'sysMessage' => 'Storage Retrieval Request Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDenied.xml', 'result' => [
+                    'success' => false,
+                    'sysMessage' => 'Storage Retrieval Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
+                'result' => [
+                    'success' => false,
+                    'sysMessage' => 'Storage Retrieval Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
+                'result' => [
+                    'success' => false,
+                    'sysMessage' => 'Storage Retrieval Request Not Successful.'
+                ],
+            ], [
+                'file' => 'RequestItemResponseDeniedEmpty.xml', 'result' => [
+                    'success' => false,
+                    'sysMessage' => 'Storage Retrieval Request Not Successful.'
+                ],
             ],
-        ],
-        [
-            'file' => 'RequestItemResponseDenied.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Storage Retrieval Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Storage Retrieval Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Storage Retrieval Request Not Successful.'
-            ],
-        ],
-        [
-            'file' => 'RequestItemResponseDeniedEmpty.xml',
-            'result' => [
-                'success' => false,
-                'sysMessage' => 'Storage Retrieval Request Not Successful.'
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testCancelHolds
      *
      * @var array[]
      */
-    protected $cancelHoldsTests = [
-        [
-            'file' => 'CancelRequestItemResponseAccepted.xml',
-            'result' => [
-                'count' => 1,
-                'items' => [
+    protected $cancelHoldsTests
+        = [
+            [
+                'file' => 'CancelRequestItemResponseAccepted.xml', 'result' => [
+                'count' => 1, 'items' => [
                     'Item1' => [
-                        'success' => true,
-                        'status' => 'hold_cancel_success',
+                        'success' => true, 'status' => 'hold_cancel_success',
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'CancelRequestItemResponseDenied.xml',
-            'result' => [
-                'count' => 0,
-                'items' => [
-                    'Item1' => [
-                        'success' => false,
-                        'status' => 'hold_cancel_fail',
+            ], [
+                'file' => 'CancelRequestItemResponseDenied.xml', 'result' => [
+                    'count' => 0, 'items' => [
+                        'Item1' => [
+                            'success' => false, 'status' => 'hold_cancel_fail',
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'CancelRequestItemResponseDeniedWithUserId.xml',
+                'result' => [
+                    'count' => 0, 'items' => [
+                        'Item1' => [
+                            'success' => false, 'status' => 'hold_cancel_fail',
+                        ],
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'CancelRequestItemResponseDeniedWithUserId.xml',
-            'result' => [
-                'count' => 0,
-                'items' => [
-                    'Item1' => [
-                        'success' => false,
-                        'status' => 'hold_cancel_fail',
-                    ],
-                ],
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testCancelStorageRetrievalRequests
      *
      * @var array[]
      */
-    protected $cancelStorageRetrievalTests = [
-        [
-            'file' => 'CancelRequestItemResponseAccepted.xml',
-            'result' => [
-                'count' => 1,
-                'items' => [
+    protected $cancelStorageRetrievalTests
+        = [
+            [
+                'file' => 'CancelRequestItemResponseAccepted.xml', 'result' => [
+                'count' => 1, 'items' => [
                     'Item1' => [
                         'success' => true,
                         'status' => 'storage_retrieval_request_cancel_success',
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'CancelRequestItemResponseDenied.xml',
-            'result' => [
-                'count' => 0,
-                'items' => [
-                    'Item1' => [
-                        'success' => false,
-                        'status' => 'storage_retrieval_request_cancel_fail',
+            ], [
+                'file' => 'CancelRequestItemResponseDenied.xml', 'result' => [
+                    'count' => 0, 'items' => [
+                        'Item1' => [
+                            'success' => false,
+                            'status' => 'storage_retrieval_request_cancel_fail',
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'CancelRequestItemResponseDeniedWithUserId.xml',
+                'result' => [
+                    'count' => 0, 'items' => [
+                        'Item1' => [
+                            'success' => false,
+                            'status' => 'storage_retrieval_request_cancel_fail',
+                        ],
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'CancelRequestItemResponseDeniedWithUserId.xml',
-            'result' => [
-                'count' => 0,
-                'items' => [
-                    'Item1' => [
-                        'success' => false,
-                        'status' => 'storage_retrieval_request_cancel_fail',
-                    ],
-                ],
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definition for testRenewMyItems
      *
      * @var array[]
      */
-    protected $renewMyItemsTests = [
-        [
-            'file' => 'RenewItemResponseAccepted.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
+    protected $renewMyItemsTests
+        = [
+            [
+                'file' => 'RenewItemResponseAccepted.xml', 'result' => [
+                'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => true,
-                        'new_date' => '09-08-2020',
-                        'new_time' => '20:00',
-                        'item_id' => 'Item1'
+                        'success' => true, 'new_date' => '09-08-2020',
+                        'new_time' => '20:00', 'item_id' => 'Item1'
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'RenewItemResponseAcceptedAlternativeDateFormat.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => true,
-                        'new_date' => '08-31-2020',
-                        'new_time' => '17:59',
-                        'item_id' => 'Item1'
+            ], [
+                'file' => 'RenewItemResponseAcceptedAlternativeDateFormat.xml',
+                'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => true, 'new_date' => '08-31-2020',
+                            'new_time' => '17:59', 'item_id' => 'Item1'
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'RenewItemResponseDenied.xml', 'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => false, 'item_id' => 'Item1'
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'RenewItemResponseDeniedInvalidMessage.xml', 'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => false, 'item_id' => 'Item1'
+                        ],
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'RenewItemResponseDenied.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
-                    ],
-                ],
-            ],
-        ],
-        [
-            'file' => 'RenewItemResponseDeniedInvalidMessage.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
-                    ],
-                ],
-            ],
-        ],
-    ];
+        ];
 
-    protected $renewMyItemsWithDisabledRenewals = [
-        [
-            'file' => 'RenewItemResponseAccepted.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
+    protected $renewMyItemsWithDisabledRenewals
+        = [
+            [
+                'file' => 'RenewItemResponseAccepted.xml', 'result' => [
+                'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1'
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'RenewItemResponseAcceptedAlternativeDateFormat.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
+            ], [
+                'file' => 'RenewItemResponseAcceptedAlternativeDateFormat.xml',
+                'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => false, 'item_id' => 'Item1'
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'RenewItemResponseDenied.xml', 'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => false, 'item_id' => 'Item1'
+                        ],
+                    ],
+                ],
+            ], [
+                'file' => 'RenewItemResponseDeniedInvalidMessage.xml', 'result' => [
+                    'blocks' => false, 'details' => [
+                        'Item1' => [
+                            'success' => false, 'item_id' => 'Item1'
+                        ],
                     ],
                 ],
             ],
-        ],
-        [
-            'file' => 'RenewItemResponseDenied.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
-                    ],
-                ],
-            ],
-        ],
-        [
-            'file' => 'RenewItemResponseDeniedInvalidMessage.xml',
-            'result' => [
-                'blocks' => false,
-                'details' => [
-                    'Item1' => [
-                        'success' => false,
-                        'item_id' => 'Item1'
-                    ],
-                ],
-            ],
-        ],
-    ];
+        ];
 
     /**
      * Test definitions for getPatronBlocks tests
      *
      * @var array
      */
-    protected $patronBlocksTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => [],
-        ],
-        [
-            'file' => 'lookupUserResponseWithBlocks.xml',
-            'result' => [
-                'Block Request Item',
-                'Block Renewal',
+    protected $patronBlocksTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => [],
+            ], [
+                'file' => 'lookupUserResponseWithBlocks.xml', 'result' => [
+                    'Block Request Item', 'Block Renewal',
+                ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test definitions for getAccountBlocks tests
      *
      * @var array
      */
-    protected $accountBlocksTests = [
-        [
-            'file' => 'lookupUserResponse.xml',
-            'result' => false,
-        ],
-        [
-            'file' => 'lookupUserResponseWithAllBlocks.xml',
-            'result' => [
-                'requests_blocked',
-                'renewal_block',
-                'checkout_block',
-                'electronic_resources_block',
-                'lost_card',
-                'message_from_library',
-                'available_for_pickup_notification',
+    protected $accountBlocksTests
+        = [
+            [
+                'file' => 'lookupUserResponse.xml', 'result' => false,
+            ], [
+                'file' => 'lookupUserResponseWithAllBlocks.xml', 'result' => [
+                    'requests_blocked', 'renewal_block', 'checkout_block',
+                    'electronic_resources_block', 'lost_card',
+                    'message_from_library', 'available_for_pickup_notification',
+                ],
             ],
-        ],
-    ];
+        ];
 
     /**
      * Test getMyTransactions
@@ -977,10 +743,8 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $transactions = $this->driver->getMyTransactions([
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'patronAgencyId' => 'Test agency',
-                'id' => "patron_id",
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency', 'id' => "patron_id",
             ]);
             $this->assertEquals(
                 $test['result'],
@@ -991,7 +755,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     }
 
     /**
-     * Test getMyTransactions
+     * Test disable renewals configutaion
      *
      * @return void
      */
@@ -999,22 +763,18 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     {
         $config = [
             'Catalog' => [
-                'url' => 'https://test.ncip.example',
-                'consortium' => false,
+                'url' => 'https://test.ncip.example', 'consortium' => false,
                 'agency' => 'Test agency',
                 'pickupLocationsFile' => 'XCNCIP2_locations.txt',
                 'disableRenewals' => true,
-            ],
-            'NCIP' => [],
+            ], 'NCIP' => [],
         ];
         foreach ($this->notRenewableTransactionsTests as $test) {
             $this->configureDriver($config);
             $this->mockResponse($test['file']);
             $transactions = $this->driver->getMyTransactions([
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'patronAgencyId' => 'Test agency',
-                'id' => "patron_id",
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency', 'id' => "patron_id",
             ]);
             $this->assertEquals(
                 $test['result'],
@@ -1025,29 +785,28 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         foreach ($this->renewMyItemsWithDisabledRenewals as $test) {
             $this->configureDriver($config);
             $this->mockResponse($test['file']);
-            $result = $this->driver->renewMyItems(
-                [
+            $result = $this->driver->renewMyItems([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
                         'patronAgencyId' => 'Test agency',
-                    ],
-                    'details' => [
+                    ], 'details' => [
                         'My University|Item1',
                     ],
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $result,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $result, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
         $config['Catalog']['disableRenewals'] = false;
         foreach ($this->transactionsTests as $test) {
             $this->configureDriver($config);
             $this->mockResponse($test['file']);
             $transactions = $this->driver->getMyTransactions([
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'patronAgencyId' => 'Test agency',
-                'id' => "patron_id",
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency', 'id' => "patron_id",
             ]);
             $this->assertEquals(
                 $test['result'],
@@ -1067,15 +826,15 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         foreach ($this->finesTests as $test) {
             $this->configureDriver();
             $this->mockResponse($test['file']);
-            $fines = $this->driver->getMyFines(
-                [
-                    'cat_username' => 'my_login',
-                    'cat_password' => 'my_password',
-                    'patronAgencyId' => 'Test agency',
-                    'id' => "patron_id",
-                ]
+            $fines = $this->driver->getMyFines([
+                    'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                    'patronAgencyId' => 'Test agency', 'id' => "patron_id",
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $fines,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $fines, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1090,7 +849,11 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $patron = $this->driver->patronLogin('my_login', 'my_password');
-            $this->assertEquals($test['result'], $patron, 'Fixture file: ' . implode(', ', (array)$test['file']));
+            $this->assertEquals(
+                $test['result'],
+                $patron,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
+            );
         }
     }
 
@@ -1105,12 +868,14 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $holds = $this->driver->getMyHolds([
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'patronAgencyId' => 'Test agency',
-                'id' => "patron_id",
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency', 'id' => "patron_id",
             ]);
-            $this->assertEquals($test['result'], $holds, 'Fixture file: ' . implode(', ', (array)$test['file']));
+            $this->assertEquals(
+                $test['result'],
+                $holds,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
+            );
         }
     }
 
@@ -1124,15 +889,15 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         foreach ($this->profileTests as $test) {
             $this->configureDriver();
             $this->mockResponse($test['file']);
-            $profile = $this->driver->getMyProfile(
-                [
-                    'cat_username' => 'my_login',
-                    'cat_password' => 'my_password',
-                    'patronAgencyId' => 'Test agency',
-                    'id' => "patron_id",
-                ]
+            $profile = $this->driver->getMyProfile([
+                    'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                    'patronAgencyId' => 'Test agency', 'id' => "patron_id",
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $profile,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $profile, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1147,12 +912,14 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $storageRetrievals = $this->driver->getMyStorageRetrievalRequests([
-                'cat_username' => 'my_login',
-                'cat_password' => 'my_password',
-                'patronAgencyId' => 'Test agency',
-                'id' => "patron_id",
+                'cat_username' => 'my_login', 'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency', 'id' => "patron_id",
             ]);
-            $this->assertEquals($test['result'], $storageRetrievals, 'Fixture file: ' . implode(', ', (array)$test['file']));
+            $this->assertEquals(
+                $test['result'],
+                $storageRetrievals,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
+            );
         }
     }
 
@@ -1167,7 +934,11 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $status = $this->driver->getStatuses(['Some Id']);
-            $this->assertEquals($test['result'], $status, 'Fixture file: ' . implode(', ', (array)$test['file']));
+            $this->assertEquals(
+                $test['result'],
+                $status,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
+            );
         }
     }
 
@@ -1182,7 +953,11 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->configureDriver();
             $this->mockResponse($test['file']);
             $holdings = $this->driver->getHolding('123456');
-            $this->assertEquals($test['result'], $holdings, 'Fixture file: ' . implode(', ', (array)$test['file']));
+            $this->assertEquals(
+                $test['result'],
+                $holdings,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
+            );
         }
     }
 
@@ -1200,45 +975,34 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             [
                 'locationID' => 'My University|1',
                 'locationDisplay' => 'Main Circulation Desk',
-            ],
-            [
-                'locationID' => 'My University|2',
-                'locationDisplay' => 'Stacks',
+            ], [
+                'locationID' => 'My University|2', 'locationDisplay' => 'Stacks',
             ]
         ], $locations);
 
         // Test reading pickup locations from NCIP responder
         $this->configureDriver([
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['Test agency'],
-                    'pickupLocationsFromNCIP' => true,
-                ],
-                'NCIP' => [],
-            ]);
+            'Catalog' => [
+                'url' => 'https://test.ncip.example', 'consortium' => false,
+                'agency' => ['Test agency'], 'pickupLocationsFromNCIP' => true,
+            ], 'NCIP' => [],
+        ]);
         $this->mockResponse('LookupAgencyResponse.xml');
         $locations = $this->driver->getPickUpLocations([]);
         $this->assertEquals([
             [
-                'locationID' => 'My library|1',
-                'locationDisplay' => 'Main library',
-            ],
-            [
-                'locationID' => 'My library|2',
-                'locationDisplay' => 'Stacks',
+                'locationID' => 'My library|1', 'locationDisplay' => 'Main library',
+            ], [
+                'locationID' => 'My library|2', 'locationDisplay' => 'Stacks',
             ]
         ], $locations);
 
         // Test reading pickup locations from NCIP, but response is without locations
         $this->configureDriver([
             'Catalog' => [
-                'url' => 'https://test.ncip.example',
-                'consortium' => false,
-                'agency' => ['Test agency'],
-                'pickupLocationsFromNCIP' => true,
-            ],
-            'NCIP' => [],
+                'url' => 'https://test.ncip.example', 'consortium' => false,
+                'agency' => ['Test agency'], 'pickupLocationsFromNCIP' => true,
+            ], 'NCIP' => [],
         ]);
         $this->mockResponse('LookupAgencyResponseWithoutLocations.xml');
         $locations = $this->driver->getPickUpLocations([]);
@@ -1255,22 +1019,21 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $this->configureDriver();
         foreach ($this->placeHoldTests as $test) {
             $this->mockResponse($test['file']);
-            $hold = $this->driver->placeHold(
-                [
+            $hold = $this->driver->placeHold([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
                         'patronAgencyId' => 'Test agency',
-                    ],
-                    'bib_id' => '1',
-                    'item_id' => '1',
-                    'pickUpLocation' => 'My University|1',
-                    'holdtype' => 'title',
+                    ], 'bib_id' => '1', 'item_id' => '1',
+                    'pickUpLocation' => 'My University|1', 'holdtype' => 'title',
                     'requiredBy' => '2020-12-30',
                     'item_agency_id' => 'My University',
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $hold,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $hold, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1284,22 +1047,21 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $this->configureDriver();
         foreach ($this->placeStorageRetrievalRequestTests as $test) {
             $this->mockResponse($test['file']);
-            $result = $this->driver->placeStorageRetrievalRequest(
-                [
+            $result = $this->driver->placeStorageRetrievalRequest([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
                         'patronAgencyId' => 'Test agency',
-                    ],
-                    'bib_id' => '1',
-                    'item_id' => '1',
-                    'pickUpLocation' => 'My University|1',
-                    'holdtype' => 'title',
+                    ], 'bib_id' => '1', 'item_id' => '1',
+                    'pickUpLocation' => 'My University|1', 'holdtype' => 'title',
                     'requiredBy' => '2020-12-30',
                     'item_agency_id' => 'My University',
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $result,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $result, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1313,20 +1075,20 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $this->configureDriver();
         foreach ($this->cancelHoldsTests as $test) {
             $this->mockResponse($test['file']);
-            $result = $this->driver->cancelHolds(
-                [
+            $result = $this->driver->cancelHolds([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
-                        'patronAgencyId' => 'Test agency',
-                        'id' => '123'
-                    ],
-                    'details' => [
+                        'patronAgencyId' => 'Test agency', 'id' => '123'
+                    ], 'details' => [
                         'My University|Request1|Item1',
                     ],
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $result,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $result, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1340,20 +1102,20 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $this->configureDriver();
         foreach ($this->cancelStorageRetrievalTests as $test) {
             $this->mockResponse($test['file']);
-            $result = $this->driver->cancelStorageRetrievalRequests(
-                [
+            $result = $this->driver->cancelStorageRetrievalRequests([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
-                        'patronAgencyId' => 'Test agency',
-                        'id' => '123'
-                    ],
-                    'details' => [
+                        'patronAgencyId' => 'Test agency', 'id' => '123'
+                    ], 'details' => [
                         'My University|Request1|Item1',
                     ],
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $result,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $result, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1367,19 +1129,20 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $this->configureDriver();
         foreach ($this->renewMyItemsTests as $test) {
             $this->mockResponse($test['file']);
-            $result = $this->driver->renewMyItems(
-                [
+            $result = $this->driver->renewMyItems([
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
                         'patronAgencyId' => 'Test agency',
-                    ],
-                    'details' => [
+                    ], 'details' => [
                         'My University|Item1',
                     ],
-                ]
+                ]);
+            $this->assertEquals(
+                $test['result'],
+                $result,
+                'Fixture file: ' . implode(', ', (array)$test['file'])
             );
-            $this->assertEquals($test['result'], $result, 'Fixture file: ' . implode(', ', (array)$test['file']));
         }
     }
 
@@ -1388,118 +1151,96 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
      *
      * @var array[]
      */
-    protected $requestTests = [
-        '1' => [
-            'method' => 'getStatusRequest',
-            'config' => [
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['Test agency'],
-                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-                    'fromAgency' => 'My portal',
+    protected $requestTests
+        = [
+            '1' => [
+                'method' => 'getStatusRequest', 'config' => [
+                    'Catalog' => [
+                        'url' => 'https://test.ncip.example', 'consortium' => false,
+                        'agency' => ['Test agency'],
+                        'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                        'fromAgency' => 'My portal',
+                    ], 'NCIP' => [],
+                ], 'params' => [['1'], null, 'Test agency'],
+                'result' => 'LookupItemSetRequest.xml',
+            ], '2' => [
+                'method' => 'getStatusRequest',
+                'params' => [['1'], null, 'Test agency'],
+                'result' => 'LookupItemSetRequestWithoutHeader.xml',
+            ], '3' => [
+                'method' => 'getCancelRequest', 'params' => [
+                    '', '', 'patron agency', 'item agency', 'rq1', 'Hold', 'item1',
+                    '12345'
+                ], 'result' => 'CancelRequestItemRequest.xml'
+            ], '4' => [
+                'method' => 'getCancelRequest', 'params' => [
+                    'username', 'password', 'patron agency', 'item agency', 'rq1',
+                    'Hold', 'item1', '12345'
+                ], 'result' => 'CancelRequestItemRequestAuthInput.xml'
+            ], '4.1' => [
+                'method' => 'getCancelRequest', 'config' => [
+                    'Catalog' => [
+                        'url' => 'https://test.ncip.example', 'consortium' => false,
+                        'agency' => ['default agency'],
+                        'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                        'fromAgency' => 'My portal',
+                    ], 'NCIP' => [],
+                ], 'params' => [
+                    'username', 'password', 'patron agency', '', 'rq1', 'Hold',
+                    'item1', '12345'
+                ], 'result' => 'CancelRequestDefaultItemAgencyRequest.xml'
+            ], '5' => [
+                'method' => 'getRenewRequest', 'params' => [
+                    'username', 'password', 'item1', 'item agency', 'patron agency'
+                ], 'result' => 'RenewItemRequest.xml'
+            ], '5.1' => [
+                'method' => 'getRenewRequest', 'config' => [
+                    'Catalog' => [
+                        'url' => 'https://test.ncip.example', 'consortium' => false,
+                        'agency' => ['default agency'],
+                        'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                        'fromAgency' => 'My portal',
+                    ], 'NCIP' => [],
                 ],
-                'NCIP' => [],
+                'params' => ['username', 'password', 'item1', '', 'patron agency'],
+                'result' => 'RenewItemDefaultAgencyRequest.xml'
+            ], '5.2' => [
+                'method' => 'getRenewRequest', 'params' => [
+                    'username', 'password', 'item1', 'item agency', 'patron agency',
+                    'username'
+                ], 'result' => 'RenewItemWithUserIdRequest.xml'
+            ], '6' => [
+                'method' => 'getRequest', 'config' => [
+                    'Catalog' => [
+                        'url' => 'https://test.ncip.example', 'consortium' => false,
+                        'agency' => ['Test agency'],
+                        'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                        'fromAgency' => 'My portal',
+                    ], 'NCIP' => [],
+                ], 'params' => [
+                    'username', '', 'bib1', 'item1', 'patron agency', 'item agency',
+                    'Hold', 'Item', '2020-12-20T00:00:00.000Z', null, 'patron1'
+                ], 'result' => 'RequestItemRequest.xml'
+            ], '7' => [
+                'method' => 'getLookupUserRequest', 'params' => [
+                    null, 'password', 'patron agency',
+                    ['<ns1:LoanedItemsDesired />'], 'patron1'
+                ], 'result' => 'LookupUserRequest.xml'
+            ], '8' => [
+                'method' => 'getLookupAgencyRequest', 'params' => [null],
+                'result' => 'LookupAgencyRequest.xml'
+            ], '9' => [
+                'method' => 'getLookupItemRequest', 'config' => [
+                    'Catalog' => [
+                        'url' => 'https://test.ncip.example', 'consortium' => false,
+                        'agency' => ['Test agency'],
+                        'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                        'fromAgency' => 'My portal',
+                    ], 'NCIP' => [],
+                ], 'params' => ['item1', 'Accession Number'],
+                'result' => 'LookupItemRequest.xml'
             ],
-            'params' => [['1'], null, 'Test agency'],
-            'result' => 'LookupItemSetRequest.xml',
-        ],
-        '2' => [
-            'method' => 'getStatusRequest',
-            'params' => [['1'], null, 'Test agency'],
-            'result' => 'LookupItemSetRequestWithoutHeader.xml',
-        ],
-        '3' => [
-            'method' => 'getCancelRequest',
-            'params' => ['', '', 'patron agency', 'item agency', 'rq1', 'Hold', 'item1', '12345'],
-            'result' => 'CancelRequestItemRequest.xml'
-        ],
-        '4' => [
-            'method' => 'getCancelRequest',
-            'params' => ['username', 'password', 'patron agency', 'item agency', 'rq1', 'Hold', 'item1', '12345'],
-            'result' => 'CancelRequestItemRequestAuthInput.xml'
-        ],
-        '4.1' => [
-            'method' => 'getCancelRequest',
-            'config' => [
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['default agency'],
-                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-                    'fromAgency' => 'My portal',
-                ],
-                'NCIP' => [],
-            ],
-            'params' => ['username', 'password', 'patron agency', '', 'rq1', 'Hold', 'item1', '12345'],
-            'result' => 'CancelRequestDefaultItemAgencyRequest.xml'
-        ],
-        '5' => [
-            'method' => 'getRenewRequest',
-            'params' => ['username', 'password', 'item1', 'item agency', 'patron agency'],
-            'result' => 'RenewItemRequest.xml'
-        ],
-        '5.1' => [
-            'method' => 'getRenewRequest',
-            'config' => [
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['default agency'],
-                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-                    'fromAgency' => 'My portal',
-                ],
-                'NCIP' => [],
-            ],
-            'params' => ['username', 'password', 'item1', '', 'patron agency'],
-            'result' => 'RenewItemDefaultAgencyRequest.xml'
-        ],
-        '5.2' => [
-            'method' => 'getRenewRequest',
-            'params' => ['username', 'password', 'item1', 'item agency', 'patron agency', 'username'],
-            'result' => 'RenewItemWithUserIdRequest.xml'
-        ],
-        '6' => [
-            'method' => 'getRequest',
-            'config' => [
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['Test agency'],
-                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-                    'fromAgency' => 'My portal',
-                ],
-                'NCIP' => [],
-            ],
-            'params' => ['username', '', 'bib1', 'item1', 'patron agency', 'item agency', 'Hold', 'Item', '2020-12-20T00:00:00.000Z', null, 'patron1'],
-            'result' => 'RequestItemRequest.xml'
-        ],
-        '7' => [
-            'method' => 'getLookupUserRequest',
-            'params' => [null, 'password', 'patron agency', ['<ns1:LoanedItemsDesired />'], 'patron1'],
-            'result' => 'LookupUserRequest.xml'
-        ],
-        '8' => [
-            'method' => 'getLookupAgencyRequest',
-            'params' => [null],
-            'result' => 'LookupAgencyRequest.xml'
-        ],
-        '9' => [
-            'method' => 'getLookupItemRequest',
-            'config' => [
-                'Catalog' => [
-                    'url' => 'https://test.ncip.example',
-                    'consortium' => false,
-                    'agency' => ['Test agency'],
-                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-                    'fromAgency' => 'My portal',
-                ],
-                'NCIP' => [],
-            ],
-            'params' => ['item1', 'Accession Number'],
-            'result' => 'LookupItemRequest.xml'
-        ],
-    ];
+        ];
 
     /**
      * Test methods for creating NCIP requests
@@ -1510,13 +1251,15 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     {
         foreach ($this->requestTests as $id => $test) {
             $this->configureDriver($test['config'] ?? null);
-            $method = new \ReflectionMethod('\VuFind\ILS\Driver\XCNCIP2', $test['method']);
+            $method = new \ReflectionMethod(
+                '\VuFind\ILS\Driver\XCNCIP2',
+                $test['method']
+            );
             $method->setAccessible(true);
             $request = $method->invokeArgs($this->driver, $test['params'] ?? []);
             $file = realpath(
-                __DIR__ .
-                '/../../../../../../tests/fixtures/xcncip2/request/' .
-                $test['result']
+                __DIR__ . '/../../../../../../tests/fixtures/xcncip2/request/'
+                . $test['result']
             );
             $expected = file_get_contents($file);
             $this->assertEquals($expected, $request, 'Test identifier: ' . $id);
@@ -1532,11 +1275,20 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     public function testGetCancelRequestException()
     {
         $this->configureDriver();
-        $method = new \ReflectionMethod('\VuFind\ILS\Driver\XCNCIP2', 'getCancelRequest');
+        $method = new \ReflectionMethod(
+            '\VuFind\ILS\Driver\XCNCIP2',
+            'getCancelRequest'
+        );
         $method->setAccessible(true);
         $this->expectException(\VuFind\Exception\ILS::class);
         $this->expectExceptionMessage('No identifiers for CancelRequest');
-        $request = $method->invokeArgs($this->driver, ['username', 'password', 'patron agency', 'item agency', '', 'Hold', null, '12345']);
+        $request = $method->invokeArgs(
+            $this->driver,
+            [
+            'username', 'password', 'patron agency', 'item agency', '', 'Hold', null,
+            '12345'
+        ]
+        );
     }
 
     /**
@@ -1550,9 +1302,15 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         foreach ($this->patronBlocksTests as $test) {
             $this->configureDriver();
             $this->mockResponse($test['file']);
-            $method = new \ReflectionMethod('\VuFind\ILS\Driver\XCNCIP2', 'getPatronBlocks');
+            $method = new \ReflectionMethod(
+                '\VuFind\ILS\Driver\XCNCIP2',
+                'getPatronBlocks'
+            );
             $method->setAccessible(true);
-            $blocks = $method->invokeArgs($this->driver, [['cat_username' => 'test']]);
+            $blocks = $method->invokeArgs(
+                $this->driver,
+                [['cat_username' => 'test']]
+            );
             $this->assertEquals($test['result'], $blocks);
         }
     }
@@ -1581,15 +1339,21 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     public function testIsPatronBlocked(): void
     {
         $tests = [
-            ['file' => 'lookupUserResponseWithBlocks.xml', 'result' => true, ],
-            ['file' => 'lookupUserResponseWithTraps.xml', 'result' => false, ],
+            ['file' => 'lookupUserResponseWithBlocks.xml', 'result' => true,],
+            ['file' => 'lookupUserResponseWithTraps.xml', 'result' => false,],
         ];
         foreach ($tests as $test) {
             $this->configureDriver();
             $this->mockResponse($test['file']);
-            $method = new \ReflectionMethod('\VuFind\ILS\Driver\XCNCIP2', 'isPatronBlocked');
+            $method = new \ReflectionMethod(
+                '\VuFind\ILS\Driver\XCNCIP2',
+                'isPatronBlocked'
+            );
             $method->setAccessible(true);
-            $blocked = $method->invokeArgs($this->driver, [['cat_username' => 'test']]);
+            $blocked = $method->invokeArgs(
+                $this->driver,
+                [['cat_username' => 'test']]
+            );
             $this->assertEquals($test['result'], $blocked);
         }
     }
@@ -1602,19 +1366,84 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
      */
     public function testParseProblem()
     {
-        $xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><NCIPMessage xmlns="http://www.niso.org/2008/ncip"><Problem><ProblemType>Needed Data Missing</ProblemType><ProblemDetail>UserId or AuthenticationInput must be provided.</ProblemDetail><ProblemElement>LookupUser</ProblemElement></Problem></NCIPMessage>';
-        $method = new \ReflectionMethod('\VuFind\ILS\Driver\XCNCIP2', 'parseProblem');
+        $xml
+            = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><NCIPMessage xmlns="http://www.niso.org/2008/ncip"><Problem><ProblemType>Needed Data Missing</ProblemType><ProblemDetail>UserId or AuthenticationInput must be provided.</ProblemDetail><ProblemElement>LookupUser</ProblemElement></Problem></NCIPMessage>';
+        $method = new \ReflectionMethod(
+            '\VuFind\ILS\Driver\XCNCIP2',
+            'parseProblem'
+        );
         $method->setAccessible(true);
         $result = $method->invokeArgs($this->driver, [$xml]);
-        $expected = 'ProblemType: Needed Data Missing, ProblemDetail: UserId or AuthenticationInput must be provided., ProblemElement: LookupUser';
+        $expected
+            = 'ProblemType: Needed Data Missing, ProblemDetail: UserId or AuthenticationInput must be provided., ProblemElement: LookupUser';
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test other accepted HTTP status code configuration
+     *
+     * @return void
+     */
+    public function testAcceptOtherHttpStastusCodes()
+    {
+        $config = [
+            'Catalog' => [
+                'url' => 'https://test.ncip.example', 'consortium' => false,
+                'agency' => 'Test agency',
+                'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                'otherAcceptedHttpStatusCodes' => '400,404',
+            ], 'NCIP' => [],
+        ];
+        $this->configureDriver($config);
+        $this->mockResponse('RenewItemResponse404.xml');
+        $renew = $this->driver->renewMyItems([
+            'patron' => [
+                'cat_username' => 'my_login',
+                'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency',
+            ], 'details' => [
+                'My University|Item1',
+            ],
+        ]);
+        $expected = [
+            'blocks' => false,
+            'details' => [
+                'Item1' => [
+                    'success' => false,
+                    'item_id' => 'Item1',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $renew);
+
+        $config = [
+            'Catalog' => [
+                'url' => 'https://test.ncip.example', 'consortium' => false,
+                'agency' => 'Test agency',
+                'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+            ], 'NCIP' => [],
+        ];
+        $this->configureDriver($config);
+        $this->mockResponse('RenewItemResponse404.xml');
+        $this->expectException(\VuFind\Exception\ILS::class);
+        $this->expectExceptionMessage('HTTP error: ProblemType: Item Not Renewable, ProblemDetail: No active registration.');
+        $renew = $this->driver->renewMyItems([
+            'patron' => [
+                'cat_username' => 'my_login',
+                'cat_password' => 'my_password',
+                'patronAgencyId' => 'Test agency',
+            ], 'details' => [
+                'My University|Item1',
+            ],
+        ]);
     }
 
     /**
      * Mock fixture as HTTP client response
      *
      * @param string|array|null $fixture Fixture file
-     **
+     *                                   *
+     *
      * @throws InvalidArgumentException Fixture file does not exist
      */
     protected function mockResponse($fixture = null)
@@ -1660,15 +1489,15 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
     protected function configureDriver($config = null)
     {
         $this->driver = new XCNCIP2(new \VuFind\Date\Converter());
-        $this->driver->setConfig($config ?? [
-            'Catalog' => [
-                'url' => 'https://test.ncip.example',
-                'consortium' => false,
-                'agency' => 'Test agency',
-                'pickupLocationsFile' => 'XCNCIP2_locations.txt',
-            ],
-            'NCIP' => [],
-        ]);
+        $this->driver->setConfig(
+            $config ?? [
+                'Catalog' => [
+                    'url' => 'https://test.ncip.example', 'consortium' => false,
+                    'agency' => 'Test agency',
+                    'pickupLocationsFile' => 'XCNCIP2_locations.txt',
+                ], 'NCIP' => [],
+            ]
+        );
         $this->driver->init();
     }
 }


### PR DESCRIPTION
Some NCIP responders could send other than 2xx codes when there is an issue, but response with 'Problem' element is still valid NCIP response and we may need to parse it.