### PR TITLE
Improve normalization of parentheses for Solr queries.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -282,7 +282,6 @@ class LuceneSyntaxHelper
     public function extractSearchTerms($query)
     {
         $result = [];
-        $inQuotes = false;
         $collected = '';
         $discardParens = 0;
         // Discard local parameters
@@ -290,37 +289,39 @@ class LuceneSyntaxHelper
         // Discard fuzziness and proximity indicators
         $query = preg_replace('/\~[^\s]*/', '', $query);
         $query = preg_replace('/\^[^\s]*/', '', $query);
-        $lastCh = '';
-        foreach (str_split($query) as $ch) {
-            // Handle quotes (everything in quotes is considered part of search
-            // terms)
-            if ($ch == '"' && $lastCh != '\\') {
-                $inQuotes = !$inQuotes;
-            }
-            if (!$inQuotes) {
-                // Discard closing parenthesis for previously discarded opening ones
-                // to keep balance
-                if ($ch == ')' && $discardParens > 0) {
-                    --$discardParens;
-                    continue;
+
+        $this->processQueryString(
+            function (
+                string $ch,
+                bool $quoted,
+                bool $esc
+            ) use (&$result, &$collected, &$discardParens) {
+                if (!$quoted) {
+                    // Discard closing parenthesis for previously discarded opening
+                    // ones to keep balance
+                    if (!$esc && ')' === $ch && $discardParens > 0) {
+                        --$discardParens;
+                        return;
+                    }
+                    // Flush to result array on word break
+                    if ($ch == ' ' && $collected !== '') {
+                        $result[] = $collected;
+                        $collected = '';
+                        return;
+                    }
+                    // If we encounter ':', discard preceding string as it's a field
+                    // name
+                    if (!$esc && $ch == ':') {
+                        // Take into account any opening parenthesis we discard here
+                        $discardParens += $this->countNonQuoted('(', $collected);
+                        $collected = '';
+                        return;
+                    }
                 }
-                // Flush to result array on word break
-                if ($ch == ' ' && $collected !== '') {
-                    $result[] = $collected;
-                    $collected = '';
-                    continue;
-                }
-                // If we encounter ':', discard preceding string as it's a field name
-                if ($ch == ':') {
-                    // Take into account any opening parenthesis we discard here
-                    $discardParens += substr_count($collected, '(');
-                    $collected = '';
-                    continue;
-                }
-            }
-            $collected .= $ch;
-            $lastCh = $ch;
-        }
+                $collected .= $ch;
+            },
+            $query
+        );
         // Flush final collected string
         if ($collected !== '') {
             $result[] = $collected;
@@ -669,7 +670,7 @@ class LuceneSyntaxHelper
     /**
      * Count occurrences of a character in non-quoted parts of the string
      *
-     * @param string $needle   Character to look for
+     * @param string $needle   Character to look for (non-escaped)
      * @param string $haystack String to process
      *
      * @return int
@@ -677,30 +678,22 @@ class LuceneSyntaxHelper
     protected function countNonQuoted(string $needle, string $haystack): int
     {
         $count = 0;
-        $inQuotes = false;
-        $lastCh = '';
-        $lastLastCh = '';
-        foreach (str_split($haystack) as $ch) {
-            // Check for escaped character (i.e. preceding character is backslash
-            // that's not escaped):
-            if ('\\' !== $lastCh || '\\' === $lastLastCh) {
-                if ('"' === $ch) {
-                    $inQuotes = !$inQuotes;
-                }
-                if (!$inQuotes && $ch === $needle) {
+        $this->processQueryString(
+            function (string $ch, bool $quoted, bool $esc) use ($needle, &$count) {
+                if (!$quoted && !$esc && $ch === $needle) {
                     ++$count;
                 }
-            }
-            $lastLastCh = $lastCh;
-            $lastCh = $ch;
-        }
+            },
+            $haystack
+        );
+
         return $count;
     }
 
     /**
      * Remove occurrences of given characters in non-quoted parts of the string
      *
-     * @param array  $needles  Characters to remove
+     * @param array  $needles  Characters to remove (non-escaped)
      * @param string $haystack String to process
      *
      * @return string
@@ -708,20 +701,42 @@ class LuceneSyntaxHelper
     protected function removeNonQuoted(array $needles, string $haystack): string
     {
         $result = '';
-        $inQuotes = false;
-        $lastCh = '';
-        $lastLastCh = '';
-        foreach (str_split($haystack) as $ch) {
-            // Check for non-escaped quote:
-            if ('"' === $ch && ('\\' !== $lastCh || '\\' === $lastLastCh)) {
-                $inQuotes = !$inQuotes;
-            }
-            if (!$inQuotes && !in_array($ch, $needles)) {
-                $result .= $ch;
-            }
-            $lastLastCh = $lastCh;
-            $lastCh = $ch;
-        }
+        $this->processQueryString(
+            function (string $ch, bool $quoted, bool $esc) use ($needles, &$result) {
+                if ($quoted || $esc || !in_array($ch, $needles)) {
+                    $result .= $ch;
+                }
+            },
+            $haystack
+        );
         return $result;
+    }
+
+    /**
+     * Process a Lucene query string with a callback
+     *
+     * @param callable $callback Callback that gets called for each character
+     * @param string   $str      String to process
+     *
+     * @return void
+     */
+    protected function processQueryString(callable $callback, string $str): void
+    {
+        $quoted = false;
+        $escaped = false;
+        foreach (str_split($str) as $ch) {
+            if ('\\' === $ch) {
+                $escaped = !$escaped;
+            }
+            // Check for escaped character (i.e. preceding character is backslash
+            // that's not escaped):
+            if (!$escaped && '"' === $ch) {
+                $quoted = !$quoted;
+            }
+            $callback($ch, $quoted, $escaped);
+            if ('\\' !== $ch) {
+                $escaped = false;
+            }
+        }
     }
 }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -422,6 +422,9 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             ['this that)', 'this that'],
             ['this (that))', 'this that'],
             ['((( this that', 'this that'],
+            ['\\((( this that', '\\( this that'],
+            ['\\\\\\((( this that', '\\\\\\( this that'],
+            ['\\"((( this that\\"', '\\" this that\\"'],
 
             // Quoted ones that must not be affected:
             ['"this - that"', '"this - that"'],
@@ -435,6 +438,8 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             ['"this) that"', '"this) that"'],
             ['"((( this that"', '"((( this that"'],
             ['"((("', '"((("'],
+            ['"\\((("', '"\\((("'],
+            ['"\\\\((("', '"\\\\((("'],
         ];
     }
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -393,44 +393,67 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testUnquotedNormalization
+     *
+     * @return array
+     */
+    public function getTestUnquotedNormalization(): array
+    {
+        return [
+            // Unquoted ones that need changes:
+            ['this - that', 'this that'],
+            ['this -- that', 'this that'],
+            ['- this that', 'this that'],
+            ['this that -', 'this that'],
+            ['-- this -- that --', 'this that'],
+            ['this -that', 'this -that'],
+            ['this + that', 'this that'],
+            ['+ this ++ that +', 'this that'],
+            ['this +that', 'this +that'],
+            ['this / that', 'this "/" that'],
+            ['this/that', 'this/that'],
+            ['/this', 'this'],
+            ['/this that', 'this that'],
+            ['this/', 'this'],
+            ['this that/', 'this that'],
+            ['/this that/', 'this that'],
+            ['(this that', 'this that'],
+            ['((this) that', 'this that'],
+            ['this that)', 'this that'],
+            ['this (that))', 'this that'],
+            ['((( this that', 'this that'],
+
+            // Quoted ones that must not be affected:
+            ['"this - that"', '"this - that"'],
+            ['"- this that"', '"- this that"'],
+            ['"this that -"', '"this that -"'],
+            ['"this + that"', '"this + that"'],
+            ['"+ this ++ that +"', '"+ this ++ that +"'],
+            ['"this / that"', '"this / that"'],
+            ['"(this that"', '"(this that"'],
+            ['"(this (that"', '"(this (that"'],
+            ['"this) that"', '"this) that"'],
+            ['"((( this that"', '"((( this that"'],
+            ['"((("', '"((("'],
+        ];
+    }
+
+    /**
      * Test normalization of unquoted special characters
+     *
+     * @param string $input    Input string
+     * @param string $expected Expected result
+     *
+     * @dataProvider getTestUnquotedNormalization
      *
      * @return void
      */
