### PR TITLE
php-cs-fixer: turn on ternary spacing setting for templates.

### DIFF
--- a/tests/vufind_templates.php-cs-fixer.php
+++ b/tests/vufind_templates.php-cs-fixer.php
@@ -63,7 +63,7 @@ $rules = [
     'standardize_not_equals' => true,
     'switch_case_semicolon_to_colon' => true,
     'switch_case_space' => true,
-    //'ternary_operator_spaces' => true, // disabled due to bug in php-cs-fixer 2.7.1
+    'ternary_operator_spaces' => true,
     'ternary_to_null_coalescing' => true,
     'visibility_required' => true,
 ];

--- a/themes/bootstrap3/templates/Helpers/star-rating.phtml
+++ b/themes/bootstrap3/templates/Helpers/star-rating.phtml
@@ -10,7 +10,7 @@
   <label class="rating__label hidden" for="rating_<?=$id?>_none" aria-label="<?=$this->transEsc('rating_none')?>"<?=$labelAttrs?>>
     &nbsp;
   </label>
-  <input class="rating__input" name="<?=$fieldName?>" id="rating_<?=$id?>_none" value="" type="radio"<?=null === $rating ? ' checked' :''?><?=$inputAttrs?>>
+  <input class="rating__input" name="<?=$fieldName?>" id="rating_<?=$id?>_none" value="" type="radio"<?=null === $rating ? ' checked' : ''?><?=$inputAttrs?>>
   <?php for ($level = 10; $level <= 100; $level += 10): ?>
     <?php
       $fieldId = "rating_{$id}_$level";

--- a/themes/bootstrap3/templates/RecordDriver/BrowZine/result-grid.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/BrowZine/result-grid.phtml
@@ -14,6 +14,6 @@
     </div>
   </div>
 
-  <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+  <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
 </div>
 

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -211,7 +211,7 @@
           </ul>
         </div>
 
-        <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+        <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
       </div>
     </div>
     <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-grid.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-grid.phtml
@@ -12,7 +12,7 @@ $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
 $recordLinker = $this->recordLinker($this->results);
 ?>
 
-<div class="grid-result<?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
+<div class="grid-result<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
   <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
   <?php if (isset($this->showCheckboxes) && $this->showCheckboxes): ?>
     <label class="grid-checkbox">
@@ -50,6 +50,6 @@ $recordLinker = $this->recordLinker($this->results);
     </div>
   </div>
 
-  <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+  <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
 </div>
 

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list.phtml
@@ -222,7 +222,7 @@
         <?php endforeach; ?>
       <?php endif; ?>
 
-      <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+      <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
     </div>
   </div>
   <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -19,7 +19,7 @@
 <?php ob_end_clean(); ?>
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
-<div class="media<?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
+<div class="media<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
@@ -151,7 +151,7 @@
         <?php endforeach; ?>
       <?php endif; ?>
 
-      <?=(!$restrictedView && $this->driver->supportsCoinsOpenUrl())?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+      <?=(!$restrictedView && $this->driver->supportsCoinsOpenUrl()) ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
     </div>
   </div>
   <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
@@ -13,7 +13,7 @@
 <?php endif; ?>
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
-<div class="media<?=$this->driver->supportsAjaxStatus()?' ajaxItem':''?>">
+<div class="media<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
@@ -119,7 +119,7 @@
         <?=$this->record($this->driver)->getPreviews()?>
       </div>
 
-      <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
+      <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
     </div>
   </div>
   <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>

--- a/themes/bootstrap3/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap3/templates/admin/feedback/home.phtml
@@ -110,7 +110,7 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
                         <?php endforeach; ?>
                         <strong><?=$this->transEsc('Created')?></strong>:
                         <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->created))?>
-                        <?=$feedbackItem->user_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->user_name) . ' (' . $feedbackItem->user_id . ')'): ''?>
+                        <?=$feedbackItem->user_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->user_name) . ' (' . $feedbackItem->user_id . ')') : ''?>
                         <br>
                         <strong><?=$this->transEsc('Updated')?></strong>:
                         <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->updated))?>

