### PR TITLE
Simplify the way "edit list" title is determined.

### DIFF
--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -1,6 +1,6 @@
 <?php
   // Set up page title:
-  $pageTitle = empty($this->list->id) ? 'Create a List' : "edit_list";
+  $pageTitle = $this->newList ? 'Create a List' : "edit_list";
   $this->headTitle($this->translate($pageTitle));
 
   // Set up breadcrumbs:

--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -19,7 +19,7 @@
 
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
-<form class="form-edit-list" method="post" name="<?=empty($this->list->id) ? 'newList' : 'editListForm'?>">
+<form class="form-edit-list" method="post" name="<?=$this->newList ? 'newList' : 'editListForm'?>">
   <input type="hidden" name="id" value="<?=empty($this->list->id) ? 'NEW' : $this->escapeHtmlAttr($this->list->id) ?>"/>
   <div class="form-group">
     <label class="control-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>


### PR DESCRIPTION
This addresses a problem discovered while testing #2417: in PostgreSQL, new rows fetched from the database come with the ID pre-populated from the sequence, even if they are never saved. This interferes with correctly differentiating between "create row" and "edit row" titles. Fortunately, an existing flag offers an easier way to do this correctly.

Note that the underlying cause of the problem may still be a problem, since hitting "create list" repeatedly exhausts IDs unnecessarily. However, I'm not going to worry too much about that right now, since I'm hopeful that switching everything to Doctrine will likely change the situation anyway (see #2233).

TODO
- [x] Run full test suite with MySQL
- [x] Run full test suite with PostgreSQL