### PR TITLE
Remove duplicate links

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -633,7 +633,7 @@ trait MarcAdvancedTrait
             }
         }
 
-        return array_unique($retVal, SORT_REGULAR);
+        return $retVal;
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -633,7 +633,7 @@ trait MarcAdvancedTrait
             }
         }
 
-        return $retVal;
+        return array_unique($retVal, SORT_REGULAR);
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -668,7 +668,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             return $link;
         };
 
-        return array_unique(array_map($formatLink, $urls), SORT_REGULAR);
+        return array_values(array_unique(array_map($formatLink, $urls), SORT_REGULAR));
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -688,7 +688,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
      * Remove duplicates from the array. All keys and values are being used
      * recursively to compare, so if there are 2 links with the same url
      * but different desc, they will both be preserved.
-     * 
+     *
      * @param array $links array of associative arrays,
      * each containing 'desc' and 'url' keys
      *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -668,8 +668,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             return $link;
         };
 
-        $arr = array_map($formatLink, $urls);
-        return array_values(array_unique($arr, SORT_REGULAR));
+        return $this->deduplicateLinks(array_map($formatLink, $urls));
     }
 
     /**
@@ -683,5 +682,20 @@ class Record extends \Laminas\View\Helper\AbstractHelper
     {
         return isset($this->config->OpenURL->replace_other_urls)
             && $this->config->OpenURL->replace_other_urls;
+    }
+
+    /**
+     * Remove duplicates from the array. All keys and values are being used
+     * recursively to compare, so if there are 2 links with the same url
+     * but different desc, they will both be preserved.
+     * 
+     * @param array $links array of associative arrays,
+     * each containing 'desc' and 'url' keys
+     *
+     * @return array
+     */
+    protected function deduplicateLinks($links)
+    {
+        return array_values(array_unique($links, SORT_REGULAR));
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -668,7 +668,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             return $link;
         };
 
-        return array_map($formatLink, $urls);
+        return array_unique(array_map($formatLink, $urls), SORT_REGULAR);
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -668,7 +668,8 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             return $link;
         };
 
-        return array_values(array_unique(array_map($formatLink, $urls), SORT_REGULAR));
+        $arr = array_map($formatLink, $urls);
+        return array_values(array_unique($arr, SORT_REGULAR));
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -516,7 +516,10 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                     ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
                     ['desc' => 'link 2', 'url' => 'http://foo/baz2'],
                     ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
-                    ['desc' => 'link 3', 'url' => 'http://foo/baz1']
+                    ['desc' => 'link 1 (alternate description)',
+                        'url' => 'http://foo/baz1'],
+                    ['url' => 'http://foo/baz3'],
+                    ['url' => 'http://foo/baz3']
                 ]
             ]
         );
@@ -525,7 +528,9 @@ class RecordTest extends \PHPUnit\Framework\TestCase
             [
                 ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
                 ['desc' => 'link 2', 'url' => 'http://foo/baz2'],
-                ['desc' => 'link 3', 'url' => 'http://foo/baz1']
+                ['desc' => 'link 1 (alternate description)',
+                    'url' => 'http://foo/baz1'],
+                ['desc' => 'http://foo/baz3', 'url' => 'http://foo/baz3']
             ],
             $record->getLinkDetails()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -503,6 +503,35 @@ class RecordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getLinkDetails with duplicate URLs
+     *
+     * @return void
+     */
+    public function testGetLinkDetailsWithDuplicateURLs()
+    {
+        $driver = new \VuFindTest\RecordDriver\TestHarness();
+        $driver->setRawData(
+            [
+                'URLs' => [
+                    ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
+                    ['desc' => 'link 2', 'url' => 'http://foo/baz2'],
+                    ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
+                    ['desc' => 'link 3', 'url' => 'http://foo/baz1']
+                ]
+            ]
+        );
+        $record = $this->getRecord($driver, [], null, 'fake-route', true);
+        $this->assertEquals(
+            [
+                ['desc' => 'link 1', 'url' => 'http://foo/baz1'],
+                ['desc' => 'link 2', 'url' => 'http://foo/baz2'],
+                ['desc' => 'link 3', 'url' => 'http://foo/baz1']
+            ],
+            $record->getLinkDetails()
+        );
+    }
+
+    /**
      * Test getUrlList
      *
      * @return void

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -520,7 +520,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                 ]
             ]
         );
-        $record = $this->getRecord($driver, [], null, 'fake-route', true);
+        $record = $this->getRecord($driver);
         $this->assertEquals(
             [
                 ['desc' => 'link 1', 'url' => 'http://foo/baz1'],


### PR DESCRIPTION
In MarcAdvancedTrait, links are extracted using a number of MARC subfields. There can be some redundancy in the data, especially with FOLIO where both instance records and holding records can have links. This change ensures the displayed links are unique (url, desc) pairs.