### PR TITLE
Update Google Analytics helper for compatibility with GA4

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2119,13 +2119,9 @@ treeSearchLimit = 100
 ;[GoogleTagManager]
 ;gtmContainerId = "GTM-1234567"
 
-; Uncomment this section and provide your API key to enable Google Analytics. Be
-; sure to set the "universal" setting to true once your account is upgraded to
-; Universal Analytics; see:
-; https://developers.google.com/analytics/devguides/collection/upgrade/guide
+; Uncomment this section and provide your API key to enable Google Analytics.
 ;[GoogleAnalytics]
 ;apiKey = "mykey"
-;universal = false
 ; Options to pass to the ga() function's create call; if omitted, defaults to
 ; 'auto'. The example below can be uncommented to work around a common problem
 ; with browsers complaining about problems with the samesite attribute. Note

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2128,7 +2128,7 @@ treeSearchLimit = 100
 ; that the value of this setting must be valid Javascript code, so be careful
 ; about quoting and escaping.
 ; Note: only supported when universal is set to true.
-;create_options_js = "{cookieFlags: 'max-age=7200;secure;samesite=none'}"
+;create_options_js = "{cookie_flags: 'max-age=7200;secure;samesite=none'}"
 
 ; Matomo analytics version 4 and later (for version 3 and earlier, use Piwik section
 ; below):

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -41,6 +41,8 @@ script-src[] = "http:"
 script-src[] = "https:"
 ;script-src-elem[] = "'self'"
 connect-src[] = "'self'"
+; If you are using Google Analytics, uncomment the line below
+;connect-src[] = "https://www.google-analytics.com"
 ; worker-src required for jsTree with browsers that don't support 'strict-dynamic' (e.g. Safari):
 worker-src[] = "blob:"
 style-src[] = "'self'"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -42,7 +42,7 @@ script-src[] = "https:"
 ;script-src-elem[] = "'self'"
 connect-src[] = "'self'"
 ; If you are using Google Analytics, uncomment the line below
-;connect-src[] = "https://www.google-analytics.com"
+;connect-src[] = "https://*.google-analytics.com"
 ; worker-src required for jsTree with browsers that don't support 'strict-dynamic' (e.g. Safari):
 worker-src[] = "blob:"
 style-src[] = "'self'"

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\View\Helper\Root;
 
+use Laminas\View\Helper\HeadScript;
+
 /**
  * GoogleAnalytics view helper
  *
@@ -46,13 +48,6 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
      * @var string|bool
      */
     protected $key;
