### PR TITLE
Fix PHP 8 deprecation notice from getSessionInitiator call.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -668,7 +668,7 @@ class Manager implements \LmcRbacMvc\Identity\IdentityProviderInterface,
         }
 
         // Validate CSRF for form-based authentication methods:
-        if (!$this->getAuth()->getSessionInitiator(null)
+        if (!$this->getAuth()->getSessionInitiator('')
             && $this->getAuth()->needsCsrfCheck($request)
         ) {
             if (!$this->csrf->isValid($request->getPost()->get('csrf'))) {


### PR DESCRIPTION
The target parameter should be a string.