### PR TITLE
VuFind 1564   add due date to folio driver

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -131,3 +131,14 @@ cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
 ; If set to true, the course number will be prefixed on the course name; if false,
 ; only the name will be displayed:
 displayCourseCodes = false
+
+[Availability]
+; The Folio ILS driver needs to make several calls to obtain availability status.
+; Indicate with showDueDate whether an additional call should be made to obtain the
+; dueDate for checked out items and set the maxNumberItems to a value that provides
+; you with a suitable tradeoff between number of API calls and load times.
+showDueDate = true
+maxNumberItems = 5
+; dueDates will be shown in Universal Time Format, e.g. 06 Jul 2022 14:59, set showTime
+; to false to show 06 Jul 2022 only
+showTime = false

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -27,6 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
+use DateTime;
+use DateTimeZone;
 use Exception;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
@@ -605,7 +607,10 @@ class Folio extends AbstractAPI implements
                     $item->itemLevelCallNumber ?? ''
                 );
 
-                $dueDate = new DateTime($item->status->date, new DateTimeZone('UTC'));
+                $dueDate = new DateTime(
+                    $item->status->date,
+                    new DateTimeZone('UTC')
+                );
                 $loc = (new DateTime)->getTimezone();
                 $dueDate->setTimezone($loc);
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -607,12 +607,16 @@ class Folio extends AbstractAPI implements
                     $item->itemLevelCallNumber ?? ''
                 );
 
-                $dueDate = new DateTime(
-                    $item->status->date,
-                    new DateTimeZone('UTC')
-                );
-                $loc = (new DateTime)->getTimezone();
-                $dueDate->setTimezone($loc);
+                $dueDateValue = '';
+                if ($item->status->name == 'Checked out') {
+                    $dueDate = new DateTime(
+                        $item->status->date,
+                        new DateTimeZone('UTC')
+                    );
+                    $loc = (new DateTime)->getTimezone();
+                    $dueDate->setTimezone($loc);
+                    $dueDateValue = $dueDate->format('j F Y');
+                }
 
                 $items[] = $callNumberData + [
                     'id' => $bibId,
@@ -621,7 +625,7 @@ class Folio extends AbstractAPI implements
                     'number' => count($items) + 1,
                     'barcode' => $item->barcode ?? '',
                     'status' => $item->status->name,
-                    'duedate' => $dueDate->format('j F Y'),
+                    'duedate' => $dueDateValue,
                     'availability' => $item->status->name == 'Available',
                     'is_holdable' => $this->isHoldable($locationName),
                     'holdings_notes'=> $hasHoldingNotes ? $holdingNotes : null,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -609,13 +609,25 @@ class Folio extends AbstractAPI implements
 
                 $dueDateValue = '';
                 if ($item->status->name == 'Checked out') {
-                    $dueDate = new DateTime(
-                        $item->status->date,
-                        new DateTimeZone('UTC')
-                    );
-                    $loc = (new DateTime)->getTimezone();
-                    $dueDate->setTimezone($loc);
-                    $dueDateValue = $dueDate->format('j F Y');
+                    // extract itemId & construct query
+                    $query = [
+                        'query' => 'itemId==' . $item->id
+                    ];
+                    // call /circulation/loans to extract dueDate
+                    foreach ($this->getPagedResults(
+                        'loans',
+                        '/circulation/loans',
+                        $query
+                    ) as $loan) { 
+                        $dueDate = new DateTime(
+                            $loan->dueDate,
+                            new DateTimeZone('UTC')
+                        );
+                        $loc = (new DateTime)->getTimezone();
+                        $dueDate->setTimezone($loc);
+                        $dueDateValue = $this->dateConverter
+                            ->convertToDisplayDateAndTime('U', $dueDate->format('U'));
+                    }
                 }
 
                 $items[] = $callNumberData + [

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -604,6 +604,11 @@ class Folio extends AbstractAPI implements
                     $item->itemLevelCallNumberPrefix ?? '',
                     $item->itemLevelCallNumber ?? ''
                 );
+
+                $dueDate = new DateTime($item->status->date, new DateTimeZone('UTC'));
+                $loc = (new DateTime)->getTimezone();
+                $dueDate->setTimezone($loc);
+
                 $items[] = $callNumberData + [
                     'id' => $bibId,
                     'item_id' => $item->id,
@@ -611,6 +616,7 @@ class Folio extends AbstractAPI implements
                     'number' => count($items) + 1,
                     'barcode' => $item->barcode ?? '',
                     'status' => $item->status->name,
+                    'duedate' => $dueDate->format('j F Y'),
                     'availability' => $item->status->name == 'Available',
                     'is_holdable' => $this->isHoldable($locationName),
                     'holdings_notes'=> $hasHoldingNotes ? $holdingNotes : null,


### PR DESCRIPTION
Work relates to:
https://openlibraryfoundation.atlassian.net/browse/VUFIND-1564

Current State:
Folio ILS Driver does not return a dueDate, as a result when you view a record that is checked out you are not given any information as to when the item is expected back

New State:
Folio ILS Driver returns a dueDate (j F Y format, e.g. 2 July 2022) and Folio will display the dueDate in the detailed record

<img width="797" alt="Screenshot 2022-07-01 at 10 18 11" src="https://user-images.githubusercontent.com/62254772/176854770-46c98476-b9fe-4df4-8a6a-fcf5074597bc.png">
Note: screenshot shows d F Y formatting
