### PR TITLE
PSR-12: allow longer lines; adjust class declarations

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserAction.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserAction.php
@@ -44,8 +44,7 @@ use VuFind\Session\Settings as SessionSettings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-abstract class AbstractIlsAndUserAction extends AbstractBase
-implements TranslatorAwareInterface
+abstract class AbstractIlsAndUserAction extends AbstractBase implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class AbstractIlsAndUserActionFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class AbstractIlsAndUserActionFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisAction.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisAction.php
@@ -43,8 +43,7 @@ use VuFind\Session\Settings as SessionSettings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-abstract class AbstractRelaisAction extends AbstractBase
-implements TranslatorAwareInterface
+abstract class AbstractRelaisAction extends AbstractBase implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class AbstractRelaisActionFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class AbstractRelaisActionFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class CommentRecordFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class CommentRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class DeleteRecordCommentFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class DeleteRecordCommentFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -54,7 +54,8 @@ use VuFind\Session\Settings as SessionSettings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetItemStatuses extends AbstractBase implements TranslatorAwareInterface,
+class GetItemStatuses extends AbstractBase implements
+    TranslatorAwareInterface,
     \VuFind\I18n\HasSorterInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatusesFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetItemStatusesFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetItemStatusesFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCommentsAsHTMLFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetRecordCommentsAsHTMLFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetRecordCommentsAsHTMLFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetailsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetRecordDetailsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetRecordDetailsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordRatingFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordRatingFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetRecordRatingFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetRecordRatingFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetRecordTagsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetRecordTagsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersionsFactory.php
