### PR TITLE
Do not suggest using AggressiveOpts; it is deprecated.

### DIFF
--- a/import-marc.bat
+++ b/import-marc.bat
@@ -44,7 +44,6 @@ rem #   Tweak these in accordance to your needs
 rem # Xmx and Xms set the heap size for the Java Virtual Machine
 rem # You may also want to add the following:
 rem # -XX:+UseParallelGC
-rem # -XX:+AggressiveOpts
 rem ##################################################
 if not "!%INDEX_OPTIONS%!"=="!!" goto indexoptionsfound
 set INDEX_OPTIONS=-Xms512m -Xmx512m -DentityExpansionLimit=0

--- a/import-marc.sh
+++ b/import-marc.sh
@@ -45,7 +45,6 @@ fi
 # Xmx and Xms set the heap size for the Java Virtual Machine
 # You may also want to add the following:
 # -XX:+UseParallelGC
-# -XX:+AggressiveOpts
 ##################################################
 if [ -z "$INDEX_OPTIONS" ]
 then


### PR DESCRIPTION
Some comments in import-marc scripts suggested possibly using AggressiveOpts, but it is now deprecated; see: https://dzone.com/articles/jdk-13-what-is-aggressiveopts for details. This PR simply removes the obsolete suggestion.