### PR TITLE
Add user object as usable parameter when building notification emails

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -454,6 +454,7 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
             return $data['selected'] ?? false;
         };
         $viewParams = [
+            'firstname' => $user->firstname,
             'records' => $newRecords,
             'info' => [
                 'baseUrl' => $viewBaseUrl,

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -454,7 +454,7 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
             return $data['selected'] ?? false;
         };
         $viewParams = [
-            'firstname' => $user->firstname,
+            'user' => $user,
             'records' => $newRecords,
             'info' => [
                 'baseUrl' => $viewBaseUrl,

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
@@ -302,6 +302,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
         };
         $message = 'sample message';
         $expectedViewParams = [
+            'user' => $this->getMockUserObject(),
             'records' => [$record],
             'info' => [
                 'baseUrl' => 'http://foo',


### PR DESCRIPTION
When sending due date reminder and scheduled alert emails this addition makes it possible to include the user's first name e.g. in the greeting to present a bit more personal feel to the recipient.