-    public function testUnquotedNormalization()
+    public function testUnquotedNormalization(string $input, string $expected)
     {
         $lh = new LuceneSyntaxHelper(false, false);
-        $tests = [
-            'this - that' => 'this that',
-            'this -- that' => 'this that',
-            '- this that' => 'this that',
-            'this that -' => 'this that',
-            '-- this -- that --' => 'this that',
-            'this -that' => 'this -that',
-            'this + that' => 'this that',
-            '+ this ++ that +' => 'this that',
-            'this +that' => 'this +that',
-            'this / that' => 'this "/" that',
-            'this/that' => 'this/that',
-            '/this' => 'this',
-            '/this that' => 'this that',
-            'this/' => 'this',
-            'this that/' => 'this that',
-            '/this that/' => 'this that',
-
-            // Quoted ones must not be affected
-            '"this - that"' => '"this - that"',
-            '"- this that"' => '"- this that"',
-            '"this that -"' => '"this that -"',
-            '"this + that"' => '"this + that"',
-            '"+ this ++ that +"' => '"+ this ++ that +"',
-            '"this / that"' => '"this / that"',
-        ];
-        foreach ($tests as $input => $expected) {
-            $this->assertEquals(
-                $expected,
-                $lh->normalizeSearchString($input)
-            );
-        }
+        $this->assertEquals(
+            $expected,
+            $lh->normalizeSearchString($input)
+        );
     }
 }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -44,41 +44,56 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
     use \VuFindTest\Feature\ReflectionTrait;
 
     /**
+     * Data provider for testCapitalizeBooleans
+     *
+     * @return array
+     */
+    public function capitalizeBooleansProvider(): array
+    {
+        return [
+            ['this not that', 'this NOT that'],        // capitalize not
+            ['this nOt that', 'this NOT that'],        // strange capitalization
+
+            ['this and that', 'this AND that'],        // capitalize and
+            ['and and and', 'and AND and'],
+            ['this aNd that', 'this AND that'],        // strange capitalization
+
+            ['this or that', 'this OR that'],          // capitalize or
+
+            // handle multiple operators:
+            ['apples and oranges (not that)', 'apples AND oranges (NOT that)'],
+            [
+                '(this or that) and (apples not oranges)',
+                '(this OR that) AND (apples NOT oranges)'
+            ],
+
+            // do not capitalize inside quotes:
+            ['"this not that"', '"this not that"'],
+            ['"this and that"', '"this and that"'],
+            ['"this or that"', '"this or that"'],
+            ['"apples and oranges (not that)"', '"apples and oranges (not that)"'],
+
+            ['this AND that', 'this AND that'], // don't mess up existing caps
+
+            // handle words resembling operators:
+            ['andornot noted andy oranges', 'andornot noted andy oranges'],
+        ];
+    }
+
+    /**
      * Test capitalizeBooleans functionality.
      *
+     * @param $input    Input to test
+     * @param $expected Expected output
+     *
      * @return void
+     *
+     * @dataProvider capitalizeBooleansProvider
      */
