### PR TITLE
Make it possible to set pcAvailability to a falsy value. 

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -246,10 +246,12 @@ class Backend extends AbstractBackend
             $options[$key] = in_array($key, $arraySettings) ? $param : $param[0];
         }
 
-        // Use special facet pcAvailabilty if it has been set
-        if (isset($params['filterList']['pcAvailability'])) {
+        // Use special pcAvailability filter if it has been set:
+        if ($values = $params['filterList']['pcAvailability']['values'] ?? []) {
+            $value = $values[0];
+            $options['pcAvailability']
+                = !in_array($value, [false, 0, '0', 'false'], true);
             unset($options['filterList']['pcAvailability']);
-            $options['pcAvailability'] = true;
         }
 
         return $options;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -249,6 +249,7 @@ class Backend extends AbstractBackend
         // Use special pcAvailability filter if it has been set:
         if ($values = $params['filterList']['pcAvailability']['values'] ?? []) {
             $value = $values[0];
+            // Note that '' is treated as true for the simple case with no value
             $options['pcAvailability']
                 = !in_array($value, [false, 0, '0', 'false'], true);
             unset($options['filterList']['pcAvailability']);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -248,7 +248,7 @@ class Backend extends AbstractBackend
 
         // Use special pcAvailability filter if it has been set:
         if ($values = $params['filterList']['pcAvailability']['values'] ?? []) {
-            $value = $values[0];
+            $value = reset($values);
             // Note that '' is treated as true for the simple case with no value
             $options['pcAvailability']
                 = !in_array($value, [false, 0, '0', 'false'], true);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -123,7 +123,9 @@ class BackendTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructorSetters()
     {
-        $fact = $this->createMock(\VuFindSearch\Response\RecordCollectionFactoryInterface::class);
+        $fact = $this->createMock(
+            \VuFindSearch\Response\RecordCollectionFactoryInterface::class
+        );
         $conn = $this->getConnectorMock();
         $back = new Backend($conn, $fact);
         $this->assertEquals($fact, $back->getRecordCollectionFactory());
@@ -137,7 +139,9 @@ class BackendTest extends \PHPUnit\Framework\TestCase
      */
     public function testSearchWrapsPrimoException()
     {
-        $this->expectException(\VuFindSearch\Backend\Exception\BackendException::class);
+        $this->expectException(
+            \VuFindSearch\Backend\Exception\BackendException::class
+        );
 
         $conn = $this->getConnectorMock(['query']);
         $conn->expects($this->once())
@@ -154,7 +158,9 @@ class BackendTest extends \PHPUnit\Framework\TestCase
      */
     public function testRetrieveWrapsPrimoException()
     {
-        $this->expectException(\VuFindSearch\Backend\Exception\BackendException::class);
+        $this->expectException(
+            \VuFindSearch\Backend\Exception\BackendException::class
+        );
 
         $conn = $this->getConnectorMock(['getRecord']);
         $conn->expects($this->once())
@@ -172,12 +178,25 @@ class BackendTest extends \PHPUnit\Framework\TestCase
     public function testMergedParamBag()
     {
         $myParams = new ParamBag(['foo' => 'bar']);
-        $expectedParams = ['foo' => 'bar', 'limit' => 10, 'pageNumber' => 1.0, 'query' => [['index' => null, 'lookfor' => 'baz']]];
+        $expectedParams = [
+            'foo' => 'bar',
+            'limit' => 10,
+            'pageNumber' => 1.0,
+            'query' => [
+                [
+                    'index' => null,
+                    'lookfor' => 'baz'
+                ]
+            ]
+        ];
         $conn = $this->getConnectorMock(['query']);
         $conn->expects($this->once())
             ->method('query')
-            ->with($this->equalTo('inst-id'), $this->equalTo($expectedParams['query']), $this->equalTo($expectedParams))
-            ->will($this->returnValue(['recordCount' => 0, 'documents' => []]));
+            ->with(
+                $this->equalTo('inst-id'),
+                $this->equalTo($expectedParams['query']),
+                $this->equalTo($expectedParams)
+            )->will($this->returnValue(['recordCount' => 0, 'documents' => []]));
         $back = new Backend($conn);
         $back->search(new Query('baz'), 0, 10, $myParams);
     }
@@ -249,12 +268,26 @@ class BackendTest extends \PHPUnit\Framework\TestCase
                 ]
             ]
         );
-        $expectedParams = ['limit' => 10, 'pageNumber' => 1, 'filterList' => [], 'pcAvailability' => $expected, 'query' => [['index' => null, 'lookfor' => 'foo']]];
+        $expectedParams = [
+            'limit' => 10,
+            'pageNumber' => 1,
+            'filterList' => [],
+            'pcAvailability' => $expected,
+            'query' => [
+                [
+                    'index' => null,
+                    'lookfor' => 'foo'
+                ]
+            ]
+        ];
         $conn = $this->getConnectorMock(['query']);
         $conn->expects($this->once())
             ->method('query')
-            ->with($this->equalTo('inst-id'), $this->equalTo($expectedParams['query']), $this->equalTo($expectedParams))
-            ->will($this->returnValue(['recordCount' => 0, 'documents' => []]));
+            ->with(
+                $this->equalTo('inst-id'),
+                $this->equalTo($expectedParams['query']),
+                $this->equalTo($expectedParams)
+            )->will($this->returnValue(['recordCount' => 0, 'documents' => []]));
         $back = new Backend($conn);
         $back->search(new Query('foo'), 0, 10, $params);
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -259,7 +259,6 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         $back->search(new Query('foo'), 0, 10, $params);
     }
 
-
     /// Internal API
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -182,6 +182,80 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         $back->search(new Query('baz'), 0, 10, $myParams);
     }
 
+    /**
+     * Data provider for testPcAvailabilityFilter
+     *
+     * @return array
+     */
+    public function getPcAvailabilityData(): array
+    {
+        return [
+            [
+                true,
+                true
+            ],
+            [
+                1,
+                true
+            ],
+            [
+                '1',
+                true
+            ],
+            [
+                'true',
+                true
+            ],
+            [
+                false,
+                false
+            ],
+            [
+                0,
+                false
+            ],
+            [
+                '0',
+                false
+            ],
+            [
+                'false',
+                false
+            ],
+        ];
+    }
+
+    /**
+     * Test pcAvailability filter.
+     *
+     * @dataProvider getPcAvailabilityData
+     *
+     * @return void
+     */
+    public function testPcAvailabilityFilter($value, $expected): void
+    {
+        $params = new ParamBag(
+            [
+                'filterList' => [
+                    'pcAvailability' => [
+                        'values' => [
+                            $value
+                        ]
+                    ]
+                ]
+            ]
+        );
+        $expectedParams = ['limit' => 10, 'pageNumber' => 1, 'filterList' => [], 'pcAvailability' => $expected, 'query' => [['index' => null, 'lookfor' => 'foo']]];
+        $conn = $this->getConnectorMock(['query']);
+        $conn->expects($this->once())
+            ->method('query')
+            ->with($this->equalTo('inst-id'), $this->equalTo($expectedParams['query']), $this->equalTo($expectedParams))
+            ->will($this->returnValue(['recordCount' => 0, 'documents' => []]));
+        $back = new Backend($conn);
+        $back->search(new Query('foo'), 0, 10, $params);
+    }
+
+
     /// Internal API
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -191,6 +191,10 @@ class BackendTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
+                '',
+                true
+            ],
+            [
                 true,
                 true
             ],


### PR DESCRIPTION
This makes it essentially a no-op, but is needed for default filter value override in upcoming blended search. Extracted from #2341, also adds unit test for different values.