### PR TITLE
Include DOI link icon in the anchor.

### DIFF
--- a/themes/bootstrap3/js/doi.js
+++ b/themes/bootstrap3/js/doi.js
@@ -38,9 +38,9 @@ VuFind.register('doi', function Doi() {
                 var icon = $('<img />');
                 icon.attr('src', response.data[currentDoi][i].icon);
                 icon.attr('class', 'doi-icon');
-                $(doiEl).append(icon);
+                newLink.prepend(icon);
               } else if (typeof response.data[currentDoi][i].localIcon !== 'undefined') {
-                $(doiEl).append(response.data[currentDoi][i].localIcon);
+                newLink.prepend(response.data[currentDoi][i].localIcon);
               }
               $(doiEl).append(newLink);
               $(doiEl).append("<br />");


### PR DESCRIPTION
I believe the icon should be part of the link. We're currently quite inconsistent [1] with that, but the results view type links can be used as an example. It causes the unsightly underlining issue, but still better for usability and the icon getting the link color.

[1] e.g. `Show QR Code` and `Save to List` don't include the icon, while `Add to Book Bag` does.