### PR TITLE
Increase flexibility in batch import marc script extension matching

### DIFF
--- a/harvest/batch-import-marc-auth.bat
+++ b/harvest/batch-import-marc-auth.bat
@@ -102,7 +102,7 @@ md %BASEPATH%\processed
 :processedfound
 
 rem Process all the files in the target directory:
-for %%a in (%BASEPATH%\*.xml %BASEPATH%\*.mrc) do (
+for %%a in (%BASEPATH%\*.xml %BASEPATH%\*.mrc %BASEPATH%\*.marc) do (
   call :run_command %%a %BASEPATH%\log\%%~nxa.log
   if not errorlevel 1 (
     if "%MOVE_DATA%"=="1" (

--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -113,15 +113,13 @@ else
 fi
 
 # Process all the files in the target directory:
-for file in $BASEPATH/*.xml $BASEPATH/*.mrc
+find $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | \
+  while read -d $'\0' file
 do
-  if [ -f $file ]
+  # Logging output handled by log() function
+  $VUFIND_HOME/import-marc-auth.sh $file $2 2> >(log $file)
+  if [ "$?" -eq "0" ] && [ $MOVE_DATA == true ]
   then
-    # Logging output handled by log() function
-    $VUFIND_HOME/import-marc-auth.sh $file $2 2> >(log $file)
-    if [ "$?" -eq "0" ] && [ $MOVE_DATA == true ]
-    then
-      mv $file $BASEPATH/processed/`basename $file`
-    fi
+    mv $file $BASEPATH/processed/`basename $file`
   fi
 done

--- a/harvest/batch-import-marc.bat
+++ b/harvest/batch-import-marc.bat
@@ -109,7 +109,7 @@ md %BASEPATH%\processed
 :processedfound
 
 rem Process all the files in the target directory:
-for %%a in (%BASEPATH%\*.xml %BASEPATH%\*.mrc) do (
+for %%a in (%BASEPATH%\*.xml %BASEPATH%\*.mrc %BASEPATH%\*.marc) do (
   call :run_command %%a %BASEPATH%\log\%%~nxa.log
   if not errorlevel 1 (
     if "%MOVE_DATA%"=="1" (

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -115,16 +115,14 @@ else
 fi
 
 # Process all the files in the target directory:
-for file in $BASEPATH/*.xml $BASEPATH/*.mrc
+find $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | \
+  while read -d $'\0' file
 do
-  if [ -f $file ]
+  # Logging output handled by log() function
+  # PROPERTIES_FILE passed via environment
+  $VUFIND_HOME/import-marc.sh $file 2> >(log $file)
+  if [ "$?" -eq "0" ] && [ $MOVE_DATA == true ]
   then
-    # Logging output handled by log() function
-    # PROPERTIES_FILE passed via environment
-    $VUFIND_HOME/import-marc.sh $file 2> >(log $file)
-    if [ "$?" -eq "0" ] && [ $MOVE_DATA == true ]
-    then
-      mv $file $BASEPATH/processed/`basename $file`
-    fi
+    mv $file $BASEPATH/processed/`basename $file`
   fi
 done


### PR DESCRIPTION
Currently the batch import marc scripts match files ending in .xml and .mrc. This update includes the additional common MARC extension, .marc, as well as adding in case-insensitive matching on the extension. So for example, now .XML and .MARC will now both be included and processed by the import scripts.

In the windows .bat scripts, the additional extension was added, but was not tested since I am not on a Windows environment. Those scripts should already include case-insensitive matching.

For context, we (The Michigan State University Libraries) are receiving MARC files from EBSCO with the .marc extension and authority files we receive from Backstage have a .MRC extension. So we thought it would be simpler to make the import script more flexible rather than rename the files every time we receive them from both places.