### PR TITLE
KohaRest: Remove bad query param

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -886,7 +886,6 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                         'query' => [
                             'patron_id' => (int)$patron['id'],
                             'query_pickup_locations' => 1,
-                            'ignore_patron_holds' => $requestId ? 1 : 0,
                         ]
                     ]
                 );


### PR DESCRIPTION
Parameter `ignore_patron_holds` is only defined for biblio availability endpoint in rest-di api plugin.