### PR TITLE
Fix validate ids logic

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -209,7 +209,7 @@ class HoldsController extends AbstractBase
         }
         // If the user input contains a value not found in the session
         // legal list, something has been tampered with -- abort the process.
-        if ($this->holds()->validateIds($selectedIds)) {
+        if (!$this->holds()->validateIds($selectedIds)) {
             $this->flashMessenger()
                 ->addErrorMessage('error_inconsistent_parameters');
             return $this->inLightbox()

--- a/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBase.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/AbstractRequestBase.php
@@ -145,7 +145,7 @@ abstract class AbstractRequestBase extends AbstractPlugin
      */
     public function validateIds($ids): bool
     {
-        return (bool)array_diff($ids, $this->getValidIds());
+        return !(bool)array_diff($ids, $this->getValidIds());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/HoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/HoldsTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Holds controller plugin test class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Moravian Library 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Josef Moravec <moravec@mzk.cz>
+ * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+namespace VuFindTest\Controller\Plugin;
+
+use Laminas\Session\SessionManager;
+use VuFind\Controller\Plugin\Holds;
+use VuFind\Crypt\HMAC;
+use VuFind\Date\Converter as DateConverter;
+
+/**
+ * Class HoldsTest
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Josef Moravec <moravec@mzk.cz>
+ * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class HoldsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Mock container
+     *
+     * @var \VuFindTest\Container\MockContainer
+     */
+    protected $container;
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->container = new \VuFindTest\Container\MockContainer($this);
+    }
+
+    /**
+     * Test validateIds method
+     *
+     * @return void
+     */
+    public function testValidateIds()
+    {
+        $hmac = $this->container->createMock(HMAC::class);
+        $sessionManager = new SessionManager();
+        $dateConverter = $this->container->createMock(DateConverter::class);
+        $plugin = new Holds($hmac, $sessionManager, $dateConverter);
+        $plugin->rememberValidId('1');
+        $plugin->rememberValidId('2');
+        $this->assertTrue($plugin->validateIds(['1', '2']));
+        $this->assertTrue($plugin->validateIds(['1']));
+        $this->assertFalse($plugin->validateIds(['3']));
+        $this->assertFalse($plugin->validateIds(['1', '3']));
+    }
+}


### PR DESCRIPTION
The method documentation says:

`Validate supplied IDs against remembered IDs. Returns true if all supplied IDs are remembered, otherwise returns false.`

Which is in not true - see the test added