### PR TITLE
SierraRest: Add support for checking canFreeze up front.

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -123,6 +123,11 @@ title_hold_bib_levels = a:b:m:d
 ; available for pickup). Supported values are "frozen" and "pickUpLocation".
 ;updateFields = frozen:pickUpLocation
 
+; If frozen is included in updateFields above, whether to check up front if the hold
+; can be frozen. This check should only be enabled with Sierra 5.6 or later since it
+; is known to be very slow in prior versions. Default is false.
+;checkFreezability = false
+
 ; Optional help texts that can be displayed on the hold form. Displayed as is;
 ; HTML tags can be used, and everything needs to be properly escaped.
 ;helpText[*] = "Default help text used if not overridden."


### PR DESCRIPTION
Since requesting the canFreeze field used to be slow, there was no option for requesting it up front. This slowness is supposedly fixed in Sierra 5.6, so I added an option to enable the check. This makes it possible to prevent trying to change a hold that doesn't have anything changeable. I intentionally kept the check in updateHolds in place at least for now to ensure VuFind doesn't request a change that should not be made.