### PR TITLE
Make getFacetLabel work for checkbox filters.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -970,8 +970,6 @@ class Params
      * @param string $default Default field name (null for default behavior).
      *
      * @return string         Human-readable description of field.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function getFacetLabel($field, $value = null, $default = null)
     {

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -973,20 +973,18 @@ class Params
      */
     public function getFacetLabel($field, $value = null, $default = null)
     {
-        $checkboxFacet = $this->checkboxFacets[$field]["$field:$value"] ?? null;
         if (!isset($this->facetConfig[$field])
             && !isset($this->extraFacetLabels[$field])
-            && null === $checkboxFacet
             && isset($this->facetAliases[$field])
         ) {
             $field = $this->facetAliases[$field];
-            $checkboxFacet = $this->checkboxFacets[$field]["$field:$value"] ?? null;
+        }
+        $checkboxFacet = $this->checkboxFacets[$field]["$field:$value"] ?? null;
+        if (null !== $checkboxFacet) {
+            return $checkboxFacet['desc'];
         }
         if (isset($this->facetConfig[$field])) {
             return $this->facetConfig[$field];
-        }
-        if (null !== $checkboxFacet) {
-            return $checkboxFacet['desc'];
         }
         return $this->extraFacetLabels[$field]
             ?? ($default ?: 'unrecognized_facet_label');

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -975,14 +975,20 @@ class Params
      */
     public function getFacetLabel($field, $value = null, $default = null)
     {
+        $checkboxFacet = $this->checkboxFacets[$field]["$field:$value"] ?? null;
         if (!isset($this->facetConfig[$field])
             && !isset($this->extraFacetLabels[$field])
+            && null === $checkboxFacet
             && isset($this->facetAliases[$field])
         ) {
             $field = $this->facetAliases[$field];
+            $checkboxFacet = $this->checkboxFacets[$field]["$field:$value"] ?? null;
         }
         if (isset($this->facetConfig[$field])) {
             return $this->facetConfig[$field];
+        }
+        if (null !== $checkboxFacet) {
+            return $checkboxFacet['desc'];
         }
         return $this->extraFacetLabels[$field]
             ?? ($default ?: 'unrecognized_facet_label');


### PR DESCRIPTION
Since Params::getFilterList can return checkbox filters, it would make sense for it to return the labels as well.

This allows Piwik and Matomo to record custom variables or dimensions properly for checkbox facets instead of `unrecognized_facet_label`.