### PR TITLE
Clean up non-standard object construction.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -810,7 +810,7 @@ class Folio extends AbstractAPI implements
     protected function getDateTimeFromString(string $str): DateTime
     {
         $dateTime = new DateTime($str, new DateTimeZone('UTC'));
-        $localTimezone = (new DateTime)->getTimezone();
+        $localTimezone = (new DateTime())->getTimezone();
         $dateTime->setTimezone($localTimezone);
         return $dateTime;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/IpRegExTest.php
@@ -59,7 +59,7 @@ class IpRegExTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $mockIpReader->expects($this->once())->method('getUserIp')
             ->will($this->returnValue($ipAddr));
-        return new IpRegEx(new $mockRequest, $mockIpReader);
+        return new IpRegEx($mockRequest, $mockIpReader);
     }
 
     /**


### PR DESCRIPTION
This PR cleans up some non-standard use of `new` -- adding more missing parentheses in one place, and eliminating an inexplicable unnecessary `new` in a test.