### PR TITLE
Enhance and apply ConfigPluginManagerTrait for tests.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
@@ -44,6 +44,7 @@ use VuFind\Db\Table\User;
  */
 final class ILSTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\LiveDetectionTrait;
 
@@ -106,9 +107,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
             new \VuFindTest\Container\MockContainer($this)
         );
         $driverManager->setService('Sample', $driver);
-        $mockConfigReader = $this->createMock(\VuFind\Config\PluginManager::class);
-        $mockConfigReader->expects($this->any())->method('get')
-            ->will($this->returnValue(new \Laminas\Config\Config([])));
+        $mockConfigReader = $this->getMockConfigPluginManager([]);
         $auth = new \VuFind\Auth\ILS(
             new \VuFind\ILS\Connection(
                 new \Laminas\Config\Config(['driver' => 'Sample']),

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
@@ -27,10 +27,8 @@
  */
 namespace VuFindTest\AjaxHandler;
 
-use Laminas\Config\Config;
 use VuFind\AjaxHandler\DoiLookup;
 use VuFind\AjaxHandler\DoiLookupFactory;
-use VuFind\Config\PluginManager as ConfigManager;
 use VuFind\DoiLinker\DoiLinkerInterface;
 use VuFind\DoiLinker\PluginManager;
 
@@ -45,6 +43,8 @@ use VuFind\DoiLinker\PluginManager;
  */
 class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Set up configuration for a test.
      *
@@ -54,11 +54,10 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
      */
     protected function setupConfig($config)
     {
-        $config = new Config($config);
-        $cm = $this->container->createMock(ConfigManager::class, ['get']);
-        $cm->expects($this->once())->method('get')->with($this->equalTo('config'))
-            ->will($this->returnValue($config));
-        $this->container->set(ConfigManager::class, $cm);
+        $this->container->set(
+            \VuFind\Config\PluginManager::class,
+            $this->getMockConfigPluginManager(compact('config'))
+        );
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/ResultScrollerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/ResultScrollerTest.php
@@ -42,6 +42,8 @@ use VuFind\Controller\Plugin\ResultScroller;
  */
 class ResultScrollerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test next_prev_nav bug
      * Expect next_prev to behave like it's disabled if the last search didn't return any results
@@ -358,11 +360,9 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $firstLast = true,
         $sort = null
     ): \VuFindTest\Search\TestHarness\Results {
-        $pm = $this->getMockBuilder(\VuFind\Config\PluginManager::class)->disableOriginalConstructor()->getMock();
-        $config = new \Laminas\Config\Config(
-            $firstLast ? $this->getFirstLastConfig() : []
+        $pm = $this->getMockConfigPluginManager(
+            ['config' => $firstLast ? $this->getFirstLastConfig() : []]
         );
-        $pm->expects($this->any())->method('get')->will($this->returnValue($config));
         $options = new \VuFindTest\Search\TestHarness\Options($pm);
         $params = new \VuFindTest\Search\TestHarness\Params($options, $pm);
         $params->setPage($page);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -44,6 +44,8 @@ use VuFindTest\Container\MockContainer;
  */
 class MailerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test that the factory configures the object correctly.
      *
@@ -51,20 +53,17 @@ class MailerTest extends \PHPUnit\Framework\TestCase
      */
     public function testFactoryConfiguration()
     {
-        $config = new \Laminas\Config\Config(
-            [
-                'Mail' => [
-                    'host' => 'vufindtest.localhost',
-                    'port' => 123,
-                    'connection_time_limit' => 600,
-                    'name' => 'foo',
-                    'username' => 'vufinduser',
-                    'password' => 'vufindpass',
-                ]
+        $config = [
+            'Mail' => [
+                'host' => 'vufindtest.localhost',
+                'port' => 123,
+                'connection_time_limit' => 600,
+                'name' => 'foo',
+                'username' => 'vufinduser',
+                'password' => 'vufindpass',
             ]
-        );
-        $cm = new MockContainer($this);
-        $cm->set('config', $config);
+        ];
+        $cm = $this->getMockConfigPluginManager(compact('config'));
         $sm = new MockContainer($this);
         $sm->set(\VuFind\Config\PluginManager::class, $cm);
         $factory = new MailerFactory();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderFactoryTest.php
@@ -42,6 +42,8 @@ use VuFind\Net\UserIpReaderFactory;
  */
 class UserIpReaderFactoryTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Get a container set up for the factory.
      *
@@ -52,13 +54,11 @@ class UserIpReaderFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function getContainer($config = [], $server = ['server' => true]): \VuFindTest\Container\MockContainer
     {
-        $configManager = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()->getMock();
-        $configManager->expects($this->once())->method('get')
-            ->with($this->equalTo('config'))
-            ->will($this->returnValue(new Config($config)));
         $container = new \VuFindTest\Container\MockContainer($this);
-        $container->set(\VuFind\Config\PluginManager::class, $configManager);
+        $container->set(
+            \VuFind\Config\PluginManager::class,
+            $this->getMockConfigPluginManager(compact('config'), [], $this->once())
+        );
         $mockRequest = $this
             ->getMockBuilder(\Laminas\Http\PhpEnvironment\Request::class)
             ->disableOriginalConstructor()->getMock();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CollectionSideFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CollectionSideFacetsTest.php
@@ -76,8 +76,7 @@ class CollectionSideFacetsTest extends \PHPUnit\Framework\TestCase
         $settings = '',
         $request = null,
         $facetHelper = true
-    )
-    {
+    ) {
         $sf = new CollectionSideFacets(
             $configLoader ?? $this->getMockConfigPluginManager([]),
             $facetHelper ? new \VuFind\Search\Solr\HierarchicalFacetHelper() : false

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CollectionSideFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CollectionSideFacetsTest.php
@@ -40,6 +40,7 @@ use VuFind\Recommend\CollectionSideFacets;
  */
 class CollectionSideFacetsTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
     use \VuFindTest\Feature\SolrSearchObjectTrait;
 
     /**
@@ -60,17 +61,25 @@ class CollectionSideFacetsTest extends \PHPUnit\Framework\TestCase
      * Get a fully configured module
      *
      * @param \VuFind\Config\PluginManager                $configLoader config loader
-     * @param \VuFind\Search\Solr\Results                 $results      results object
+     * @param \VuFind\Search\Solr\Results                 $results      results
+     * object
      * @param string                                      $settings     settings
-     * @param \Laminas\Stdlib\Parameters                     $request      request
-     * @param \VuFind\Search\Solr\HierarchicalFacetHelper $facetHelper  hierarchical facet helper (true to build default, null to omit)
+     * @param \Laminas\Stdlib\Parameters                  $request      request
+     * @param \VuFind\Search\Solr\HierarchicalFacetHelper $facetHelper  hierarchical
+     * facet helper (true to build default, null to omit)
      *
      * @return SideFacets
      */
-    protected function getSideFacets($configLoader = null, $results = null, $settings = '', $request = null, $facetHelper = true)
+    protected function getSideFacets(
+        $configLoader = null,
+        $results = null,
+        $settings = '',
+        $request = null,
+        $facetHelper = true
+    )
     {
         $sf = new CollectionSideFacets(
-            $configLoader ?? $this->getMockConfigLoader(),
+            $configLoader ?? $this->getMockConfigPluginManager([]),
             $facetHelper ? new \VuFind\Search\Solr\HierarchicalFacetHelper() : false
         );
         $sf->setConfig($settings);
@@ -80,23 +89,6 @@ class CollectionSideFacetsTest extends \PHPUnit\Framework\TestCase
         );
         $sf->process($results ?? $this->getSolrResults());
         return $sf;
-    }
-
-    /**
-     * Get a mock config loader.
-     *
-     * @param array  $config Configuration to return
-     * @param string $key    Key to store configuration under
-     *
-     * @return \VuFind\Config\PluginManager
-     */
-    protected function getMockConfigLoader($config = [], $key = 'facets')
-    {
-        $loader = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()->getMock();
-        $loader->expects($this->once())->method('get')->with($this->equalTo($key))
-            ->will($this->returnValue(new \Laminas\Config\Config($config)));
-        return $loader;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/FacetCloudTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/FacetCloudTest.php
@@ -40,6 +40,8 @@ use VuFind\Recommend\FacetCloud;
  */
 class FacetCloudTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test getEmptyResults()
      *
@@ -61,46 +63,31 @@ class FacetCloudTest extends \PHPUnit\Framework\TestCase
      * @param \VuFind\Search\Solr\Results  $results      populated results object
      * @param \VuFind\Search\Solr\Results  $emptyResults empty results object
      * @param string                       $settings     settings
-     * @param \Laminas\Stdlib\Parameters      $request      request
+     * @param \Laminas\Stdlib\Parameters   $request      request
      *
      * @return FacetCloud
      */
-    protected function getFacetCloud($configLoader = null, $results = null, $emptyResults = null, $settings = '', $request = null)
-    {
-        if (null === $configLoader) {
-            $configLoader = $this->getMockConfigLoader();
-        }
+    protected function getFacetCloud(
+        $configLoader = null,
+        $results = null,
+        $emptyResults = null,
+        $settings = '',
+        $request = null
+    ) {
         if (null === $results) {
             $results = $this->getMockResults();
         }
-        if (null === $emptyResults) {
-            $emptyResults = $this->getMockResults();
-        }
-        if (null === $request) {
-            $request = new \Laminas\Stdlib\Parameters([]);
-        }
-        $fc = new FacetCloud($configLoader, $emptyResults);
+        $fc = new FacetCloud(
+            $configLoader ?? $this->getMockConfigPluginManager([]),
+            $emptyResults ?? $this->getMockResults()
+        );
         $fc->setConfig($settings);
-        $fc->init($results->getParams(), $request);
+        $fc->init(
+            $results->getParams(),
+            $request ?? new \Laminas\Stdlib\Parameters([])
+        );
         $fc->process($results);
         return $fc;
-    }
-
-    /**
-     * Get a mock config loader.
-     *
-     * @param array  $config Configuration to return
-     * @param string $key    Key to store configuration under
-     *
-     * @return \VuFind\Config\PluginManager
-     */
-    protected function getMockConfigLoader($config = [], $key = 'facets')
-    {
-        $loader = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()->getMock();
-        $loader->expects($this->once())->method('get')->with($this->equalTo($key))
-            ->will($this->returnValue(new \Laminas\Config\Config($config)));
-        return $loader;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/FavoriteFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/FavoriteFacetsTest.php
@@ -40,6 +40,8 @@ use VuFind\Recommend\FavoriteFacets;
  */
 class FavoriteFacetsTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test facet initialization with disabled tags.
      *
@@ -80,40 +82,21 @@ class FavoriteFacetsTest extends \PHPUnit\Framework\TestCase
      */
     protected function getFavoriteFacets($results = null, $tagSetting = 'enabled', $settings = '', $request = null, $facetHelper = null, $configLoader = null)
     {
-        if (null === $configLoader) {
-            $configLoader = $this->getMockConfigLoader();
-        }
         if (null === $results) {
             $results = $this->getMockResults();
         }
-        if (true === $facetHelper) {
-            $facetHelper = new \VuFind\Search\Solr\HierarchicalFacetHelper();
-        }
-        if (null === $request) {
-            $request = new \Laminas\Stdlib\Parameters([]);
-        }
-        $sf = new FavoriteFacets($configLoader, $facetHelper, $tagSetting);
+        $sf = new FavoriteFacets(
+            $configLoader ?? $this->getMockConfigPluginManager([]),
+            $facetHelper ?? new \VuFind\Search\Solr\HierarchicalFacetHelper(),
+            $tagSetting
+        );
         $sf->setConfig($settings);
-        $sf->init($results->getParams(), $request);
+        $sf->init(
+            $results->getParams(),
+            $request ?? new \Laminas\Stdlib\Parameters([])
+        );
         $sf->process($results);
         return $sf;
-    }
-
-    /**
-     * Get a mock config loader.
-     *
-     * @param array  $config Configuration to return
-     * @param string $key    Key to store configuration under
-     *
-     * @return \VuFind\Config\PluginManager
-     */
-    protected function getMockConfigLoader($config = [], $key = 'config')
-    {
-        $loader = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()->getMock();
-        $loader->expects($this->any())->method('get')->with($this->equalTo($key))
-            ->will($this->returnValue(new \Laminas\Config\Config($config)));
-        return $loader;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/RecommendLinksTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/RecommendLinksTest.php
@@ -40,6 +40,8 @@ use VuFind\Recommend\RecommendLinks;
  */
 class RecommendLinksTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test configuration data.
      *
@@ -79,7 +81,9 @@ class RecommendLinksTest extends \PHPUnit\Framework\TestCase
      */
     public function testRecommendLinksWithDefaultConfiguration()
     {
-        $cm = $this->getConfigManager('RecommendLinks', 'searches');
+        $cm = $this->getMockConfigPluginManager(
+            ['searches' => ['RecommendLinks' => $this->sampleLinks]]
+        );
         $this->runTestProcedure($cm, '');
     }
 
@@ -90,25 +94,9 @@ class RecommendLinksTest extends \PHPUnit\Framework\TestCase
      */
     public function testRecommendLinksWithCustomConfiguration()
     {
-        $cm = $this->getConfigManager('bar', 'foo');
+        $cm = $this->getMockConfigPluginManager(
+            ['foo' => ['bar' => $this->sampleLinks]]
+        );
         $this->runTestProcedure($cm, 'bar:foo');
-    }
-
-    /**
-     * Build a mock config manager to support the test.
-     *
-     * @return \VuFind\Config\PluginManager
-     */
-    protected function getConfigManager(string $section, string $ini)
-    {
-        $config = new \Laminas\Config\Config([$section => $this->sampleLinks]);
-        $mock = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['get'])
-            ->getMock();
-        $mock->expects($this->once())->method('get')
-            ->with($this->equalTo($ini))
-            ->will($this->returnValue($config));
-        return $mock;
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
@@ -42,6 +42,26 @@ use VuFind\RecordTab\TabManager;
  */
 class TabManagerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
+    /**
+     * Default configuration for mock plugin manager
+     *
+     * @var array
+     */
+    protected $defaultConfig = [
+        'RecordTabs' => [
+            'VuFind\RecordDriver\EDS' => [
+                'tabs' => [
+                    'xyzzy' => 'yzzyx',
+                    'zip' => 'line',
+                ],
+                'defaultTab' => 'zip',
+                'backgroundLoadedTabs' => ['xyzzy'],
+            ],
+        ]
+    ];
+
     /**
      * Set up a tab manager for testing.
      *
@@ -75,7 +95,8 @@ class TabManagerTest extends \PHPUnit\Framework\TestCase
         ];
         return new TabManager(
             $pluginManager ?? $this->getMockPluginManager(),
-            $configManager ?? $this->getMockConfigManager(),
+            $configManager
+                ?? $this->getMockConfigPluginManager($this->defaultConfig),
             $legacyConfig
         );
     }
@@ -98,36 +119,6 @@ class TabManagerTest extends \PHPUnit\Framework\TestCase
         $pm->expects($this->any())->method('get')
             ->will($this->returnValue($mockTab));
         return $pm;
-    }
-
-    /**
-     * Build a mock config manager.
-     *
-     * @return ConfigManager
-     */
-    protected function getMockConfigManager()
-    {
-        $iniConfig = new \Laminas\Config\Config(
-            [
-                'VuFind\RecordDriver\EDS' => [
-                    'tabs' => [
-                        'xyzzy' => 'yzzyx',
-                        'zip' => 'line',
-                    ],
-                    'defaultTab' => 'zip',
-                    'backgroundLoadedTabs' => ['xyzzy'],
-                ],
-            ]
-        );
-        $configManager = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['has', 'get'])
-            ->getMock();
-        $configManager->expects($this->any())->method('has')
-            ->will($this->returnValue(true));
-        $configManager->expects($this->any())->method('get')
-            ->will($this->returnValue($iniConfig));
-        return $configManager;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Related/BookplateTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Related/BookplateTest.php
@@ -27,7 +27,6 @@
  */
 namespace VuFindTest\Related;
 
-use Laminas\Config\Config;
 use VuFind\Config\PluginManager as ConfigManager;
 use VuFind\Related\Bookplate;
 use VuFind\Related\BookplateFactory;
@@ -45,6 +44,8 @@ use VuFindTest\RecordDriver\TestHarness as RecordDriver;
  */
 class BookplateTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test default behavior (no bookplates)
      *
@@ -168,9 +169,10 @@ class BookplateTest extends \PHPUnit\Framework\TestCase
         array $config = []
     ): MockContainer {
         $container = new MockContainer($this);
-        $container->get(ConfigManager::class)->expects($this->once())->method('get')
-            ->with($this->equalTo($expectedConfig))
-            ->will($this->returnValue(new Config($config)));
+        $container->set(
+            ConfigManager::class,
+            $this->getMockConfigPluginManager([$expectedConfig => $config])
+        );
         return $container;
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
@@ -33,7 +33,6 @@ namespace VuFindTest\Search\Base;
 use VuFind\Config\PluginManager;
 use VuFind\Search\Base\Options;
 use VuFind\Search\Base\Params;
-use VuFindTest\Feature\ReflectionTrait;
 
 /**
  * Base Search Object Parameters Test
@@ -48,19 +47,8 @@ use VuFindTest\Feature\ReflectionTrait;
  */
 class ParamsTest extends \PHPUnit\Framework\TestCase
 {
-    use ReflectionTrait;
-
-    /**
-     * Get mock configuration plugin manager
-     *
-     * @return PluginManager
-     */
-    protected function getMockConfigManager(): PluginManager
-    {
-        return $this->getMockBuilder(PluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+    use \VuFindTest\Feature\ReflectionTrait;
 
     /**
      * Get mock Options object
@@ -74,7 +62,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
     {
         return $this->getMockForAbstractClass(
             Options::class,
-            [$configManager ?? $this->getMockConfigManager()]
+            [$configManager ?? $this->getMockConfigPluginManager([])]
         );
     }
 
@@ -92,7 +80,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         ?Options $options = null,
         ?PluginManager $configManager = null
     ): Params {
-        $configManager = $configManager ?? $this->getMockConfigManager();
+        $configManager = $configManager ?? $this->getMockConfigPluginManager([]);
         return $this->getMockForAbstractClass(
             Params::class,
             [$options ?? $this->getMockOptions($configManager), $configManager]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
@@ -27,7 +27,6 @@
  */
 namespace VuFindTest\Search\EDS;
 
-use Laminas\Config\Config;
 use VuFind\Config\PluginManager;
 use VuFind\Search\EDS\Options;
 use VuFind\Search\EDS\Params;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/OptionsTest.php
@@ -41,17 +41,7 @@ use VuFind\Search\Solr\Options;
  */
 class OptionsTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * Get mock configuration plugin manager
-     *
-     * @return PluginManager
-     */
-    protected function getMockConfigManager()
-    {
-        return $this->getMockBuilder(PluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
 
     /**
      * Get Options object
@@ -63,7 +53,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
      */
     protected function getOptions($configManager = null)
     {
-        return new Options($configManager ?? $this->getMockConfigManager());
+        return new Options($configManager ?? $this->getMockConfigPluginManager([]));
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
@@ -27,7 +27,6 @@
  */
 namespace VuFindTest\Search\Solr;
 
-use Laminas\Config\Config;
 use VuFind\Config\PluginManager;
 use VuFind\Search\Solr\Options;
 use VuFind\Search\Solr\Params;
@@ -43,6 +42,8 @@ use VuFind\Search\Solr\Params;
  */
 class ParamsTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test that filters work as expected.
      *
@@ -117,9 +118,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckboxVisibility()
     {
-        $emptyConfig = new Config([]);
-        $facetConfig = new Config(
-            [
+        $config = [
+            'facets' => [
                 'CheckboxFacets' => [
                     'format:book' => 'Book filter',
                     'vufind:inverted' => 'Inverted filter',
@@ -130,13 +130,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     ],
                 ],
             ]
-        );
-        $configManager = $this->createMock(PluginManager::class);
-        $callback = function ($config) use ($emptyConfig, $facetConfig) {
-            return $config === 'facets' ? $facetConfig : $emptyConfig;
-        };
-        $configManager->expects($this->any())->method('get')
-            ->will($this->returnCallback($callback));
+        ];
+        $configManager = $this->getMockConfigPluginManager($config);
         $params = $this->getParams(null, $configManager);
         // We expect "normal" filters to NOT be always visible, and inverted
         // filters to be always visible.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
@@ -43,6 +43,8 @@ use VuFind\Search\Summon\Params;
  */
 class ParamsTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test that checkbox filters are always visible (or not) as appropriate.
      *
@@ -50,22 +52,16 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckboxVisibility()
     {
-        $emptyConfig = new Config([]);
-        $facetConfig = new Config(
-            [
+        $config = [
+            'Summon' => [
                 'CheckboxFacets' => [
                     'IsScholarly:true' => 'scholarly_limit',
                     'holdingsOnly:false' => 'add_other_libraries',
                     'queryExpansion:true' => 'include_synonyms',
                 ],
             ]
-        );
-        $configManager = $this->createMock(PluginManager::class);
-        $callback = function ($config) use ($emptyConfig, $facetConfig) {
-            return $config === 'Summon' ? $facetConfig : $emptyConfig;
-        };
-        $configManager->expects($this->any())->method('get')
-            ->will($this->returnCallback($callback));
+        ];
+        $configManager = $this->getMockConfigPluginManager($config);
         $params = $this->getParams(null, $configManager);
         // We expect "normal" filters to NOT be always visible, and inverted
         // filters to be always visible.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/MarkdownFactoryTest.php
@@ -28,7 +28,6 @@
  */
 namespace VuFindTest\Service;
 
-use Laminas\Config\Config;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use League\CommonMark\MarkdownConverterInterface;
 use VuFind\Service\MarkdownFactory;
@@ -44,6 +43,8 @@ use VuFind\Service\MarkdownFactory;
  */
 class MarkdownFactoryTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Test to ensure the markdown factory is using right config for markdown
      * service
@@ -213,13 +214,11 @@ class MarkdownFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMarkdownConverter(array $config): MarkdownConverterInterface
     {
-        $config = new Config($config);
         $container = new \VuFindTest\Container\MockContainer($this);
-        $configManager = $container
-            ->createMock(\VuFind\Config\PluginManager::class, ['get']);
-        $configManager->expects($this->any())->method('get')
-            ->will($this->returnValue($config));
-        $container->set(\VuFind\Config\PluginManager::class, $configManager);
+        $container->set(
+            \VuFind\Config\PluginManager::class,
+            $this->getMockConfigPluginManager(['markdown' => $config])
+        );
         $markdownFactory = new MarkdownFactory();
         $markdown = $markdownFactory(
             $container,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/ContentPagesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/ContentPagesTest.php
@@ -44,6 +44,8 @@ use VuFindTheme\ThemeInfo;
  */
 class ContentPagesTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
     /**
      * Mock container
      *
@@ -109,10 +111,10 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
         ?ThemeInfo $themeInfo = null
     ): ContentPages {
         // Set up configuration:
-        $configObj = new \Laminas\Config\Config($config);
-        $configManager = $this->container->get(\VuFind\Config\PluginManager::class);
-        $configManager->expects($this->once())->method('get')
-            ->with($this->equalTo('config'))->will($this->returnValue($configObj));
+        $this->container->set(
+            \VuFind\Config\PluginManager::class,
+            $this->getMockConfigPluginManager(compact('config'))
+        );
 
         // Set up other dependencies:
         $this->container->set('HttpRouter', $router ?? $this->getMockRouter());


### PR DESCRIPTION
This PR is a follow-up to #2387. It makes the ConfigPluginManagerTrait for tests a little more robust and flexible, and applies it to all existing tests where its use is appropriate.