### PR TITLE
Make Blender's check for enabled backends more robust.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
@@ -67,7 +67,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
         }
         $configLoader = $container->get(\VuFind\Config\PluginManager::class);
         $blenderConfig = $configLoader->get('Blender');
-        if ($blenderConfig->Backends->count() === 0) {
+        if (empty($blenderConfig->Backends)) {
             throw new \Exception('No backends enabled in Blender.ini');
         }
 

--- a/module/VuFind/src/VuFind/Search/Factory/BlenderBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/BlenderBackendFactory.php
@@ -96,7 +96,7 @@ class BlenderBackendFactory implements FactoryInterface
         $yamlReader = $sm->get(\VuFind\Config\YamlReader::class);
         $blenderConfig = $this->config->get($this->searchConfig);
 
-        if ($blenderConfig->Backends->count() === 0) {
+        if (empty($blenderConfig->Backends)) {
             throw new \Exception("No backends enabled in {$this->searchConfig}.ini");
         }
         $backends = [];


### PR DESCRIPTION
The old check caused a crash if Backends section was undefined.