### PR TITLE
Set RSS feed type to avoid PHP deprecation notices.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
@@ -118,6 +118,7 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
 
         // Create the parent feed
         $feed = new Feed();
+        $feed->setType('rss');
         if (null !== $this->overrideTitle) {
             $feed->setTitle($this->translate($this->overrideTitle));
         } else {


### PR DESCRIPTION
Feed type doesn't have a default, but gets used with strtolower.