### PR TITLE
Use a callback to create a HTTP client in Solr connector.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
@@ -72,17 +72,20 @@ abstract class AbstractBackendFactory implements FactoryInterface
     /**
      * Create HTTP Client
      *
-     * @param int   $timeout Request timeout
-     * @param array $options Other options
+     * @param int    $timeout Request timeout
+     * @param array  $options Other options
+     * @param string $url     Request URL (needed for proper local address check when
+     * the client is being proxified)
      *
      * @return \Laminas\Http\Client
      */
     protected function createHttpClient(
         ?int $timeout = null,
-        array $options = []
+        array $options = [],
+        string $url = null
     ): \Laminas\Http\Client {
         $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient();
+            ->createClient($url);
         if (null !== $timeout) {
             $options['timeout'] = $timeout;
         }

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -398,7 +398,13 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
         $connector = new $this->connectorClass(
             $this->getSolrUrl(),
             new HandlerMap($handlers),
-            $this->createHttpClient($config->Index->timeout ?? 30),
+            function (string $url) use ($config) {
+                return $this->createHttpClient(
+                    $config->Index->timeout ?? 30,
+                    [],
+                    $url
+                );
+            },
             $this->uniqueKey
         );
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -99,8 +99,13 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $handlermap    = new HandlerMap(['select' => ['fallback' => true]]);
-        $client        = new \Laminas\Http\Client();
-        $connector     = new Connector('http://example.org/', $handlermap, $client);
+        $connector     = new Connector(
+            'http://localhost/',
+            $handlermap,
+            function () {
+                return new \Laminas\Http\Client();
+            }
+        );
         $this->backend = new Backend($connector);
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
@@ -127,8 +127,13 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $handlermap     = new HandlerMap(['select' => ['fallback' => true]]);
-        $client         = new \Laminas\Http\Client();
-        $connector      = new Connector('http://example.org/', $handlermap, $client);
+        $connector      = new Connector(
+            'http://localhost/',
+            $handlermap,
+            function () {
+                return new \Laminas\Http\Client();
+            }
+        );
         $this->backend  = new Backend($connector);
         $this->backend->setIdentifier('foo');
         $this->listener = new MultiIndexListener($this->backend, self::$shards, self::$fields, self::$specs);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Solr/WriterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Solr/WriterTest.php
@@ -52,8 +52,9 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      */
     public function testCommit()
     {
-        $command = new WriteDocumentCommand('Solr', new CommitDocument(), 60 * 60);
-        $this->getWriter($command)->commit('Solr');
+        $expectedCommand
+            = new WriteDocumentCommand('Solr', new CommitDocument(), 60 * 60);
+        $this->getWriter($expectedCommand)->commit('Solr');
     }
 
     /**
@@ -64,8 +65,8 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     public function testSave()
     {
         $commit = new CommitDocument();
-        $command = new WriteDocumentCommand('Solr', $commit);
-        $this->getWriter($command)->save('Solr', $commit);
+        $expectedCommand = new WriteDocumentCommand('Solr', $commit);
+        $this->getWriter($expectedCommand)->save('Solr', $commit);
     }
 
     /**
@@ -77,14 +78,14 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     {
         $csv = new \VuFindSearch\Backend\Solr\Document\RawCSVDocument('a,b,c');
         $params = new \VuFindSearch\ParamBag(['foo' => 'bar']);
-        $command = new WriteDocumentCommand(
+        $expectedCommand = new WriteDocumentCommand(
             'Solr',
             $csv,
             null,
             'customUpdateHandler',
             $params
         );
-        $this->getWriter($command)
+        $this->getWriter($expectedCommand)
             ->save('Solr', $csv, 'customUpdateHandler', $params);
     }
 
@@ -95,9 +96,9 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      */
     public function testOptimize()
     {
-        $command
+        $expectedCommand
             = new WriteDocumentCommand('Solr', new OptimizeDocument(), 60 * 60 * 24);
-        $this->getWriter($command)->optimize('Solr');
+        $this->getWriter($expectedCommand)->optimize('Solr');
     }
 
     /**
@@ -109,8 +110,8 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     {
         $deleteDoc = new DeleteDocument();
         $deleteDoc->addQuery('*:*');
-        $command = new WriteDocumentCommand('Solr', $deleteDoc);
-        $this->getWriter($command)->deleteAll('Solr');
+        $expectedCommand = new WriteDocumentCommand('Solr', $deleteDoc);
+        $this->getWriter($expectedCommand)->deleteAll('Solr');
     }
 
     /**
@@ -122,8 +123,8 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     {
         $deleteDoc = new DeleteDocument();
         $deleteDoc->addKeys(['foo', 'bar']);
-        $command = new WriteDocumentCommand('Solr', $deleteDoc);
-        $this->getWriter($command, ['core' => 'biblio'])
+        $expectedCommand = new WriteDocumentCommand('Solr', $deleteDoc);
+        $this->getWriter($expectedCommand, ['core' => 'biblio'])
             ->deleteRecords('Solr', ['foo', 'bar']);
     }
 
@@ -136,7 +137,6 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     {
         return $this->getMockBuilder(\VuFind\Db\Table\ChangeTracker::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['markDeleted'])
             ->getMock();
     }
 
@@ -150,7 +150,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockSearchService($expectedCommand, $result)
     {
-        $resultCommand = $this->getMockBuilder(WriteDocumentCommand::class)
+        $resultCommand = $this->getMockBuilder(get_class($expectedCommand))
             ->disableOriginalConstructor()
             ->getMock();
         $resultCommand->expects($this->once())->method('getResult')

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -100,21 +100,29 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
     /**
      * Constructor
      *
-     * @param string|array $url       SOLR core URL or an array of alternative URLs
-     * @param HandlerMap   $map       Handler map
-     * @param callable     $cf        HTTP client factory
-     * @param string       $uniqueKey Solr field used to store unique identifier
+     * @param string|array        $url       SOLR core URL or an array of alternative
+     * URLs
+     * @param HandlerMap          $map       Handler map
+     * @param callable|HttpClient $cf        HTTP client factory or a client to clone
+     * @param string              $uniqueKey Solr field used to store unique
+     * identifier
      */
     public function __construct(
         $url,
         HandlerMap $map,
-        callable $cf,
+        $cf,
         $uniqueKey = 'id'
     ) {
         $this->url = $url;
         $this->map = $map;
         $this->uniqueKey = $uniqueKey;
-        $this->clientFactory = $cf;
+        if ($cf instanceof HttpClient) {
+            $this->clientFactory = function () use ($cf) {
+                return clone $cf;
+            };
+        } else {
+            $this->clientFactory = $cf;
+        }
     }
 
     /// Public API

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
@@ -1116,11 +1116,18 @@ class BackendTest extends TestCase
         $map = new \VuFindSearch\Backend\Solr\HandlerMap(
             ['select' => ['fallback' => true]]
         );
-        $client = $this->createMock(\Laminas\Http\Client::class);
         $connector
             = $this->getMockBuilder(\VuFindSearch\Backend\Solr\Connector::class)
             ->onlyMethods(['query'])
-            ->setConstructorArgs(['http://localhost/', $map, $client])
+            ->setConstructorArgs(
+                [
+                    'http://localhost/',
+                    $map,
+                    function () {
+                        return $this->createMock(\Laminas\Http\Client::class);
+                    }
+                ]
+            )
             ->getMock();
         $connector->expects($this->any())
             ->method('query')

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
@@ -608,35 +608,6 @@ class BackendTest extends TestCase
         );
     }
 
