### PR TITLE
Check that there are pick up locations to choose from. 

### DIFF
--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -180,3 +180,6 @@ extraHoldFields = "comments:requestGroup:pickUpLocation:startDate:requiredByDate
 ; 2) "user-selected" to indicate that the user always has to choose the location
 ; 3) a value within the Location IDs returned by getPickUpLocations()
 ;defaultPickUpLocation = ""
+
+; This setting can be used to exclude locations from the pickup location list
+;excludePickupLocations = A:B

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -114,6 +114,14 @@ trait HoldsTrait
         }
         $pickup = $catalog->getPickUpLocations($patron, $pickupDetails);
 
+        // Check that there are pick up locations to choose from if the field is
+        // required:
+        if (in_array('pickUpLocation', $extraHoldFields) && !$pickup) {
+            $this->flashMessenger()
+                ->addErrorMessage('No pickup locations available');
+            return $this->redirectToRecord('#top');
+        }
+
         // Process form submissions if necessary:
         if (null !== $this->params()->fromPost('placeHold')) {
             // If the form contained a pickup location, request group, start date or

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -150,6 +150,14 @@ trait ILLRequestsTrait
         // selected.
         $pickupLocations = $catalog->getPickUpLocations($patron, $gatheredDetails);
 
+        // Check that there are pick up locations to choose from if the field is
+        // required:
+        if (in_array('pickUpLocation', $extraFields) && !$pickupLocations) {
+            $this->flashMessenger()
+                ->addErrorMessage('No pickup locations available');
+            return $this->redirectToRecord('#top');
+        }
+
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->home_library : '';

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -94,6 +94,14 @@ trait StorageRetrievalRequestsTrait
         $extraFields = isset($checkRequests['extraFields'])
             ? explode(":", $checkRequests['extraFields']) : [];
 
+        // Check that there are pick up locations to choose from if the field is
+        // required:
+        if (in_array('pickUpLocation', $extraFields) && !$pickup) {
+            $this->flashMessenger()
+                ->addErrorMessage('No pickup locations available');
+            return $this->redirectToRecord('#top');
+        }
+
         // Process form submissions if necessary:
         if (null !== $this->params()->fromPost('placeStorageRetrievalRequest')) {
             // If we made it this far, we're ready to place the hold;

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -155,6 +155,26 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
     protected $instructors = ["Instructor A", "Instructor B", "Instructor C"];
 
     /**
+     * Item and pick up locations
+     *
+     * @var array
+     */
+    protected $locations = [
+        [
+            'locationID' => 'A',
+            'locationDisplay' => 'Campus A'
+        ],
+        [
+            'locationID' => 'B',
+            'locationDisplay' => 'Campus B'
+        ],
+        [
+            'locationID' => 'C',
+            'locationDisplay' => 'Campus C'
+        ]
+    ];
+
+    /**
      * Default pickup location
      *
      * @var string
@@ -248,7 +268,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
      */
     protected function getFakeLoc($returnText = true)
     {
-        $locations = $this->getPickUpLocations();
+        $locations = $this->locations;
         $loc = rand() % count($locations);
         return $returnText
             ? $locations[$loc]['locationDisplay']
@@ -1386,26 +1406,25 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
     public function getPickUpLocations($patron = false, $holdDetails = null)
     {
         $this->checkIntermittentFailure();
-        $result = [
-            [
-                'locationID' => 'A',
-                'locationDisplay' => 'Campus A'
-            ],
-            [
-                'locationID' => 'B',
-                'locationDisplay' => 'Campus B'
-            ],
-            [
-                'locationID' => 'C',
-                'locationDisplay' => 'Campus C'
-            ]
-        ];
+        $result = $this->locations;
         if (($holdDetails['reqnum'] ?? '') == 1) {
             $result[] = [
                 'locationID' => 'D',
                 'locationDisplay' => 'Campus D'
             ];
         }
+
+        if (isset($this->config['Holds']['excludePickupLocations'])) {
+            $excluded
+                = explode(':', $this->config['Holds']['excludePickupLocations']);
+            $result = array_filter(
+                $result,
+                function ($loc) use ($excluded) {
+                    return !in_array($loc['locationID'], $excluded);
+                }
+            );
+        }
+
         return $result;
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -40,7 +40,7 @@ use Behat\Mink\Element\Element;
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
- * @retry    2
+ * @retry    4
  */
 final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -40,7 +40,7 @@ use Behat\Mink\Element\Element;
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
- * @retry    4
+ * @retry    2
  */
 final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 {
@@ -555,6 +555,50 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test placing a hold with no valid pick up locations
+     *
+     * @retryCallback removeUsername3
+     *
+     * @return void
+     */
+    public function testPlaceHoldWithoutPickUpLocations(): void
+    {
+        $demoConfig = $this->getDemoIniOverrides();
+        $demoConfig['Holds']['excludePickupLocations'] = 'A:B:C:D';
+        $this->changeConfigs(
+            [
+                'config' => $this->getConfigIniOverrides(),
+                'Demo' => $demoConfig,
+            ]
+        );
+
+        // Create account and log in the user on the record page:
+        $page = $this->gotoRecordById();
+        $element = $this->findCss($page, '.alert.alert-info a');
+        $this->assertEquals('Login for hold and recall information', $element->getText());
+        $element->click();
+        $this->clickCss($page, '.modal-body .createAccountLink');
+        $this->fillInAccountForm(
+            $page,
+            [
+                'username' => 'username3',
+                'email' => "username3@ignore.com"
+            ]
+        );
+        $this->clickCss($page, 'input.btn.btn-primary');
+        $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
+
+        // Open the "place hold" dialog and check for error message:
+        $this->waitForPageLoad($page);
+        $this->clickCss($page, 'a.placehold');
+        $this->waitForPageLoad($page);
+        $this->assertEquals(
+            'No pickup locations available',
+            $this->findCss($page, '.alert.alert-danger')->getText()
+        );
+    }
+
+    /**
      * Retry cleanup method in case of failure during testHoldsAll.
      *
      * @return void
@@ -565,12 +609,23 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Retry cleanup method in case of failure during
+     * testPlaceHoldWithoutPickUpLocations.
+     *
+     * @return void
+     */
+    protected function removeUsername3(): void
+    {
+        static::removeUsers(['username3']);
+    }
+
+    /**
      * Standard teardown method.
      *
      * @return void
      */
     public static function tearDownAfterClass(): void
     {
-        static::removeUsers(['username1', 'username2']);
+        static::removeUsers(['username1', 'username2', 'username3']);
     }
 }


### PR DESCRIPTION
When placing a hold it doesn't make sense to let the user to the hold form if we know that a pick up location is needed but there are none available. Otherwise the request will fail when the user tries to place with a confusing error message "An invalid pick up location was entered. Please try again" when the user never even saw the field.