### PR TITLE
Make sure to not set cookie domain for consent unless configured.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
@@ -277,17 +277,22 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper
         $categories = $this->config['Cookies']['consentCategories'] ?? '';
         $enabledCategories = $categories ? explode(',', $categories) : ['essential'];
         $lang = $this->getTranslatorLocale();
+        $cookieSettings = [
+            'name' => $this->consentCookieName,
+            'path' => $this->cookieManager->getPath(),
+            'expiresAfterDays' => $this->consentCookieExpiration,
+            'sameSite' => $this->cookieManager->getSameSite()
+        ];
+        // Set domain only if we have a value for it to avoid overriding the default
+        // (i.e. window.location.hostname):
+        if ($domain = $this->cookieManager->getDomain()) {
+            $cookieSettings['domain'] = $domain;
+        }
         $consentDialogConfig = [
             'autoClearCookies' => $this->consentConfig['AutoClear'] ?? true,
             'manageScriptTags' => $this->consentConfig['ManageScripts'] ?? true,
             'hideFromBots' => $this->consentConfig['HideFromBots'] ?? true,
-            'cookie' => [
-                'name' => $this->consentCookieName,
-                'domain' => $this->cookieManager->getDomain(),
-                'path' => $this->cookieManager->getPath(),
-                'expiresAfterDays' => $this->consentCookieExpiration,
-                'sameSite' => $this->cookieManager->getSameSite()
-            ],
+            'cookie' => $cookieSettings,
             'revision' => (int)($this->config['Cookies']['consentRevision'] ?? 0),
             'guiOptions' => [
                 'consentModal' => [


### PR DESCRIPTION
Setting it to any value overrides the default in the cookie consent component.

This is only an issue when host name isn't localhost, which prevented it from coming up in tests.