### PR TITLE
FOLIO: Enhance getMyHolds to provide more properties

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -142,3 +142,10 @@ maxNumberItems = 5
 ; dueDates will be shown in Universal Time Format, e.g. 06 Jul 2022 14:59, set showTime
 ; to false to show 06 Jul 2022 only
 showTime = false
+
+[Holds]
+
+available[] = "Open - Awaiting pickup"
+in_transit[] = "Open - Not yet filled"
+in_transit[] = "Open - In transit"
+in_transit[] = "Open - Awaiting delivery"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -144,8 +144,13 @@ maxNumberItems = 5
 showTime = false
 
 [Holds]
+; This section associates status text found in FOLIO with specific VuFind statuses
+; all possible Folio status messages for holds are found at (2022-12-19)
+; https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json.
 
+; FOLIO statuses indicating available-for-pickup items
 available[] = "Open - Awaiting pickup"
+; FOLIO statuses indicating in-transit items
 in_transit[] = "Open - Not yet filled"
 in_transit[] = "Open - In transit"
 in_transit[] = "Open - Awaiting delivery"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -142,10 +142,3 @@ maxNumberItems = 5
 ; dueDates will be shown in Universal Time Format, e.g. 06 Jul 2022 14:59, set showTime
 ; to false to show 06 Jul 2022 only
 showTime = false
-
-[Holds]
-
-available[] = "Open - Awaiting pickup"
-in_transit[] = "Open - Not yet filled"
-in_transit[] = "Open - In transit"
-in_transit[] = "Open - Awaiting delivery"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -128,8 +128,8 @@ cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
 ;helpText[en-gb] = "Help text for British English localization."
 
 ; This folowing settings associate status text found in FOLIO with specific VuFind 
-; statuses all possible Folio status messages for holds are found at (2022-12-19)
-; https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json.
+; statuses. All possible Folio status messages for holds are found at:
+; https://github.com/folio-org/mod-circulation-storage/blob/master/ramls/request.json
 
 ; FOLIO statuses indicating available-for-pickup items
 available[] = "Open - Awaiting pickup"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -127,6 +127,17 @@ cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
 ;helpText[*] = "Default help text used if not overridden."
 ;helpText[en-gb] = "Help text for British English localization."
 
+; This folowing settings associates status text found in FOLIO with specific VuFind 
+; statuses all possible Folio status messages for holds are found at (2022-12-19)
+; https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json.
+
+; FOLIO statuses indicating available-for-pickup items
+available[] = "Open - Awaiting pickup"
+; FOLIO statuses indicating in-transit items
+in_transit[] = "Open - Not yet filled"
+in_transit[] = "Open - In transit"
+in_transit[] = "Open - Awaiting delivery"
+
 [CourseReserves]
 ; If set to true, the course number will be prefixed on the course name; if false,
 ; only the name will be displayed:
@@ -142,15 +153,3 @@ maxNumberItems = 5
 ; dueDates will be shown in Universal Time Format, e.g. 06 Jul 2022 14:59, set showTime
 ; to false to show 06 Jul 2022 only
 showTime = false
-
-[Holds]
-; This section associates status text found in FOLIO with specific VuFind statuses
-; all possible Folio status messages for holds are found at (2022-12-19)
-; https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json.
-
-; FOLIO statuses indicating available-for-pickup items
-available[] = "Open - Awaiting pickup"
-; FOLIO statuses indicating in-transit items
-in_transit[] = "Open - Not yet filled"
-in_transit[] = "Open - In transit"
-in_transit[] = "Open - Awaiting delivery"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -134,7 +134,6 @@ cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
 ; FOLIO statuses indicating available-for-pickup items
 available[] = "Open - Awaiting pickup"
 ; FOLIO statuses indicating in-transit items
-in_transit[] = "Open - Not yet filled"
 in_transit[] = "Open - In transit"
 in_transit[] = "Open - Awaiting delivery"
 

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -127,7 +127,7 @@ cancellation_reason = 75187e8d-e25a-47a7-89ad-23ba612338de
 ;helpText[*] = "Default help text used if not overridden."
 ;helpText[en-gb] = "Help text for British English localization."
 
