### PR TITLE
Primo: Handle format as an array and fix a dangling reference.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Primo.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Primo.php
@@ -146,8 +146,7 @@ class Primo extends DefaultRecord
      */
     public function getFormats()
     {
-        return isset($this->fields['format'])
-            ? (array)$this->fields['format'] : [];
+        return (array)($this->fields['format'] ?? []);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -454,14 +454,15 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                 = substr((string)$prefix->PrimoNMBib->record->control->recordid, 3);
             $item['title']
                 = (string)$prefix->PrimoNMBib->record->display->title;
-            // format
-            $item['format'] = ucwords(
+            // Format -- Convert to displayable words and return as an array:
+            $format = ucwords(
                 str_replace(
                     '_',
                     ' ',
                     (string)$prefix->PrimoNMBib->record->display->type
                 )
             );
+            $item['format'] = [$format];
             // creators
             $creator
                 = trim((string)$prefix->PrimoNMBib->record->display->creator);
@@ -764,6 +765,8 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                     $value
                 );
             }
+            // Unset reference:
+            unset($value);
             $record[$field] = is_array($fieldData) ? $values : $values[0];
 
             if ($highlight) {


### PR DESCRIPTION
This is extracted from #2341 and is needed for mapping format values that can contain TranslatableString objects. Avoids casting a single format to an array because casting a TranslatableString to an array doesn't result in the right thing. 