### PR TITLE
Add retry support to Redis session handler.

### DIFF
--- a/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
+++ b/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
@@ -58,7 +58,8 @@ trait RetryTrait
      *
      * @param callable  $callback       Method to call
      * @param ?callable $statusCallback Status callback called before retry and after
-     * a successful retry. The callback gets the number of
+     * a successful retry. The callback gets the attempt number and either an
+     * exception if an error occurred or null if the request succeeded after retries.
      * @param array     $options        Optional options to override defaults in
      * $this->retryOptions. Options can also include a retryableExceptionCallback
      * for a callback that gets the attempt number and exception as parameters and

--- a/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
+++ b/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Trait that provides support for calling a method with configurable retries
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Service
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development
+ */
+namespace VuFind\Service\Feature;
+
+/**
+ * Trait that provides support for calling a method with configurable retries
+ *
+ * @category VuFind
+ * @package  Service
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development
+ */
+trait RetryTrait
+{
+    /**
+     * Retry options
+     *
+     * @var array
+     */
+    protected $retryOptions = [
+        'retryCount' => 5,            // number of retries (set to 0 to disable)
+        'firstBackoff' => 0,          // backoff (delay) before first retry
+                                      // (milliseconds)
+        'subsequentBackoff' => 200,   // backoff (delay) before subsequent retries
+                                      // (milliseconds)
+        'exponentialBackoff' => true, // whether to use exponential backoff
+        'maximumBackoff' => 1000      // maximum backoff (milliseconds)
+    ];
+
+    /**
+     * Call a method and retry the call if an exception is thrown
+     *
+     * @param callable  $callback       Method to call
+     * @param ?callable $statusCallback Status callback called before retry and after
+     * a successful retry
+     * @param array     $options        Optional options to override defaults in
+     * $this->retryOptions
+     *
+     * @return mixed
+     */
+    protected function callWithRetry(
+        callable $callback,
+        ?callable $statusCallback = null,
+        array $options = []
+    ) {
+        $attempt = 0;
+        $exception = null;
+        $options = array_merge($this->retryOptions, $options);
+        do {
+            if (++$attempt > 1 && $statusCallback) {
+                $statusCallback($attempt, false);
+            }
+            try {
+                $result = $callback();
+                if ($attempt > 1 && $statusCallback) {
+                    $statusCallback($attempt, true);
+                }
+                return $result;
+            } catch (\Exception $e) {
+                if (null === $exception) {
+                    $exception = $e;
+                }
+                if ($checkCallback = $options['retryableExceptionCallback'] ?? '') {
+                    if (!$checkCallback($e)) {
+                        break;
+                    }
+                }
+            }
+        } while ($this->checkRetryAndSleep($attempt, $options));
+        // No success, re-throw the original exception:
+        throw $exception;
+    }
+
+    /**
+     * Check if the call needs to be retried and sleep before the retry
+     *
+     * @param int   $attempt Failed attempt number
+     * @param array $options Current options
+     *
+     * @return bool
+     */
+    protected function checkRetryAndSleep(int $attempt, array $options): bool
+    {
+        if ($attempt > $options['retryCount']) {
+            return false;
+        }
+        if (1 === $attempt) {
+            usleep($options['firstBackoff'] * 1000);
+        } else {
+            $backoff = $options['subsequentBackoff'];
+            if ($options['exponentialBackoff']) {
+                $backoff = min(
+                    2 ** ($attempt - 2) * $backoff,
+                    $options['maximumBackoff']
+                );
+            }
+            usleep($backoff * 1000);
+        }
+        return true;
+    }
+}

--- a/module/VuFind/src/VuFind/Session/Redis.php
+++ b/module/VuFind/src/VuFind/Session/Redis.php
@@ -7,7 +7,8 @@
  *
  * PHP version 7
  *
- * Coypright (C) Moravian Library 2019.
+ * Copyright (C) Moravian Library 2019.
+ * Copyright (C) The National Library of Finland 2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -26,6 +27,7 @@
  * @package  Session_Handlers
  * @author   Veros Kaplan <cpk-dev@mzk.cz>
  * @author   Josef Moravec <moravec@mzk.cz>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:session_handlers Wiki
  */
