### PR TITLE
Fix cookie consent mink test.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CookieConsentTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CookieConsentTest.php
@@ -90,6 +90,16 @@ final class CookieConsentTest extends \VuFindTest\Integration\MinkTestCase
                 ]
             ]
         );
+        // Make sure the cookie dialog is not hidden from a headless client:
+        $this->changeYamlConfigs(
+            [
+                'CookieConsent' => [
+                    'CookieConsent' => [
+                        'HideFromBots' => false
+                    ]
+                ]
+            ]
+        );
 
         $page = $this->getStartPage();
         $html = $page->getHtml();


### PR DESCRIPTION
By default the dialog is hidden from bots, and this caused the dialog to be hidden from headless Chrome.

I used non-headless Chrome when testing to see what happens and failed to test headless properly. The cookie consent library is checking [navigator.webdriver](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver) in addition to user agent, and it's set when Chrome is controlled by automation, but apparently only in headless mode.