### PR TITLE
Always return true from Redis session handler's destroy method.

### DIFF
--- a/module/VuFind/src/VuFind/Session/Redis.php
+++ b/module/VuFind/src/VuFind/Session/Redis.php
@@ -119,8 +119,8 @@ class Redis extends AbstractBase
 
         // Perform Redis-specific cleanup
         $unlinkMethod = ($this->redisVersion >= 4) ? 'unlink' : 'del';
-        $return = $this->connection->$unlinkMethod("vufind_sessions/{$sessId}");
+        $this->connection->$unlinkMethod("vufind_sessions/{$sessId}");
 
-        return $return > 0;
+        return true;
     }
 }


### PR DESCRIPTION
Since Redis could have already unlinked an expired session, it's not an error if it's not found. But if we return false, PHP will log an error.