### PR TITLE
SierraRest: Add option to display orders and fix display of itemless …

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -198,3 +198,5 @@ title_hold_bib_levels = a:b:m:d
 ; Whether to sort items by enum/chron (v field) instead of order they are returned
 ; from Sierra. Default is true.
 ;sort_by_enum_chron = false
+; Whether to retrieve and display orders (default is false):
+;display_orders = false

--- a/languages/HoldingStatus/en.ini
+++ b/languages/HoldingStatus/en.ini
@@ -1,3 +1,5 @@
+copies_ordered_on_date = "%%copies%% copies ordered on %%date%%"
+copy_ordered_on_date = "1 copy ordered on %%date%%"
 service_available_presentation = "In Library Use Only"
 service_loan = "Loan"
 service_presentation = "In Library Use"

--- a/languages/HoldingStatus/fi.ini
+++ b/languages/HoldingStatus/fi.ini
@@ -1,3 +1,5 @@
+copies_ordered_on_date = "%%copies%% kappaletta tilattu %%date%%"
+copy_ordered_on_date = "%%copies%% kappale tilattu %%date%%"
 service_available_presentation = "Käyttö vain kirjastossa"
 service_loan = "Lainaus"
 service_presentation = "Käyttö kirjastossa"

--- a/languages/HoldingStatus/sv.ini
+++ b/languages/HoldingStatus/sv.ini
@@ -1,3 +1,5 @@
+copies_ordered_on_date = "%%copies%% exemplar beställt %%date%%"
+copy_ordered_on_date = "1 exemplar beställt %%date%%"
 service_available_presentation = "Endast i biblioteksbruk"
 service_loan = "Lån"
 service_presentation = "I biblioteksbruk"

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2108,7 +2108,9 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
             $messages[] = $this->translate(
                 [
                     'HoldingStatus',
-                    ($order['copies'] === 1 ? 'copy' : 'copies') . '_ordered_on_date'
+                    1 === $order['copies']
+                        ? 'copy_ordered_on_date'
+                        : 'copies_ordered_on_date'
                 ],
                 [
                     '%%copies%%' => $order['copies'],
@@ -2586,7 +2588,7 @@ class SierraRest extends AbstractBase implements TranslatorAwareInterface,
         }
         // Fetch requested fields as well as any cached fields to keep everything in
         // sync:
-        $allFields = [...$fieldsArray, ...$cached['fields']];
+        $allFields = array_unique([...$fieldsArray, ...$cached['fields']]);
         $result = $this->makeRequest(
             [$this->apiBase, 'bibs', $this->extractBibId($id)],
             ['fields' => implode(',', $allFields)],


### PR DESCRIPTION
…holdings.

Orders are displayed like items, but only one item per location with further information in the item notes. 

Also changes \DateTime:ISO8601 to \DateTime::ATOM since the former is deprecated.

