### PR TITLE
Fix collection search links.

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-collection.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-collection.phtml
@@ -1,5 +1,7 @@
-<?=$this->url(
-    'collection',
-    ['id' => $this->lookfor],
-    ['query' => ['recordID' => $this->driver->getUniqueID(), 'sid' => ($this->results ? $this->results->getSearchId() : null) ?? $this->searchMemory()->getCurrentSearchId()]]
+<?=htmlspecialchars(
+    $this->url(
+        'collection',
+        ['id' => $this->lookfor],
+        ['query' => ['recordID' => $this->driver->getUniqueID(), 'sid' => ($this->results ? $this->results->getSearchId() : null) ?? $this->searchMemory()->getCurrentSearchId()]]
+    )
 )?>

--- a/themes/bootstrap3/templates/RecordDriver/Search2Default/link-collection.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Search2Default/link-collection.phtml
@@ -1,1 +1,7 @@
-<?=$this->url('search2collection', ['id' => $this->lookfor])?>?recordID=<?=urlencode($this->driver->getUniqueID())?>
+<?=htmlspecialchars(
+    $this->url(
+        'search2collection',
+        ['id' => $this->lookfor],
+        ['query' => ['recordID' => $this->driver->getUniqueID(), 'sid' => ($this->results ? $this->results->getSearchId() : null) ?? $this->searchMemory()->getCurrentSearchId()]]
+    )
+)?>


### PR DESCRIPTION
Fixes Search2Default link-collection template to match that of DefaultRecord and fixes encoding of returned URLs to match other templates and the expected result.

Since Record helper's getLink is expected to return the URL with HTML special characters encoded as entities.