### PR TITLE
Raise minimum PHP version to 7.4.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,10 @@ jobs:
       VUFIND_LOCAL_DIR: $GITHUB_WORKSPACE/local
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1']
         # We run most tests on all platforms, but we only run Javascript-related tests in 8.1,
         # since the results should be the same on all platforms, so we don't need to repeat them.
         include:
-          - php-version: 7.3
-            phing_tasks: "qa-php"
           - php-version: 7.4
             phing_tasks: "qa-php"
           - php-version: 8.0

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "GPL-2.0",
     "config": {
         "platform": {
-            "php": "7.3.0"
+            "php": "7.4.0"
         },
         "process-timeout": 0,
         "allow-plugins": {
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.4.0",
         "ahand/mobileesp": "dev-master",
         "cap60552/php-sip2": "1.0.0",
         "colinmollenhour/credis": "1.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbc041e1d158e125b8c2a0b0a51003ed",
+    "content-hash": "791596c74733a512de473ecae5f146cc",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -5642,20 +5642,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -5684,9 +5684,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/log",
@@ -11558,11 +11558,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3.0"
+        "php": ">=7.4.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.0"
+        "php": "7.4.0"
     },
     "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
We are finally ready to raise the dev-9.0 branch's PHP requirement to 7.4, thanks to @EreMaijala's work on eliminating PEAR dependencies in #2252. I've pulled @xmorave2's PHP version configuration updates out of #2048 and into this separate PR so that we can merge them independently.

TODO
- [x] Update changelog when merging