### PR TITLE
Add test for email subject

### DIFF
--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -150,3 +150,34 @@ forms:
             value: option-1
         label: checkbox
         requireOne: true
+
+  TestSubjectEmailWithPlaceholders:
+    emailSubject: Subject %%text1%% %%text2%% %%checkbox%% 
+    fields:
+      - name: text1
+        type: text
+        label: Sender Name
+      - name: text2
+        type: text
+        label: Topic
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+        label: checkbox
+  TestSubjectEmailWithoutPlaceholders:
+    emailSubject: Subject without placeholders
+    fields:
+      - name: text1
+        type: text
+        label: Sender Name
+      - name: text2
+        type: text
+        label: Topic
+      - name: checkbox
+        type: checkbox
+        options:
+          - label: Option 1
+            value: option-1
+        label: checkbox

--- a/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
+++ b/module/VuFind/tests/fixtures/configs/feedbackforms/test.yaml
@@ -166,6 +166,7 @@ forms:
           - label: Option 1
             value: option-1
         label: checkbox
+
   TestSubjectEmailWithoutPlaceholders:
     emailSubject: Subject without placeholders
     fields:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -22,6 +22,7 @@
  * @category VuFind
  * @package  Tests
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
@@ -37,6 +38,7 @@ use VuFind\Form\Form;
  * @category VuFind
  * @package  Tests
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -564,4 +564,36 @@ class FormTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($form->isValid());
         }
     }
+
+    /**
+     * Test email subjects.
+     *
+     * @return void
+     */
+    public function testEmailSubjects()
+    {
+        $ids = [
+            'TestSubjectEmailWithPlaceholders',
+            'TestSubjectEmailWithoutPlaceholders'
+        ];
+        $results = [
+            'Subject One Two option-1',
+            'Subject without placeholders'
+        ];
+        for ($i = 0; $i < count($ids); $i++) {
+            $form = $this->getMockTestForm($ids[$i]);
+            $form->setData(
+                [
+                    'text1' => 'One',
+                    'text2' => 'Two',
+                    'checkbox' => ['option-1']
+                ]
+            );
+            $this->assertTrue($form->isValid());
+            $this->assertEquals(
+                $results[$i],
+                $form->getEmailSubject($form->getData())
+            );
+        }
+    }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -568,34 +568,51 @@ class FormTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Function to get testEmailSubjects data.
+     * 
+     * @return array
+     */
+    public function getEmailSubjectsData(): array
+    {
+        return [
+            'with placeholders'
+                => [
+                    'TestSubjectEmailWithPlaceholders',
+                    'Subject One Two option-1'
+                ],
+            'without placeholders'
+                => [
+                    'TestSubjectEmailWithoutPlaceholders',
+                    'Subject without placeholders'
+                ],
+       ];
+    }
+
+    /**
      * Test email subjects.
+     * @dataProvider getEmailSubjectsData
      *
+     * @param string $formToTest      ID of the form to test.
+     * @param string $expectedSubject String to be expected.
+     * 
      * @return void
      */
-    public function testEmailSubjects()
-    {
-        $ids = [
-            'TestSubjectEmailWithPlaceholders',
-            'TestSubjectEmailWithoutPlaceholders'
-        ];
-        $results = [
-            'Subject One Two option-1',
-            'Subject without placeholders'
-        ];
-        for ($i = 0; $i < count($ids); $i++) {
-            $form = $this->getMockTestForm($ids[$i]);
-            $form->setData(
-                [
-                    'text1' => 'One',
-                    'text2' => 'Two',
-                    'checkbox' => ['option-1']
-                ]
-            );
-            $this->assertTrue($form->isValid());
-            $this->assertEquals(
-                $results[$i],
-                $form->getEmailSubject($form->getData())
-            );
-        }
+    public function testEmailSubjects(
+        string $formToTest,
+        string $expectedSubject
+    ): void {
+        $form = $this->getMockTestForm($formToTest);
+        $form->setData(
+            [
+                'text1' => 'One',
+                'text2' => 'Two',
+                'checkbox' => ['option-1']
+            ]
+        );
+        $this->assertTrue($form->isValid());
+        $this->assertEquals(
+            $expectedSubject,
+            $form->getEmailSubject($form->getData())
+        );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -569,7 +569,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Function to get testEmailSubjects data.
-     * 
+     *
      * @return array
      */
     public function getEmailSubjectsData(): array
@@ -594,7 +594,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
      *
      * @param string $formToTest      ID of the form to test.
      * @param string $expectedSubject String to be expected.
-     * 
+     *
      * @return void
      */
     public function testEmailSubjects(


### PR DESCRIPTION
This is my first unit test provided here so any tips would be appreciated. It just tests if the subject email is properly formed. One subject email is with placeholders and the second is without.