### PR TITLE
Avoid notice in EIT code when results are missing.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EIT/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EIT/Connector.php
@@ -119,7 +119,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         $response = $this->call('GET', $params->getArrayCopy());
         $xml = simplexml_load_string($response);
         $finalDocs = [];
-        foreach ($xml->SearchResults->records->rec as $doc) {
+        foreach ($xml->SearchResults->records->rec ?? [] as $doc) {
             $finalDocs[] = simplexml_load_string($doc->asXML());
         }
         return [
@@ -211,7 +211,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         $response = $this->call('GET', $params->getArrayCopy());
         $xml = simplexml_load_string($response);
         $finalDocs = [];
-        foreach ($xml->SearchResults->records->rec as $doc) {
+        foreach ($xml->SearchResults->records->rec ?? [] as $doc) {
             $finalDocs[] = simplexml_load_string($doc->asXML());
         }
         return [


### PR DESCRIPTION
While testing #2229, I encountered some notices when EIT was not fully configured. This PR eliminates the notices to avoid noise in logs; better overall validation might also be in order, but I didn't want to invest a lot of time in this rarely-used backend.