### PR TITLE
Web-based installer: add installation report link; format success message as info box.

### DIFF
--- a/themes/bootstrap3/templates/install/home.phtml
+++ b/themes/bootstrap3/templates/install/home.phtml
@@ -13,5 +13,7 @@
 <?php endforeach; ?>
 
 <?php if ($errors == 0): ?>
-  <p>No problems were found.  You may wish to <a href="<?=$this->url('install-done')?>">Disable Auto Configuration</a> at this time.</p>
+  <div class="alert alert-info">No problems were found.  You may wish to <a href="<?=$this->url('install-done')?>">Disable Auto Configuration</a> at this time.</div>
 <?php endif; ?>
+
+<div class="alert alert-info">Please consider <a href="https://vufind.org/advanced_demo/Feedback/Form/InstallationReport">reporting your new instance to the VuFind Community</a>. This will ensure that you are included on the <a href="https://vufind.org/wiki/community:installations">VuFind Installation List</a> and will help others find your site.</div>


### PR DESCRIPTION
This PR adds a link to the new installation report form to encourage users to share their VuFind instances with the community. It also reformats the existing message about disabling auto-configuration as an info box for a more consistent display.