### PR TITLE
[VUFIND-1544] Eliminate use of deprecated strftime function

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -1264,11 +1264,7 @@ class Unicorn extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
     {
         $dateTimeString = '';
         if ($time) {
-            $dateTimeString = strftime('%m/%d/%Y %H:%M', $time);
-            $dateTimeString = $this->dateConverter->convertToDisplayDate(
-                'm/d/Y H:i',
-                $dateTimeString
-            );
+            $dateTimeString = $this->dateConverter->convertToDisplayDate('U', $time);
         }
         return $dateTimeString;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/UnicornTest.php
@@ -54,6 +54,20 @@ class UnicornTest extends \VuFindTest\Unit\ILSDriverTestCase
     }
 
     /**
+     * Test date formatting.
+     *
+     * @return void
+     */
+    public function testDateFormatting(): void
+    {
+        $time = 1649275905;
+        $this->assertEquals(
+            '04-06-2022',
+            $this->callMethod($this->driver, 'formatDateTime', [$time])
+        );
+    }
+
+    /**
      * Test MARC holdings parsing.
      *
      * @return void

--- a/themes/bootstrap3/templates/RecordTab/reviews.phtml
+++ b/themes/bootstrap3/templates/RecordTab/reviews.phtml
@@ -13,7 +13,13 @@
           <?php if (isset($review['Rating'])): ?>
             <img src="<?=$this->imageLink($review['Rating'] . '.gif')?>" alt="<?=$review['Rating']?>/5 Stars"/>
           <?php endif; ?>
-          <strong><?=$review['Summary']?></strong> <?=isset($review['Date']) ? strftime('%B %e, %Y', strtotime($review['Date'])) : ''?>
+          <strong><?=$review['Summary']?></strong>
+          <?php
+            if (isset($review['Date'])) {
+              $formatter = new \IntlDateFormatter(null, \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE);
+              echo $formatter->format(strtotime($review['Date']));
+            }
+          ?>
         </p>
       <?php endif; ?>
       <?php if (isset($review['Source'])): ?><strong><?=$this->transEsc('Review by')?> <?=$review['Source']?></strong><?php endif; ?>

--- a/themes/bootstrap3/templates/admin/home.phtml
+++ b/themes/bootstrap3/templates/admin/home.phtml
@@ -33,12 +33,12 @@
         <tr>
           <th><?=$this->transEsc('Start Time')?>: </th>
           <?php $startTime = $core->xpath('//lst[@name="' . $coreName . '"]/date[@name="startTime"]') ?>
-          <td><?=$this->escapeHtml(date("M d, Y g:i:sA", strtotime((string)array_pop($startTime))))?></td>
+          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d\TH:i:s.uP', (string)array_pop($startTime)))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Last Modified')?>: </th>
           <?php $lastModified = $core->xpath('//lst[@name="' . $coreName . '"]/lst/date[@name="lastModified"]') ?>
-          <td><?=$this->escapeHtml(date("M d, Y g:i:sA", strtotime((string)array_pop($lastModified))))?></td>
+          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d\TH:i:s.uP', (string)array_pop($lastModified)))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Uptime')?>: </th>

--- a/themes/bootstrap3/templates/admin/home.phtml
+++ b/themes/bootstrap3/templates/admin/home.phtml
@@ -33,12 +33,12 @@
         <tr>
           <th><?=$this->transEsc('Start Time')?>: </th>
           <?php $startTime = $core->xpath('//lst[@name="' . $coreName . '"]/date[@name="startTime"]') ?>
-          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d\TH:i:s.uP', (string)array_pop($startTime)))?></td>
+          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime(DATE_RFC3339_EXTENDED, (string)array_pop($startTime)))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Last Modified')?>: </th>
           <?php $lastModified = $core->xpath('//lst[@name="' . $coreName . '"]/lst/date[@name="lastModified"]') ?>
-          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d\TH:i:s.uP', (string)array_pop($lastModified)))?></td>
+          <td><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime(DATE_RFC3339_EXTENDED, (string)array_pop($lastModified)))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Uptime')?>: </th>

--- a/themes/bootstrap3/templates/admin/home.phtml
+++ b/themes/bootstrap3/templates/admin/home.phtml
@@ -33,12 +33,12 @@
         <tr>
           <th><?=$this->transEsc('Start Time')?>: </th>
           <?php $startTime = $core->xpath('//lst[@name="' . $coreName . '"]/date[@name="startTime"]') ?>
-          <td><?=$this->escapeHtml(strftime("%b %d, %Y %l:%M:%S%p", strtotime((string)array_pop($startTime))))?></td>
+          <td><?=$this->escapeHtml(date("M d, Y g:i:sA", strtotime((string)array_pop($startTime))))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Last Modified')?>: </th>
           <?php $lastModified = $core->xpath('//lst[@name="' . $coreName . '"]/lst/date[@name="lastModified"]') ?>
-          <td><?=$this->escapeHtml(strftime("%b %d, %Y %l:%M:%S%p", strtotime((string)array_pop($lastModified))))?></td>
+          <td><?=$this->escapeHtml(date("M d, Y g:i:sA", strtotime((string)array_pop($lastModified))))?></td>
         </tr>
         <tr>
           <th><?=$this->transEsc('Uptime')?>: </th>


### PR DESCRIPTION
Another discovery made while working on #2381: some of our templates were using a deprecated function. This provides non-deprecated equivalents. Since `strftime` was locale-aware and `date` is not, I had to use the `IntlDateFormatter` class in one place to provide equivalent functionality. (I'm not worried about locales in the admin screen, since that is not fully translated anyway and is rarely used).

I've hand-tested both modified templates and added test coverage to confirm an appropriate fix in the case of the impacted ILS driver.

TODO
- [x] Resolve [VUFIND-1544](https://vufind.org/jira/browse/VUFIND-1544) when merging