-; This folowing settings associates status text found in FOLIO with specific VuFind 
+; This folowing settings associate status text found in FOLIO with specific VuFind 
 ; statuses all possible Folio status messages for holds are found at (2022-12-19)
 ; https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json.
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1190,11 +1190,11 @@ class Folio extends AbstractAPI implements
                 'available' => in_array(
                     $hold->status, 
                     $this->config['Holds']['available']
-                    ),
+                ),
                 'in_transit' => in_array(
                     $hold->status, 
                     $this->config['Holds']['in_transit']
-                    ),
+                ),
                 'last_pickup_date' => $lastPickup,
                 'position' => $hold->position,
             ];

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -93,6 +93,23 @@ class Folio extends AbstractAPI implements
     protected $dateConverter;
 
     /**
+     * Default availability messages, in case they are not defined in Folio.ini
+     *
+     * @var string[]
+     */
+    protected $defaultAvailabilityStatuses = ['Open - Awaiting pickup'];
+
+    /**
+     * Default in_transit messages, in case they are not defined in Folio.ini
+     *
+     * @var string[]
+     */
+    protected $defaultInTransitStatuses = [
+        'Open - In transit',
+        'Open - Awaiting delivery'
+    ];
+
+    /**
      * Constructor
      *
      * @param \VuFind\Date\Converter $dateConverter  Date converter object
@@ -1185,10 +1202,7 @@ class Folio extends AbstractAPI implements
                     $hold->holdShelfExpirationDate
                 )
                 : null;
-            // setting some default availability / inTransit messages,
-            // in case they are not defined in Folio.ini
-            $availabilityArray = ['Open - Awaiting pickup'];
-            $inTransitArray = ['Open - In transit', 'Open - Awaiting delivery'];
+
             $holds[] = [
                 'type' => $hold->requestType,
                 'create' => $requestDate,
@@ -1204,11 +1218,13 @@ class Folio extends AbstractAPI implements
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',
                 'available' => in_array(
                     $hold->status,
-                    $this->config['Holds']['available'] ?? $availabilityArray
+                    $this->config['Holds']['available']
+                    ?? $this->defaultAvailabilityStatuses
                 ),
                 'in_transit' => in_array(
                     $hold->status,
-                    $this->config['Holds']['in_transit'] ?? $inTransitArray
+                    $this->config['Holds']['in_transit']
+                    ?? $this->defaultInTransitStatuses
                 ),
                 'last_pickup_date' => $lastPickup,
                 'position' => $hold->position,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1171,12 +1171,10 @@ class Folio extends AbstractAPI implements
             // Set expire date if it was included in the response
             $expireDate = isset($hold->requestExpirationDate)
                 ? date_create($hold->requestExpirationDate) : null;
-            
             //set lastPickup Date if provided, format to j M Y
-            $lastPickup = isset($hold->holdShelfExpirationDate) 
+            $lastPickup = isset($hold->holdShelfExpirationDate)
                 ? date_format(date_create($hold->holdShelfExpirationDate), "j M Y")
                 : null;
-
             $holds[] = [
                 'type' => $hold->requestType,
                 'create' => date_format($requestDate, "j M Y"),
@@ -1188,11 +1186,11 @@ class Folio extends AbstractAPI implements
                 // Title moved from item to instance in Lotus release:
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',
                 'available' => in_array(
-                    $hold->status, 
+                    $hold->status,
                     $this->config['Holds']['available']
                 ),
                 'in_transit' => in_array(
-                    $hold->status, 
+                    $hold->status,
                     $this->config['Holds']['in_transit']
                 ),
                 'last_pickup_date' => $lastPickup,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1193,7 +1193,7 @@ class Folio extends AbstractAPI implements
                 'type' => $hold->requestType,
                 'create' => $requestDate,
                 'expire' => $expireDate ?? "",
-                'id' => $this->getBibId(null, null, $hold->itemId),
+                'id' => $this->getBibId($hold->instanceId, $hold->holdingsRecordId, $hold->itemId),
                 'item_id' => $hold->itemId,
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1171,6 +1171,12 @@ class Folio extends AbstractAPI implements
             // Set expire date if it was included in the response
             $expireDate = isset($hold->requestExpirationDate)
                 ? date_create($hold->requestExpirationDate) : null;
+            
+            //set lastPickup Date if provided, format to j M Y
+            $lastPickup = isset($hold->holdShelfExpirationDate) 
+                ? date_format(date_create($hold->holdShelfExpirationDate), "j M Y")
+                : null;
+
             $holds[] = [
                 'type' => $hold->requestType,
                 'create' => date_format($requestDate, "j M Y"),
@@ -1181,6 +1187,10 @@ class Folio extends AbstractAPI implements
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',
+                'available' => in_array($hold->status, $this->config['Holds']['available']),
+                'in_transit' => in_array($hold->status, $this->config['Holds']['in_transit']),
+                'last_pickup_date' => $lastPickup,
+                'position' => $hold->position,
             ];
         }
         return $holds;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1171,12 +1171,6 @@ class Folio extends AbstractAPI implements
             // Set expire date if it was included in the response
             $expireDate = isset($hold->requestExpirationDate)
                 ? date_create($hold->requestExpirationDate) : null;
-            
-            //set lastPickup Date if provided, format to j M Y
-            $lastPickup = isset($hold->holdShelfExpirationDate) 
-                ? date_format(date_create($hold->holdShelfExpirationDate), "j M Y")
-                : null;
-
             $holds[] = [
                 'type' => $hold->requestType,
                 'create' => date_format($requestDate, "j M Y"),
@@ -1187,10 +1181,6 @@ class Folio extends AbstractAPI implements
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',
-                'available' => in_array($hold->status, $this->config['Holds']['available']),
-                'in_transit' => in_array($hold->status, $this->config['Holds']['in_transit']),
-                'last_pickup_date' => $lastPickup,
-                'position' => $hold->position,
             ];
         }
         return $holds;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1187,8 +1187,14 @@ class Folio extends AbstractAPI implements
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',
-                'available' => in_array($hold->status, $this->config['Holds']['available']),
-                'in_transit' => in_array($hold->status, $this->config['Holds']['in_transit']),
+                'available' => in_array(
+                    $hold->status, 
+                    $this->config['Holds']['available']
+                    ),
+                'in_transit' => in_array(
+                    $hold->status, 
+                    $this->config['Holds']['in_transit']
+                    ),
                 'last_pickup_date' => $lastPickup,
                 'position' => $hold->position,
             ];

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1176,14 +1176,14 @@ class Folio extends AbstractAPI implements
                 ? $this->dateConverter->convertToDisplayDate(
                     "Y-m-d H:i",
                     $hold->requestExpirationDate
-                    )
+                )
                 : null;
             //set lastPickup Date if provided, format to j M Y
             $lastPickup = isset($hold->holdShelfExpirationDate)
                 ? $this->dateConverter->convertToDisplayDate(
                     "Y-m-d H:i",
                     $hold->holdShelfExpirationDate
-                    )
+                )
                 : null;
             // setting some default availability / inTransit messages,
             // in case they are not defined in Folio.ini
@@ -1193,7 +1193,11 @@ class Folio extends AbstractAPI implements
                 'type' => $hold->requestType,
                 'create' => $requestDate,
                 'expire' => $expireDate ?? "",
-                'id' => $this->getBibId($hold->instanceId, $hold->holdingsRecordId, $hold->itemId),
+                'id' => $this->getBibId(
+                    $hold->instanceId,
+                    $hold->holdingsRecordId,
+                    $hold->itemId
+                ),
                 'item_id' => $hold->itemId,
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1178,7 +1178,7 @@ class Folio extends AbstractAPI implements
                     $hold->requestExpirationDate
                 )
                 : null;
-            //set lastPickup Date if provided, format to j M Y
+            // Set lastPickup Date if provided, format to j M Y
             $lastPickup = isset($hold->holdShelfExpirationDate)
                 ? $this->dateConverter->convertToDisplayDate(
                     "Y-m-d H:i",

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1227,7 +1227,7 @@ class Folio extends AbstractAPI implements
                     ?? $this->defaultInTransitStatuses
                 ),
                 'last_pickup_date' => $lastPickup,
-                'position' => $hold->position,
+                'position' => $hold->position ?? null,
             ];
         }
         return $holds;

--- a/module/VuFind/tests/fixtures/folio/responses/get-my-holds-available.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-my-holds-available.json
@@ -1,0 +1,8 @@
+[
+  { "comment": "Initial request for token" },
+  {
+    "comment": "User with 1 hold, hold is available for pickup until 2022-12-29T05:59:59.000+00:00",
+    "status": 200,
+    "body": "{\"requests\":[{\"id\":\"c5a8af9d-9877-453c-bbcb-f63cb5ccb3b4\",\"requestLevel\":\"Item\",\"requestType\":\"Page\",\"requestDate\":\"2022-12-20T05:55:33.000+00:00\",\"requesterId\":\"162c474e-ca1f-4310-b233-7ad3a2ad8c34\",\"instanceId\":\"3311d5df-731f-4e2c-8000-00960a9d8bf7\",\"holdingsRecordId\":\"10c3dc8e-4e7c-4c21-ad23-95e3887c1f5c\",\"itemId\":\"fc0064b4-e2e4-4be0-8251-7ca93282c9b4\",\"status\":\"Open - Awaiting pickup\",\"position\":1,\"instance\":{\"title\":\"Presentation secrets : do what you never thought possible with your presentations \",\"identifiers\":[{\"value\":\"9781118034965 (pbk : alk paper)\",\"identifierTypeId\":\"8261054f-be78-422d-bd51-4ed9f33c3422\"}]},\"item\":{\"barcode\":\"431332678\"},\"requester\":{\"firstName\":\"John\",\"lastName\":\"TestuserJohn\",\"barcode\":\"995324292\"},\"fulfilmentPreference\":\"Hold Shelf\",\"holdShelfExpirationDate\":\"2022-12-29T05:59:59.000+00:00\",\"pickupServicePointId\":\"7bfc4faa-e731-47db-92c9-da18c4ca9bc8\",\"metadata\":{\"createdDate\":\"2022-12-20T05:55:34.325+00:00\",\"createdByUserId\":\"d916e883-f8f1-4188-bc1d-f0dce1511b50\",\"updatedDate\":\"2022-12-20T06:07:27.712+00:00\",\"updatedByUserId\":\"d916e883-f8f1-4188-bc1d-f0dce1511b50\"}}],\"totalRecords\":1}"
+  }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/get-my-holds-in_transit.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-my-holds-in_transit.json
@@ -1,0 +1,8 @@
+[
+  { "comment": "Initial request for token" },
+  {
+    "comment": "User with 1 hold, item is currently in_transit",
+    "status": 200,
+    "body": "{\"requests\":[{\"id\":\"074c0f3d-e8a0-47b5-b598-74a45c29d3d7\",\"requestLevel\":\"Item\",\"requestType\":\"Page\",\"requestDate\":\"2022-11-07T09:23:46.508+00:00\",\"requesterId\":\"162c474e-ca1f-4310-b233-7ad3a2ad8c34\",\"instanceId\":\"c112b154-720c-486c-890d-81e1c288c097\",\"holdingsRecordId\":\"4a086d33-0b5a-4be1-a96b-5aa656ab6ba9\",\"itemId\":\"795759ad-0b33-41dd-a658-947405261360\",\"status\":\"Open - In transit\",\"position\":1,\"instance\":{\"title\":\"Basic economics : a common sense guide to the economy \",\"identifiers\":[{\"value\":\"0465060730 :\",\"identifierTypeId\":\"8261054f-be78-422d-bd51-4ed9f33c3422\"}]},\"item\":{\"barcode\":\"8026657307\"},\"requester\":{\"firstName\":\"John\",\"lastName\":\"Testuser\",\"barcode\":\"995324292\"},\"fulfilmentPreference\":\"Hold Shelf\",\"pickupServicePointId\":\"b61315ba-a759-42de-9303-0d51cbd4edbb\",\"metadata\":{\"createdDate\":\"2022-11-07T09:23:48.197+00:00\",\"createdByUserId\":\"d37c7201-e679-47df-8b73-5ea01eeba0cf\",\"updatedDate\":\"2022-12-20T06:02:03.248+00:00\",\"updatedByUserId\":\"d916e883-f8f1-4188-bc1d-f0dce1511b50\"}}],\"totalRecords\":1}"
+  }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/get-my-holds-none.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-my-holds-none.json
@@ -1,0 +1,8 @@
+[
+  { "comment": "Initial request for token" },
+  {
+    "comment": "User with 0 holds, will return an empty requests array",
+    "status": 200,
+    "body": "{\"requests\": [],\"totalRecords\": 0}"
+  }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/get-my-holds-single.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-my-holds-single.json
@@ -1,0 +1,8 @@
+[
+  { "comment": "Initial request for token" },
+  {
+    "comment": "User with 1 holds, request will expire on 2022-12-28T05:59:59.000+00:00",
+    "status": 200,
+    "body": "{\"requests\":[{\"id\":\"bb07eb2c-bf3a-449f-8e8b-a114ce410c7f\",\"requestLevel\":\"Item\",\"requestType\":\"Hold\",\"requestDate\":\"2022-12-20T05:55:01.000+00:00\",\"requesterId\":\"162c474e-ca1f-4310-b233-7ad3a2ad8c34\",\"instanceId\":\"c7a7df0d-36a2-486c-85f5-008191e6b32d\",\"holdingsRecordId\":\"a6630c3f-8ecd-4d2b-809b-abeeaa4ac111\",\"itemId\":\"26532648-67a3-4459-a97f-9b54b4c5ebd9\",\"status\":\"Open - Not yet filled\",\"position\":3,\"instance\":{\"title\":\"Organic farming : everything you need to know \",\"identifiers\":[{\"value\":\"9780760324691 (pbk.) :\",\"identifierTypeId\":\"8261054f-be78-422d-bd51-4ed9f33c3422\"}]},\"item\":{\"barcode\":\"2713958827\"},\"requester\":{\"firstName\":\"John\",\"lastName\":\"Testuser\",\"barcode\":\"995324292\"},\"fulfilmentPreference\":\"Hold Shelf\",\"requestExpirationDate\":\"2022-12-28T05:59:59.000+00:00\",\"pickupServicePointId\":\"7bfc4faa-e731-47db-92c9-da18c4ca9bc8\",\"metadata\":{\"createdDate\":\"2022-12-20T05:55:02.908+00:00\",\"createdByUserId\":\"d916e883-f8f1-4188-bc1d-f0dce1511b50\",\"updatedDate\":\"2022-12-20T05:55:02.970+00:00\",\"updatedByUserId\":\"d916e883-f8f1-4188-bc1d-f0dce1511b50\"}}],\"totalRecords\":1}"
+  }
+]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -406,7 +406,6 @@ class FolioTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-
     public function testNoItemsGetMyHolds(): void
     {
         $this->createConnector('get-my-holds-none');
@@ -423,15 +422,14 @@ class FolioTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-
-     public function testAvailbleItemGetMyHolds(): void
-     {
-         $this->createConnector('get-my-holds-available');
-         $patron = [
-             'id' => 'foo'
-         ];
-         $result = $this->driver->getMyHolds($patron);
-         $expected[0] = [
+    public function testAvailbleItemGetMyHolds(): void
+    {
+        $this->createConnector('get-my-holds-available');
+        $patron = [
+            'id' => 'foo'
+        ];
+        $result = $this->driver->getMyHolds($patron);
+        $expected[0] = [
             'type' => 'Page',
             'create' => '12-20-2022',
             'expire' => '',
@@ -444,7 +442,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'last_pickup_date' => '12-29-2022',
             'position' => 1
         ];
-         $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -452,15 +450,14 @@ class FolioTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-
-     public function testInTransitItemGetMyHolds(): void
-     {
-         $this->createConnector('get-my-holds-in_transit');
-         $patron = [
-             'id' => 'foo'
-         ];
-         $result = $this->driver->getMyHolds($patron);
-         $expected[0] = [
+    public function testInTransitItemGetMyHolds(): void
+    {
+        $this->createConnector('get-my-holds-in_transit');
+        $patron = [
+            'id' => 'foo'
+        ];
+        $result = $this->driver->getMyHolds($patron);
+        $expected[0] = [
             'type' => 'Page',
             'create' => '11-07-2022',
             'expire' => '',
@@ -473,7 +470,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'last_pickup_date' => null,
             'position' => 1
         ];
-         $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -481,15 +478,14 @@ class FolioTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-
-     public function testSingleItemGetMyHolds(): void
-     {
-         $this->createConnector('get-my-holds-single');
-         $patron = [
-             'id' => 'foo'
-         ];
-         $result = $this->driver->getMyHolds($patron);
-         $expected[0] = [
+    public function testSingleItemGetMyHolds(): void
+    {
+        $this->createConnector('get-my-holds-single');
+        $patron = [
+            'id' => 'foo'
+        ];
+        $result = $this->driver->getMyHolds($patron);
+        $expected[0] = [
             'type' => 'Hold',
             'create' => '12-20-2022',
             'expire' => '12-28-2022',
@@ -502,6 +498,6 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'last_pickup_date' => null,
             'position' => 3
         ];
-         $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -400,4 +400,108 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             $this->testRequestLog[1]['params']
         );
     }
+
+    /**
+     * Test successful call to holds, no items
+     *
+     * @return void
+     */
+
+    public function testNoItemsGetMyHolds(): void
+    {
+        $this->createConnector('get-my-holds-none');
+        $patron = [
+            'id' => 'foo'
+        ];
+        $result = $this->driver->getMyHolds($patron);
+        $expected = [];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test successful call to holds, one available item
+     *
+     * @return void
+     */
+
+     public function testAvailbleItemGetMyHolds(): void
+     {
+         $this->createConnector('get-my-holds-available');
+         $patron = [
+             'id' => 'foo'
+         ];
+         $result = $this->driver->getMyHolds($patron);
+         $expected[0] = [
+            'type' => 'Page',
+            'create' => '12-20-2022',
+            'expire' => '',
+            'id' => '3311d5df-731f-4e2c-8000-00960a9d8bf7',
+            'item_id' => 'fc0064b4-e2e4-4be0-8251-7ca93282c9b4',
+            'reqnum' => 'c5a8af9d-9877-453c-bbcb-f63cb5ccb3b4',
+            'title' => 'Presentation secrets : do what you never thought possible with your presentations ',
+            'available' => true,
+            'in_transit' => false,
+            'last_pickup_date' => '12-29-2022',
+            'position' => 1
+        ];
+         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test successful call to holds, one in_transit item
+     *
+     * @return void
+     */
+
+     public function testInTransitItemGetMyHolds(): void
+     {
+         $this->createConnector('get-my-holds-in_transit');
+         $patron = [
+             'id' => 'foo'
+         ];
+         $result = $this->driver->getMyHolds($patron);
+         $expected[0] = [
+            'type' => 'Page',
+            'create' => '11-07-2022',
+            'expire' => '',
+            'id' => 'c112b154-720c-486c-890d-81e1c288c097',
+            'item_id' => '795759ad-0b33-41dd-a658-947405261360',
+            'reqnum' => '074c0f3d-e8a0-47b5-b598-74a45c29d3d7',
+            'title' => 'Basic economics : a common sense guide to the economy ',
+            'available' => false,
+            'in_transit' => true,
+            'last_pickup_date' => null,
+            'position' => 1
+        ];
+         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test successful call to holds, item in queue, position x
+     *
+     * @return void
+     */
+
+     public function testSingleItemGetMyHolds(): void
+     {
+         $this->createConnector('get-my-holds-single');
+         $patron = [
+             'id' => 'foo'
+         ];
+         $result = $this->driver->getMyHolds($patron);
+         $expected[0] = [
+            'type' => 'Hold',
+            'create' => '12-20-2022',
+            'expire' => '12-28-2022',
+            'id' => 'c7a7df0d-36a2-486c-85f5-008191e6b32d',
+            'item_id' => '26532648-67a3-4459-a97f-9b54b4c5ebd9',
+            'reqnum' => 'bb07eb2c-bf3a-449f-8e8b-a114ce410c7f',
+            'title' => 'Organic farming : everything you need to know ',
+            'available' => false,
+            'in_transit' => false,
+            'last_pickup_date' => null,
+            'position' => 3
+        ];
+         $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
The changes in this pull request will enhance the Folio Driver to populate the following properties of the "holds" object of the getMyHolds method:

- available
- in_transit
- last_pickup_date
- position

Populating these properties should enable VuFind to provide an improved user experience for Holds / Recalls:

- Show bell icon next to the My Holds menu item in the My Account area, if an item is available for pickup
- Show clock icon next to the My Holds menu item in the My Account area, if an item is in transit
- Show status message below hold entry if they are available or in transit
- Show last pickup date below hold entry if item is available for pickup
- Show position for hold entry if item is not yet in_transit or available

The status of a hold is described as an enum, see [https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json](https://github.com/folio-org/mod-circulation-storage/blob/v14.1.0/ramls/request.json). 

Folio.ini has been extended to define, which of the status messages constitute an available or in_transit.

Question / Request for Comments and Suggestion:

- [x] Would you please look at line 1175 and the formatting of the lastPickup Date - I believe there is room for improvement

<img width="1220" alt="Screen Shot 2022-12-16 at 15 18 18" src="https://user-images.githubusercontent.com/62254772/208118408-976a477f-fd93-4f85-9379-074b9faa70c8.png">

Kudos for this work should go to Ben Taylor of Trinity College Cambridge, who identified the fact that this functionality was missing and documented the requirements.