### PR TITLE
Blender: Make sure to ignore hidden filters in initFromRequest.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Blender/Params.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Params.php
@@ -119,7 +119,8 @@ class Params extends \VuFind\Search\Solr\Params
             'type',
             'sort',
             'filter',
-            'hiddenFilter'
+            'hiddenFilter',
+            'hiddenFilters'
         ];
         foreach ($this->searchParams as $params) {
             $translatedRequest = clone $request;

--- a/module/VuFind/src/VuFind/Search/Blender/Params.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Params.php
@@ -119,7 +119,6 @@ class Params extends \VuFind\Search\Solr\Params
             'type',
             'sort',
             'filter',
-            'hiddenFilter',
             'hiddenFilters'
         ];
         foreach ($this->searchParams as $params) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
@@ -899,7 +899,9 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             'lookfor' => 'foo',
             'type'  => 'Title',
             'sort' => 'year',
-            'page' => '2'
+            'page' => '2',
+            'hiddenFilter' => ['foo:"bar"'],
+            'hiddenFilters' => ['foo:"baz"'],
         ];
         $params = $this->getParams();
         $params->initFromRequest(new Parameters($query));
@@ -911,6 +913,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(ParamBag::class, $solrParams);
         $this->assertInstanceOf(ParamBag::class, $primoParams);
         $this->assertInstanceOf(ParamBag::class, $edsParams);
+        $this->assertNull($solrParams->get('fq'));
 
         $solrQuery = $backendParams->get('query_Solr')[0];
         $primoQuery = $backendParams->get('query_Primo')[0];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
@@ -900,7 +900,6 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             'type'  => 'Title',
             'sort' => 'year',
             'page' => '2',
-            'hiddenFilter' => ['foo:"bar"'],
             'hiddenFilters' => ['foo:"baz"'],
         ];
         $params = $this->getParams();


### PR DESCRIPTION
Previously only hiddenFilter used in combined search was ignored, while hiddenFilters is used elsewhere.