### PR TITLE
Display deprecations in CI, but don't fail VuFind module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: intl, xsl
           tools: composer:2.1.6
+          ini-values: error_reporting=E_ALL
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" convertDeprecationsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">../src/VuFind</directory>


### PR DESCRIPTION
We have some known deprecation warnings in third-party libraries, so we need to allow them for the time being.