### PR TITLE
Fix config sanitization threading bug

### DIFF
--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -172,9 +172,9 @@ public class ConfigManager
      * @param filename configuration file name
      * @param section section name within the file
      */
-    public Map<String, String> getSanitizedConfigSection(String filename, String section)
+    public Map<String, String> getConfigSection(String filename, String section)
     {
-        Map<String, String> retVal = getConfigSection(filename, section);
+        Map<String, String> retVal = getRawConfigSection(filename, section);
         if (retVal == null) {
             return new ConcurrentHashMap<String, String>();
         }
@@ -195,7 +195,7 @@ public class ConfigManager
      * @param filename configuration file name
      * @param section section name within the file
      */
-    public Map<String, String> getConfigSection(String filename, String section)
+    public Map<String, String> getRawConfigSection(String filename, String section)
     {
         // Grab the ini file.
         Ini ini = loadConfigFile(filename);
@@ -229,14 +229,22 @@ public class ConfigManager
     }
 
     /**
+     * @deprecated
+     */
+    public Map<String, String> getSanitizedConfigSection(String filename, String section)
+    {
+        return getConfigSection(filename, section);
+    }
+
+    /**
      * Get a setting from a VuFind configuration file and sanitize the value.
      * @param filename configuration file name
      * @param section section name within the file
      * @param setting setting name within the section
      */
-    public String getSanitizedConfigSetting(String filename, String section, String setting)
+    public String getConfigSetting(String filename, String section, String setting)
     {
-        String retVal = getConfigSetting(filename, section, setting);
+        String retVal = getRawConfigSetting(filename, section, setting);
         return retVal == null ? retVal : sanitizeConfigSetting(retVal);
     }
 
@@ -246,7 +254,7 @@ public class ConfigManager
      * @param section section name within the file
      * @param setting setting name within the section
      */
-    public String getConfigSetting(String filename, String section, String setting)
+    public String getRawConfigSetting(String filename, String section, String setting)
     {
         Map<String, String> sectionMap = getConfigSection(filename, section);
         if (sectionMap == null) {
@@ -258,6 +266,14 @@ public class ConfigManager
             logger.warn(section + "." + setting + " setting missing from " + filename);
         }
         return retVal;
+    }
+
+    /**
+     * @deprecated
+     */
+    public String getSanitizedConfigSetting(String filename, String section, String setting)
+    {
+        return getConfigSetting(filename, section, setting);
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -170,7 +170,6 @@ public class ConfigManager
     {
         Map<String, String> retVal = getConfigSection(filename, section);
         if (retVal == null) {
-            logger.warn(section + " section missing from " + filename);
             return new ConcurrentHashMap<String, String>();
         }
 
@@ -217,6 +216,9 @@ public class ConfigManager
             }
         }
 
+        if (retVal == null) {
+            logger.warn(section + " section missing from " + filename);
+        }
         return retVal;
     }
 
