### PR TITLE
Add birthdate support to several ILS drivers.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -823,7 +823,10 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             }
             $profile['email'] = $this->getPreferredEmail($xml);
         }
-        $profile['birthdate'] = (string)($xml->birth_date ?? '');
+        if ($xml->birth_date) {
+            // Drop any time zone designator from the date:
+            $profile['birthdate'] = substr((string)$xml->birth_date, 0, 10);
+        }
 
         // Cache the user group code
         $cacheId = 'alma|user|' . $patronId . '|group_code';

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -823,6 +823,7 @@ class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface
             }
             $profile['email'] = $this->getPreferredEmail($xml);
         }
+        $profile['birthdate'] = (string)($xml->birth_date ?? '');
 
         // Cache the user group code
         $cacheId = 'alma|user|' . $patronId . '|group_code';

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -893,7 +893,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
     public function getMyProfile($patron)
     {
         $this->checkIntermittentFailure();
-        $age = 13 + rand(0, 100);
+        $age = rand(13, 113);
         $birthDate = new \DateTime();
         $birthDate->sub(new \DateInterval("P{$age}Y"));
         $patron = [

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -893,6 +893,9 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
     public function getMyProfile($patron)
     {
         $this->checkIntermittentFailure();
+        $age = 13 + rand(0, 100);
+        $birthDate = new \DateTime();
+        $birthDate->sub(new \DateInterval("P{$age}Y"));
         $patron = [
             'firstname'       => 'Lib-' . $patron['cat_username'],
             'lastname'        => 'Rarian',
@@ -904,7 +907,8 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             'phone'           => '1900 CALL ME',
             'mobile_phone'    => '1234567890',
             'group'           => 'Library Staff',
-            'expiration_date' => 'Someday'
+            'expiration_date' => 'Someday',
+            'birthdate'       => $birthDate->format('Y-m-d')
         ];
         return $patron;
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -621,7 +621,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             'zip' => $result['postal_code'],
             'city' => $result['city'],
             'country' => $result['country'],
-            'expiration_date' => $this->convertDate($result['expiry_date'] ?? null)
+            'expiration_date' => $this->convertDate($result['expiry_date'] ?? null),
+            'birthdate' => $result['date_of_birth'] ?? ''
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -511,7 +511,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         $result = $this->makeRequest(
             [$this->apiBase, 'patrons', $patron['id']],
             [
-                'fields' => 'names,emails,phones,addresses,expirationDate'
+                'fields' => 'names,emails,phones,addresses,birthDate,expirationDate'
             ],
             'GET',
             $patron
@@ -554,6 +554,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             'address1' => $address,
             'zip' => $zip,
             'city' => $city,
+            'birthdate' => $result['birthDate'] ?? '',
             'expiration_date' => $expirationDate
         ];
     }


### PR DESCRIPTION
The field is now returned in patron profile with Alma, Demo, KohaRest and SierraRest drivers. It isn't displayed since that's rarely useful for the user, but is provided so that it could be used to determine if the user should be able to access age-restricted material.

TODO:
- [x] Update ILS driver wiki page.