### PR TITLE
Fix setting of language cookie.

### DIFF
--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorCookieStrategy.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorCookieStrategy.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Locale Detector Strategy for language cookie
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2022.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  I18n\Locale
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace VuFind\I18n\Locale;
+
+use SlmLocale\LocaleEvent;
+use SlmLocale\Strategy\CookieStrategy;
+
+/**
+ * Locale Detector Strategy for language cookie
+ *
+ * @category VuFind
+ * @package  I18n\Locale
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class LocaleDetectorCookieStrategy extends CookieStrategy
+{
+    /**
+     * Event handler for the 'found' event
+     *
+     * @param LocaleEvent $event Event
+     *
+     * @return void
+     */
+    public function found(LocaleEvent $event) {
+        // Setting a cookie is handled separately, so we don't need to do anything
+        // here (see LocaleDetectorFactory).
+    }
+}

--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorCookieStrategy.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorCookieStrategy.php
@@ -48,7 +48,8 @@ class LocaleDetectorCookieStrategy extends CookieStrategy
      *
      * @return void
      */
-    public function found(LocaleEvent $event) {
+    public function found(LocaleEvent $event)
+    {
         // Setting a cookie is handled separately, so we don't need to do anything
         // here (see LocaleDetectorFactory).
     }

--- a/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Locale/LocaleDetectorFactory.php
@@ -36,7 +36,6 @@ use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use SlmLocale\LocaleEvent;
-use SlmLocale\Strategy\CookieStrategy;
 use SlmLocale\Strategy\QueryStrategy;
 use VuFind\Cookie\CookieManager;
 
@@ -87,7 +86,10 @@ class LocaleDetectorFactory implements DelegatorFactoryInterface
         $detector->getEventManager()->attach(
             LocaleEvent::EVENT_FOUND,
             function (EventInterface $event) use ($cookies) {
-                $cookies->set('language', $event->getParam('locale'));
+                $language = $event->getParam('locale');
+                if ($language !== $cookies->get('language')) {
+                    $cookies->set('language', $language);
+                }
             }
         );
 
@@ -109,7 +111,7 @@ class LocaleDetectorFactory implements DelegatorFactoryInterface
         $queryStrategy->setOptions(['query_key' => 'lng']);
         yield $queryStrategy;
 
-        $cookieStrategy = new CookieStrategy();
+        $cookieStrategy = new LocaleDetectorCookieStrategy();
         $cookieStrategy->setCookieName('language');
         yield $cookieStrategy;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleDetectorFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleDetectorFactoryTest.php
@@ -27,9 +27,9 @@
  */
 namespace VuFindTest\I18n\Locale;
 
-use SlmLocale\Strategy\CookieStrategy;
 use SlmLocale\Strategy\HttpAcceptLanguageStrategy;
 use SlmLocale\Strategy\QueryStrategy;
+use VuFind\I18n\Locale\LocaleDetectorCookieStrategy;
 use VuFind\I18n\Locale\LocaleDetectorFactory;
 use VuFind\I18n\Locale\LocaleDetectorParamStrategy;
 use VuFind\I18n\Locale\LocaleSettings;
@@ -73,7 +73,7 @@ class LocaleDetectorFactoryTest extends \PHPUnit\Framework\TestCase
             [
                 LocaleDetectorParamStrategy::class,
                 QueryStrategy::class,
-                CookieStrategy::class,
+                LocaleDetectorCookieStrategy::class,
                 HttpAcceptLanguageStrategy::class
             ],
             $this->getStrategyClasses()
@@ -96,7 +96,7 @@ class LocaleDetectorFactoryTest extends \PHPUnit\Framework\TestCase
             [
                 LocaleDetectorParamStrategy::class,
                 QueryStrategy::class,
-                CookieStrategy::class,
+                LocaleDetectorCookieStrategy::class,
                 HttpAcceptLanguageStrategy::class
             ],
             $this->getStrategyClasses($mockSettings)
@@ -120,7 +120,7 @@ class LocaleDetectorFactoryTest extends \PHPUnit\Framework\TestCase
             [
                 LocaleDetectorParamStrategy::class,
                 QueryStrategy::class,
-                CookieStrategy::class,
+                LocaleDetectorCookieStrategy::class,
             ],
             $this->getStrategyClasses($mockSettings)
         );


### PR DESCRIPTION
- Overrides the cookie strategy to avoid it setting a cookie with wrong parameters.
- Only sets the language cookie if it doesn't already exist or match the detected language.