### PR TITLE
Add a post-processor to support <Consume-Whitespace /> tag.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -335,6 +335,9 @@ $config = [
             'storageRetrievalRequests' => 'VuFind\Controller\Plugin\StorageRetrievalRequests',
         ],
     ],
+    'listeners' => [
+        \VuFind\Mvc\PhpPostProcess::class,
+    ],
     'service_manager' => [
         'allow_override' => true,
         'factories' => [
@@ -402,6 +405,7 @@ $config = [
             'VuFind\Log\Logger' => 'VuFind\Log\LoggerFactory',
             'VuFind\Mailer\Mailer' => 'VuFind\Mailer\Factory',
             'VuFind\MetadataVocabulary\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
+            'VuFind\Mvc\PhpPostProcess' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFind\Net\IpAddressUtils' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFind\Net\UserIpReader' => 'VuFind\Net\UserIpReaderFactory',
             'VuFind\OAI\Server' => 'VuFind\OAI\ServerFactory',

--- a/module/VuFind/src/VuFind/Mvc/PhpPostProcess.php
+++ b/module/VuFind/src/VuFind/Mvc/PhpPostProcess.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PHP-rendered page post-processor.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Service
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\Mvc;
+
+use Laminas\EventManager\AbstractListenerAggregate;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Http\PhpEnvironment\Response;
+use Laminas\Mvc\MvcEvent;
+
+/**
+ * PHP-rendered page post-processor.
+ *
+ * @category VuFind
+ * @package  Service
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class PhpPostProcess extends AbstractListenerAggregate
+{
+    /**
+     * Attach the listener
+     *
+     * @param EventManagerInterface $events   EventManager
+     * @param int                   $priority Event priority
+     *
+     * @return void
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(
+            MvcEvent::EVENT_FINISH,
+            [$this, 'handlePostProcess'],
+            $priority
+        );
+    }
+
+    /**
+     * Post-process the response.
+     *
+     * @param MvcEvent $e Event
+     *
+     * @return void
+     */
+    public function handlePostProcess(MvcEvent $e)
+    {
+        $response = $e->getResponse();
+        if (!($response instanceof Response)) {
+            return;
+        }
+        $contentTypeHeader = $response->getHeaders()->get('Content-Type');
+        $contentType = $contentTypeHeader ? $contentTypeHeader->getFieldValue() : '';
+        if (!$contentType || 'text/html' === $contentType) {
+            $content = $response->getContent();
+            $response->setContent($this->postProcessHtml($response->getContent()));
+        } elseif ('application/json' === $contentType) {
+            $content = json_decode($response->getContent(), true);
+            if (!empty($content['data']['html'])) {
+                $content['data']['html']
+                    = $this->postProcessHtml($content['data']['html']);
+                $response->setContent(json_encode($content));
+            }
+        }
+    }
+
+    /**
+     * Process response HTML content.
+     *
+     * @param string $content HTML
+     *
+     * @return string
+     */
+    protected function postProcessHtml(string $content): string
+    {
+        return preg_replace('/\s+<Consume-Whitespace\s*\/>\s+/', '', $content);
+    }
+}

--- a/module/VuFind/src/VuFind/Mvc/PhpPostProcess.php
+++ b/module/VuFind/src/VuFind/Mvc/PhpPostProcess.php
@@ -74,8 +74,9 @@ class PhpPostProcess extends AbstractListenerAggregate
             return;
         }
         $contentTypeHeader = $response->getHeaders()->get('Content-Type');
-        $contentType = $contentTypeHeader ? $contentTypeHeader->getFieldValue() : '';
-        if (!$contentType || 'text/html' === $contentType) {
+        $contentType = $contentTypeHeader ? $contentTypeHeader->getFieldValue()
+            : ini_get('default_mimetype');
+        if ('text/html' === $contentType) {
             $content = $response->getContent();
             $response->setContent($this->postProcessHtml($response->getContent()));
         } elseif ('application/json' === $contentType) {


### PR DESCRIPTION
The tag is used to remove all whitespace around it (and the tag itself).

So the template code can be something like this:

```
<a href="#">
  <i class="something">
  <Consume-Whitespace />
  Label Text
</a>

```
And the resulting HTML is:

<a href="#">
  <i class="something">Label Text
</a>

This could help with the underline issue in #1962.