-
-    /**
-     * Are we using Universal Analytics?
-     *
-     * @var bool
-     */
-    protected $universal;
 
     /**
      * Options to pass to the ga() create command.
@@ -78,7 +73,6 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
             $options = ['universal' => (bool)$options];
         }
         $this->key = $key;
-        $this->universal = $options['universal'] ?? false;
         $this->createOptions = $options['create_options_js'] ?? "'auto'";
     }
 
@@ -91,38 +85,12 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
      */
     protected function getRawJavascript($customUrl = false)
     {
-        // Simple case: Universal
-        if ($this->universal) {
-            return '(function(i,s,o,g,r,a,m){'
-                . "i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){"
-                . '(i[r].q=i[r].q||[]).push(arguments)},'
-                . 'i[r].l=1*new Date();a=s.createElement(o),'
-                . 'm=s.getElementsByTagName(o)[0];a.async=1;a.src=g;'
-                . 'm.parentNode.insertBefore(a,m)'
-                . "})(window,document,'script',"
-                . "'//www.google-analytics.com/analytics.js','ga');"
-                . "ga('create', '{$this->key}', {$this->createOptions});"
-                . "ga('send', 'pageview');";
-        }
-
-        // Alternate (legacy) case:
-        $code = 'var key = "' . $this->key . '";' . "\n"
-            . "var _gaq = _gaq || [];\n"
-            . "_gaq.push(['_setAccount', key]);\n";
-        if ($customUrl) {
-            $code .= "_gaq.push(['_trackPageview', '" . $customUrl . "']);\n";
-        } else {
-            $code .= "_gaq.push(['_trackPageview']);\n";
-        }
-        $code .= "(function() {\n"
-            . "var ga = document.createElement('script'); "
-            . "ga.type = 'text/javascript'; ga.async = true;\n"
-            . "ga.src = ('https:' == document.location.protocol ? "
-            . "'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';\n"
-            . "var s = document.getElementsByTagName('script')[0]; "
-            . "s.parentNode.insertBefore(ga, s);\n"
-            . "})();";
-        return $code;
+        return <<<JS
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '{$this->key}', {$this->createOptions});
+            JS;
     }
 
     /**
@@ -137,8 +105,11 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
         if (!$this->key) {
             return '';
         }
-        $code = $this->getRawJavascript($customUrl);
         $inlineScript = $this->getView()->plugin('inlinescript');
-        return $inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $code, 'SET');
+        $url = 'https://www.googletagmanager.com/gtag/js?id=' . urlencode($this->key);
+        $code = $this->getRawJavascript($customUrl);
+        return
+            $inlineScript(HeadScript::FILE, $url, 'SET', ['async' => true]) . "\n"
+            . $inlineScript(HeadScript::SCRIPT, $code, 'SET');
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
@@ -74,7 +74,6 @@ class GoogleAnalyticsFactory implements FactoryInterface
         $options = [
             'create_options_js' =>
                 $config->GoogleAnalytics->create_options_js ?? null,
-            'universal' => $config->GoogleAnalytics->universal ?? false,
         ];
         return new $requestedName($key, $options);
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) Villanova University 2010.
+ * Copyright (C) Villanova University 2010-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -73,7 +73,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
      */
     public function testCustomCreateOptions(): void
     {
-        $createJs = "{cookieFlags: 'max-age=7200;secure;samesite=none'}";
+        $createJs = "{cookie_flags: 'max-age=7200;secure;samesite=none'}";
         $options = [
             'universal' => true,
             'create_options_js' => $createJs,
@@ -86,7 +86,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
                 window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'myfakekey', {cookieFlags: 'max-age=7200;secure;samesite=none'});
+            gtag('config', 'myfakekey', {cookie_flags: 'max-age=7200;secure;samesite=none'});
                 //-->
             </script>
             JS;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -45,29 +45,25 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
     use \VuFindTest\Feature\ViewTrait;
 
     /**
-     * Test the helper (old mode)
+     * Test the helper (basic setup)
      *
      * @return void
      */
-    public function testOldSetup(): void
+    public function testBasicSetup(): void
     {
-        $output = $this->renderGA('myfakekey', false);
-        $this->assertTrue(false !== strstr($output, 'ga.js'));
-        $this->assertFalse(strstr($output, 'analytics.js'));
-        $this->assertTrue(false !== strstr($output, 'myfakekey'));
-    }
-
-    /**
-     * Test the helper (Universal Analytics mode)
-     *
-     * @return void
-     */
-    public function testNewSetup(): void
-    {
-        $output = $this->renderGA('myfakekey', true);
-        $this->assertTrue(false !== strstr($output, 'analytics.js'));
-        $this->assertFalse(strstr($output, 'ga.js'));
-        $this->assertTrue(false !== strstr($output, 'myfakekey'));
+        $expectedUrl = "https&#x3A;&#x2F;&#x2F;www.googletagmanager.com&#x2F;gtag&#x2F;js&#x3F;id&#x3D;myfakekey";
+        $expected = <<<JS
+            <script type="text&#x2F;javascript" async="async" src="$expectedUrl"></script>
+            <script type="text&#x2F;javascript">
+                //<!--
+                window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'myfakekey', 'auto');
+                //-->
+            </script>
+            JS;
+        $this->assertEquals($expected, $this->renderGA('myfakekey'));
     }
 
     /**
@@ -82,24 +78,19 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
             'universal' => true,
             'create_options_js' => $createJs,
         ];
-        $output = $this->renderGA('myfakekey', $options);
-        // Confirm that the custom JS appears in the output, and that the
-        // default 'auto' does not:
-        $this->assertTrue(false !== strstr($output, $createJs));
-        $this->assertFalse(strstr($output, "'auto'"));
-    }
-
-    /**
-     * Test default create options.
-     *
-     * @return void
-     */
-    public function testDefaultCreateOptions(): void
-    {
-        $output = $this->renderGA('myfakekey', true);
-        // Confirm that the default JS appears in the output:
-        $expectedJs = "ga('create', 'myfakekey', 'auto');";
-        $this->assertTrue(false !== strstr($output, $expectedJs));
+        $expectedUrl = "https&#x3A;&#x2F;&#x2F;www.googletagmanager.com&#x2F;gtag&#x2F;js&#x3F;id&#x3D;myfakekey";
+        $expected = <<<JS
+            <script type="text&#x2F;javascript" async="async" src="$expectedUrl"></script>
+            <script type="text&#x2F;javascript">
+                //<!--
+                window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'myfakekey', {cookieFlags: 'max-age=7200;secure;samesite=none'});
+                //-->
+            </script>
+            JS;
+        $this->assertEquals($expected, $this->renderGA('myfakekey', $options));
     }
 
     /**
@@ -115,8 +106,8 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
     /**
      * Render the GA code
      *
-     * @param string     $key     GA key (false for disabled)
-     * @param array|bool $options Options for GA helper
+     * @param string $key     GA key (false for disabled)
+     * @param array  $options Options for GA helper
      *
      * @return string
      */


### PR DESCRIPTION
The Google Analytics code has not been updated since Universal Analytics was new... and now it has reached end of life, being deprecated in favor of GA4 in 2023. This PR removes the legacy code which is no longer functional and also removes references to Universal Analytics, since they will soon be irrelevant. It also updates the Javascript to the latest standard.

TODO
- [x] Confirm that this still works correctly with a GA4 API key
- [x] Update changelog with note about need to migrate to GA4 (and also to change cookieFlags to cookie_flags where applicable).