### PR TITLE
DbUpgrade fixes

### DIFF
--- a/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
@@ -775,6 +775,22 @@ class DbUpgrade extends AbstractPlugin
     }
 
     /**
+     * Given a current row default, return true if the current nullability matches
+     * the one found in the SQL provided as the $sql parameter. Return false if there
+     * is a mismatch that will require table structure updates.
+     *
+     * @param bool   $currentNullable Current nullability
+     * @param string $sql             SQL to compare against
+     *
+     * @return bool
+     */
+    protected function nullableMatches(bool $currentNullable, string $sql): bool
+    {
+        $expectedNullable = stripos($sql, 'NOT NULL') ? false : true;
+        return $expectedNullable === $currentNullable;
+    }
+
+    /**
      * Given a table column object, return true if the object's type matches the
      * specified $type parameter.  Return false if there is a mismatch that will
      * require table structure updates.
@@ -919,6 +935,10 @@ class DbUpgrade extends AbstractPlugin
                 if (!$this->typeMatches($currentColumn, $expectedTypes[$i])
                     || !$this->defaultMatches(
                         $currentColumn->getColumnDefault(),
+                        $columnDefinitions[$column]
+                    )
+                    || !$this->nullableMatches(
+                        $currentColumn->getIsNullable(),
                         $columnDefinitions[$column]
                     )
                 ) {

--- a/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
@@ -379,6 +379,10 @@ class DbUpgrade extends AbstractPlugin
             case 'UNIQUE':
                 $retVal['unique'][$current->getName()] = $fields;
                 break;
+            case 'CHECK':
+                // We don't get enough information from getConstraints() to handle
+                // CHECK constraints, so just ignore them for now:
+                break;
             default:
                 throw new \Exception(
                     'Unexpected constraint type: ' . $current->getType()

--- a/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
@@ -200,16 +200,18 @@ class DbUpgrade extends AbstractPlugin
             $this->dbCommands[$table][0],
             $matches
         );
-        $expectedTypes = $matches[2];
+        $expectedTypes = array_combine($matches[1], $matches[2]);
 
         // Load details:
         $retVal = [];
-        foreach ($results as $i => $current) {
+        foreach ($results as $current) {
+            // json fields default to utf8mb4_bin, and we only support that:
+            if (($expectedTypes[$current->Field] ?? '') === 'json') {
+                continue;
+            }
             if (!empty($current->Collation)) {
                 $normalizedCollation = strtolower($current->Collation);
-                if ($normalizedCollation !== $collation
-                    && $expectedTypes[$i] !== 'json'
-                ) {
+                if ($normalizedCollation !== $collation) {
                     $retVal[$current->Field] = (array)$current;
                 }
             }


### PR DESCRIPTION
When preparing a database change for PR #2546, I stumbled on several issues that the independent commits here address:

- Nullability was not checked
- MySQL stores json as longtext with a check constraint, and we couldn't handle the discepancy.