### PR TITLE
Add status-available and status-unavailable to js-icons.

### DIFF
--- a/themes/bootstrap3/templates/layout/js-icons.phtml
+++ b/themes/bootstrap3/templates/layout/js-icons.phtml
@@ -22,7 +22,9 @@ $list = [
     'place-hold',
     'place-ill-request',
     'place-storage-retrieval',
+    'status-available',
     'status-indicator',
+    'status-unavailable',
     'ui-failure',
     'ui-success',
     // Truncate


### PR DESCRIPTION
The icons are used in check_item_statuses.js.
