### PR TITLE
Clear out any empty filter arrays after removing a filter.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -892,6 +892,9 @@ class Params
             // If necessary, rebuild the array to remove gaps in the key sequence:
             if ($rebuildArray) {
                 $this->filterList[$field] = array_values($this->filterList[$field]);
+                if (!$this->filterList[$field]) {
+                    unset($this->filterList[$field]);
+                }
             }
         }
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
@@ -113,7 +113,23 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             $params->getBackendParameters()->get('filterList')
         );
 
-        // Add a hidden filter:
+        // Remove building filter:
+        $params->removeFilter('building:main');
+        $this->assertEquals(
+            [
+                'format' => [
+                    'facetOp' => 'OR',
+                    'values' => [
+                        'foo',
+                        'bar',
+                    ]
+                ],
+            ],
+            $params->getBackendParameters()->get('filterList')
+        );
+
+        // Add a filter and a hidden filter:
+        $params->addFilter('building:main');
         $params->addHiddenFilter('building:sub');
         $this->assertEquals(
             [
@@ -150,7 +166,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             $params->getBackendParameters()->get('filterList')
         );
 
-        // Remove building filter:
+        // Remove building:main filter:
         $params->removeFilter('building:main');
         $this->assertEquals(
             [


### PR DESCRIPTION
While working on Blender tests I noticed that Primo Params returns empty filter lists for fields that have previously had a filter set but later removed with `removeFilter()`. This makes sure any empty filter array is unset.