### PR TITLE
[VUFIND-1446] Unify HTTP client creation across backends.

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -45,6 +45,10 @@ retain_filters_by_default = true
 ; This is the timeout in seconds when communicating with the EDS server.
 timeout = 120
 
+; By default the SSL certificate needs to be valid for the server. Uncomment this
+; setting to allow an untrusted certificate.
+;sslverifypeer = false
+
 ; This is the HTTP method to use for EDS search operations; legal options are GET
 ; or POST (the default). GET and POST use significantly different APIs, so it
 ; may be useful to switch between methods for troubleshooting purposes. Under

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
@@ -57,24 +57,15 @@ abstract class AbstractBackendFactory implements FactoryInterface
     }
 
     /**
-     * Create service
+     * Initialize the factory
      *
-     * @param ContainerInterface $sm      Service manager
-     * @param string             $name    Requested service name
-     * @param array              $options Extra options (unused)
+     * @param ContainerInterface $sm Service manager
      *
-     * @return Backend
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return void
      */
-    public function __invoke(
-        ContainerInterface $sm,
-        $name,
-        array $options = null
-    ) {
+    public function setup(ContainerInterface $sm)
+    {
         $this->serviceLocator = $sm;
-
-        return null;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Abstract factory for backends.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2021.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\Search\Factory;
+
+use Interop\Container\ContainerInterface;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+/**
+ * Abstract factory for backends.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   David Maus <maus@hab.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+abstract class AbstractBackendFactory implements FactoryInterface
+{
+    /**
+     * Superior service manager.
+     *
+     * @var ContainerInterface
+     */
+    protected $serviceLocator;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Create service
+     *
+     * @param ContainerInterface $sm      Service manager
+     * @param string             $name    Requested service name
+     * @param array              $options Extra options (unused)
+     *
+     * @return Backend
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __invoke(
+        ContainerInterface $sm,
+        $name,
+        array $options = null
+    ) {
+        $this->serviceLocator = $sm;
+
+        return null;
+    }
+
+    /**
+     * Create HTTP Client
+     *
+     * @param int   $timeout Request timeout
+     * @param array $options Other options
+     *
+     * @return \Laminas\Http\Client
+     */
+    protected function createHttpClient(
+        ?int $timeout = null,
+        array $options = []
+    ): \Laminas\Http\Client {
+        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
+            ->createClient();
+        $options = $options ?? [];
+        if (null !== $timeout) {
+            $options['timeout'] = $timeout;
+        }
+        $client->setOptions($options);
+        return $client;
+    }
+}

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -31,7 +31,6 @@ namespace VuFind\Search\Factory;
 use Interop\Container\ContainerInterface;
 
 use Laminas\Config\Config;
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFind\Search\Solr\DeduplicationListener;
 use VuFind\Search\Solr\DefaultParametersListener;
 use VuFind\Search\Solr\FilterFieldConversionListener;
@@ -63,7 +62,7 @@ use VuFindSearch\Backend\Solr\SimilarBuilder;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-abstract class AbstractSolrBackendFactory implements FactoryInterface
+abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -71,13 +70,6 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Primary configuration file identifier.
@@ -147,6 +139,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      */
     public function __construct()
     {
+        parent::__construct();
     }
 
     /**
@@ -162,7 +155,7 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
@@ -377,16 +370,12 @@ abstract class AbstractSolrBackendFactory implements FactoryInterface
             array_push($handlers['select']['appends']['fq'], $filter);
         }
 
-        $httpService = $this->serviceLocator->get(\VuFindHttp\HttpService::class);
-        $client = $httpService->createClient();
-
         $connector = new $this->connectorClass(
             $this->getSolrUrl(),
             new HandlerMap($handlers),
-            $this->uniqueKey,
-            $client
+            $this->createHttpClient($config->Index->timeout ?? 30),
+            $this->uniqueKey
         );
-        $connector->setTimeout($config->Index->timeout ?? 30);
 
         if ($this->logger) {
             $connector->setLogger($this->logger);

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -155,7 +155,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {

--- a/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
@@ -73,7 +73,7 @@ class BrowZineBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->browzineConfig = $configReader->get('BrowZine');

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -30,7 +30,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\EIT\Backend;
 use VuFindSearch\Backend\EIT\Connector;
 use VuFindSearch\Backend\EIT\QueryBuilder;
@@ -47,7 +46,7 @@ use VuFindSearch\Backend\EIT\Response\XML\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class EITBackendFactory implements FactoryInterface
+class EITBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -55,13 +54,6 @@ class EITBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * VuFind configuration
@@ -83,7 +75,7 @@ class EITBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('EIT');
@@ -122,9 +114,13 @@ class EITBackendFactory implements FactoryInterface
         $base = $this->config->General->base_url
             ?? 'https://eit.ebscohost.com/Services/SearchService.asmx/Search';
         $dbs = $this->config->General->dbs ?? null;
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
-        $connector = new Connector($base, $client, $prof, $pwd, $dbs);
+        $connector = new Connector(
+            $base,
+            $this->createHttpClient(),
+            $prof,
+            $pwd,
+            $dbs
+        );
         $connector->setLogger($this->logger);
         return $connector;
     }

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -75,7 +75,7 @@ class EITBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('EIT');

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -79,7 +79,7 @@ class EdsBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $this->edsConfig = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('EDS');

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Factory for EDS backends.
  *
@@ -30,7 +29,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\EDS\Backend;
 use VuFindSearch\Backend\EDS\Connector;
 use VuFindSearch\Backend\EDS\QueryBuilder;
@@ -45,7 +43,7 @@ use VuFindSearch\Backend\EDS\Response\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class EdsBackendFactory implements FactoryInterface
+class EdsBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -53,13 +51,6 @@ class EdsBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger = null;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * EDS configuration
@@ -88,7 +79,7 @@ class EdsBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $this->edsConfig = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('EDS');
@@ -140,7 +131,6 @@ class EdsBackendFactory implements FactoryInterface
     protected function createConnector()
     {
         $options = [
-            'timeout' => $this->edsConfig->General->timeout ?? 120,
             'search_http_method' => $this->edsConfig->General->search_http_method
                 ?? 'POST'
         ];
@@ -150,10 +140,18 @@ class EdsBackendFactory implements FactoryInterface
         if (isset($this->edsConfig->General->auth_url)) {
             $options['auth_url'] = $this->edsConfig->General->auth_url;
         }
-        // Build HTTP client:
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
-        $connector = new Connector($options, $client);
+
+        $httpOptions = [
+            'sslverifypeer'
+                => (bool)($this->edsConfig->General->sslverifypeer ?? true),
+        ];
+        $connector = new Connector(
+            $options,
+            $this->createHttpClient(
+                $this->edsConfig->General->timeout ?? 120,
+                $httpOptions
+            )
+        );
         $connector->setLogger($this->logger);
         return $connector;
     }

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
@@ -74,7 +74,7 @@ class LibGuidesBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->libGuidesConfig = $configReader->get('LibGuides');

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
@@ -30,7 +30,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\LibGuides\Backend;
 use VuFindSearch\Backend\LibGuides\Connector;
 use VuFindSearch\Backend\LibGuides\QueryBuilder;
@@ -46,7 +45,7 @@ use VuFindSearch\Backend\LibGuides\Response\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class LibGuidesBackendFactory implements FactoryInterface
+class LibGuidesBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -54,13 +53,6 @@ class LibGuidesBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * LibGuides configuration
@@ -82,7 +74,7 @@ class LibGuidesBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->libGuidesConfig = $configReader->get('LibGuides');
@@ -130,12 +122,13 @@ class LibGuidesBackendFactory implements FactoryInterface
         // Get base URI, if available:
         $baseUrl = $this->libGuidesConfig->General->baseUrl ?? null;
 
-        // Build HTTP client:
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient($baseUrl);
-        $timeout = $this->libGuidesConfig->General->timeout ?? 30;
-        $client->setOptions(['timeout' => $timeout]);
-        $connector = new Connector($iid, $client, $ver, $baseUrl);
+        // Create connector:
+        $connector = new Connector(
+            $iid,
+            $this->createHttpClient($this->libGuidesConfig->General->timeout ?? 30),
+            $ver,
+            $baseUrl
+        );
         $connector->setLogger($this->logger);
         return $connector;
     }

--- a/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
@@ -74,7 +74,7 @@ class Pazpar2BackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('Pazpar2');

--- a/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
@@ -30,9 +30,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
-
-use VuFindHttp\HttpService;
 use VuFindSearch\Backend\Pazpar2\Backend;
 use VuFindSearch\Backend\Pazpar2\Connector;
 use VuFindSearch\Backend\Pazpar2\QueryBuilder;
@@ -48,7 +45,7 @@ use VuFindSearch\Backend\Pazpar2\Response\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class Pazpar2BackendFactory implements FactoryInterface
+class Pazpar2BackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -56,13 +53,6 @@ class Pazpar2BackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * VuFind configuration
@@ -84,7 +74,7 @@ class Pazpar2BackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('Pazpar2');
@@ -128,7 +118,7 @@ class Pazpar2BackendFactory implements FactoryInterface
     {
         $connector = new Connector(
             $this->config->General->base_url,
-            $this->serviceLocator->get(HttpService::class)->createClient()
+            $this->createHttpClient()
         );
         $connector->setLogger($this->logger);
         return $connector;

--- a/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
@@ -30,11 +30,9 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use LmcRbacMvc\Service\AuthorizationService;
 use VuFind\Search\Primo\InjectOnCampusListener;
 use VuFind\Search\Primo\PrimoPermissionHandler;
-
 use VuFindSearch\Backend\Primo\Backend;
 use VuFindSearch\Backend\Primo\Connector;
 
@@ -51,7 +49,7 @@ use VuFindSearch\Backend\Primo\Response\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class PrimoBackendFactory implements FactoryInterface
+class PrimoBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -59,13 +57,6 @@ class PrimoBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Primo configuration
@@ -87,7 +78,7 @@ class PrimoBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->primoConfig = $configReader->get('Primo');
@@ -148,16 +139,11 @@ class PrimoBackendFactory implements FactoryInterface
             ? $permHandler->getInstCode()
             : null;
 
-        // Build HTTP client:
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
-        $timeout = $this->primoConfig->General->timeout ?? 30;
-        $client->setOptions(['timeout' => $timeout]);
-
+        // Create connector:
         $connector = new Connector(
             $this->primoConfig->General->url,
             $instCode,
-            $client
+            $this->createHttpClient($this->primoConfig->General->timeout ?? 30)
         );
         $connector->setLogger($this->logger);
         return $connector;

--- a/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
@@ -92,7 +92,7 @@ class PrimoBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->primoConfig = $configReader->get('Primo');

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -82,7 +82,7 @@ class SummonBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->config = $configReader->get('config');

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -30,7 +30,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use SerialsSolutions\Summon\Laminas as Connector;
 use VuFindSearch\Backend\Solr\LuceneSyntaxHelper;
 use VuFindSearch\Backend\Summon\Backend;
@@ -47,7 +46,7 @@ use VuFindSearch\Backend\Summon\Response\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class SummonBackendFactory implements FactoryInterface
+class SummonBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -55,13 +54,6 @@ class SummonBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * VuFind configuration
@@ -90,7 +82,7 @@ class SummonBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $configReader = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class);
         $this->config = $configReader->get('config');
@@ -129,14 +121,14 @@ class SummonBackendFactory implements FactoryInterface
         $id = $this->config->Summon->apiId ?? null;
         $key = $this->config->Summon->apiKey ?? null;
 
-        // Build HTTP client:
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
-        $timeout = $this->summonConfig->General->timeout ?? 30;
-        $client->setOptions(['timeout' => $timeout]);
-
+        // Create connector:
         $options = ['authedUser' => $this->isAuthed()];
-        $connector = new Connector($id, $key, $options, $client);
+        $connector = new Connector(
+            $id,
+            $key,
+            $options,
+            $this->createHttpClient($this->summonConfig->General->timeout ?? 30)
+        );
         $connector->setLogger($this->logger);
         return $connector;
     }

--- a/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
@@ -81,7 +81,7 @@ class WorldCatBackendFactory extends AbstractBackendFactory
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        parent::__invoke($sm, $name, $options);
+        $this->setup($sm);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('config');

--- a/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
@@ -30,7 +30,6 @@ namespace VuFind\Search\Factory;
 
 use Interop\Container\ContainerInterface;
 
-use Laminas\ServiceManager\Factory\FactoryInterface;
 use VuFindSearch\Backend\WorldCat\Backend;
 use VuFindSearch\Backend\WorldCat\Connector;
 use VuFindSearch\Backend\WorldCat\QueryBuilder;
@@ -46,7 +45,7 @@ use VuFindSearch\Backend\WorldCat\Response\XML\RecordCollectionFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class WorldCatBackendFactory implements FactoryInterface
+class WorldCatBackendFactory extends AbstractBackendFactory
 {
     /**
      * Logger.
@@ -54,13 +53,6 @@ class WorldCatBackendFactory implements FactoryInterface
      * @var \Laminas\Log\LoggerInterface
      */
     protected $logger;
-
-    /**
-     * Superior service manager.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * VuFind configuration
@@ -89,7 +81,7 @@ class WorldCatBackendFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
-        $this->serviceLocator = $sm;
+        parent::__invoke($sm, $name, $options);
         $this->config = $this->serviceLocator
             ->get(\VuFind\Config\PluginManager::class)
             ->get('config');
@@ -128,9 +120,11 @@ class WorldCatBackendFactory implements FactoryInterface
         $wsKey = $this->config->WorldCat->apiKey ?? null;
         $connectorOptions = isset($this->wcConfig->Connector)
             ? $this->wcConfig->Connector->toArray() : [];
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
-        $connector = new Connector($wsKey, $client, $connectorOptions);
+        $connector = new Connector(
+            $wsKey,
+            $this->createHttpClient(),
+            $connectorOptions
+        );
         $connector->setLogger($this->logger);
         return $connector;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -98,9 +98,10 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp(): void
     {
-        $handlermap     = new HandlerMap(['select' => ['fallback' => true]]);
-        $connector      = new Connector('http://example.org/', $handlermap);
-        $this->backend  = new Backend($connector);
+        $handlermap    = new HandlerMap(['select' => ['fallback' => true]]);
+        $client        = new \Laminas\Http\Client();
+        $connector     = new Connector('http://example.org/', $handlermap, $client);
+        $this->backend = new Backend($connector);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
@@ -127,7 +127,8 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $handlermap     = new HandlerMap(['select' => ['fallback' => true]]);
-        $connector      = new Connector('http://example.org/', $handlermap);
+        $client         = new \Laminas\Http\Client();
+        $connector      = new Connector('http://example.org/', $handlermap, $client);
         $this->backend  = new Backend($connector);
         $this->backend->setIdentifier('foo');
         $this->listener = new MultiIndexListener($this->backend, self::$shards, self::$fields, self::$specs);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
@@ -28,7 +28,6 @@
  */
 namespace VuFindSearch\Backend\EDS;
 
-use Laminas\Http\Client\Adapter\Curl as CurlAdapter;
 use Laminas\Http\Client as HttpClient;
 use Laminas\Log\LoggerAwareInterface;
 
@@ -64,23 +63,12 @@ class Connector extends Base implements LoggerAwareInterface
      *      <li>orgid - Organization making calls to the EDS API</li>
      *      <li>timeout - HTTP timeout value (default = 120)</li>
      *    </ul>
-     * @param HttpClient $client   HTTP client object (optional)
+     * @param HttpClient $client   HTTP client object
      */
-    public function __construct($settings = [], $client = null)
+    public function __construct($settings, $client)
     {
         parent::__construct($settings);
-        if ($client) {
-            $this->client = $client;
-        } else {
-            $this->client = new HttpClient();
-            $this->client->setAdapter(new CurlAdapter());
-        }
-        $this->client->setOptions(
-            [
-                'timeout' => $settings['timeout'] ?? 120,
-                'sslverifypeer' => false,
-            ]
-        );
+        $this->client = $client;
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -441,17 +441,13 @@ class Backend extends AbstractBackend
         $connector = $this->getConnector();
 
         // Write!
-        if (is_int($timeout ?? null)) {
-            $connector->callWithHttpOptions(
-                compact('timeout'),
-                'write',
-                $doc,
-                $handler ?? 'update',
-                $params
-            );
-        } else {
-            $connector->write($doc, $handler ?? 'update', $params);
-        }
+        $connector->callWithHttpOptions(
+            is_int($timeout ?? null) ? compact('timeout') : [],
+            'write',
+            $doc,
+            $handler ?? 'update',
+            $params
+        );
 
         // Save the core name in the results in case the caller needs it.
         return ['core' => $connector->getCore()];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -440,20 +440,17 @@ class Backend extends AbstractBackend
     ) {
         $connector = $this->getConnector();
 
-        // If we have a custom timeout, remember the old timeout value and then
-        // override it with a different one:
-        $oldTimeout = null;
-        if (is_int($timeout ?? null)) {
-            $oldTimeout = $connector->getTimeout();
-            $connector->setTimeout($timeout);
-        }
-
         // Write!
-        $connector->write($doc, $handler ?? 'update', $params);
-
-        // Restore previous timeout value, if necessary:
-        if (null !== $oldTimeout) {
-            $connector->setTimeout($oldTimeout);
+        if (is_int($timeout ?? null)) {
+            $connector->callWithHttpOptions(
+                compact('timeout'),
+                'write',
+                $doc,
+                $handler ?? 'update',
+                $params
+            );
+        } else {
+            $connector->write($doc, $handler ?? 'update', $params);
         }
 
         // Save the core name in the results in case the caller needs it.

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -115,7 +115,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         $url,
         HandlerMap $map,
         HttpClient $client,
-        $uniqueKey = 'id',
+        $uniqueKey = 'id'
     ) {
         $this->url = $url;
         $this->map = $map;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -40,6 +40,7 @@ use VuFindSearch\Backend\Exception\HttpErrorException;
 use VuFindSearch\Backend\Exception\RemoteErrorException;
 use VuFindSearch\Backend\Exception\RequestErrorException;
 use VuFindSearch\Backend\Solr\Document\DocumentInterface;
+use VuFindSearch\Exception\InvalidArgumentException;
 use VuFindSearch\ParamBag;
 
 /**
@@ -311,6 +312,10 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         string $method,
         ...$args
     ) {
+        $reflectionMethod = new \ReflectionMethod($this, $method);
+        if (!$reflectionMethod->isPublic()) {
+            throw new InvalidArgumentException("Method '$method' is not public");
+        }
         if (empty($options)) {
             return call_user_func_array([$this, $method], $args);
         }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -311,6 +311,9 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         string $method,
         ...$args
     ) {
+        if (empty($options)) {
+            return call_user_func_array([$this, $method], $args);
+        }
         $saveClient = $this->client;
         try {
             $this->client = clone $this->client;

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
@@ -131,7 +131,7 @@ class ConnectorTest extends TestCase
             ->with($this->equalTo($csvData));
         $conn = $this->getMockBuilder(Connector::class)
             ->onlyMethods(['send'])
-            ->setConstructorArgs(['http://foo', $map, 'id', $client])
+            ->setConstructorArgs(['http://foo', $map, $client, 'id'])
             ->getMock();
         $conn->expects($this->once())->method('send')
             ->with($this->equalTo($client));
@@ -161,7 +161,7 @@ class ConnectorTest extends TestCase
             ->with($this->equalTo($jsonData));
         $conn = $this->getMockBuilder(Connector::class)
             ->onlyMethods(['send'])
-            ->setConstructorArgs(['http://foo', $map, 'id', $client])
+            ->setConstructorArgs(['http://foo', $map, $client, 'id'])
             ->getMock();
         $conn->expects($this->once())->method('send')
             ->with($this->equalTo($client));
@@ -219,20 +219,10 @@ class ConnectorTest extends TestCase
         $url = 'http://example.tld/';
         $map  = new HandlerMap(['select' => ['fallback' => true]]);
         $key = 'foo';
-        $conn = new Connector($url, $map, $key);
+        $conn = new Connector($url, $map, new \Laminas\Http\Client(), $key);
         $this->assertEquals($url, $conn->getUrl());
         $this->assertEquals($map, $conn->getMap());
         $this->assertEquals($key, $conn->getUniqueKey());
-    }
-
-    /**
-     * Test default timeout value
-     *
-     * @return void
-     */
-    public function testDefaultTimeout()
-    {
-        $this->assertEquals(30, $this->createConnector()->getTimeout());
     }
 
     /**
@@ -252,7 +242,7 @@ class ConnectorTest extends TestCase
         }
 
         $map  = new HandlerMap(['select' => ['fallback' => true]]);
-        return new Connector('http://example.tld/', $map, 'id', $this->createClient());
+        return new Connector('http://example.tld/', $map, $this->createClient(), 'id');
     }
 
     /**


### PR DESCRIPTION
Adds a common base class and modifies the Solr connector a bit to avoid storing timeout there.

Potentially controversial:
- Makes HTTP Client a mandatory constructor parameter in all connector classes.
- As a result of above change, shuffles constructor parameters so that optional ones follow the required ones.
- Turns SSL peer verification on in EDS connector by default but allows turning it off in settings (I've tested that at least the default server has a valid certificate).
- Modifies Solr Connector to avoid storing HTTP client's timeout in it.
