### PR TITLE
CSP Headers Update

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -25,7 +25,11 @@ use_nonce = true
 ; See also the VuFind wiki for additional recommendations and tools:
 ; https://vufind.org/wiki/administration:security:content_security_policy
 [Directives]
-default-src[] = "'none'"
+; default of 'self' with 'none' on child, object, prefetch allows SVG requests.
+default-src[] = "'self'"
+child-src[] = "'none'"
+object-src[] = "'none'"
+prefetch-src[] = "'none'"
 ; 'strict-dynamic' would allow any trusted script to load other scripts. However, it
 ; is currently not supported by Safari.
 ;script-src[] = "'strict-dynamic'"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -31,8 +31,10 @@ child-src[] = "'none'"
 object-src[] = "'none'"
 prefetch-src[] = "'none'"
 ; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
-; Recent versions of Safari do not support this feature, so it is disabled by default.
-; https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
+;   Safari 15.3 and earlier does not support this feature. Since these browser
+;   versions constitute a significant portion of users, especially mobile users,
+;   'string-dynamic' is disabled by default.
+;   https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
 ;script-src[] = "'strict-dynamic'"
 ; backwards compatible to CSP 2
 script-src[] = "http:"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -30,9 +30,9 @@ default-src[] = "'self'"
 child-src[] = "'none'"
 object-src[] = "'none'"
 prefetch-src[] = "'none'"
-; 'strict-dynamic' would allow any trusted script to load other scripts. However, it
-; is currently not supported by Safari.
-;script-src[] = "'strict-dynamic'"
+; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
+script-src[] = "'strict-dynamic'"
+; backwards compatible to CSP 2
 script-src[] = "http:"
 script-src[] = "https:"
 connect-src[] = "'self'"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -31,7 +31,9 @@ child-src[] = "'none'"
 object-src[] = "'none'"
 prefetch-src[] = "'none'"
 ; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
-script-src[] = "'strict-dynamic'"
+; Recent versions of Safari do not support this feature, so it is disabled by default.
+; https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
+;script-src[] = "'strict-dynamic'"
 ; backwards compatible to CSP 2
 script-src[] = "http:"
 script-src[] = "https:"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -33,7 +33,7 @@ prefetch-src[] = "'none'"
 ; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
 ;   Safari 15.3 and earlier does not support this feature. Since these browser
 ;   versions constitute a significant portion of users, especially mobile users,
-;   'string-dynamic' is disabled by default.
+;   'strict-dynamic' is disabled by default.
 ;   https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
 ;script-src[] = "'strict-dynamic'"
 ; backwards compatible to CSP 2


### PR DESCRIPTION
Updates to the default Content Security Policy (CSP) headers to allow for:

1. SVG images to use loaded and used.
2. Updates to Safari to support the more secure and recommended [strict-dynamic](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic).