### PR TITLE
Add as-needed option to ESLint func-names rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   rules: {
     // errors
     "block-scoped-var": "error",
-    "func-names": "error",
+    "func-names": ["error", "as-needed"],
     "no-loop-func": "error",
     "no-param-reassign": "error",
     "no-shadow": "error",


### PR DESCRIPTION
We have a large existing JavaScript codebase with which we would like to start using VuFind's coding standards. This small change would save us from a lot of refactoring and should not affect existing VuFind code.

https://eslint.org/docs/rules/func-names#as-needed