-    public function testCapitalizeBooleans()
+    public function testCapitalizeBooleans(string $input, string $expected): void
     {
         $lh = new LuceneSyntaxHelper();
-
-        // Set up an array of expected inputs and outputs:
-        // @codingStandardsIgnoreStart
-        $tests = [
-            ['this not that', 'this NOT that'],        // capitalize not
-            ['this and that', 'this AND that'],        // capitalize and
-            ['this or that', 'this OR that'],          // capitalize or
-            ['apples and oranges (not that)', 'apples AND oranges (NOT that)'],
-            ['"this not that"', '"this not that"'],    // do not capitalize inside quotes
-            ['"this and that"', '"this and that"'],    // do not capitalize inside quotes
-            ['"this or that"', '"this or that"'],      // do not capitalize inside quotes
-            ['"apples and oranges (not that)"', '"apples and oranges (not that)"'],
-            ['this AND that', 'this AND that'],        // don't mess up existing caps
-            ['and and and', 'and AND and'],
-            ['andornot noted andy oranges', 'andornot noted andy oranges'],
-            ['(this or that) and (apples not oranges)', '(this OR that) AND (apples NOT oranges)'],
-            ['this aNd that', 'this AND that'],        // strange capitalization of AND
-            ['this nOt that', 'this NOT that'],        // strange capitalization of NOT
-        ];
-        // @codingStandardsIgnoreEnd
-
-        // Test all the operations:
-        foreach ($tests as $current) {
-            $this->assertEquals(
-                $lh->capitalizeBooleans($current[0]),
-                $current[1]
-            );
-        }
+        $this->assertEquals($expected, $lh->capitalizeBooleans($input));
     }
 
     /**
@@ -86,7 +101,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testContainsBooleans()
+    public function testContainsBooleans(): void
     {
         $lh = new LuceneSyntaxHelper();
         $this->assertTrue($lh->containsBooleans('this AND that'));
@@ -108,7 +123,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSelectiveBooleanCapitalization()
+    public function testSelectiveBooleanCapitalization(): void
     {
         $lh = new LuceneSyntaxHelper();
         $in = 'this or that and the other not everything else (not me)';
@@ -139,7 +154,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetBoolsToCap()
+    public function testGetBoolsToCap(): void
     {
         $lh = new LuceneSyntaxHelper();
 
@@ -184,7 +199,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testHasCaseSensitiveBooleans()
+    public function testHasCaseSensitiveBooleans(): void
     {
         $lh = new LuceneSyntaxHelper();
 
@@ -207,20 +222,19 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test capitalizeRanges functionality.
+     * Data provider for testCapitalizeRanges
      *
-     * @return void
+     * @return array
      */