--- a/themes/bootstrap3/templates/admin/overdrive/home.phtml
+++ b/themes/bootstrap3/templates/admin/overdrive/home.phtml
@@ -22,13 +22,13 @@
 
     <ul class="list-group">
         <li class="list-group-item"><?php echo "<strong>Mode: </strong>";
-            echo $this->overdriveConfig->productionMode?"Production":"Integration";?></li>
+            echo $this->overdriveConfig->productionMode ? "Production" : "Integration";?></li>
         <li class="list-group-item"> <?php echo "<strong>Client Key:</strong> " . $this->overdriveConfig->clientKey;?></li>
         <li class="list-group-item"> <?php echo "<strong>Library ID:</strong> " . $this->overdriveConfig->libraryID;?></li>
         <li class="list-group-item"> <?php echo "<strong>Website ID:</strong> " . $this->overdriveConfig->websiteID;?></li>
         <li class="list-group-item"> <?php echo "<strong>ILS Name:</strong> " . $this->overdriveConfig->ILSname;?></li>
         <li class="list-group-item"> <?php echo "<strong>Records in Marc Format: </strong>";
-             echo $this->overdriveConfig->isMarc?"Yes":"No"?></li>
+             echo $this->overdriveConfig->isMarc ? "Yes" : "No"?></li>
     </ul>
 
     <h2><?=$this->transEsc('User Access')?></h2>

--- a/themes/bootstrap3/templates/ajax/resolverLink.phtml
+++ b/themes/bootstrap3/templates/ajax/resolverLink.phtml
@@ -1,5 +1,5 @@
 <?php if (!empty($link['href'])): ?>
-  <a href="<?=$this->escapeHtmlAttr($link['href'])?>" title="<?=$this->transEscAttr($link['service_type'] ?? '')?>"<?=!empty($link['access']) ? ' class="access-' . $link['access'] . '"':''?>>
+  <a href="<?=$this->escapeHtmlAttr($link['href'])?>" title="<?=$this->transEscAttr($link['service_type'] ?? '')?>"<?=!empty($link['access']) ? ' class="access-' . $link['access'] . '"' : ''?>>
     <?=$this->escapeHtml($link['title'] ?? '')?>
   </a>
 <?php else: ?>

--- a/themes/bootstrap3/templates/authority/record.phtml
+++ b/themes/bootstrap3/templates/authority/record.phtml
@@ -5,4 +5,4 @@
   $tab = $this->tabs['Details'] ?? current($this->tabs) ?? null;
 ?>
 <h1><?=$this->escapeHtml($this->driver->getBreadcrumb())?></h1>
-<p><?=empty($tab) ? $this->transEsc('no_description') :  $this->record($this->driver)->getTab($tab)?></p>
+<p><?=empty($tab) ? $this->transEsc('no_description') : $this->record($this->driver)->getTab($tab)?></p>

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -87,7 +87,7 @@
       </div>
     <?php endif; ?>
 
-    <?=$this->driver->supportsCoinsOpenURL()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>':''?>
+    <?=$this->driver->supportsCoinsOpenURL() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>' : ''?>
   </div>
 </div>
 <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>

--- a/themes/bootstrap3/templates/feedback/form.phtml
+++ b/themes/bootstrap3/templates/feedback/form.phtml
@@ -88,7 +88,7 @@
           $requireOne = $el['requireOne'] ?? false;
         ?>
         <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
-          <p id="<?=$this->escapeHtmlAttr($formElement->getAttribute('id'))?>" class="control-label radio-label<?=$required && !$requireOne? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
+          <p id="<?=$this->escapeHtmlAttr($formElement->getAttribute('id'))?>" class="control-label radio-label<?=$required && !$requireOne ? ' required' : ''?><?=$requireOne ? ' require-one' : ''?>"><?=$this->transEsc($el['label'])?>:</p>
         <?php elseif ('hidden' !== $el['type']): ?>
           <label for="<?=$this->escapeHtmlAttr($formElement->getAttribute('id'))?>" class="control-label<?=$required ? ' required' : ''?>"><?=$this->transEsc($el['label'])?>:</label>
         <?php endif ?>

