### PR TITLE
Fix labeling of blended results and the Blender test.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -4,7 +4,7 @@
  *
  * PHP version 7
  *
- * Copyright (C) The National Library of Finland 2022.
+ * Copyright (C) The National Library of Finland 2022-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -50,6 +50,15 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
             'Backends' => [
                 'Solr' => 'Items in Library',
                 'SolrAuth' => 'Authors',
+            ],
+            'Blending' => [
+                'initialResults' => [
+                    'Solr',
+                    'Solr',
+                    'SolrAuth',
+                    'SolrAuth',
+                ],
+                'blockSize' => 7,
             ],
             'CheckboxFacets' => [
                 'blender_backend:Solr' => 'Items in Library',
@@ -114,7 +123,15 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
     public function testSearch(array $queryParams, array $expectedLabels): void
     {
         $this->changeConfigs(
-            ['Blender' => $this->getBlenderIniOverrides()],
+            [
+                'config' => [
+                    'SearchTabs' => [
+                        'Solr' => 'Catalog',
+                        'Blender' => 'Blended',
+                    ]
+                ],
+                'Blender' => $this->getBlenderIniOverrides()
+            ],
             ['Blender']
         );
 
@@ -131,10 +148,13 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals(1 + $offset, intval($start));
         $this->assertEquals(20 + $offset, intval($limit));
 
-        $i = 0;
-        foreach ($this->findCss($page, '.result span.label-source') as $label) {
-            $this->assertEquals($expectedLabels[$i], $label->getText(), $i);
-            ++$i;
+        for ($i = 0; $i < count($expectedLabels); $i++) {
+            $this->assertEquals(
+                $expectedLabels[$i],
+                $this->findCss($page, '.result span.label-source', null, $i)
+                    ->getText(),
+                "Result index $i"
+            );
         }
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -123,15 +123,7 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
     public function testSearch(array $queryParams, array $expectedLabels): void
     {
         $this->changeConfigs(
-            [
-                'config' => [
-                    'SearchTabs' => [
-                        'Solr' => 'Catalog',
-                        'Blender' => 'Blended',
-                    ]
-                ],
-                'Blender' => $this->getBlenderIniOverrides()
-            ],
+            ['Blender' => $this->getBlenderIniOverrides()],
             ['Blender']
         );
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -28,6 +28,8 @@
  */
 namespace VuFindSearch\Backend\Blender\Response\Json;
 
+use VuFindSearch\Response\RecordInterface;
+
 /**
  * JSON-based record collection for records from multiple sources.
  *
@@ -215,19 +217,34 @@ class RecordCollection
         foreach ($collections as $backendId => $collection) {
             $result[$backendId] = [];
             $records = $collection->getRecords();
-            $label = $this->config->Backends[$backendId];
             foreach ($records as $record) {
                 $record->setSourceIdentifiers(
                     $record->getSourceIdentifier(),
                     $backendId
                 );
-                if ($label) {
-                    $record->addLabel($label, 'source');
-                }
                 $result[$backendId][] = $record;
             }
         }
         return $result;
+    }
+
+    /**
+     * Add a record to the collection.
+     *
+     * @param RecordInterface $record        Record to add
+     * @param bool            $checkExisting Whether to check for existing record in
+     * the collection (slower, but makes sure there are no duplicates)
+     *
+     * @return void
+     */
+    public function add(RecordInterface $record, $checkExisting = true)
+    {
+        $label = $this->config->Backends[$record->getSearchBackendIdentifier()]
+            ?? '';
+        if ($label) {
+            $record->addLabel($label, 'source');
+        }
+        parent::add($record, $checkExisting);
     }
 
     /**


### PR DESCRIPTION
While working on tests for #2701 I noticed that the Blender test wasn't working properly and didn't check the labels of the records. After fixing that I realized that Blender added labels for the initial batch of records only, so on second result screen some of the records were missing the label. This fixes both issues.