-    public function testCapitalizeRanges()
+    public function capitalizeRangesProvider(): array
     {
-        $lh = new LuceneSyntaxHelper();
-
-        // Set up an array of expected inputs and outputs:
-        // @codingStandardsIgnoreStart
-        $tests = [
-            ['"{a to b}"', '"{a to b}"'],              // don't capitalize inside quotes
+        return [
+            // don't capitalize inside quotes
+            ['"{a to b}"', '"{a to b}"'],
             ['"[a to b]"', '"[a to b]"'],
-            ['[a to b]', '([a TO b] OR [A TO B])'],    // expand alphabetic cases
+
+            // expand alphabetic cases
+            ['[a to b]', '([a TO b] OR [A TO B])'],
             ['[a TO b]', '([a TO b] OR [A TO B])'],
             ['[a To b]', '([a TO b] OR [A TO B])'],
             ['[a tO b]', '([a TO b] OR [A TO B])'],
@@ -228,24 +242,42 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             ['{a TO b}', '({a TO b} OR {A TO B})'],
             ['{a To b}', '({a TO b} OR {A TO B})'],
             ['{a tO b}', '({a TO b} OR {A TO B})'],
-            ['[1900 to 1910]', '[1900 TO 1910]'],      // don't expand numeric cases
+
+            // don't expand numeric cases
+            ['[1900 to 1910]', '[1900 TO 1910]'],
             ['[1900 TO 1910]', '[1900 TO 1910]'],
             ['{1900 to 1910}', '{1900 TO 1910}'],
             ['{1900 TO 1910}', '{1900 TO 1910}'],
-            ['[a      to      b]', '([a TO b] OR [A TO B])'],   // handle extra spaces
-            // special case for timestamps:
-            ['[1900-01-01t00:00:00z to 1900-12-31t23:59:59z]', '[1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z]'],
-            ['{1900-01-01T00:00:00Z       TO   1900-12-31T23:59:59Z}', '{1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z}']
-        ];
-        // @codingStandardsIgnoreEnd
 
-        // Test all the operations:
-        foreach ($tests as $current) {
-            $this->assertEquals(
-                $lh->capitalizeRanges($current[0]),
-                $current[1]
-            );
-        }
+            // handle extra spaces
+            ['[a      to      b]', '([a TO b] OR [A TO B])'],
+
+            // special case for timestamps:
+            [
+                '[1900-01-01t00:00:00z to 1900-12-31t23:59:59z]',
+                '[1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z]'
+            ],
+            [
+                '{1900-01-01T00:00:00Z       TO   1900-12-31T23:59:59Z}',
+                '{1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z}'
+            ],
+        ];
+    }
+
+    /**
+     * Test capitalizeRanges functionality.
+     *
+     * @param $input    Input to test
+     * @param $expected Expected output
+     *
+     * @return void
+     *
+     * @dataProvider capitalizeRangesProvider
+     */
+    public function testCapitalizeRanges(string $input, string $expected): void
+    {
+        $lh = new LuceneSyntaxHelper();
+        $this->assertEquals($expected, $lh->capitalizeRanges($input));
     }
 
     /**
@@ -253,7 +285,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testContainsAdvancedLuceneSyntaxWithDefaults()
+    public function testContainsAdvancedLuceneSyntaxWithDefaults(): void
     {
         $lh = new LuceneSyntaxHelper();
 
@@ -297,7 +329,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testContainsAdvancedLuceneSyntaxWithCaseInsensitivity()
+    public function testContainsAdvancedLuceneSyntaxWithCaseInsensitivity(): void
     {
         $lh = new LuceneSyntaxHelper(false, false);
 
@@ -319,7 +351,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCaseInsensitiveRangeNormalization()
+    public function testCaseInsensitiveRangeNormalization(): void
     {
         $lh = new LuceneSyntaxHelper(false, false);
         $this->assertFalse($lh->hasCaseSensitiveRanges());
@@ -330,66 +362,88 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testColonNormalization
+     *
+     * @return array
+     */
+    public function colonNormalizationProvider(): array
+    {
+        return [
+            ['this : that', 'this  that'],
+            ['this: that', 'this that'],
+            ['this that:', 'this that'],
+            [':this that', 'this that'],
+            ['this :that', 'this that'],
+            ['this:that', 'this:that'],
+            ['this::::::that', 'this:that'],
+            ['"this : that"', '"this : that"'],
+            ['::::::::::::::::::::', ''],
+        ];
+    }
+
+    /**
      * Test colon normalization
      *
+     * @param $input    Input to test
+     * @param $expected Expected output
+     *
      * @return void
+     *
+     * @dataProvider colonNormalizationProvider
      */
