### PR TITLE
Fix search tabs versions.

### DIFF
--- a/themes/bootstrap3/templates/search/searchTabs.phtml
+++ b/themes/bootstrap3/templates/search/searchTabs.phtml
@@ -2,7 +2,7 @@
   <ul class="nav nav-tabs">
     <?php foreach ($searchTabs as $tab): ?>
         <?php if ($this->permission()->allowDisplay($tab['permission'])): ?>
-          <li<?=$tab['selected'] ? ' class="active"' : ''?><?=$showCounts ? ' data-show-counts' : ''?>>
+          <li<?=$tab['selected'] ? ' class="active"' : ''?><?=$this->showCounts ? ' data-show-counts' : ''?>>
             <a <?=$tab['selected'] ? '' : 'href="' . $this->escapeHtmlAttr($tab['url']) . '"' ?> data-source="<?=$this->escapeHtmlAttr($tab['class'])?>"><?=$this->transEsc($tab['label']); ?></a>
           </li>
         <?php elseif ($block = $this->permission()->getAlternateContent($tab['permission'])): ?>
@@ -10,7 +10,7 @@
         <?php endif; ?>
     <?php endforeach; ?>
   </ul>
-  <?php if ($showCounts): ?>
+  <?php if ($this->showCounts): ?>
     <?php $this->headScript()->appendFile('resultcount.js'); ?>
   <?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
Using bare `$showCounts` will cause a notice when it's not passed to the renderer.