### PR TITLE
Make sure an exception when doing a spelling query doesn't break ever…

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -249,7 +249,11 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
         if ($config->Spelling->enabled ?? true) {
             $dictionaries = ($config->Spelling->simple ?? false)
                 ? ['basicSpell'] : ['default', 'basicSpell'];
-            $spellingListener = new InjectSpellingListener($backend, $dictionaries);
+            $spellingListener = new InjectSpellingListener(
+                $backend,
+                $dictionaries,
+                $this->logger
+            );
             $spellingListener->attach($events);
         }
 


### PR DESCRIPTION
…ything.

This is taken from #2341 where we don't want to let an exception during spelling handling to propagate an exception that causes the whole search to fail.