### PR TITLE
Always pass a string to Bcrypt verify method.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Database.php
+++ b/module/VuFind/src/VuFind/Auth/Database.php
@@ -284,7 +284,7 @@ class Database extends AbstractBase
             }
 
             $bcrypt = new Bcrypt();
-            return $bcrypt->verify($password, $userRow->pass_hash);
+            return $bcrypt->verify($password, $userRow->pass_hash ?? '');
         }
 
         // Default case: unencrypted passwords:


### PR DESCRIPTION
Fixes a PHP 8.1 deprecation warning and wrong error message (authentication_error_technical instead of authentication_error_invalid) if user's password hash is null. 