### PR TITLE
Fix PHP 8.1 deprecation notice.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -340,7 +340,8 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         ) {
             return $ex;
         }
-        return new BackendException('Problem connecting to Solr.', null, $ex);
+        return
+            new BackendException('Problem connecting to Solr.', $ex->getCode(), $ex);
     }
 
     /**


### PR DESCRIPTION
Second parameter to BackendException should be an int. Use original exception's code for the converted exception as well (like in EDS).