### PR TITLE
improve format detection for articles encoded as "Monograph Component Parts"

### DIFF
--- a/import/index_java/src/org/vufind/index/FormatCalculator.java
+++ b/import/index_java/src/org/vufind/index/FormatCalculator.java
@@ -214,7 +214,7 @@ public class FormatCalculator
                 break;
             // Component parts
             case 'a':
-                return (hasSerialHost(record)) ? "SerialComponentPart" : "BookComponentPart";
+                return (hasSerialHost(record)) ? "Article" : "BookComponentPart";
             case 'b':
                 return "SerialComponentPart";
             // Integrating resources (e.g. loose-leaf binders, databases)

--- a/import/index_java/src/org/vufind/index/FormatCalculator.java
+++ b/import/index_java/src/org/vufind/index/FormatCalculator.java
@@ -214,7 +214,7 @@ public class FormatCalculator
                 break;
             // Component parts
             case 'a':
-                return "BookComponentPart";
+                return (hasSerialHost(record)) ? "SerialComponentPart" : "BookComponentPart";
             case 'b':
                 return "SerialComponentPart";
             // Integrating resources (e.g. loose-leaf binders, databases)
@@ -369,8 +369,31 @@ public class FormatCalculator
      * @return boolean
      */
     protected boolean isThesis(Record record) {
-        // Is there a dissertation note? If so, it's a government document.
+        // Is there a dissertation note? If so, it's a thesis.
         return record.getVariableField("502") != null;
+    }
+
+    /**
+     * Determine whether a record has a host item that is a serial.
+     *
+     * @param Record record
+     * @return boolean
+     */
+    protected boolean hasSerialHost(Record record) {
+        // The 773 could possibly have more then one entry, although probably unlikely.
+        // If any contain a subfield 'g' return true to indicate the host is a serial
+        // see https://www.oclc.org/bibformats/en/specialcataloging.html#relatedpartsandpublications
+        List hostFields = record.getVariableFields("773");
+        Iterator hostFieldsIter = hostFields.iterator();
+        if (hostFields != null) {
+            while (hostFieldsIter.hasNext()) {
+                DataField hostField = (DataField) hostFieldsIter.next();
+                if (hostField.getSubfield('g') != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/import/translation_maps/format_map.properties
+++ b/import/translation_maps/format_map.properties
@@ -1,6 +1,7 @@
 #
 # DATA FROM INDEXER = Label
 #
+Article             = Article
 Atlas               = Map
 Book                = Book
 BookComponentPart   = Book Chapter

--- a/import/translation_maps/format_map_level0.properties
+++ b/import/translation_maps/format_map_level0.properties
@@ -5,6 +5,7 @@
 #
 # DATA FROM INDEXER = Label
 #
+Article             = 0/Serial/
 Atlas               = 0/Map/
 Book                = 0/Book/
 BookComponentPart   = 0/Book/

--- a/import/translation_maps/format_map_level1.properties
+++ b/import/translation_maps/format_map_level1.properties
@@ -8,6 +8,7 @@
 #
 # DATA FROM INDEXER = Label
 #
+Article             = 1/Serial/Journal Article/
 Atlas               = 1/Map/Atlas/
 Book                = 1/Book/Book/
 BookComponentPart   = 1/Book/Book Chapter/


### PR DESCRIPTION
Hi,
A small tweak to correctly identify journal articles. 

Some context:

- MARC uses LDR/07 to encode "component parts" with "a" for "Monographic Component Parts" and "b" for "Serial Component Parts"
- Despite the name, "Monographic Component Parts" is the correct encoding for "an article in a single issue of a periodical" as well as things like book chapters. "Serial Component Parts" is for things like ongoing columns or features that appear regularly in a parent serial. See https://www.loc.gov/marc/bibliographic/bdleader.html
- Vufind currently maps "Monographic Component Parts" to "book chapter" only, and maps "Serial Component Parts" to article
- In order to distinguish "book chapters" and "articles" that have been encoded as "Monographic Component Parts", the convention seems to be to rely on the corresponding 773 host field: if there is a $g, the item is journal article, otherwise "book chapter". See https://www.oclc.org/bibformats/en/specialcataloging.html#relatedpartsandpublications

Note: this PR simply forces a value of "SerialComponentPart" where a 773$g is detected, which gets mapped on to "Article". Technically it isn't a "Serial Component Part" but since these map to Article anyway, this is probably fine for now.