### PR TITLE
Add CSRF check to SMS functionality to prevent abuse.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -531,6 +531,14 @@ class AbstractRecord extends AbstractBase
         $view->useCaptcha = $this->captcha()->active('sms');
         // Process form submission:
         if ($this->formWasSubmitted('submit', $view->useCaptcha)) {
+            // Do CSRF check
+            $csrf = $this->serviceLocator->get(\VuFind\Validator\Csrf::class);
+            if (!$csrf->isValid($this->getRequest()->getPost()->get('csrf'))) {
+                throw new \VuFind\Exception\BadRequest(
+                    'error_inconsistent_parameters'
+                );
+            }
+
             // Send parameters back to view so form can be re-populated:
             $view->to = $this->params()->fromPost('to');
             $view->provider = $this->params()->fromPost('provider');

--- a/themes/bootstrap3/templates/record/sms.phtml
+++ b/themes/bootstrap3/templates/record/sms.phtml
@@ -20,6 +20,7 @@ JS;
   <?=$this->flashmessages()?>
   <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
   <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
   <div class="form-group">
     <label class="control-label" for="sms_to"><?=$this->transEsc('Number')?>:</label>
     <input id="sms_to" type="tel" name="to" placeholder="<?=$this->transEscAttr('sms_phone_number')?>" class="form-control"/>


### PR DESCRIPTION
There have been reports of abuse of the SMS functionality. In addition to the existing possibility of turning on CAPTCHA, I thought a built-in CSRF check would also be helpful.

TODO
- [x] Run full test suite