### PR TITLE
MultiBackend: Skip null values when adding or removing prefixes.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -1311,6 +1311,9 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         }
 
         foreach ($data as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
             if (is_array($value)) {
                 $data[$key] = $this->addIdPrefixes(
                     $value,
@@ -1353,6 +1356,9 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $array = is_array($data) ? $data : [$data];
 
         foreach ($array as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
             if (is_array($value)) {
                 if (in_array($key, $ignoreFields)) {
                     continue;


### PR DESCRIPTION
Fixes a PHP 8.1 deprecation notice and prevents mangling of null.