### PR TITLE
Handle collections in merge-marc utility.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
@@ -46,6 +46,11 @@ use VuFindConsole\Command\RelativeFileAwareCommand;
 class MergeMarcCommand extends RelativeFileAwareCommand
 {
     /**
+     * XML namespace for MARC21.
+     */
+    public const MARC21_NAMESPACE = 'http://www.loc.gov/MARC21/slim';
+
+    /**
      * The name of the command (the part after "public/index.php")
      *
      * @var string
@@ -104,7 +109,16 @@ class MergeMarcCommand extends RelativeFileAwareCommand
 
             // output content:
             $output->writeln("<!-- $filePath -->");
-            $output->write($fileContent);
+
+            // If the current file is a collection, we need to extract records:
+            $xml = simplexml_load_string($fileContent);
+            if (stristr($xml->getName(), 'collection') !== false) {
+                foreach ($xml->children(self::MARC21_NAMESPACE) as $record) {
+                    $output->write($record->asXml());
+                }
+            } else {
+                $output->write($fileContent);
+            }
         }
         $output->writeln('</collection>');
         return 0;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
@@ -146,10 +146,22 @@ class MergeMarcCommand extends RelativeFileAwareCommand
              ? [$xml->children(self::MARC21_NAMESPACE), $xml->children()]
              : [[$xml]];
         foreach ($childSets as $children) {
+            // We'll set a flag to indicate whether or not we found anything in
+            // the most recent set. This allows us to break out of the loop once
+            // a record has been found, which enables us to favor namespaced
+            // matches over non-namespaced matches. This is not ideal (we might
+            // miss records in a weird file containing a mix of namespaced and
+            // non-namespaced records), but the alternative would cause namespaced
+            // but non-prefixed records to get loaded twice.
+            $foundSomething = false;
             foreach ($children as $record) {
                 if (stristr($record->getName(), 'record') !== false) {
+                    $foundSomething = true;
                     $output->write(trim($this->recordXmlToString($record)) . "\n");
                 }
+            }
+            if ($foundSomething) {
+                break;
             }
         }
     }

--- a/module/VuFindConsole/tests/fixtures/xml/b.xml
+++ b/module/VuFindConsole/tests/fixtures/xml/b.xml
@@ -1,1 +1,1 @@
-<record id="b" />
+<record id="b" xmlns="http://www.loc.gov/MARC21/slim"/>

--- a/module/VuFindConsole/tests/fixtures/xml/c.xml
+++ b/module/VuFindConsole/tests/fixtures/xml/c.xml
@@ -1,0 +1,1 @@
+<collection><record id="c" /><record id="d" /></collection>

--- a/module/VuFindConsole/tests/fixtures/xml/d.xml
+++ b/module/VuFindConsole/tests/fixtures/xml/d.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim">
   <marc:record id="e" />
-  <marc:record  xmlns:marc="http://www.loc.gov/MARC21/slim" id="f" />
+  <marc:record id="f" />
 </marc:collection>

--- a/module/VuFindConsole/tests/fixtures/xml/d.xml
+++ b/module/VuFindConsole/tests/fixtures/xml/d.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim">
+  <marc:record id="e" />
+  <marc:record  xmlns:marc="http://www.loc.gov/MARC21/slim" id="f" />
+</marc:collection>

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
@@ -72,19 +72,20 @@ class MergeMarcCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester = new CommandTester($command);
         $directory = $this->getFixtureDir('VuFindConsole') . 'xml';
         $commandTester->execute(compact('directory'));
+        $xmlns = MergeMarcCommand::MARC21_NAMESPACE;
         $expected = <<<EXPECTED
-<collection>
+<marc:collection xmlns:marc="$xmlns">
 <!-- $directory/a.xml -->
-<record id="a" />
+<marc:record id="a"/>
 <!-- $directory/b.xml -->
-<record id="b" />
+<marc:record id="b"/>
 <!-- $directory/c.xml -->
-<record id="c"/>
-<record id="d"/>
+<marc:record id="c"/>
+<marc:record id="d"/>
 <!-- $directory/d.xml -->
-<marc:record id="e" xmlns:marc="http://www.loc.gov/MARC21/slim"/>
-<marc:record xmlns:marc="http://www.loc.gov/MARC21/slim" id="f"/>
-</collection>
+<marc:record id="e"/>
+<marc:record id="f"/>
+</marc:collection>
 
 EXPECTED;
         $this->assertEquals($expected, $commandTester->getDisplay());

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
@@ -78,6 +78,12 @@ class MergeMarcCommandTest extends \PHPUnit\Framework\TestCase
 <record id="a" />
 <!-- $directory/b.xml -->
 <record id="b" />
+<!-- $directory/c.xml -->
+<record id="c"/>
+<record id="d"/>
+<!-- $directory/d.xml -->
+<marc:record id="e" xmlns:marc="http://www.loc.gov/MARC21/slim"/>
+<marc:record xmlns:marc="http://www.loc.gov/MARC21/slim" id="f"/>
 </collection>
 
 EXPECTED;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Harvest/MergeMarcCommandTest.php
@@ -78,7 +78,7 @@ class MergeMarcCommandTest extends \PHPUnit\Framework\TestCase
 <!-- $directory/a.xml -->
 <marc:record id="a"/>
 <!-- $directory/b.xml -->
-<marc:record id="b"/>
+<marc:record xmlns="http://www.loc.gov/MARC21/slim" id="b"/>
 <!-- $directory/c.xml -->
 <marc:record id="c"/>
 <marc:record id="d"/>


### PR DESCRIPTION
This adds support for `<collection>`s as well as single records in the merge-marc utility; useful when OAI-PMH harvesting MARC records in batches.

TODO
- [x] Thoroughly test (and ensure unit test coverage of new case)