### PR TITLE
Handle collapsed facets properly when loading hierarchical facets.

### DIFF
--- a/themes/bootstrap3/js/facets.js
+++ b/themes/bootstrap3/js/facets.js
@@ -98,7 +98,7 @@ function buildFacetTree(treeNode, facetData, inSidebar) {
   });
 }
 
-function initFacetTree(treeNode, inSidebar)
+function loadFacetTree(treeNode, inSidebar)
 {
   var loaded = treeNode.data('loaded');
   if (loaded) {
@@ -127,6 +127,20 @@ function initFacetTree(treeNode, inSidebar)
       buildFacetTree(treeNode, response.data.facets, inSidebar);
     }
   );
+}
+
+function initFacetTree(treeNode, inSidebar)
+{
+  // Defer init if the facet is collapsed:
+  let $collapse = treeNode.parents('.facet-group').find('.collapse');
+  if (!$collapse.hasClass('in')) {
+    $collapse.on('show.bs.collapse', function onExpand() {
+      loadFacetTree(treeNode, inSidebar);
+    });
+    return;
+  } else {
+    loadFacetTree(treeNode, inSidebar);
+  }
 }
 
 /* --- Side Facets --- */

--- a/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/hierarchical-facet.phtml
@@ -13,25 +13,6 @@
   // of the suppressed query:
   $extraUrlFields = $this->results->getUrlQuery()->getParamsWithConfiguredDefaults();
 ?>
-<?php if (!in_array($this->title, $this->collapsedFacets)): ?>
-  <?php
-    $script = <<<JS
-$(document).ready(function() {
-  initFacetTree($('#facet_{$this->escapeHtml($this->title)}'), true);
-});
-JS;
-  ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
-<?php else: ?>
-  <?php
-  $script = <<<JS
-$('#side-collapse-{$this->escapeHtmlAttr($this->title)}').on('show.bs.collapse', function() {
-  initFacetTree($('#facet_{$this->escapeHtml($this->title)}'), true);
-});
-JS;
-  ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
-<?php endif; ?>
 <?php
   $truncateSettings = $this->facets_before_more < 1 ? false : [
     'rows' => $this->facets_before_more,
@@ -54,3 +35,11 @@ JS;
     data-extra-fields="<?=$this->escapeHtml(implode(',', $extraUrlFields))?>">
   </div>
 </div>
+<?php
+  $script = <<<JS
+$(document).ready(function () {
+  initFacetTree($('#facet_{$this->escapeHtml($this->title)}'), true);
+});
+JS;
+?>
+<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>


### PR DESCRIPTION
Moves the check for collapsed facet into JS to take into account the client-side session storage that overrides collapsedFacets from configuration.

Before the change a collapsed facet could have been loaded in the background. While this doesn't cause any actual problems, it's just extra work for the server in case the user never sees the results.