### PR TITLE
Remove no-JS support from cart add/remove.

### DIFF
--- a/themes/bootstrap3/templates/record/cart-buttons.phtml
+++ b/themes/bootstrap3/templates/record/cart-buttons.phtml
@@ -8,15 +8,5 @@
     <a href="#" class="cart-remove hidden<?php if($cart->contains($cartId)): ?> correct<?php endif ?>">
       <span class="cart-link-label"><?=$this->icon('cart-remove') ?><?=$this->transEsc('Remove from Book Bag') ?></span>
     </a>
-    <noscript>
-      <form method="post" name="addForm" action="<?=$this->url('cart-processor')?>">
-        <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($cartId)?>" />
-        <?php if ($cart->contains($cartId)): ?>
-          <input class="btn btn-default" type="submit" name="delete" value="<?=$this->transEscAttr('Remove from Book Bag')?>"/>
-        <?php else: ?>
-          <input class="btn btn-default" type="submit" name="add" value="<?=$this->transEscAttr('Add to Book Bag')?>"/>
-        <?php endif; ?>
-      </form>
-    </noscript>
   </span>
 <?php endif; ?>


### PR DESCRIPTION
It was breaking the HTML markup while adding quite a bit of markup to each result.

Mink tests are passing.

TODO
- [x] Update changelog when merging
- [x] Create "legacy" branch so feature can be reinstated if needed