### PR TITLE
Clean up header login/logout links and fix issues.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -154,6 +154,12 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInAccountForm($page);
         $this->clickCss($page, 'input.btn.btn-primary');
 
+        // Start establishing library catalog profile
+        $this->waitForPageLoad($page);
+        $element = $this->findCss($page, '.alert.alert-info a');
+        $this->assertEquals('Library Catalog Profile', $element->getText());
+        $element->click();
+
         // Test invalid patron login
         $this->submitCatalogLoginForm($page, 'bad', 'incorrect');
         $this->assertEquals(
@@ -586,6 +592,13 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
             ]
         );
         $this->clickCss($page, 'input.btn.btn-primary');
+
+        // Start establishing library catalog profile
+        $this->waitForPageLoad($page);
+        $element = $this->findCss($page, '.alert.alert-info a');
+        $this->assertEquals('Library Catalog Profile', $element->getText());
+        $element->click();
+
         $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
 
         // Open the "place hold" dialog and check for error message:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -81,7 +81,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             $page,
             ['username' => $username, 'email' => $username . '@vufind.org']
         );
-        $this->clickCss($page, '.modal-body .btn.btn-primary');
+        $this->clickCss($page, '#accountForm .btn.btn-primary');
     }
 
     /**
@@ -545,6 +545,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '.modal.in [name="username"]');
         // Make account
         $this->makeAccount($page, 'username2');
+        $this->waitForPageLoad($page);
+        $this->closeLightbox($page);
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.logoutOptions a.logout');
         // Click rating link:

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -3,6 +3,7 @@ VuFind.register('lightbox', function Lightbox() {
   // State
   var _originalUrl = false;
   var _currentUrl = false;
+  var _lbReferrerUrl = false;
   var _lightboxTitle = false;
   var refreshOnClose = false;
   var _modalParams = {};
@@ -128,9 +129,6 @@ VuFind.register('lightbox', function Lightbox() {
     if (_xhr !== false) {
       return;
     }
-    if (_originalUrl === false) {
-      _originalUrl = obj.url;
-    }
     // Loading
     _modalBody.find('.modal-loading-overlay,.loading-spinner').remove();
     if (_modalBody.children().length > 0) {
@@ -145,10 +143,18 @@ VuFind.register('lightbox', function Lightbox() {
         ? parts[0] + '?'
         : parts[0] + '&';
       obj.url += 'layout=lightbox';
-      if (_currentUrl) {
-        obj.url += '&lbreferer=' + encodeURIComponent(_currentUrl);
+      // Set referrer to current url if it isn't already set:
+      if (_currentUrl && !_lbReferrerUrl) {
+        _lbReferrerUrl = _currentUrl;
+      }
+      if (_lbReferrerUrl) {
+        obj.url += '&lbreferer=' + encodeURIComponent(_lbReferrerUrl);
       }
       obj.url += parts.length < 2 ? '' : '#' + parts[1];
+    }
+    // Store original URL with the layout=lightbox parameter:
+    if (_originalUrl === false) {
+      _originalUrl = obj.url;
     }
     _xhr = $.ajax(obj);
     _xhr.always(function lbAjaxAlways() { _xhr = false; })
@@ -185,7 +191,6 @@ VuFind.register('lightbox', function Lightbox() {
             || obj.url.match(/MyResearch\/(?!Bulk|Delete|Recover)/)
           ) && flashMessages.length === 0
         ) {
-
           var eventResult = _emit('VuFind.lightbox.login', {
             originalUrl: _originalUrl,
             formUrl: obj.url
@@ -462,6 +467,7 @@ VuFind.register('lightbox', function Lightbox() {
     _html('');
     _originalUrl = false;
     _currentUrl = false;
+    _lbReferrerUrl = false;
     _lightboxTitle = false;
     _modalParams = {};
   }

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -29,39 +29,42 @@
             </li>
           <?php endif; ?>
           <?php if (is_object($account) && $account->loginEnabled()): // hide login/logout if unavailable ?>
-            <li class="logoutOptions<?php if($account->dropdownEnabled()): ?> with-dropdown<?php endif ?><?php if(!$account->isLoggedIn()): ?> hidden<?php endif ?>">
-              <a href="<?=$this->url('myresearch-home', [], ['query' => ['redirect' => 0]])?>">
-                <span id="account-icon"><?=$this->icon('my-account') ?></span>
-                <?=$this->transEsc("Your Account")?>
-              </a>
-            </li>
-            <?php if ($account->dropdownEnabled()): ?>
-              <li id="login-dropdown" class="dropdown<?php if(!$account->isLoggedIn()): ?> hidden<?php endif ?>">
-                <a href="#" data-toggle="dropdown"><?=$this->icon('dropdown-caret') ?></a>
-                <div class="dropdown-menu">
-                  <?=$this->render('myresearch/menu'); ?>
-                </div>
+            <?php if ($account->isLoggedIn()): ?>
+              <li class="logoutOptions<?php if ($account->dropdownEnabled()): ?> with-dropdown<?php endif ?>">
+                <a href="<?=$this->url('myresearch-home', [], ['query' => ['redirect' => 0]])?>">
+                  <span id="account-icon"><?=$this->icon('my-account') ?></span>
+                  <?=$this->transEsc("Your Account")?>
+                </a>
+              </li>
+              <?php if ($account->dropdownEnabled()): ?>
+                <li id="login-dropdown" class="dropdown">
+                  <a href="#" data-toggle="dropdown"><?=$this->icon('dropdown-caret') ?></a>
+                  <div class="dropdown-menu">
+                    <?=$this->render('myresearch/menu'); ?>
+                  </div>
+                </li>
+              <?php endif; ?>
+              <li class="logoutOptions">
+                <a href="<?=$this->url('myresearch-logout')?>" class="logout">
+                  <?=$this->icon('sign-out') ?>
+                  <?=$this->transEsc("Log Out")?>
+                </a>
+              </li>
+            <?php else: ?>
+              <li id="loginOptions">
+                <?php if ($account->getSessionInitiator($this->serverUrl($this->url('myresearch-home')))): ?>
+                  <a href="<?=$this->url('myresearch-userlogin')?>">
+                    <?=$this->icon('sign-in') ?>
+                    <?=$this->transEsc("Institutional Login")?>
+                  </a>
+                <?php else: ?>
+                  <a href="<?=$this->url('myresearch-userlogin')?>" data-lightbox>
+                    <?=$this->icon('sign-in') ?>
+                    <?=$this->transEsc("Login")?>
+                  </a>
+                <?php endif; ?>
               </li>
             <?php endif; ?>
-            <li class="logoutOptions<?php if(!$account->isLoggedIn()): ?> hidden<?php endif ?>">
-              <a href="<?=$this->url('myresearch-logout')?>" class="logout">
-                <?=$this->icon('sign-out') ?>
-                <?=$this->transEsc("Log Out")?>
-              </a>
-            </li>
-            <li id="loginOptions"<?php if($account->isLoggedIn()): ?> class="hidden"<?php endif ?>>
-              <?php if ($account->getSessionInitiator($this->serverUrl($this->url('myresearch-home')))): ?>
-                <a href="<?=$this->url('myresearch-userlogin')?>">
-                  <?=$this->icon('sign-in') ?>
-                  <?=$this->transEsc("Institutional Login")?>
-                </a>
-              <?php else: ?>
-                <a href="<?=$this->url('myresearch-userlogin')?>" data-lightbox>
-                  <?=$this->icon('sign-in') ?>
-                  <?=$this->transEsc("Login")?>
-                </a>
-              <?php endif; ?>
-            </li>
           <?php endif; ?>
 
           <?php if (isset($this->layout()->themeOptions) && count($this->layout()->themeOptions) > 1): ?>


### PR DESCRIPTION
Only relevant links are now included in header html. This uncovered issues in our tests, and fixing the tests uncovered issues with lightbox referrer handling for multi-step flows. The original referrer was lost when there were many steps in a lightbox, but the tests still worked because they used the hidden '.logoutOptions .logout' link to log out, but e.g. the following flow ended up with a broken lightbox:

1. Enable record rating, Database login and account creation
2. start a new session (not logged in)
3. Navigate to a record
4. Start adding a rating by clicking the stars
5. Click the "You must be logged in first" button
6. Click the "Create New Account" button
7. Enter user information and click Submit
8. If catalog login is enabled, observe prompt for Library Catalog Profile and enter credentials
9. Observe a broken lightbox