### PR TITLE
Fix: construction of query string for EDS Autocomplete requests

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -95,11 +95,9 @@ abstract class Base
      *
      * @param array $settings Associative array of setting to use in
      *                        conjunction with the EDS API
-     *    <ul>
-     *      <li>debug - boolean to control debug mode</li>
-     *      <li>orgid - Organization making calls to the EDS API </li>
-     *      <li>search_http_method - HTTP method for search API calls</li>
-     *    </ul>
+     *                        -- debug - boolean to control debug mode
+     *                        -- orgid - Organization making calls to the EDS API
+     *                        -- search_http_method - HTTP method for API calls
      */
     public function __construct($settings = [])
     {
@@ -183,13 +181,13 @@ abstract class Base
      * Retrieves a record specified by its identifiers
      *
      * @param string $an                  An of the record to retrieve from the
-     * EdsApi
+     *                                    EdsApi
      * @param string $dbId                Database identifier of the record to
-     * retrieve from the EdsApi
+     *                                    retrieve from the EdsApi
      * @param string $authenticationToken Authentication token
      * @param string $sessionToken        Session token
      * @param string $highlightTerms      Comma separated list of terms to highlight
-     * in the retrieved record responses
+     *                                    in the retrieved record responses
      * @param array  $extraQueryParams    Extra query string parameters
      *
      * @return array    The requested record
@@ -261,9 +259,10 @@ abstract class Base
      * @param string $query Search term
      * @param string $type  Autocomplete type (e.g. 'rawqueries' or 'holdings')
      * @param array  $data  Autocomplete API details (from authenticating with
-     * 'autocomplete' option set -- requires token, custid and url keys).
+     *                      'autocomplete' option set 
+     *                      -- requires token, custid and url keys).
      * @param bool   $raw   Should we return the results raw (true) or processed
