### PR TITLE
Remove Laminas\Soap from Shibboleth logout handler and add Mink test.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "laminas/laminas-serializer": "2.12.0",
         "laminas/laminas-servicemanager": "3.7.0",
         "laminas/laminas-session": "2.12.0",
-        "laminas/laminas-soap": "2.9.0",
         "laminas/laminas-stdlib": "3.7.1",
         "laminas/laminas-text": "2.9.0",
         "laminas/laminas-validator": "2.16.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f4345689539b43cf22f88fc6a0b1736",
+    "content-hash": "d0d66650eac1c51611d242e8003305dd",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -3903,67 +3903,6 @@
             "time": "2021-12-06T04:52:05+00:00"
         },
         {
-            "name": "laminas/laminas-server",
-            "version": "2.11.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-server.git",
-                "reference": "f45e1a6f614a11af8eff5d2d409f12229101cfc1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-server/zipball/f45e1a6f614a11af8eff5d2d409f12229101cfc1",
-                "reference": "f45e1a6f614a11af8eff5d2d409f12229101cfc1",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-code": "^3.5.1 || ^4.0.0",
-                "laminas/laminas-stdlib": "^3.3.1",
-                "laminas/laminas-zendframework-bridge": "^1.2.0",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "replace": {
-                "zendframework/zend-server": "^2.8.1"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "vimeo/psalm": "^4.6.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Server\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create Reflection-based RPC servers",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "server"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-server/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-server/issues",
-                "rss": "https://github.com/laminas/laminas-server/releases.atom",
-                "source": "https://github.com/laminas/laminas-server"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-02-25T14:41:51+00:00"
-        },
-        {
             "name": "laminas/laminas-servicemanager",
             "version": "3.7.0",
             "source": {
@@ -4133,74 +4072,6 @@
                 }
             ],
             "time": "2021-09-21T19:25:14+00:00"
-        },
-        {
-            "name": "laminas/laminas-soap",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-soap.git",
-                "reference": "11672a79e9074fd8e4e7aedd75849902e7b45e23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-soap/zipball/11672a79e9074fd8e4e7aedd75849902e7b45e23",
-                "reference": "11672a79e9074fd8e4e7aedd75849902e7b45e23",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-soap": "*",
-                "laminas/laminas-server": "^2.9",
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-uri": "^2.8",
-                "laminas/laminas-zendframework-bridge": "^1.1.0",
-                "php": "^7.3 || ~8.0.0"
-            },
-            "replace": {
-                "zendframework/zend-soap": "^2.8.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^3.4",
-                "laminas/laminas-http": "^2.14",
-                "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^9.4.3"
-            },
-            "suggest": {
-                "ext-curl": "Curl is required when .NET compatibility is required",
-                "laminas/laminas-http": "Laminas\\Http component"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Soap\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "soap"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-soap/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-soap/issues",
-                "rss": "https://github.com/laminas/laminas-soap/releases.atom",
-                "source": "https://github.com/laminas/laminas-soap"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-02-17T18:59:03+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -11761,5 +11632,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/module/VuFind/tests/fixtures/shibboleth/logout_notification.xml
+++ b/module/VuFind/tests/fixtures/shibboleth/logout_notification.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <LogoutNotification xmlns="urn:mace:shibboleth:2.0:sp:notify" type="global">
+      <SessionID>EXTERNAL_SESSION_ID</SessionID>
+    </LogoutNotification>
+  </s:Body>
+</s:Envelope>

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Shibboleth logout notification test class.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+namespace VuFindTest\Mink;
+
+use VuFind\Db\Table\ExternalSession;
+
+/**
+ * Shibboleth logout notification test class.
+ *
+ * Class must be final due to use of "new static()" by LiveDatabaseTrait.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ * @retry    4
+ */
+final class ShibbolethLogoutNotificationTest
+    extends \VuFindTest\Integration\MinkTestCase
+{
+    use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\LiveDatabaseTrait;
+    use \VuFindTest\Feature\LiveDetectionTrait;
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        // Give up if we're not running in CI:
+        if (!$this->continuousIntegrationRunning()) {
+            $this->markTestSkipped('Continuous integration not running.');
+            return;
+        }
+    }
+
+    /**
+     * Test Shibboleth logout notification.
+     *
+     * @return void
+     */
+    public function testLogoutNotification()
+    {
+        $this->changeConfigs(
+            [
+                'permissions' => [
+                    'api.ShibbolethLogoutNotification' => [
+                        'permission' => 'access.api.ShibbolethLogoutNotification',
+                        'require' => 'ANY',
+                        'ipRange' => [
+                            '127.0.0.1',
+                            '::1',
+                        ],
+                    ]
+                ]
+            ]
+        );
+
+        // Do a search and make sure it's in history:
+        $page = $this->performSearch('building:weird_ids.mrc');
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/History');
+        $this->findCss($page, 'table#recent-searches');
+
+        // Add a session id mapping to external_session table:
+        $sessionId = $session->getCookie('VUFIND_SESSION');
+        $table = $this->getTable(ExternalSession::class);
+        $table->addSessionMapping($sessionId, 'EXTERNAL_SESSION_ID');
+
+        // Call the notification endpoint:
+        $http = new \VuFindHttp\HttpService();
+        $result = $http->post(
+            $this->getVuFindUrl() . '/soap/shiblogout',
+            $this->getFixture('shibboleth/logout_notification.xml'),
+            'application/xml'
+        );
+        $this->assertTrue($result->isSuccess());
+        $this->assertEquals(200, $result->getStatusCode());
+
+        $session->visit($this->getVuFindUrl() . '/Search/History');
+        $this->unFindCss($page, 'table#recent-searches');
+    }
+}


### PR DESCRIPTION
This removes dependency on laminas-soap, which is in security-only maintenance mode, and paves the way for several other dependency updates.