### PR TITLE
Clarify solrmarc.path in SolrMarc's import.properties

### DIFF
--- a/import/import.properties
+++ b/import/import.properties
@@ -8,8 +8,11 @@ solr.core.name = biblio
 solr.indexer.properties = marc.properties, marc_local.properties
 solr.hosturl = http://localhost:8983/solr/biblio/update
 
-# where to look for properties files, translation maps, and custom scripts
-# note that . refers to the directory where the jarfile for SolrMarc is located.
+# Where to look for properties files, translation maps, and custom scripts.
+# Note that . refers to the directory where the jarfile for SolrMarc is located.
+# You can use a pipe (|) character to create a multi-directory search path.
+# You can use install.php to automatically create and configure your local
+# override of this file for common use cases.
 solrmarc.path = /usr/local/vufind/import
 
 # Path to your marc file

--- a/import/import_auth.properties
+++ b/import/import_auth.properties
@@ -8,8 +8,11 @@ solr.core.name = authority
 solr.indexer.properties = marc_auth.properties
 solr.hosturl = http://localhost:8983/solr/authority/update
 
-# where to look for properties files, translation maps, and custom scripts
-# note that . refers to the directory where the jarfile for SolrMarc is located.
+# Where to look for properties files, translation maps, and custom scripts.
+# Note that . refers to the directory where the jarfile for SolrMarc is located.
+# You can use a pipe (|) character to create a multi-directory search path.
+# You can use install.php to automatically create and configure your local
+# override of this file for common use cases.
 solrmarc.path = /usr/local/vufind/import
 
 # Path to your marc file


### PR DESCRIPTION
Addresses issue when a user copies `import/import.properties` to `local/import/import.properties` but does not modify `solrmarc.path` variable (there is no indication to the user that they ought to do this, and would otherwise be easy to miss). This results in solrmarc failing to read in overrides from `local/import/marc_local.properties` _unless_ the original `import/marc_local.properties` file is first removed.

Commenting out the default solrmarc.path from `import/import.properties` prevents this unexpected behavior. In testing this change, solrmarc still successfully loads the default `import/marc.properties` and `import/marc_local.properties` with that line now commented. Users are still free to uncomment the line and set the value if needed.