### PR TITLE
Set TranslatableString::displayString default value as an empty string

### DIFF
--- a/module/VuFind/src/VuFind/I18n/TranslatableString.php
+++ b/module/VuFind/src/VuFind/I18n/TranslatableString.php
@@ -50,10 +50,12 @@ class TranslatableString implements TranslatableStringInterface
      *
      * @var string
      */
-    protected $displayString;
+    protected $displayString = '';
 
     /**
      * Whether translation is allowed
+     *
+     * @var bool
      */
     protected $translatable;
 

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -214,7 +214,7 @@ trait TranslatorAwareTrait
      */
     protected function extractTextDomain($target)
     {
-        $parts = is_array($target) ? $target : explode('::', $target ?? [], 2);
+        $parts = is_array($target) ? $target : explode('::', $target, 2);
         if (count($parts) < 1 || count($parts) > 2) {
             throw new \Exception('Unexpected value sent to translator!');
         }

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -214,7 +214,7 @@ trait TranslatorAwareTrait
      */
     protected function extractTextDomain($target)
     {
-        $parts = is_array($target) ? $target : explode('::', $target, 2);
+        $parts = is_array($target) ? $target : explode('::', $target ?? [], 2);
         if (count($parts) < 1 || count($parts) > 2) {
             throw new \Exception('Unexpected value sent to translator!');
         }


### PR DESCRIPTION
Using null in php 8.1 gives dep notice when passed into explode.