### PR TITLE
Fix hierarchical facet markup.

### DIFF
--- a/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
@@ -41,7 +41,7 @@ JS;
   ];
 ?>
 <div<?php if ($truncateSettings): ?> class="truncate-hierarchy" data-truncate="<?=$this->escapeHtml(json_encode($truncateSettings))?>"<?php endif; ?>>
-  <li id="facet_<?=$this->escapeHtml($this->title)?>" class="jstree-facet"
+  <div id="facet_<?=$this->escapeHtml($this->title)?>" class="jstree-facet"
     data-source="<?=$this->escapeHtml($this->searchClassId)?>"
     data-facet="<?=$this->escapeHtmlAttr($this->title)?>"
     data-path="<?=$this->currentPath()?>"
@@ -52,5 +52,5 @@ JS;
     data-query="<?=$this->escapeHtmlAttr($urlQuery)?>"
     data-query-suppressed="<?=$querySuppressed ? '1' : '0' ?>"
     data-extra-fields="<?=$this->escapeHtml(implode(',', $extraUrlFields))?>">
-  </li>
+  </div>
 </div>


### PR DESCRIPTION
Hierarchical facets previously used an inappropriate `<li>` tag as a placeholder. This PR changes it to a `<div>`, which is legal in context. No functionality or styling appears to be impacted by the change.

This is a follow-up to discussion on #2454.