### PR TITLE
Fix broken collections/home filter mechanism.

### DIFF
--- a/themes/bootstrap3/templates/collections/home.phtml
+++ b/themes/bootstrap3/templates/collections/home.phtml
@@ -3,10 +3,12 @@
   $this->layout()->breadcrumbs = '<a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a>';
   $filterList = [];
   $filterString = '';
-  foreach ($filters['Other'] ?? [] as $filter) {
-    $filter['urlPart'] = $filter['field'] . ':' . $filter['value'];
-    $filterList[] = $filter;
-    $filterString .= '&' . urlencode('filter[]') . '=' . urlencode($filter['urlPart']);
+  foreach ($filters ?? [] as $label => $filterBatch) {
+    foreach ($filterBatch as $filter) {
+      $filter['urlPart'] = $filter['field'] . ':' . $filter['value'];
+      $filterList[] = $filter;
+      $filterString .= '&' . urlencode('filter[]') . '=' . urlencode($filter['urlPart']);
+    }
   }
 ?>
 


### PR DESCRIPTION
While testing icon functionality in #1962, I discovered that the collections/home screen had a filter mechanism with a hard-coded field name value that was preventing it from working. I honestly can't remember why/where/how this is used, but this PR at least fixes what is broken by processing ALL of the filters, instead of just a subset. (I think in practice there is only ever going to be one group of filters on this screen, but I could be mistaken).

I wish I had a better recollection of this, but I suspect the code hasn't been touched in a decade or more, and it seemed better to make it functional than to ignore or remove it.