### PR TITLE
Fix PHP 8.x deprecation warnings.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -204,7 +204,7 @@ class Shibboleth extends AbstractBase
 
         // Check if required attributes match up:
         foreach ($this->getRequiredAttributes($shib) as $key => $value) {
-            if (!preg_match("/$value/", $this->getAttribute($request, $key))) {
+            if (!preg_match("/$value/", $this->getAttribute($request, $key) ?? '')) {
                 $details = ($this->useHeaders) ? $request->getHeaders()->toArray()
                     : $request->getServer()->toArray();
                 $this->debug(
@@ -439,7 +439,7 @@ class Shibboleth extends AbstractBase
      */
     protected function getCurrentEntityId($request)
     {
-        return $this->getAttribute($request, $this->shibIdentityProvider);
+        return $this->getAttribute($request, $this->shibIdentityProvider) ?? '';
     }
 
     /**

--- a/module/VuFind/src/VuFind/ContentBlock/BlockLoader.php
+++ b/module/VuFind/src/VuFind/ContentBlock/BlockLoader.php
@@ -144,7 +144,7 @@ class BlockLoader
             foreach ($config->$section->$setting as $current) {
                 $parts = explode(':', $current, 2);
                 $block = $this->blockManager->get($parts[0]);
-                $block->setConfig($parts[1] ?? null);
+                $block->setConfig($parts[1] ?? '');
                 $blocks[] = $block;
             }
         }

--- a/module/VuFind/src/VuFind/Cookie/CookieManager.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManager.php
@@ -221,7 +221,7 @@ class CookieManager
         }
         return setcookie(
             $key,
-            $value,
+            $value ?? '',
             [
                 'expires' => $expire,
                 'path' => $path,

--- a/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
+++ b/module/VuFind/src/VuFind/Http/PhpEnvironment/Request.php
@@ -117,19 +117,23 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
     }
 
     /**
-     * Check if a string is a valid parameter
+     * Check if a parameter is valid
      *
-     * @param string $str String to check
+     * @param mixed $param Parameter to check
      *
      * @return bool
      */
-    protected function isValid($str)
+    protected function isValid($param)
     {
-        // Check if the string is UTF-8
-        if (is_string($str) && $str !== '' && !preg_match('/^./su', $str)) {
+        if (!is_string($param)) {
+            return true;
+        }
+        // Check if the string is UTF-8:
+        if ($param !== '' && !preg_match('/^./su', $param)) {
             return false;
         }
-        if (strpos($str, "\x00") !== false) {
+        // Check for null in string:
+        if (strpos($param, "\x00") !== false) {
             return false;
         }
         return true;

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -1103,6 +1103,6 @@ abstract class Options implements TranslatorAwareInterface
         $limits = $facetSettings->Advanced_Settings->limitOrderOverride ?? null;
         $delimiter = $facetSettings->Advanced_Settings->limitDelimiter ?? '::';
         $limitConf = $limits ? $limits->get($limit) : '';
-        return array_map('trim', explode($delimiter, $limitConf));
+        return array_map('trim', explode($delimiter, $limitConf ?? ''));
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
@@ -150,9 +150,12 @@ class SearchMemory extends AbstractHelper
         // if the user jumps from search results of one backend to a record of a
         // different backend, we don't want to display irrelevant filters. If there
         // is a backend mismatch, don't initialize the parameter object!
-        $expectedPath = $this->view->url($params->getOptions()->getSearchAction());
-        if (substr($lastUrl, 0, strlen($expectedPath)) === $expectedPath) {
-            $params->initFromRequest($request);
+        if ($lastUrl) {
+            $expectedPath
+                = $this->view->url($params->getOptions()->getSearchAction());
+            if (substr($lastUrl, 0, strlen($expectedPath)) === $expectedPath) {
+                $params->initFromRequest($request);
+            }
         }
         return $params;
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
@@ -94,11 +94,21 @@ class ResultFeedTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockTranslator()
     {
+        $translations = [
+            'Results for' => 'Results for',
+            'showing_results_of_html' => 'Showing <strong>%%start%% - %%end%%'
+                . '</strong> results of <strong>%%total%%</strong>'
+        ];
         $mock = $this->getMockBuilder(\Laminas\I18n\Translator\TranslatorInterface::class)
             ->getMock();
         $mock->expects($this->any())->method('translate')
-            ->withConsecutive(['Results for'], ['showing_results_of_html', 'default'])
-            ->willReturnOnConsecutiveCalls('Results for', 'Showing <strong>%%start%% - %%end%%</strong> results of <strong>%%total%%</strong>');
+            ->will(
+                $this->returnCallback(
+                    function ($str, $params, $default) use ($translations) {
+                        return $translations[$str] ?? $default ?? $str;
+                    }
+                )
+            );
         return $mock;
     }
 

--- a/themes/bootstrap3/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap3/templates/combined/results-ajax.phtml
@@ -11,7 +11,7 @@
     $searchClassIdEncoded = urlencode($searchClassId);
     $targetIdHtmlEscaped = $this->escapeHtml('#' . $currentSearch['domId']);
     $lookforEncoded = urlencode($lookfor);
-    $typeEncoded = urlencode($params->getSearchHandler());
+    $typeEncoded = urlencode($params->getSearchHandler() ?? '');
     $loadJs = <<<JS
 $(document).ready(function(){
     var url = VuFind.path


### PR DESCRIPTION
* Consists mostly of fixes to null being passed to functions that take a string.
* ResultFeedTest changes ensure that translate() always returns a valid string instead of null (this caused null to be passed as format to the Dublin Core renderer).