### PR TITLE
Update Node.js and dependencies for CI. Use local eslint and jshint.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,19 +32,20 @@ jobs:
           extensions: intl, xsl
           tools: composer:2.1.6
 
-      - name: Setup node
-        if: ${{ matrix.phing_tasks == 'qa-console' }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Disable Solr installation
         run: touch solr/.disableAutomaticInstall
 
+      - name: Setup node
+        if: ${{ matrix.phing_tasks == 'qa-console' }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
       - name: Cache NPM dependencies
+        if: ${{ matrix.phing_tasks == 'qa-console' }}
         uses: actions/cache@v2
         with:
           path: ~/.npm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.phing_tasks == 'qa-console' }}
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,12 +44,16 @@ jobs:
       - name: Disable Solr installation
         run: touch solr/.disableAutomaticInstall
 
+      - name: Cache NPM dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Install node dependencies
         if: ${{ matrix.phing_tasks == 'qa-console' }}
-        run: |
-          npm install -g eslint@"<5.0.0"
-          npm install -g jshint@"2.9.6"
-          npm install
+        run: npm install --ignore-scripts
 
       - name: Get composer cache directory
         id: composer-cache

--- a/build.xml
+++ b/build.xml
@@ -159,21 +159,21 @@
 
   <!-- ESLint -->
   <target name="eslint">
-    <exec command="eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js" escape="false" checkreturn="true" passthru="true" />
+    <exec command="npx eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js" escape="false" checkreturn="true" passthru="true" />
   </target>
   <target name="eslint-fix">
-    <exec command="eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js --fix" escape="false" passthru="true" />
+    <exec command="npx eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js --fix" escape="false" passthru="true" />
   </target>
   <target name="eslint-report">
-    <exec command="eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml" escape="false" />
+    <exec command="npx eslint -c ${srcdir}/.eslintrc.js ${srcdir}/themes/bootstrap3/js/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml" escape="false" />
   </target>
 
   <!-- JSHint -->
   <target name="jshint">
-    <exec command="jshint --config=${srcdir}/tests/jshint.json --exclude=themes/*/js/vendor ${srcdir}/themes" checkreturn="true" passthru="true" />
+    <exec command="npx jshint --config=${srcdir}/tests/jshint.json --exclude=themes/*/js/vendor ${srcdir}/themes" checkreturn="true" passthru="true" />
   </target>
   <target name="jshint-report">
-    <exec command="jshint --config=${srcdir}/tests/jshint.json --exclude=themes/*/js/vendor --reporter=checkstyle ${srcdir}/themes &gt; ${builddir}/reports/jshint-checkstyle.xml" />
+    <exec command="npx jshint --config=${srcdir}/tests/jshint.json --exclude=themes/*/js/vendor --reporter=checkstyle ${srcdir}/themes &gt; ${builddir}/reports/jshint-checkstyle.xml" />
   </target>
 
   <!-- Run LessToSass, error if there are uncommitted changes (used by Travis) -->

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "node-sass": "^7.0.1"
   },
   "devDependencies": {
-    "grunt-contrib-watch": "^1.1.0"
+    "eslint": "^8.15.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "jshint": "^2.13.4"
   }
 }


### PR DESCRIPTION
- Updates CI to use Node.js 16. This fixes slow installation due to old git protocol.
- Adds caching of NPM dependencies.
- Updates eslint and jshint and installs them locally.
