### PR TITLE
Avoid calling urlencode() with null.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/ParamBag.php
+++ b/module/VuFindSearch/src/VuFindSearch/ParamBag.php
@@ -240,7 +240,7 @@ class ParamBag implements \Countable
                             return sprintf(
                                 '%s=%s',
                                 urlencode($name),
-                                urlencode($value)
+                                urlencode($value ?? '')
                             );
                         },
                         $values


### PR DESCRIPTION
At least EDS has sort set to null.

Note that a change could be in order in the EDS Params code, but it explicitly says it needs to be null, so changing that to an empty string or such without more extensive research was too scary.