### PR TITLE
Upgrade to Solr 8.11.2.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,7 +31,7 @@
   <property name="snooze_multiplier" value="1" /><!-- can be used to slow down tests (selenium only) -->
   <property name="solr_startup_sleep" value="0" />
   <property name="solr_additional_jvm_options" value="-Dlog4j2.formatMsgNoLookups=true" />
-  <property name="solr_version" value="8.11.1" />
+  <property name="solr_version" value="8.11.2" />
   <property name="skip_phpdoc" value="false" />
   <property name="phpdoc_version" value="3.0.0" />
 

--- a/solr/vufind/authority/conf/solrconfig.xml
+++ b/solr/vufind/authority/conf/solrconfig.xml
@@ -32,7 +32,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
     -->
-  <luceneMatchVersion>8.11.1</luceneMatchVersion>
+  <luceneMatchVersion>8.11.2</luceneMatchVersion>
 
   <!-- Use the classic schema style by default for VuFind -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -32,7 +32,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
     -->
-  <luceneMatchVersion>8.11.1</luceneMatchVersion>
+  <luceneMatchVersion>8.11.2</luceneMatchVersion>
 
   <!-- Use the classic schema style by default for VuFind -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/vufind/reserves/conf/solrconfig.xml
+++ b/solr/vufind/reserves/conf/solrconfig.xml
@@ -32,7 +32,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
     -->
-  <luceneMatchVersion>8.11.1</luceneMatchVersion>
+  <luceneMatchVersion>8.11.2</luceneMatchVersion>
 
   <!-- Use the classic schema style by default for VuFind -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/vufind/website/conf/solrconfig.xml
+++ b/solr/vufind/website/conf/solrconfig.xml
@@ -32,7 +32,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
     -->
-  <luceneMatchVersion>8.11.1</luceneMatchVersion>
+  <luceneMatchVersion>8.11.2</luceneMatchVersion>
 
   <!-- Use the classic schema style by default for VuFind -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>


### PR DESCRIPTION
This minor Solr upgrade is being targeted against the release-8.1 branch so we can release it as part of VuFind 8.1.2, which will make it easy for people to upgrade to a version with the latest log4j jars built in.

Once this is tested and merged, I will also merge it to dev and then start a new PR to begin testing Solr 9.

TODO
- [x] Run full test suite