### PR TITLE
Fix trying to pass null into strtolower in Browse::getSolrField

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Browse.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Browse.php
@@ -51,7 +51,7 @@ class Browse extends AbstractHelper
     public function getSolrField($action, $backup = null)
     {
         $action = strtolower($action);
-        $backup = strtolower($backup);
+        $backup = strtolower($backup ?? '');
         switch ($action) {
         case 'dewey':
             return 'dewey-hundreds';
@@ -68,7 +68,7 @@ class Browse extends AbstractHelper
         case 'era':
             return 'era_facet';
         }
-        if ($backup == null) {
+        if (empty($backup)) {
             return $action;
         }
         return $this->getSolrField($backup);


### PR DESCRIPTION
This warning shows up with php 8.1