### PR TITLE
Fix account status array for requests to match the AJAX array.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractUserRequestAction.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractUserRequestAction.php
@@ -40,6 +40,8 @@ use Laminas\Mvc\Controller\Plugin\Params;
  */
 abstract class AbstractUserRequestAction extends AbstractIlsAndUserAction
 {
+    use \VuFind\ILS\Logic\SummaryTrait;
+
     /**
      * ILS driver method for data retrieval.
      *
@@ -65,20 +67,6 @@ abstract class AbstractUserRequestAction extends AbstractIlsAndUserAction
             return $this->formatResponse('', self::STATUS_HTTP_ERROR);
         }
         $requests = $this->ils->{$this->lookupMethod}($patron);
-        $status = [
-            'available' => 0,
-            'in_transit' => 0,
-            'other' => 0
-        ];
-        foreach ($requests as $request) {
-            if (!empty($request['available'])) {
-                $status['available'] ++;
-            } elseif (!empty($request['in_transit'])) {
-                $status['in_transit'] ++;
-            } else {
-                $status['other'] ++;
-            }
-        }
-        return $this->formatResponse($status);
+        return $this->formatResponse($this->getRequestSummary($requests));
     }
 }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
@@ -45,6 +45,8 @@ use VuFind\Session\Settings as SessionSettings;
  */
 class GetUserFines extends AbstractIlsAndUserAction
 {
+    use \VuFind\ILS\Logic\SummaryTrait;
+
     /**
      * Currency formatter
      *
@@ -89,11 +91,8 @@ class GetUserFines extends AbstractIlsAndUserAction
         if (!$this->ils->checkCapability('getMyFines')) {
             return $this->formatResponse('', self::STATUS_HTTP_ERROR);
         }
-        $sum = 0;
-        foreach ($this->ils->getMyFines($patron) as $fine) {
-            $sum += $fine['balance'];
-        }
-        $value = $sum / 100;
+        $summary = $this->getFineSummary($this->ils->getMyFines($patron));
+        $value = $summary['sum'] / 100;
         $display = $this->currencyFormatter->convertToDisplayFormat($value);
         return $this->formatResponse(compact('value', 'display'));
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
@@ -91,9 +91,9 @@ class GetUserFines extends AbstractIlsAndUserAction
         if (!$this->ils->checkCapability('getMyFines')) {
             return $this->formatResponse('', self::STATUS_HTTP_ERROR);
         }
-        $summary = $this->getFineSummary($this->ils->getMyFines($patron));
-        $value = $summary['sum'] / 100;
-        $display = $this->currencyFormatter->convertToDisplayFormat($value);
-        return $this->formatResponse(compact('value', 'display'));
+        $fines = $this->ils->getMyFines($patron);
+        return $this->formatResponse(
+            $this->getFineSummary($fines, $this->currencyFormatter)
+        );
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
@@ -41,6 +41,8 @@ use VuFind\Record\Loader;
  */
 class IlsRecords extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
 {
+    use \VuFind\ILS\Logic\SummaryTrait;
+
     /**
      * VuFind configuration
      *
@@ -115,21 +117,13 @@ class IlsRecords extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
         if (empty($this->config->Authentication->enableAjax)) {
             return null;
         }
-        $accountStatus = [
-            'available' => 0,
-            'in_transit' => 0,
-            'other' => 0,
-        ];
-        foreach ($records as $record) {
-            $request = $record->getExtraDetail('ils_details');
-            if ($request['available'] ?? false) {
-                $accountStatus['available']++;
-            } elseif ($request['in_transit'] ?? false) {
-                $accountStatus['in_transit']++;
-            } else {
-                $accountStatus['other']++;
-            }
-        }
-        return $accountStatus;
+        return $this->getRequestSummary(
+            array_map(
+                function ($record) {
+                    return $record->getExtraDetail('ils_details');
+                },
+                $records
+            )
+        );
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
@@ -117,15 +117,17 @@ class IlsRecords extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
         }
         $accountStatus = [
             'available' => 0,
-            'in_transit' => 0
+            'in_transit' => 0,
+            'other' => 0,
         ];
         foreach ($records as $record) {
             $request = $record->getExtraDetail('ils_details');
             if ($request['available'] ?? false) {
                 $accountStatus['available']++;
-            }
-            if ($request['in_transit'] ?? false) {
+            } elseif ($request['in_transit'] ?? false) {
                 $accountStatus['in_transit']++;
+            } else {
+                $accountStatus['other']++;
             }
         }
         return $accountStatus;

--- a/module/VuFind/src/VuFind/ILS/Logic/SummaryTrait.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/SummaryTrait.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Trait for getting a summary for checkouts, fines, holds, ILL requests or storage
+ * retrieval requests.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2019.
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  ILS
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace VuFind\ILS\Logic;
+
+/**
+ * Trait for getting a summary for checkouts, fines, holds, ILL requests or storage
+ * retrieval requests.
+ *
+ * @category VuFind
+ * @package  ILS
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+trait SummaryTrait
+{
+    /**
+     * Get a status summary for an array of fines
+     *
+     * @param iterable $fines Fines
+     *
+     * @return array Associative array with key sum.
+     */
+    protected function getFineSummary(iterable $fines): array
+    {
+        $sum = 0;
+        foreach ($fines as $fine) {
+            $sum += $fine['balance'];
+        }
+        return compact('sum');
+    }
+
+    /**
+     * Get a status summary for an array of requests
+     *
+     * @param iterable $requests Requests
+     *
+     * @return array Associative array with keys available, in_transit and other.
+     */
+    protected function getRequestSummary(iterable $requests): array
+    {
+        $available = 0;
+        $in_transit = 0;
+        $other = 0;
+        foreach ($requests as $request) {
+            if ($request['available'] ?? false) {
+                ++$available;
+            } elseif ($request['in_transit'] ?? false) {
+                ++$in_transit;
+            } else {
+                ++$other;
+            }
+        }
+        return compact('available', 'in_transit', 'other');
+    }
+
+    /**
+     * Get a status summary for an array of checkouts
+     *
+     * @param iterable $requests Requests
+     *
+     * @return array Associative array with keys available, in_transit and other.
+     */
+    protected function getTransactionSummary(iterable $transactions): array
+    {
+        $ok = 0;
+        $overdue = 0;
+        $warn = 0;
+        foreach ($transactions as $transaction) {
+            switch ($transaction['dueStatus'] ?? '') {
+                case 'due':
+                    ++$warn;
+                    break;
+                case 'overdue':
+                    ++$overdue;
+                    break;
+                default:
+                    ++$ok;
+                    break;
+            }
+        }
+        return compact('ok', 'overdue', 'warn');
+    }
+}

--- a/module/VuFind/src/VuFind/ILS/Logic/SummaryTrait.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/SummaryTrait.php
@@ -30,6 +30,8 @@
  */
 namespace VuFind\ILS\Logic;
 
+use VuFind\Service\CurrencyFormatter;
+
 /**
  * Trait for getting a summary for checkouts, fines, holds, ILL requests or storage
  * retrieval requests.
@@ -46,17 +48,21 @@ trait SummaryTrait
     /**
      * Get a status summary for an array of fines
      *
-     * @param iterable $fines Fines
+     * @param iterable          $fines     Fines
+     * @param CurrencyFormatter $formatter Currency formatter
      *
-     * @return array Associative array with key sum.
+     * @return array Associative array with keys total and display.
      */
-    protected function getFineSummary(iterable $fines): array
-    {
-        $sum = 0;
+    protected function getFineSummary(
+        iterable $fines,
+        CurrencyFormatter $formatter
+    ): array {
+        $total = 0;
         foreach ($fines as $fine) {
-            $sum += $fine['balance'];
+            $total += $fine['balance'];
         }
-        return compact('sum');
+        $display = $formatter->convertToDisplayFormat($total / 100);
+        return compact('total', 'display');
     }
 
     /**
@@ -86,7 +92,7 @@ trait SummaryTrait
     /**
      * Get a status summary for an array of checkouts
      *
-     * @param iterable $requests Requests
+     * @param iterable $transactions Checkouts
      *
      * @return array Associative array with keys available, in_transit and other.
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -334,13 +334,36 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $this->login();
         $storage = [
             // No fines
-            ['fines' => ['value' => 0, 'display' => 'ZILTCH']],
+            [
+                'fines' => [
+                    'total' => 0,
+                    'display' => 'ZILTCH'
+                ]
+            ],
             // Holds in transit only
-            ['holds' => ['in_transit' => 1, 'available' => 0]],
+            [
+                'holds' => [
+                    'in_transit' => 1,
+                    'available' => 0,
+                    'other' => 0
+                ]
+            ],
             // ILL Requests in transit only
-            ['illRequests' => ['in_transit' => 1, 'available' => 0]],
+            [
+                'illRequests' => [
+                    'in_transit' => 1,
+                    'available' => 0,
+                    'other' => 0
+                ]
+            ],
             // Storage Retrievals in transit only
-            ['storageRetrievalRequests' => ['in_transit' => 1, 'available' => 0]]
+            [
+                'storageRetrievalRequests' => [
+                    'in_transit' => 1,
+                    'available' => 0,
+                    'other' => 0
+                ]
+            ]
         ];
         $this->checkIcon($storage, '.account-status-none');
     }
@@ -436,7 +459,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             [
                 [
                     'holds' => ['available' => 1],
-                    'fines' => ['value' => 0, 'display' => 'none']
+                    'fines' => ['total' => 0, 'display' => 'none']
                 ]
             ],
             '.account-status-good'

--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -185,7 +185,7 @@ $(document).ready(function registerAccountAjax() {
     selector: ".fines-status",
     ajaxMethod: "getUserFines",
     render: function render($element, status, ICON_LEVELS) {
-      if (status.value === 0) {
+      if (status.total === 0) {
         $element.addClass("hidden");
         return ICON_LEVELS.NONE;
       }
@@ -193,7 +193,7 @@ $(document).ready(function registerAccountAjax() {
       return ICON_LEVELS.DANGER;
     },
     updateNeeded: function updateNeeded(currentStatus, status) {
-      return status.total !== currentStatus.value;
+      return status.total !== currentStatus.total;
     }
   });
 


### PR DESCRIPTION
Now matches the logic in AbstractUserRequestAction. Fixes account status for requests getting refreshed any time e.g. holds screen loads.

TODO
- [x] Update changelog when merging (The data provided by the GetUserFines AJAX handler has changed, using "total" instead of "value" for the element containing the sum of all fines; the associated logic in account_ajax.js has been adjusted to match. If you have customized this, please change local code to reflect the change.)