### PR TITLE
CookieConsent: Do not pass null description into translate function

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
@@ -410,7 +410,7 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper
                 $section['cookieTable']['body'][] = [
                     'name' => $name,
                     'domain' => $cookie['Domain'],
-                    'desc' => $this->translate($cookie['Description']),
+                    'desc' => $this->translate($cookie['Description'] ?? ''),
                     'exp' => $expiration
                 ];
             }


### PR DESCRIPTION
@demiankatz this was the real culprit it seems.