--- a/themes/bootstrap3/templates/holds/list.phtml
+++ b/themes/bootstrap3/templates/holds/list.phtml
@@ -224,7 +224,7 @@
               <?=$thumbnail ?>
             <?php endif ?>
           </div>
-          <?=$resource->tryMethod('supportsCoinsOpenUrl')?'<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>':''?>
+          <?=$resource->tryMethod('supportsCoinsOpenUrl') ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>' : ''?>
         </li>
       <?php endforeach; ?>
     </ul>

--- a/themes/bootstrap3/templates/install/home.phtml
+++ b/themes/bootstrap3/templates/install/home.phtml
@@ -9,7 +9,7 @@
 <?=$this->flashmessages()?>
 <?php $errors = 0; foreach ($this->checks as $check): ?>
 <?php if (!$check['status']) $errors++; ?>
-  <div class="alert alert-<?=$check['status'] ? 'success':'danger'?>"><?=$this->escapeHtml($check['title'])?><?=$this->transEsc('eol_ellipsis')?> <?=$check['status'] ? $this->transEsc('test_ok') : $this->transEsc('test_fail') . ' <a class="btn btn-danger" href="' . $this->url('install-' . strtolower($check['fix'])) . '">' . $this->transEsc('test_fix') . '</a>' ?></div>
+  <div class="alert alert-<?=$check['status'] ? 'success' : 'danger'?>"><?=$this->escapeHtml($check['title'])?><?=$this->transEsc('eol_ellipsis')?> <?=$check['status'] ? $this->transEsc('test_ok') : $this->transEsc('test_fail') . ' <a class="btn btn-danger" href="' . $this->url('install-' . strtolower($check['fix'])) . '">' . $this->transEsc('test_fix') . '</a>' ?></div>
 <?php endforeach; ?>
 
 <?php if ($errors == 0): ?>

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -216,7 +216,7 @@
               <?=$thumbnail ?>
             <?php endif ?>
           </div>
-          <?=$resource->tryMethod('supportsCoinsOpenUrl')?'<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>':''?>
+          <?=$resource->tryMethod('supportsCoinsOpenUrl') ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>' : ''?>
         </li>
       <?php endforeach; ?>
     </ul>

--- a/themes/bootstrap3/templates/myresearch/controls/sort.phtml
+++ b/themes/bootstrap3/templates/myresearch/controls/sort.phtml
@@ -3,7 +3,7 @@
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
     <select id="sort_options_1" name="sort" class="jumpMenu form-control">
       <?php foreach ($this->sortList as $sortType => $sortData): ?>
-        <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
+        <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected'] ? ' selected="selected"' : ''?>><?=$this->transEsc($sortData['desc'])?></option>
       <?php endforeach; ?>
     </select>
     <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>

--- a/themes/bootstrap3/templates/myresearch/delete.phtml
+++ b/themes/bootstrap3/templates/myresearch/delete.phtml
@@ -21,6 +21,6 @@
     <?php foreach ($this->deleteIDS as $deleteID): ?>
       <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($deleteID)?>" />
     <?php endforeach; ?>
-      <input type="hidden" name="listID" value="<?=$this->list?$this->escapeHtmlAttr($this->list->id):''?>" />
+      <input type="hidden" name="listID" value="<?=$this->list ? $this->escapeHtmlAttr($this->list->id) : ''?>" />
   </div>
 </form>

--- a/themes/bootstrap3/templates/myresearch/historicloans.phtml
+++ b/themes/bootstrap3/templates/myresearch/historicloans.phtml
@@ -120,7 +120,7 @@
               <?=$thumbnail ?>
             <?php endif ?>
           </div>
-          <?=$resource->tryMethod('supportsCoinsOpenUrl')?'<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>':''?>
+          <?=$resource->tryMethod('supportsCoinsOpenUrl') ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>' : ''?>
         </li>
       <?php endforeach; ?>
     </ul>

--- a/themes/bootstrap3/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/illrequests.phtml
@@ -171,7 +171,7 @@
               <?=$thumbnail ?>
             <?php endif ?>
           </div>
