### PR TITLE
Disable default filters when using an alphabetic search result

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1900,6 +1900,14 @@ page_size = 20
 rows_before = 0
 ; highlight the match row (or spot where match would have been)? default false
 highlighting = false
+; AlphaBrowse results are not subject to dynamic filtering. If you have default
+; filters defined in searches.ini, you most likely will want to disable them when
+; users navigate from browse results to search results, to ensure that the result
+; count is consistent between the browse listing and the search listing. However,
+; in the rare situation that you have configured default filters that BROADEN
+; rather than NARROW search results, you will likely want to change this setting
+; to false to avoid inconsistencies.
+bypass_default_filters = true
 ; SEE ALSO: the General/includeAlphaBrowse setting in searchbox.ini, for including
 ; alphabrowse options in the main search drop-down options.
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
@@ -48,13 +48,22 @@ class AlphaBrowse extends \Laminas\View\Helper\AbstractHelper
     protected $url;
 
     /**
+     * Additional configuration options.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
      * Constructor
      *
-     * @param Url $helper URL helper
+     * @param Url   $helper  URL helper
+     * @param array $options Additional configuration options
      */
-    public function __construct(Url $helper)
+    public function __construct(Url $helper, array $options = [])
     {
         $this->url = $helper;
+        $this->options = $options;
     }
 
     /**
@@ -74,8 +83,10 @@ class AlphaBrowse extends \Laminas\View\Helper\AbstractHelper
         $query = [
             'type' => ucwords($source) . 'Browse',
             'lookfor' => $this->escapeForSolr($item['heading']),
-            'dfApplied' => 1,
         ];
+        if ($this->options['bypass_default_filters'] ?? true) {
+            $query['dfApplied'] = 1;
+        }
         if ($item['count'] == 1) {
             $query['jumpto'] = 1;
         }

--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowse.php
@@ -74,6 +74,7 @@ class AlphaBrowse extends \Laminas\View\Helper\AbstractHelper
         $query = [
             'type' => ucwords($source) . 'Browse',
             'lookfor' => $this->escapeForSolr($item['heading']),
+            'dfApplied' => 1,
         ];
         if ($item['count'] == 1) {
             $query['jumpto'] = 1;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AlphaBrowseFactory.php
@@ -67,6 +67,10 @@ class AlphaBrowseFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         $helpers = $container->get('ViewHelperManager');
-        return new $requestedName($helpers->get('url'));
+        $config = $container->get(\VuFind\Config\PluginManager::class)
+            ->get('config');
+        $options = isset($config->AlphaBrowse)
+            ? $config->AlphaBrowse->toArray() : [];
+        return new $requestedName($helpers->get('url'), $options);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/AlphaBrowseTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/AlphaBrowseTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * AlphaBrowse view helper Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\View\Helper\Root;
+
+use Laminas\View\Helper\Url;
+use VuFind\View\Helper\Root\AlphaBrowse;
+
+/**
+ * AlphaBrowse view helper Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Get mock URL helper.
+     *
+     * @return Url
+     */
+    protected function getMockUrlHelper($expectedQuery): Url
+    {
+        $mock = $this->createMock(Url::class);
+        $mock->expects($this->once())->method('__invoke')
+            ->with(
+                $this->equalTo('search-results'),
+                $this->equalTo([]),
+                $this->equalTo(['query' => $expectedQuery])
+            )->will($this->returnValue('foo'));
+        return $mock;
+    }
+
+    /**
+     * Get configured AlphaBrowse helper for testing.
+     *
+     * @param Url $ url      URL helper
+     * @param array $options Extra options
+     *
+     * @return AlphaBrowse
+     */
+    protected function getHelper(Url $url, array $options = []): AlphaBrowse
+    {
+        return new AlphaBrowse($url, $options);
+    }
+
+    /**
+     * Test that get URL displays an appropriate link for multiple results with
+     * default settings.
+     *
+     * @return void
+     */
+    public function testGetUrlWithMultipleRecordsAndDefaultSettings(): void
+    {
+        $url = $this->getMockUrlHelper(
+            [
+                'type' => 'TitleBrowse',
+                'lookfor' => '"xyzzy"',
+                'dfApplied' => 1,
+            ]
+        );
+        $helper = $this->getHelper($url);
+        $item = ['heading' => 'xyzzy', 'count' => 2];
+        $this->assertEquals('foo', $helper->getUrl('title', $item));
+    }
+
+    /**
+     * Test that get URL displays an appropriate link for a single result with
+     * default settings.
+     *
+     * @return void
+     */
+    public function testGetUrlWithSingleRecordAndDefaultSettings(): void
+    {
+        $url = $this->getMockUrlHelper(
+            [
+                'type' => 'TitleBrowse',
+                'lookfor' => '"xyzzy"',
+                'dfApplied' => 1,
+                'jumpto' => 1,
+            ]
+        );
+        $helper = $this->getHelper($url);
+        $item = ['heading' => 'xyzzy', 'count' => 1];
+        $this->assertEquals('foo', $helper->getUrl('title', $item));
+    }
+
+    /**
+     * Test that get URL properly escapes quotes in headings.
+     *
+     * @return void
+     */
+    public function testGetUrlEscapesQuotes(): void
+    {
+        $url = $this->getMockUrlHelper(
+            [
+                'type' => 'TitleBrowse',
+                'lookfor' => '"\\"xyzzy\\""',
+                'dfApplied' => 1,
+            ]
+        );
+        $helper = $this->getHelper($url);
+        $item = ['heading' => '"xyzzy"', 'count' => 100];
+        $this->assertEquals('foo', $helper->getUrl('title', $item));
+    }
+
+    /**
+     * Test that get URL omits dfApplied when the bypass_default_filters option is
+     * false.
+     *
+     * @return void
+     */
+    public function testGetUrlAppliesFilterBypassSetting(): void
+    {
+        $url = $this->getMockUrlHelper(
+            [
+                'type' => 'TitleBrowse',
+                'lookfor' => '"xyzzy"',
+            ]
+        );
+        $helper = $this->getHelper($url, ['bypass_default_filters' => false]);
+        $item = ['heading' => 'xyzzy', 'count' => 100];
+        $this->assertEquals('foo', $helper->getUrl('title', $item));
+    }
+}


### PR DESCRIPTION
See JIRA [VUFIND-1577](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1577) ("Default filters should not be applied when clicking on an alphabetic search result.")