### PR TITLE
Avoid session manager's writeClose in disableWrite.

### DIFF
--- a/module/VuFind/src/VuFind/Session/Settings.php
+++ b/module/VuFind/src/VuFind/Session/Settings.php
@@ -72,14 +72,14 @@ class Settings
 
         // If the session manager is already instantiated, close it!
         if (null !== $this->manager) {
-            // Store and restore current $_SESSION contents since session_abort()
-            // will reset it:
-            $sessionData = $_SESSION;
-            session_abort();
-            $_SESSION = $sessionData;
-            if ($storage = $this->manager->getStorage()) {
-                $storage->markImmutable();
+            // Try to disable writes so that writeClose() below doesn't actually
+            // write anything:
+            $saveHandler = $this->manager->getSaveHandler();
+            if (is_callable([$saveHandler, 'disableWrites'])) {
+                $saveHandler->disableWrites();
             }
+            // Close the session:
+            $this->manager->writeClose();
         }
     }
 

--- a/module/VuFind/src/VuFind/Session/Settings.php
+++ b/module/VuFind/src/VuFind/Session/Settings.php
@@ -72,7 +72,14 @@ class Settings
 
         // If the session manager is already instantiated, close it!
         if (null !== $this->manager) {
-            $this->manager->writeClose();
+            // Store and restore current $_SESSION contents since session_abort()
+            // will reset it:
+            $sessionData = $_SESSION;
+            session_abort();
+            $_SESSION = $sessionData;
+            if ($storage = $this->manager->getStorage()) {
+                $storage->markImmutable();
+            }
         }
     }
 


### PR DESCRIPTION
If the session is already active (and it probably is since bootstrapper will have it initialized), writeClose will write the session data, which needs to be avoided.