### PR TITLE
Remove obsolete cache settings; make some PHP extensions optional.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
             "wikimedia/composer-merge-plugin": true
         }
     },
+    "provide": {
+        "ext-memcached": "*",
+        "ext-soap": "*"
+    },
     "require": {
         "php": ">=7.4.0",
         "ahand/mobileesp": "dev-master",
@@ -98,14 +102,6 @@
         "phpunit/phpunit": "9.5.10",
         "sebastian/phpcpd": "6.0.3",
         "squizlabs/php_codesniffer": "3.6.2"
-    },
-    "replace": {
-        "laminas/laminas-cache-storage-adapter-apc": "*",
-        "laminas/laminas-cache-storage-adapter-dba": "*",
-        "laminas/laminas-cache-storage-adapter-memcache": "*",
-        "laminas/laminas-cache-storage-adapter-mongodb": "*",
-        "laminas/laminas-cache-storage-adapter-wincache": "*",
-        "laminas/laminas-cache-storage-adapter-xcache": "*"
     },
     "extra": {
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ea8adf4dc07e123441a2beabcd8e833",
+    "content-hash": "ec4f654e55f746101b4bec67deeddfbd",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -8108,6 +8108,9 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -11264,5 +11267,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
- When moving from laminas-cache v2 to v3, some compatibility settings could be removed
- Some rarely-used VuFind dependencies require specific PHP extensions; adding a "provides" section allows us to effectively make them optional