### PR TITLE
Clarify/simplify highlighting code/comments.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -71,7 +71,10 @@ default_noresults_recommend[] = SpellingSuggestions
 default_noresults_recommend[] = RemoveFilters
 
 ; Set this to true in order to highlight keywords from the search query when they
-; appear in fields displayed in search results.
+; appear in fields displayed in search results. Note: while this setting will
+; always prevent highlighting from displaying in your output, if you want to
+; prevent VuFind from requesting highlighting data from Solr, you must also turn
+; off the snippets setting below, since snippets depend on highlighting data.
 highlighting = true
 
 ; Set this to restrict the list of fields that will be highlighted (the hl.fl

--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -66,8 +66,7 @@ class DefaultRecord extends AbstractBase
         $searchSettings = null
     ) {
         // Turn on highlighting as needed:
-        $this->highlight = !isset($searchSettings->General->highlighting)
-            ? false : $searchSettings->General->highlighting;
+        $this->highlight = $searchSettings->General->highlighting ?? false;
 
         parent::__construct($mainConfig, $recordConfig);
     }

--- a/module/VuFind/src/VuFind/Search/Solr/Options.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Options.php
@@ -197,10 +197,8 @@ class Options extends \VuFind\Search\Base\Options
 
         // Turn on highlighting if the user has requested highlighting or snippet
         // functionality:
-        $highlight = !isset($searchSettings->General->highlighting)
-            ? false : $searchSettings->General->highlighting;
-        $snippet = !isset($searchSettings->General->snippets)
-            ? false : $searchSettings->General->snippets;
+        $highlight = $searchSettings->General->highlighting ?? false;
+        $snippet = $searchSettings->General->snippets ?? false;
         if ($highlight || $snippet) {
             $this->highlight = true;
         }


### PR DESCRIPTION
I've been working with @welblaud to troubleshoot a problem he is seeing where, after upgrading to Solr 9, he is getting `java.lang.IllegalArgumentException: field 'author' was indexed without offsets, cannot highlight` errors. We haven't yet determined whether this is tied to local customizations or something else, but while troubleshooting, I discovered that the problem goes away if we disable highlighting in Solr, but turning off highlighting in searches.ini doesn't automatically prevent VuFind from requesting highlighting data. This is because highlighting data is also required for snippets, but I had forgotten about that.

While investigating, I noticed some code that could be simplified, and I thought adding a comment about the snippet detail might save somebody some time in the future -- hence this pull request. If the Solr error is identified as something related to the core project, I'll address that in a separate PR... but for now, investigation is ongoing.