### PR TITLE
[VUFIND-1365] Add admin API with a cache flush action.

### DIFF
--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -61,7 +61,7 @@
 ; ipRange[] = "1.2.3.7-1.2.5.254"
 ; permission = sample.permission
 
-; Example configuration (grants the "sample.permission" permission to users 
+; Example configuration (grants the "sample.permission" permission to users
 ; who are from myCollege or who is a studentmajor (.*studentmajor.*):
 ; user[] = "college myCollege"
 ; user[] = "major .*studentmajor.*"
@@ -148,7 +148,7 @@ permission = feature.Favorites
 ;role = loggedin ; if you want to allow authenticated users to use Primo module
 ;permission = primoOnCampus.MYINSTITUTION
 
-; Example Shibboleth logout API access permission. 
+; Example Shibboleth logout API access permission.
 ; See https://vufind.org/wiki/configuration:shibboleth for more information.
 ;[api.ShibbolethLogoutNotification]
 ;permission = access.api.ShibbolethLogoutNotification
@@ -166,6 +166,13 @@ role = loggedin
 ;[api.SearchAndRecord]
 ;permission[] = access.api.Search
 ;permission[] = access.api.Record
+;require = ANY
+;ipRange[] = '127.0.0.1'
+;ipRange[] = '::1'
+
+; Cache methods admin API permissions.
+;[api.Admin.Cache]
+;permission[] = access.api.admin.cache
 ;require = ANY
 ;ipRange[] = '127.0.0.1'
 ;ipRange[] = '::1'

--- a/module/VuFindApi/config/module.config.php
+++ b/module/VuFindApi/config/module.config.php
@@ -4,12 +4,14 @@ namespace VuFindApi\Module\Configuration;
 $config = [
     'controllers' => [
         'factories' => [
+            'VuFindApi\Controller\AdminApiController' => 'VuFindApi\Controller\AdminApiControllerFactory',
             'VuFindApi\Controller\ApiController' => 'VuFindApi\Controller\ApiControllerFactory',
             'VuFindApi\Controller\SearchApiController' => 'VuFindApi\Controller\SearchApiControllerFactory',
             'VuFindApi\Controller\Search2ApiController' => 'VuFindApi\Controller\Search2ApiControllerFactory',
             'VuFindApi\Controller\WebApiController' => 'VuFindApi\Controller\WebApiControllerFactory',
         ],
         'aliases' => [
+            'AdminApi' => 'VuFindApi\Controller\AdminApiController',
             'Api' => 'VuFindApi\Controller\ApiController',
             'SearchApi' => 'VuFindApi\Controller\SearchApiController',
             'Search2Api' => 'VuFindApi\Controller\Search2ApiController',
@@ -18,14 +20,34 @@ $config = [
     ],
     'service_manager' => [
         'factories' => [
+            'VuFindApi\ApiPluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFindApi\Formatter\FacetFormatter' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFindApi\Formatter\RecordFormatter' => 'VuFindApi\Formatter\RecordFormatterFactory',
             'VuFindApi\Formatter\Search2RecordFormatter' => 'VuFindApi\Formatter\Search2RecordFormatterFactory',
             'VuFindApi\Formatter\WebRecordFormatter' => 'VuFindApi\Formatter\WebRecordFormatterFactory',
         ],
     ],
+    'vufind_api' => [
+        'register_controllers' => [
+            \VuFindApi\Controller\AdminApiController::class,
+            \VuFindApi\Controller\SearchApiController::class,
+            \VuFindApi\Controller\Search2ApiController::class,
+            \VuFindApi\Controller\WebApiController::class,
+        ]
+    ],
     'router' => [
         'routes' => [
+            'adminClearCacheApiv1' => [
+                'type' => 'Laminas\Router\Http\Literal',
+                'verb' => 'delete,options',
+                'options' => [
+                    'route'    => '/api/v1/admin/cache',
+                    'defaults' => [
+                        'controller' => 'AdminApi',
+                        'action'     => 'clearCache',
+                    ]
+                ]
+            ],
             'apiHome' => [
                 'type' => 'Laminas\Router\Http\Segment',
                 'verb' => 'get,post,options',

--- a/module/VuFindApi/config/module.config.php
+++ b/module/VuFindApi/config/module.config.php
@@ -20,7 +20,6 @@ $config = [
     ],
     'service_manager' => [
         'factories' => [
-            'VuFindApi\ApiPluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFindApi\Formatter\FacetFormatter' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFindApi\Formatter\RecordFormatter' => 'VuFindApi\Formatter\RecordFormatterFactory',
             'VuFindApi\Formatter\Search2RecordFormatter' => 'VuFindApi\Formatter\Search2RecordFormatterFactory',

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Admin Api Controller
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA    02111-1307    USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+namespace VuFindApi\Controller;
+
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use VuFind\Cache\Manager as CacheManager;
+
+/**
+ * Admin Api Controller
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class AdminApiController extends \VuFind\Controller\AbstractBase
+    implements ApiInterface
+{
+    use ApiTrait;
+
+    /**
+     * Cache manager
+     *
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    /**
+     * Constructor
+     *
+     * @param ServiceLocatorInterface $sm Service locator
+     * @param CacheManager            $cm Cache manager
+     */
+    public function __construct(ServiceLocatorInterface $sm, CacheManager $cm)
+    {
+        $this->serviceLocator = $sm;
+        $this->cacheManager = $cm;
+    }
+
+    /**
+     * Permission required for the clear cache endpoint
+     *
+     * @var string
+     */
+    protected $cacheAccessPermission = 'access.api.admin.cache';
+
+    /**
+     * Caches that are not cleared by the clearCache command by default
+     *
+     * @var array
+     */
+    protected $defaultIgnoredCaches = ['cover'];
+
+    /**
+     * Clear the cache
+     *
+     * @return \Laminas\Http\Response
+     */
+    public function clearCacheAction()
+    {
+        $this->disableSessionWrites();
+        $this->determineOutputMode();
+
+        if ($result = $this->isAccessDenied($this->cacheAccessPermission)) {
+            return $result;
+        }
+
+        try {
+            $cacheList = $this->getRequest()->getQuery()->get('id')
+                ?: $this->getDefaultCachesToClear();
+            foreach ((array)$cacheList as $id) {
+                $cache = $this->cacheManager->getCache($id);
+                if (!($cache instanceof \Laminas\Cache\Storage\FlushableInterface)) {
+                    throw new \Exception("Cache $id is not flushable");
+                }
+                $cache->flush();
+            }
+        } catch (\Exception $e) {
+            return $this->output([], self::STATUS_ERROR, 500, $e->getMessage());
+        }
+
+        return $this->output([], self::STATUS_OK);
+    }
+
+    /**
+     * Get Swagger specification JSON fragment for services provided by the
+     * controller
+     *
+     * @return string
+     */
+    public function getSwaggerSpecFragment()
+    {
+        $spec = [];
+        if (!$this->isAccessDenied($this->cacheAccessPermission)) {
+            $defaultCaches = implode(',', $this->getDefaultCachesToClear());
+            $spec['paths']['/admin/cache']['delete'] = [
+                'summary' => 'Clear caches',
+                'description' => 'Flushes the specified caches',
+                'parameters' => [
+                    [
+                        'name' => 'id[]',
+                        'in' => 'query',
+                        'description' => 'Caches to clear. By default the following'
+                            . " caches are cleared: $defaultCaches",
+                        'required' => false,
+                        'type' => 'array',
+                        'collectionFormat' => 'multi',
+                        'items' => [
+                            'type' => 'string'
+                        ]
+                    ]
+                ],
+                'tags' => ['admin'],
+                'responses' => [
+                    '200' => [
+                        'description' => 'An OK response',
+                        'schema' => [
+                            '$ref' => '#/definitions/Success'
+                        ]
+                    ],
+                    'default' => [
+                        'description' => 'Error',
+                        'schema' => [
+                            '$ref' => '#/definitions/Error'
+                        ]
+                    ]
+                ]
+            ];
+        }
+
+        // Admin API endpoints are not published
+        return json_encode($spec);
+    }
+
+    /**
+     * Get an array of caches to clear by default
+     *
+     * @return array
+     */
+    protected function getDefaultCachesToClear(): array
+    {
+        return array_diff(
+            $this->cacheManager->getCacheList(),
+            $this->defaultIgnoredCaches
+        );
+    }
+}

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiControllerFactory.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Factory for ApiController.
+ * Factory for AdminApiController.
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2016-2021.
+ * Copyright (C) The National Library of Finland 2021.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -34,7 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
- * Factory for ApiController.
+ * Factory for AdminApiController.
  *
  * @category VuFind
  * @package  Controller
@@ -42,20 +42,8 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
  */
-class ApiControllerFactory implements FactoryInterface
+class AdminApiControllerFactory implements FactoryInterface
 {
-    /**
-     * API controllers to register
-     *
-     * @var array
-     */
-    protected $apiControllers = [
-        \VuFindApi\Controller\AdminApiController::class,
-        \VuFindApi\Controller\SearchApiController::class,
-        \VuFindApi\Controller\Search2ApiController::class,
-        \VuFindApi\Controller\WebApiController::class,
-    ];
-
     /**
      * Create an object
      *
@@ -78,24 +66,9 @@ class ApiControllerFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $controller = new $requestedName($container);
-        $controllerManager = $container->get('ControllerManager');
-        foreach ($this->getApiControllersToRegister($container) as $apiName) {
-            $controller->addApi($controllerManager->get($apiName));
-        }
-        return $controller;
-    }
-
-    /**
-     * Get the API controllers to register with ApiController
-     *
-     * @param ContainerInterface $container Service manager
-     *
-     * @return array
-     */
-    protected function getApiControllersToRegister(ContainerInterface $container)
-    {
-        $config = $container->get('Config');
-        return $config['vufind_api']['register_controllers'];
+        return new $requestedName(
+            $container,
+            $container->get(\VuFind\Cache\Manager::class)
+        );
     }
 }

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiControllerFactory.php
@@ -45,18 +45,6 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 class ApiControllerFactory implements FactoryInterface
 {
     /**
-     * API controllers to register
-     *
-     * @var array
-     */
-    protected $apiControllers = [
-        \VuFindApi\Controller\AdminApiController::class,
-        \VuFindApi\Controller\SearchApiController::class,
-        \VuFindApi\Controller\Search2ApiController::class,
-        \VuFindApi\Controller\WebApiController::class,
-    ];
-
-    /**
      * Create an object
      *
      * @param ContainerInterface $container     Service manager

--- a/themes/root/templates/api/swagger.phtml
+++ b/themes/root/templates/api/swagger.phtml
@@ -1,4 +1,6 @@
-<?php // This template is a JSON Swagger specification ?>
+<?php // This template is a JSON Swagger specification base.
+      // Fragments from other controllers will get merged with this one.
+?>
 <?php $basePath = rtrim($this->url('home'), '/') . '/api/v1'; ?>
 {
     "swagger": "2.0",
@@ -10,5 +12,36 @@
     "produces": [
         "application/json"
     ],
-    <?=$this->specs ?>
+    "definitions": {
+        "Success": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "description": "Status code",
+                    "type": "string",
+                    "enum": ["OK"]
+                },
+                "statusMessage": {
+                    "description": "A descriptive error message",
+                    "type": "string"
+                }
+            },
+            "required": ["status"]
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "description": "Status code",
+                    "type": "string",
+                    "enum": ["ERROR"]
+                },
+                "statusMessage": {
+                    "description": "A descriptive error message",
+                    "type": "string"
+                }
+            },
+            "required": ["status", "statusMessage"]
+        }
+    }
 }

--- a/themes/root/templates/searchapi/swagger.phtml
+++ b/themes/root/templates/searchapi/swagger.phtml
@@ -220,21 +220,6 @@
                 }
             }
         },
-        "Error": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "description": "Status code",
-                    "type": "string",
-                    "enum": ["ERROR"]
-                },
-                "statusMessage": {
-                    "description": "A descriptive error message",
-                    "type": "string"
-                }
-            },
-            "required": ["status", "statusMessage"]
-        },
         "Facet": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Includes changes to make it possible to include definitions and other shared elements in the base Swagger spec.

I've tried to design the admin API controller so that additional admin functionality can be added in future with granular permissions. Admin API's Swagger spec fragment is created in code as opposed to a template to allow for this granularity (endpoints are not advertised unless the user has access).

Note that this does not currently address the use case of removing a specific image from the cover cache. I think that should be a separate API method.