### PR TITLE
[VUFIND-1476] Improvements to the Evergreen ILS driver

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
@@ -894,7 +894,9 @@ HERE;
      */
     private function _formatDate($date)
     {
+        if (!$date) {
+            return '';
+        }
         return $this->dateConverter->convertToDisplayDate('Y-m-d', $date);
-        //return $date ? (new \DateTime($date))->format('Y-m-d') : '';
     }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
@@ -22,6 +22,7 @@
  * @category VuFind
  * @package  ILS_Drivers
  * @author   Warren Layton, NRCan Library <warren.layton@gmail.com>
+ * @author   Galen Charlton, Equinox Open Library Initiative <gmcharlt@equinoxOLI.org>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
@@ -43,8 +44,10 @@ use VuFind\Exception\ILS as ILSException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class Evergreen extends AbstractBase
+class Evergreen extends AbstractBase implements \Laminas\Log\LoggerAwareInterface
 {
+    use \VuFind\Log\LoggerAwareTrait;
+
     /**
      * Database connection
      *
@@ -58,6 +61,29 @@ class Evergreen extends AbstractBase
      * @var string
      */
     protected $dbName;
+
+
+    /**
+     * Date converter object
+     *
+     * @var \VuFind\Date\Converter
+     */
+    protected $dateConverter;
+
+    /**
+     * Constructor
+     *
+     * @param \VuFind\Date\Converter $dateConverter Date converter
+     */
+    public function __construct(\VuFind\Date\Converter $dateConverter)
+    {
+        $this->dateConverter = $dateConverter;
+    }
+
+    /**
+     * Evergreen constants
+     */
+    public const EVG_ITEM_STATUS_IN_TRANSIT = '6';
 
     /**
      * Initialize the driver.
@@ -317,7 +343,7 @@ SELECT usr.id, usr.first_given_name as firstName,
 FROM actor.usr usr
     INNER JOIN actor.card ON usr.card = card.id
 WHERE card.active = true
-    AND usr.passwd = MD5(?)
+    AND actor.verify_passwd(usr.id, 'main', MD5(actor.get_salt(usr.id, 'main') || MD5(?)))
 HERE;
         if (is_numeric($barcode)) {
             // A barcode was supplied as ID
@@ -368,33 +394,68 @@ HERE;
     {
         $transList = [];
 
-        $sql = "select circulation.target_copy as bib_id, " .
-               "extract (year from circulation.due_date) as due_year, " .
-               "extract (month from circulation.due_date) as due_month, " .
-               "extract (day from circulation.due_date) as due_day " .
+        $sql = "select call_number.record as bib_id, " .
+               "circulation.due_date as due_date, " .
+               "circulation.target_copy as item_id, " .
+               "circulation.renewal_remaining as renewal_remaining, " .
+               "aou_circ.name as borrowing_location, " .
+               "aou_own.name as owning_library, " .
+               "copy.barcode as barcode " .
                "from $this->dbName.action.circulation " .
+               "join $this->dbName.asset.copy ON (circulation.target_copy = copy.id) " .
+               "join $this->dbName.asset.call_number ON (copy.call_number = call_number.id) " .
+               "join $this->dbName.actor.org_unit aou_circ ON (circulation.circ_lib = aou_circ.id) " .
+               "join $this->dbName.actor.org_unit aou_own ON (call_number.owning_lib = aou_own.id) " .
                "where circulation.usr = '" . $patron['id'] . "' " .
-               "and circulation.checkin_time is null";
+               "and circulation.checkin_time is null " .
+               "and circulation.xact_finish is null";
 
         try {
             $sqlStmt = $this->db->prepare($sql);
             $sqlStmt->execute();
 
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
-                if ($row['due_year']) {
-                    $due_date = $row['due_year'] . "-" . $row['due_month'] . "-" .
-                                $row['due_day'];
+                $due_date = $this->_format_date($row['due_date']);
+                $_due_time = new \DateTime($row['due_date']);
+                if ($_due_time->format('H:i:s') == "23:59:59") {
+                    $dueTime = ""; // don't display due time for non-hourly loans
                 } else {
-                    $due_date = "";
+                    $dueTime = $this->dateConverter->convertToDisplayTime("Y-m-d H:i", $row['due_date']);
                 }
 
-                $transList[] = ['duedate' => $due_date,
-                                     'id' => $row['bib_id']];
+                $today = new \DateTime();
+                $now = time();
+                // since Evergreen normalizes the due time of non-hourly
+                // loans to be 23:59:59, we use a slightly flexible definition
+                // of "due in 24 hours"
+                $end_of_today = strtotime($today->format('Y-m-d 23:59:59'));
+                $dueTimeStamp = strtotime($row['due_date']);
+                $dueStatus = false;
+                if (is_numeric($dueTimeStamp)) {
+                    if ($now > $dueTimeStamp) {
+                        $dueStatus = 'overdue';
+                    } elseif ($end_of_today > $dueTimeStamp - (1 * 24 * 60 * 60) - 1) {
+                        $dueStatus = 'due';
+                    }
+                }
+
+                $transList[] = [
+                                    'duedate' => $due_date,
+                                    'dueTime' => $dueTime,
+                                    'id' => $row['bib_id'],
+                                    'barcode' => $row['barcode'],
+                                    'item_id' => $row['item_id'],
+                                    'renewLimit' => $row['renewal_remaining'],
+                                    'renewable' => $row['renewal_remaining'] > 1,
+                                    'institution_name' => $row['owning_library'],
+                                    'borrowingLocation' => $row['borrowing_location'],
+                                    'dueStatus' => $dueStatus
+                               ];
             }
         } catch (PDOException $e) {
             $this->throwAsIlsException($e);
         }
-        return $transList;
+        return ['count' => count($transList), 'records' => $transList];
     }
 
     /**
@@ -412,21 +473,22 @@ HERE;
     {
         $fineList = [];
 
-        $sql = "select billable_xact_summary.total_owed, " .
-               "billable_xact_summary.balance_owed, " .
+        $sql = "select billable_xact_summary.total_owed * 100 as total_owed, " .
+               "billable_xact_summary.balance_owed * 100 as balance_owed, " .
                "billable_xact_summary.last_billing_type, " .
-               "extract (year from billable_xact_summary.xact_start) " .
-               "as start_year, " .
-               "extract (month from billable_xact_summary.xact_start) " .
-               "as start_month, " .
-               "extract (day from billable_xact_summary.xact_start) " .
-               "as start_day, " .
-               "billable_cirulations.target_copy " .
+               "billable_xact_summary.last_billing_ts, " .
+               "billable_circulations.create_time as checkout_time, " .
+               "billable_circulations.due_date, " .
+               "billable_circulations.target_copy, " .
+               "call_number.record " .
                "from $this->dbName.money.billable_xact_summary " .
-               "LEFT JOIN $this->dbName.action.billable_cirulations " .
-               "ON (billable_xact_summary.id = billable_cirulations.id " .
-               " and billable_cirulations.xact_finish is null) " .
+               "LEFT JOIN $this->dbName.action.billable_circulations " .
+               "ON (billable_xact_summary.id = billable_circulations.id " .
+               " and billable_circulations.xact_finish is null) " .
+               "LEFT JOIN $this->dbName.asset.copy ON (billable_circulations.target_copy = copy.id) " .
+               "LEFT JOIN $this->dbName.asset.call_number ON (copy.call_number = call_number.id) " .
                "where billable_xact_summary.usr = '" . $patron['id'] . "' " .
+               "and billable_xact_summary.total_owed <> 0 " .
                "and billable_xact_summary.xact_finish is null";
 
         try {
@@ -434,19 +496,15 @@ HERE;
             $sqlStmt->execute();
 
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
-                if ($row['start_year']) {
-                    $charge_date = $row['start_year'] . "-" . $row['start_month'] .
-                            "-" . $row['start_day'];
-                } else {
-                    $charge_date = "";
-                }
-
-                $fineList[] = ['amount' => $row['total_owed'],
-                                    'fine' => $row['last_billing_type'],
-                                    'balance' => $row['balance_owed'],
-                                    'checkout' => $charge_date,
-                                    'duedate' => "",
-                                    'id' => $row['target_copy']];
+                $fineList[] = [
+                    'amount' => $row['total_owed'],
+                    'fine' => $row['last_billing_type'],
+                    'balance' => $row['balance_owed'],
+                    'checkout' => $this->_format_date($row['checkout_time']),
+                    'createdate' => $this->_format_date($row['last_billing_ts']),
+                    'duedate' => $this->_format_date($row['due_date']),
+                    'id' => $row['record']
+                ];
             }
             return $fineList;
         } catch (PDOException $e) {
@@ -469,44 +527,36 @@ HERE;
     {
         $holdList = [];
 
-        $sql = "select hold_request.hold_type, hold_request.current_copy, " .
-               "extract (year from hold_request.expire_time) as exp_year, " .
-               "extract (month from hold_request.expire_time) as exp_month, " .
-               "extract (day from hold_request.expire_time) as exp_day, " .
-               "extract (year from hold_request.request_time) as req_year, " .
-               "extract (month from hold_request.request_time) as req_month, " .
-               "extract (day from hold_request.request_time) as req_day, " .
-               "org_unit.name as lib_name " .
-               "from $this->dbName.action.hold_request, " .
-               "$this->dbName.actor.org_unit " .
-               "where hold_request.usr = '" . $patron['id'] . "' " .
-               "and hold_request.pickup_lib = org_unit.id " .
-               "and hold_request.capture_time is not null " .
-               "and hold_request.fulfillment_time is null";
+        $sql = "select ahr.hold_type, bib_record, " .
+               "ahr.id as hold_id, " .
+               "expire_time, request_time, shelf_time, capture_time, " .
+               "shelf_time, shelf_expire_time, frozen, thaw_date, " .
+               "org_unit.name as lib_name, acp.status as copy_status " .
+               "from $this->dbName.action.hold_request ahr " .
+               "join $this->dbName.actor.org_unit on (ahr.pickup_lib = org_unit.id) " .
+               "join $this->dbName.reporter.hold_request_record rhrr on (rhrr.id = ahr.id) " .
+               "left join $this->dbName.asset.copy acp on (acp.id = ahr.current_copy) " .
+               "where ahr.usr = '" . $patron['id'] . "' " .
+               "and ahr.fulfillment_time is null " .
+               "and ahr.cancel_time is null";
 
         try {
             $sqlStmt = $this->db->prepare($sql);
             $sqlStmt->execute();
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
-                if ($row['req_year']) {
-                    $req_time = $row['req_year'] . "-" . $row['req_month'] .
-                            "-" . $row['req_day'];
-                } else {
-                    $req_time = "";
-                }
-
-                if ($row['exp_year']) {
-                    $exp_time = $row['exp_year'] . "-" . $row['exp_month'] .
-                            "-" . $row['exp_day'];
-                } else {
-                    $exp_time = "";
-                }
-
-                $holdList[] = ['type' => $row['hold_type'],
-                                    'id' => $row['current_copy'],
-                                    'location' => $row['lib_name'],
-                                    'expire' => $exp_time,
-                                    'create' => $req_time];
+                $holdList[] = [
+                    'type' => $row['hold_type'],
+                    'id' => $row['bib_record'],
+                    'reqnum' => $row['hold_id'],
+                    'location' => $row['lib_name'],
+                    'expire' => $this->_format_date($row['expire_time']),
+                    'last_pickup_date' => $this->_format_date($row['shelf_expire_time']),
+                    'available' => $row['shelf_time'],
+                    'frozen' => $row['frozen'],
+                    'frozenThrough' => $this->_format_date($row['thaw_date']),
+                    'create' => $this->_format_date($row['request_time']),
+                    'in_transit' => $row['copy_status'] == self::EVG_ITEM_STATUS_IN_TRANSIT,
+                ];
             }
         } catch (PDOException $e) {
             $this->throwAsIlsException($e);
@@ -529,7 +579,8 @@ HERE;
         $sql = <<<HERE
 SELECT usr.family_name, usr.first_given_name, usr.day_phone,
     usr.evening_phone, usr.other_phone, aua.street1,
-    aua.street2, aua.post_code, pgt.name AS usrgroup
+    aua.street2, aua.post_code, pgt.name AS usrgroup,
+    aua.city, aua.country, usr.expire_date
 FROM actor.usr
     FULL JOIN actor.usr_address aua ON aua.id = usr.mailing_address
     INNER JOIN permission.grp_tree pgt ON pgt.id = usr.profile
@@ -557,9 +608,12 @@ HERE;
                     'lastname' => $row['family_name'],
                     'address1' => $row['street1'],
                     'address2' => $row['street2'],
+                    'city' => $row['city'],
                     'zip' => $row['post_code'],
+                    'country' => $row['country'],
                     'phone' => $phone,
-                    'group' => $row['usrgroup']
+                    'group' => $row['usrgroup'],
+                    'expiration_date' => $this->_format_date($row['expire_date']),
                 ];
                 return $patron;
             }
@@ -650,19 +704,14 @@ HERE;
     {
         $items = [];
 
-        // Prevent unnecessary load
-        // (Taken from Voyager driver - does Evergreen need this?)
-        if ($daysOld > 30) {
-            $daysOld = 30;
-        }
-
         $enddate = date('Y-m-d', strtotime('now'));
         $startdate = date('Y-m-d', strtotime("-$daysOld day"));
 
         $sql = "select count(distinct copy.id) as count " .
                "from asset.copy " .
                "where copy.create_date >= '$startdate' " .
-               "and copy.create_date < '$enddate'";
+               "and copy.status = 0 " .
+               "and copy.create_date < '$enddate' LIMIT 50";
 
         try {
             $sqlStmt = $this->db->prepare($sql);
@@ -679,15 +728,17 @@ HERE;
         //$startRow = (($page-1)*$limit)+1;
         //$endRow = ($page*$limit);
 
-        $sql = "select copy.id from asset.copy " .
+        $sql = "select copy.id, call_number.record from asset.copy " .
+               "join asset.call_number on (call_number.id = copy.call_number) " .
                "where copy.create_date >= '$startdate' " .
-               "and copy.create_date < '$enddate'";
+               "and copy.status = 0 " .
+               "and copy.create_date < '$enddate' LIMIT 50";
 
         try {
             $sqlStmt = $this->db->prepare($sql);
             $sqlStmt->execute();
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
-                $items['results'][]['id'] = $row['id'];
+                $items['results'][]['id'] = $row['record'];
             }
         } catch (PDOException $e) {
             $this->throwAsIlsException($e);
@@ -813,5 +864,21 @@ HERE;
     {
         // TODO
         return [];
+    }
+
+    /**
+     * Format date
+     *
+     * This formats a date coming from Evergreen for display
+     *
+     * @param string $date The date string to format; may be null
+     *
+     * @throws ILSException
+     * @return string The formatted date
+     */
+    private function _format_date($date)
+    {
+        return $this->dateConverter->convertToDisplayDate('Y-m-d', $date);
+        //return $date ? (new \DateTime($date))->format('Y-m-d') : '';
     }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
@@ -419,7 +419,7 @@ HERE;
             $sqlStmt->execute();
 
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
-                $due_date = $this->_formatDate($row['due_date']);
+                $due_date = $this->formatDate($row['due_date']);
                 $_due_time = new \DateTime($row['due_date']);
                 if ($_due_time->format('H:i:s') == "23:59:59") {
                     $dueTime = ""; // don't display due time for non-hourly loans
@@ -511,9 +511,9 @@ HERE;
                     'amount' => $row['total_owed'],
                     'fine' => $row['last_billing_type'],
                     'balance' => $row['balance_owed'],
-                    'checkout' => $this->_formatDate($row['checkout_time']),
-                    'createdate' => $this->_formatDate($row['last_billing_ts']),
-                    'duedate' => $this->_formatDate($row['due_date']),
+                    'checkout' => $this->formatDate($row['checkout_time']),
+                    'createdate' => $this->formatDate($row['last_billing_ts']),
+                    'duedate' => $this->formatDate($row['due_date']),
                     'id' => $row['record']
                 ];
             }
