### PR TITLE
Fix Swagger UI API documentation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -304,11 +304,10 @@
     </copy>
     <reflexive>
       <fileset dir="${srcdir}/public/swagger-ui">
-        <include pattern="index.html" />
+        <include pattern="swagger-initializer.js" />
       </fileset>
       <filterchain>
         <replaceregexp>
-          <regexp pattern="defaultModelRendering: 'schema'" replace="defaultModelRendering: 'model'" />
           <regexp pattern="url: &quot;.*&quot;" replace="url: &quot;../api/v1?openapi&quot;" />
         </replaceregexp>
       </filterchain>


### PR DESCRIPTION
In swagger-ui 4.9.0 was dist/index.html file refactored and the url is no more defined here, but in file swagger-initializer.js

I also removed 'defaultModelRendering' setting change as it is not part of dist/index.html from version 3.0.0