### PR TITLE
Add DOIs to MLA citations.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
@@ -334,6 +334,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
             ':',
             true,
             'https://dx.doi.org/',
+            false,
             false
         );
     }
@@ -357,6 +358,8 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
      * @param string $doiPrefix       Prefix to display in front of DOI; set to
      * false to omit DOIs.
      * @param bool   $labelPageRange  Should we include p./pp. before page ranges?
+     * @param bool   $doiArticleComma Should we put a comma instead of period before
+     * a DOI in an article-style citation?
      *
      * @return string
      */
@@ -368,8 +371,9 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
         $yearFormat = ', %s',
         $pageNoSeparator = ',',
         $includePubPlace = false,
-        $doiPrefix = false,
-        $labelPageRange = true
+        $doiPrefix = 'https://dx.doi.org/',
+        $labelPageRange = true,
+        $doiArticleComma = true
     ) {
         $mla = [
             'title' => $this->getMLATitle(),
@@ -392,6 +396,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
             return $partial('Citation/mla.phtml', $mla);
         }
         // If we got this far, we should add other journal-specific details:
+        $mla['doiArticleComma'] = $doiArticleComma;
         $mla['pageRange'] = $this->getPageRange();
         $mla['journal'] = $this->capitalizeTitle($this->details['journal']);
         $mla['numberAndDate'] = $numPrefix . $this->getMLANumberAndDate(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
@@ -89,7 +89,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'CleanDOI' => 'myDOI',
             ],
             'apa' => 'Lewis, S. (2007). <i>Even if you &quot;test&quot; Medical-surgical nursing: Assessment and management of clinical problems on top of crazy capitalization</i> (7th ed.). Mosby Elsevier. https://doi.org/myDOI',
-            'mla' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. Mosby Elsevier, 2007.',
+            'mla' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. Mosby Elsevier, 2007. https://dx.doi.org/myDOI.',
             'chicago' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. St. Louis, Mo: Mosby Elsevier, 2007. https://dx.doi.org/myDOI.',
         ],
         [
@@ -353,7 +353,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'CleanDOI' => 'testDOI'
             ],
             'apa' => 'One, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21. https://doi.org/testDOI',
-            'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
+            'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21, https://dx.doi.org/testDOI.',
             'chicago' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i> 1, no. 7 (1999): 19-21. https://dx.doi.org/testDOI.',
         ]
         // @codingStandardsIgnoreEnd

--- a/themes/root/templates/Citation/mla-article.phtml
+++ b/themes/root/templates/Citation/mla-article.phtml
@@ -1,6 +1,7 @@
+<?php $hasDoi = isset($this->doiPrefix) && !empty($this->doi); ?>
 <?php if (!empty($this->authors)): ?><?=$this->escapeHtml($this->authors)?>. <?php endif; ?>
 &quot;<?=$this->title?><?php if ($this->periodAfterTitle): ?>.<?php endif ?>&quot;
 <i><?=$this->escapeHtml($this->journal)?></i><?php if (!empty($this->numberAndDate)): ?><?=$this->escapeHtml($this->numberAndDate)?><?php if (!empty($this->pageRange)): ?><?=$this->escapeHtml($this->pageNumberSeparator)?> <?php endif; ?><?php endif; ?>
 <?php if ($this->labelPageRange && !empty($this->pageRange)) echo strstr($this->pageRange, '-') ? 'pp. ' : 'p. '; ?>
-<?php if (!empty($this->pageRange)): ?><?=$this->escapeHtml($this->pageRange)?><?php endif; ?>.
-<?php if (isset($this->doiPrefix) && !empty($this->doi)): ?> <?=$this->escapeHtml($this->doiPrefix . $this->doi)?>.<?php endif; ?>
+<?php if (!empty($this->pageRange)): ?><?=$this->escapeHtml($this->pageRange)?><?php endif; ?><?=$hasDoi && $this->doiArticleComma ? ',' : '.'?>
+<?php if ($hasDoi): ?> <?=$this->escapeHtml($this->doiPrefix . $this->doi)?>.<?php endif; ?>


### PR DESCRIPTION
This PR adds DOIs to MLA citations -- they were excluded before because many common examples exclude them, but the style does support their inclusion. Here is an example of how this looks for an article:

![image](https://user-images.githubusercontent.com/309069/172706268-44521637-7488-4963-a094-3df9847f4bb4.png)

...and here's a book example (note that the DOI here is fictitious):

![image](https://user-images.githubusercontent.com/309069/172706385-6bc1a68c-f15f-43f3-a8e8-4747651e6719.png)

Thanks to @sturkel89 for background research on this project.
