### PR TITLE
Add !default flags to accessibility.scss

### DIFF
--- a/themes/bootstrap3/less/components/accessibility.less
+++ b/themes/bootstrap3/less/components/accessibility.less
@@ -8,12 +8,35 @@ a {
 }
 
 /* AAA Color Contrasts */
+/* #LESS> */
 @badge-bg: #595959;
+/* <#LESS */
+/* #SCSS>
+$badge-bg: #595959 !default;
+<#SCSS */
 
+/* #LESS> */
 @breadcrumb-color: #535353;
-@breadcrumb-active-color: #444;
+/* <#LESS */
+/* #SCSS>
+@breadcrumb-color: #535353 !default;
+<#SCSS */
 
+/* #LESS> */
+@breadcrumb-active-color: #444;
+/* <#LESS */
+/* #SCSS>
+@breadcrumb-active-color: #444 !default;
+<#SCSS */
+
+/* #LESS> */
 @state-danger-text: #8a211e;
+/* <#LESS */
+/* #SCSS>
+@state-danger-text: #8a211e !default;
+<#SCSS */
+
+
 .alert-danger,
 .alert-danger a {
   color: @state-danger-text;

--- a/themes/bootstrap3/scss/components/accessibility.scss
+++ b/themes/bootstrap3/scss/components/accessibility.scss
@@ -8,12 +8,12 @@ a {
 }
 
 /* AAA Color Contrasts */
-$badge-bg: #595959;
+$badge-bg: #595959 !default;
 
-$breadcrumb-color: #535353;
-$breadcrumb-active-color: #444;
+$breadcrumb-color: #535353 !default;
+$breadcrumb-active-color: #444 !default;
 
-$state-danger-text: #8a211e;
+$state-danger-text: #8a211e !default;
 .alert-danger,
 .alert-danger a {
   color: $state-danger-text;

--- a/themes/bootstrap3/scss/components/accessibility.scss
+++ b/themes/bootstrap3/scss/components/accessibility.scss
@@ -8,12 +8,35 @@ a {
 }
 
 /* AAA Color Contrasts */
+/* #LESS>
 $badge-bg: #595959;
+<#LESS */
+/* #SCSS> */
+$badge-bg: #595959 !default;
+/* <#SCSS */
 
+/* #LESS>
 $breadcrumb-color: #535353;
-$breadcrumb-active-color: #444;
+<#LESS */
+/* #SCSS> */
+$breadcrumb-color: #535353 !default;
+/* <#SCSS */
 
+/* #LESS>
+$breadcrumb-active-color: #444;
+<#LESS */
+/* #SCSS> */
+$breadcrumb-active-color: #444 !default;
+/* <#SCSS */
+
+/* #LESS>
 $state-danger-text: #8a211e;
+<#LESS */
+/* #SCSS> */
+$state-danger-text: #8a211e !default;
+/* <#SCSS */
+
+
 .alert-danger,
 .alert-danger a {
   color: $state-danger-text;

--- a/themes/bootstrap3/scss/components/accessibility.scss
+++ b/themes/bootstrap3/scss/components/accessibility.scss
@@ -8,12 +8,12 @@ a {
 }
 
 /* AAA Color Contrasts */
-$badge-bg: #595959 !default;
+$badge-bg: #595959;
 
-$breadcrumb-color: #535353 !default;
-$breadcrumb-active-color: #444 !default;
+$breadcrumb-color: #535353;
+$breadcrumb-active-color: #444;
 
-$state-danger-text: #8a211e !default;
+$state-danger-text: #8a211e;
 .alert-danger,
 .alert-danger a {
   color: $state-danger-text;


### PR DESCRIPTION
This adds missing !default flags to variables in components/accessibility.scss. The !default flags are necessary to allow overwriting variables in inheriting themes.

All releases since 6.x are affected.