### PR TITLE
Add support for username with Redis sessions.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -203,6 +203,7 @@ secure = false
 ;redis_port               = 6379
 ;redis_connection_timeout = 0.5
 ;redis_db                 = 0
+;redis_user               = username (optional)
 ;redis_auth               = some_secret_password
 ;redis_version            = 3
 ;redis_standalone         = true

--- a/module/VuFind/src/VuFind/Session/RedisFactory.php
+++ b/module/VuFind/src/VuFind/Session/RedisFactory.php
@@ -87,11 +87,20 @@ class RedisFactory implements FactoryInterface
         $host = $config->redis_host ?? 'localhost';
         $port = $config->redis_port ?? 6379;
         $timeout = $config->redis_connection_timeout ?? 0.5;
-        $auth = $config->redis_auth ?? false;
+        $password = $config->redis_auth ?? null;
+        $username = $config->redis_user ?? null;
         $redisDb = $config->redis_db ?? 0;
 
         // Create Credis client, the connection is established lazily
-        $client = new \Credis_Client($host, $port, $timeout, '', $redisDb, $auth);
+        $client = new \Credis_Client(
+            $host,
+            $port,
+            $timeout,
+            '',
+            $redisDb,
+            $password,
+            $username
+        );
         if ((bool)($config->redis_standalone ?? true)) {
             $client->forceStandalone();
         }


### PR DESCRIPTION
Redis 6 supports username in addition to password. Also use null instead of false for undefined password since that's what Credis_Client documents as a valid option.