-          <?=$resource->tryMethod('supportsCoinsOpenUrl')?'<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>':''?>
+          <?=$resource->tryMethod('supportsCoinsOpenUrl') ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>' : ''?>
         </li>
       <?php endforeach; ?>
     </ul>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -48,7 +48,7 @@
                   <?=$this->transEsc('Always ask me')?>
                 </option>
                 <?php foreach ($this->pickup as $lib): ?>
-                  <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID'])?' selected="selected"':''?>><?=$this->transEscWithPrefix('location_', $lib['locationDisplay'])?></option>
+                  <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>><?=$this->transEscWithPrefix('location_', $lib['locationDisplay'])?></option>
                 <?php endforeach; ?>
               </select>
               <input class="btn btn-default" type="submit" value="<?=$this->transEscAttr('Save')?>" />

--- a/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
@@ -167,7 +167,7 @@
               <?=$thumbnail ?>
             <?php endif ?>
           </div>
-          <?=$resource->tryMethod('supportsCoinsOpenUrl')?'<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>':''?>
+          <?=$resource->tryMethod('supportsCoinsOpenUrl') ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($resource->getCoinsOpenUrl()) . '"></span>' : ''?>
         </li>
       <?php endforeach; ?>
     </ul>

--- a/themes/bootstrap3/templates/primo/advanced.phtml
+++ b/themes/bootstrap3/templates/primo/advanced.phtml
@@ -56,15 +56,15 @@
             <div class="search">
               <select id="search_type<?=$i?>_<?=$j?>" name="type<?=$i?>[]" class="form-control">
                 <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
-                  <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getHandler() == $searchVal)?' selected="selected"':''?>><?=$this->transEsc($searchDesc)?></option>
+                  <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getHandler() == $searchVal) ? ' selected="selected"' : ''?>><?=$this->transEsc($searchDesc)?></option>
                 <?php endforeach; ?>
               </select>
               <select name="op<?=$i?>[]" id="searchForm_op<?=$i?>_<?=$j?>" class="form-control">
                 <?php foreach ($this->options->getAdvancedOperators() as $searchVal => $searchDesc): ?>
-                  <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getOperator() == $searchVal)?' selected="selected"':''?>><?=$this->transEsc($searchDesc)?></option>
+                  <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getOperator() == $searchVal) ? ' selected="selected"' : ''?>><?=$this->transEsc($searchDesc)?></option>
                 <?php endforeach; ?>
               </select>
-                <input id="search_lookfor<?=$i?>_<?=$j?>" type="text" value="<?=$currRow?$this->escapeHtmlAttr($currRow->getString()):''?>" size="30" name="lookfor<?=$i?>[]" class="form-control primo-adv-input" aria-label="<?=$this->transEscAttr("search_terms")?>"/>
+                <input id="search_lookfor<?=$i?>_<?=$j?>" type="text" value="<?=$currRow ? $this->escapeHtmlAttr($currRow->getString()) : ''?>" size="30" name="lookfor<?=$i?>[]" class="form-control primo-adv-input" aria-label="<?=$this->transEscAttr("search_terms")?>"/>
             </div>
           <?php endfor; ?>
         </div>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -78,7 +78,7 @@
       </div>
     <?php endif; ?>
 
-    <?=$this->driver->supportsCoinsOpenURL()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>':''?>
+    <?=$this->driver->supportsCoinsOpenURL() ? '<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>' : ''?>
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -5,7 +5,7 @@
       $value = $expander['Value'] ?>
       <div class="checkbox">
         <label for="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected'])?'checked="checked" data-checked-by-default="true"':''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
+          <input id="expand_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($expander['selected']) && $expander['selected']) ? 'checked="checked" data-checked-by-default="true"' : ''?> name="filter[]" value="EXPAND:<?=$this->escapeHtmlAttr($value)?>">
           <?=$this->transEsc('eds_expander_' . $value, [], $expander['Label'])?>
         </label>
       </div>
