### PR TITLE
Adds refresh buttons to jumpMenu select boxes

### DIFF
--- a/themes/bootstrap3/less/components/search.less
+++ b/themes/bootstrap3/less/components/search.less
@@ -44,6 +44,19 @@ header .container.navbar { margin-bottom: 0; }
   line-height: @input-height-base;
   padding-right: .5rem;
 }
+
+.search-sort,
+.search-result-limit {
+  .form-control {
+    max-width: 180px;
+  }
+
+  .btn {
+    border-color: @brand-primary;
+    height: fit-content;
+  }
+}
+
 .search-stats {
   display: block;
   padding-top: 0.5rem;

--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -2,7 +2,7 @@
   <?php $cards = $this->user->getLibraryCards(); if ($cards->count() > 1): ?>
     <form class="form-inline" action="<?=$this->url('librarycards-selectcard')?>" method="get" data-clear-account-cache>
       <label for="library_card"><?=$this->transEsc('Library Card')?></label>
-      <select id="library_card" name="cardID" class="jumpMenu form-control">
+      <select id="library_card" name="cardID" class="form-control">
         <?php if (null === $this->user->cat_username): ?>
           <option value="" selected="selected">-</option>
         <?php endif; ?>
@@ -22,6 +22,9 @@
         <?php endforeach; ?>
       </select>
       <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+      <button type="submit" class="btn btn-primary" aria-label="<?=$this->transEsc("Set")?>">
+        <i class="fa fa-refresh" aria-hidden="true"></i>
+      </button>
     </form>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/controls/sort.phtml
+++ b/themes/bootstrap3/templates/myresearch/controls/sort.phtml
@@ -1,7 +1,7 @@
 <div class="search-controls">
   <form class="search-sort" action="<?=$this->currentPath()?>" method="get" name="sort">
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
-    <select id="sort_options_1" name="sort" class="jumpMenu form-control">
+    <select id="sort_options_1" name="sort" class="form-control">
       <?php foreach ($this->sortList as $sortType => $sortData): ?>
         <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
       <?php endforeach; ?>

--- a/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
+++ b/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
@@ -38,12 +38,15 @@
       <th><?=$this->transEsc('history_schedule')?>: </th>
       <td>
         <form class="form-inline jumpMenuForm" action="<?= $this->url('myresearch-savesearch')?>" method="get" name="schedule">
-          <select name="schedule" class="jumpMenu form-control" aria-haspopup="true" title="<?=$this->transEscAttr("history_schedule")?>">
+          <select name="schedule" class="form-control" aria-haspopup="true" title="<?=$this->transEscAttr("history_schedule")?>">
             <?php foreach ($scheduleOptions as $scheduleValue => $scheduleLabel): ?>
               <option value="<?=$this->escapeHtmlAttr($scheduleValue)?>"<?=($this->search->notification_frequency == $scheduleValue) ? (' selected') : ('')?>><?=$this->transEsc($scheduleLabel)?></option>
             <?php endforeach; ?>
           </select>
           <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($this->search->id) ?>"/>
+          <button type="submit" class="btn btn-primary" aria-label="<?=$this->transEsc("Set")?>">
+            <i class="fa fa-refresh" aria-hidden="true"></i>
+          </button>
         </form>
       </td>
     </tr>

--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -3,7 +3,7 @@
   <form class="form-inline search-result-limit" action="<?=$this->currentPath() . $this->results->getUrlQuery()->setLimit(null)?>" method="get">
     <?=$this->results->getUrlQuery()->asHiddenFields(['sort' => '/.*/']);?>
     <label for="limit"><?=$this->transEsc('Results per page')?></label>
-    <select id="limit" name="limit" class="jumpMenu form-control">
+    <select id="limit" name="limit" class="form-control">
       <?php foreach ($limitList as $limitVal => $limitData): ?>
         <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=$limitData['selected']?' selected="selected"':''?>><?=$this->escapeHtml($limitData['desc'])?></option>
       <?php endforeach; ?>

--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -9,5 +9,8 @@
       <?php endforeach; ?>
     </select>
     <noscript><input type="submit" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+    <button type="submit" class="btn btn-primary" aria-label="<?=$this->transEsc("Set")?>">
+      <i class="fa fa-refresh" aria-hidden="true"></i>
+    </button>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/sort.phtml
+++ b/themes/bootstrap3/templates/search/controls/sort.phtml
@@ -2,7 +2,7 @@
   <form class="search-sort" action="<?=$this->currentPath()?>" method="get" name="sort">
     <?=$this->results->getUrlQuery()->asHiddenFields(['sort' => '/.*/']);?>
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
-    <select id="sort_options_1" name="sort" class="jumpMenu form-control">
+    <select id="sort_options_1" name="sort" class="form-control">
     <?php foreach ($list as $sortType => $sortData): ?>
       <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
     <?php endforeach; ?>
@@ -12,4 +12,5 @@
       <i class="fa fa-refresh" aria-hidden="true"></i>
     </button>
   </form>
+
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/sort.phtml
+++ b/themes/bootstrap3/templates/search/controls/sort.phtml
@@ -3,10 +3,13 @@
     <?=$this->results->getUrlQuery()->asHiddenFields(['sort' => '/.*/']);?>
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
     <select id="sort_options_1" name="sort" class="jumpMenu form-control">
-      <?php foreach ($list as $sortType => $sortData): ?>
-        <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
-      <?php endforeach; ?>
+    <?php foreach ($list as $sortType => $sortData): ?>
+      <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
+    <?php endforeach; ?>
     </select>
     <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+    <button type="submit" class="btn btn-primary" aria-label="<?=$this->transEsc("Set")?>">
+      <i class="fa fa-refresh" aria-hidden="true"></i>
+    </button>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/history-table.phtml
+++ b/themes/bootstrap3/templates/search/history-table.phtml
@@ -40,12 +40,15 @@
         <?php if (isset($this->schedule[$info->getSearchId()])): ?>
           <?php $schedule = $this->schedule[$info->getSearchId()]; ?>
             <form class="form-inline jumpMenuForm" action="<?= $this->url('myresearch-savesearch')?>" method="get" name="schedule">
-              <select name="schedule" class="jumpMenu form-control" aria-haspopup="true" title="<?=$this->transEscAttr("history_schedule")?>">
+              <select name="schedule" class="form-control" aria-haspopup="true" title="<?=$this->transEscAttr("history_schedule")?>">
                 <?php foreach ($scheduleOptions as $scheduleValue => $scheduleLabel): ?>
                   <option value="<?=$this->escapeHtmlAttr($scheduleValue)?>"<?=($schedule == $scheduleValue) ? (' selected') : ('')?>><?=$this->transEsc($scheduleLabel)?></option>
                 <?php endforeach; ?>
               </select>
               <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($info->getSearchId()) ?>"/>
+              <button type="submit" class="btn btn-primary" aria-label="<?=$this->transEsc("Set")?>">
+                <i class="fa fa-refresh" aria-hidden="true"></i>
+              </button>
             </form>
           <?php else: ?>
             <span class="disable"><?=$this->transEsc("cannot set")?></span>


### PR DESCRIPTION
This adds refresh buttons to the limit and sort select boxes (result list/favorites) to prevent unexpected page reloads. 
It affects limit and sort select boxes in search results and favorites lists.

The background for this was reported to us during our accessibility checks: Select elements must not automatically change users' context when keyboard navigation moves between options. See also, e.g., https://fae.disability.illinois.edu/rulesets/FOCUS_4/
Generally, one may navigate select boxes by opening them (SPACE on most Windows settings, I believe) and making the selection. OR one may navigate straight away, selecting options with the arrow keys.

Due to the jumpMenu class, both menus reload the page immediately when using the arrow keys-method (there is no chance to choose) and place the focus to the top of the page! This may be disorienting to non-sighted (and other users).

The suggestion of the accessibility testing people was to add a refresh button next to the select boxes.

Desired behavior: Tab to the new sort box in result list and select an option with the arrow keys. Press TAB again and confirm on the new button with ENTER.

For comparison, tab to the sort box in the Live demo and use the arrow keys ...

There will be more focus loss-related issues I'd like to discuss in subsequent PRs.

TODO
- [ ] Decide whether to use "select with button" or "collapsible link list" for each scenario; probably best to resolve #2378 first to have easy access to MenuButton component.