### PR TITLE
Improve Unicorn MARC test.

### DIFF
--- a/module/VuFind/tests/fixtures/marc/unicornholdings.mrc
+++ b/module/VuFind/tests/fixtures/marc/unicornholdings.mrc
@@ -1,1 +1,1 @@
-00208nam  2200073   45e0852003900000863002300039866002000062852005200082\\\a852fieldblibraryclocationznote\\\a863field8foo.bar\\\a866field81234\\\a852field2blibrary2clocation2znote2aznote2b
+00267nam  2200085   45e0852003900000863003700039866002000076852005200096866003300148  \a852fieldblibraryclocationznote  \a863fieldzlinked note81234.bar  \a866field81234  \a852field2blibrary2clocation2znote2aznote2b  aunlinked 866 will be ignored

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
@@ -85,8 +85,7 @@ class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
                         'note',
                     ],
                     'summary' => [
-                        0 => '863field',
-                        1234000000000 => '863field',
+                        1234000000000 => '863field linked note',
                     ],
                 ],
                 [
@@ -99,8 +98,7 @@ class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
                         'note2b',
                     ],
                     'summary' => [
-                        0 => '863field',
-                        1234000000000 => '863field',
+                        1234000000000 => '863field linked note',
                     ],
                 ],
             ],


### PR DESCRIPTION
A quick look at the code coverage in Jenkins revealed a couple of details that I wasn't testing before, so I've added a bit more data to cover more edges. I don't think this will get us to 100%, but it at least should hit all the remaining File_MARC logic.