### PR TITLE
Prevent duplicate bib_id values in Solr for course reserves

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
@@ -159,7 +159,9 @@ class IndexReservesCommand extends AbstractSolrAndIlsCommand
                     'department' => $departments[$departmentId] ?? ''
                 ];
             }
-            $index[$id]['bib_id'][] = $record['BIB_ID'];
+            if (!in_array($record['BIB_ID'], $index[$id]['bib_id'])) {
+                $index[$id]['bib_id'][] = $record['BIB_ID'];
+            }
         }
 
         $updates = new UpdateDocument();


### PR DESCRIPTION
Currently, when a course has several items in the same instance in FOLIO, the number of items returned for a search does not match the number of returned instances when the user clicks on a course. This is because of duplicate values for bib_id in Solr (one for each item instead of one for each instance). This fix prevents the duplicates, which fixes the issue with the number of items.