### PR TITLE
 Fix a PHP notice when a driver does not return callnumber_prefix.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -377,7 +377,7 @@ class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface,
             }
             // Store call number/location info:
             $locations[$info['location']]['callnumbers'][] = $this->formatCallNo(
-                $info['callnumber_prefix'],
+                $info['callnumber_prefix'] ?? '',
                 $info['callnumber']
             );
         }


### PR DESCRIPTION
This usually remains hidden as it happens during an AJAX call and just produces an additional field in the JSON response.

Another instance was fixed in commit df231793.