### PR TITLE
Set a more reasonable default sort for course reserves.

### DIFF
--- a/config/vufind/reserves.ini
+++ b/config/vufind/reserves.ini
@@ -3,6 +3,7 @@
 [General]
 default_handler      = AllFields    ; Search handler to use if none is specified
 default_sort         = relevance
+empty_search_relevance_override = course_str,instructor_str
 case_sensitive_bools = true
 default_side_recommend[] = SideFacets:Facets:CheckboxFacets:reserves
 facet_limit = 20


### PR DESCRIPTION
This is a trivial but useful improvement: since course reserves displays the results of an empty sort when first accessed (if the Solr-based mode is in use), it makes sense to have a more meaningful/useful sort for empty searches.