-     * (false)?
+     *                      (false)?
      *
      * @return array An array of autocomplete terns as returned from the api
      */

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -269,7 +269,6 @@ abstract class Base
      */
     public function autocomplete($query, $type, $data, $raw = false)
     {
-
         // $filters is an array of filter objects
         // filter objects consist of name and an array of values (customer ids)
         $filters = [['name' => 'custid', 'values' => [$data['custid']]]];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -274,11 +274,12 @@ abstract class Base
         // filter objects consist of name and an array of values (customer ids)
         $filters = [['name' => 'custid', 'values' => [$data['custid']]]];
 
-        $params = [];
-        $params['idx'] = $type;
-        $params['token'] = $data['token'];
-        $params['filters'] = json_encode($filters);
-        $params['term'] = $query;
+        $params = [
+            'idx' => $type,
+            'token' => $data['token'],
+            'filters' => json_encode($filters),
+            'term' => $query,
+        ];
 
         $url = $data['url'] . '?' . http_build_query($params);
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -269,11 +269,14 @@ abstract class Base
      */
     public function autocomplete($query, $type, $data, $raw = false)
     {
-        // build request
-        $url = $data['url'] . '?idx=' . urlencode($type) .
-            '&token=' . urlencode($data['token']) .
-            '&filters=[{"name"%3A"custid"%2C"values"%3A["' .
-            urlencode($data['custid']) . '"]}]&term=' . urlencode($query);
+        $params = [];
+        $params['idx'] = $type;
+        $params['token'] = $data['token'];
+        $params['filters'] = '[{"name" : "custid", "values": ["'.$data['custid'].'"]}]';
+        $params['term'] = $query;
+        
+        $url = $data['url'].'?'.http_build_query($params);
+
         $this->debugPrint("Autocomplete URL: " . $url);
         $response = $this->call($url, null, null, 'GET', null);
         return $raw ? $response : $this->parseAutocomplete($response);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -95,9 +95,11 @@ abstract class Base
      *
      * @param array $settings Associative array of setting to use in
      *                        conjunction with the EDS API
-     *                        -- debug - boolean to control debug mode
-     *                        -- orgid - Organization making calls to the EDS API
-     *                        -- search_http_method - HTTP method for API calls
+     *    <ul>
+     *      <li>debug - boolean to control debug mode</li>
+     *      <li>orgid - Organization making calls to the EDS API </li>
+     *      <li>search_http_method - HTTP method for search API calls</li>
+     *    </ul>
      */
     public function __construct($settings = [])
     {
@@ -181,13 +183,13 @@ abstract class Base
      * Retrieves a record specified by its identifiers
      *
      * @param string $an                  An of the record to retrieve from the
-     *                                    EdsApi
+     * EdsApi
      * @param string $dbId                Database identifier of the record to
-     *                                    retrieve from the EdsApi
+     * retrieve from the EdsApi
      * @param string $authenticationToken Authentication token
      * @param string $sessionToken        Session token
      * @param string $highlightTerms      Comma separated list of terms to highlight
-     *                                    in the retrieved record responses
+     * in the retrieved record responses
      * @param array  $extraQueryParams    Extra query string parameters
      *
      * @return array    The requested record
@@ -259,19 +261,17 @@ abstract class Base
      * @param string $query Search term
      * @param string $type  Autocomplete type (e.g. 'rawqueries' or 'holdings')
      * @param array  $data  Autocomplete API details (from authenticating with
-     *                      'autocomplete' option set
-     *                      -- requires token, custid and url keys).
+     * 'autocomplete' option set -- requires token, custid and url keys).
      * @param bool   $raw   Should we return the results raw (true) or processed
-     *                      (false)?
+     * (false)?
      *
      * @return array An array of autocomplete terns as returned from the api
      */
     public function autocomplete($query, $type, $data, $raw = false)
     {
 
-        //filters is an array of filter objects
-        //filter object consists of name and an array of values (customer ids)
-
+        // $filters is an array of filter objects
+        // filter objects consist of name and an array of values (customer ids)
         $filters = [['name' => 'custid', 'values' => [$data['custid']]]];
 
         $params = [];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -259,7 +259,7 @@ abstract class Base
      * @param string $query Search term
      * @param string $type  Autocomplete type (e.g. 'rawqueries' or 'holdings')
      * @param array  $data  Autocomplete API details (from authenticating with
-     *                      'autocomplete' option set 
+     *                      'autocomplete' option set
      *                      -- requires token, custid and url keys).
      * @param bool   $raw   Should we return the results raw (true) or processed
      *                      (false)?
@@ -271,16 +271,16 @@ abstract class Base
 
         //filters is an array of filter objects
         //filter object consists of name and an array of values (customer ids)
-        $filters[0]['name'] = 'custid';
-        $filters[0]['values'][] = $data['custid'];
-        
+
+        $filters = [['name' => 'custid', 'values' => [$data['custid']]]];
+
         $params = [];
         $params['idx'] = $type;
         $params['token'] = $data['token'];
         $params['filters'] = json_encode($filters);
         $params['term'] = $query;
-        
-        $url = $data['url'].'?'.http_build_query($params);
+
+        $url = $data['url'] . '?' . http_build_query($params);
 
         $this->debugPrint("Autocomplete URL: " . $url);
         $response = $this->call($url, null, null, 'GET', null);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -269,10 +269,16 @@ abstract class Base
      */
     public function autocomplete($query, $type, $data, $raw = false)
     {
+
+        //filters is an array of filter objects
+        //filter object consists of name and an array of values (customer ids)
+        $filters[0]['name'] = 'custid';
+        $filters[0]['values'][] = $data['custid'];
+        
         $params = [];
         $params['idx'] = $type;
         $params['token'] = $data['token'];
-        $params['filters'] = '[{"name" : "custid", "values": ["'.$data['custid'].'"]}]';
+        $params['filters'] = json_encode($filters);
         $params['term'] = $query;
         
         $url = $data['url'].'?'.http_build_query($params);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
@@ -55,7 +55,7 @@ class BackendTest extends \PHPUnit\Framework\TestCase
     {
         $conn = $this->getConnectorMock(['call']);
         $expectedUri = 'http://foo?idx=rawdata&token=auth1234'
-            . '&filters=[{"name"%3A"custid"%2C"values"%3A["foo"]}]&term=bla';
+            . '&filters=%5B%7B%22name%22%3A%22custid%22%2C%22values%22%3A%5B%22foo%22%5D%7D%5D&term=bla';
         $conn->expects($this->once())
             ->method('call')
             ->with($this->equalTo($expectedUri))


### PR DESCRIPTION
Current implementation of EDS Autocomplete URL fails to resolve correctly and Autocomplete did not work. This minor fix introduces an array of required parameters and use's PHP's built in `http_build_query` to correctly built the URL.

Example of Autocomplete URL that was built by original function:

`https://global.ac.ebsco-content.com/autocomplete/rest/autoComplete?idx=rawqueries&token=AhC%2Bjs6yALBfPr7DbjKT5r0ASLTpEESVpsbUcdq%2BdsZE4xMDZEHXZQylrftQvsOAr0nrkUZ0AA%3D%3D&filters=[{"name"%3A"custid"%2C"values"%3A["ns123456"]}]&term=bacter`

Example of Autocomplete URL that was built by amended function:

`https://global.ac.ebsco-content.com/autocomplete/rest/autoComplete?idx=rawqueries&token=AhDQQ4bnYjJIjTTXxaBdpyIMwNifUA%2FotBOvrMOmJD0ckVos4IolahosrYstNMYdYBIpY8SuxA%3D%3D&filters=%5B%7B%22name%22%3A%22custid%22%2C%22values%22%3A%5B%22ns123456%22%5D%7D%5D&term=bacter`

Note: customer id was obfuscated