### PR TITLE
FOLIO: Add patron comment support for requests

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -97,7 +97,7 @@ HMACKeys = holding_id:item_id:status:level
 defaultRequiredDate = 0:1:0
 
 ; extraHoldFields - A colon-separated list used to display extra visible fields in the
-; place holds form. Supported values are "requiredByDate",
+; place holds form. Supported values are "comments", "requiredByDate",
 ; "pickUpLocation" and "requestGroup"
 extraHoldFields = requiredByDate:pickUpLocation
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1279,6 +1279,9 @@ class Folio extends AbstractAPI implements
             'requestExpirationDate' => $requiredBy,
             'pickupServicePointId' => $holdDetails['pickUpLocation']
         ];
+        if (!empty($holdDetails['comment'])) {
+            $requestBody['patronComments'] = $holdDetails['comment'];
+        }
         $response = $this->makeRequest(
             'POST',
             '/circulation/requests',


### PR DESCRIPTION
I noticed that we didn't support patron comments on requests yet; this PR adds the feature. I'd be interested in feedback from other FOLIO users. I have confirmed that this works as expected for Villanova's instance.