### PR TITLE
Rename cookie consent events and add event for initial consent.

### DIFF
--- a/themes/bootstrap3/js/cookie.js
+++ b/themes/bootstrap3/js/cookie.js
@@ -25,7 +25,7 @@ VuFind.register('cookie', function cookie() {
     };
     consentConfig.consentDialog.onChange = function onChange() {
       updateServiceStatus();
-      VuFind.emit('vf-cookie-consent-change');
+      VuFind.emit('vf-cookie-consent-changed');
     };
     CookieConsent.run(consentConfig.consentDialog);
     VuFind.emit('vf-cookie-consent-initialized');

--- a/themes/bootstrap3/js/cookie.js
+++ b/themes/bootstrap3/js/cookie.js
@@ -16,16 +16,19 @@ VuFind.register('cookie', function cookie() {
 
   function setupConsent(_config) {
     consentConfig = _config;
+    consentConfig.consentDialog.onFirstConsent = function onFirstConsent() {
+      VuFind.emit('vf-cookie-consent-first-done');
+    };
     consentConfig.consentDialog.onConsent = function onConsent() {
       updateServiceStatus();
-      VuFind.emit('cookie-consent-done');
+      VuFind.emit('vf-cookie-consent-done');
     };
     consentConfig.consentDialog.onChange = function onChange() {
       updateServiceStatus();
-      VuFind.emit('cookie-consent-change');
+      VuFind.emit('vf-cookie-consent-change');
     };
     CookieConsent.run(consentConfig.consentDialog);
-    VuFind.emit('cookie-consent-initialized');
+    VuFind.emit('vf-cookie-consent-initialized');
   }
 
   function isCategoryAccepted(category) {


### PR DESCRIPTION
I had missed the recommendation in common.js of prefixing events with `vf-`. Also added an event for the initial consent given by user.

I already updated the [wiki](https://vufind.org/wiki/configuration:cookie_consent#javascript_events) in anticipation of this change.