### PR TITLE
KohaRest: Add an option to allow canceling of holds in transit.

### DIFF
--- a/config/vufind/KohaRest.ini
+++ b/config/vufind/KohaRest.ini
@@ -107,6 +107,10 @@ updateFields = frozen:frozenThrough:pickUpLocation
 ;updateHelpText[*] = "Hold update default help text used if not overridden."
 ;updateHelpText[en-gb] = "Hold update help text for British English localization."
 
+; Whether to allow canceling of holds while in transit to pick up location. Default
+; is false.
+;allowCancelInTransit = false
+
 ; This section controls article request behavior. To enable, uncomment (at minimum)
 ; the HMACKeys and extraFields settings below.
 [StorageRetrievalRequests]

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2016-2020.
+ * Copyright (C) The National Library of Finland 2016-2023.
  * Copyright (C) Moravian Library 2019.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -108,7 +108,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @var bool
      */
-    protected $allowCancelInTransit;
+    protected $allowCancelInTransit = false;
 
     /**
      * Item status rankings. The lower the value, the more important the status.
@@ -220,7 +220,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @var bool
      */
-    protected $sortItemsBySerialIssue;
+    protected $sortItemsBySerialIssue = true;
 
     /**
      * Constructor


### PR DESCRIPTION
Some libraries want to allow canceling of holds in transit to pick up location. Koha seems to support this, so this adds a  configuration option to support it in VuFind.