-    public function testColonNormalization()
+    public function testColonNormalization(string $input, string $expected): void
     {
         $lh = new LuceneSyntaxHelper(false, false);
-        $tests = [
-            'this : that' => 'this  that',
-            'this: that' => 'this that',
-            'this that:' => 'this that',
-            ':this that' => 'this that',
-            'this :that' => 'this that',
-            'this:that' => 'this:that',
-            'this::::::that' => 'this:that',
-            '"this : that"' => '"this : that"',
-            '::::::::::::::::::::' => '',
-         ];
-        foreach ($tests as $input => $expected) {
-            $this->assertEquals(
-                $expected,
-                $lh->normalizeSearchString($input)
-            );
-        }
+        $this->assertEquals(
+            $expected,
+            $lh->normalizeSearchString($input)
+        );
+    }
+
+    /**
+     * Data provider for testExtractSearchTerms.
+     *
+     * @return array
+     */
+    public function extractSearchTermsProvider(): array
+    {
+        return [
+            ['keyword', 'keyword'],
+            ['two keywords', 'two keywords'],
+            ['index:keyword', 'keyword'],
+            ['index:keyword anotherkeyword', 'keyword anotherkeyword'],
+            ['index:keyword anotherindex:anotherkeyword', 'keyword anotherkeyword'],
+            ['(index:keyword)', 'keyword'],
+            ['index:(keyword1 keyword2)', '(keyword1 keyword2)'],
+            ['{!local params}keyword', 'keyword'],
+            ['keyword~', 'keyword'],
+            ['keyword~0.8', 'keyword'],
+            ['keyword keyword2^20', 'keyword keyword2'],
+            ['"keyword keyword2 keyword3"~2', '"keyword keyword2 keyword3"'],
+            ['"kw1 kw2 kw3"~2 kw4^200', '"kw1 kw2 kw3" kw4'],
+            ['+keyword -keyword2^20', 'keyword keyword2'],
+            ['index:+keyword index2:-keyword2^20', 'keyword keyword2'],
+            ['index:[start TO end]', '[start TO end]'],
+            ['index:{start TO end}', '{start TO end}'],
+            ['es\\"caped field:test', 'es\\"caped test'],
+            ['field:"quoted:contents"', '"quoted:contents"'],
+        ];
     }
 
     /**
      * Test search term extraction
      *
+     * @param $input    Input to test
+     * @param $expected Expected output
+     *
      * @return void
+     *
+     * @dataProvider extractSearchTermsProvider
      */
