### PR TITLE
Build OpenURL without http_build_query to avoid PHP array syntax in URL

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -886,7 +886,14 @@ class DefaultRecord extends AbstractBase
         }
 
         // Assemble the URL:
-        return http_build_query($params);
+        $query = [];
+        foreach ($params as $key => $value) {
+            $value = (array)$value;
+            foreach ($value as $sub) {
+                $query[] = $key . '=' . urlencode($sub);
+            }
+        }
+        return implode("&", $query);
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -890,7 +890,7 @@ class DefaultRecord extends AbstractBase
         foreach ($params as $key => $value) {
             $value = (array)$value;
             foreach ($value as $sub) {
-                $query[] = $key . '=' . urlencode($sub);
+                $query[] = urlencode($key) . '=' . urlencode($sub);
             }
         }
         return implode("&", $query);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -289,39 +289,39 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
             . "ambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.edition=Fiction"
             . "al+edition.&rft.isbn=8820737493&rft_id=info%3Adoi%2Fxxx&rft_id=pmid%3Ayyy";
 
-            // Parameters returned by getBookOpenUrlParams with rft_id added
-            $openUrlParams = [
-                "url_ver" => "Z39.88-2004",
-                "ctx_ver" => "Z39.88-2004",
-                "ctx_enc" => "info:ofi/enc:UTF-8",
-                "rfr_id" => "info:sid/vufind.svn.sourceforge.net:generator",
-                "rft.title" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
-                "rft.date" => "1992",
-                "rft_val_fmt" => "info:ofi/fmt:kev:mtx:book",
-                "rft.genre" => "book",
-                "rft.btitle" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
-                "rft.series" => "Vico, Giambattista, 1668-1744. Works. 1982 ;",
-                "rft.au" => "Vico, Giambattista, 1668-1744.",
-                "rft.pub" => "Centro di Studi Vichiani,",
-                "rft.edition" => "Fictional edition.",
-                "rft.isbn" => "8820737493",
-                "rft_id" => [
-                    "info:doi/xxx",
-                    "pmid:yyy"
-                ]
-            ];
+        // Parameters returned by getBookOpenUrlParams with rft_id added
+        $openUrlParams = [
+            "url_ver" => "Z39.88-2004",
+            "ctx_ver" => "Z39.88-2004",
+            "ctx_enc" => "info:ofi/enc:UTF-8",
+            "rfr_id" => "info:sid/vufind.svn.sourceforge.net:generator",
+            "rft.title" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
+            "rft.date" => "1992",
+            "rft_val_fmt" => "info:ofi/fmt:kev:mtx:book",
+            "rft.genre" => "book",
+            "rft.btitle" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
+            "rft.series" => "Vico, Giambattista, 1668-1744. Works. 1982 ;",
+            "rft.au" => "Vico, Giambattista, 1668-1744.",
+            "rft.pub" => "Centro di Studi Vichiani,",
+            "rft.edition" => "Fictional edition.",
+            "rft.isbn" => "8820737493",
+            "rft_id" => [
+                "info:doi/xxx",
+                "pmid:yyy"
+            ]
+        ];
 
-            $fixture = $this->getJsonFixture('misc/testbug2.json');
-            $fields = $fixture['response']['docs'][0];
-            $mock = $this->getMockBuilder(\VuFind\RecordDriver\DefaultRecord::Class)
+        $fixture = $this->getJsonFixture('misc/testbug2.json');
+        $fields = $fixture['response']['docs'][0];
+        $mock = $this->getMockBuilder(\VuFind\RecordDriver\DefaultRecord::Class)
             ->setMethods(['getBookOpenUrlParams'])
             ->getMock();
-            $mock->setRawData($fields);
-            $mock->expects($this->any())
+        $mock->setRawData($fields);
+        $mock->expects($this->any())
             ->method('getBookOpenUrlParams')
             ->will($this->returnValue($openUrlParams));
 
-            $this->assertEquals($openUrl, $mock->getOpenUrl());
+        $this->assertEquals($openUrl, $mock->getOpenUrl());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -274,6 +274,57 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getOpenUrl for a record.
+     *
+     * @return void
+     */
+    public function testGetOpenUrl()
+    {
+        $openUrl = "url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&ctx_enc=info%3Aofi%2Fenc%3A"
+            . "UTF-8&rfr_id=info%3Asid%2Fvufind.svn.sourceforge.net%3Agenerator&rft.title=La+co"
+            . "ngiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F&rft.da"
+            . "te=1992&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&rft.genre=book&rft.btitl"
+            . "e=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F"
+            . "&rft.series=Vico%2C+Giambattista%2C+1668-1744.+Works.+1982+%3B&rft.au=Vico%2C+Gi"
+            . "ambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.edition=Fiction"
+            . "al+edition.&rft.isbn=8820737493&rft_id=info%3Adoi%2Fxxx&rft_id=pmid%3Ayyy";
+
+            // Parameters returned by getBookOpenUrlParams with rft_id added
+            $openUrlParams = [
+                "url_ver" => "Z39.88-2004",
+                "ctx_ver" => "Z39.88-2004",
+                "ctx_enc" => "info:ofi/enc:UTF-8",
+                "rfr_id" => "info:sid/vufind.svn.sourceforge.net:generator",
+                "rft.title" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
+                "rft.date" => "1992",
+                "rft_val_fmt" => "info:ofi/fmt:kev:mtx:book",
+                "rft.genre" => "book",
+                "rft.btitle" => "La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /",
+                "rft.series" => "Vico, Giambattista, 1668-1744. Works. 1982 ;",
+                "rft.au" => "Vico, Giambattista, 1668-1744.",
+                "rft.pub" => "Centro di Studi Vichiani,",
+                "rft.edition" => "Fictional edition.",
+                "rft.isbn" => "8820737493",
+                "rft_id" => [
+                    "info:doi/xxx",
+                    "pmid:yyy"
+                ]
+            ];
+
+            $fixture = $this->getJsonFixture('misc/testbug2.json');
+            $fields = $fixture['response']['docs'][0];
+            $mock = $this->getMockBuilder(\VuFind\RecordDriver\DefaultRecord::Class)
+            ->setMethods(['getBookOpenUrlParams'])
+            ->getMock();
+            $mock->setRawData($fields);
+            $mock->expects($this->any())
+            ->method('getBookOpenUrlParams')
+            ->will($this->returnValue($openUrlParams));
+
+            $this->assertEquals($openUrl, $mock->getOpenUrl());
+    }
+
+    /**
      * Test getNewerTitles for a record.
      *
      * @return void

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -313,7 +313,7 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
 
         $fixture = $this->getJsonFixture('misc/testbug2.json');
         $fields = $fixture['response']['docs'][0];
-        $mock = $this->getMockBuilder(\VuFind\RecordDriver\DefaultRecord::Class)
+        $mock = $this->getMockBuilder(\VuFind\RecordDriver\DefaultRecord::class)
             ->setMethods(['getBookOpenUrlParams'])
             ->getMock();
         $mock->setRawData($fields);


### PR DESCRIPTION
PHP array syntax in url parameters does not work with OpenURL