### PR TITLE
Demo driver: make new/recent IDs configurable.

### DIFF
--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -49,6 +49,16 @@ services[] = 'custom'
 ; driver.
 ;historicTransactions = '[{"id":"1234", ... "dueDate": "01/01/2017"}]';
 
+; This setting can be used to flag specific records as recently returned; if
+; commented out, a random set of IDs will be selected.
+;recently_returned[] = myBibId001
+;recently_returned[] = myBibId002
+
+; This setting can be used to flag specific records as newly acquired; if
+; commented out, a random set of IDs will be selected.
+;new_items[] = myBibId001
+;new_items[] = myBibId002
+
 ; This setting may be used to simulate suppressed records (through the
 ; getSuppressedRecords method):
 ;suppressed[] = suppressedRecordId1

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -1549,7 +1549,7 @@ class Demo extends AbstractBase
      *
      * @return string[]
      */
-    protected function getRandomBiBIds($limit): array
+    protected function getRandomBibIds($limit): array
     {
         $count = rand(0, $limit > 30 ? 30 : $limit);
         $results = [];

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -1543,6 +1543,28 @@ class Demo extends AbstractBase
     }
 
     /**
+     * Get a set of random bib IDs
+     *
+     * @param int $limit Maximum number of IDs to return (max 30)
+     *
+     * @return string[]
+     */
+    protected function getRandomBiBIds($limit): array
+    {
+        $count = rand(0, $limit > 30 ? 30 : $limit);
+        $results = [];
+        for ($x = 0; $x < $count; $x++) {
+            $randomId = $this->getRandomBibId();
+
+            // avoid duplicate entries in array:
+            if (!in_array($randomId, $results)) {
+                $results[] = $randomId;
+            }
+        }
+        return $results;
+    }
+
+    /**
      * Get New Items
      *
      * Retrieve the IDs of items recently added to the catalog.
@@ -1566,16 +1588,8 @@ class Demo extends AbstractBase
         $this->checkIntermittentFailure();
         // Pick a random number of results to return -- don't exceed limit or 30,
         // whichever is smaller (this can be pretty slow due to the random ID code).
-        $count = rand(0, $limit > 30 ? 30 : $limit);
-        $results = [];
-        for ($x = 0; $x < $count; $x++) {
-            $randomId = $this->getRandomBibId();
-
-            // avoid duplicate entries in array:
-            if (!in_array($randomId, $results)) {
-                $results[] = $randomId;
-            }
-        }
+        $results = $this->config['Records']['new_items']
+            ?? $this->getRandomBibIds(30);
         $retVal = ['count' => count($results), 'results' => []];
         foreach ($results as $result) {
             $retVal['results'][] = ['id' => $result];
@@ -2569,9 +2583,14 @@ class Demo extends AbstractBase
         $maxage = 30,
         $patron = null
     ) {
-        // This is similar to getNewItems for demo purposes.
-        $results = $this->getNewItems(1, $limit, $maxage);
-        return $results['results'];
+        $this->checkIntermittentFailure();
+
+        $results = $this->config['Records']['recently_returned']
+            ?? $this->getRandomBibIds($limit);
+        $mapper = function ($id) {
+            return ['id' => $id];
+        };
+        return array_map($mapper, $results);
     }
 
     /**


### PR DESCRIPTION
While working on #2295, I needed an easy mechanism to test with a specific set of new records, so I created these new settings.