-    /**
-     * Test writeDocument
-     *
-     * @return void
-     */
-    public function testDelayedClientCreation()
-    {
-        $doc = new CommitDocument();
-        $client = $this->getMockBuilder(\Laminas\Http\Client::class)
-            ->onlyMethods(['setOptions'])
-            ->getMock();
-        $client->expects($this->exactly(0))->method('setOptions')
-            ->with(['timeout' => 60]);
-        $connector = $this->getConnectorMock(['getUrl', 'write'], $client);
-        $connector->expects($this->once())->method('write')
-            ->with(
-                $this->equalTo($doc),
-                $this->equalTo('update'),
-                $this->isNull()
-            );
-        $connector->expects($this->once())->method('getUrl')
-            ->will($this->returnValue('http://localhost:8983/solr/core/biblio'));
-        $backend = new Backend($connector);
-        $this->assertEquals(
-            ['core' => 'biblio'],
-            $backend->writeDocument($doc, 60)
-        );
-    }
-
     /// Internal API
 
     /**
@@ -690,7 +661,7 @@ class BackendTest extends TestCase
                 [
                     'http://localhost/',
                     $map,
-                    function () use (&$client) {
+                    function () use ($client) {
                         // If client is provided, return it since it may have test
                         // expectations:
                         return $client ?? new \Laminas\Http\Client();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
@@ -51,6 +51,7 @@ use VuFindSearch\Query\Query;
 class BackendTest extends TestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\ReflectionTrait;
 
     /**
      * Test retrieving a record.
@@ -587,6 +588,45 @@ class BackendTest extends TestCase
                 $this->equalTo($doc),
                 $this->equalTo('update'),
                 $this->isNull()
+            )
+            ->will(
+                $this->returnCallback(
+                    function () use ($connector) {
+                        // Call client factory for expectations to be met:
+                        $factory = $this->getProperty($connector, 'clientFactory');
+                        $factory('');
+                        return true;
+                    }
+                )
+            );
+        $connector->expects($this->once())->method('getUrl')
+            ->will($this->returnValue('http://localhost:8983/solr/core/biblio'));
+        $backend = new Backend($connector);
+        $this->assertEquals(
+            ['core' => 'biblio'],
+            $backend->writeDocument($doc, 60)
+        );
+    }
+
+    /**
+     * Test writeDocument
+     *
+     * @return void
+     */
+    public function testDelayedClientCreation()
+    {
+        $doc = new CommitDocument();
+        $client = $this->getMockBuilder(\Laminas\Http\Client::class)
+            ->onlyMethods(['setOptions'])
+            ->getMock();
+        $client->expects($this->exactly(0))->method('setOptions')
+            ->with(['timeout' => 60]);
+        $connector = $this->getConnectorMock(['getUrl', 'write'], $client);
+        $connector->expects($this->once())->method('write')
+            ->with(
+                $this->equalTo($doc),
+                $this->equalTo('update'),
+                $this->isNull()
             );
         $connector->expects($this->once())->method('getUrl')
             ->will($this->returnValue('http://localhost:8983/solr/core/biblio'));
@@ -644,10 +684,19 @@ class BackendTest extends TestCase
     protected function getConnectorMock(array $mock = [], $client = null)
     {
         $map = new HandlerMap(['select' => ['fallback' => true]]);
-        $client = $client ?? new \Laminas\Http\Client();
         return $this->getMockBuilder(\VuFindSearch\Backend\Solr\Connector::class)
             ->onlyMethods($mock)
-            ->setConstructorArgs(['http://example.org/', $map, $client])
+            ->setConstructorArgs(
+                [
+                    'http://localhost/',
+                    $map,
+                    function () use (&$client) {
+                        // If client is provided, return it since it may have test
+                        // expectations:
+                        return $client ?? new \Laminas\Http\Client();
+                    }
+                ]
+            )
             ->getMock();
     }
 }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
