### PR TITLE
Fix Feedback admin pagination.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Table/Feedback.php
@@ -114,6 +114,7 @@ class Feedback extends Gateway
             $select::JOIN_LEFT
         )->order('created DESC');
 
+        $page = null === $page ? null : intval($page);
         if (null !== $page) {
             $select->limit($limit);
             $select->offset($limit * ($page - 1));

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
@@ -70,7 +70,8 @@ class FeedbackController extends AbstractAdmin
         $feedback = $feedbackTable->getFeedbackByFilter(
             $this->convertFilter($this->getParam('form_name')),
             $this->convertFilter($this->getParam('site_url')),
-            $this->convertFilter($this->getParam('status'))
+            $this->convertFilter($this->getParam('status')),
+            $this->getParam('page')
         );
         $view = $this->createViewModel(
             [


### PR DESCRIPTION
I just discovered that if you have more than 20 feedback items, you can't page through them. This PR should fix the problem.