### PR TITLE
Add test for MARC processing in Unicorn driver.

### DIFF
--- a/module/VuFind/tests/fixtures/marc/unicornholdings.mrc
+++ b/module/VuFind/tests/fixtures/marc/unicornholdings.mrc
@@ -1,0 +1,1 @@
+00208nam  2200073   45e0852003900000863002300039866002000062852005200082\\\a852fieldblibraryclocationznote\\\a863field8foo.bar\\\a866field81234\\\a852field2blibrary2clocation2znote2aznote2b

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
@@ -40,6 +40,9 @@ use VuFind\ILS\Driver\Unicorn;
  */
 class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
 {
+    use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\ReflectionTrait;
+
     /**
      * Standard setup method.
      *
@@ -48,5 +51,57 @@ class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
     public function setUp(): void
     {
         $this->driver = new Unicorn(new \VuFind\Date\Converter());
+    }
+
+    /**
+     * Test MARC holdings parsing.
+     *
+     * @return void
+     */
+    public function testMarcParsing(): void
+    {
+        $marc = $this->getFixture('marc/unicornholdings.mrc');
+        $checkAndRemove852 = function ($result) {
+            $this->assertTrue(isset($result['marc852']));
+            unset($result['marc852']);
+            return $result;
+        };
+        $results = array_map(
+            $checkAndRemove852,
+            $this->callMethod($this->driver, 'getMarcHoldings', [$marc])
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    'library_code' => 'library',
+                    'library' => 'library',
+                    'location_code' => 'location',
+                    'location' => 'location',
+                    'notes' => [
+                        'note',
+                    ],
+                    'summary' => [
+                        0 => '863field',
+                        1234000000000 => '863field',
+                    ],
+                ],
+                [
+                    'library_code' => 'library2',
+                    'library' => 'library2',
+                    'location_code' => 'location2',
+                    'location' => 'location2',
+                    'notes' => [
+                        'note2a',
+                        'note2b',
+                    ],
+                    'summary' => [
+                        0 => '863field',
+                        1234000000000 => '863field',
+                    ],
+                ],
+            ],
+            $results
+        );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
@@ -61,6 +61,9 @@ class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
     public function testMarcParsing(): void
     {
         $marc = $this->getFixture('marc/unicornholdings.mrc');
+        // The 'marc852' element contains an object and is not used in existing code.
+        // Let's just make sure that the element is present, then remove it from the
+        // array to simplify subsequent comparison assertions.
         $checkAndRemove852 = function ($result) {
             $this->assertTrue(isset($result['marc852']));
             unset($result['marc852']);


### PR DESCRIPTION
This is a quick-and-dirty effort to add some test coverage for MARC processing in the Unicorn driver, so we can validate the refactoring in #2252 without the need for a running Unicorn system.

I'm not convinced that there's need to maintain the Unicorn driver -- it hasn't been touched in a decade, and I suspect no one is using it in production -- so while this test is pretty crude and minimal, I think it's probably an adequate good faith effort.