### PR TITLE
Fix truncate default labels.

### DIFF
--- a/themes/bootstrap3/js/truncate.js
+++ b/themes/bootstrap3/js/truncate.js
@@ -1,19 +1,19 @@
 /* global VuFind */
 
 VuFind.register('truncate', function Truncate() {
-  const defaultSettings = {
-    'btn-class': '',
-    'in-place-toggle': false,
-    'label': null,
-    'less-label': VuFind.translate('show_less'),
-    'more-label': VuFind.translate('show_more'),
-    'rows': 3,
-    'top-toggle': Infinity,
-    'wrapper-class': '', // '' will glean from element, false or null will exclude a class
-    'wrapper-tagname': null, // falsey values will glean from element
-  };
-
   function initTruncate(_container, _element, _fill) {
+    const defaultSettings = {
+      'btn-class': '',
+      'in-place-toggle': false,
+      'label': null,
+      'less-label': VuFind.translate('less'),
+      'more-label': VuFind.translate('more'),
+      'rows': 3,
+      'top-toggle': Infinity,
+      'wrapper-class': '', // '' will glean from element, false or null will exclude a class
+      'wrapper-tagname': null, // falsey values will glean from element
+    };
+
     var zeroHeightContainers = [];
 
     $(_container).not('.truncate-done').each(function truncate() {

--- a/themes/bootstrap3/templates/layout/js-translations.phtml
+++ b/themes/bootstrap3/templates/layout/js-translations.phtml
@@ -13,6 +13,7 @@ $this->jsTranslations()->addStrings(
       'error_occurred' => 'An error has occurred',
       'go_to_list' => 'go_to_list',
       'hold_available' => 'hold_available',
+      'less' => 'less',
       'libphonenumber_invalid' => 'libphonenumber_invalid',
       'libphonenumber_invalidcountry' => 'libphonenumber_invalidcountry',
       'libphonenumber_invalidregion' => 'libphonenumber_invalidregion',


### PR DESCRIPTION
Initialize the default settings in the initTruncate method to make sure that translations have been added to the VuFind object. Use translations that are actually available. 