### PR TITLE
Do not translate card name or cat_username in library card list.

### DIFF
--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -13,7 +13,7 @@
             if (strstr($username, '.')) {
               [$target, $username] = explode('.', $username, 2);
             }
-            $display = $this->transEsc($card->card_name ? $card->card_name : $card->cat_username);
+            $display = $this->escapeHtml($card->card_name ? $card->card_name : $card->cat_username);
             if ($target) {
               $display .= ' (' . $this->transEsc("source_$target", null, $target) . ')';
             }


### PR DESCRIPTION
To test: 
- Add two cards
- Set the name of one card to e.g. `Favorites`
- Go to profile page and observe `Saved Items`instead of `Favorites` displayed