-    public function testExtractSearchTerms()
+    public function testExtractSearchTerms(string $input, string $expected): void
     {
         $lh = new LuceneSyntaxHelper(false, false);
-        $tests = [
-            'keyword' => 'keyword',
-            'two keywords' => 'two keywords',
-            'index:keyword' => 'keyword',
-            'index:keyword anotherkeyword' => 'keyword anotherkeyword',
-            'index:keyword anotherindex:anotherkeyword' => 'keyword anotherkeyword',
-            '(index:keyword)' => 'keyword',
-            'index:(keyword1 keyword2)' => '(keyword1 keyword2)',
-            '{!local params}keyword' => 'keyword',
-            'keyword~' => 'keyword',
-            'keyword~0.8' => 'keyword',
-            'keyword keyword2^20' => 'keyword keyword2',
-            '"keyword keyword2 keyword3"~2' => '"keyword keyword2 keyword3"',
-            '"kw1 kw2 kw3"~2 kw4^200' => '"kw1 kw2 kw3" kw4',
-            '+keyword -keyword2^20' => 'keyword keyword2',
-            'index:+keyword index2:-keyword2^20' => 'keyword keyword2',
-            'index:[start TO end]' => '[start TO end]',
-            'index:{start TO end}' => '{start TO end}',
-            'es\\"caped field:test' => 'es\\"caped test'
-        ];
-        foreach ($tests as $input => $expected) {
-            $this->assertEquals(
-                $expected,
-                $lh->extractSearchTerms($input)
-            );
-        }
+        $this->assertEquals($expected, $lh->extractSearchTerms($input));
     }
 
     /**
@@ -397,7 +451,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getTestUnquotedNormalization(): array
+    public function unquotedNormalizationProvider(): array
     {
         return [
             // Unquoted ones that need changes:
@@ -449,7 +503,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      * @param string $input    Input string
      * @param string $expected Expected result
      *
-     * @dataProvider getTestUnquotedNormalization
+     * @dataProvider unquotedNormalizationProvider
      *
      * @return void
      */


### PR DESCRIPTION
Leaves quoted content unchanged.

This allows one to search for weird titles such as [(((](https://www.finna.fi/Record/samk.991457813605968?lng=en-gb) (ISBN 1-953035-71-X) by targeting a string field (or any other field that does not disregard parentheses) in the index, e.g. `title_sort:"((("`.
