### PR TITLE
FOLIO: more flexible hold exclusion configuration

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -113,6 +113,7 @@ extraHoldFields = requiredByDate:pickUpLocation
 ; See https://issues.folio.org/browse/UXPROD-2422.
 ; Checks against the location's Discovery Display Name in FOLIO.
 ; If no Discovery Display Name is configured, checks against name.
+; Legal excludeHoldLocationsCompareMode settings: exact, regex; see examples below.
 ;excludeHoldLocationsCompareMode = exact
 ; Exact mode examples
 ;excludeHoldLocations[] = "24 Hour Reserve"

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -107,15 +107,18 @@ extraHoldFields = requiredByDate:pickUpLocation
 
 ; Hide the place hold/recall/page link when an item is in the configured
 ; list of locations. This can either match the full location name exactly or
-; do a substring match depending on how you set the excludeHoldLocationsBySubString
+; do a regex match depending on how you set the excludeHoldLocationsCompareMode
 ; setting. Ideally, this would not be needed and FOLIO would include an
 ; indicator of whether or not an item is holdable with item details.
 ; See https://issues.folio.org/browse/UXPROD-2422.
 ; Checks against the location's Discovery Display Name in FOLIO.
 ; If no Discovery Display Name is configured, checks against name.
-;excludeHoldLocationsBySubString = false
+;excludeHoldLocationsCompareMode = exact
+; Exact mode examples
 ;excludeHoldLocations[] = "24 Hour Reserve"
 ;excludeHoldLocations[] = "Reference Collection"
+; Regex mode example
+;excludeHoldLocations[] = "/.*RESERVE.*/i"
 
 ; When a request is cancelled through VuFind, use this cancellation reason ID. Most users
 ; will not have to change this ID unless they have replaced the cancellation reason

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -106,11 +106,14 @@ extraHoldFields = requiredByDate:pickUpLocation
 ;default_request = Hold
 
 ; Hide the place hold/recall/page link when an item is in the configured
-; list of locations. Ideally, this would not be needed and FOLIO would include an
+; list of locations. This can either match the full location name exactly or
+; do a substring match depending on how you set the excludeHoldLocationsBySubString
+; setting. Ideally, this would not be needed and FOLIO would include an
 ; indicator of whether or not an item is holdable with item details.
 ; See https://issues.folio.org/browse/UXPROD-2422.
 ; Checks against the location's Discovery Display Name in FOLIO.
 ; If no Discovery Display Name is configured, checks against name.
+;excludeHoldLocationsBySubString = false
 ;excludeHoldLocations[] = "24 Hour Reserve"
 ;excludeHoldLocations[] = "Reference Collection"
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -483,10 +483,9 @@ class Folio extends AbstractAPI implements
                 }
             }
             return true;
-        } else {
-            // Otherwise exclude checking by exact match
-            return !in_array($locationName, $excludeLocs);
         }
+        // Otherwise exclude checking by exact match
+        return !in_array($locationName, $excludeLocs);
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -463,14 +463,13 @@ class Folio extends AbstractAPI implements
      */
     protected function isHoldable($locationName)
     {
-        $setSubSt = (bool)$this->config['Holds']['excludeHoldLocationsBySubString']
-                    ?? false;
+        $mode = $this->config['Holds']['excludeHoldLocationsCompareMode'] ?? 'exact';
         $excludeLocs = (array)$this->config['Holds']['excludeHoldLocations'] ?? [];
 
-        // Exclude Checking by substring match
-        if ($setSubSt) {
-            foreach ($excludeLocs as $exclude) {
-                if (strpos($locationName, $exclude) !== false) {
+        // Exclude checking by regex match
+        if ($mode == "regex") {
+            foreach ($excludeLocs as $pattern) {
+                if (preg_match($pattern, $locationName) === 1) {
                     return false;
                 }
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -467,19 +467,25 @@ class Folio extends AbstractAPI implements
         $excludeLocs = (array)$this->config['Holds']['excludeHoldLocations'] ?? [];
 
         // Exclude checking by regex match
-        if ($mode == "regex") {
+        if (trim(strtolower($mode)) == "regex") {
             foreach ($excludeLocs as $pattern) {
-                if (preg_match($pattern, $locationName) === 1) {
+                $match = @preg_match($pattern, $locationName);
+                // Invalid regex, skip this pattern
+                if ($match === false) {
+                    $this->logWarning(
+                        'Invalid regex found in excludeHoldLocations: ' .
+                        $pattern
+                    );
+                    continue;
+                }
+                if ($match === 1) {
                     return false;
                 }
             }
             return true;
         } else {
             // Otherwise exclude checking by exact match
-            return !in_array(
-                $locationName,
-                $excludeLocs
-            );
+            return !in_array($locationName, $excludeLocs);
         }
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -463,10 +463,21 @@ class Folio extends AbstractAPI implements
      */
     protected function isHoldable($locationName)
     {
-        return !in_array(
-            $locationName,
-            (array)($this->config['Holds']['excludeHoldLocations'] ?? [])
-        );
+        // Exclude Checking by substring match
+        if ((bool)$this->config['Holds']['excludeHoldLocationsBySubString'] ?? false){
+            foreach((array)($this->config['Holds']['excludeHoldLocations'] ?? []) as $exclude) {
+                if (strpos($locationName, $exclude) !== false) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+        // Otherwise exclude checking by exact match
+            return !in_array(
+                $locationName,
+                (array)($this->config['Holds']['excludeHoldLocations'] ?? [])
+            );
+        }
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -463,19 +463,23 @@ class Folio extends AbstractAPI implements
      */
     protected function isHoldable($locationName)
     {
+        $setSubSt = (bool)$this->config['Holds']['excludeHoldLocationsBySubString']
+                    ?? false;
+        $excludeLocs = (array)$this->config['Holds']['excludeHoldLocations'] ?? [];
+
         // Exclude Checking by substring match
-        if ((bool)$this->config['Holds']['excludeHoldLocationsBySubString'] ?? false){
-            foreach((array)($this->config['Holds']['excludeHoldLocations'] ?? []) as $exclude) {
+        if ($setSubSt) {
+            foreach ($excludeLocs as $exclude) {
                 if (strpos($locationName, $exclude) !== false) {
                     return false;
                 }
             }
             return true;
         } else {
-        // Otherwise exclude checking by exact match
+            // Otherwise exclude checking by exact match
             return !in_array(
                 $locationName,
-                (array)($this->config['Holds']['excludeHoldLocations'] ?? [])
+                $excludeLocs
             );
         }
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -502,7 +502,6 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $result);
     }
 
-
     /**
      * Test calls to isHoldable with various config settings
      * for the exclude holds properties


### PR DESCRIPTION
This adds a new config in the FOLIO driver to optionally exclude hold location matches by substrings instead of full string matches. This config is set to false by default for backwards compatibility.

This was useful for us because we have a dozens of locations we need to exclude that either start with or contain a string (such as "Reserve" or "Special Collection") but the full location have more specific qualifiers in them like the floor and the list would be quite long and difficult to maintain anytime a new location was added or changed.