### PR TITLE
Allow filtering of optional text domains in language dev tool

### DIFF
--- a/module/VuFindDevTools/src/VuFindDevTools/Controller/DevtoolsController.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/Controller/DevtoolsController.php
@@ -132,6 +132,9 @@ class DevtoolsController extends \VuFind\Controller\AbstractBase
         $langs = $this->serviceLocator->get(LocaleSettings::class)
             ->getEnabledLocales();
         $helper = new LanguageHelper($loader, $langs);
-        return $helper->getAllDetails($this->params()->fromQuery('main', 'en'));
+        return $helper->getAllDetails(
+            $this->params()->fromQuery('main', 'en'),
+            (bool)$this->params()->fromQuery('includeOptional', 1)
+        );
     }
 }

--- a/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
@@ -172,11 +172,14 @@ class LanguageHelper
     /**
      * Get text domains for a language.
      *
+     * @param bool $includeOptional Include optional translations (e.g. DDC23)
+     *
      * @return array
      */
-    protected function getTextDomains()
+    protected function getTextDomains($includeOptional)
     {
         static $domains = false;
+        $filter = $includeOptional ? [] : ['CreatorRoles', 'DDC23'];
         if (!$domains) {
             $base = APPLICATION_PATH . '/languages';
             $dir = opendir($base);
@@ -184,6 +187,7 @@ class LanguageHelper
             while ($current = readdir($dir)) {
                 if ($current != '.' && $current != '..'
                     && is_dir("$base/$current")
+                    && !in_array($current, $filter)
                 ) {
                     $domains[] = $current;
                 }
@@ -196,14 +200,15 @@ class LanguageHelper
     /**
      * Load a language, including text domains.
      *
-     * @param string $lang Language to load
+     * @param string $lang            Language to load
+     * @param bool   $includeOptional Include optional translations (e.g. DDC23)
      *
      * @return array
      */
-    protected function loadLanguage($lang)
+    protected function loadLanguage($lang, $includeOptional)
     {
         $base = $this->loader->load($lang, null);
-        foreach ($this->getTextDomains() as $domain) {
+        foreach ($this->getTextDomains($includeOptional) as $domain) {
             $current = $this->loader->load($lang, $domain);
             foreach ($current as $k => $v) {
                 if ($k != '@parent_ini') {
@@ -221,14 +226,15 @@ class LanguageHelper
     /**
      * Return details on how $langCode differs from $main.
      *
-     * @param array  $main     The main language (full details)
-     * @param string $langCode The code of a language to compare against $main
+     * @param array  $main            The main language (full details)
+     * @param string $langCode        The code of a language to compare against $main
+     * @param bool   $includeOptional Include optional translations (e.g. DDC23)
      *
      * @return array
      */
-    protected function getLanguageDetails($main, $langCode)
+    protected function getLanguageDetails($main, $langCode, $includeOptional)
     {
-        $lang = $this->loadLanguage($langCode);
+        $lang = $this->loadLanguage($langCode, $includeOptional);
         $details = $this->compareLanguages($main, $lang);
         $details['object'] = $lang;
         $details['name'] = $this->getLangName($langCode);
@@ -239,17 +245,19 @@ class LanguageHelper
     /**
      * Return details on how all languages differ from $main.
      *
-     * @param array $main The main language (full details)
+     * @param array $main            The main language (full details)
+     * @param bool  $includeOptional Include optional translations (e.g. DDC23)
      *
      * @return array
      */
-    protected function getAllLanguageDetails($main)
+    protected function getAllLanguageDetails($main, $includeOptional)
     {
         $details = [];
         $allLangs = $this->getLanguages();
         sort($allLangs);
         foreach ($allLangs as $langCode) {
-            $details[$langCode] = $this->getLanguageDetails($main, $langCode);
+            $details[$langCode] = $this
+                ->getLanguageDetails($main, $langCode, $includeOptional);
         }
         return $details;
     }
@@ -292,27 +300,26 @@ class LanguageHelper
      * Return language comparison information, using $mainLanguage as the
      * baseline.
      *
-     * @param string $mainLanguage Language code
+     * @param string $mainLanguage    Language code
+     * @param bool   $includeOptional Include optional translations (e.g. DDC23)
      *
      * @return array
      */
-    public function getAllDetails($mainLanguage)
+    public function getAllDetails($mainLanguage, $includeOptional = true)
     {
-        $main = $this->loadLanguage($mainLanguage);
-        $details = $this->getAllLanguageDetails($main);
+        $main = $this->loadLanguage($mainLanguage, $includeOptional);
+        $details = $this->getAllLanguageDetails($main, $includeOptional);
         $dirHelpParts = [
             APPLICATION_PATH, 'themes', 'root', 'templates', 'HelpTranslations'
         ];
         $dirLangParts = [APPLICATION_PATH, 'languages'];
-        return [
-            'details' => $details,
+        return compact('details', 'main', 'includeOptional') + [
             'dirHelp' => implode(DIRECTORY_SEPARATOR, $dirHelpParts)
                 . DIRECTORY_SEPARATOR,
             'dirLang' => implode(DIRECTORY_SEPARATOR, $dirLangParts)
                 . DIRECTORY_SEPARATOR,
             'mainCode' => $mainLanguage,
             'mainName' => $this->getLangName($mainLanguage),
-            'main' => $main,
             'summaryData' => $this->summarizeData($details),
         ];
     }

--- a/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
@@ -179,7 +179,7 @@ class LanguageHelper
     protected function getTextDomains($includeOptional)
     {
         static $domains = false;
-        $filter = $includeOptional ? [] : ['CreatorRoles', 'DDC23'];
+        $filter = $includeOptional ? [] : ['CallNumberFirst', 'CreatorRoles', 'DDC23'];
         if (!$domains) {
             $base = APPLICATION_PATH . '/languages';
             $dir = opendir($base);

--- a/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
@@ -179,8 +179,10 @@ class LanguageHelper
     protected function getTextDomains($includeOptional)
     {
         static $domains = false;
-        $filter = $includeOptional ? [] : ['CallNumberFirst', 'CreatorRoles', 'DDC23'];
         if (!$domains) {
+            $filter = $includeOptional
+                ? []
+                : ['CallNumberFirst', 'CreatorRoles', 'DDC23'];
             $base = APPLICATION_PATH . '/languages';
             $dir = opendir($base);
             $domains = [];

--- a/themes/bootstrap3/templates/devtools/language.phtml
+++ b/themes/bootstrap3/templates/devtools/language.phtml
@@ -13,6 +13,11 @@
 
 <h1><?=$this->escapeHtml($pageTitle)?></h1>
 
+Current filter mode: <?=$includeOptional ? "Unfiltered" : "Mandatory strings only"?><br />
+<a href="?main=<?=urlencode($mainCode)?>&amp;includeOptional=<?=$includeOptional ? 0 : 1?>">
+  <?=$includeOptional ? "Exclude optional text domains" : "Include optional text domains"?>
+</a>
+
 <table id="lang-summary" class="table table-striped">
   <caption>Summarize status of translations in language files</caption>
   <thead>


### PR DESCRIPTION
VuFind's language files now include some specialized text domains that may not be desired in every language (e.g. call number schemes). This PR adds a parameter to filter the language dev tool to focus in on the "most important" non-optional strings, in case we need to prioritize translation work.

The user interface is very crude and can likely be improved. It might also make sense to offer something more robust where the user can specify exactly which text domains to exclude. This is just a rough first pass proof of concept.