### PR TITLE
End session if the user of the session cannot be found.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -496,13 +496,17 @@ class Manager implements \LmcRbacMvc\Identity\IdentityProviderInterface,
                     ->select(['id' => $this->session->userId]);
                 $this->currentUser = count($results) < 1
                     ? false : $results->current();
+                // End the session since the logged-in user cannot be found:
+                if (false === $this->currentUser) {
+                    $this->logout('');
+                }
             } elseif (isset($this->session->userDetails)) {
                 // privacy mode
                 $results = $this->userTable->createRow();
                 $results->exchangeArray($this->session->userDetails);
                 $this->currentUser = $results;
             } else {
-                // unexpected state
+                // not logged in
                 $this->currentUser = false;
             }
         }


### PR DESCRIPTION
If we cannot find the user, we need to ensure that any session containers with anything related to the session state are cleared, and I believe the easiest and most appropriate action is to end the session. Otherwise logging out is not possible and there could be e.g. ChoiceAuth state information in the session making it impossible to log in again.