### PR TITLE
Fix for query string character prefix

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -267,8 +267,8 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
                 }
             }
             if ($hiddenFilters = $params->getHiddenFiltersAsQueryParams()) {
-                $this->cachedHiddenFilterParams[$searchClassId] = $prepend
-                    . UrlQueryHelper::buildQueryString(
+                $this->cachedHiddenFilterParams[$searchClassId]
+                    = UrlQueryHelper::buildQueryString(
                         [
                             'hiddenFilters' => $hiddenFilters
                         ]
@@ -277,7 +277,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
                 $this->cachedHiddenFilterParams[$searchClassId] = '';
             }
         }
-        return $this->cachedHiddenFilterParams[$searchClassId];
+        return $prepend . $this->cachedHiddenFilterParams[$searchClassId];
     }
 
     /**


### PR DESCRIPTION
This fixes a minor bug in getting params of the hidden filters.

Previously, the query string was cached including the prefix char (default `&amp;`), hence the intentional prefixing did not work (specifically in the [searchbox](https://github.com/vufind-org/vufind/blob/dev/themes/bootstrap3/templates/search/searchbox.phtml#L29)).