### PR TITLE
Make form sender fields overridable.

### DIFF
--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -53,7 +53,7 @@
 #
 #   fields (array) List of form elements with the following options:
 #
-#     name (string)        Element name
+#     name (string)        Element name (see below for reserved element names)
 #     label (string)       Element label (translation key)
 #     required (boolean)   Is the element required? (for checkbox elements this means that
 #                          all options have to be selected.)
@@ -113,6 +113,19 @@
 #       can be configured by adding a HTML-attribute via 'settings', for example:
 #       settings:
 #         - [placeholder, Please select...]
+#
+#
+# Reserved element names:
+#
+# - name       Sender name. You can add the field to fields configuration to define
+#              its position on the form.
+# - email      Sender email. You can add the field to fields configuration to define
+#              its position on the form.
+# - referrer   Used for browser's referrer information when reportReferrer is
+#              enabled.
+# - useragent  Used for reporting browser's user agent string when reportUserAgent is
+#              enabled.
+# - submit     Form submit button.
 #
 #-----------------------------------------------------------------------------------
 

--- a/config/vufind/FeedbackForms.yaml
+++ b/config/vufind/FeedbackForms.yaml
@@ -59,6 +59,8 @@
 #                          all options have to be selected.)
 #     requireOne (boolean) Require at least one checkbox option to be selected.
 #     settings (array)     HTML attributes as key-value pairs, for example:
+#       - class: "custom-css-class another-class"
+#                          or
 #       - [class, "custom-css-class another-class"]
 #     type (string)        Element type (text|textarea|date|email|url|select|radio|checkbox|hidden)
 #

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -548,14 +548,24 @@ class Form extends \Laminas\Form\Form implements
         $elements = [];
         $configuredElements = $this->getFormElements($config);
 
-        // Add sender contact name & email fields
+        // Defaults for sender contact name & email fields:
         $senderName = [
-            'name' => 'name', 'type' => 'text', 'label' => 'feedback_name',
-            'group' => '__sender__'
+            'name' => 'name',
+            'type' => 'text',
+            'label' => $this->translate('feedback_name'),
+            'group' => '__sender__',
+            'settings' => [
+                'size' => 50
+            ]
         ];
         $senderEmail = [
-            'name' => 'email', 'type' => 'email', 'label' => 'feedback_email',
-            'group' => '__sender__'
+            'name' => 'email',
+            'type' => 'email',
+            'label' => $this->translate('feedback_email'),
+            'group' => '__sender__',
+            'settings' => [
+                'size' => 254
+            ]
         ];
         if ($formConfig['senderInfoRequired'] ?? false) {
             $senderEmail['required'] = $senderEmail['aria-required']
@@ -567,8 +577,6 @@ class Form extends \Laminas\Form\Form implements
         if ($formConfig['senderEmailRequired'] ?? false) {
             $senderEmail['required'] = $senderEmail['aria-required'] = true;
         }
-        $configuredElements[] = $senderName;
-        $configuredElements[] = $senderEmail;
 
         foreach ($configuredElements as $el) {
             $element = [];
@@ -585,7 +593,7 @@ class Form extends \Laminas\Form\Form implements
             }
 
             if (in_array($element['type'], ['checkbox', 'radio'])
-                && ! isset($element['group'])
+                && !isset($element['group'])
             ) {
                 $element['group'] = $element['name'];
             }
@@ -673,7 +681,25 @@ class Form extends \Laminas\Form\Form implements
                     $element['settings']['rows'] = 8;
                 }
             }
+
+            // Merge sender fields with any existing field definitions:
+            if ('name' === $element['name']) {
+                $element = array_merge($senderName, $element);
+                $senderName = null;
+            } elseif ('email' === $element['name']) {
+                $element = array_merge($senderEmail, $element);
+                $senderEmail = null;
+            }
+
             $elements[] = $element;
+        }
+
+        // Add sender fields if they were not merged in the loop above:
+        if ($senderName) {
+            $elements[] = $senderName;
+        }
+        if ($senderEmail) {
+            $elements[] = $senderEmail;
         }
 
         if ($this->reportReferrer()) {

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -667,6 +667,16 @@ class Form extends \Laminas\Form\Form implements
                 $element['settings'] = $settings;
             }
 
