### PR TITLE
Add tests for VuFind\Search\Solr\Results

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -33,6 +33,7 @@ use VuFind\Search\Solr\Options;
 use VuFind\Search\Solr\Params;
 use VuFind\Search\Solr\Results;
 use VuFind\Search\Solr\SpellingProcessor;
+use VuFindSearch\Backend\Solr\Response\Json\RecordCollection;
 use VuFindSearch\Service as SearchService;
 
 /**
@@ -75,6 +76,35 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
         $results->setSpellingProcessor($mockProcessor);
         $this->assertEquals($mockProcessor, $results->getSpellingProcessor());
         $this->assertNotEquals($defaultProcessor, $mockProcessor);
+    }
+
+    /**
+     * Test retrieving a result count.
+     *
+     * @return void
+     */
+    public function testGetResultTotal(): void
+    {
+        $collection = new RecordCollection(['response' => ['numFound' => 5]]);
+        $searchService = $this->createMock(SearchService::class);
+        $searchService->expects($this->once())
+            ->method('search')
+            ->with(
+                $this->equalTo('Solr'),
+                $this->equalTo(new \VuFindSearch\Query\Query()),
+                $this->equalTo(0),
+                $this->equalTo(20),
+                $this->equalTo(
+                    new \VuFindSearch\ParamBag(
+                        [
+                            'spellcheck' => ['true'],
+                            'hl' => ['false'],
+                        ]
+                    )
+                )
+            )->will($this->returnValue($collection));
+        $results = $this->getResults(null, $searchService);
+        $this->assertEquals(5, $results->getResultTotal());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Solr Search Object Results Test
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Search\Solr;
+
+use VuFind\Config\PluginManager;
+use VuFind\Record\Loader;
+use VuFind\Search\Solr\Options;
+use VuFind\Search\Solr\Params;
+use VuFind\Search\Solr\Results;
+use VuFind\Search\Solr\SpellingProcessor;
+use VuFindSearch\Service as SearchService;
+
+/**
+ * Solr Search Object Parameters Test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ResultsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test CursorMark functionality.
+     *
+     * @return void
+     */
+    public function testCursorMark(): void
+    {
+        $results = $this->getResults();
+        $results->setCursorMark('foo');
+        $this->assertEquals('foo', $results->getCursorMark());
+    }
+
+    /**
+     * Test spelling processor support.
+     *
+     * @return void
+     */
+    public function testSpellingProcessor(): void
+    {
+        $results = $this->getResults();
+        $defaultProcessor = $results->getSpellingProcessor();
+        $this->assertTrue(
+            $defaultProcessor instanceof SpellingProcessor,
+            'default spelling processor was created'
+        );
+        $mockProcessor = $this->createMock(SpellingProcessor::class);
+        $results->setSpellingProcessor($mockProcessor);
+        $this->assertEquals($mockProcessor, $results->getSpellingProcessor());
+        $this->assertNotEquals($defaultProcessor, $mockProcessor);
+    }
+
+    /**
+     * Get Results object
+     *
+     * @return Results
+     */
+    protected function getResults(
+        Params $params = null,
+        SearchService $searchService = null,
+        Loader $loader = null
+    ): Results {
+        return new Results(
+            $params ?? $this->getParams(),
+            $searchService ?? $this->createMock(SearchService::class),
+            $loader ?? $this->createMock(Loader::class)
+        );
+    }
+
+    /**
+     * Get Params object
+     *
+     * @param Options       $options    Options object (null to create)
+     * @param PluginManager $mockConfig Mock config plugin manager (null to create)
+     *
+     * @return Params
+     */
+    protected function getParams(
+        Options $options = null,
+        PluginManager $mockConfig = null
+    ): Params {
+        $mockConfig = $mockConfig ?? $this->createMock(PluginManager::class);
+        return new Params(
+            $options ?? new Options($mockConfig),
+            $mockConfig
+        );
+    }
+}


### PR DESCRIPTION
As discussed in #2352, we currently lack a test for \VuFind\Search\Solr\Results. It would be useful to have such a test so that we can expand the coverage to address new/changed features. (This may also be useful for #2372).

I'm opening this PR to get the ball rolling. There's not a whole lot here, but this is what I was able to accomplish in 30 minutes, and it's a start! I'd suggest that it may be worthwhile to merge this even though it's incomplete, and then build upon it in the other PR's cited above.