@@ -40,11 +42,14 @@ use Laminas\Config\Config;
  * @package  Session_Handlers
  * @author   Veros Kaplan <cpk-dev@mzk.cz>
  * @author   Josef Moravec <moravec@mzk.cz>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:session_handlers Wiki
  */
 class Redis extends AbstractBase
 {
+    use \VuFind\Service\Feature\RetryTrait;
+
     /**
      * Redis connection
      *
@@ -71,6 +76,7 @@ class Redis extends AbstractBase
         parent::__construct($config);
         $this->redisVersion = (int)($config->redis_version ?? 3);
         $this->connection = $connection;
+        $this->retryOptions['retryCount'] = 2;
     }
 
     /**
@@ -83,8 +89,12 @@ class Redis extends AbstractBase
      */
     public function read($sessId): string
     {
-        $session = $this->connection->get("vufind_sessions/{$sessId}");
-        return $session !== false ? $session : '';
+        return $this->callWithRetry(
+            function () use ($sessId): string {
+                $session = $this->connection->get("vufind_sessions/{$sessId}");
+                return $session !== false ? $session : '';
+            }
+        );
     }
 
     /**
@@ -97,10 +107,14 @@ class Redis extends AbstractBase
      */
     protected function saveSession($sessId, $data): bool
     {
-        return $this->connection->setex(
-            "vufind_sessions/{$sessId}",
-            $this->lifetime,
-            $data
+        return $this->callWithRetry(
+            function () use ($sessId, $data): bool {
+                return $this->connection->setex(
+                    "vufind_sessions/{$sessId}",
+                    $this->lifetime,
+                    $data
+                );
+            }
         );
     }
 
@@ -119,8 +133,11 @@ class Redis extends AbstractBase
 
         // Perform Redis-specific cleanup
         $unlinkMethod = ($this->redisVersion >= 4) ? 'unlink' : 'del';
-        $this->connection->$unlinkMethod("vufind_sessions/{$sessId}");
-
-        return true;
+        return $this->callWithRetry(
+            function () use ($unlinkMethod, $sessId): bool {
+                $this->connection->$unlinkMethod("vufind_sessions/{$sessId}");
+                return true;
+            }
+        );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * RetryTrait Test Class
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+namespace VuFindTest\Service\Feature;
+
+use VuFind\Service\Feature\RetryTrait;
+
+/**
+ * RetryTrait Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RetryTraitTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test retry with an eventually successful method
+     *
+     * @return void
+     */
+    public function testRetrySuccess()
+    {
+        $testClass = new MockRetryTestClass();
+
+        $counter = 0;
+        $result = $testClass->call(
+            function () use (&$counter) {
+                ++$counter;
+                if ($counter > 2) {
+                    return 'success';
+                }
+                throw new \Exception("Fail attempt $counter");
+            }
+        );
+        $this->assertEquals('success', $result);
+    }
+
+    /**
+     * Test the trait with a failing method
+     *
+     * @return void
+     */
+    public function testRetryFail()
+    {
+        $testClass = new MockRetryTestClass();
+
+        $counter = 0;
+        $startTime = microtime(true);
+        $this->expectExceptionMessage('Fail attempt 1');
+        $testClass->call(
+            function () use (&$counter, $startTime) {
+                ++$counter;
+                // Check timing:
+                if ($counter > 1) {
+                    $backoff = 0.050 * ($counter - 2);
+                    $this->assertGreaterThanOrEqual(
+                        $backoff,
+                        microtime(true) - $startTime
+                    );
+                    $this->assertLessThan(
+                        $backoff + 0.2, // given some slack
+                        microtime(true) - $startTime
+                    );
+                }
+                throw new \Exception("Fail attempt $counter");
+            },
+            function ($attempt, $success) use (&$counter) {
+                $this->assertEquals($counter + 1, $attempt);
+                $this->assertFalse($success);
+            },
+            [
+                'subsequentBackoff' => 50
+            ]
+        );
+    }
+}
+
+/**
+ * Mock test class for RetryTrait
+ */
+class MockRetryTestClass
+{
+    use RetryTrait;
+
+    /**
+     * Call a method and retry the call if an exception is thrown
+     *
+     * @param callable  $callback       Method to call
+     * @param ?callable $statusCallback Status callback called before retry and after
+     * a successful retry
+     * @param array     $options        Optional options to override defaults in
+     * $this->retryOptions
+     *
+     * @return mixed
+     */
+    public function call(
+        callable $callback,
+        ?callable $statusCallback = null,
+        array $options = []
+    ) {
+        return $this->callWithRetry($callback, $statusCallback, $options);
+    }
+}


### PR DESCRIPTION
If Redis is configured with a short timeout, a long-running request (or utility) may be unable to process the session since the Redis client gets disconnected in the middle. Introduces a new generic retry trait to help implementation.