### PR TITLE
Use doi.org instead of dx.doi.org in all citations.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
@@ -333,7 +333,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
             ' (%s)',
             ':',
             true,
-            'https://dx.doi.org/',
+            'https://doi.org/',
             false,
             false
         );
@@ -371,7 +371,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper
         $yearFormat = ', %s',
         $pageNoSeparator = ',',
         $includePubPlace = false,
-        $doiPrefix = 'https://dx.doi.org/',
+        $doiPrefix = 'https://doi.org/',
         $labelPageRange = true,
         $doiArticleComma = true
     ) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
@@ -89,8 +89,8 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'CleanDOI' => 'myDOI',
             ],
             'apa' => 'Lewis, S. (2007). <i>Even if you &quot;test&quot; Medical-surgical nursing: Assessment and management of clinical problems on top of crazy capitalization</i> (7th ed.). Mosby Elsevier. https://doi.org/myDOI',
-            'mla' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. Mosby Elsevier, 2007. https://dx.doi.org/myDOI.',
-            'chicago' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. St. Louis, Mo: Mosby Elsevier, 2007. https://dx.doi.org/myDOI.',
+            'mla' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. Mosby Elsevier, 2007. https://doi.org/myDOI.',
+            'chicago' => 'Lewis, S.M. <i>Even if You &quot;Test&quot; Medical-surgical Nursing: Assessment and Management of Clinical Problems on top of Crazy Capitalization</i>. 7th ed. St. Louis, Mo: Mosby Elsevier, 2007. https://doi.org/myDOI.',
         ],
         [
             'raw' => [
@@ -353,8 +353,8 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'CleanDOI' => 'testDOI'
             ],
             'apa' => 'One, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21. https://doi.org/testDOI',
-            'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21, https://dx.doi.org/testDOI.',
-            'chicago' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i> 1, no. 7 (1999): 19-21. https://dx.doi.org/testDOI.',
+            'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21, https://doi.org/testDOI.',
+            'chicago' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i> 1, no. 7 (1999): 19-21. https://doi.org/testDOI.',
         ]
         // @codingStandardsIgnoreEnd
     ];


### PR DESCRIPTION
- dx.doi.org was deprecated in 2017; see https://www.crossref.org/display-guidelines/
- thanks to @sturkel89 for guidance on this issue