### PR TITLE
PSR-12: fix multi-line foreach styling.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SirsiDynix Unicorn ILS Driver (VuFind side)
  *
@@ -24,6 +25,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://code.google.com/p/vufind-unicorn/ vufind-unicorn project
  */
+
 namespace VuFind\ILS\Driver;
 
 use VuFind\Exception\ILS as ILSException;
@@ -1363,10 +1365,8 @@ class Unicorn extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
         // PS: Does this make this implementation year-3K safe?
         $link_digits = floor(strlen((string)PHP_INT_MAX) / 2);
 
-        foreach ((array_key_exists(0, $textuals)
-                  ? []
-                  : $record->getFields('863'))
-                 as $field) {
+        $data863 = array_key_exists(0, $textuals) ? [] : $record->getFields('863');
+        foreach ($data863 as $field) {
             $linking_field = $record->getSubfield($field, '8');
 
             if ($linking_field === false) {

--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Abstract options search model.
  *
@@ -25,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
+
 namespace VuFind\Search\Base;
 
 use Laminas\Config\Config;
@@ -317,9 +319,8 @@ abstract class Options implements TranslatorAwareInterface
         $id = $this->getSearchClassId();
         $facetSettings = $configLoader->get($this->facetsIni);
         if (isset($facetSettings->AvailableFacetSortOptions[$id])) {
-            foreach ($facetSettings->AvailableFacetSortOptions[$id]->toArray()
-                     as $facet => $sortOptions
-            ) {
+            $sortArray = $facetSettings->AvailableFacetSortOptions[$id]->toArray();
+            foreach ($sortArray as $facet => $sortOptions) {
                 $this->facetSortOptions[$facet] = [];
                 foreach (explode(',', $sortOptions) as $fieldAndLabel) {
                     [$field, $label] = explode('=', $fieldAndLabel);

--- a/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CookieConsent view helper
  *
@@ -25,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
+
 namespace VuFind\View\Helper\Root;
 
 use VuFind\Cookie\CookieManager;
@@ -360,9 +362,8 @@ implements TranslatorAwareInterface
             'desc' => $this->translate('CookieConsent::Description'),
             'exp' => $this->translate('CookieConsent::Expiration'),
         ];
-        foreach ($this->consentConfig['Categories'] ?? []
-            as $categoryId => $categoryConfig
-        ) {
+        $categoryData = $this->consentConfig['Categories'] ?? [];
+        foreach ($categoryData as $categoryId => $categoryConfig) {
             if ($enabledCategories && !in_array($categoryId, $enabledCategories)) {
                 continue;
             }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Content Security Policy view helper
  *
@@ -25,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
  */
+
 namespace VuFind\View\Helper\Root;
 
 use Laminas\Http\Response;
@@ -68,9 +70,11 @@ class Csp extends \Laminas\View\Helper\AbstractHelper
             return;
         }
         $headers = $this->response->getHeaders();
-        foreach (['Content-Security-Policy', 'Content-Security-Policy-Report-Only']
-            as $field
-        ) {
+        $fieldsToCheck = [
+            'Content-Security-Policy',
+            'Content-Security-Policy-Report-Only'
+        ];
+        foreach ($fieldsToCheck as $field) {
             if ($cspHeaders = $headers->get($field)) {
                 // Make sure the result is iterable (an array cast doesn't work here
                 // as a single header may be castable as an array):

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Search API Controller
  *
@@ -25,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
  */
+
 namespace VuFindApi\Controller;
 
 use Laminas\ServiceManager\ServiceLocatorInterface;
@@ -324,9 +326,7 @@ implements ApiInterface
                     $request,
                     $requestedFields
                 ) {
-                    foreach ($request['facet'] ?? []
-                       as $facet
-                    ) {
+                    foreach ($request['facet'] ?? [] as $facet) {
                         if (!isset($hierarchicalFacets[$facet])) {
                             $params->addFacet($facet);
                         }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -26,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://vufind.org
  */
+
 namespace VuFindSearch\Backend\Blender\Response\Json;
 
 use VuFindSearch\Response\RecordInterface;
@@ -192,9 +193,8 @@ extends \VuFindSearch\Backend\Solr\Response\Json\RecordCollection
      */
     public function getFacetDelimiter(string $field): string
     {
-        foreach ($this->config->Advanced_Settings->delimited_facets ?? []
-            as $current
-        ) {
+        $delimitedFacets = $this->config->Advanced_Settings->delimited_facets ?? [];
+        foreach ($delimitedFacets as $current) {
             $parts = explode('|', $current);
             if ($parts[0] === $field) {
                 return $parts[1] ?? $this->config->Advanced_Settings->delimiter
@@ -318,9 +318,8 @@ extends \VuFindSearch\Backend\Solr\Response\Json\RecordCollection
 
         // Iterate through mappings and merge values. It is important to do it this
         // way since multiple facets may map to a single one.
-        foreach ($this->mappings['Facets']['Fields'] ?? []
-            as $facetField => $settings
-        ) {
+        $facetFieldData = $this->mappings['Facets']['Fields'] ?? [];
+        foreach ($facetFieldData as $facetField => $settings) {
             // Get merged list of facet values:
             $list = $this->mapFacetValues($collections, $settings);
             // Re-sort the list:

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
@@ -26,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
+
 namespace VuFindSearch\Backend\Solr\Response\Json;
 
 use VuFindSearch\Response\AbstractRecordCollection;
@@ -133,9 +134,8 @@ class RecordCollection extends AbstractRecordCollection
     {
         if (null === $this->facetFields) {
             $this->facetFields = [];
-            foreach ($this->response['facet_counts']['facet_fields'] ?? []
-                as $field => $facetData
-            ) {
+            $facetFieldData = $this->response['facet_counts']['facet_fields'] ?? [];
+            foreach ($facetFieldData as $field => $facetData) {
                 $values = [];
                 foreach ($facetData as $value) {
                     $values[$value[0]] = $value[1];

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Unit tests for Blender backend.
  *
@@ -25,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
+
 namespace VuFindTest\Backend\Blender;
 
 use Laminas\Config\Config;
@@ -565,9 +567,7 @@ class BackendTest extends TestCase
                 $facetCounts = $facets[$facet];
                 $expectedCounts = [];
                 foreach ($active as $source) {
-                    foreach ($expectedCountsForSources[$source]
-                        as $field => $count
-                    ) {
+                    foreach ($expectedCountsForSources[$source] as $field => $count) {
                         $expectedCounts[$field] =
                             ($expectedCounts[$field] ?? 0) + $count;
                     }


### PR DESCRIPTION
Multi-line foreach statements seem to cause phpcbf to choke. This PR eliminates all multi-line foreach statements from VuFind's code (and also makes some minor PSR-12 related changes in the files that are being edited). This is further progress on #2745 preparation.