### PR TITLE
Remove invalid attribute from cookie settings links.

### DIFF
--- a/themes/bootstrap3/templates/content/privacy.phtml
+++ b/themes/bootstrap3/templates/content/privacy.phtml
@@ -19,6 +19,6 @@
     <p>You have not yet given consent.</p>
   <?php endif; ?>
   <p>
-    <a href="#" type="button" data-cc="show-preferencesModal" aria-haspopup="dialog"><?=$this->transEsc('Cookie Settings')?></a>
+    <a href="#" data-cc="show-preferencesModal" aria-haspopup="dialog"><?=$this->transEsc('Cookie Settings')?></a>
   </p>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/footer.phtml
+++ b/themes/bootstrap3/templates/footer.phtml
@@ -29,7 +29,7 @@
           <li><a href="<?=$this->url('content-page', ['page' => 'asklibrary']) ?>"><?=$this->transEsc('Ask a Librarian')?></a></li>
           <li><a href="<?=$this->url('content-page', ['page' => 'faq']) ?>"><?=$this->transEsc('FAQs')?></a></li>
           <?php if ($this->cookieConsent()->isEnabled()): ?>
-            <li><a href="#" type="button" data-cc="show-preferencesModal" aria-haspopup="dialog"><?=$this->transEsc('Cookie Settings')?></a></li>
+            <li><a href="#" data-cc="show-preferencesModal" aria-haspopup="dialog"><?=$this->transEsc('Cookie Settings')?></a></li>
           <?php endif; ?>
         </ul>
       <?=$this->slot('footer-right')->end(); ?>


### PR DESCRIPTION
I must have accidentally left the type attribute there when changing a button to a link. 