### PR TITLE
FOLIO use item effective call number

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -608,8 +608,8 @@ class Folio extends AbstractAPI implements
                 $callNumberData = $this->chooseCallNumber(
                     $holdingCallNumberPrefix,
                     $holdingCallNumber,
-                    $item->itemLevelCallNumberPrefix ?? '',
-                    $item->itemLevelCallNumber ?? ''
+                    $item->effectiveCallNumberComponents->prefix ?? $item->itemLevelCallNumberPrefix ?? '',
+                    $item->effectiveCallNumberComponents->callNumber ?? $item->itemLevelCallNumber ?? ''
                 );
 
                 $dueDateValue = '';

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -608,8 +608,10 @@ class Folio extends AbstractAPI implements
                 $callNumberData = $this->chooseCallNumber(
                     $holdingCallNumberPrefix,
                     $holdingCallNumber,
-                    $item->effectiveCallNumberComponents->prefix ?? $item->itemLevelCallNumberPrefix ?? '',
-                    $item->effectiveCallNumberComponents->callNumber ?? $item->itemLevelCallNumber ?? ''
+                    $item->effectiveCallNumberComponents->prefix
+                        ?? $item->itemLevelCallNumberPrefix ?? '',
+                    $item->effectiveCallNumberComponents->callNumber
+                        ?? $item->itemLevelCallNumber ?? ''
                 );
 
                 $dueDateValue = '';


### PR DESCRIPTION
Prefer to use effective call number. FOLIO generates this one. I think it should always exist, but left a fallback to item level JIC.