### PR TITLE
Redirect to profile page after email verification.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1946,7 +1946,7 @@ class MyResearchController extends AbstractBase
             if (time() - $hashtime > $hashLifetime) {
                 $this->flashMessenger()
                     ->addMessage('recovery_expired_hash', 'error');
-                return $this->forwardTo('MyResearch', 'Login');
+                return $this->forwardTo('MyResearch', 'Profile');
             } else {
                 $table = $this->getTable('User');
                 $user = $table->getByVerifyHash($hash);
@@ -1960,12 +1960,12 @@ class MyResearchController extends AbstractBase
                     $user->saveEmailVerified();
 
                     $this->flashMessenger()->addMessage('verification_done', 'info');
-                    return $this->redirect()->toRoute('myresearch-userlogin');
+                    return $this->redirect()->toRoute('myresearch-profile');
                 }
             }
         }
         $this->flashMessenger()->addMessage('recovery_invalid_hash', 'error');
-        return $this->redirect()->toRoute('myresearch-userlogin');
+        return $this->redirect()->toRoute('myresearch-profile');
     }
 
     /**


### PR DESCRIPTION
Since it was probably initiated from the profile page, it's a logical target as well. It also ensures the alert messages are shown. Otherwise they could be hidden until a page that displays them is shown. This would happen e.g. when defaultLoggedInModule = Search in config.ini.