### PR TITLE
advanced search: set focus to first input after adding new search field or group

### DIFF
--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -56,8 +56,6 @@ function addSearch(group, _fieldValues, isUser = false) {
 
   if (isUser) {
     $newSearch.find('input.form-control').focus();
-  } else if (group === 0 || fieldValues.term === '') {
-    $('#group' + group).find('input.form-control').first().focus();
   }
 
   return false;
@@ -87,7 +85,7 @@ deleteSearch = function _deleteSearch(group, sindex) {
   return false;
 };
 
-function addGroup(_firstTerm, _firstField, _join) {
+function addGroup(_firstTerm, _firstField, _join, isUser = false) {
   var firstTerm = _firstTerm || '';
   var firstField = _firstField || '';
   var join = _join || '';
@@ -123,7 +121,7 @@ function addGroup(_firstTerm, _firstField, _join) {
   $('#groupPlaceHolder').before($newGroup);
   // Populate
   groupLength[nextGroup] = 0;
-  addSearch(nextGroup, {term: firstTerm, field: firstField}, false);
+  addSearch(nextGroup, {term: firstTerm, field: firstField}, isUser);
   // Show join menu
   if (nextGroup > 0) {
     $('#groupJoin').removeClass('hidden');

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -54,7 +54,6 @@ function addSearch(group, _fieldValues, isUser) {
   }
   groupLength[group]++;
 
-  // #17985 finc barf
   if (isUser) {
     $newSearch.find('input.form-control').focus();
   } else {
@@ -132,7 +131,6 @@ function addGroup(_firstTerm, _firstField, _join) {
     $('.adv-group-close').removeClass('hidden');
   }
 
-  // #17985 finc barf
   $newGroup.children('input.form-control').first().focus();
 
   return nextGroup++;

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -3,7 +3,7 @@ var nextGroup = 0;
 var groupLength = [];
 var deleteGroup, deleteSearch;
 
-function addSearch(group, _fieldValues, isUser) {
+function addSearch(group, _fieldValues, isUser = false) {
   var fieldValues = _fieldValues || {};
   // Build the new search
   var inputID = group + '_' + groupLength[group];

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -3,7 +3,7 @@ var nextGroup = 0;
 var groupLength = [];
 var deleteGroup, deleteSearch;
 
-function addSearch(group, _fieldValues) {
+function addSearch(group, _fieldValues, isUser) {
   var fieldValues = _fieldValues || {};
   // Build the new search
   var inputID = group + '_' + groupLength[group];
@@ -53,6 +53,14 @@ function addSearch(group, _fieldValues) {
     $('#group' + group + ' .adv-term-remove').removeClass('hidden');
   }
   groupLength[group]++;
+
+  // #17985 finc barf
+  if (isUser) {
+    $newSearch.find('input.form-control').focus();
+  } else {
+    $('#group' + group).find('input.form-control').first().focus();
+  }
+
   return false;
 }
 
@@ -67,7 +75,12 @@ deleteSearch = function _deleteSearch(group, sindex) {
   }
   if (groupLength[group] > 1) {
     groupLength[group]--;
-    $('#search' + group + '_' + groupLength[group]).remove();
+    var toRemove = $('#search' + group + '_' + groupLength[group]);
+    var parent = toRemove.parent();
+    toRemove.remove();
+    if (parent.length) {
+      parent.find('.adv-search input.form-control').focus();
+    }
     if (groupLength[group] === 1) {
       $('#group' + group + ' .adv-term-remove').addClass('hidden'); // Hide x
     }
@@ -91,7 +104,7 @@ function addGroup(_firstTerm, _firstField, _join) {
     .attr('id', 'add_search_link_' + nextGroup)
     .data('nextGroup', nextGroup)
     .click(function addSearchHandler() {
-      return addSearch($(this).data('nextGroup'));
+      return addSearch($(this).data('nextGroup'), {}, true);
     })
     .removeClass('hidden');
   $newGroup.find('.adv-group-close')
@@ -111,13 +124,17 @@ function addGroup(_firstTerm, _firstField, _join) {
   $('#groupPlaceHolder').before($newGroup);
   // Populate
   groupLength[nextGroup] = 0;
-  addSearch(nextGroup, {term: firstTerm, field: firstField});
+  addSearch(nextGroup, {term: firstTerm, field: firstField}, false);
   // Show join menu
   if (nextGroup > 0) {
     $('#groupJoin').removeClass('hidden');
     // Show x
     $('.adv-group-close').removeClass('hidden');
   }
+
+  // #17985 finc barf
+  $newGroup.children('input.form-control').first().focus();
+
   return nextGroup++;
 }
 

--- a/themes/bootstrap3/js/advanced_search.js
+++ b/themes/bootstrap3/js/advanced_search.js
@@ -56,7 +56,7 @@ function addSearch(group, _fieldValues, isUser = false) {
 
   if (isUser) {
     $newSearch.find('input.form-control').focus();
-  } else {
+  } else if (group === 0 || fieldValues.term === '') {
     $('#group' + group).find('input.form-control').first().focus();
   }
 

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -186,7 +186,7 @@
 <?php
 $script = <<<JS
 $('#groupPlaceHolder a').click(function(e) {
-  addGroup();
+  addGroup(null, null, null, true);
   return false;
 })
 JS;


### PR DESCRIPTION
When a search field or group is added in the Advanced Search page, the new group of input fields appears above the current focus. Blind users may not notice this new content.