@@ -15,7 +15,7 @@
     <select id="searchMode_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" class="form-control">
       <?php foreach ($this->searchModes as $field => $searchMode):
         $value = $searchMode['Value'] ?>
-        <option <?=(isset($searchMode['selected']) && $searchMode['selected'])?'selected="selected"':''?> value="SEARCHMODE:<?=$this->escapeHtmlAttr($value)?>">
+        <option <?=(isset($searchMode['selected']) && $searchMode['selected']) ? 'selected="selected"' : ''?> value="SEARCHMODE:<?=$this->escapeHtmlAttr($value)?>">
           <?= /* 'Label' comes from API and is always in English; try to translate structured value before using it: */ $this->transEsc('eds_mode_' . $value, [], $searchMode['Label']) ?>
         </option>
       <?php endforeach; ?>
@@ -33,7 +33,7 @@
             <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-control">
               <?php foreach ($facet['LimiterValues'] as $id => $facetValue): ?>
                 <?php $value = $facetValue['Value']; ?>
-                <option value="<?='LIMIT|' . $this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
+                <option value="<?='LIMIT|' . $this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
               <?php endforeach; ?>
             </select>
             <!-- <br/> -->
@@ -42,7 +42,7 @@
             $value = $facet['LimiterValues'][0]['Value'] ?>
             <div class="checkbox">
               <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>">
-                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected'])?'checked="checked" data-checked-by-default="true"':''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
+                <input id="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>" type="checkbox" <?=(isset($facet['LimiterValues'][0]['selected']) && $facet['LimiterValues'][0]['selected']) ? 'checked="checked" data-checked-by-default="true"' : ''?> name="filter[]" value="<?=$this->escapeHtmlAttr('LIMIT|' . $field . ':' . $value)?>">
                 <?=$this->transEsc($facet['Label'])?>
               </label>
             </div>

--- a/themes/bootstrap3/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap3/templates/search/advanced/ranges.phtml
@@ -8,11 +8,11 @@
       <div class="date-fields">
         <div class="date-from">
           <label for="<?=$escField?>from" id="<?=$escField?>from-label"><?=$this->transEsc('date_from')?>:</label>
-          <input type="text" name="<?=$escField?>from" id="<?=$escField?>from" value="<?=isset($current['values'][0])?$this->escapeHtmlAttr($current['values'][0]):''?>" class="form-control" <?=$extraInputAttribs?>/>
+          <input type="text" name="<?=$escField?>from" id="<?=$escField?>from" value="<?=isset($current['values'][0]) ? $this->escapeHtmlAttr($current['values'][0]) : ''?>" class="form-control" <?=$extraInputAttribs?>/>
         </div>
         <div class="date-to">
           <label for="<?=$escField?>to" id="<?=$escField?>to-label"><?=$this->transEsc('date_to')?>:</label>
-          <input type="text" name="<?=$escField?>to" id="<?=$escField?>to" value="<?=isset($current['values'][1])?$this->escapeHtmlAttr($current['values'][1]):''?>" class="form-control" <?=$extraInputAttribs?>/>
+          <input type="text" name="<?=$escField?>to" id="<?=$escField?>to" value="<?=isset($current['values'][1]) ? $this->escapeHtmlAttr($current['values'][1]) : ''?>" class="form-control" <?=$extraInputAttribs?>/>
         </div>
       </div>
       <?php if ($current['type'] == 'date'): ?>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -12,7 +12,7 @@
             <?php if (is_array($this->hierarchicalFacets) && in_array($field, $this->hierarchicalFacets)): ?>
               <?php foreach ($list['list'] as $value): ?>
                 <?php $display = str_pad('', 4 * $value['level'] * 6, '&nbsp;', STR_PAD_LEFT) . $this->escapeHtml($value['displayText']); ?>
-                <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$display?></option>
+                <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected']) ? ' selected="selected"' : ''?>><?=$display?></option>
               <?php endforeach; ?>
             <?php else: ?>
               <?php
@@ -49,7 +49,7 @@
               ?>
               <?php foreach ($sorted as $i => $display): ?>
                 <?php $value = $list['list'][$i]; ?>