@@ -563,13 +563,13 @@ HERE;
                     'id' => $row['bib_record'],
                     'reqnum' => $row['hold_id'],
                     'location' => $row['lib_name'],
-                    'expire' => $this->_formatDate($row['expire_time']),
+                    'expire' => $this->formatDate($row['expire_time']),
                     'last_pickup_date' =>
-                        $this->_formatDate($row['shelf_expire_time']),
+                        $this->formatDate($row['shelf_expire_time']),
                     'available' => $row['shelf_time'],
                     'frozen' => $row['frozen'],
-                    'frozenThrough' => $this->_formatDate($row['thaw_date']),
-                    'create' => $this->_formatDate($row['request_time']),
+                    'frozenThrough' => $this->formatDate($row['thaw_date']),
+                    'create' => $this->formatDate($row['request_time']),
                     'in_transit' =>
                         $row['copy_status'] == self::EVG_ITEM_STATUS_IN_TRANSIT,
                 ];
@@ -629,7 +629,7 @@ HERE;
                     'country' => $row['country'],
                     'phone' => $phone,
                     'group' => $row['usrgroup'],
-                    'expiration_date' => $this->_formatDate($row['expire_date']),
+                    'expiration_date' => $this->formatDate($row['expire_date']),
                 ];
                 return $patron;
             }
