### PR TITLE
Fix redirect after updating feedback status.

### DIFF
--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
@@ -232,11 +232,13 @@ class FeedbackController extends AbstractAdmin
             'admin/feedback',
             [],
             [
-                'query' => [
-                    'form_name' => $this->getParam('form_name'),
-                    'site_url' => $this->getParam('site_url'),
-                    'status' => $this->getParam('status'),
-                ],
+                'query' => array_filter(
+                    [
+                        'form_name' => $this->getParam('form_name'),
+                        'site_url' => $this->getParam('site_url'),
+                        'status' => $this->getParam('status'),
+                    ]
+                ),
             ]
         );
     }


### PR DESCRIPTION
This fixes another small bug I found while testing the Feedback admin -- after changing a status, invalid filters get applied to the URL. This is caused by passing null values as part of the query option when building the URL; it can be fixed with a simple array_filter.