-                <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($display)?></option>
+                <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($display)?></option>
               <?php endforeach; ?>
             <?php endif; ?>
           </select>
@@ -62,7 +62,7 @@
   <fieldset class="solr">
     <legend><?=$this->transEsc("Illustrated")?>:</legend>
     <?php foreach ($this->illustratedLimit as $current): ?>
-      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected']?' checked="checked" data-checked-by-default="true"':''?>/>
+      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected'] ? ' checked="checked" data-checked-by-default="true"' : ''?>/>
       <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br/>
     <?php endforeach; ?>
   </fieldset>

--- a/themes/bootstrap3/templates/search/advanced/summon.phtml
+++ b/themes/bootstrap3/templates/search/advanced/summon.phtml
@@ -20,7 +20,7 @@
           ?>
           <?php foreach ($sorted as $i => $display): ?>
             <?php $value = $list['list'][$i]; ?>
-            <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected'])?' selected="selected"':''?>><?=$this->escapeHtml($display)?></option>
+            <option value="<?=$this->escapeHtmlAttr(($value['operator'] == 'OR' ? '~' : '') . $field . ':"' . $value['value'] . '"')?>"<?=(isset($value['selected']) && $value['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($display)?></option>
           <?php endforeach; ?>
         </select>
       </div>

--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -5,7 +5,7 @@
     <label for="limit"><?=$this->transEsc('Results per page')?></label>
     <select id="limit" name="limit" class="jumpMenu form-control">
       <?php foreach ($limitList as $limitVal => $limitData): ?>
-        <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=$limitData['selected']?' selected="selected"':''?>><?=$this->escapeHtml($limitData['desc'])?></option>
+        <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=$limitData['selected'] ? ' selected="selected"' : ''?>><?=$this->escapeHtml($limitData['desc'])?></option>
       <?php endforeach; ?>
     </select>
     <noscript><input type="submit" value="<?=$this->transEscAttr("Set")?>" /></noscript>

--- a/themes/bootstrap3/templates/search/controls/sort.phtml
+++ b/themes/bootstrap3/templates/search/controls/sort.phtml
@@ -4,7 +4,7 @@
     <label for="sort_options_1"><?=$this->transEsc('Sort')?></label>
     <select id="sort_options_1" name="sort" class="jumpMenu form-control">
       <?php foreach ($list as $sortType => $sortData): ?>
-        <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected']?' selected="selected"':''?>><?=$this->transEsc($sortData['desc'])?></option>
+        <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected'] ? ' selected="selected"' : ''?>><?=$this->transEsc($sortData['desc'])?></option>
       <?php endforeach; ?>
     </select>
     <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>

--- a/themes/bootstrap3/templates/search/list-list.phtml
+++ b/themes/bootstrap3/templates/search/list-list.phtml
@@ -5,7 +5,7 @@
   <?php foreach ($this->results->getResults() as $current): ?>
     <?php $recordNumber = $this->results->getStartRecord() + $i - $this->indexStart; ?>
     <?php // Data-record-number attribute is for analytics use.  Do not remove. ?>
-    <li<?php if (empty($this->excludeResultIds)): ?> id="result<?=$i++ ?>"<?php endif; ?> class="result<?=$current->supportsAjaxStatus()?' ajaxItem':''?>" data-record-number="<?=$this->escapeHtmlAttr($recordNumber)?>">
+    <li<?php if (empty($this->excludeResultIds)): ?> id="result<?=$i++ ?>"<?php endif; ?> class="result<?=$current->supportsAjaxStatus() ? ' ajaxItem' : ''?>" data-record-number="<?=$this->escapeHtmlAttr($recordNumber)?>">
       <?php if (isset($this->showCheckboxes) && $this->showCheckboxes): ?>
         <?=$this->record($current)->getCheckbox('', 'search-cart-form', $recordNumber)?>
       <?php endif; ?>


### PR DESCRIPTION
I noticed that we had a php-cs-fixer rule disabled due to a bug in a past version. The bug has now been fixed, so I've turned the rule back on and used it to fix several templates.