### PR TITLE
Always show inverted Solr checkbox filters, even if no results.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -668,4 +668,36 @@ class Params extends \VuFind\Search\Base\Params
 
         return $filter;
     }
+
+    /**
+     * Get information on the current state of the boolean checkbox facets.
+     *
+     * @param array $include List of checkbox filters to return (null for all)
+     *
+     * @return array
+     */
+    public function getCheckboxFacets(array $include = null)
+    {
+        // Grab checkbox facet details using the standard method:
+        $facets = parent::getCheckboxFacets($include);
+
+        $config = $this->configLoader->get($this->getOptions()->getFacetsIni());
+        $filterField = $config->CustomFilters->custom_filter_field ?? 'vufind';
+
+        // Special case -- inverted checkbox facets should always appear, even on
+        // the "no results" screen, since setting them actually EXPANDS rather than
+        // reduces the result set.
+        foreach ($facets as $i => $facet) {
+            // Append colon on end to ensure that $customFilter is always set.
+            [$field, $customFilter] = explode(':', $facet['filter'] . ':');
+            if ($field == $filterField
+                && isset($config->CustomFilters->inverted_filters[$customFilter])
+            ) {
+                $facets[$i]['alwaysVisible'] = true;
+            }
+        }
+
+        // Return modified list:
+        return $facets;
+    }
 }


### PR DESCRIPTION
This is a follow-up to #2340, which ensures that inverted checkbox filters are always visible, even if there are no search results, since they may be needed to expand the result set.