### PR TITLE
Form: Add support for labels in email subject, fix form validation etc.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -96,11 +96,10 @@ class FeedbackController extends AbstractBase
             return $view;
         }
 
-        [$messageParams, $template]
-            = $form->formatEmailMessage($this->params()->fromPost());
+        $fields = $form->mapRequestParamsToFieldValues($this->params()->fromPost());
         $emailMessage = $this->getViewRenderer()->partial(
-            $template,
-            ['fields' => $messageParams]
+            'Email/form.phtml',
+            compact('fields')
         );
 
         [$senderName, $senderEmail] = $this->getSender($form);

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -143,6 +143,7 @@ class FeedbackController extends AbstractBase
 
         if ($sendSuccess) {
             $this->showResponse($view, $form, true);
+            $view->setTemplate('feedback/response');
         }
 
         return $view;
@@ -223,10 +224,7 @@ class FeedbackController extends AbstractBase
     protected function showResponse($view, $form, $success, $errorMsg = null)
     {
         if ($success) {
-            $this->flashMessenger()->addMessage(
-                $form->getSubmitResponse(),
-                'success'
-            );
+            $view->setTemplate('feedback/response');
         } else {
             $this->flashMessenger()->addMessage($errorMsg, 'error');
         }

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -152,7 +152,7 @@ class Form extends \Laminas\Form\Form implements
         $this->formElementConfig
             = $this->parseConfig($formId, $config, $params);
 
-        $this->buildForm($this->formElementConfig);
+        $this->buildForm();
     }
 
     /**
@@ -283,6 +283,9 @@ class Form extends \Laminas\Form\Form implements
     /**
      * Return form email message subject.
      *
+     * Replaces any placeholders for form field values or labels with the submitted
+     * values.
+     *
      * @param array $postParams Posted form data
      *
      * @return string
@@ -297,16 +300,37 @@ class Form extends \Laminas\Form\Form implements
             $subject = $this->defaultFormConfig['email_subject'];
         }
 
-        $translated = [];
-        foreach ($postParams as $key => $val) {
-            $translatedVals = array_map([$this, 'translate'], (array)$val);
-            $translated["%%{$key}%%"] = implode(', ', $translatedVals);
+        $mappings = [];
+        foreach ($this->mapRequestParamsToFieldValues($postParams) as $field) {
+            // Use translated value as default for backward compatibility:
+            $mappings["%%{$field['name']}%%"]
+                = $mappings["%%translatedValue:{$field['name']}%%"]
+                    = implode(
+                        ', ',
+                        array_map(
+                            [$this, 'translate'],
+                            (array)($field['value'] ?? [])
+                        )
+                    );
+            $mappings["%%value:{$field['name']}%%"]
+                = implode(', ', (array)($field['value'] ?? []));
+            $mappings["%%label:{$field['name']}%%"]
+                = implode(', ', (array)($field['valueLabel'] ?? []));
+            $mappings["%%translatedLabel:{$field['name']}%%"] = implode(
+                ', ',
+                array_map(
+                    [$this, 'translate'],
+                    (array)($field['valueLabel'] ?? [])
+                )
+            );
         }
 
-        return str_replace(
-            array_keys($translated),
-            array_values($translated),
-            $subject
+        return trim(
+            str_replace(
+                array_keys($mappings),
+                array_values($mappings),
+                $subject
+            )
         );
     }
 
@@ -352,8 +376,25 @@ class Form extends \Laminas\Form\Form implements
      * @param array $requestParams Request parameters
      *
      * @return array Array with template parameters and template name.
+     *
+     * @deprecated Use mapRequestParamsToFieldValues
      */
     public function formatEmailMessage(array $requestParams = [])
