### PR TITLE
Fix admin panel tags menu template PHP 8.1 deprecation notice

### DIFF
--- a/themes/bootstrap3/templates/admin/tags/menu.phtml
+++ b/themes/bootstrap3/templates/admin/tags/menu.phtml
@@ -1,6 +1,6 @@
 <div class="nav navbar">
   <ul class="nav nav-pills">
-    <li<?=strtolower($this->active) == "list" ? ' class="active"' : ''?>><a href="<?=$this->url('admin/tags', ['action' => 'List'])?>"><?=$this->transEsc('List Tags')?></a></li>
-    <li<?=strtolower($this->active) == "manage" ? ' class="active"' : ''?>><a href="<?=$this->url('admin/tags', ['action' => 'Manage'])?>"><?=$this->transEsc('Manage Tags')?></a></li>
+    <li<?=strtolower($this->active ?? '') == "list" ? ' class="active"' : ''?>><a href="<?=$this->url('admin/tags', ['action' => 'List'])?>"><?=$this->transEsc('List Tags')?></a></li>
+    <li<?=strtolower($this->active ?? '') == "manage" ? ' class="active"' : ''?>><a href="<?=$this->url('admin/tags', ['action' => 'Manage'])?>"><?=$this->transEsc('Manage Tags')?></a></li>
   </ul>
 </div>


### PR DESCRIPTION
Just a quick fix for something I noticed testing the Doctrine PR on PHP 8.1.