### PR TITLE
Properly escape quotes in GeniePlus queries.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
@@ -323,8 +323,8 @@ class GeniePlus extends AbstractAPI
      */
     protected function sanitizeQueryParam(string $value): string
     {
-        // Eliminate single quotes to avoid SQL-injection-style query manipulation.
-        return str_replace("'", '', $value);
+        // The query language used by GeniePlus doubles quotes to escape them.
+        return str_replace("'", "''", $value);
     }
 
     /**


### PR DESCRIPTION
I've received more detailed documentation on the GeniePlus query language and was thus able to improve escaping. I have tested that this really works as it should.