### PR TITLE
Fix PHP 8.1 compatibility of hierarchy tree formatter.

### DIFF
--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/AbstractBase.php
@@ -146,7 +146,7 @@ abstract class AbstractBase implements \VuFind\I18n\HasSorterInterface
             && is_array($fields->title_in_hierarchy)
         ) {
             $titles = $fields->title_in_hierarchy;
-            $parentIDs = $fields->hierarchy_parent_id;
+            $parentIDs = (array)($fields->hierarchy_parent_id ?? []);
             if (count($titles) === count($parentIDs)) {
                 foreach ($parentIDs as $key => $val) {
                     $retVal[$val] = $titles[$key];
@@ -192,11 +192,14 @@ abstract class AbstractBase implements \VuFind\I18n\HasSorterInterface
      */
     protected function pickTitle($record, $parentID)
     {
-        $titles = $this->getTitlesInHierarchy($record);
+        if (null !== $parentID) {
+            $titles = $this->getTitlesInHierarchy($record);
+            if (isset($titles[$parentID])) {
+                return $titles[$parentID];
+            }
+        }
         // TODO: handle missing titles more gracefully (title not available?)
-        $title = $record->title ?? $record->id;
-        return null != $parentID && isset($titles[$parentID])
-            ? $titles[$parentID] : $title;
+        return $record->title ?? $record->id;
     }
 
     /**


### PR DESCRIPTION
Trying to get titles in hierarchy for the top-level record failed with TypeError since it doesn't have hierarchy_parent_id. Also avoids getting titles in hierarchy unless the node has a parent ID.