+    {
+        return [
+            $this->mapRequestParamsToFieldValues($requestParams),
+            'Email/form.phtml'
+        ];
+    }
+
+    /**
+     * Map request parameters to field values
+     *
+     * @param array $requestParams Request parameters
+     *
+     * @return array
+     */
+    public function mapRequestParamsToFieldValues(array $requestParams): array
     {
         $params = [];
         foreach ($this->getFormElementConfig() as $el) {
@@ -362,25 +403,50 @@ class Form extends \Laminas\Form\Form implements
                 continue;
             }
             $value = $requestParams[$el['name']] ?? null;
+            $valueLabel = null;
 
             if (in_array($type, ['radio', 'select'])) {
-                $value = $this->translate($value);
-            } elseif ($type === 'checkbox' && !empty($value)) {
-                $translated = [];
-                foreach ($value as $val) {
-                    $translated[] = $this->translate($val);
+                if (isset($el['options'])) {
+                    $option = $el['options'][$value] ?? null;
+                } elseif (isset($el['optionGroups'])) {
+                    $option = null;
+                    foreach ($el['optionGroups'] as $group) {
+                        if (isset($group['options'][$value])) {
+                            $option = $group['options'][$value];
+                            break;
+                        }
+                    }
                 }
-                $value = implode(', ', $translated);
+                if (null === $option) {
+                    $value = null;
+                    $valueLabel = null;
+                } else {
+                    $value = $option['value'];
+                    $valueLabel = $option['label'];
+                }
+            } elseif ($type === 'checkbox' && !empty($value)) {
+                $labels = [];
+                $values = [];
+                foreach ($value as $val) {
+                    $option = $el['options'][$val] ?? null;
+                    if (null === $option) {
+                        continue;
+                    }
+                    $labels[] = $option['label'];
+                    $values[] = $option['value'];
+                }
+                $value = $values;
+                $valueLabel = $labels;
             } elseif ($type === 'date' && !empty($value)) {
                 $format = $el['format']
                     ?? $this->vufindConfig['Site']['displayDateFormat'] ?? 'Y-m-d';
-                $value = date($format, strtotime($value));
+                $date = strtotime($value);
+                $value = date($format, $date);
             }
-            $label = isset($el['label']) ? $this->translate($el['label']) : null;
-            $params[] = $el + compact('value', 'label');
+            $params[] = $el + compact('value', 'valueLabel');
         }
 
-        return [$params, 'Email/form.phtml'];
+        return $params;
     }
 
     /**
@@ -558,14 +624,13 @@ class Form extends \Laminas\Form\Form implements
             'group' => '__sender__'
         ];
         if ($formConfig['senderInfoRequired'] ?? false) {
-            $senderEmail['required'] = $senderEmail['aria-required']
-                = $senderName['required'] = $senderName['aria-required'] = true;
+            $senderEmail['required'] = $senderName['required'] = true;
         }
         if ($formConfig['senderNameRequired'] ?? false) {
-            $senderName['required'] = $senderName['aria-required'] = true;
+            $senderName['required'] = true;
         }
         if ($formConfig['senderEmailRequired'] ?? false) {
-            $senderEmail['required'] = $senderEmail['aria-required'] = true;
+            $senderEmail['required'] = true;
         }
         $configuredElements[] = $senderName;
         $configuredElements[] = $senderEmail;
@@ -590,59 +655,14 @@ class Form extends \Laminas\Form\Form implements
                 $element['group'] = $element['name'];
             }
 
-            $element['label'] = $this->translate($el['label'] ?? null);
+            $element['label'] = $el['label'] ?? '';
 
             $elementType = $element['type'];
             if (in_array($elementType, ['checkbox', 'radio', 'select'])) {
-                if (empty($el['options']) && empty($el['optionGroups'])) {
-                    continue;
-                }
-                if (isset($el['options'])) {
-                    $options = [];
-                    $isSelect = $elementType === 'select';
-                    $placeholder = $element['placeholder'] ?? null;
-
-                    if ($isSelect && $placeholder) {
-                        // Add placeholder option (without value) for
-                        // select element.
-                        $options[] = [
-                            'value' => '',
-                            'label' => $this->translate($placeholder),
-                            'attributes' => [
-                                'selected' => 'selected', 'disabled' => 'disabled'
-                            ]
-                        ];
-                    }
-                    foreach ($el['options'] as $option) {
-                        $value = $option['value'] ?? $option;
-                        $label = $option['label'] ?? $option;
-                        if ($isSelect) {
-                            $options[] = [
-                                'value' => $value,
-                                'label' => $this->translate($label)
-                            ];
-                        } else {
-                            $options[$value] = $this->translate($label);
-                        }
-                    }
+                if ($options = $this->getElementOptions($el)) {
                     $element['options'] = $options;
-                } elseif (isset($el['optionGroups'])) {
-                    $groups = [];
-                    foreach ($el['optionGroups'] as $group) {
-                        if (empty($group['options'])) {
-                            continue;
-                        }
-                        $options = [];
-                        foreach ($group['options'] as $option) {
-                            $value = $option['value'] ?? $option;
-                            $label = $option['label'] ?? $option;
-
-                            $options[$value] = $this->translate($label);
-                        }
-                        $label = $this->translate($group['label']);
-                        $groups[$label] = ['label' => $label, 'options' => $options];
-                    }
-                    $element['optionGroups'] = $groups;
+                } elseif ($optionGroups = $this->getElementOptionGroups($el)) {
+                    $element['optionGroups'] = $optionGroups;
                 }
             }
 
@@ -651,9 +671,6 @@ class Form extends \Laminas\Form\Form implements
                 foreach ($el['settings'] as [$settingId, $settingVal]) {
                     $settingId = trim($settingId);
                     $settingVal = trim($settingVal);
-                    if ($settingId === 'placeholder') {
-                        $settingVal = $this->translate($settingVal);
-                    }
                     $settings[$settingId] = $settingVal;
                 }
                 $element['settings'] = $settings;
@@ -682,7 +699,7 @@ class Form extends \Laminas\Form\Form implements
                     'type' => 'hidden',
                     'name' => 'referrer',
                     'settings' => ['value' => $referrer],
-                    'label' => $this->translate('Referrer'),
+                    'label' => 'Referrer',
                 ];
             }
         }
@@ -693,7 +710,7 @@ class Form extends \Laminas\Form\Form implements
                     'type' => 'hidden',
                     'name' => 'useragent',
                     'settings' => ['value' => $userAgent],
-                    'label' => $this->translate('User Agent'),
+                    'label' => 'User Agent',
                 ];
             }
         }
@@ -701,10 +718,88 @@ class Form extends \Laminas\Form\Form implements
         $elements[] = [
             'type' => 'submit',
             'name' => 'submit',
-            'label' => $this->translate('Send')
+            'label' => 'Send'
         ];
 
         return $elements;
+    }
+
+    /**
+     * Get options for an element
+     *
+     * @param array $element Element configuration
+     *
+     * @return array
+     */
+    protected function getElementOptions(array $element): array
+    {
+        if (!isset($element['options'])) {
+            return [];
+        }
+
+        $options = [];
+        $isSelect = $element['type'] === 'select';
+        $placeholder = $element['placeholder'] ?? null;
+
+        if ($isSelect && $placeholder) {
+            // Add placeholder option (without value) for
+            // select element.
+            $options['o0'] = [
+                'value' => '',
+                'label' => $placeholder,
+                'attributes' => [
+                    'selected' => 'selected', 'disabled' => 'disabled'
+                ]
+            ];
+        }
+        $idx = 0;
+        foreach ($element['options'] as $option) {
+            ++$idx;
+            $value = $option['value'] ?? $option;
+            $label = $option['label'] ?? $option;
+            $options["o$idx"] = [
+                'value' => $value,
+                'label' => $label
+            ];
+        }
+        return $options;
+    }
+
+    /**
+     * Get option groups for an element
+     *
+     * @param array $element Element configuration
+     *
+     * @return array
+     */
+    protected function getElementOptionGroups(array $element): array
+    {
+        if (!isset($element['optionGroups'])) {
+            return [];
+        }
+        $groups = [];
+        $idx = 0;
+        foreach ($element['optionGroups'] as $group) {
+            if (empty($group['options'])) {
+                continue;
+            }
+            $options = [];
+            foreach ($group['options'] as $option) {
+                ++$idx;
+                $value = $option['value'] ?? $option;
+                $label = $option['label'] ?? $option;
+
+                $options["o$idx"] = [
+                    'value' => $value,
+                    'label' => $label,
+                ];
+            }
+            $groups[$group['label']] = [
+                'label' => $group['label'],
+                'options' => $options
+            ];
+        }
+        return $groups;
     }
 
     /**
@@ -757,13 +852,11 @@ class Form extends \Laminas\Form\Form implements
     /**
      * Build form.
      *
-     * @param array $elements Parsed configuration elements
-     *
      * @return void
      */
