### PR TITLE
Folio: optimized course reserve lookup

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1463,16 +1463,17 @@ class Folio extends AbstractAPI implements
     public function findReserves($course, $inst, $dept)
     {
         $retVal = [];
+        $idType = $this->getBibIdType();
 
         // Results can be paginated, so let's loop until we've gotten everything:
         foreach ($this->getPagedResults(
             'reserves',
             '/coursereserves/reserves'
         ) as $item) {
-            try {
-                $bibId = $this->getBibId(null, null, $item->itemId);
-            } catch (\Exception $e) {
-                $bibId = null;
+            if ($idType == 'hrid') {
+                $bibId = $item->copiedItem->instanceHrid ?? null;
+            } else {
+                $bibId = $item->copiedItem->instanceId ?? null;
             }
             if ($bibId !== null) {
                 $courseData = $this->getCourseDetails(


### PR DESCRIPTION
Currently the Folio driver is slow to find reserve information in findReserves(). This is mostly because for each reserve item, it looks for the item, the holdings and the instance in Folio. This is not necessary because we can use the returned copiedItem.instanceId or copiedItem.instanceHrid, depending on getBibIdType().
After this optimization, indexing the course reserves takes a third of the time it took before.