### PR TITLE
Fix filtering of dynamic checkbox facets.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -301,13 +301,18 @@ WorkKeys = year
 ;       displaying in a small result set. (default = 0)
 ;       [facet-n] A facet to apply to the random selection
 ;       [facetvalue-n] The facet value to apply to the random selection
-; SideFacets:[regular facet section]:[checkbox facet section]:[ini name]
+; SideFacets:[regular facet section]:[checkbox facet section]:[ini name
+;       :[include dynamic checkboxes]
 ;       Display the specified facets, where [ini name] is the name of an ini file
 ;       in your config directory (defaults to "facets" if not supplied),
 ;       [regular facet section] is the name of a section of the ini file containing
 ;       standard facet settings (defaults to "Results" if not specified),
-;       and [checkbox facet section] is the name of a section of the ini file
-;       containing checkbox facet settings (leave blank for no checkbox facets).
+;       [checkbox facet section] is the name of a section of the ini file
+;       containing checkbox facet settings (leave blank for no checkbox facets), and
+;       [include dynamic checkboxes] is a true/false value indicating whether or not
+;       to display dynamically-generated checkbox facets (it defaults to true, but
+;       if you use multiple instances of SideFacets to split up your display, you
+;       should set it to false in all but one of the instances to avoid duplication).
 ;       Checkbox facets are normally in filter => label format; prefix the section
 ;       name with ~ to reverse this and use label => filter format (useful if your
 ;       filters contain values that are illegal in configuration keys -- e.g. []).

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -86,6 +86,14 @@ class SideFacets extends AbstractFacets
     protected $checkboxFacets = [];
 
     /**
+     * Should we display dynamically-generated checkbox facets that are not
+     * explicitly configured in $checkboxFacets?
+     *
+     * @var bool
+     */
+    protected $showDynamicCheckboxFacets = true;
+
+    /**
      * Settings controlling how lightbox is used for facet display.
      *
      * @var bool|string
@@ -156,6 +164,7 @@ class SideFacets extends AbstractFacets
         $mainSection = empty($settings[0]) ? 'Results' : $settings[0];
         $checkboxSection = $settings[1] ?? false;
         $iniName = $settings[2] ?? 'facets';
+        $showDynamicCheckboxFacets = $settings[3] ?? true;
 
         // Load the desired facet information...
         $config = $this->configLoader->get($iniName);
@@ -195,6 +204,11 @@ class SideFacets extends AbstractFacets
             ? $config->$checkboxSection->toArray() : [];
         if ($flipCheckboxes) {
             $this->checkboxFacets = array_flip($this->checkboxFacets);
+        }
+        if (!$showDynamicCheckboxFacets
+            || strtolower(trim($showDynamicCheckboxFacets)) === 'false'
+        ) {
+            $this->showDynamicCheckboxFacets = false;
         }
 
         // Show more settings:
@@ -256,12 +270,10 @@ class SideFacets extends AbstractFacets
      */
     public function getCheckboxFacetSet()
     {
-        // If no checkboxes are configured, return nothing:
-        if (empty($this->checkboxFacets)) {
-            return [];
-        }
-        return $this->results->getParams()
-            ->getCheckboxFacets(array_keys($this->checkboxFacets));
+        return $this->results->getParams()->getCheckboxFacets(
+            array_keys($this->checkboxFacets),
+            $this->showDynamicCheckboxFacets
+        );
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -950,18 +950,20 @@ class Params
      * will be applied to the search.  When the checkbox is not checked, no filter
      * will be applied.
      *
-     * @param string $filter [field]:[value] pair to associate with checkbox
-     * @param string $desc   Description to associate with the checkbox
+     * @param string $filter  [field]:[value] pair to associate with checkbox
+     * @param string $desc    Description to associate with the checkbox
+     * @param bool   $dynamic Is this being added dynamically (true) or in response
+     * to a user configuration (false)?
      *
      * @return void
      */
-    public function addCheckboxFacet($filter, $desc)
+    public function addCheckboxFacet($filter, $desc, $dynamic = false)
     {
         // Extract the facet field name from the filter, then add the
         // relevant information to the array.
         [$fieldName] = explode(':', $filter);
         $this->checkboxFacets[$fieldName][$filter]
-            = ['desc' => $desc, 'filter' => $filter];
+            = compact('desc', 'filter', 'dynamic');
     }
 
     /**
@@ -1146,20 +1148,26 @@ class Params
     /**
      * Get information on the current state of the boolean checkbox facets.
      *
-     * @param array $include List of checkbox filters to return (null for all)
+     * @param array $include        List of checkbox filters to return (null for all)
+     * @param bool  $includeDynamic Should we include dynamically-generated
+     * checkboxes that are not part of the include list above?
      *
      * @return array
      */
-    public function getCheckboxFacets(array $include = null)
-    {
+    public function getCheckboxFacets(
+        array $include = null,
+        bool $includeDynamic = true
+    ) {
         // Build up an array of checkbox facets with status booleans and
         // toggle URLs.
         $result = [];
         foreach ($this->checkboxFacets as $facets) {
             foreach ($facets as $facet) {
                 // If the current filter is not on the include list, skip it (but
-                // accept everything if the include list is empty).
-                if (!empty($include) && !in_array($facet['filter'], $include)) {
+                // accept everything if the include list is null).
+                if (($include !== null && !in_array($facet['filter'], $include))
+                    && !($includeDynamic && $facet['dynamic'])
+                ) {
                     continue;
                 }
                 $facet['selected'] = $this->hasFilter($facet['filter']);

--- a/module/VuFind/src/VuFind/Search/EDS/Params.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Params.php
@@ -301,7 +301,8 @@ class Params extends \VuFind\Search\Base\Params
             foreach ($ssLimiters as $ssLimiter) {
                 $this->addCheckboxFacet(
                     $ssLimiter['selectedvalue'],
-                    $ssLimiter['description']
+                    $ssLimiter['description'],
+                    true
                 );
             }
         }
@@ -321,7 +322,8 @@ class Params extends \VuFind\Search\Base\Params
             foreach ($availableExpanders as $expander) {
                 $this->addCheckboxFacet(
                     $expander['selectedvalue'],
-                    $expander['description']
+                    $expander['description'],
+                    true
                 );
             }
         }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -672,14 +672,18 @@ class Params extends \VuFind\Search\Base\Params
     /**
      * Get information on the current state of the boolean checkbox facets.
      *
-     * @param array $include List of checkbox filters to return (null for all)
+     * @param array $include        List of checkbox filters to return (null for all)
+     * @param bool  $includeDynamic Should we include dynamically-generated
+     * checkboxes that are not part of the include list above?
      *
      * @return array
      */
-    public function getCheckboxFacets(array $include = null)
-    {
+    public function getCheckboxFacets(
+        array $include = null,
+        bool $includeDynamic = true
+    ) {
         // Grab checkbox facet details using the standard method:
-        $facets = parent::getCheckboxFacets($include);
+        $facets = parent::getCheckboxFacets($include, $includeDynamic);
 
         $config = $this->configLoader->get($this->getOptions()->getFacetsIni());
         $filterField = $config->CustomFilters->custom_filter_field ?? 'vufind';

--- a/module/VuFind/src/VuFind/Search/Summon/Params.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Params.php
@@ -168,14 +168,18 @@ class Params extends \VuFind\Search\Base\Params
     /**
      * Get information on the current state of the boolean checkbox facets.
      *
-     * @param array $include List of checkbox filters to return (null for all)
+     * @param array $include        List of checkbox filters to return (null for all)
+     * @param bool  $includeDynamic Should we include dynamically-generated
+     * checkboxes that are not part of the include list above?
      *
      * @return array
      */
-    public function getCheckboxFacets(array $include = null)
-    {
+    public function getCheckboxFacets(
+        array $include = null,
+        bool $includeDynamic = true
+    ) {
         // Grab checkbox facet details using the standard method:
-        $facets = parent::getCheckboxFacets($include);
+        $facets = parent::getCheckboxFacets($include, $includeDynamic);
 
         // Special case -- if we have a "holdings only" or "expand query" facet,
         // we want this to always appear, even on the "no results" screen, since

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
@@ -278,7 +278,9 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
     {
         $results = $this->getMockResults();
         $params = $results->getParams();
-        $params->expects($this->never())->method('getCheckboxFacets');
+        $params->expects($this->once())->method('getCheckboxFacets')
+            ->with($this->equalTo([]), $this->equalTo(true))
+            ->will($this->returnValue([]));
         $params->expects($this->never())->method('addCheckboxFacet');
         $sf = $this->getSideFacets(null, $results);
         $this->assertEquals([], $sf->getCheckboxFacetSet());
@@ -298,7 +300,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
         $results = $this->getMockResults();
         $params = $results->getParams();
         $params->expects($this->once())->method('getCheckboxFacets')
-            ->with($this->equalTo(['foo']))
+            ->with($this->equalTo(['foo']), $this->equalTo(true))
             ->will($this->returnValue($checkboxData));
         $params->expects($this->once())->method('addCheckboxFacet')
             ->with($this->equalTo('foo'), $this->equalTo('bar'));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
@@ -309,6 +309,29 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that dynamic checkboxes can be disabled.
+     *
+     * @return void
+     */
+    public function testDynamicCheckboxesCanBeDisabled(): void
+    {
+        $configLoader = $this->getMockConfigLoader(
+            ['Checkboxes' => ['foo' => 'bar']]
+        );
+        $checkboxData = ['fake result'];
+        $results = $this->getMockResults();
+        $params = $results->getParams();
+        $params->expects($this->once())->method('getCheckboxFacets')
+            ->with($this->equalTo(['foo']), $this->equalTo(false))
+            ->will($this->returnValue($checkboxData));
+        $params->expects($this->once())->method('addCheckboxFacet')
+            ->with($this->equalTo('foo'), $this->equalTo('bar'));
+        $settings = 'Results:Checkboxes:facets:false';
+        $sf = $this->getSideFacets($configLoader, $results, $settings);
+        $this->assertEquals($checkboxData, $sf->getCheckboxFacetSet());
+    }
+
+    /**
      * Get a fully configured module
      *
      * @param \VuFind\Config\PluginManager $configLoader config loader

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
@@ -111,7 +111,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             'desc' => 'checkbox_label',
             'filter' => 'foo:bar',
             'selected' => false,
-            'alwaysVisible' => false
+            'alwaysVisible' => false,
+            'dynamic' => false,
         ];
         $expectedSelected['selected'] = true;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * EDS Search Object Parameters Test
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Search\EDS;
+
+use Laminas\Config\Config;
+use VuFind\Config\PluginManager;
+use VuFind\Search\EDS\Options;
+use VuFind\Search\EDS\Params;
+
+/**
+ * EDS Search Object Parameters Test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ParamsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test that checkbox filters are always visible (or not) as appropriate.
+     *
+     * @return void
+     */
+    public function testDynamicCheckboxes()
+    {
+        $options = $this->getMockBuilder(Options::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $limiters = [
+            ['selectedvalue' => 'limitervalue', 'description' => 'limiter']
+        ];
+        $options->expects($this->once())->method('getSearchScreenLimiters')
+            ->will($this->returnValue($limiters));
+        $expanders = [
+            ['selectedvalue' => 'expandervalue', 'description' => 'expander']
+        ];
+        $options->expects($this->once())->method('getSearchScreenExpanders')
+            ->will($this->returnValue($expanders));
+        $params = $this->getParams($options);
+        // We expect "normal" filters to NOT be always visible, and inverted
+        // filters to be always visible.
+        $this->assertEquals(
+            [
+                [
+                    'desc' => 'limiter',
+                    'filter' => 'limitervalue',
+                    'selected' => false,
+                    'alwaysVisible' => false,
+                    'dynamic' => true,
+                ],
+                [
+                    'desc' => 'expander',
+                    'filter' => 'expandervalue',
+                    'selected' => false,
+                    'alwaysVisible' => false,
+                    'dynamic' => true,
+                ],
+            ],
+            $params->getCheckboxFacets()
+        );
+    }
+
+    /**
+     * Get Params object
+     *
+     * @param Options       $options    Options object (null to create)
+     * @param PluginManager $mockConfig Mock config plugin manager (null to create)
+     *
+     * @return Params
+     */
+    protected function getParams(
+        Options $options = null,
+        PluginManager $mockConfig = null
+    ): Params {
+        $mockConfig = $mockConfig ?? $this->createMock(PluginManager::class);
+        return new Params(
+            $options ?? new Options($mockConfig),
+            $mockConfig
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
@@ -147,12 +147,14 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'filter' => 'format:book',
                     'selected' => false,
                     'alwaysVisible' => false,
+                    'dynamic' => false,
                 ],
                 [
                     'desc' => 'Inverted filter',
                     'filter' => 'vufind:inverted',
                     'selected' => false,
                     'alwaysVisible' => true,
+                    'dynamic' => false,
                 ],
             ],
             $params->getCheckboxFacets()

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
@@ -33,7 +33,7 @@ use VuFind\Search\Summon\Options;
 use VuFind\Search\Summon\Params;
 
 /**
- * Solr Search Object Parameters Test
+ * Summon Search Object Parameters Test
  *
  * @category VuFind
  * @package  Tests

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Summon Search Object Parameters Test
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Search\Summon;
+
+use Laminas\Config\Config;
+use VuFind\Config\PluginManager;
+use VuFind\Search\Summon\Options;
+use VuFind\Search\Summon\Params;
+
+/**
+ * Solr Search Object Parameters Test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ParamsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test that checkbox filters are always visible (or not) as appropriate.
+     *
+     * @return void
+     */
+    public function testCheckboxVisibility()
+    {
+        $emptyConfig = new Config([]);
+        $facetConfig = new Config(
+            [
+                'CheckboxFacets' => [
+                    'IsScholarly:true' => 'scholarly_limit',
+                    'holdingsOnly:false' => 'add_other_libraries',
+                    'queryExpansion:true' => 'include_synonyms',
+                ],
+            ]
+        );
+        $configManager = $this->createMock(PluginManager::class);
+        $callback = function ($config) use ($emptyConfig, $facetConfig) {
+            return $config === 'Summon' ? $facetConfig : $emptyConfig;
+        };
+        $configManager->expects($this->any())->method('get')
+            ->will($this->returnCallback($callback));
+        $params = $this->getParams(null, $configManager);
+        // We expect "normal" filters to NOT be always visible, and inverted
+        // filters to be always visible.
+        $this->assertEquals(
+            [
+                [
+                    'desc' => 'scholarly_limit',
+                    'filter' => 'IsScholarly:true',
+                    'selected' => false,
+                    'alwaysVisible' => false,
+                    'dynamic' => false,
+                ],
+                [
+                    'desc' => 'add_other_libraries',
+                    'filter' => 'holdingsOnly:false',
+                    'selected' => false,
+                    'alwaysVisible' => true,
+                    'dynamic' => false,
+                ],
+                [
+                    'desc' => 'include_synonyms',
+                    'filter' => 'queryExpansion:true',
+                    'selected' => false,
+                    'alwaysVisible' => true,
+                    'dynamic' => false,
+                ],
+            ],
+            $params->getCheckboxFacets()
+        );
+    }
+
+    /**
+     * Get Params object
+     *
+     * @param Options       $options    Options object (null to create)
+     * @param PluginManager $mockConfig Mock config plugin manager (null to create)
+     *
+     * @return Params
+     */
+    protected function getParams(
+        Options $options = null,
+        PluginManager $mockConfig = null
+    ): Params {
+        $mockConfig = $mockConfig ?? $this->createMock(PluginManager::class);
+        return new Params(
+            $options ?? new Options($mockConfig),
+            $mockConfig
+        );
+    }
+}


### PR DESCRIPTION
I just discovered that #2358 has the unfortunate side effect of breaking checkbox facets in EDS, because the EDS checkboxes are dynamically-generated, rather than tied directly to SideFacets configuration.

This PR attempts to sort that out, by adding a new flag to identify dynamic vs. user-configured checkboxes, and a new setting for filtering these out (or not) from SideFacets. Some aspects of this could be viewed as backward-breaking (we changed the way the first parameter to getCheckboxFacets works -- by making it actually match the documented behavior more strictly -- and we added an optional second parameter to that function), but I think they are justified in being necessary to effect a fix.

I think there is room to have more test coverage (at very least, I'd like to get coverage on the EDS and Summon classes impacted by the change), but I'm going to wait for feedback on the general approach before I invest more time in test coverage.

TODO
- [x] Add more tests