### PR TITLE
Aleph: set Holds config defaults without erasing other settings.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1877,14 +1877,12 @@ class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
     {
         if ($func == "Holds") {
             $holdsConfig = $this->config['Holds'] ?? [];
-            return [
-                "HMACKeys" => $holdsConfig['HMACKeys'] ?? "id:item_id",
-                "extraHoldFields"
-                    => $holdsConfig['extraHoldFields']
-                        ?? "comments:requiredByDate:pickUpLocation",
-                "defaultRequiredDate"
-                    => $holdsConfig['defaultRequiredDate'] ?? "0:1:0"
+            $defaults = [
+                'HMACKeys' => 'id:item_id',
+                'extraHoldFields' => 'comments:requiredByDate:pickUpLocation',
+                'defaultRequiredDate' => '0:1:0',
             ];
+            return $holdsConfig + $defaults;
         } elseif ('getMyTransactionHistory' === $func) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
                 return false;


### PR DESCRIPTION
@welblaud discovered a problem where after #2306, some Holds-related configuration settings (e.g. the itemLimit for pagination, or the helpText settings) are lost by the Aleph driver. This PR refactors the code to set defaults without erasing additional settings. I was unable to test (since I don't have an Aleph system) but hope that @welblaud and/or @xmorave2 can try it out and let me know if I broke anything.