@@ -892,7 +892,7 @@ HERE;
      * @throws ILSException
      * @return string The formatted date
      */
-    private function _formatDate($date)
+    protected function formatDate($date)
     {
         if (!$date) {
             return '';

--- a/module/VuFind/src/VuFind/ILS/Driver/PluginManager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PluginManager.php
@@ -86,7 +86,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         Amicus::class => InvokableFactory::class,
         DAIA::class => DriverWithDateConverterFactory::class,
         Demo::class => DemoFactory::class,
-        Evergreen::class => InvokableFactory::class,
+        Evergreen::class => DriverWithDateConverterFactory::class,
         Folio::class => FolioFactory::class,
         Horizon::class => DriverWithDateConverterFactory::class,
         HorizonXMLAPI::class => DriverWithDateConverterFactory::class,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/EvergreenTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/EvergreenTest.php
@@ -47,6 +47,6 @@ class EvergreenTest extends \VuFindTest\Unit\ILSDriverTestCase
      */
     public function setUp(): void
     {
-        $this->driver = new Evergreen();
+        $this->driver = new Evergreen(new \VuFind\Date\Converter());
     }
 }


### PR DESCRIPTION
This patch fixes and enhances the current Evergreen ILS driver by:

- updating authentication to use bcrypt password hashing, which was
  introduced in Evergreen 2.10. This breaks compatibility with
  versions of Evergreen older than 2.10, but those are years past
  Evergreen community support
- fix various places where an Evergreen item record ID was returned
  when a bib ID was wanted.
- Various fixes to retrieving current checkouts:
    - use the new return style for getMyTransactions
    - ensure that titles are displayed
    - return the due time for hourly loans
    - return owning and borrowing locations
    - return information about available renewals
- Various fixes to retrieving current fines:
    - excluded transactions for which nothing has been billed
    - link to the relevant title if the billing is for a loan
    - return the due date, fine creation date, and original loan
      date where applicable and properly distinguish between them
- Various fixes to retrieving hold requests:
    - ensure that all active holds are retrieved
    - excluded canceled holds
    - indicate when a hold is available, on the pickup shelf, frozen,
      or has an item in transit to fill it
- Various fixes to item and bib retrieval
    - for now, limit the new item pull to 50 copies and only available items
- Various fixes to the user profile retrieval:
    - include country, city, and expiration date
- Various modernizations:
    - Use VuFind's date and time formatter

Signed-off-by: Galen Charlton <gmc@equinoxOLI.org>