-    protected function buildForm($elements)
+    protected function buildForm()
     {
-        foreach ($elements as $el) {
+        foreach ($this->formElementConfig as $el) {
             if ($element = $this->getFormElement($el)) {
                 $this->add($element);
             }
@@ -771,7 +864,7 @@ class Form extends \Laminas\Form\Form implements
     }
 
     /**
-     * Get form element attributes.
+     * Get configuration for a Laminas form element
      *
      * @param array $el Element configuration
      *
@@ -780,7 +873,7 @@ class Form extends \Laminas\Form\Form implements
     protected function getFormElement($el)
     {
         $type = $el['type'];
-        if (!$class = $this->getFormElementClass($type)) {
+        if (!($class = $this->getFormElementClass($type))) {
             return null;
         }
 
@@ -793,7 +886,7 @@ class Form extends \Laminas\Form\Form implements
         $attributes = $el['settings'] ?? [];
 
         $attributes = [
-            'id' => $el['name'],
+            'id' => $this->getElementId($el['name']),
             'class' => [$el['settings']['class'] ?? null]
         ];
 
@@ -803,15 +896,12 @@ class Form extends \Laminas\Form\Form implements
 
         if (!empty($el['required'])) {
             $attributes['required'] = true;
-            $attributes['aria-required'] = "true";
-        } elseif ($type !== 'submit') {
-            $attributes['aria-required'] = "false";
         }
         if (!empty($el['settings'])) {
             $attributes += $el['settings'];
         }
-        if (!empty($el['label'])) {
-            $attributes['aria-label'] = $el['label'];
+        if (!empty($el['label']) && 'hidden' !== $type) {
+            $attributes['aria-label'] = $this->translate($el['label']);
         }
 
         switch ($type) {
@@ -821,11 +911,13 @@ class Form extends \Laminas\Form\Form implements
                 $options = $el['options'];
             }
             $optionElements = [];
-            foreach ($options as $key => $val) {
+            foreach ($options as $key => $item) {
                 $optionElements[] = [
-                    'label' => $val,
+                    'label' => $this->translate($item['label']),
                     'value' => $key,
-                    'attributes' => ['id' => $val]
+                    'attributes' => [
+                        'id' => $this->getElementId($el['name'] . '_' . $key)
+                    ]
                 ];
             }
             $conf['options'] = ['value_options' => $optionElements];
@@ -845,12 +937,15 @@ class Form extends \Laminas\Form\Form implements
             }
             $optionElements = [];
             $first = true;
-            foreach ($options as $key => $val) {
+            foreach ($options as $key => $option) {
+                $elemId = $this->getElementId($el['name'] . '_' . $key);
                 $optionElements[] = [
-                    'label' => $val,
+                    'label' => $this->translate($option['label']),
                     'value' => $key,
-                    'label_attributes' => ['for' => $val],
-                    'attributes' => ['id' => $val],
+                    'label_attributes' => ['for' => $elemId],
+                    'attributes' => [
+                        'id' => $elemId
+                    ],
                     'selected' => $first
                 ];
                 $first = false;
@@ -859,9 +954,25 @@ class Form extends \Laminas\Form\Form implements
             break;
         case 'select':
             if (isset($el['options'])) {
-                $conf['options'] = ['value_options' => $el['options']];
+                $options = $el['options'];
+                foreach ($options as $key => &$option) {
+                    $option['value'] = $key;
+                }
+                // Unset reference:
+                unset($option);
+                $conf['options'] = ['value_options' => $options];
             } elseif (isset($el['optionGroups'])) {
-                $conf['options'] = ['value_options' => $el['optionGroups']];
+                $groups = $el['optionGroups'];
+                foreach ($groups as &$group) {
+                    foreach ($group['options'] as $key => &$option) {
+                        $option['value'] = $key;
+                    }
+                    // Unset reference:
+                    unset($key);
+                }
+                // Unset reference:
+                unset($group);
+                $conf['options'] = ['value_options' => $groups];
             }
             break;
         case 'submit':
@@ -933,5 +1044,17 @@ class Form extends \Laminas\Form\Form implements
             $elements[] = $field;
         }
         return $elements;
+    }
+
+    /**
+     * Get a complete id for an element
+     *
+     * @param string $id Element ID
+     *
+     * @return string
+     */
+    protected function getElementId(string $id): string
+    {
+        return 'form_' . $this->formConfig['id'] . '_' . $id;
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
@@ -109,7 +109,8 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '#modal .form-control[name="name"]')->setValue('Me');
         $this->findCss($page, '#modal .form-control[name="email"]')
             ->setValue('test@test.com');
-        $this->findCss($page, "#modal #message")->setValue('test test test');
+        $this->findCss($page, "#modal #form_FeedbackSite_message")
+            ->setValue('test test test');
         $this->clickCss($page, '#modal input[type="submit"]');
         $this->snooze();
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -73,6 +73,8 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $form->getSubmitResponse()
         );
         $this->assertEquals([[], 'Email/form.phtml'], $form->formatEmailMessage([]));
+        $this->assertEquals([], $form->mapRequestParamsToFieldValues([]));
+
         $this->assertEquals(
             'Laminas\InputFilter\InputFilter',
             get_class($form->getInputFilter())
@@ -180,43 +182,51 @@ class FormTest extends \PHPUnit\Framework\TestCase
             'Thank you for your feedback.',
             $form->getSubmitResponse()
         );
+        $expectedFields = [
+            [
+                'type' => 'textarea',
+                'value' => 'x',
+                'valueLabel' => null,
+                'label' => 'Comments',
+                'name' => 'message',
+                'required' => true,
+                'settings' => ['cols' => 50, 'rows' => 8],
+            ],
+            [
+                'type' => 'text',
+                'value' => 'y',
+                'valueLabel' => null,
+                'name' => 'name',
+                'group' => '__sender__',
+                'label' => 'feedback_name',
+                'settings' => ['size' => 50],
+            ],
+            [
+                'type' => 'email',
+                'value' => 'z@foo.com',
+                'valueLabel' => null,
+                'name' => 'email',
+                'group' => '__sender__',
+                'label' => 'feedback_email',
+                'settings' => ['size' => 50],
+            ],
+        ];
+        $postParams = [
+            'message' => 'x',
+            'name' => 'y',
+            'email' => 'z@foo.com'
+        ];
+
         $this->assertEquals(
             [
-                [
-                    [
-                        'type' => 'textarea',
-                        'value' => 'x',
-                        'label' => 'Comments',
-                        'name' => 'message',
-                        'required' => true,
-                        'settings' => ['cols' => 50, 'rows' => 8],
-                    ],
-                    [
-                        'type' => 'text',
-                        'value' => 'y',
-                        'name' => 'name',
-                        'group' => '__sender__',
-                        'label' => 'feedback_name',
-                        'settings' => ['size' => 50],
-                    ],
-                    [
-                        'type' => 'email',
-                        'value' => 'z@foo.com',
-                        'name' => 'email',
-                        'group' => '__sender__',
-                        'label' => 'feedback_email',
-                        'settings' => ['size' => 50],
-                    ],
-                ],
+                $expectedFields,
                 'Email/form.phtml'
             ],
-            $form->formatEmailMessage(
-                [
-                    'message' => 'x',
-                    'name' => 'y',
-                    'email' => 'z@foo.com'
-                ]
-            )
+            $form->formatEmailMessage($postParams)
+        );
+        $this->assertEquals(
+            $expectedFields,
+            $form->mapRequestParamsToFieldValues($postParams)
         );
         $this->assertEquals(
             'Laminas\InputFilter\InputFilter',
@@ -306,58 +316,128 @@ class FormTest extends \PHPUnit\Framework\TestCase
         // Select element optionGroup: options with labels and values
         $el = $getElement('select', $elements);
         $this->assertEquals(
-            ['value-1' => 'label-1', 'value-2' => 'label-2'],
+            [
+                'o1' => [
+                    'value' => 'value-1',
+                    'label' => 'label-1'
+                ],
+                'o2' => [
+                    'value' => 'value-2',
+                    'label' => 'label-2'
+                ]
+            ],
             $el['optionGroups']['group-1']['options']
         );
 
         // Select element optionGroup: options with values
         $el = $getElement('select2', $elements);
         $this->assertEquals(
-            ['option-1' => 'option-1', 'option-2' => 'option-2'],
+            [
+                'o1' => [
+                    'value' => 'option-1',
+                    'label' => 'option-1'
+                ],
+                'o2' => [
+                    'value' => 'option-2',
+                    'label' => 'option-2'
+                ]
+            ],
             $el['optionGroups']['group-1']['options']
         );
 
         // Select element options with labels and values
         $el = $getElement('select3', $elements);
         $this->assertEquals(
-            [['label' => 'label-1', 'value' => 'value-1'],
-             ['value' => 'value-2', 'label' => 'label-2']],
+            [
+                'o1' => [
+                    'label' => 'label-1',
+                    'value' => 'value-1'
+                ],
+                'o2' => [
+                    'label' => 'label-2',
+                    'value' => 'value-2'
+                ]
+            ],
             $el['options']
         );
 
         // Select element options with values
         $el = $getElement('select4', $elements);
         $this->assertEquals(
-            [['label' => 'option-1', 'value' => 'option-1'],
-             ['value' => 'option-2', 'label' => 'option-2']],
+            [
+                'o1' => [
+                    'label' => 'option-1',
+                    'value' => 'option-1'
+                ],
+                'o2' => [
+                    'label' => 'option-2',
+                    'value' => 'option-2'
+                ]
+            ],
             $el['options']
         );
 
         // Radio element options with labels and values
         $el = $getElement('radio', $elements);
         $this->assertEquals(
-            ['value-1' => 'label-1', 'value-2' => 'label-2'],
+            [
+                'o1' => [
+                    'label' => 'label-1',
+                    'value' => 'value-1'
+                ],
+                'o2' => [
+                    'label' => 'label-2',
+                    'value' => 'value-2'
+                ]
+            ],
             $el['options']
         );
 
         // Radio element options with values
         $el = $getElement('radio2', $elements);
         $this->assertEquals(
-            ['option-1' => 'option-1', 'option-2' => 'option-2'],
+            [
+                'o1' => [
+                    'label' => 'option-1',
+                    'value' => 'option-1'
+                ],
+                'o2' => [
+                    'label' => 'option-2',
+                    'value' => 'option-2'
+                ]
+            ],
             $el['options']
         );
 
         // Checkbox element options with labels and values
         $el = $getElement('checkbox', $elements);
         $this->assertEquals(
-            ['value-1' => 'label-1', 'value-2' => 'label-2'],
+            [
+                'o1' => [
+                    'label' => 'label-1',
+                    'value' => 'value-1'
+                ],
+                'o2' => [
+                    'label' => 'label-2',
+                    'value' => 'value-2'
+                ]
+            ],
             $el['options']
         );
 
         // Checkbox element options with values
         $el = $getElement('checkbox2', $elements);
         $this->assertEquals(
-            ['option-1' => 'option-1', 'option-2' => 'option-2'],
+            [
+                'o1' => [
+                    'label' => 'option-1',
+                    'value' => 'option-1'
+                ],
+                'o2' => [
+                    'label' => 'option-2',
+                    'value' => 'option-2'
+                ]
+            ],
             $el['options']
         );
     }
@@ -373,15 +453,19 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Select element optionGroup: options with labels and values
         // Valid option value
-        $form->setData(['select' => 'value-1']);
+        $form->setData(['select' => 'o1']);
         $this->assertTrue($form->isValid());
-        // Invalid option value
+        // Invalid option values
         $form->setData(['select' => 'invalid-value']);
+        $this->assertFalse($form->isValid());
+        $form->setData(['select' => 0]);
+        $this->assertFalse($form->isValid());
+        $form->setData(['select' => 'o11']);
         $this->assertFalse($form->isValid());
 
         // Select element optionGroup: options with values
         // Valid option value
-        $form->setData(['select2' => 'option-1']);
+        $form->setData(['select2' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['select2' => 'invalid-option']);
@@ -389,7 +473,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Select element options with labels and values
         // Valid option value
-        $form->setData(['select3' => 'value-1']);
+        $form->setData(['select3' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['select3' => 'invalid-value']);
@@ -397,7 +481,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Select element options with values
         // Valid option value
-        $form->setData(['select4' => 'option-1']);
+        $form->setData(['select4' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['select4' => 'invalid-option']);
@@ -405,7 +489,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Radio element options with labels and values
         // Valid option value
-        $form->setData(['radio' => 'value-1']);
+        $form->setData(['radio' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['radio' => 'invalid-value']);
@@ -413,7 +497,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Radio element options with values
         // Valid option value
-        $form->setData(['radio2' => 'option-1']);
+        $form->setData(['radio2' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['radio2' => 'invalid-option']);
@@ -421,7 +505,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Checkbox element options with labels and values
         // Valid option value
-        $form->setData(['checkbox' => 'value-1']);
+        $form->setData(['checkbox' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['checkbox' => 'invalid-value']);
@@ -429,7 +513,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
         // Checkbox element options with values
         // Valid option value
-        $form->setData(['checkbox2' => 'option-1']);
+        $form->setData(['checkbox2' => 'o1']);
         $this->assertTrue($form->isValid());
         // Invalid option value
         $form->setData(['checkbox2' => 'invalid-option']);
@@ -457,19 +541,19 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($form->isValid());
 
             // One OK option, another missing
-            $form->setData(['checkbox' => ['option-1']]);
+            $form->setData(['checkbox' => ['o1']]);
             $this->assertFalse($form->isValid());
 
             // One OK option, another invalid
-            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $form->setData(['checkbox' => ['o1', 'invalid-option']]);
             $this->assertFalse($form->isValid());
 
             // Both required options
-            $form->setData(['checkbox' => ['option-1', 'option-2']]);
+            $form->setData(['checkbox' => ['o1', 'o2']]);
             $this->assertTrue($form->isValid());
 
             // Both required options and one invalid
-            $form->setData(['checkbox' => ['option-1', 'option-2', 'invalid-option']]);
+            $form->setData(['checkbox' => ['o1', 'o2', 'invalid-option']]);
             $this->assertFalse($form->isValid());
         }
 
@@ -491,19 +575,19 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($form->isValid());
 
             // One OK option
-            $form->setData(['checkbox' => ['option-1']]);
+            $form->setData(['checkbox' => ['o1']]);
             $this->assertTrue($form->isValid());
 
             // One OK option
-            $form->setData(['checkbox' => ['option-2']]);
+            $form->setData(['checkbox' => ['o2']]);
             $this->assertTrue($form->isValid());
 
             // Both options OK
-            $form->setData(['checkbox' => ['option-1', 'option-2']]);
+            $form->setData(['checkbox' => ['o1', 'o2']]);
             $this->assertTrue($form->isValid());
 
             // One OK and one invalid option
-            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $form->setData(['checkbox' => ['o1', 'invalid-option']]);
             $this->assertFalse($form->isValid());
         }
 
@@ -527,11 +611,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($form->isValid());
 
             // One OK option
-            $form->setData(['checkbox' => ['option-1']]);
+            $form->setData(['checkbox' => ['o1']]);
             $this->assertTrue($form->isValid());
 
             // One OK and one invalid option
-            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $form->setData(['checkbox' => ['o1', 'invalid-option']]);
             $this->assertFalse($form->isValid());
         }
 
@@ -556,11 +640,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($form->isValid());
 
             // One OK option
-            $form->setData(['checkbox' => ['option-1']]);
+            $form->setData(['checkbox' => ['o1']]);
             $this->assertTrue($form->isValid());
 
             // One OK and one invalid option
-            $form->setData(['checkbox' => ['option-1', 'invalid-option']]);
+            $form->setData(['checkbox' => ['o1', 'invalid-option']]);
             $this->assertFalse($form->isValid());
         }
     }

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -4,7 +4,7 @@
 
   $title = $form->getTitle();
   $title = !empty($title)
-    ? $this->transEsc($title) : null;
+    ? $this->translate($title) : null;
 
   $formUrl = $this->url('feedback-form', ['id' => $this->formId]);
   $form->setAttribute('action', $formUrl);
@@ -20,7 +20,7 @@
   <?php if ($title): ?>
     <?php $this->headTitle($title); ?>
     <?php $headTag = $this->inLightbox ? 'h2' : 'h1'; ?>
-    <<?=$headTag?>><?=$title?></<?=$headTag?>>
+    <<?=$headTag?>><?=$this->escapeHtml($title)?></<?=$headTag?>>
   <?php endif; ?>
   <?=$this->flashmessages()?>
 

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -71,7 +71,7 @@
     <?php endif ?>
     <?php if (in_array($handleGroup, ['open', 'openAndClose'])): ?>
       <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
-        <div class="field-set" role="group"<?= !empty($el['label']) ? ' aria-labelledby="' . $this->escapeHtmlAttr($el['name']) . '"' : ''?>>
+        <div class="field-set" role="group"<?= !empty($el['label']) ? ' aria-labelledby="' . $this->escapeHtmlAttr($formElement->getAttribute('id')) . '"' : ''?>>
       <?php else: ?>
         <div class="field-set"<?= !empty($elementHelpPre) ? ' role="contentinfo" aria-label="' . $this->escapeHtmlAttr($elementHelpPre) . '"' : ''?>>
       <?php endif ?>
@@ -88,9 +88,9 @@
           $requireOne = $el['requireOne'] ?? false;
         ?>
         <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
-          <p id="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label radio-label<?=$required && !$requireOne? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
-        <?php else: ?>
-          <label for="<?=$this->escapeHtmlAttr($el['name'])?>" class="control-label<?=$required ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
+          <p id="<?=$this->escapeHtmlAttr($formElement->getAttribute('id'))?>" class="control-label radio-label<?=$required && !$requireOne? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
+        <?php elseif ('hidden' !== $el['type']): ?>
+          <label for="<?=$this->escapeHtmlAttr($formElement->getAttribute('id'))?>" class="control-label<?=$required ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
         <?php endif ?>
       <?php endif ?>
     <?php else: ?>

--- a/themes/bootstrap3/templates/feedback/response.phtml
+++ b/themes/bootstrap3/templates/feedback/response.phtml
@@ -1,0 +1,18 @@
+<?php
+  $form = $this->form;
+  $form->prepare();
+
+  $title = $form->getTitle();
+  $title = !empty($title) ? $this->translate($title) : null;
+?>
+<?php if (!$this->inLightbox): ?><div class="feedback-content"><?php endif; ?>
+<?php if ($title): ?>
+  <?php $this->headTitle($title); ?>
+  <?php $headTag = $this->inLightbox ? 'h2' : 'h1'; ?>
+  <<?=$headTag?>><?=$this->escapeHtml($title)?></<?=$headTag?>>
+<?php endif; ?>
+<?=$this->flashmessages()?>
+<div role="status" class="alert alert-success">
+  <?=$this->translate($form->getSubmitResponse()) ?>
+</div>
+<?php if (!$this->inLightbox): ?></div><?php endif; ?>

--- a/themes/root/templates/Email/form.phtml
+++ b/themes/root/templates/Email/form.phtml
@@ -6,7 +6,9 @@
 <?=$data['value']?>
 
 -----
+<?php elseif (in_array($data['type'], ['checkbox', 'radio', 'select'])): ?>
+<?=($label ? "$label: " : '') . implode(', ', array_map([$this, 'translate'], (array)$data['value'])) . PHP_EOL ?>
 <?php else: ?>
-<?= ($label ? "$label: " : '') . implode(', ', array_map([$this, 'translate'], (array)$data['value'])) . PHP_EOL ?>
+<?=($label ? "$label: " : '') . $data['value'] . PHP_EOL ?>
 <?php endif ?>
 <?php endforeach ?>

--- a/themes/root/templates/Email/form.phtml
+++ b/themes/root/templates/Email/form.phtml
@@ -1,8 +1,9 @@
 <?php foreach($this->fields as $data): ?>
 <?php $label = $this->translate($data['label'] ?? '') ?>
 <?php if ($data['type'] === 'textarea'): ?>
------
 <?=$label ? "$label: " : ''?>
+
+-----
 <?=$data['value']?>
 
 -----

--- a/themes/root/templates/Email/form.phtml
+++ b/themes/root/templates/Email/form.phtml
@@ -1,13 +1,12 @@
 <?php foreach($this->fields as $data): ?>
-<?php $label = $data['label'] ?? null ?>
-<?php $isTextarea = $data['type'] === 'textarea'; ?>
-<?php if ($isTextarea): ?>
+<?php $label = $this->translate($data['label'] ?? '') ?>
+<?php if ($data['type'] === 'textarea'): ?>
 -----
 <?=$label ? "$label: " : ''?>
 <?=$data['value']?>
 
 -----
 <?php else: ?>
-<?= ($label ? "$label: " : '') . $data['value'] . PHP_EOL ?>
+<?= ($label ? "$label: " : '') . implode(', ', array_map([$this, 'translate'], (array)$data['value'])) . PHP_EOL ?>
 <?php endif ?>
 <?php endforeach ?>


### PR DESCRIPTION
This started from two requirements: 

1.) Need to be able to use select field labels in email subject
2.) Need to hide select values from the form

The other refactoring and fixes revolve around these and are so intertwined that I couldn't split this into more sensible pieces. Some notes:

1.) Avoid translating stuff early. Leave it more to the UI layer. This makes the separation more well-defined and would make it possible to use the data in other ways than just an email message (like storing feedback in database).
2.) formatEmailMessage is deprecated. I don't think the form should return the template name to use.
3.) aria attributes were removed and changed to fix HTML validation.
4.) Element id's were modified to make it less likely for them to collide with other UI elements. Also, this would make it possible to display multiple forms on a page without duplicate id's.
