### PR TITLE
MultiBackend: remove unnecessary require statements.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -33,14 +33,6 @@ use Laminas\Config\Exception\RuntimeException;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\ILS\Driver\MultiBackend;
 
-require_once __DIR__ . '/MultiBackendTest/ILSMockTrait.php';
-require_once __DIR__ . '/MultiBackendTest/DemoMock.php';
-require_once __DIR__ . '/MultiBackendTest/DummyILS.php';
-require_once __DIR__ . '/MultiBackendTest/UnicornMock.php';
-require_once __DIR__ . '/MultiBackendTest/VoyagerMock.php';
-require_once __DIR__ . '/MultiBackendTest/Voyager2Mock.php';
-require_once __DIR__ . '/MultiBackendTest/VoyagerNoSupportMock.php';
-
 /**
  * ILS driver test
  *


### PR DESCRIPTION
I'm not exactly sure what autoloading magic is allowing this to work, but this works without explicit require statements. Better to get rid of them!