### PR TITLE
Fix holds problem in FOLIO Lotus release.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1087,7 +1087,8 @@ class Folio extends AbstractAPI implements
                 'id' => $this->getBibId(null, null, $hold->itemId),
                 'item_id' => $hold->itemId,
                 'reqnum' => $hold->id,
-                'title' => $hold->item->title
+                // Title moved from item to instance in Lotus release:
+                'title' => $hold->instance->title ?? $hold->item->title ?? '',
             ];
         }
         return $holds;


### PR DESCRIPTION
This PR fixes a compatibility issue introduced by the FOLIO Lotus release and discussed on [CIRC-1546](https://issues.folio.org/browse/CIRC-1546). That ticket also discusses backward-breaking API changes that will be corrected in a FOLIO hotfix. Since that is being treated as a FOLIO bug, adding complexity to VuFind to work around it does not seem worthwhile.

This PR originally had some work to add title-level hold support, but since that feature is not fully functional yet on the FOLIO side, it has been separated into PR #2479.