@@ -230,7 +232,6 @@ public class ConfigManager
     {
         String retVal = getConfigSetting(filename, section, setting);
         if (retVal == null) {
-            logger.warn(section + "." + setting + " setting missing from " + filename);
             return retVal;
         }
 
@@ -251,7 +252,15 @@ public class ConfigManager
     public String getConfigSetting(String filename, String section, String setting)
     {
         Map<String, String> sectionMap = getConfigSection(filename, section);
-        return sectionMap.get(setting);
+        if (sectionMap == null) {
+            return null;
+        }
+
+        String retVal = sectionMap.get(setting);
+        if (retVal == null) {
+            logger.warn(section + "." + setting + " setting missing from " + filename);
+        }
+        return retVal;
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -109,21 +109,27 @@ public class ConfigManager
      */
     private String sanitizeConfigSetting(String str)
     {
+        // Work on a copy of the string.
+        // We do not want the sanitizer to update the cache, because it might
+        // cause problems when executing them multiple times, like
+        // e.g. in multithreaded scenarios.
+        String retVal = new String(str);
+
         // Drop comments if necessary; if the semi-colon is inside quotes, leave
         // it alone. TODO: handle complex cases with comment AND quoted semi-colon
-        int pos = str.indexOf(';');
-        if (pos >= 0 && !str.matches("\"[^\"]*;[^\"]*\"")) {
-            str = str.substring(0, pos).trim();
+        int pos = retVal.indexOf(';');
+        if (pos >= 0 && !retVal.matches("\"[^\"]*;[^\"]*\"")) {
+            retVal = retVal.substring(0, pos).trim();
         }
 
         // Strip wrapping quotes if necessary (the ini reader won't do this for us):
-        if (str.startsWith("\"")) {
-            str = str.substring(1, str.length());
+        if (retVal.startsWith("\"")) {
+            retVal = retVal.substring(1, retVal.length());
         }
-        if (str.endsWith("\"")) {
-            str = str.substring(0, str.length() - 1);
+        if (retVal.endsWith("\"")) {
+            retVal = retVal.substring(0, retVal.length() - 1);
         }
-        return str;
+        return retVal;
     }
 
     /**
@@ -179,7 +185,7 @@ public class ConfigManager
         // e.g. in multithreaded scenarios.
         Map<String, String> retValCopy = new ConcurrentHashMap<>();
         for (Map.Entry<String, String> entry : retVal.entrySet()) {
-            retValCopy.put(entry.getKey(), sanitizeConfigSetting(new String(entry.getValue())));
+            retValCopy.put(entry.getKey(), sanitizeConfigSetting(entry.getValue()));
         }
         return retValCopy;
     }
@@ -231,16 +237,7 @@ public class ConfigManager
     public String getSanitizedConfigSetting(String filename, String section, String setting)
     {
         String retVal = getConfigSetting(filename, section, setting);
-        if (retVal == null) {
-            return retVal;
-        }
-
-        // Return a copy of the string.
-        // We do not want the sanitizer to update the cache, because it might
-        // cause problems when executing them multiple times, like
-        // e.g. in multithreaded scenarios.
-        String retValCopy = new String(retVal);
-        return sanitizeConfigSetting(retValCopy);
+        return retVal == null ? retVal : sanitizeConfigSetting(retVal);
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -174,8 +174,8 @@ public class ConfigManager
      */
     public Map<String, String> getConfigSection(String filename, String section)
     {
-        Map<String, String> retVal = getRawConfigSection(filename, section);
-        if (retVal == null) {
+        Map<String, String> rawSection = getRawConfigSection(filename, section);
+        if (rawSection == null) {
             return new ConcurrentHashMap<String, String>();
         }
 
@@ -183,11 +183,11 @@ public class ConfigManager
         // We do not want the sanitizer to update the cache, because it might
         // cause problems when executing them multiple times, like
         // e.g. in multithreaded scenarios.
-        Map<String, String> retValCopy = new ConcurrentHashMap<>();
-        for (Map.Entry<String, String> entry : retVal.entrySet()) {
-            retValCopy.put(entry.getKey(), sanitizeConfigSetting(entry.getValue()));
+        Map<String, String> retVal = new ConcurrentHashMap<>();
+        for (Map.Entry<String, String> entry : rawSection.entrySet()) {
+            retVal.put(entry.getKey(), sanitizeConfigSetting(entry.getValue()));
         }
-        return retValCopy;
+        return retVal;
     }
 
     /**
@@ -256,16 +256,8 @@ public class ConfigManager
      */
     public String getRawConfigSetting(String filename, String section, String setting)
     {
-        Map<String, String> sectionMap = getConfigSection(filename, section);
-        if (sectionMap == null) {
-            return null;
-        }
-
-        String retVal = sectionMap.get(setting);
-        if (retVal == null) {
-            logger.warn(section + "." + setting + " setting missing from " + filename);
-        }
-        return retVal;
+        Map<String, String> sectionMap = getRawConfigSection(filename, section);
+        return sectionMap == null ? null : sectionMap.get(setting);
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -222,9 +222,6 @@ public class ConfigManager
             }
         }
 
-        if (retVal == null) {
-            logger.warn(section + " section missing from " + filename);
-        }
         return retVal;
     }
 

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -230,8 +230,10 @@ public class ConfigManager
     }
 
     /**
-     * @deprecated
+     * @deprecated Please use getConfigSection instead, or getRawConfigSection
+     *             if you would like to get the non-sanitized values.
      */
+    @Deprecated
     public Map<String, String> getSanitizedConfigSection(String filename, String section)
     {
         return getConfigSection(filename, section);
@@ -262,8 +264,10 @@ public class ConfigManager
     }
 
     /**
-     * @deprecated
+     * @deprecated Please use getConfigSetting instead, or getRawConfigSetting
+     *             if you would like to get the non-sanitized value.
      */
+    @Deprecated
     public String getSanitizedConfigSetting(String filename, String section, String setting)
     {
         return getConfigSetting(filename, section, setting);

--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -210,7 +210,17 @@ public class ConfigManager
                 retVal.put(key, overrideSection.get(key));
             }
         }
-        return retVal;
+
+        // Return a copy of the section.
+        // If there are other operations performed later (e.g. sanitize)
+        // we do not want them to update the cache, because they might cause
+        // problems when executing them multiple times, like
+        // e.g. in multithreaded scenarios.
+        Map<String, String> retValCopy = new ConcurrentHashMap<>();
+        for (Map.Entry<String, String> entry : retVal.entrySet()) {
+            retValCopy.put(entry.getKey(), new String(entry.getValue()));
+        }
+        return retValCopy;
     }
 
     /**

--- a/import/index_java/src/org/vufind/index/PunctuationContainer.java
+++ b/import/index_java/src/org/vufind/index/PunctuationContainer.java
@@ -22,12 +22,16 @@ import java.util.LinkedHashSet;
 import java.util.regex.Pattern;
 import java.util.Map;
 import java.util.Set;
+import org.apache.log4j.Logger;
 
 /**
  * Singleton for storing punctuation configuration information.
  */
 public class PunctuationContainer
 {
+    // Initialize logging category
+    static Logger logger = Logger.getLogger(ConfigManager.class.getName());
+
     private static ThreadLocal<PunctuationContainer> containerCache =
         new ThreadLocal<PunctuationContainer>()
         {
@@ -38,6 +42,8 @@ public class PunctuationContainer
             }
         };
 
+    private static String configFilename = "author-classification.ini";
+
     private Set<Pattern> punctuationRegEx = new LinkedHashSet<Pattern>();
     private Set<String> punctuationPairs = new LinkedHashSet<String>();
     private Set<String> untrimmedAbbreviations = new LinkedHashSet<String>();
@@ -45,11 +51,15 @@ public class PunctuationContainer
     public Set<Pattern> getPunctuationRegEx()
     {
         // Populate set if empty:
-        if (punctuationRegEx.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationRegExToStrip");
-            punctuationRegEx = new LinkedHashSet<Pattern>();
-            for (String pattern : all.values()) {
-                punctuationRegEx.add(Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS));
+        if (punctuationRegEx.isEmpty()) {
+            String configSection = "PunctuationRegExToStrip";
+            Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
+            if (all == null) {
+                logger.warn(configSection + " section missing from " + configFilename);
+            } else {
+                for (String pattern : all.values()) {
+                    punctuationRegEx.add(Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS));
+                }
             }
         }
         return punctuationRegEx;
@@ -58,9 +68,14 @@ public class PunctuationContainer
     public Set<String> getPunctuationPairs()
     {
         // Populate set if empty:
-        if (punctuationPairs.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationMatchedChars");
-            punctuationPairs = new LinkedHashSet<String>(all.values());
+        if (punctuationPairs.isEmpty()) {
+            String configSection = "PunctuationMatchedChars";
+            Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
+            if (all == null) {
+                logger.warn(configSection + " section missing from " + configFilename);
+            } else {
+                punctuationPairs = new LinkedHashSet<String>(all.values());
+            }
         }
         return punctuationPairs;
     }
@@ -68,8 +83,9 @@ public class PunctuationContainer
     public Set<String> getUntrimmedAbbreviations()
     {
         // Populate set if empty:
-        if (untrimmedAbbreviations.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationUntrimmedAbbreviations");
+        if (untrimmedAbbreviations.isEmpty()) {
+            String configSection = "PunctuationUntrimmedAbbreviations";
+            Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
             untrimmedAbbreviations = new LinkedHashSet<String>(all.values());
         }
         return untrimmedAbbreviations;

--- a/import/index_java/src/org/vufind/index/PunctuationContainer.java
+++ b/import/index_java/src/org/vufind/index/PunctuationContainer.java
@@ -54,7 +54,7 @@ public class PunctuationContainer
         if (punctuationRegEx.isEmpty()) {
             String configSection = "PunctuationRegExToStrip";
             Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
-            if (all == null) {
+            if (all.isEmpty()) {
                 logger.warn(configSection + " section missing from " + configFilename);
             } else {
                 for (String pattern : all.values()) {
@@ -71,7 +71,7 @@ public class PunctuationContainer
         if (punctuationPairs.isEmpty()) {
             String configSection = "PunctuationMatchedChars";
             Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
-            if (all == null) {
+            if (all.isEmpty()) {
                 logger.warn(configSection + " section missing from " + configFilename);
             } else {
                 punctuationPairs = new LinkedHashSet<String>(all.values());
@@ -86,7 +86,11 @@ public class PunctuationContainer
         if (untrimmedAbbreviations.isEmpty()) {
             String configSection = "PunctuationUntrimmedAbbreviations";
             Map<String, String> all = ConfigManager.instance().getConfigSection(configFilename, configSection);
-            untrimmedAbbreviations = new LinkedHashSet<String>(all.values());
+            if (all.isEmpty()) {
+                logger.warn(configSection + " section missing from " + configFilename);
+            } else {
+                untrimmedAbbreviations = new LinkedHashSet<String>(all.values());
+            }
         }
         return untrimmedAbbreviations;
     }

--- a/import/index_java/src/org/vufind/index/PunctuationContainer.java
+++ b/import/index_java/src/org/vufind/index/PunctuationContainer.java
@@ -46,7 +46,7 @@ public class PunctuationContainer
     {
         // Populate set if empty:
         if (punctuationRegEx.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getSanitizedConfigSection("author-classification.ini", "PunctuationRegExToStrip");
+            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationRegExToStrip");
             punctuationRegEx = new LinkedHashSet<Pattern>();
             for (String pattern : all.values()) {
                 punctuationRegEx.add(Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS));
@@ -59,7 +59,7 @@ public class PunctuationContainer
     {
         // Populate set if empty:
         if (punctuationPairs.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getSanitizedConfigSection("author-classification.ini", "PunctuationMatchedChars");
+            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationMatchedChars");
             punctuationPairs = new LinkedHashSet<String>(all.values());
         }
         return punctuationPairs;
@@ -69,7 +69,7 @@ public class PunctuationContainer
     {
         // Populate set if empty:
         if (untrimmedAbbreviations.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getSanitizedConfigSection("author-classification.ini", "PunctuationUntrimmedAbbreviations");
+            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationUntrimmedAbbreviations");
             untrimmedAbbreviations = new LinkedHashSet<String>(all.values());
         }
         return untrimmedAbbreviations;

--- a/import/index_java/src/org/vufind/index/PunctuationContainer.java
+++ b/import/index_java/src/org/vufind/index/PunctuationContainer.java
@@ -46,7 +46,7 @@ public class PunctuationContainer
     {
         // Populate set if empty:
         if (punctuationRegEx.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationRegExToStrip");
+            Map<String, String> all = ConfigManager.instance().getSanitizedConfigSection("author-classification.ini", "PunctuationRegExToStrip");
             punctuationRegEx = new LinkedHashSet<Pattern>();
             for (String pattern : all.values()) {
                 punctuationRegEx.add(Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS));

--- a/import/index_java/src/org/vufind/index/PunctuationContainer.java
+++ b/import/index_java/src/org/vufind/index/PunctuationContainer.java
@@ -46,7 +46,7 @@ public class PunctuationContainer
     {
         // Populate set if empty:
         if (punctuationRegEx.size() == 0) {
-            Map<String, String> all = ConfigManager.instance().getSanitizedConfigSection("author-classification.ini", "PunctuationRegExToStrip");
+            Map<String, String> all = ConfigManager.instance().getConfigSection("author-classification.ini", "PunctuationRegExToStrip");
             punctuationRegEx = new LinkedHashSet<Pattern>();
             for (String pattern : all.values()) {
                 punctuationRegEx.add(Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS));


### PR DESCRIPTION
If you have a regex in the INI, e.g. `[\\s/:;,=(\\[]*$`
getSanitizedConfigSection() is causing problems and returns `[\s/:`
so it should be better to use getConfigSection() instead, which returns `[\s/:;,=(\[]*$`

TODO
- [x] Update changelog when merging
- [x] Close [VUFIND-1546](https://vufind.org/jira/browse/VUFIND-1546) when merging