### PR TITLE
Add data-attribute title to facet-groups

### DIFF
--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -54,7 +54,8 @@
 <?php $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
 <?php if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
   <?php foreach ($sideFacetSet as $title => $cluster): ?>
-    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>" data-title="<?=$this->transEsc($cluster['label']) ?>">
+    <?php // Data-title attribute is for analytics use.  Do not remove. ?>
+    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>" data-title="<?=$this->escapeHtmlAttr($cluster['label']) ?>">
       <button class="title<?php if (in_array($title, $collapsedFacets)): ?> collapsed<?php endif ?>" data-toggle="collapse" data-target="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
         <span class="facet-title"><?=$this->transEsc($cluster['label'])?></span>
         <?=$this->icon('collapse', 'facet-title-icon') ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -54,7 +54,7 @@
 <?php $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
 <?php if (!empty($sideFacetSet) && $results->getResultTotal() > 0): ?>
   <?php foreach ($sideFacetSet as $title => $cluster): ?>
-    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>">
+    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($title) ?>" data-title="<?=$this->transEsc($cluster['label']) ?>">
       <button class="title<?php if (in_array($title, $collapsedFacets)): ?> collapsed<?php endif ?>" data-toggle="collapse" data-target="#side-collapse-<?=$this->escapeHtmlAttr($title) ?>" >
         <span class="facet-title"><?=$this->transEsc($cluster['label'])?></span>
         <?=$this->icon('collapse', 'facet-title-icon') ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
@@ -68,7 +68,7 @@
 <?php $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
 <?php if (!empty($activeFacets) && $results->getResultTotal() > 0): ?>
   <?php foreach ($activeFacets as $field => $facetName): ?>
-    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($field) ?>">
+    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($field) ?>" data-title="<?=$this->transEsc($facetName) ?>">
       <button class="title<?php if (in_array($field, $collapsedFacets)): ?> collapsed<?php endif ?>" data-toggle="collapse" data-target="#side-collapse-<?=$this->escapeHtmlAttr($field) ?>" >
         <?=$this->transEsc($facetName)?>
       </button>

--- a/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
@@ -68,7 +68,8 @@
 <?php $hierarchicalFacetSortOptions = $this->recommend->getHierarchicalFacetSortOptions() ?>
 <?php if (!empty($activeFacets) && $results->getResultTotal() > 0): ?>
   <?php foreach ($activeFacets as $field => $facetName): ?>
-    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($field) ?>" data-title="<?=$this->transEsc($facetName) ?>">
+    <?php // Data-title attribute is for analytics use.  Do not remove. ?>
+    <div class="facet-group" id="side-panel-<?=$this->escapeHtmlAttr($field) ?>" data-title="<?=$this->escapeHtmlAttr($facetName) ?>">
       <button class="title<?php if (in_array($field, $collapsedFacets)): ?> collapsed<?php endif ?>" data-toggle="collapse" data-target="#side-collapse-<?=$this->escapeHtmlAttr($field) ?>" >
         <?=$this->transEsc($facetName)?>
       </button>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -196,7 +196,8 @@
         <?php endforeach; ?>
       <?php endif; ?>
       <h2><?=$this->transEsc("Search Tips")?></h2>
-      <div class="facet-group" data-title="<?=$this->transEsc("Search Tips") ?>">
+      <?php // Data-title attribute is for analytics use.  Do not remove. ?>
+      <div class="facet-group" data-title="<?=$this->escapeHtmlAttr("Search Tips") ?>">
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=advsearch&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Advanced Search")?></a>
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=search&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Search Operators")?></a>
       </div>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -196,7 +196,7 @@
         <?php endforeach; ?>
       <?php endif; ?>
       <h2><?=$this->transEsc("Search Tips")?></h2>
-      <div class="facet-group">
+      <div class="facet-group" data-title="<?=$this->transEsc("Search Tips") ?>">
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=advsearch&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Advanced Search")?></a>
         <a class="facet help-link" data-lightbox href="<?=$this->url('help-home')?>?topic=search&amp;_=<?=time() ?>"><?=$this->transEsc("Help with Search Operators")?></a>
       </div>


### PR DESCRIPTION
I'm building GTM tracking for clicking facets, to record the specific facet as well as the facet group.  This way one can filter analytics for (say) all Format facets before seeing the individual use of each facet within Format.

Within sidebar facets, the individual facet elements have a data-title attribute with the title of the facet.  That makes getting the facet link text simpler than parsing the link text.

This PR adds the same data-title to the facet-group element.  Until recently there was no clean way to extract a facet group title; we'd have identify the first button element within the facet group (brittle), get its text and then strip it of the leading and trailing whitespace.  I see a [recent change](https://github.com/vufind-org/vufind/pull/1962/files) added a span.facet-title within one use of facet-group, but doesn't appear to be for analytics purposes (so I'm not clear if it will best stable for that) and wasn't implemented in other facet-group declarations.  This PR has the potential to be intentional for analytics and thus safer for that use.
