### PR TITLE
Hide "searches" in history that are made for the print view

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -380,16 +380,13 @@ class AbstractSearch extends AbstractBase
             if ($jump = $this->processJumpTo($results)) {
                 return $jump;
             }
-            
-            // do not remember in case of print view
-            if( !$this->params()->fromQuery('print') ) { 
-                // Remember the current URL as the last search.
-                $this->rememberSearch($results);
 
-                // Add to search history:
-                if ($this->saveToHistory) {
-                    $this->saveSearchToHistory($results);
-                }
+            // Remember the current URL as the last search.
+            $this->rememberSearch($results);
+
+            // Add to search history:
+            if ($this->saveToHistory) {
+                $this->saveSearchToHistory($results);
             }
 
             // Set up results scroller:

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -380,13 +380,16 @@ class AbstractSearch extends AbstractBase
             if ($jump = $this->processJumpTo($results)) {
                 return $jump;
             }
+            
+            // do not remember in case of print view
+            if( !$this->params()->fromQuery('print') ) { 
+                // Remember the current URL as the last search.
+                $this->rememberSearch($results);
 
-            // Remember the current URL as the last search.
-            $this->rememberSearch($results);
-
-            // Add to search history:
-            if ($this->saveToHistory) {
-                $this->saveSearchToHistory($results);
+                // Add to search history:
+                if ($this->saveToHistory) {
+                    $this->saveSearchToHistory($results);
+                }
             }
 
             // Set up results scroller:

--- a/module/VuFind/src/VuFind/Controller/RecordsController.php
+++ b/module/VuFind/src/VuFind/Controller/RecordsController.php
@@ -60,13 +60,17 @@ class RecordsController extends AbstractSearch
     {
         // If there is exactly one record, send the user directly there:
         $ids = $this->params()->fromQuery('id', []);
+        $print = $this->params()->fromQuery('print');
         if (count($ids) == 1) {
             $details = $this->getRecordRouter()->getTabRouteDetails($ids[0]);
             $target = $this->url()->fromRoute($details['route'], $details['params']);
             // forward print param, if necessary:
-            $print = $this->params()->fromQuery('print');
             $params = empty($print) ? '' : '?print=' . urlencode($print);
             return $this->redirect()->toUrl($target . $params);
+        }
+        // Ignore Print for Search History:
+        if (!empty($print)) {
+            $this->saveToHistory = false;
         }
 
         // Not exactly one record -- show search results:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -716,6 +716,24 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Get the search history data.
+     *
+     * @return array
+     */
+    protected function getSearchHistory()
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/History');
+        $page = $session->getPage();
+        $this->waitForPageLoad($page);
+        $matches = $page->findAll('css', '#recent-searches td:nth-child(2) a');
+        $callback = function ($match) {
+            return $match->getText();
+        };
+        return array_map($callback, $matches);
+    }
+
+    /**
      * Test that the print control works.
      *
      * @return void
@@ -734,6 +752,13 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEqualsWithTimeout(
             'print=true&id[]=Solr|testsample1&id[]=Solr|testsample2',
             [$this, 'getCurrentQueryString']
+        );
+
+        // Printing should not have added anything to the search history beyond
+        // the initial search that set everything up.
+        $this->assertEquals(
+            ['id:(testsample1 OR testsample2)'],
+            $this->getSearchHistory()
         );
     }
 


### PR DESCRIPTION
Reproduction: 
1.) Add Elements to the book bag from search
2.) open book bag, select elements and click print
3.) print view will open
4.) open search history
5.) search "5 elements" will be present

As far as i can see printing creates a fake search with a fixed number of IDs and goes through the normal processes via the `RecordsController->HomeAction()` which in turn calls `resultsAction()` which is mostly inherited from `AbstractSearch`

By intercepting the saving to the search history with an additional condition the bloating of the search history can be avoided.

TODO
- [x] Add mink test
- [x] Run full test suite