### PR TITLE
Improve advanced search "clear" behavior for radio buttons/checkboxes

### DIFF
--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -137,7 +137,11 @@ deleteGroup = function _deleteGroup(group) {
 $(document).ready(function advSearchReady() {
   $('.clear-btn').click(function clearBtnClick() {
     $('input[type="text"]').val('');
-    $('input[type="checkbox"]').prop("checked", false);
+    $('input[type="checkbox"]').each(function onEachCheckbox() {
+      var checked = $(this).data('reset-checked');
+      checked = (checked == null) ? false : checked;
+      $(this).prop("checked", checked);
+    });
     $("option:selected").prop("selected", false);
     $("#illustrated_-1").click();
   });

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -137,12 +137,11 @@ deleteGroup = function _deleteGroup(group) {
 $(document).ready(function advSearchReady() {
   $('.clear-btn').click(function clearBtnClick() {
     $('input[type="text"]').val('');
-    $('input[type="checkbox"]').each(function onEachCheckbox() {
+    $('input[type="checkbox"],input[type="radio"]').each(function onEachCheckbox() {
       var checked = $(this).data('reset-checked');
       checked = (checked == null) ? false : checked;
       $(this).prop("checked", checked);
     });
     $("option:selected").prop("selected", false);
-    $("#illustrated_-1").click();
   });
 });

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -138,7 +138,7 @@ $(document).ready(function advSearchReady() {
   $('.clear-btn').click(function clearBtnClick() {
     $('input[type="text"]').val('');
     $('input[type="checkbox"],input[type="radio"]').each(function onEachCheckbox() {
-      var checked = $(this).data('reset-checked');
+      var checked = $(this).data('checked-by-default');
       checked = (checked == null) ? false : checked;
       $(this).prop("checked", checked);
     });

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -137,6 +137,7 @@ deleteGroup = function _deleteGroup(group) {
 $(document).ready(function advSearchReady() {
   $('.clear-btn').click(function clearBtnClick() {
     $('input[type="text"]').val('');
+    $('input[type="checkbox"]').prop("checked", false);
     $("option:selected").prop("selected", false);
     $("#illustrated_-1").click();
   });

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -5,7 +5,7 @@
       $value = $expander['Value'] ?>
       <div class="checkbox">
         <label for="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected'])?'checked="checked"':''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
+          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected'])?'checked="checked" data-reset-checked="true"':''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
           <?=$this->transEsc('eds_expander_' . $value, [], $expander['Label'])?>
         </label>
       </div>
@@ -42,7 +42,7 @@
             $value = $facet['LimiterValues'][0]['Value'] ?>
             <div class="checkbox">
               <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected'])?'checked="checked"':''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
+                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected'])?'checked="checked" data-reset-checked="true"':''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
                 <?=$this->transEsc($facet['Label'])?>
               </label>
             </div>

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -5,7 +5,7 @@
       $value = $expander['Value'] ?>
       <div class="checkbox">
         <label for="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected'])?'checked="checked" data-reset-checked="true"':''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
+          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected'])?'checked="checked" data-checked-by-default="true"':''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
           <?=$this->transEsc('eds_expander_' . $value, [], $expander['Label'])?>
         </label>
       </div>
@@ -42,7 +42,7 @@
             $value = $facet['LimiterValues'][0]['Value'] ?>
             <div class="checkbox">
               <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected'])?'checked="checked" data-reset-checked="true"':''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
+                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected'])?'checked="checked" data-checked-by-default="true"':''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
                 <?=$this->transEsc($facet['Label'])?>
               </label>
             </div>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -62,7 +62,7 @@
   <fieldset class="solr">
     <legend><?=$this->transEsc("Illustrated")?>:</legend>
     <?php foreach ($this->illustratedLimit as $current): ?>
-      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked" data-reset-checked="true"':''?>/>
+      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked" data-checked-by-default="true"':''?>/>
       <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br/>
     <?php endforeach; ?>
   </fieldset>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -62,7 +62,7 @@
   <fieldset class="solr">
     <legend><?=$this->transEsc("Illustrated")?>:</legend>
     <?php foreach ($this->illustratedLimit as $current): ?>
-      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked"':''?>/>
+      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked" data-reset-checked="true"':''?>/>
       <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br/>
     <?php endforeach; ?>
   </fieldset>


### PR DESCRIPTION
We noticed that advanced search in EDS contains checkboxes that are not cleared when clear button is used.