### PR TITLE
Blender: count ignored facet mappings in facet values

### DIFF
--- a/config/vufind/BlenderMappings.yaml
+++ b/config/vufind/BlenderMappings.yaml
@@ -27,6 +27,7 @@
 # Ignore        true to ignore all values for a filter, or an array of values to
 #               ignore. Otherwise any filter value that does not have a field and
 #               value mapping causes the backend to be disabled for the search.
+# CountIgnored  Count ignored mappings to facet results. Default: true.
 # DefaultValue  Filter value used for the backend unless a filter is active.
 #               For example the pcAvailability filter by default limits results to
 #               those that have full text available, so a DefaultValue can be used to

--- a/config/vufind/BlenderMappings.yaml
+++ b/config/vufind/BlenderMappings.yaml
@@ -27,7 +27,6 @@
 # Ignore        true to ignore all values for a filter, or an array of values to
 #               ignore. Otherwise any filter value that does not have a field and
 #               value mapping causes the backend to be disabled for the search.
-# CountIgnored  Count ignored mappings to facet results. Default: true.
 # DefaultValue  Filter value used for the backend unless a filter is active.
 #               For example the pcAvailability filter by default limits results to
 #               those that have full text available, so a DefaultValue can be used to

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -380,18 +380,9 @@ class RecordCollection
                 ($ignore = $mappings['Ignore'] ?? '') &&
                 ($mappings['CountIgnored'] ?? true))
             {
-                if (is_array($ignore)) {
-                    foreach ($ignore as $ignoredValue)
-                    {
-                        $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
-                    }
-                }
-                else
+                foreach (is_array($ignore) ? $ignore : array_keys($result) as $ignoredValue)
                 {
-                    foreach ($result as $ignoredValue)
-                    {
-                        $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
-                    }
+                    $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
                 }
             }
         }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -374,6 +374,28 @@ class RecordCollection
                 }
             }
         }
+
+        foreach ($settings['Mappings'] as $backendId => $mappings) {
+            if (($collections[$backendId] ?? false) &&
+                ($ignore = $mappings['Ignore'] ?? '') &&
+                ($mappings['CountIgnored'] ?? true))
+            {
+                if (is_array($ignore)) {
+                    foreach ($ignore as $ignoredValue)
+                    {
+                        $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
+                    }
+                }
+                else
+                {
+                    foreach ($result as $ignoredValue)
+                    {
+                        $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
+                    }
+                }
+            }
+        }
+
         return $result;
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -376,12 +376,8 @@ class RecordCollection
         }
 
         foreach ($settings['Mappings'] as $backendId => $mappings) {
-            if (($collections[$backendId] ?? false) &&
-                ($ignore = $mappings['Ignore'] ?? '') &&
-                ($mappings['CountIgnored'] ?? true))
-            {
-                foreach (is_array($ignore) ? $ignore : array_keys($result) as $ignoredValue)
-                {
+            if (($collections[$backendId] ?? false) && ($ignore = $mappings['Ignore'] ?? false)) {
+                foreach (is_array($ignore) ? $ignore : array_keys($result) as $ignoredValue) {
                     $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
                 }
             }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -376,9 +376,12 @@ class RecordCollection
         }
 
         foreach ($settings['Mappings'] as $backendId => $mappings) {
-            if (($collections[$backendId] ?? false) && ($ignore = $mappings['Ignore'] ?? false)) {
-                foreach (is_array($ignore) ? $ignore : array_keys($result) as $ignoredValue) {
-                    $result[$ignoredValue] = ($result[$ignoredValue] ?? 0) + $collections[$backendId]->getTotal();
+            $ignore = $mappings['Ignore'] ?? false;
+            if ($ignore && ($collections[$backendId] ?? false)) {
+                $ignoredKeys = is_array($ignore) ? $ignore : array_keys($result);
+                foreach ($ignoredKeys as $ignoredValue) {
+                    $result[$ignoredValue] = ($result[$ignoredValue] ?? 0)
+                        + $collections[$backendId]->getTotal();
                 }
             }
         }


### PR DESCRIPTION
The blender only displays the facet results from mapped facets currently. This is confusing for users since the count behind a facet indicates e.g. 600 and the search result is different since the 1000 from the ignored mapping were not counted. 

Here is a solution for this problem. Please let me know if you have improvement ideas.