### PR TITLE
Redi-Resolver - Add missing array indexes to parseDOI return array and set service_type to getDOI

### DIFF
--- a/module/VuFind/src/VuFind/Resolver/Driver/Redi.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Redi.php
@@ -142,7 +142,9 @@ class Redi extends AbstractBase
                     'title' => $doiTerm->item($i)->textContent
                         . $doiDefinition->item($i)->textContent,
                     'href' => $href,
-                    'service_type' => 'getFullTxt',
+                    'access' => 'unknown',
+                    'coverage' => null,
+                    'service_type' => 'getDOI',
                 ];
             }
         }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/RediTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/RediTest.php
@@ -83,7 +83,9 @@ class RediTest extends \PHPUnit\Framework\TestCase
             0 => [
                 'title' => "DOI:10.1007/s11606-014-2915-9",
                 'href' => "http://www-fr.redi-bw.de/links/?rl_site=ubl&rl_action=link&rl_link_target=citation&rl_link_name=doi&rl_citation=9443914d0e261c0c1f6a3fd8151213c1d4cec05f5d3053097da6fa5597bbb9d7",
-                'service_type' => "getFullTxt",
+                'access' => 'unknown',
+                'coverage' => null,
+                'service_type' => "getDOI",
              ],
             1 => [
                 'title' => "Zum Volltext (via SpringerLink)",


### PR DESCRIPTION
In template errors might show up when the DOI in Redi resolver results is shown as it does not containt `access` and `coverarge` index. This has been fixed plus a more specific value of `service_type` for the DOI.