### PR TITLE
Clean up error handling in form email handler.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -122,10 +122,9 @@ class Email implements HandlerInterface, LoggerAwareInterface
         $recipients = $form->getRecipient($params->fromPost());
         $emailSubject = $form->getEmailSubject($params->fromPost());
 
-        $sendSuccess = true;
-        $success = false;
+        $result = true;
         foreach ($recipients as $recipient) {
-            [$success, $errorMsg] = $this->sendEmail(
+            $success = $this->sendEmail(
                 $recipient['name'],
                 $recipient['email'],
                 $senderName,
@@ -136,12 +135,9 @@ class Email implements HandlerInterface, LoggerAwareInterface
                 $emailMessage
             );
 
-            $sendSuccess = $sendSuccess && $success;
-            if (!$success) {
-                $this->logError($errorMsg);
-            }
+            $result = $result && $success;
         }
-        return $success;
+        return $result;
     }
 
     /**
@@ -174,7 +170,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
      * @param string $emailSubject   Email subject
      * @param string $emailMessage   Email message
      *
-     * @return array with elements success:boolean, errorMessage:string (optional)
+     * @return bool
      */
     protected function sendEmail(
         $recipientName,
@@ -185,7 +181,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
         $replyToEmail,
         $emailSubject,
         $emailMessage
-    ): array {
+    ): bool {
         try {
             $this->mailer->send(
                 new Address($recipientEmail, $recipientName),
@@ -196,9 +192,12 @@ class Email implements HandlerInterface, LoggerAwareInterface
                 !empty($replyToEmail)
                     ? new Address($replyToEmail, $replyToName) : null
             );
-            return [true, null];
+            return true;
         } catch (MailException $e) {
-            return [false, $e->getMessage()];
+            $this->logError(
+                "Failed to send email to '$recipientEmail': " . $e->getMessage()
+            );
+            return false;
         }
     }
 }


### PR DESCRIPTION
This simplifies return value of `sendEmail` and makes sure it's true only when all emails were successfully sent.