@@ -40,8 +40,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetRecordVersionsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetRecordVersionsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinksFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetResolverLinksFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetResolverLinksFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
@@ -40,8 +40,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetResultCountFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetResultCountFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetSaveStatusesFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetSaveStatusesFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
@@ -49,8 +49,7 @@ use VuFind\Session\Settings as SessionSettings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetSideFacets extends \VuFind\AjaxHandler\AbstractBase
-implements \Laminas\Log\LoggerAwareInterface
+class GetSideFacets extends \VuFind\AjaxHandler\AbstractBase implements \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacetsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetSideFacetsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class GetSideFacetsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFinesFactory.php
@@ -44,8 +44,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class GetUserFinesFactory extends AbstractIlsAndUserActionFactory
-implements FactoryInterface
+class GetUserFinesFactory extends AbstractIlsAndUserActionFactory implements FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Auth/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Auth/AbstractBase.php
@@ -44,7 +44,8 @@ use VuFind\Exception\Auth as AuthException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-abstract class AbstractBase implements \VuFind\Db\Table\DbTableAwareInterface,
+abstract class AbstractBase implements
+    \VuFind\Db\Table\DbTableAwareInterface,
     \VuFind\I18n\Translator\TranslatorAwareInterface,
     \Laminas\Log\LoggerAwareInterface
 {

--- a/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/EmailAuthenticatorFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class EmailAuthenticatorFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class EmailAuthenticatorFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -46,7 +46,8 @@ use VuFind\Validator\CsrfInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class Manager implements \LmcRbacMvc\Identity\IdentityProviderInterface,
+class Manager implements
+    \LmcRbacMvc\Identity\IdentityProviderInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/Auth/Shibboleth/MultiIdPConfigurationLoader.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth/MultiIdPConfigurationLoader.php
@@ -25,7 +25,8 @@ use VuFind\Exception\Auth as AuthException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class MultiIdPConfigurationLoader implements ConfigurationLoaderInterface,
+class MultiIdPConfigurationLoader implements
+    ConfigurationLoaderInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProvider.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AbstractILSChannelProvider.php
@@ -43,8 +43,7 @@ use VuFindSearch\Command\RetrieveBatchCommand;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-abstract class AbstractILSChannelProvider extends AbstractChannelProvider
-implements TranslatorAwareInterface
+abstract class AbstractILSChannelProvider extends AbstractChannelProvider implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
@@ -48,8 +48,7 @@ use VuFindSearch\ParamBag;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class AlphaBrowse extends AbstractChannelProvider
-implements TranslatorAwareInterface
+class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/ChannelProvider/Facets.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/Facets.php
@@ -45,8 +45,7 @@ use VuFind\Search\Results\PluginManager as ResultsManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Facets extends AbstractChannelProvider
-implements TranslatorAwareInterface
+class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/ChannelProvider/Random.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/Random.php
@@ -44,8 +44,7 @@ use VuFindSearch\Command\RandomCommand;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Random extends AbstractChannelProvider
-implements TranslatorAwareInterface
+class Random extends AbstractChannelProvider implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
@@ -46,8 +46,7 @@ use VuFindSearch\Command\SimilarCommand;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SimilarItems extends AbstractChannelProvider
-implements TranslatorAwareInterface
+class SimilarItems extends AbstractChannelProvider implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/Content/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Content/AbstractBase.php
@@ -40,7 +40,8 @@ use VuFindCode\ISBN;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-abstract class AbstractBase implements \VuFindHttp\HttpServiceAwareInterface,
+abstract class AbstractBase implements
+    \VuFindHttp\HttpServiceAwareInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/Content/Covers/Google.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Google.php
@@ -38,8 +38,7 @@ namespace VuFind\Content\Covers;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Google extends \VuFind\Content\AbstractCover
-implements \VuFindHttp\HttpServiceAwareInterface
+class Google extends \VuFind\Content\AbstractCover implements \VuFindHttp\HttpServiceAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;
 

--- a/module/VuFind/src/VuFind/Content/Covers/Orb.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Orb.php
@@ -38,8 +38,7 @@ namespace VuFind\Content\Covers;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:content_provider_components
  */
-class Orb extends \VuFind\Content\AbstractCover
-implements \VuFindHttp\HttpServiceAwareInterface
+class Orb extends \VuFind\Content\AbstractCover implements \VuFindHttp\HttpServiceAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;
 

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -38,7 +38,8 @@ namespace VuFind\Content;
  * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ObalkyKnihService implements \VuFindHttp\HttpServiceAwareInterface,
+class ObalkyKnihService implements
+    \VuFindHttp\HttpServiceAwareInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;

--- a/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
+++ b/module/VuFind/src/VuFind/Content/PageLocatorFactory.php
@@ -44,8 +44,7 @@ use VuFind\I18n\Locale\LocaleSettings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class PageLocatorFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class PageLocatorFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/TemplateBasedFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class TemplateBasedFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class TemplateBasedFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -69,8 +69,7 @@ use VuFind\I18n\Translator\TranslatorAwareTrait;
  *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class AbstractBase extends AbstractActionController
-implements TranslatorAwareInterface
+class AbstractBase extends AbstractActionController implements TranslatorAwareInterface
 {
     use TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/Controller/AjaxController.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxController.php
@@ -42,8 +42,7 @@ use VuFind\I18n\Translator\TranslatorAwareInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
  */
-class AjaxController extends AbstractActionController
-implements TranslatorAwareInterface
+class AjaxController extends AbstractActionController implements TranslatorAwareInterface
 {
     use AjaxResponseTrait;
     use \VuFind\I18n\Translator\TranslatorAwareTrait;

--- a/module/VuFind/src/VuFind/Controller/Plugin/Permission.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Permission.php
@@ -45,7 +45,8 @@ use VuFind\Role\PermissionManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class Permission extends AbstractPlugin implements LoggerAwareInterface,
+class Permission extends AbstractPlugin implements
+    LoggerAwareInterface,
     TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -66,7 +66,8 @@ use Laminas\Db\Sql\Select;
  * @property ?string $auth_method
  * @property string  $last_language
  */
-class User extends RowGateway implements \VuFind\Db\Table\DbTableAwareInterface,
+class User extends RowGateway implements
+    \VuFind\Db\Table\DbTableAwareInterface,
     \LmcRbacMvc\Identity\IdentityInterface
 {
     use \VuFind\Db\Table\DbTableAwareTrait;

--- a/module/VuFind/src/VuFind/DigitalContent/OverdriveConnector.php
+++ b/module/VuFind/src/VuFind/DigitalContent/OverdriveConnector.php
@@ -61,8 +61,10 @@ use VuFind\Exception\ILS as ILSException;
  *       provide option for asking about autocheckout for every hold
  *       provide config options for how to handle patrons with no access to OD
  */
-class OverdriveConnector implements LoggerAwareInterface,
-    AuthorizationServiceAwareInterface, \VuFindHttp\HttpServiceAwareInterface
+class OverdriveConnector implements
+    LoggerAwareInterface,
+    AuthorizationServiceAwareInterface,
+    \VuFindHttp\HttpServiceAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait {
         logError as error;

--- a/module/VuFind/src/VuFind/DoiLinker/Unpaywall.php
+++ b/module/VuFind/src/VuFind/DoiLinker/Unpaywall.php
@@ -41,7 +41,9 @@ use VuFindHttp\HttpServiceAwareInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:doi_linkers Wiki
  */
-class Unpaywall implements DoiLinkerInterface, TranslatorAwareInterface,
+class Unpaywall implements
+    DoiLinkerInterface,
+    TranslatorAwareInterface,
     HttpServiceAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;

--- a/module/VuFind/src/VuFind/Exception/RecordMissing.php
+++ b/module/VuFind/src/VuFind/Exception/RecordMissing.php
@@ -38,7 +38,8 @@ namespace VuFind\Exception;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class RecordMissing extends \Exception implements HttpStatusInterface,
+class RecordMissing extends \Exception implements
+    HttpStatusInterface,
     SeverityLevelInterface
 {
     /**

--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/AbstractBaseFactory.php
@@ -45,8 +45,7 @@ use Psr\Container\ContainerInterface;
  * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class AbstractBaseFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class AbstractBaseFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTree.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTree.php
@@ -42,8 +42,7 @@ use Laminas\Mvc\Controller\Plugin\Url as UrlPlugin;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:hierarchy_components Wiki
  */
-class JSTree extends AbstractBase
-implements \VuFind\I18n\Translator\TranslatorAwareInterface
+class JSTree extends AbstractBase implements \VuFind\I18n\Translator\TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
@@ -43,7 +43,8 @@ use VuFindHttp\HttpServiceAwareInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-abstract class AbstractAPI extends AbstractBase implements HttpServiceAwareInterface,
+abstract class AbstractAPI extends AbstractBase implements
+    HttpServiceAwareInterface,
     LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait {

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -57,7 +57,8 @@ use VuFind\Exception\ILS as ILSException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class Aleph extends AbstractBase implements \Laminas\Log\LoggerAwareInterface,
+class Aleph extends AbstractBase implements
+    \Laminas\Log\LoggerAwareInterface,
     \VuFindHttp\HttpServiceAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -45,8 +45,10 @@ use VuFind\Marc\MarcReader;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class Alma extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface,
-    \Laminas\Log\LoggerAwareInterface, TranslatorAwareInterface
+class Alma extends AbstractBase implements
+    \VuFindHttp\HttpServiceAwareInterface,
+    \Laminas\Log\LoggerAwareInterface,
+    TranslatorAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -51,7 +51,8 @@ use VuFindHttp\HttpServiceAwareInterface as HttpServiceAwareInterface;
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
 class DAIA extends AbstractBase implements
-    HttpServiceAwareInterface, LoggerAwareInterface
+    HttpServiceAwareInterface,
+    LoggerAwareInterface
 {
     use \VuFind\Cache\CacheTrait {
         getCacheKey as protected getBaseCacheKey;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -46,7 +46,8 @@ use VuFindHttp\HttpServiceAwareInterface as HttpServiceAwareInterface;
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
 class Folio extends AbstractAPI implements
-    HttpServiceAwareInterface, TranslatorAwareInterface
+    HttpServiceAwareInterface,
+    TranslatorAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\I18n\Translator\TranslatorAwareTrait;

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -52,7 +52,8 @@ use VuFindHttp\HttpServiceAwareInterface;
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
 class KohaILSDI extends AbstractBase implements
-    HttpServiceAwareInterface, LoggerAwareInterface
+    HttpServiceAwareInterface,
+    LoggerAwareInterface
 {
     use \VuFind\Cache\CacheTrait {
         getCacheKey as protected getBaseCacheKey;

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -44,8 +44,10 @@ use VuFindHttp\HttpServiceAwareInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class SierraRest extends AbstractBase implements TranslatorAwareInterface,
-    HttpServiceAwareInterface, LoggerAwareInterface,
+class SierraRest extends AbstractBase implements
+    TranslatorAwareInterface,
+    HttpServiceAwareInterface,
+    LoggerAwareInterface,
     \VuFind\I18n\HasSorterInterface
 {
     public const HOLDINGS_LINE_NUMBER = 40;

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -47,7 +47,8 @@ use VuFind\Marc\MarcReader;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://code.google.com/p/vufind-unicorn/ vufind-unicorn project
  **/
-class Unicorn extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface,
+class Unicorn extends AbstractBase implements
+    \VuFindHttp\HttpServiceAwareInterface,
     \VuFind\I18n\HasSorterInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -52,8 +52,7 @@ use Yajra\Pdo\Oci8;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class Voyager extends AbstractBase
-implements TranslatorAwareInterface, \Laminas\Log\LoggerAwareInterface
+class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
     use \VuFind\Log\LoggerAwareTrait {

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -43,7 +43,8 @@ use VuFind\Exception\ILS as ILSException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
  */
-class XCNCIP2 extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterface,
+class XCNCIP2 extends AbstractBase implements
+    \VuFindHttp\HttpServiceAwareInterface,
     \Laminas\Log\LoggerAwareInterface,
     \VuFind\I18n\Translator\TranslatorAwareInterface
 {

--- a/module/VuFind/src/VuFind/OAuth2/Repository/AccessTokenRepository.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/AccessTokenRepository.php
@@ -45,8 +45,7 @@ use VuFind\OAuth2\Entity\AccessTokenEntity;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class AccessTokenRepository extends AbstractTokenRepository
-implements AccessTokenRepositoryInterface
+class AccessTokenRepository extends AbstractTokenRepository implements AccessTokenRepositoryInterface
 {
     /**
      * Constructor

--- a/module/VuFind/src/VuFind/OAuth2/Repository/AuthCodeRepository.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/AuthCodeRepository.php
@@ -43,8 +43,7 @@ use VuFind\OAuth2\Entity\AuthCodeEntity;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class AuthCodeRepository extends AbstractTokenRepository
-implements AuthCodeRepositoryInterface
+class AuthCodeRepository extends AbstractTokenRepository implements AuthCodeRepositoryInterface
 {
     /**
      * Constructor

--- a/module/VuFind/src/VuFind/OAuth2/Repository/RefreshTokenRepository.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/RefreshTokenRepository.php
@@ -43,8 +43,7 @@ use VuFind\OAuth2\Entity\RefreshTokenEntity;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class RefreshTokenRepository extends AbstractTokenRepository
-implements RefreshTokenRepositoryInterface
+class RefreshTokenRepository extends AbstractTokenRepository implements RefreshTokenRepositoryInterface
 {
     /**
      * Constructor

--- a/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/CollectionSideFacetsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class CollectionSideFacetsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class CollectionSideFacetsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/EuropeanaResults.php
+++ b/module/VuFind/src/VuFind/Recommend/EuropeanaResults.php
@@ -44,8 +44,10 @@ use Laminas\Feed\Reader\Reader as FeedReader;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class EuropeanaResults implements RecommendInterface,
-    \VuFindHttp\HttpServiceAwareInterface, \Laminas\Log\LoggerAwareInterface
+class EuropeanaResults implements
+    RecommendInterface,
+    \VuFindHttp\HttpServiceAwareInterface,
+    \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;
     use \VuFindHttp\HttpServiceAwareTrait;

--- a/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/EuropeanaResultsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class EuropeanaResultsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class EuropeanaResultsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/FavoriteFacetsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class FavoriteFacetsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class FavoriteFacetsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectConfigManagerFactory.php
@@ -45,8 +45,7 @@ use VuFind\Config\PluginManager as ConfigManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class InjectConfigManagerFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class InjectConfigManagerFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectResultsManagerFactory.php
@@ -45,8 +45,7 @@ use VuFind\Search\Results\PluginManager as ResultsManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class InjectResultsManagerFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class InjectResultsManagerFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/InjectSearchRunnerFactory.php
@@ -45,8 +45,7 @@ use VuFind\Search\SearchRunner;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class InjectSearchRunnerFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class InjectSearchRunnerFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/MapSelection.php
+++ b/module/VuFind/src/VuFind/Recommend/MapSelection.php
@@ -43,7 +43,8 @@ use VuFindSearch\Service;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class MapSelection implements \VuFind\Recommend\RecommendInterface,
+class MapSelection implements
+    \VuFind\Recommend\RecommendInterface,
     \VuFind\I18n\Translator\TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;

--- a/module/VuFind/src/VuFind/Recommend/OpenLibrarySubjects.php
+++ b/module/VuFind/src/VuFind/Recommend/OpenLibrarySubjects.php
@@ -46,7 +46,8 @@ use VuFind\Solr\Utils as SolrUtils;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class OpenLibrarySubjects implements RecommendInterface,
+class OpenLibrarySubjects implements
+    RecommendInterface,
     \VuFindHttp\HttpServiceAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;

--- a/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/RandomRecommendFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class RandomRecommendFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class RandomRecommendFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
+++ b/module/VuFind/src/VuFind/Recommend/WorldCatIdentitiesFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class WorldCatIdentitiesFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class WorldCatIdentitiesFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -42,7 +42,8 @@ use VuFind\XSLT\Import\VuFind as ArticleStripper;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-abstract class AbstractBase implements \VuFind\Db\Table\DbTableAwareInterface,
+abstract class AbstractBase implements
+    \VuFind\Db\Table\DbTableAwareInterface,
     \VuFind\I18n\Translator\TranslatorAwareInterface,
     \VuFindSearch\Response\RecordInterface
 {

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -49,7 +49,8 @@ use VuFindSearch\Command\SearchCommand;
  *
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  */
-class SolrDefault extends DefaultRecord implements Feature\PreviousUniqueIdInterface,
+class SolrDefault extends DefaultRecord implements
+    Feature\PreviousUniqueIdInterface,
     Feature\VersionAwareInterface
 {
     use Feature\HierarchyAwareTrait;

--- a/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrMarcRemote.php
@@ -49,7 +49,8 @@ use VuFindHttp\HttpServiceAwareInterface as HttpServiceAwareInterface;
  * @link     https://vufind.org/wiki/configuration:remote_marc_records
  */
 class SolrMarcRemote extends SolrMarc implements
-    HttpServiceAwareInterface, LoggerAwareInterface
+    HttpServiceAwareInterface,
+    LoggerAwareInterface
 {
     use \VuFindHttp\HttpServiceAwareTrait;
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/RecordTab/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordTab/AbstractBase.php
@@ -41,7 +41,8 @@ use LmcRbacMvc\Service\AuthorizationServiceAwareTrait;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:record_tabs Wiki
  */
-abstract class AbstractBase implements TabInterface,
+abstract class AbstractBase implements
+    TabInterface,
     AuthorizationServiceAwareInterface
 {
     use AuthorizationServiceAwareTrait;

--- a/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/AbstractContentFactory.php
@@ -46,8 +46,7 @@ use VuFind\Content\PluginManager as ContentManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-abstract class AbstractContentFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+abstract class AbstractContentFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * The name of the tab being constructed.

--- a/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionHierarchyTreeFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class CollectionHierarchyTreeFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class CollectionHierarchyTreeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionListFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class CollectionListFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class CollectionListFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/ComponentPartsFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ComponentPartsFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class ComponentPartsFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HierarchyTreeFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class HierarchyTreeFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class HierarchyTreeFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsWorldCatFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class HoldingsWorldCatFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class HoldingsWorldCatFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
+++ b/module/VuFind/src/VuFind/RecordTab/SimilarItemsCarouselFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SimilarItemsCarouselFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class SimilarItemsCarouselFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/RecordTab/Versions.php
+++ b/module/VuFind/src/VuFind/RecordTab/Versions.php
@@ -41,8 +41,7 @@ use VuFind\I18n\Translator\TranslatorAwareTrait;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:record_tabs Wiki
  */
-class Versions extends \VuFind\RecordTab\AbstractBase
-implements TranslatorAwareInterface
+class Versions extends \VuFind\RecordTab\AbstractBase implements TranslatorAwareInterface
 {
     use TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectAuthorizationServiceFactory.php
@@ -45,8 +45,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class InjectAuthorizationServiceFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class InjectAuthorizationServiceFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/InjectRequestFactory.php
@@ -43,8 +43,7 @@ use Psr\Container\ContainerInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class InjectRequestFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class InjectRequestFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/ServerParam.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/ServerParam.php
@@ -44,7 +44,8 @@ use Laminas\Http\PhpEnvironment\Request;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class ServerParam implements PermissionProviderInterface,
+class ServerParam implements
+    PermissionProviderInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/Role/PermissionProvider/User.php
+++ b/module/VuFind/src/VuFind/Role/PermissionProvider/User.php
@@ -41,7 +41,8 @@ use LmcRbacMvc\Service\AuthorizationService;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://www.vufind.org  Main Page
  */
-class User implements PermissionProviderInterface,
+class User implements
+    PermissionProviderInterface,
     \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFind/src/VuFind/Search/Favorites/Results.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/Results.php
@@ -48,8 +48,7 @@ use VuFindSearch\Service as SearchService;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class Results extends BaseResults
-implements AuthorizationServiceAwareInterface
+class Results extends BaseResults implements AuthorizationServiceAwareInterface
 {
     use AuthorizationServiceAwareTrait;
 

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -46,8 +46,10 @@ use VuFind\Search\UrlQueryHelper;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class HierarchicalFacetHelper implements HierarchicalFacetHelperInterface,
-    TranslatorAwareInterface, HasSorterInterface
+class HierarchicalFacetHelper implements
+    HierarchicalFacetHelperInterface,
+    TranslatorAwareInterface,
+    HasSorterInterface
 {
     use TranslatorAwareTrait;
     use HasSorterTrait;

--- a/module/VuFind/src/VuFind/Validator/SessionCsrf.php
+++ b/module/VuFind/src/VuFind/Validator/SessionCsrf.php
@@ -38,8 +38,7 @@ namespace VuFind\Validator;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SessionCsrf extends \Laminas\Validator\Csrf
-implements CsrfInterface
+class SessionCsrf extends \Laminas\Validator\Csrf implements CsrfInterface
 {
     /**
      * Keep only the most recent N tokens.

--- a/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
@@ -43,8 +43,7 @@ use VuFind\I18n\Translator\TranslatorAwareInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Citation extends \Laminas\View\Helper\AbstractHelper
-implements TranslatorAwareInterface
+class Citation extends \Laminas\View\Helper\AbstractHelper implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
@@ -43,8 +43,7 @@ use VuFind\I18n\Translator\TranslatorAwareTrait;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class CookieConsent extends \Laminas\View\Helper\AbstractHelper
-implements TranslatorAwareInterface
+class CookieConsent extends \Laminas\View\Helper\AbstractHelper implements TranslatorAwareInterface
 {
     use TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/SortFacetListFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SortFacetListFactory.php
@@ -45,8 +45,7 @@ use Psr\Container\ContainerInterface;
  * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SortFacetListFactory
-implements \Laminas\ServiceManager\Factory\FactoryInterface
+class SortFacetListFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/View/Helper/Root/Translate.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Translate.php
@@ -38,8 +38,7 @@ namespace VuFind\View\Helper\Root;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Translate extends \Laminas\View\Helper\AbstractHelper
-implements \VuFind\I18n\Translator\TranslatorAwareInterface
+class Translate extends \Laminas\View\Helper\AbstractHelper implements \VuFind\I18n\Translator\TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
@@ -43,8 +43,7 @@ use VuFind\Db\Table\ExternalSession;
  * @link     https://vufind.org Main Page
  * @retry    4
  */
-final class ShibbolethLogoutNotificationTest
-extends \VuFindTest\Integration\MinkTestCase
+final class ShibbolethLogoutNotificationTest extends \VuFindTest\Integration\MinkTestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PermissionTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PermissionTest.php
@@ -42,7 +42,7 @@ use VuFind\View\Helper\Root\Permission;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class PermissionTest  extends \PHPUnit\Framework\TestCase
+class PermissionTest extends \PHPUnit\Framework\TestCase
 {
     use \VuFindTest\Feature\ViewTrait;
 

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -41,8 +41,7 @@ use VuFind\Cache\Manager as CacheManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class AdminApiController extends \VuFind\Controller\AbstractBase
-implements ApiInterface
+class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiInterface
 {
     use ApiTrait;
 

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -44,8 +44,7 @@ use VuFindApi\Formatter\RecordFormatter;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
  */
-class SearchApiController extends \VuFind\Controller\AbstractSearch
-implements ApiInterface
+class SearchApiController extends \VuFind\Controller\AbstractSearch implements ApiInterface
 {
     use ApiTrait;
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -40,8 +40,7 @@ use VuFindSearch\Response\RecordInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     http://vufind.org
  */
-class RecordCollection
-extends \VuFindSearch\Backend\Solr\Response\Json\RecordCollection
+class RecordCollection extends \VuFindSearch\Backend\Solr\Response\Json\RecordCollection
 {
     /**
      * Blender configuration

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -59,9 +59,12 @@ use VuFindSearch\Response\RecordCollectionInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class Backend extends AbstractBackend
-implements SimilarInterface, RetrieveBatchInterface, RandomInterface,
-    GetIdsInterface, WorkExpressionsInterface
+class Backend extends AbstractBackend implements
+    SimilarInterface,
+    RetrieveBatchInterface,
+    RandomInterface,
+    GetIdsInterface,
+    WorkExpressionsInterface
 {
     /**
      * Limit for records per query in a batch retrieval.

--- a/module/VuFindSearch/src/VuFindSearch/Exception/InvalidArgumentException.php
+++ b/module/VuFindSearch/src/VuFindSearch/Exception/InvalidArgumentException.php
@@ -38,7 +38,6 @@ namespace VuFindSearch\Exception;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class InvalidArgumentException extends \InvalidArgumentException
-implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -44,8 +44,7 @@ use VuFindTheme\ThemeInfo;
  * @method getIndent()
  * @method getSeparator()
  */
-class HeadLink extends \Laminas\View\Helper\HeadLink
-implements \Laminas\Log\LoggerAwareInterface
+class HeadLink extends \Laminas\View\Helper\HeadLink implements \Laminas\Log\LoggerAwareInterface
 {
     use ConcatTrait;
     use \VuFind\Log\LoggerAwareTrait;

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
@@ -44,8 +44,7 @@ use VuFindTheme\ThemeInfo;
  * @method getIndent()
  * @method getSeparator()
  */
-class HeadScript extends \Laminas\View\Helper\HeadScript
-implements \Laminas\Log\LoggerAwareInterface
+class HeadScript extends \Laminas\View\Helper\HeadScript implements \Laminas\Log\LoggerAwareInterface
 {
     use ConcatTrait {
         getMinifiedData as getBaseMinifiedData;

--- a/tests/phpcs.xml
+++ b/tests/phpcs.xml
@@ -15,4 +15,11 @@
       <property name="multilevel" value="true" />
     </properties>
   </rule>
+  <!-- Lines can be 120 chars long, but never show errors -->
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="120"/>
+      <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
 </ruleset>


### PR DESCRIPTION
This PR extracts some changes from #2745 to make the review process easier and to keep the commits more granular. This applies the PSR-12 recommended `class_definition` style rules with php-cs-fixer and increases the line length warning threshold to 120 characters in PHP_CodeSniffer to avoid creating errors.