### PR TITLE
Fix password reset when using ChoiceAuth.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -2006,6 +2006,8 @@ class MyResearchController extends AbstractBase
         if (!$this->formWasSubmitted('submit')) {
             return $this->redirect()->toRoute('home');
         }
+        // Set up authentication so that we can retrieve the correct password policy:
+        $this->setUpAuthenticationFromRequest();
         // Pull in from POST
         $request = $this->getRequest();
         $post = $request->getPost();
@@ -2015,12 +2017,10 @@ class MyResearchController extends AbstractBase
             : false;
         // View, password policy and Captcha
         $view = $this->createViewModel($post);
-        $view->passwordPolicy = $this->getAuthManager()
-            ->getPasswordPolicy();
+        $view->passwordPolicy = $this->getAuthManager()->getPasswordPolicy();
         $view->useCaptcha = $this->captcha()->active('changePassword');
         // Check Captcha
         if (!$this->formWasSubmitted('submit', $view->useCaptcha)) {
-            $this->setUpAuthenticationFromRequest();
             return $this->resetNewPasswordForm($userFromHash, $view);
         }
         // Missing or invalid hash


### PR DESCRIPTION
`setUpAuthenticationFromRequest()` needs to be called before `$this->getAuthManager()->getPasswordPolicy()`. Otherwise ChoiceAuth state is invalid and it returns false instead of correct information.