### PR TITLE
Update ThemeConfigFactory to use latest laminas-cache settings.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/ThemeConfigFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ThemeConfigFactory.php
@@ -74,7 +74,10 @@ class ThemeConfigFactory implements FactoryInterface
         // As of release 1.1.0, the memory storage adapter has a flaw which can cause
         // unnecessary out of memory exceptions when a memory limit is enabled; we
         // can disable these problematic checks by setting memory_limit to -1.
-        $cacheConfig = ['name' => 'memory', 'options' => ['memory_limit' => -1]];
+        $cacheConfig = [
+            'adapter' => \Laminas\Cache\Storage\Adapter\Memory::class,
+            'options' => ['memory_limit' => -1]
+        ];
         $cache = $container->get(\Laminas\Cache\Service\StorageAdapterFactory::class)
             ->createFromArrayConfiguration($cacheConfig);
 


### PR DESCRIPTION
This is a continuation of #2218 to update the cache configuration for compatibility with laminas-cache v3.

@crhallberg, could you test this when time permits? I applied the changes but didn't have time to try running the helper.

TODO
- [x] Test