+            // Merge sender fields with any existing field definitions:
+            if ('name' === $element['name']) {
+                $element = array_merge($senderName, $element);
+                $senderName = null;
+            } elseif ('email' === $element['name']) {
+                $element = array_merge($senderEmail, $element);
+                $senderEmail = null;
+            }
+
+            // Add default field size settings for fields that don't define them:
             if (in_array($elementType, ['text', 'url', 'email'])
                 && !isset($element['settings']['size'])
             ) {
@@ -680,15 +690,6 @@ class Form extends \Laminas\Form\Form implements
                 if (!isset($element['settings']['rows'])) {
                     $element['settings']['rows'] = 8;
                 }
-            }
-
-            // Merge sender fields with any existing field definitions:
-            if ('name' === $element['name']) {
-                $element = array_merge($senderName, $element);
-                $senderName = null;
-            } elseif ('email' === $element['name']) {
-                $element = array_merge($senderEmail, $element);
-                $senderEmail = null;
             }
 
             $elements[] = $element;

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -656,9 +656,19 @@ class Form extends \Laminas\Form\Form implements
 
             $settings = [];
             if (isset($el['settings'])) {
-                foreach ($el['settings'] as [$settingId, $settingVal]) {
-                    $settingId = trim($settingId);
-                    $settingVal = trim($settingVal);
+                foreach ($el['settings'] as $setting) {
+                    if (!is_array($setting)) {
+                        continue;
+                    }
+                    // Allow both [key => value] and [key, value]:
+                    if (count($setting) !== 2) {
+                        reset($setting);
+                        $settingId = trim(key($setting));
+                        $settingVal = trim(current($setting));
+                    } else {
+                        $settingId = trim($setting[0]);
+                        $settingVal = trim($setting[1]);
+                    }
                     if ($settingId === 'placeholder') {
                         $settingVal = $this->translate($settingVal);
                     }
@@ -669,10 +679,10 @@ class Form extends \Laminas\Form\Form implements
 
             // Merge sender fields with any existing field definitions:
             if ('name' === $element['name']) {
-                $element = array_merge($senderName, $element);
+                $element = array_replace_recursive($senderName, $element);
                 $senderName = null;
             } elseif ('email' === $element['name']) {
-                $element = array_merge($senderEmail, $element);
+                $element = array_replace_recursive($senderEmail, $element);
                 $senderEmail = null;
             }
 
@@ -837,7 +847,7 @@ class Form extends \Laminas\Form\Form implements
         if (!empty($el['settings'])) {
             $attributes += $el['settings'];
         }
-        if (!empty($el['label'])) {
+        if (!empty($el['label']) && !isset($attributes['aria-label'])) {
             $attributes['aria-label'] = $el['label'];
         }
 

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -20,7 +20,7 @@ forms:
              - option-1
              - option-2
         label: select2
-        
+
       - name: select3
         type: select
         options:
@@ -150,3 +150,20 @@ forms:
             value: option-1
         label: checkbox
         requireOne: true
+
+  TestSenderFields:
+    fields:
+      - name: name
+        type: text
+        label: Sender Name
+      - name: phone
+        type: text
+        label: Phone Number
+        group: __sender__
+      - name: email
+        type: email
+        label: feedback_email
+      - name: message
+        type: textarea
+        label: Comments
+        required: true

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -167,3 +167,24 @@ forms:
         type: textarea
         label: Comments
         required: true
+
+  TestSenderFieldsWithSettings:
+    fields:
+      - name: name
+        type: text
+        label: Sender Name
+        settings:
+        - size: 100
+      - name: phone
+        type: text
+        label: Phone Number
+        group: __sender__
+      - name: email
+        type: email
+        label: feedback_email
+        settings:
+        - [aria-label, Test label]
+      - name: message
+        type: textarea
+        label: Comments
+        required: true

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -245,6 +245,92 @@ class FormTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test sender field merging.
+     *
+     * @return void
+     */
+    public function testSenderFieldMerging()
+    {
+        $form = new Form(
+            new YamlReader(),
+            $this->createMock(\Laminas\View\HelperPluginManager::class)
+        );
+        $form->setFormId('FeedbackSite');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'textarea',
+                    'name' => 'message',
+                    'required' => true,
+                    'label' => 'Comments',
+                    'settings' => ['cols' => 50, 'rows' => 8],
+                ],
+                [
+                    'type' => 'text',
+                    'name' => 'name',
+                    'group' => '__sender__',
+                    'label' => 'feedback_name',
+                    'settings' => ['size' => 50],
+                ],
+                [
+                    'type' => 'email',
+                    'name' => 'email',
+                    'group' => '__sender__',
+                    'label' => 'feedback_email',
+                    'settings' => ['size' => 254],
+                ],
+                [
+                    'type' => 'submit',
+                    'name' => 'submit',
+                    'label' => 'Send',
+                ],
+            ],
+            $form->getFormElementConfig()
+        );
+
+        $form = $this->getMockTestForm('TestSenderFields');
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'text',
+                    'name' => 'name',
+                    'group' => '__sender__',
+                    'label' => 'Sender Name',
+                    'settings' => ['size' => 50],
+                ],
+                [
+                    'type' => 'text',
+                    'name' => 'phone',
+                    'group' => '__sender__',
+                    'label' => 'Phone Number',
+                    'settings' => ['size' => 50],
+                ],
+                [
+                    'type' => 'email',
+                    'name' => 'email',
+                    'group' => '__sender__',
+                    'label' => 'feedback_email',
+                    'settings' => ['size' => 254],
+                ],
+                [
+                    'type' => 'textarea',
+                    'name' => 'message',
+                    'required' => true,
+                    'label' => 'Comments',
+                    'settings' => ['cols' => 50, 'rows' => 8],
+                ],
+                [
+                    'type' => 'submit',
+                    'name' => 'submit',
+                    'label' => 'Send',
+                ],
+            ],
+            $form->getFormElementConfig()
+        );
+    }
+
+    /**
      * Get a mock YamlReader object.
      *
      * @return YamlReader

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -157,7 +157,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
-                    'settings' => ['size' => 50],
+                    'settings' => ['size' => 254],
                 ],
                 [
                     'type' => 'submit',
@@ -205,7 +205,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                         'name' => 'email',
                         'group' => '__sender__',
                         'label' => 'feedback_email',
-                        'settings' => ['size' => 50],
+                        'settings' => ['size' => 254],
                     ],
                 ],
                 'Email/form.phtml'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -331,6 +331,57 @@ class FormTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test sender field merging.
+     *
+     * @return void
+     */
+    public function testSenderFieldMergingWithSettings()
+    {
+        $form = $this->getMockTestForm('TestSenderFieldsWithSettings');
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'text',
+                    'name' => 'name',
+                    'group' => '__sender__',
+                    'label' => 'Sender Name',
+                    'settings' => ['size' => 100],
+                ],
+                [
+                    'type' => 'text',
+                    'name' => 'phone',
+                    'group' => '__sender__',
+                    'label' => 'Phone Number',
+                    'settings' => ['size' => 50],
+                ],
+                [
+                    'type' => 'email',
+                    'name' => 'email',
+                    'group' => '__sender__',
+                    'label' => 'feedback_email',
+                    'settings' => [
+                        'size' => 254,
+                        'aria-label' => 'Test label'
+                    ],
+                ],
+                [
+                    'type' => 'textarea',
+                    'name' => 'message',
+                    'required' => true,
+                    'label' => 'Comments',
+                    'settings' => ['cols' => 50, 'rows' => 8],
+                ],
+                [
+                    'type' => 'submit',
+                    'name' => 'submit',
+                    'label' => 'Send',
+                ],
+            ],
+            $form->getFormElementConfig()
+        );
+    }
+
+    /**
      * Get a mock YamlReader object.
      *
      * @return YamlReader


### PR DESCRIPTION
This makes it possible to e.g. define the field positions on the form and add additional fields like a phone number in the correct position. These and other reserved fields are now documented in FeedbackForms.yaml.

The email field now accepts the maximum length that an email address can be.