### PR TITLE
Override relevance for ID-based searches.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -12,7 +12,7 @@ default_sort         = relevance
 ; searches when relevance sort is selected. Since relevance doesn't have a
 ; meaningful function without query terms, this can be set to e.g. "title" or
 ; "year desc".
-empty_search_relevance_override = year desc
+;empty_search_relevance_override = title
 
 ; This setting controls the default view for search results; the selected option
 ; should be one of the options present in the [Views] section below.

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -8,10 +8,11 @@ default_handler      = AllFields    ; Search handler to use if none is specified
 ; below.
 default_sort         = relevance
 
-; This setting controls the sort order to be used for empty search when relevance
-; sort is selected. Since relevance doesn't have a meaningful function with an empty
-; search, this can be set to e.g. "title".
-;empty_search_relevance_override = title
+; This setting controls the sort order to be used for empty (or purely ID-based)
+; searches when relevance sort is selected. Since relevance doesn't have a
+; meaningful function without query terms, this can be set to e.g. "title" or
+; "year desc".
+empty_search_relevance_override = year desc
 
 ; This setting controls the default view for search results; the selected option
 ; should be one of the options present in the [Views] section below.

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -102,6 +102,13 @@ class Params extends \VuFind\Search\Base\Params
     protected $facetHelper;
 
     /**
+     * Are we searching by ID only (instead of a normal query)?
+     *
+     * @var bool
+     */
+    protected $searchingById = false;
+
+    /**
      * Config sections to search for facet labels if no override configuration
      * is set.
      *
@@ -427,6 +434,7 @@ class Params extends \VuFind\Search\Base\Params
             return '"' . addcslashes($i, '"') . '"';
         };
         $ids = array_map($callback, $ids);
+        $this->searchingById = true;
         $this->setOverrideQuery('id:(' . implode(' OR ', $ids) . ')');
     }
 
@@ -541,7 +549,7 @@ class Params extends \VuFind\Search\Base\Params
             $sortFields = explode(',', $sort);
             $allTerms = trim($this->getQuery()->getAllTerms());
             if ('relevance' === $sortFields[0]
-                && ('' === $allTerms || '*:*' === $allTerms)
+                && ('' === $allTerms || '*:*' === $allTerms || $this->searchingById)
                 && ($relOv = $this->getOptions()->getEmptySearchRelevanceOverride())
             ) {
                 $sort = $relOv;


### PR DESCRIPTION
It was recently brought to my attention that having relevance-based sorting for ID-based searches is meaningless, just as it is for empty searches. This makes the results in course reserves and new items searches potentially confusing. This PR extends the empty search relevance override to also impact ID-based searches.