### PR TITLE
Solr 8 deprecation cleanup

### DIFF
--- a/solr/vufind/authority/conf/solrconfig.xml
+++ b/solr/vufind/authority/conf/solrconfig.xml
@@ -89,20 +89,6 @@
 
   </indexConfig>
 
-  <!--	Enables JMX if and only if an existing MBeanServer is found, use
-  		this if you want to configure JMX through JVM parameters. Remove
-  		this to disable exposing Solr configuration and statistics to JMX.
-
-		If you want to connect to a particular server, specify the agentId
-		e.g. <jmx agentId="myAgent" />
-
-		If you want to start a new MBeanServer, specify the serviceUrl
-		e.g <jmx serviceurl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr" />
-
-		For more details see http://wiki.apache.org/solr/SolrJmx
-  -->
-  <jmx />
-
   <!-- the default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 

--- a/solr/vufind/authority/conf/solrconfig.xml
+++ b/solr/vufind/authority/conf/solrconfig.xml
@@ -249,12 +249,6 @@
          queryResultCache. -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <!-- This entry enables an int hash representation for filters (DocSets)
-         when the number of items in the set is less than maxSize.  For smaller
-         sets, this representation is more memory efficient, more efficient to
-         iterate over, and faster to take intersections.  -->
-    <HashDocSet maxSize="3000" loadFactor="0.75"/>
-
     <!-- a newSearcher event is fired whenever a new searcher is being prepared
          and there is a current searcher handling requests (aka registered). -->
     <!-- QuerySenderListener takes an array of NamedList and executes a

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -252,12 +252,6 @@
          queryResultCache. -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <!-- This entry enables an int hash representation for filters (DocSets)
-         when the number of items in the set is less than maxSize.  For smaller
-         sets, this representation is more memory efficient, more efficient to
-         iterate over, and faster to take intersections.  -->
-    <HashDocSet maxSize="3000" loadFactor="0.75"/>
-
     <!-- a newSearcher event is fired whenever a new searcher is being prepared
          and there is a current searcher handling requests (aka registered). -->
     <!-- QuerySenderListener takes an array of NamedList and executes a

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -92,20 +92,6 @@
 
   </indexConfig>
 
-  <!--  Enables JMX if and only if an existing MBeanServer is found, use
-        this if you want to configure JMX through JVM parameters. Remove
-        this to disable exposing Solr configuration and statistics to JMX.
-
-        If you want to connect to a particular server, specify the agentId
-        e.g. <jmx agentId="myAgent" />
-
-        If you want to start a new MBeanServer, specify the serviceUrl
-        e.g <jmx serviceurl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr" />
-
-        For more details see http://wiki.apache.org/solr/SolrJmx
-  -->
-  <jmx />
-
   <!-- the default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 

--- a/solr/vufind/reserves/conf/solrconfig.xml
+++ b/solr/vufind/reserves/conf/solrconfig.xml
@@ -89,20 +89,6 @@
 
   </indexConfig>
 
-  <!--	Enables JMX if and only if an existing MBeanServer is found, use
-  		this if you want to configure JMX through JVM parameters. Remove
-  		this to disable exposing Solr configuration and statistics to JMX.
-
-		If you want to connect to a particular server, specify the agentId
-		e.g. <jmx agentId="myAgent" />
-
-		If you want to start a new MBeanServer, specify the serviceUrl
-		e.g <jmx serviceurl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr" />
-
-		For more details see http://wiki.apache.org/solr/SolrJmx
-  -->
-  <jmx />
-
   <!-- the default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 

--- a/solr/vufind/reserves/conf/solrconfig.xml
+++ b/solr/vufind/reserves/conf/solrconfig.xml
@@ -249,12 +249,6 @@
          queryResultCache. -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <!-- This entry enables an int hash representation for filters (DocSets)
-         when the number of items in the set is less than maxSize.  For smaller
-         sets, this representation is more memory efficient, more efficient to
-         iterate over, and faster to take intersections.  -->
-    <HashDocSet maxSize="3000" loadFactor="0.75"/>
-
     <!-- a newSearcher event is fired whenever a new searcher is being prepared
          and there is a current searcher handling requests (aka registered). -->
     <!-- QuerySenderListener takes an array of NamedList and executes a

--- a/solr/vufind/website/conf/solrconfig.xml
+++ b/solr/vufind/website/conf/solrconfig.xml
@@ -89,20 +89,6 @@
 
   </indexConfig>
 
-  <!--  Enables JMX if and only if an existing MBeanServer is found, use
-        this if you want to configure JMX through JVM parameters. Remove
-        this to disable exposing Solr configuration and statistics to JMX.
-
-        If you want to connect to a particular server, specify the agentId
-        e.g. <jmx agentId="myAgent" />
-
-        If you want to start a new MBeanServer, specify the serviceUrl
-        e.g <jmx serviceurl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr" />
-
-        For more details see http://wiki.apache.org/solr/SolrJmx
-  -->
-  <jmx />
-
   <!-- the default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 

--- a/solr/vufind/website/conf/solrconfig.xml
+++ b/solr/vufind/website/conf/solrconfig.xml
@@ -249,12 +249,6 @@
          queryResultCache. -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <!-- This entry enables an int hash representation for filters (DocSets)
-         when the number of items in the set is less than maxSize.  For smaller
-         sets, this representation is more memory efficient, more efficient to
-         iterate over, and faster to take intersections.  -->
-    <HashDocSet maxSize="3000" loadFactor="0.75"/>
-
     <!-- a newSearcher event is fired whenever a new searcher is being prepared
          and there is a current searcher handling requests (aka registered). -->
     <!-- QuerySenderListener takes an array of NamedList and executes a


### PR DESCRIPTION
This PR removes settings from solrconfig.xml that have been deprecated as of Solr 8.

HashDocSet has apparently been meaningless since Solr 1.4 more than a decade ago (see [SolrPerformanceFactors documentation](https://cwiki.apache.org/confluence/display/SOLR/SolrPerformanceFactors#SolrPerformanceFactors-MaxSizeConsiderations)), so I don't anticipate that removing it will have any impact.

The `<jmx />` setting has been replaced by `<metrics><reporter /></metrics>`, but I think it's probably best to omit this by default and let people set up reporting locally as needed.

I'm targeting this PR on the release-8.1 branch because this seems like an opportunity to eliminate warning messages in people's logs without hurting anything... but if anyone thinks that the jmx change is potentially "breaking" I can just re-target this to dev and we can wait a little longer to get it out in an official release.

TODO:
- [x] Run full test suite
- [x] Close [VUFIND-1571](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1571) when merging