### PR TITLE
Repopulate SMS form when CAPTCHA fails.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -529,6 +529,9 @@ class AbstractRecord extends AbstractBase
         $view->validation = $sms->getValidationType();
         // Set up Captcha
         $view->useCaptcha = $this->captcha()->active('sms');
+        // Send parameters back to view so form can be re-populated:
+        $view->to = $this->params()->fromPost('to');
+        $view->provider = $this->params()->fromPost('provider');
         // Process form submission:
         if ($this->formWasSubmitted('submit', $view->useCaptcha)) {
             // Do CSRF check
@@ -538,10 +541,6 @@ class AbstractRecord extends AbstractBase
                     'error_inconsistent_parameters'
                 );
             }
-
-            // Send parameters back to view so form can be re-populated:
-            $view->to = $this->params()->fromPost('to');
-            $view->provider = $this->params()->fromPost('provider');
 
             // Attempt to send the email and show an appropriate flash message:
             try {

--- a/themes/bootstrap3/templates/record/sms.phtml
+++ b/themes/bootstrap3/templates/record/sms.phtml
@@ -23,7 +23,7 @@ JS;
   <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
   <div class="form-group">
     <label class="control-label" for="sms_to"><?=$this->transEsc('Number')?>:</label>
-    <input id="sms_to" type="tel" name="to" placeholder="<?=$this->transEscAttr('sms_phone_number')?>" class="form-control"/>
+    <input id="sms_to" type="tel" name="to" value="<?=$this->escapeHtmlAttr($this->to)?>" placeholder="<?=$this->transEscAttr('sms_phone_number')?>" class="form-control"/>
     <div class="help-block with-errors"></div>
   </div>
   <?php if (is_array($this->carriers) && count($this->carriers) > 1): ?>
@@ -32,7 +32,7 @@ JS;
       <select id="sms_provider" name="provider" class="form-control">
         <option selected="selected" value=""><?=$this->transEsc('Select your carrier')?></option>
         <?php foreach ($this->carriers as $val => $details): ?>
-          <option value="<?=$this->escapeHtmlAttr($val)?>"><?=$this->escapeHtml($details['name'])?></option>
+          <option value="<?=$this->escapeHtmlAttr($val)?>"<?=$val === $this->provider ? " selected" : ""?>><?=$this->escapeHtml($details['name'])?></option>
         <?php endforeach; ?>
       </select>
     </div>


### PR DESCRIPTION
It was just brought to my attention that when you fail CAPTCHA on a "Text This" link, the form does not automatically repopulate. This PR corrects the problem.

TODO
- [x] Run full test suite