### PR TITLE
Return appropriate errorlevels from import .bat files.

### DIFF
--- a/import-marc-auth.bat
+++ b/import-marc-auth.bat
@@ -61,5 +61,6 @@ set EXTRA_SOLRMARC_SETTINGS="-Dsolr.indexer.properties=%MAPPINGS_FILES%"
 
 rem Call the standard script:
 call %VUFIND_HOME%\import-marc.bat %1
+exit /b %ERRORLEVEL%
 
 :end

--- a/import-marc.bat
+++ b/import-marc.bat
@@ -123,6 +123,7 @@ set RUN_CMD=%JAVA% %INDEX_OPTIONS% -Duser.timezone=UTC -Dlog4j.configuration="fi
 echo Now Importing %1 ...
 echo %RUN_CMD%
 %RUN_CMD%
+exit /b %ERRORLEVEL%
 
 :end
 


### PR DESCRIPTION
This is an incremental step toward implementing Windows support in #2175 -- it makes sure that the import .bat files return appropriate error levels after running SolrMarc.