### PR TITLE
Include all primary authors in export formats.

### DIFF
--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -60,12 +60,24 @@ if (is_array($series)) {
     }
 }
 
-foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
-    echo "author = {{$current}},\n";
+$mergeAuthors = function (array $a): string {
+    return implode(
+        ' and ',
+        array_map(
+            function ($s) {
+                return str_replace(' and ', ' {and} ', $s);
+            },
+            $a
+        )
+    );
+};
+
+if ($authors = $mergeAuthors($this->driver->tryMethod('getPrimaryAuthors', [], []))) {
+    echo "author = {{$authors}},\n";
 }
 
-foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
-    echo "editor = {{$current}},\n";
+if ($authors = $mergeAuthors($this->driver->tryMethod('getSecondaryAuthors', [], []))) {
+    echo "editor = {{$authors}},\n";
 }
 
 $pubPlaces = $this->driver->tryMethod('getPlacesOfPublication');

--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -60,16 +60,12 @@ if (is_array($series)) {
     }
 }
 
-$author = $this->driver->tryMethod('getPrimaryAuthor');
-if (!empty($author)) {
-    echo "author = {{$author}},\n";
+foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
+    echo "author = {{$current}},\n";
 }
 
-$secondaryAuthors = $this->driver->tryMethod('getSecondaryAuthors');
-if (is_array($secondaryAuthors)) {
-    foreach ($secondaryAuthors as $current) {
-        echo "editor = {{$current}},\n";
-    }
+foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
+    echo "editor = {{$current}},\n";
 }
 
 $pubPlaces = $this->driver->tryMethod('getPlacesOfPublication');

--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -76,8 +76,8 @@ if ($authors = $mergeAuthors($this->driver->tryMethod('getPrimaryAuthors', [], [
     echo "author = {{$authors}},\n";
 }
 
-if ($authors = $mergeAuthors($this->driver->tryMethod('getSecondaryAuthors', [], []))) {
-    echo "editor = {{$authors}},\n";
+if ($editors = $mergeAuthors($this->driver->tryMethod('getSecondaryAuthors', [], []))) {
+    echo "editor = {{$editors}},\n";
 }
 
 $pubPlaces = $this->driver->tryMethod('getPlacesOfPublication');

--- a/themes/root/templates/RecordDriver/AbstractBase/export-endnote.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-endnote.phtml
@@ -10,16 +10,12 @@ if (is_array($formats) && !empty($formats)) {
     echo "%0 Book\n";
 }
 
-$author = $this->driver->tryMethod('getPrimaryAuthor');
-if (!empty($author)) {
-    echo "%A $author\n";
+foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
+    echo "%A $current\n";
 }
 
-$secondaryAuthors = $this->driver->tryMethod('getSecondaryAuthors');
-if (is_array($secondaryAuthors)) {
-    foreach ($secondaryAuthors as $current) {
-        echo "%E $current\n";
-    }
+foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
+    echo "%E $current\n";
 }
 
 $pubPlaces = $this->driver->tryMethod('getPlacesOfPublication');

--- a/themes/root/templates/RecordDriver/AbstractBase/export-endnoteweb.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-endnoteweb.phtml
@@ -58,16 +58,12 @@ if (!empty($journalTitle)) {
     }
 }
 
-$author = $this->driver->tryMethod('getPrimaryAuthor');
-if (!empty($author)) {
-    echo "A1  - $author\n";
+foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
+    echo "A1  - $current\n";
 }
 
-$secondaryAuthors = $this->driver->tryMethod('getSecondaryAuthors');
-if (is_array($secondaryAuthors)) {
-    foreach ($secondaryAuthors as $current) {
-        echo "A2  - $current\n";
-    }
+foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
+    echo "A2  - $current\n";
 }
 
 $languages = $this->driver->tryMethod('getLanguages');

--- a/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
@@ -48,7 +48,7 @@ foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
     echo "A2 $current\n";
 }
 
-$languages = $this->driver->tryMethod('getLanguages', [], []);
+$languages = $this->driver->tryMethod('getLanguages');
 if (is_array($languages)) {
     foreach ($languages as $lang) {
         echo "LA $lang\n";

--- a/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-refworks.phtml
@@ -40,19 +40,15 @@ if (!empty($journalTitle)) {
     }
 }
 
-$author = $this->driver->tryMethod('getPrimaryAuthor');
-if (!empty($author)) {
-    echo "A1 $author\n";
+foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
+    echo "A1 $current\n";
 }
 
-$secondaryAuthors = $this->driver->tryMethod('getSecondaryAuthors');
-if (is_array($secondaryAuthors)) {
-    foreach ($secondaryAuthors as $current) {
-        echo "A2 $current\n";
-    }
+foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
+    echo "A2 $current\n";
 }
 
-$languages = $this->driver->tryMethod('getLanguages');
+$languages = $this->driver->tryMethod('getLanguages', [], []);
 if (is_array($languages)) {
     foreach ($languages as $lang) {
         echo "LA $lang\n";

--- a/themes/root/templates/RecordDriver/AbstractBase/export-ris.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-ris.phtml
@@ -63,16 +63,12 @@ if (is_array($series)) {
     }
 }
 
-$author = $this->driver->tryMethod('getPrimaryAuthor');
-if (!empty($author)) {
-    echo 'AU  - ' . "$author\r\n";
+foreach ($this->driver->tryMethod('getPrimaryAuthors', [], []) as $current) {
+    echo 'AU  - ' . "$current\r\n";
 }
 
-$secondaryAuthors = $this->driver->tryMethod('getSecondaryAuthors');
-if (is_array($secondaryAuthors)) {
-    foreach ($secondaryAuthors as $current) {
-        echo 'A2  - ' . "$current\r\n";
-    }
+foreach ($this->driver->tryMethod('getSecondaryAuthors', [], []) as $current) {
+    echo 'A2  - ' . "$current\r\n";
 }
 
 $pubPlaces = $this->driver->tryMethod('getPlacesOfPublication');


### PR DESCRIPTION
Most export formats included all secondary authors but only the first primary author. This adds support for all primary authors and simplifies the code for secondary authors a bit while at it.