### PR TITLE
Folio Driver | getMyTransactions | add correctly formatted dueDate and dueStatus

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -27,6 +27,8 @@
  */
 namespace VuFind\ILS\Driver;
 
+use DateTime;
+use DateTimeZone;
 use Exception;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
@@ -897,7 +899,6 @@ class Folio extends AbstractAPI implements
             '/circulation/loans',
             $query
         ) as $trans) {
-            
             $date = new DateTime($trans->dueDate, new DateTimeZone('UTC'));
             $loc = (new DateTime)->getTimezone();
             $date->setTimezone($loc);
@@ -906,10 +907,9 @@ class Folio extends AbstractAPI implements
             $tmpDueDate = strtotime($trans->dueDate);
 
             $now = time();
-            if($now > $tmpDueDate){
+            if ($now > $tmpDueDate) {
                 $dueStatus = 'overdue';
-            }
-            elseif($now > $tmpDueDate - (1 * 24 * 60 * 60)){
+            } elseif ($now > $tmpDueDate - (1 * 24 * 60 * 60)) {
                 $dueStatus = 'due';
             }
             $transactions[] = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -900,21 +900,29 @@ class Folio extends AbstractAPI implements
             $query
         ) as $trans) {
             $date = new DateTime($trans->dueDate, new DateTimeZone('UTC'));
-            $loc = (new DateTime)->getTimezone();
-            $date->setTimezone($loc);
+            $localTimezone = (new DateTime)->getTimezone();
+            $date->setTimezone($localTimezone);
 
             $dueStatus = false;
-            $tmpDueDate = $date->getTimestamp();
+            $dueDateTimestamp = $date->getTimestamp();
 
             $now = time();
-            if ($now > $tmpDueDate) {
+            if ($now > $dueDateTimestamp) {
                 $dueStatus = 'overdue';
-            } elseif ($now > $tmpDueDate - (1 * 24 * 60 * 60)) {
+            } elseif ($now > $dueDateTimestamp - (1 * 24 * 60 * 60)) {
                 $dueStatus = 'due';
             }
             $transactions[] = [
-                'duedate' => $date->format('d F Y'),
-                'dueTime' => $date->format('g:i a'),
+                'duedate' =>
+                    $this->dateConverter->convertToDisplayDate(
+                        'U',
+                        $dueDateTimestamp
+                    ),
+                'dueTime' =>
+                    $this->dateConverter->convertToDisplayTime(
+                        'U',
+                        $dueDateTimestamp
+                    ),
                 'dueStatus' => $dueStatus,
                 'id' => $this->getBibId($trans->item->instanceId),
                 'item_id' => $trans->item->id,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -897,12 +897,25 @@ class Folio extends AbstractAPI implements
             '/circulation/loans',
             $query
         ) as $trans) {
-            $date = date_create($trans->dueDate);
+            
+            $date = new DateTime($trans->dueDate, new DateTimeZone('UTC'));
+            $loc = (new DateTime)->getTimezone();
+            $date->setTimezone($loc);
+
+            $dueStatus = false;
+            $tmpDueDate = strtotime($trans->dueDate);
+
+            $now = time();
+            if($now > $tmpDueDate){
+                $dueStatus = 'overdue';
+            }
+            elseif($now > $tmpDueDate - (1 * 24 * 60 * 60)){
+                $dueStatus = 'due';
+            }
             $transactions[] = [
-                'duedate' => date_format($date, "j M Y"),
-                'dueTime' => date_format($date, "g:i:s a"),
-                // TODO: Due Status
-                // 'dueStatus' => $trans['itemId'],
+                'duedate' => $date->format('d F Y'),
+                'dueTime' => $date->format('g:i a'),
+                'dueStatus' => $dueStatus,
                 'id' => $this->getBibId($trans->item->instanceId),
                 'item_id' => $trans->item->id,
                 'barcode' => $trans->item->barcode,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -904,7 +904,7 @@ class Folio extends AbstractAPI implements
             $date->setTimezone($loc);
 
             $dueStatus = false;
-            $tmpDueDate = strtotime($trans->dueDate);
+            $tmpDueDate = $date->getTimestamp();
 
             $now = time();
             if ($now > $tmpDueDate) {


### PR DESCRIPTION
Current State:
Folio Driver would not indicate whether an loaned item (from /circulation/loans endpoint) was due or overdue

New State:
Folio Driver will:
* consider an item due if it's dueDate timestamp is within 24 hours of now
* consider an item overdue, if now is greater than dueTime
* set false (neither due nor overdue) in all other cases

This will display bootstrap alert divs next to relevant loans, additionally it will update the pills in the my account menu appropriately