### PR TITLE
SierraRest: Use RetryTrait to retry requests that receive an empty re…

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -32,6 +32,9 @@ http_timeout = 30
 ; set it to false (the default value) if you are only indexing the numeric ID without
 ; the .b prefix or checksum suffix.
 use_prefixed_ids = false
+; Number of retries in case an API request fails with a retryable error.
+; Default is 2. Set to 0 to disable retries.
+;http_retries = 2
 
 [Authentication]
 ; When using patron-specific data access, different values may be used as the


### PR DESCRIPTION
…ply.

Sierra, depending on server configuration, may sometimes fail with an empty reply. An immediate retry was recommended by the vendor.