### PR TITLE
PHPUnit: convert deprecations to exceptions.

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">../src/VuFind</directory>

--- a/module/VuFindAdmin/tests/unit-tests/.phpunit.result.cache
+++ b/module/VuFindAdmin/tests/unit-tests/.phpunit.result.cache
@@ -1,1 +1,0 @@
-{"version":1,"defects":[],"times":{"VuFindTest\\Controller\\SocialstatsControllerTest::testHome":0.064}}

--- a/module/VuFindAdmin/tests/unit-tests/.phpunit.result.cache
+++ b/module/VuFindAdmin/tests/unit-tests/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":{"VuFindTest\\Controller\\SocialstatsControllerTest::testHome":0.064}}

--- a/module/VuFindAdmin/tests/unit-tests/phpunit.xml
+++ b/module/VuFindAdmin/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindAdmin">
       <directory>src</directory>

--- a/module/VuFindApi/tests/unit-tests/phpunit.xml
+++ b/module/VuFindApi/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindApi">
       <directory>src</directory>

--- a/module/VuFindConsole/tests/unit-tests/phpunit.xml
+++ b/module/VuFindConsole/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindConsole">
       <directory>src</directory>

--- a/module/VuFindDevTools/tests/unit-tests/phpunit.xml
+++ b/module/VuFindDevTools/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindDevTools">
       <directory>src</directory>

--- a/module/VuFindSearch/tests/unit-tests/phpunit.xml
+++ b/module/VuFindSearch/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindSearch">
       <directory>src</directory>

--- a/module/VuFindTheme/tests/unit-tests/phpunit.xml
+++ b/module/VuFindTheme/tests/unit-tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../../../VuFind/tests/bootstrap.php">
+<phpunit bootstrap="../../../VuFind/tests/bootstrap.php" convertDeprecationsToExceptions="true">
   <testsuites>
     <testsuite name="VuFindTheme">
       <directory>src</directory>


### PR DESCRIPTION
Newer versions of PHPUnit no longer automatically fail tests that emit deprecation warnings. This PR turns on converting deprecations to exceptions, as this makes it much easier to identify and troubleshoot these types of problems. I discovered this while working on a deprecation issue in #2600.