### PR TITLE
Eliminate private properties/methods.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -2788,7 +2788,7 @@ class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      *
      * @return string Scheme attribute or empty string
      */
-    private function _schemeAttr(string $element, $namespacePrefix = 'ns1'): string
+    protected function schemeAttr(string $element, $namespacePrefix = 'ns1'): string
     {
         return isset($this->schemes[$element])
             ? ' ' . $namespacePrefix . ':Scheme="' . $this->schemes[$element] . '"'
@@ -2811,7 +2811,7 @@ class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
     ): string {
         $fullElementName = $namespacePrefix . ':' . $elementName;
         return '<' . $fullElementName .
-            $this->_schemeAttr($elementName, $namespacePrefix) . '>' .
+            $this->schemeAttr($elementName, $namespacePrefix) . '>' .
             htmlspecialchars($text) .
             '</' . $fullElementName . '>';
     }

--- a/module/VuFind/src/VuFind/Security/NonceGenerator.php
+++ b/module/VuFind/src/VuFind/Security/NonceGenerator.php
@@ -47,7 +47,7 @@ class NonceGenerator
      *
      * @var string
      */
-    private $_nonce;
+    protected $nonce;
 
     /**
      * Generates a random nonce parameter.
@@ -57,9 +57,9 @@ class NonceGenerator
      */
     public function getNonce() : String
     {
-        if (!$this->_nonce) {
-            $this->_nonce = base64_encode(random_bytes(32));
+        if (!$this->nonce) {
+            $this->nonce = base64_encode(random_bytes(32));
         }
-        return $this->_nonce;
+        return $this->nonce;
     }
 }


### PR DESCRIPTION
We generally avoid private methods/properties in VuFind to promote maximum extensibility, but it appears that a couple slipped through the cracks. These were caught by PSR-12 style checking due to the leading underscores. This PR just switches them to protected.