### PR TITLE
Fix MarcReaderTrait::getFirstFieldValue when field does not exist.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
@@ -136,7 +136,7 @@ trait MarcReaderTrait
     protected function getFirstFieldValue($field, $subfields = null)
     {
         $matches = $this->getFieldArray($field, $subfields);
-        return $matches[0] ?? null;
+        return $matches[0] ?? '';
     }
 
     /**

--- a/module/VuFind/tests/fixtures/marc/marctraitsempty.xml
+++ b/module/VuFind/tests/fixtures/marc/marctraitsempty.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim'>
+    <record
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+        xmlns="http://www.loc.gov/MARC21/slim"
+        type="Bibliographic">
+        <leader>00000cam a22000004i 4500</leader>
+        <controlfield tag="001">123</controlfield>
+    </record>
+</collection>

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcBasicTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcBasicTraitTest.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2020.
+ * Copyright (C) The National Library of Finland 2020-2022.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -27,6 +27,8 @@
  */
 namespace VuFindTest\RecordDriver\Feature;
 
+use VuFind\RecordDriver\WorldCat;
+
 /**
  * Record Driver Marc Traits Test Class
  *
@@ -47,13 +49,7 @@ class MarcBasicTraitTest extends \PHPUnit\Framework\TestCase
      */
     public function testMarcBasicTrait()
     {
-        $xml = $this->getFixture('marc/marctraits.xml');
-        $record = new \VuFind\Marc\MarcReader($xml);
-        $obj = $this->getMockBuilder(\VuFind\RecordDriver\WorldCat::class)
-            ->onlyMethods(['getMarcReader'])->getMock();
-        $obj->expects($this->any())
-            ->method('getMarcReader')
-            ->will($this->returnValue($record));
+        $obj = $this->createMockRecord('marctraits.xml');
 
         $this->assertEquals(
             ['9783161484100', '9783161484101', '1843560283'],
@@ -88,5 +84,41 @@ class MarcBasicTraitTest extends \PHPUnit\Framework\TestCase
             ['1 book : colored, 28 cm 1 cd'],
             $obj->getPhysicalDescriptions()
         );
+    }
+
+    /**
+     * Test methods in MarcBasicTrait with missing fields.
+     *
+     * @return void
+     */
+    public function testMarcBasicTraitMissingFields()
+    {
+        $obj = $this->createMockRecord('marctraitsempty.xml');
+
+        $this->assertSame([], $obj->getFormats());
+        $this->assertSame([], $obj->getCallNumbers());
+        $this->assertSame([], $obj->getISBNs());
+        $this->assertSame([], $obj->getISSNs());
+        $this->assertSame([], $obj->getPrimaryAuthors());
+        $this->assertSame('', $obj->getTitle());
+    }
+
+    /**
+     * Create mock record
+     *
+     * @param string $fixture Record metadata fixture
+     *
+     * @return MockObjec&WorldCat
+     */
+    protected function createMockRecord(string $fixture): WorldCat
+    {
+        $xml = $this->getFixture("marc/$fixture");
+        $record = new \VuFind\Marc\MarcReader($xml);
+        $obj = $this->getMockBuilder(WorldCat::class)
+            ->onlyMethods(['getMarcReader'])->getMock();
+        $obj->expects($this->any())
+            ->method('getMarcReader')
+            ->will($this->returnValue($record));
+        return $obj;
     }
 }


### PR DESCRIPTION
- Avoids returning null when string is the only documented return type.
- Adds tests to ensure several different kinds of methods return the correct result when the requested metadata is not available.
- Fixes PHP 8.1 deprecation notices.