### PR TITLE
Use better factory/remove constructor for SolrAuthor results.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Results/PluginManager.php
+++ b/module/VuFind/src/VuFind/Search/Results/PluginManager.php
@@ -94,7 +94,8 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         \VuFind\Search\Solr\Results::class =>
             \VuFind\Search\Solr\ResultsFactory::class,
         \VuFind\Search\SolrAuth\Results::class => ResultsFactory::class,
-        \VuFind\Search\SolrAuthor\Results::class => ResultsFactory::class,
+        \VuFind\Search\SolrAuthor\Results::class =>
+            \VuFind\Search\Solr\ResultsFactory::class,
         \VuFind\Search\SolrAuthorFacets\Results::class => ResultsFactory::class,
         \VuFind\Search\SolrCollection\Results::class => ResultsFactory::class,
         \VuFind\Search\SolrReserves\Results::class => ResultsFactory::class,

--- a/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
@@ -43,22 +43,6 @@ use VuFindSearch\Service as SearchService;
 class Results extends SolrResults
 {
     /**
-     * Constructor
-     *
-     * @param \VuFind\Search\Base\Params $params        Object representing user
-     * search parameters.
-     * @param SearchService              $searchService Search service
-     * @param Loader                     $recordLoader  Record loader
-     */
-    public function __construct(
-        \VuFind\Search\Base\Params $params,
-        SearchService $searchService,
-        Loader $recordLoader
-    ) {
-        parent::__construct($params, $searchService, $recordLoader);
-    }
-
-    /**
      * Options for UrlQueryHelper
      *
      * @return array

--- a/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuthor/Results.php
@@ -27,9 +27,7 @@
  */
 namespace VuFind\Search\SolrAuthor;
 
-use VuFind\Record\Loader;
 use VuFind\Search\Solr\Results as SolrResults;
-use VuFindSearch\Service as SearchService;
 
 /**
  * Author Search Options


### PR DESCRIPTION
I discovered today that hierarchical facets break the Author module because the facet helper doesn't get injected correctly. It should be safe to simply use the Solr-specific factory to ensure appropriate dependencies.

Reviewing related code also revealed a completely redundant constructor, which I have removed for simplicity.