### PR TITLE
Improvements to facet/filter processing logic.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1071,7 +1071,7 @@ class Params
      *
      * @return string
      */
-    public function getFacetValueDisplayText(string $field, string $value): string
+    public function getFacetValueRawDisplayText(string $field, string $value): string
     {
         // Check for delimited facets -- if $field is a delimited facet field,
         // process $displayText accordingly:
@@ -1096,7 +1096,7 @@ class Params
      */
     protected function formatFilterListEntry($field, $value, $operator, $translate)
     {
-        $displayText = $this->getFacetValueDisplayText($field, $value);
+        $displayText = $this->getFacetValueRawDisplayText($field, $value);
 
         if ($translate) {
             $domain = $this->getOptions()->getTextDomainForTranslatedFacet($field);

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1064,23 +1064,24 @@ class Params
     }
 
     /**
-     * Check for delimited facets -- if $field is a delimited facet field,
-     * process $displayText accordingly. Return the appropriate display value.
+     * Get a display text for a facet field.
      *
-     * @param string $field       The facet
-     * @param string $displayText The facet value
+     * @param string $field Facet field
+     * @param string $value Facet value
      *
      * @return string
      */
-    public function checkForDelimitedFacetDisplayText($field, $displayText)
+    public function getFacetValueDisplayText(string $field, string $value): string
     {
+        // Check for delimited facets -- if $field is a delimited facet field,
+        // process $displayText accordingly:
         $delimitedFacetFields = $this->getOptions()->getDelimitedFacets(true);
         if (isset($delimitedFacetFields[$field])) {
-            $parts = explode($delimitedFacetFields[$field], $displayText);
-            $displayText = end($parts);
+            $parts = explode($delimitedFacetFields[$field], $value);
+            return end($parts);
         }
 
-        return $displayText;
+        return $value;
     }
 
     /**
@@ -1095,7 +1096,7 @@ class Params
      */
     protected function formatFilterListEntry($field, $value, $operator, $translate)
     {
-        $displayText = $this->checkForDelimitedFacetDisplayText($field, $value);
+        $displayText = $this->getFacetValueDisplayText($field, $value);
 
         if ($translate) {
             $domain = $this->getOptions()->getTextDomainForTranslatedFacet($field);

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1085,6 +1085,29 @@ class Params
     }
 
     /**
+     * Translate a facet value.
+     *
+     * @param string $field Field name
+     * @param string $text  Field value (processed by getFacetValueRawDisplayText)
+     *
+     * @return string
+     */
+    public function translateFacetValue(string $field, string $text): string
+    {
+        $domain = $this->getOptions()->getTextDomainForTranslatedFacet($field);
+        $translateFormat = $this->getOptions()->getFormatForTranslatedFacet($field);
+        $translated = $this->translate([$domain, $text]);
+        return $translateFormat
+            ? $this->translate(
+                $translateFormat,
+                [
+                    '%%raw%%' => $text,
+                    '%%translated%%' => $translated
+                ]
+            ) : $translated;
+    }
+
+    /**
      * Format a single filter for use in getFilterList().
      *
      * @param string $field     Field name
@@ -1096,12 +1119,10 @@ class Params
      */
     protected function formatFilterListEntry($field, $value, $operator, $translate)
     {
-        $displayText = $this->getFacetValueRawDisplayText($field, $value);
-
-        if ($translate) {
-            $domain = $this->getOptions()->getTextDomainForTranslatedFacet($field);
-            $displayText = $this->translate("$domain::$displayText");
-        }
+        $rawDisplayText = $this->getFacetValueRawDisplayText($field, $value);
+        $displayText = $translate
+            ? $this->translateFacetValue($field, $rawDisplayText)
+            : $rawDisplayText;
 
         return compact('value', 'displayText', 'field', 'operator');
     }

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -28,6 +28,7 @@
  */
 namespace VuFind\Search\Base;
 
+use VuFind\I18n\TranslatableString;
 use VuFind\Search\QueryAdapter;
 use VuFind\Solr\Utils as SolrUtils;
 use VuFindSearch\Backend\Solr\LuceneSyntaxHelper;
@@ -1087,12 +1088,13 @@ class Params
     /**
      * Translate a facet value.
      *
-     * @param string $field Field name
-     * @param string $text  Field value (processed by getFacetValueRawDisplayText)
+     * @param string                    $field Field name
+     * @param string|TranslatableString $text  Field value (processed by
+     * getFacetValueRawDisplayText)
      *
      * @return string
      */
-    public function translateFacetValue(string $field, string $text): string
+    public function translateFacetValue(string $field, $text): string
     {
         $domain = $this->getOptions()->getTextDomainForTranslatedFacet($field);
         $translateFormat = $this->getOptions()->getFormatForTranslatedFacet($field);

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -337,7 +337,7 @@ class Results extends \VuFind\Search\Base\Results
                 $currentSettings['value'] = $value;
 
                 $displayText = $this->getParams()
-                    ->checkForDelimitedFacetDisplayText($field, $value);
+                    ->getFacetValueDisplayText($field, $value);
 
                 if ($hierarchical) {
                     if (!$this->hierarchicalFacetHelper) {

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -320,21 +320,12 @@ class Results extends \VuFind\Search\Base\Results
             // Build our array of values for this field
             $list[$field]['list']  = [];
             // Should we translate values for the current facet?
-            $translateTextDomain = '';
-            $translateFormat = '';
             $translate = in_array($field, $translatedFacets);
-            if ($translate) {
-                $translateTextDomain = $this->getOptions()
-                    ->getTextDomainForTranslatedFacet($field);
-                $translateFormat = $this->getOptions()
-                    ->getFormatForTranslatedFacet($field);
-            }
             $hierarchical = in_array($field, $hierarchicalFacets);
             // Loop through values:
             foreach ($data as $value => $count) {
                 // Initialize the array of data about the current facet:
-                $currentSettings = [];
-                $currentSettings['value'] = $value;
+                $currentSettings = compact('value', 'count');
 
                 $displayText = $this->getParams()
                     ->getFacetValueRawDisplayText($field, $value);
@@ -350,24 +341,9 @@ class Results extends \VuFind\Search\Base\Results
                         ->formatDisplayText($displayText);
                 }
 
-                if ($translate) {
-                    $translated = $this->translate(
-                        [$translateTextDomain, $displayText]
-                    );
-                    // Apply a format to the translation (if available)
-                    if ($translateFormat) {
-                        $translated = $this->translate(
-                            $translateFormat,
-                            ['%%raw%%' => $displayText,
-                            '%%translated%%' => $translated]
-                        );
-                    }
-                    $currentSettings['displayText'] = $translated;
-                } else {
-                    $currentSettings['displayText'] = $displayText;
-                }
-
-                $currentSettings['count'] = $count;
+                $currentSettings['displayText'] = $translate
+                    ? $this->getParams()->translateFacetValue($field, $displayText)
+                    : $displayText;
                 $currentSettings['operator']
                     = $this->getParams()->getFacetOperator($field);
                 $currentSettings['isApplied']

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -337,7 +337,7 @@ class Results extends \VuFind\Search\Base\Results
                 $currentSettings['value'] = $value;
 
                 $displayText = $this->getParams()
-                    ->getFacetValueDisplayText($field, $value);
+                    ->getFacetValueRawDisplayText($field, $value);
 
                 if ($hierarchical) {
                     if (!$this->hierarchicalFacetHelper) {


### PR DESCRIPTION
This is a follow-up to #2352 that renames and slightly revises a method for increased clarity and fixes a problem where filters were not processed the same way as facets. Some of this work is extracted from #2372 -- I think we should get this change merged to the dev branch BEFORE we release VuFind 8.1 so that #2352 doesn't introduce an additional unnecessary BC break between 8.1 and 9.0.

TODO
- [x] Run full test suite