### PR TITLE
[VUFIND-1597] include available ISSNs in OpenURLs for Serial format

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -686,11 +686,24 @@ class DefaultRecord extends AbstractBase
             return 'Article';
         } elseif (in_array('Journal', $formats)) {
             return 'Journal';
+        } elseif (strlen($this->getCleanISSN()) > 0) {
+            // If the record has an ISSN and we have not already
+            // decided it is an Article, we'll treat it as a Book
+            // if it has an ISBN and is therefore likely part of a
+            // monographic series. Otherwise, we'll treat it as a
+            // Journal.
+            // Anecdotally, some link resolvers do not return correct
+            // results when given both ISBN and ISSN for a member of a
+            // monographic series.
+            return strlen($this->getCleanISBN()) > 0 ? 'Book' : 'Journal';
         } elseif (isset($formats[0])) {
             return $formats[0];
-        } elseif (strlen($this->getCleanISSN()) > 0) {
-            return 'Journal';
         } elseif (strlen($this->getCleanISBN()) > 0) {
+            // Last ditch. Note that this is last by intention; if the
+            // record has a format set and also has an ISBN, we don't
+            // necessarily want to send the ISBN, as it may be a game
+            // or a DVD that wouldn't typically be found in OpenURL
+            // knowledgebases.
             return 'Book';
         }
         return 'UnknownFormat';

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
@@ -102,7 +102,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test an OpenURL for an unknown material type.
+     * Test an OpenURL for an unknown material type with no ISBN or ISSN
      *
      * @return void
      */
@@ -110,9 +110,39 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
     {
         $overrides = [
             'format' => ['Thingie'],
+            'isbn' => [],
         ];
         $driver = $this->getDriver($overrides);
         $this->assertEquals('url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&ctx_enc=info%3Aofi%2Fenc%3AUTF-8&rfr_id=info%3Asid%2Fvufind.svn.sourceforge.net%3Agenerator&rft.title=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F&rft.date=1992&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&rft.creator=Vico%2C+Giambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.format=Thingie&rft.language=Italian', $driver->getOpenUrl());
+    }
+
+    /**
+     * Test an OpenURL for an unknown material type with only ISBNs
+     *
+     * @return void
+     */
+    public function testUnknownTypeOnlyISBNsOpenURL()
+    {
+        $overrides = [
+            'format' => ['Thingie'],
+        ];
+        $driver = $this->getDriver($overrides);
+        $this->assertEquals('url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&ctx_enc=info%3Aofi%2Fenc%3AUTF-8&rfr_id=info%3Asid%2Fvufind.svn.sourceforge.net%3Agenerator&rft.title=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F&rft.date=1992&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&rft.creator=Vico%2C+Giambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.format=Thingie&rft.language=Italian', $driver->getOpenUrl());
+    }
+
+    /**
+     * Test an OpenURL for an unknown material type with both ISBN and ISSN
+     *
+     * @return void
+     */
+    public function testUnknownTypeBothISBNsandISSNsOpenURL()
+    {
+        $overrides = [
+            'format' => ['Thingie'],
+            'issn' => ['1234-5678'],
+        ];
+        $driver = $this->getDriver($overrides);
+        $this->assertEquals('url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&ctx_enc=info%3Aofi%2Fenc%3AUTF-8&rfr_id=info%3Asid%2Fvufind.svn.sourceforge.net%3Agenerator&rft.title=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F&rft.date=1992&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&rft.genre=book&rft.btitle=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F&rft.series=Vico%2C+Giambattista%2C+1668-1744.+Works.+1982+%3B&rft.au=Vico%2C+Giambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.edition=Fictional+edition.&rft.isbn=8820737493', $driver->getOpenUrl());
     }
 
     /**


### PR DESCRIPTION
Records whose format ends up as Serial due to vagaries of the cataloging of the original MARC record should nonetheless have any available ISSNs included in their OpenURL. With this patch, the OpenURL format is set as 'Journal' for such records.

TODO
- [x] Resolve [VUFIND-1597](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1597) when closing