### PR TITLE
FOLIO: Add config setting to allow debug of GET requests.

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -3,6 +3,9 @@ base_url = https://localhost:9130
 username = diku_admin
 password = admin
 tenant = diku
+; If set to true, the driver will log all GET requests as debug messages; if false
+; (the default), it will only log POSTs to reduce noise.
+debug_get_requests = false
 
 [IDs]
 ; Which FOLIO ID is VuFind using as its internal bibliographic ID?

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -144,8 +144,10 @@ class Folio extends AbstractAPI implements
      */
     protected function debugRequest($method, $path, $params, $req_headers)
     {
-        // Only log non-GET requests
-        if ($method == 'GET') {
+        // Only log non-GET requests, unless configured otherwise
+        if ($method == 'GET'
+            && !($this->config['API']['debug_get_requests'] ?? false)
+        ) {
             return;
         }
         // remove passwords


### PR DESCRIPTION
While troubleshooting #2236, I found this feature helpful, so I propose making it a config setting. Would appreciate a review from a FOLIO user if time permits!