@@ -131,7 +131,16 @@ class ConnectorTest extends TestCase
             ->with($this->equalTo($csvData));
         $conn = $this->getMockBuilder(Connector::class)
             ->onlyMethods(['send'])
-            ->setConstructorArgs(['http://foo', $map, $client, 'id'])
+            ->setConstructorArgs(
+                [
+                    'http://localhost',
+                    $map,
+                    function () use ($client) {
+                        return $client;
+                    },
+                    'id'
+                ]
+            )
             ->getMock();
         $conn->expects($this->once())->method('send')
             ->with($this->equalTo($client));
@@ -161,7 +170,16 @@ class ConnectorTest extends TestCase
             ->with($this->equalTo($jsonData));
         $conn = $this->getMockBuilder(Connector::class)
             ->onlyMethods(['send'])
-            ->setConstructorArgs(['http://foo', $map, $client, 'id'])
+            ->setConstructorArgs(
+                [
+                    'http://localhost',
+                    $map,
+                    function () use ($client) {
+                        return $client;
+                    },
+                    'id'
+                ]
+            )
             ->getMock();
         $conn->expects($this->once())->method('send')
             ->with($this->equalTo($client));
@@ -219,7 +237,14 @@ class ConnectorTest extends TestCase
         $url = 'http://example.tld/';
         $map  = new HandlerMap(['select' => ['fallback' => true]]);
         $key = 'foo';
-        $conn = new Connector($url, $map, new \Laminas\Http\Client(), $key);
+        $conn = new Connector(
+            $url,
+            $map,
+            function () {
+                return new \Laminas\Http\Client();
+            },
+            $key
+        );
         $this->assertEquals($url, $conn->getUrl());
         $this->assertEquals($map, $conn->getMap());
         $this->assertEquals($key, $conn->getUniqueKey());
@@ -285,7 +310,9 @@ class ConnectorTest extends TestCase
         return new Connector(
             'http://example.tld/',
             $map,
-            $client ?: $this->createClient(),
+            function () use ($client) {
+                return $client ?: $this->createClient();
+            },
             'id'
         );
     }


### PR DESCRIPTION
This makes it possible to create the client when the URL is available so that any proxy can be bypassed for local addresses.

This is provided as a starting point for solving the issue where proxy configuration prevents connection to a local Solr instance. If deemed appropriate, similar mechanism could be used to fix other cases where just passing HttpService in constructor instead of a Client is not sufficient.

TODO
- [x] Update changelog when merging