### PR TITLE
Pass full configuration to Holdings view helper.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Holdings.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Holdings.php
@@ -65,8 +65,9 @@ class Holdings extends \Laminas\View\Helper\AbstractHelper
      */
     public function holdingIsVisible(array $holding): bool
     {
+        $catalogConfig = $this->config['Catalog'] ?? [];
         $showEmptyBarcodes
-            = (bool)($this->config['display_items_without_barcodes'] ?? true);
+            = (bool)($catalogConfig['display_items_without_barcodes'] ?? true);
         return $showEmptyBarcodes || strlen($holding['barcode'] ?? '') > 0;
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/HoldingsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HoldingsFactory.php
@@ -63,8 +63,9 @@ class HoldingsFactory implements FactoryInterface
         $requestedName,
         array $options = null
     ) {
-        $full = $container->get(\VuFind\Config\PluginManager::class)->get('config');
-        $config = isset($full->Catalog) ? $full->Catalog->toArray() : [];
-        return new $requestedName($config);
+        return new $requestedName(
+            $container->get(\VuFind\Config\PluginManager::class)->get('config')
+                ->toArray()
+        );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HoldingsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HoldingsTest.php
@@ -70,7 +70,7 @@ class HoldingsTest extends \PHPUnit\Framework\TestCase
         bool $expectedNoBarcodeResult
     ): void {
         // Create a helper object:
-        $helper = new \VuFind\View\Helper\Root\Holdings($config);
+        $helper = new \VuFind\View\Helper\Root\Holdings(['Catalog' => $config]);
         $this->assertEquals(
             $expectedBarcodeResult,
             $helper->holdingIsVisible(['barcode' => '1234'])


### PR DESCRIPTION
This will allow the helper to access other relevant sections without constructor change.