### PR TITLE
OIDC: Add support for 'age' scope.

### DIFF
--- a/config/vufind/OAuth2Server.yaml
+++ b/config/vufind/OAuth2Server.yaml
@@ -105,6 +105,11 @@ Scopes:
       - name
       - given_name
       - family_name
+  age:
+    description: external_auth_scope_age
+    ils: true
+    claims:
+      - age
   birthdate:
     description: external_auth_scope_birthdate
     ils: true
@@ -141,6 +146,7 @@ ClaimMappings:
   given_name: firstname
   family_name: lastname
   email: email
+  age: age
   birthdate: birthdate
   locale: last_language
   phone: phone

--- a/languages/en.ini
+++ b/languages/en.ini
@@ -426,6 +426,7 @@ external_auth_ils_prompt = "Some of the requested information is retrieved from 
 external_auth_login_message = "Login to access licensed material"
 external_auth_prompt_html = "is requesting the following access rights:"
 external_auth_scope_address = "Read your address"
+external_auth_scope_age = "Read your age"
 external_auth_scope_birthdate = "Read your date of birth"
 external_auth_scope_block_status = "Check if your account has blocks"
 external_auth_scope_email = "Read your email address"

--- a/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
@@ -132,16 +132,13 @@ class UserEntity implements UserEntityInterface, ClaimSetInterface
 
         foreach ($this->oauth2Config['ClaimMappings'] as $claim => $field) {
             switch ($field) {
-            case 'full_name':
-                // full_name is a special field for firstname + lastname:
-                $result[$claim] = trim(
-                    $this->user['firstname'] . ' ' . $this->user['lastname']
-                );
-                break;
-            case 'block_status':
-                // account_blocked is a flag indicating whether the patron has
-                // blocks:
-                $result[$claim] = $blocked;
+            case 'age':
+                if ($birthDate = $profile['birthdate'] ?? '') {
+                    if ($date = \DateTime::createFromFormat('Y-m-d', $birthDate)) {
+                        $diff = $date->diff(new \DateTimeImmutable(), true);
+                        $result[$claim] = (int)$diff->format('%y');
+                    }
+                }
                 break;
             case 'address_json':
                 if ($profile) {
@@ -161,6 +158,17 @@ class UserEntity implements UserEntityInterface, ClaimSetInterface
                     ];
                     $result[$claim] = json_encode($address);
                 }
+                break;
+            case 'block_status':
+                // account_blocked is a flag indicating whether the patron has
+                // blocks:
+                $result[$claim] = $blocked;
+                break;
+            case 'full_name':
+                // full_name is a special field for firstname + lastname:
+                $result[$claim] = trim(
+                    $this->user['firstname'] . ' ' . $this->user['lastname']
+                );
                 break;
             case 'last_language':
                 // Make sure any country code is in uppercase:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -179,7 +179,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         // Go to OAuth2 authorization screen:
         $params = [
             'client_id' => 'test',
-            'scope' => 'openid profile library_user_id',
+            'scope' => 'openid profile library_user_id age',
             'response_type' => 'code',
             'redirect_uri' => $redirectUri,
             'nonce' => $nonce,
@@ -209,6 +209,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'Read your user identifier',
             'Read your basic profile information (name, language, birthdate)',
             'Read a unique hash based on your library user identifier',
+            'Read your age',
         ];
         foreach ($expectedPermissions as $index => $permission) {
             $this->assertEquals(
@@ -270,6 +271,11 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         $this->assertMatchesRegularExpression(
             '/^\d{4}-\d{2}-\d{2}$/',
             $idToken->birthdate
+        );
+        $this->assertEquals(
+            \DateTime::createFromFormat('Y-m-d', $idToken->birthdate)
+                ->diff(new \DateTimeImmutable())->format('%y'),
+            $idToken->age
         );
 
         // Test the userinfo endpoint:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
@@ -63,6 +63,7 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
             'given_name' => 'firstname',
             'family_name' => 'lastname',
             'email' => 'email',
+            'age' => 'age',
             'birthdate' => 'birthdate',
             'locale' => 'last_language',
             'phone' => 'phone',
@@ -71,6 +72,24 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
             'library_user_id' => 'library_user_id_hash',
         ],
     ];
+
+    /**
+     * User's birth date
+     *
+     * @var string
+     */
+    protected $userBirthDate;
+
+    /**
+     * Setup tests
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->userBirthDate = (new \DateTimeImmutable('18 years 6 months ago'))
+            ->format('Y-m-d');
+    }
 
     /**
      * Data provider for testIdentityRepository
@@ -118,7 +137,8 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
                 'name' => 'Lib Rarian',
                 'given_name' => 'Lib',
                 'family_name' => 'Rarian',
-                'birthdate' => '2022-08-05',
+                'age' => 18,
+                'birthdate' => $this->userBirthDate,
                 'locale' => 'en-GB',
                 'phone' => '1900 CALL ME',
                 'address' => '{"street_address":"Somewhere...\\nOver the Rainbow","locality":"City","postal_code":"12345","country":"Country"}',
@@ -240,7 +260,7 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
             'mobile_phone'    => '1234567890',
             'group'           => 'Library Staff',
             'expiration_date' => 'Someday',
-            'birthdate'       => '2022-08-05',
+            'birthdate'       => $this->userBirthDate,
         ];
 
         $ils = $this->getMockBuilder(Connection::class)


### PR DESCRIPTION
If exact birth date is not required, 'age' may be used.