### PR TITLE
Add support for merging sections of yaml config files.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Locator.php
+++ b/module/VuFind/src/VuFind/Config/Locator.php
@@ -39,6 +39,28 @@ namespace VuFind\Config;
 class Locator
 {
     /**
+     * Mode for getConfigPath: try to find a local file but fall back to base file
+     * if not available.
+     *
+     * @const int
+     */
+    public const MODE_AUTO = 0;
+
+    /**
+     * Mode for getConfigPath: try to find a local file.
+     *
+     * @const int
+     */
+    public const MODE_LOCAL = 1;
+
+    /**
+     * Mode for getConfigPath: get the base configuration file path.
+     *
+     * @const int
+     */
+    public const MODE_BASE = 2;
+
+    /**
      * Get the file path to the local configuration file (null if none found).
      *
      * @param string $filename config file name
@@ -83,21 +105,31 @@ class Locator
     /**
      * Get the file path to a config file.
      *
-     * @param string $filename config file name
-     * @param string $path     path relative to VuFind base (optional; defaults
+     * @param string  $filename Config file name
+     * @param ?string $path     Path relative to VuFind base (optional; defaults
      * to config/vufind
+     * @param int     $mode     Whether to check for local file, base file or both
      *
-     * @return string
+     * @return ?string
      */
-    public static function getConfigPath($filename, $path = 'config/vufind')
-    {
-        // Check if config exists in local dir:
-        $local = static::getLocalConfigPath($filename, $path);
-        if (!empty($local)) {
-            return $local;
+    public static function getConfigPath(
+        $filename,
+        $path = null,
+        int $mode = self::MODE_AUTO
+    ) {
+        if (null === $path) {
+            $path = 'config/vufind';
+        }
+        if (self::MODE_BASE !== $mode) {
+            // Check if config exists in local dir:
+            $local = static::getLocalConfigPath($filename, $path);
+            // Return local config if found or $mode requires:
+            if (!empty($local) || self::MODE_LOCAL === $mode) {
+                return $local;
+            }
         }
 
-        // No local version?  Return default core version:
+        // Return base version:
         return static::getBaseConfigPath($filename, $path);
     }
 }

--- a/module/VuFind/src/VuFind/Config/Locator.php
+++ b/module/VuFind/src/VuFind/Config/Locator.php
@@ -42,23 +42,30 @@ class Locator
      * Mode for getConfigPath: try to find a local file but fall back to base file
      * if not available.
      *
-     * @const int
+     * @var int
      */
     public const MODE_AUTO = 0;
 
     /**
      * Mode for getConfigPath: try to find a local file.
      *
-     * @const int
+     * @var int
      */
     public const MODE_LOCAL = 1;
 
     /**
      * Mode for getConfigPath: get the base configuration file path.
      *
-     * @const int
+     * @var int
      */
     public const MODE_BASE = 2;
+
+    /**
+     * Default configuration path.
+     *
+     * @var string
+     */
+    public const DEFAULT_CONFIG_PATH = 'config/vufind';
 
     /**
      * Get the file path to the local configuration file (null if none found).
@@ -106,8 +113,8 @@ class Locator
      * Get the file path to a config file.
      *
      * @param string  $filename Config file name
-     * @param ?string $path     Path relative to VuFind base (optional; defaults
-     * to config/vufind
+     * @param ?string $path     Path relative to VuFind base (optional; use null for
+     * default)
      * @param int     $mode     Whether to check for local file, base file or both
      *
      * @return ?string
@@ -118,7 +125,7 @@ class Locator
         int $mode = self::MODE_AUTO
     ) {
         if (null === $path) {
-            $path = 'config/vufind';
+            $path = self::DEFAULT_CONFIG_PATH;
         }
         if (self::MODE_BASE !== $mode) {
             // Check if config exists in local dir:

--- a/module/VuFind/src/VuFind/Config/YamlReader.php
+++ b/module/VuFind/src/VuFind/Config/YamlReader.php
@@ -193,15 +193,14 @@ class YamlReader
             $parentSections = $this->parseYaml($defaultParent);
             // Process merged sections:
             foreach ($mergedSections as $path) {
-                $resultElemRef = &$this->getArrayElemRefByPath($results, $path);
-                if (is_array($resultElemRef)) {
-                    $parentElem
-                        = $this->getArrayElemRefByPath($parentSections, $path);
-                    if (is_array($parentElem)) {
-                        $resultElemRef
-                            = array_merge_recursive($parentElem, $resultElemRef);
-                        unset($parentElem);
-                    }
+                $parentElem
+                    = $this->getArrayElemRefByPath($parentSections, $path);
+                if (is_array($parentElem)) {
+                    $resultElemRef
+                        = &$this->getArrayElemRefByPath($results, $path, true);
+                    $resultElemRef
+                        = array_merge_recursive($parentElem, $resultElemRef);
+                    unset($parentElem);
                     unset($resultElemRef);
                 }
             }
@@ -219,20 +218,27 @@ class YamlReader
     /**
      * Return array element reference by path
      *
-     * @param array $arr  Array to access
-     * @param array $path Path to retrieve
+     * @param array $arr    Array to access
+     * @param array $path   Path to retrieve
+     * @param bool  $create Whether to create the path if it doesn't exist. Default
+     * is false.
      *
      * @return mixed
      */
-    protected function &getArrayElemRefByPath(array &$arr, array $path)
-    {
+    protected function &getArrayElemRefByPath(
+        array &$arr,
+        array $path,
+        bool $create = false
+    ) {
         $result = &$arr;
         foreach ($path as $pathPart) {
-            if (array_key_exists($pathPart, $result)) {
-                $result = &$result[$pathPart];
-            } else {
-                return null;
+            if (!array_key_exists($pathPart, $result)) {
+                if (!$create) {
+                    return null;
+                }
+                $result[$pathPart] = [];
             }
+            $result = &$result[$pathPart];
         }
         return $result;
     }

--- a/module/VuFind/tests/fixtures/configs/yaml/yamlreader-child.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/yamlreader-child.yaml
@@ -1,0 +1,17 @@
+"@parent_yaml": "yamlreader-parent.yaml"
+"@merge_sections":
+  - [Other, Merged]
+
+Overridden:
+  Original: Not so original
+Other:
+  Merged:
+    Baz:
+      - ChildBaz
+    Child:
+      - Foo
+      - Baz
+  NonMerged:
+    Original: Not so original either
+ChildOnly:
+  Child: 'true'

--- a/module/VuFind/tests/fixtures/configs/yaml/yamlreader-child.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/yamlreader-child.yaml
@@ -1,6 +1,7 @@
 "@parent_yaml": "yamlreader-parent.yaml"
 "@merge_sections":
   - [Other, Merged]
+  - [Other, ParentOnly]
 
 Overridden:
   Original: Not so original

--- a/module/VuFind/tests/fixtures/configs/yaml/yamlreader-parent.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/yamlreader-parent.yaml
@@ -10,3 +10,5 @@ Other:
       - Bar
   NonMerged:
     Original: Will not exist
+  ParentOnly:
+    - true

--- a/module/VuFind/tests/fixtures/configs/yaml/yamlreader-parent.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/yamlreader-parent.yaml
@@ -1,0 +1,12 @@
+Overridden:
+  Original: Will not exist
+Other:
+  Merged:
+    Foo:
+      - Foo
+      - Bar
+    Baz:
+      - Bar
+      - Bar
+  NonMerged:
+    Original: Will not exist

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
@@ -167,6 +167,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
                     'NonMerged' => [
                         'Original' => 'Not so original either'
                     ],
+                    'ParentOnly' => [true]
                 ],
                 'ChildOnly' => [
                     'Child' => 'true'


### PR DESCRIPTION
Two commits: first one adds support for passing config file path locator callback to YamlReader for easier unit tests and future work, second one adds the merge support and tests.

All tests are including Mink tests are passing for me.

TODO:
- [x] Document the options in the wiki. Where? We only have a change log entry for the existing `@parent_yaml` directive. [Local Settings Directory](https://vufind.org/wiki/configuration:local_settings_directory) is at least related...