### PR TITLE
Show cover for non-existent records

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCover.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCover.php
@@ -31,7 +31,6 @@ use Laminas\Mvc\Controller\Plugin\Params;
 use Laminas\View\Renderer\PhpRenderer;
 use VuFind\Cache\CacheTrait;
 use VuFind\Cover\Router as CoverRouter;
-use VuFind\Exception\RecordMissing as RecordMissingException;
 use VuFind\Record\Loader as RecordLoader;
 use VuFind\Session\Settings as SessionSettings;
 
@@ -117,22 +116,10 @@ class GetRecordCover extends AbstractBase implements AjaxHandlerInterface
         $recordId = $params->fromQuery('recordId');
         $recordSource = $params->fromQuery('source', DEFAULT_SEARCH_BACKEND);
         $size = $params->fromQuery('size', 'small');
-        try {
-            $record = $this->recordLoader->load($recordId, $recordSource);
-        } catch (RecordMissingException $exception) {
-            return $this->formatResponse(
-                'Could not load record: ' . $exception->getMessage(),
-                self::STATUS_HTTP_BAD_REQUEST
-            );
-        }
-
         if (!in_array($size, ['small', 'medium', 'large'])) {
-            return $this->formatResponse(
-                'Not valid size: ' . $size,
-                self::STATUS_HTTP_BAD_REQUEST
-            );
+            $size = 'small';
         }
-
+        $record = $this->recordLoader->load($recordId, $recordSource, true);
         $metadata = $this->coverRouter->getMetadata(
             $record,
             $size ?? 'small',

--- a/module/VuFind/src/VuFind/RecordDriver/Missing.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Missing.php
@@ -103,4 +103,14 @@ class Missing extends DefaultRecord
         $title = parent::getShortTitle();
         return empty($title) ? $this->determineMissingTitle() : $title;
     }
+
+    /**
+     * Get an array of all the formats associated with the record.
+     *
+     * @return array
+     */
+    public function getFormats()
+    {
+        return ['other'];
+    }
 }

--- a/module/VuFind/src/VuFind/RecordDriver/Missing.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Missing.php
@@ -111,6 +111,6 @@ class Missing extends DefaultRecord
      */
     public function getFormats()
     {
-        return ['other'];
+        return ['Unknown'];
     }
 }


### PR DESCRIPTION
When loading cover for records that are not indexed in solr (usually in user account, where data comes from ILS driver and could not be in index), the cover is never load and spinner stay visible.

I've changed the missing record handling to show format-other fallback icon.