### PR TITLE
Stop using error_log for connector cache debug messages.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Feature/ConnectorCacheTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Feature/ConnectorCacheTrait.php
@@ -159,8 +159,6 @@ trait ConnectorCacheTrait
     {
         if (($this->logger ?? null) instanceof LoggerInterface) {
             $this->logger->debug("Cache: $msg");
-        } else {
-            error_log("Debug: Cache: $msg");
         }
     }
 }


### PR DESCRIPTION
Only uses logger if available to avoid dumping debug messages e.g. when running unit tests.

Error messages will still be logged.