### PR TITLE
php-cs-fixer: apply PHP 7.4 compatibility rules.

### DIFF
--- a/module/VuFind/Module.php
+++ b/module/VuFind/Module.php
@@ -62,8 +62,8 @@ class Module
         return [
             'Laminas\Loader\ClassMapAutoloader' => [
                 'classes' => [
-                    'minSO' => __DIR__ . '/src/VuFind/Search/minSO.php'
-                ]
+                    'minSO' => __DIR__ . '/src/VuFind/Search/minSO.php',
+                ],
             ],
             'Laminas\Loader\StandardAutoloader' => [
                 'namespaces' => [

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -43,7 +43,7 @@ $config = [
                     'defaults' => [
                         'controller' => 'Content',
                         'action'     => 'Content',
-                    ]
+                    ],
                 ],
             ],
             'shortlink' => [
@@ -56,7 +56,7 @@ $config = [
                     'defaults' => [
                         'controller' => 'Shortlink',
                         'action'     => 'redirect',
-                    ]
+                    ],
                 ],
             ],
             'legacy-alphabrowse-results' => [
@@ -66,8 +66,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'Alphabrowse',
                         'action'     => 'Home',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'legacy-bookcover' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -76,8 +76,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'Cover',
                         'action'     => 'Show',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'legacy-summonrecord' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -86,8 +86,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'SummonRecord',
                         'action'     => 'Home',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'legacy-worldcatrecord' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -96,8 +96,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'WorldcatRecord',
                         'action'     => 'Home',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'soap-shibboleth-logout-notification-handler' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -105,8 +105,8 @@ $config = [
                     'route' => '/soap/shiblogout',
                     'defaults' => [
                         'controller' => 'ShibbolethLogoutNotification',
-                        'action' => 'index'
-                    ]
+                        'action' => 'index',
+                    ],
                 ],
                 'child_routes' => [
                     'get' => [
@@ -114,7 +114,7 @@ $config = [
                         'options' => [
                             'verb' => 'get',
                             'defaults' => [
-                                'action' => 'get'
+                                'action' => 'get',
                             ],
                         ],
                     ],
@@ -123,12 +123,12 @@ $config = [
                         'options' => [
                             'verb' => 'post',
                             'defaults' => [
-                                'action' => 'post'
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                                'action' => 'post',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
     ],
     'controllers' => [
@@ -554,7 +554,7 @@ $config = [
             'VuFind\I18n\Translator\Loader\ExtendedIni' => 'VuFind\I18n\Translator\Loader\ExtendedIniFactory',
         ],
         'aliases' => [
-            'ExtendedIni' => 'VuFind\I18n\Translator\Loader\ExtendedIni'
+            'ExtendedIni' => 'VuFind\I18n\Translator\Loader\ExtendedIni',
         ],
     ],
     'view_helpers' => [
@@ -683,7 +683,7 @@ $recordRoutes = [
 $nonTabRecordActions = [
     'AddComment', 'DeleteComment', 'AddTag', 'DeleteTag', 'Save', 'Email', 'SMS',
     'Cite', 'Export', 'RDF', 'Hold', 'Home', 'StorageRetrievalRequest',
-    'AjaxTab', 'ILLRequest', 'PDF', 'Epub', 'LinkedText', 'Permalink', 'Rating'
+    'AjaxTab', 'ILLRequest', 'PDF', 'Epub', 'LinkedText', 'Permalink', 'Rating',
 ];
 
 // Define dynamic routes -- controller => [route name => action]
@@ -752,7 +752,7 @@ $staticRoutes = [
     'Upgrade/Reset', 'Upgrade/ShowSQL', 'Upgrade/CriticalFixBlowfish',
     'Upgrade/CriticalFixInsecureDatabase',
     'Web/Home', 'Web/FacetList', 'Web/Results',
-    'Worldcat/Advanced', 'Worldcat/Home', 'Worldcat/Search'
+    'Worldcat/Advanced', 'Worldcat/Home', 'Worldcat/Search',
 ];
 
 $routeGenerator = new \VuFind\Route\RouteGenerator();
@@ -769,8 +769,8 @@ $config['router']['routes']['home'] = [
         'defaults' => [
             'controller' => 'index',
             'action'     => 'Home',
-        ]
-    ]
+        ],
+    ],
 ];
 
 return $config;

--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -345,7 +345,7 @@ class GetItemStatuses extends AbstractBase implements
                 ? $this->translate('on_reserve')
                 : $this->translate('Not On Reserve'),
             'callnumber' => htmlentities($callNumber, ENT_COMPAT, 'UTF-8'),
-            'callnumber_handler' => $callnumberHandler
+            'callnumber_handler' => $callnumberHandler,
         ];
     }
 
@@ -412,7 +412,7 @@ class GetItemStatuses extends AbstractBase implements
                 'callnumbers' =>
                     htmlentities($locationCallnumbers, ENT_COMPAT, 'UTF-8'),
                 'status_unknown' => $details['status_unknown'] ?? false,
-                'callnumber_handler' => $callnumberHandler
+                'callnumber_handler' => $callnumberHandler,
             ];
             $locationList[] = $locationInfo;
         }
@@ -433,7 +433,7 @@ class GetItemStatuses extends AbstractBase implements
             'reserve_message' => $record[0]['reserve'] == 'Y'
                 ? $this->translate('on_reserve')
                 : $this->translate('Not On Reserve'),
-            'callnumber' => false
+            'callnumber' => false,
         ];
     }
 
@@ -456,7 +456,7 @@ class GetItemStatuses extends AbstractBase implements
             'locationList' => [],
             'reserve' => false,
             'reserve_message' => '',
-            'callnumber' => false
+            'callnumber' => false,
         ];
     }
 
@@ -473,7 +473,7 @@ class GetItemStatuses extends AbstractBase implements
         $values = array_merge(
             [
                 'statusItems' => $record,
-                'callnumberHandler' => $this->getCallnumberHandler()
+                'callnumberHandler' => $this->getCallnumberHandler(),
             ],
             $values
         );
@@ -503,8 +503,8 @@ class GetItemStatuses extends AbstractBase implements
                 $results[] = [
                     [
                         'id' => $id,
-                        'error' => 'An error has occurred'
-                    ]
+                        'error' => 'An error has occurred',
+                    ],
                 ];
             }
         }
@@ -526,7 +526,7 @@ class GetItemStatuses extends AbstractBase implements
             'available' => $this->renderer->render('ajax/status-available.phtml'),
             'unavailable' =>
                 $this->renderer->render('ajax/status-unavailable.phtml'),
-            'unknown' => $this->renderer->render('ajax/status-unknown.phtml')
+            'unknown' => $this->renderer->render('ajax/status-unknown.phtml'),
         ];
 
         // Load callnumber and location settings:
@@ -588,7 +588,7 @@ class GetItemStatuses extends AbstractBase implements
                 'reserve_message'      => $this->translate('Not On Reserve'),
                 'callnumber'           => '',
                 'missing_data'         => true,
-                'record_number'        => $recordNumber
+                'record_number'        => $recordNumber,
             ];
         }
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordCover.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordCover.php
@@ -137,7 +137,7 @@ class GetRecordCover extends AbstractBase implements AjaxHandlerInterface
                     'html' => $this->renderer->render(
                         'record/coverReplacement',
                         ['driver' => $record]
-                    )
+                    ),
                 ]
             );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordRating.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordRating.php
@@ -91,7 +91,7 @@ class GetRecordRating extends AbstractBase
         return $this->formatResponse(
             [
                 'ratingData' => $driver->getRatingData(),
-                'html' => $html
+                'html' => $html,
             ]
         );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTags.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTags.php
@@ -108,7 +108,7 @@ class GetRecordTags extends AbstractBase
             $tagList[] = [
                 'tag'   => $tag->tag,
                 'cnt'   => $tag->cnt,
-                'is_me' => !empty($tag->is_me)
+                'is_me' => !empty($tag->is_me),
             ];
         }
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRequestGroupPickupLocations.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRequestGroupPickupLocations.php
@@ -74,7 +74,7 @@ class GetRequestGroupPickupLocations extends AbstractIlsAndUserAction
             if ($patron = $this->ilsAuthenticator->storedCatalogLogin()) {
                 $details = [
                     'id' => $id,
-                    'requestGroupId' => $requestGroupId
+                    'requestGroupId' => $requestGroupId,
                 ];
                 $results = $this->ils->getPickupLocations($patron, $details);
                 foreach ($results as &$result) {

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinks.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResolverLinks.php
@@ -163,7 +163,7 @@ class GetResolverLinks extends AbstractBase implements TranslatorAwareInterface
             'openUrlBase' => $base, 'openUrl' => $openUrl, 'print' => $print,
             'electronic' => $electronic, 'services' => $services,
             'searchClassId' => $searchClassId,
-            'moreOptionsLink' => $moreOptionsLink
+            'moreOptionsLink' => $moreOptionsLink,
         ];
         $html = $this->renderer->render('ajax/resolverLinks.phtml', $view);
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSideFacets.php
@@ -157,7 +157,7 @@ class GetSideFacets extends \VuFind\AjaxHandler\AbstractBase implements \Laminas
         $context = [
             'recommend' => $recommend,
             'params' => $results->getParams(),
-            'searchClassId' => $request['searchClassId'] ?? DEFAULT_SEARCH_BACKEND
+            'searchClassId' => $request['searchClassId'] ?? DEFAULT_SEARCH_BACKEND,
         ];
         if (isset($request['enabledFacets'])) {
             // Render requested facets separately

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -138,7 +138,7 @@ class CAS extends AbstractBase
         // Has the user configured attributes to use for populating the user table?
         $attribsToCheck = [
             "cat_username", "cat_password", "email", "lastname", "firstname",
-            "college", "major", "home_library"
+            "college", "major", "home_library",
         ];
         $catPassword = null;
         foreach ($attribsToCheck as $attribute) {

--- a/module/VuFind/src/VuFind/Auth/Database.php
+++ b/module/VuFind/src/VuFind/Auth/Database.php
@@ -177,7 +177,7 @@ class Database extends AbstractBase
         // Ensure that all expected parameters are populated to avoid notices
         // in the code below.
         $params = [
-            'username' => '', 'password' => '', 'password2' => ''
+            'username' => '', 'password' => '', 'password2' => '',
         ];
         foreach ($params as $param => $default) {
             $params[$param] = $request->getPost()->get($param, $default);
@@ -400,7 +400,7 @@ class Database extends AbstractBase
         // in the code below.
         $params = [
             'firstname' => '', 'lastname' => '', 'username' => '',
-            'password' => '', 'password2' => '', 'email' => ''
+            'password' => '', 'password2' => '', 'email' => '',
         ];
         foreach ($params as $param => $default) {
             $params[$param] = $request->getPost()->get($param, $default);

--- a/module/VuFind/src/VuFind/Auth/Email.php
+++ b/module/VuFind/src/VuFind/Auth/Email.php
@@ -86,7 +86,7 @@ class Email extends AbstractBase
             $user = $this->getUserTable()->getByEmail($email);
             if ($user) {
                 $loginData = [
-                    'vufind_id' => $user['id']
+                    'vufind_id' => $user['id'],
                 ];
                 $this->emailAuthenticator->sendAuthenticationLink(
                     $user['email'],

--- a/module/VuFind/src/VuFind/Auth/EmailAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/EmailAuthenticator.php
@@ -175,7 +175,7 @@ class EmailAuthenticator implements \VuFind\I18n\Translator\TranslatorAwareInter
             'timestamp' => time(),
             'data' => $data,
             'email' => $email,
-            'ip' => $this->remoteAddress->getIpAddress()
+            'ip' => $this->remoteAddress->getIpAddress(),
         ];
         $hash = $this->csrf->getHash(true);
 

--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -190,7 +190,7 @@ class ILS extends AbstractBase
             [
                 'patron' => $patron,
                 'oldPassword' => $params['oldpwd'],
-                'newPassword' => $params['password']
+                'newPassword' => $params['password'],
             ]
         );
         if (!$result['success']) {

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -104,7 +104,7 @@ class ILSAuthenticator
         if (($user = $this->auth->isLoggedIn()) && !empty($user->cat_username)) {
             return [
                 'cat_username' => $user->cat_username,
-                'cat_password' => $user->cat_password
+                'cat_password' => $user->cat_password,
             ];
         }
         return false;

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -266,7 +266,7 @@ class LDAP extends AbstractBase
         // Database fields that we may be able to load from LDAP:
         $fields = [
             'firstname', 'lastname', 'email', 'cat_username', 'cat_password',
-            'college', 'major'
+            'college', 'major',
         ];
 
         // User object to populate from LDAP:

--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -70,7 +70,7 @@ class Shibboleth extends AbstractBase
      */
     protected $attribsToCheck = [
         'cat_username', 'cat_password', 'email', 'lastname', 'firstname',
-        'college', 'major', 'home_library'
+        'college', 'major', 'home_library',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -158,7 +158,7 @@ class Bootstrapper
             [
                 "{$this->config->Site->locale}.UTF8",
                 "{$this->config->Site->locale}.UTF-8",
-                $this->config->Site->locale
+                $this->config->Site->locale,
             ]
         );
         date_default_timezone_set($this->config->Site->timezone);

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -263,7 +263,7 @@ class Manager
     {
         $this->cacheSettings[$cacheName] = [
             'adapter' => \Laminas\Cache\Storage\Adapter\BlackHole::class,
-            'options' => []
+            'options' => [],
         ];
     }
 

--- a/module/VuFind/src/VuFind/Captcha/ImageFactory.php
+++ b/module/VuFind/src/VuFind/Captcha/ImageFactory.php
@@ -73,7 +73,7 @@ class ImageFactory implements FactoryInterface
             'font' => APPLICATION_PATH
                     . '/vendor/webfontkit/open-sans/fonts/opensans-regular.ttf',
             'imgDir' => $container->get(\VuFind\Cache\Manager::class)
-                ->getCache('public')->getOptions()->getCacheDir()
+                ->getCache('public')->getOptions()->getCacheDir(),
         ];
 
         $config = $container->get(\VuFind\Config\PluginManager::class)

--- a/module/VuFind/src/VuFind/Captcha/Interval.php
+++ b/module/VuFind/src/VuFind/Captcha/Interval.php
@@ -114,7 +114,7 @@ class Interval extends AbstractBase implements TranslatorAwareInterface
             $this->errorMessage = $this->translate(
                 'interval_captcha_not_passed',
                 [
-                    '%%delay%%' => max($requiredInterval - $timePassed, 1)
+                    '%%delay%%' => max($requiredInterval - $timePassed, 1),
                 ]
             );
             return false;

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
@@ -234,7 +234,7 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
                     'title' => $item['extras']['title'][0][0],
                     'source' => $this->source,
                     'thumbnail' => false, // TODO: better thumbnails!
-                    'id' => $id
+                    'id' => $id,
                 ];
             }
         }
@@ -278,7 +278,7 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
                 ['%%title%%' => $driver->getBreadcrumb()]
             ),
             'providerId' => $this->providerId,
-            'links' => []
+            'links' => [],
         ];
         $raw = $driver->getRawData();
         $from = isset($raw[$this->solrField]) ? (array)$raw[$this->solrField] : null;
@@ -306,21 +306,21 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
                 'label' => 'View Record',
                 'icon' => 'fa-file-text-o',
                 'url' => $this->url
-                    ->fromRoute($route['route'], $route['params'])
+                    ->fromRoute($route['route'], $route['params']),
             ];
             $retVal['links'][] = [
                 'label' => 'channel_expand',
                 'icon' => 'fa-search-plus',
                 'url' => $this->url->fromRoute('channels-record')
                     . '?id=' . urlencode($driver->getUniqueID())
-                    . '&source=' . urlencode($driver->getSourceIdentifier())
+                    . '&source=' . urlencode($driver->getSourceIdentifier()),
             ];
             $retVal['links'][] = [
                 'label' => 'channel_browse',
                 'icon' => 'fa-list',
                 'url' => $this->url->fromRoute('alphabrowse-home')
                     . '?source=' . urlencode($this->browseIndex)
-                    . '&from=' . $from[0]
+                    . '&from=' . $from[0],
             ];
         }
         return $retVal;

--- a/module/VuFind/src/VuFind/ChannelProvider/Facets.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/Facets.php
@@ -254,7 +254,7 @@ class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
             'providerId' => $this->providerId,
             'groupId' => current(explode(':', $filter)),
             'token' => $this->getToken($filter, $title),
-            'links' => []
+            'links' => [],
         ];
         if ($tokenOnly) {
             return $retVal;
@@ -271,13 +271,13 @@ class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
             'label' => 'channel_search',
             'icon' => 'fa-list',
             'url' => $this->url->fromRoute($params->getOptions()->getSearchAction())
-                . $query
+                . $query,
         ];
         $retVal['links'][] = [
             'label' => 'channel_expand',
             'icon' => 'fa-search-plus',
             'url' => $this->url->fromRoute('channels-search')
-                . $query . '&source=' . urlencode($params->getSearchClassId())
+                . $query . '&source=' . urlencode($params->getSearchClassId()),
         ];
 
         // Run the search and convert the results into a channel:

--- a/module/VuFind/src/VuFind/ChannelProvider/ListItems.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ListItems.php
@@ -331,7 +331,7 @@ class ListItems extends AbstractChannelProvider
             'title' => $list->title,
             'providerId' => $this->providerId,
             'token' => $list->id,
-            'links' => []
+            'links' => [],
         ];
         if ($tokenOnly) {
             return $retVal;
@@ -342,7 +342,7 @@ class ListItems extends AbstractChannelProvider
         $retVal['links'][] = [
             'label' => 'channel_search',
             'icon' => 'fa-list',
-            'url' => $this->url->fromRoute('userList', ['id' => $list->id])
+            'url' => $this->url->fromRoute('userList', ['id' => $list->id]),
         ];
         return $retVal;
     }

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
@@ -205,7 +205,7 @@ class SimilarItems extends AbstractChannelProvider implements TranslatorAwareInt
         $retVal = [
             'title' => "{$heading}: {$driver->getBreadcrumb()}",
             'providerId' => $this->providerId,
-            'links' => []
+            'links' => [],
         ];
         if ($tokenOnly) {
             $retVal['token'] = $driver->getUniqueID();
@@ -223,14 +223,14 @@ class SimilarItems extends AbstractChannelProvider implements TranslatorAwareInt
                 'label' => 'View Record',
                 'icon' => 'fa-file-text-o',
                 'url' => $this->url
-                    ->fromRoute($route['route'], $route['params'])
+                    ->fromRoute($route['route'], $route['params']),
             ];
             $retVal['links'][] = [
                 'label' => 'channel_expand',
                 'icon' => 'fa-search-plus',
                 'url' => $this->url->fromRoute('channels-record')
                     . '?id=' . urlencode($driver->getUniqueID())
-                    . '&source=' . urlencode($driver->getSourceIdentifier())
+                    . '&source=' . urlencode($driver->getSourceIdentifier()),
             ];
         }
         return $retVal;

--- a/module/VuFind/src/VuFind/Config/Locator.php
+++ b/module/VuFind/src/VuFind/Config/Locator.php
@@ -106,13 +106,13 @@ class Locator
             ? [
                 [
                     'directory' => LOCAL_OVERRIDE_DIR,
-                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
-                ]
+                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
+                ],
             ] : [];
         return new \VuFind\Config\PathResolver(
             [
                 'directory' => APPLICATION_PATH,
-                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
+                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
             ],
             $localDirs
         );

--- a/module/VuFind/src/VuFind/Config/PathResolverFactory.php
+++ b/module/VuFind/src/VuFind/Config/PathResolverFactory.php
@@ -87,13 +87,13 @@ class PathResolverFactory implements FactoryInterface
                 ? [
                     [
                         'directory' => LOCAL_OVERRIDE_DIR,
-                        'defaultConfigSubdir' => $this->defaultLocalConfigSubdir
-                    ]
+                        'defaultConfigSubdir' => $this->defaultLocalConfigSubdir,
+                    ],
                 ] : [];
         return new $requestedName(
             [
                 'directory' => APPLICATION_PATH,
-                'defaultConfigSubdir' => $this->defaultBaseConfigSubdir
+                'defaultConfigSubdir' => $this->defaultBaseConfigSubdir,
             ],
             $localDirs
         );

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -814,7 +814,7 @@ class Upgrade
         // exactly as-is
         $facetGroups = [
             'Results', 'ResultsTop', 'Advanced', 'Author', 'CheckboxFacets',
-            'HomePage'
+            'HomePage',
         ];
         $this->applyOldSettings('facets.ini', $facetGroups);
         $this->applyOldSettings('Collection.ini', ['Facets', 'Sort']);
@@ -859,7 +859,7 @@ class Upgrade
         // we want to retain the old installation's Basic/Advanced search settings
         // and sort settings exactly as-is
         $groups = [
-            'Basic_Searches', 'Advanced_Searches', 'Sorting', 'DefaultSortingByType'
+            'Basic_Searches', 'Advanced_Searches', 'Sorting', 'DefaultSortingByType',
         ];
         $this->applyOldSettings('searches.ini', $groups);
 
@@ -993,7 +993,7 @@ class Upgrade
         // we want to retain the old installation's search and facet settings
         // exactly as-is
         $groups = [
-            'Facets', 'Basic_Searches', 'Advanced_Searches', 'Sorting'
+            'Facets', 'Basic_Searches', 'Advanced_Searches', 'Sorting',
         ];
         $this->applyOldSettings('authority.ini', $groups);
 
@@ -1020,7 +1020,7 @@ class Upgrade
         // we want to retain the old installation's search and facet settings
         // exactly as-is
         $groups = [
-            'Facets', 'Basic_Searches', 'Advanced_Searches', 'Sorting'
+            'Facets', 'Basic_Searches', 'Advanced_Searches', 'Sorting',
         ];
         $this->applyOldSettings('reserves.ini', $groups);
 
@@ -1045,7 +1045,7 @@ class Upgrade
         // we want to retain the old installation's search and facet settings
         // exactly as-is
         $groups = [
-            'Facets', 'FacetsTop', 'Basic_Searches', 'Advanced_Searches', 'Sorting'
+            'Facets', 'FacetsTop', 'Basic_Searches', 'Advanced_Searches', 'Sorting',
         ];
         $this->applyOldSettings('Summon.ini', $groups);
 
@@ -1116,7 +1116,7 @@ class Upgrade
         // we want to retain the old installation's search and facet settings
         // exactly as-is
         $groups = [
-            'Facets', 'FacetsTop', 'Basic_Searches', 'Advanced_Searches', 'Sorting'
+            'Facets', 'FacetsTop', 'Basic_Searches', 'Advanced_Searches', 'Sorting',
         ];
         $this->applyOldSettings('Primo.ini', $groups);
 
@@ -1225,7 +1225,7 @@ class Upgrade
 
         // we want to retain the old installation's search settings exactly as-is
         $groups = [
-            'Basic_Searches', 'Advanced_Searches', 'Sorting'
+            'Basic_Searches', 'Advanced_Searches', 'Sorting',
         ];
         $this->applyOldSettings('WorldCat.ini', $groups);
 

--- a/module/VuFind/src/VuFind/Connection/Relais.php
+++ b/module/VuFind/src/VuFind/Connection/Relais.php
@@ -104,8 +104,8 @@ class Relais implements \Laminas\Log\LoggerAwareInterface
                 [
                     'Type' => 'OCLC',
                     'Value' => $oclc,
-                ]
-            ]
+                ],
+            ],
         ];
     }
 

--- a/module/VuFind/src/VuFind/Connection/Wikipedia.php
+++ b/module/VuFind/src/VuFind/Connection/Wikipedia.php
@@ -198,7 +198,7 @@ class Wikipedia implements TranslatorAwareInterface
         foreach ($matches[1] as $m) {
             // Check if this is the Infobox; name may vary by language
             $infoboxTags = [
-                'Bio', 'Ficha de escritor', 'Infobox', 'Info/Biografia'
+                'Bio', 'Ficha de escritor', 'Infobox', 'Info/Biografia',
             ];
             foreach ($infoboxTags as $tag) {
                 if (substr($m, 0, strlen($tag) + 1) == '{' . $tag) {
@@ -223,7 +223,7 @@ class Wikipedia implements TranslatorAwareInterface
         $imageName = $imageCaption = null;
         // The tag marking image files will vary depending on API language:
         $tags = [
-            'Archivo', 'Bestand', 'Datei', 'Ficheiro', 'Fichier', 'File', 'Image'
+            'Archivo', 'Bestand', 'Datei', 'Ficheiro', 'Fichier', 'File', 'Image',
         ];
         $pattern = '/(\x5b\x5b)('
             . implode('|', $tags)

--- a/module/VuFind/src/VuFind/Content/AuthorNotes/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/AuthorNotes/Syndetics.php
@@ -49,8 +49,8 @@ class Syndetics extends \VuFind\Content\AbstractSyndetics
         'ANOTES' => [
             'title' => 'Author Notes',
             'file' => 'ANOTES.XML',
-            'div' => '<div id="syn_anotes"></div>'
-        ]
+            'div' => '<div id="syn_anotes"></div>',
+        ],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Content/Covers/LocalFile.php
+++ b/module/VuFind/src/VuFind/Content/Covers/LocalFile.php
@@ -53,7 +53,7 @@ class LocalFile extends \VuFind\Content\AbstractCover
      * @var array
      */
     protected $allowedMimeTypes = [
-        "image/gif", "image/jpeg", "image/png", "image/tiff"
+        "image/gif", "image/jpeg", "image/png", "image/tiff",
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Content/Covers/ObalkyKnih.php
+++ b/module/VuFind/src/VuFind/Content/Covers/ObalkyKnih.php
@@ -128,7 +128,7 @@ class ObalkyKnih extends \VuFind\Content\AbstractCover
             return [
                 'url' => $url,
                 'backlink_url' => $data->backlink_url ?? '',
-                'backlink_text' => 'ObálkyKnih.cz'
+                'backlink_text' => 'ObálkyKnih.cz',
             ];
         }
         return [];

--- a/module/VuFind/src/VuFind/Content/Excerpts/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/Excerpts/Syndetics.php
@@ -49,8 +49,8 @@ class Syndetics extends \VuFind\Content\AbstractSyndetics
         'DBCHAPTER' => [
             'title' => 'First Chapter or Excerpt',
             'file' => 'DBCHAPTER.XML',
-            'div' => '<div id="syn_dbchapter"></div>'
-        ]
+            'div' => '<div id="syn_dbchapter"></div>',
+        ],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Content/PageLocator.php
+++ b/module/VuFind/src/VuFind/Content/PageLocator.php
@@ -107,7 +107,7 @@ class PageLocator
             '%pathPrefix%' => $pathPrefix,
             '%pageName%' => $pageName,
             '%language%' => $language,
-            '//' => '/'
+            '//' => '/',
         ];
         $languagePatternExtended = '"\\{(.*)%language%(.*)\\}"';
         $languagePatternExtendedReplacement = $language ? "\\1$language\\2" : '';

--- a/module/VuFind/src/VuFind/Content/Reviews/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/Reviews/Syndetics.php
@@ -78,7 +78,7 @@ class Syndetics extends \VuFind\Content\AbstractSyndetics
         'KIREVIEW' => ['title' => 'Kirkus Book Review',
                             'file' => 'KIREVIEW.XML'],
         'CRITICASEREVIEW' => ['title' => 'Criti Case Review',
-                            'file' => 'CRITICASEREVIEW.XML']
+                            'file' => 'CRITICASEREVIEW.XML'],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Content/Summaries/Demo.php
+++ b/module/VuFind/src/VuFind/Content/Summaries/Demo.php
@@ -55,7 +55,7 @@ class Demo extends \VuFind\Content\AbstractBase
         // Initialize return value:
         return [
             'Demo summary key: ' . $key,
-            'Demo summary ISBN: ' . $isbnObj->get13()
+            'Demo summary ISBN: ' . $isbnObj->get13(),
         ];
     }
 }

--- a/module/VuFind/src/VuFind/Content/Summaries/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/Summaries/Syndetics.php
@@ -49,12 +49,12 @@ class Syndetics extends \VuFind\Content\AbstractSyndetics
         'AVSUMMARY' => [
             'title' => 'Summaries',
             'file' => 'AVSUMMARY.XML',
-            'div' => '<div id="syn_avsummary"></div>'
+            'div' => '<div id="syn_avsummary"></div>',
         ],
         'SUMMARY' => [
             'title' => 'Summaries',
             'file' => 'SUMMARY.XML',
-            'div' => '<div id="syn_summary"></div>'
+            'div' => '<div id="syn_summary"></div>',
         ],
     ];
 

--- a/module/VuFind/src/VuFind/Content/TOC/Demo.php
+++ b/module/VuFind/src/VuFind/Content/TOC/Demo.php
@@ -55,7 +55,7 @@ class Demo extends \VuFind\Content\AbstractBase
         // Initialize return value:
         return [
             'Demo TOC key: ' . $key,
-            'Demo TOC ISBN: ' . $isbnObj->get13()
+            'Demo TOC ISBN: ' . $isbnObj->get13(),
         ];
     }
 }

--- a/module/VuFind/src/VuFind/Content/TOC/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/TOC/Syndetics.php
@@ -49,8 +49,8 @@ class Syndetics extends \VuFind\Content\AbstractSyndetics
         'TOC' => [
             'title' => 'TOC',
             'file' => 'TOC.XML',
-            'div' => '<div id="syn_toc"></div>'
-        ]
+            'div' => '<div id="syn_toc"></div>',
+        ],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -597,8 +597,8 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
                     'confirm' => $yesTarget,
                     'cancel' => $noTarget,
                     'messages' => (array)$messages,
-                    'extras' => $extras
-                ]
+                    'extras' => $extras,
+                ],
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -269,7 +269,7 @@ class AbstractRecord extends AbstractBase
             $this->flashMessenger()->addMessage(
                 [
                     'msg' => 'tags_deleted',
-                    'tokens' => ['%count%' => 1]
+                    'tokens' => ['%count%' => 1],
                 ],
                 'success'
             );
@@ -316,7 +316,7 @@ class AbstractRecord extends AbstractBase
         // Display the "add rating" form:
         $view = $this->createViewModel(
             [
-                'currentRating' => $user ? $driver->getRatingData($user->id) : null
+                'currentRating' => $user ? $driver->getRatingData($user->id) : null,
             ]
         );
         return $view;
@@ -407,7 +407,7 @@ class AbstractRecord extends AbstractBase
             'html' => true,
             'msg' => $this->translate('bulk_save_success') . '. '
             . '<a href="' . $listUrl . '" class="gotolist">'
-            . $this->translate('go_to_list') . '</a>.'
+            . $this->translate('go_to_list') . '</a>.',
         ];
         $this->flashMessenger()->addMessage($message, 'success');
 
@@ -495,7 +495,7 @@ class AbstractRecord extends AbstractBase
         $view = $this->createViewModel(
             [
                 'containingLists' => $containingLists,
-                'nonContainingLists' => $nonContainingLists
+                'nonContainingLists' => $nonContainingLists,
             ]
         );
         $view->setTemplate('record/save');
@@ -700,14 +700,14 @@ class AbstractRecord extends AbstractBase
                 'postData' => $exportedRecord,
                 'targetWindow' => $export->getTargetWindow($format),
                 'url' => $export->getRedirectUrl($format, ''),
-                'format' => $format
+                'format' => $format,
             ];
             $msg = [
                 'translate' => false, 'html' => true,
                 'msg' => $this->getViewRenderer()->render(
                     'cart/export-success.phtml',
                     $params
-                )
+                ),
             ];
             $this->flashMessenger()->addSuccessMessage($msg);
             return $this->redirectToRecord();

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -610,7 +610,7 @@ class AbstractSearch extends AbstractBase
             $parts[] = [
                 'field' => $field,
                 'type' => $type,
-                'values' => [$from, $to]
+                'values' => [$from, $to],
             ];
         }
 

--- a/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
@@ -97,13 +97,13 @@ class AbstractSolrSearch extends AbstractSearch
     protected function getIllustrationSettings($savedSearch = false)
     {
         $illYes = [
-            'text' => 'Has Illustrations', 'value' => 1, 'selected' => false
+            'text' => 'Has Illustrations', 'value' => 1, 'selected' => false,
         ];
         $illNo = [
-            'text' => 'Not Illustrated', 'value' => 0, 'selected' => false
+            'text' => 'Not Illustrated', 'value' => 0, 'selected' => false,
         ];
         $illAny = [
-            'text' => 'No Preference', 'value' => -1, 'selected' => false
+            'text' => 'No Preference', 'value' => -1, 'selected' => false,
         ];
 
         // Find the selected value by analyzing facets -- if we find match, remove

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -380,7 +380,7 @@ class AlmaController extends AbstractBase
                         'lastname' => $user->lastname,
                         'username' => $user->username,
                         'url' => $this->getServerUrl('myresearch-verify') . '?hash='
-                            . $user->verify_hash . '&auth_method=' . $method
+                            . $user->verify_hash . '&auth_method=' . $method,
                     ]
                 );
                 // Send the email

--- a/module/VuFind/src/VuFind/Controller/AlphabrowseController.php
+++ b/module/VuFind/src/VuFind/Controller/AlphabrowseController.php
@@ -60,7 +60,7 @@ class AlphabrowseController extends AbstractBase
         'topic'  => 'By Topic',
         'author' => 'By Author',
         'title'  => 'By Title',
-        'lcc'    => 'By Call Number'
+        'lcc'    => 'By Call Number',
     ];
 
     /**
@@ -71,7 +71,7 @@ class AlphabrowseController extends AbstractBase
     protected $defaultExtras = [
         'title' => 'author:format:publishDate',
         'lcc' => 'title',
-        'dewey' => 'title'
+        'dewey' => 'title',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Controller/BrowseController.php
+++ b/module/VuFind/src/VuFind/Controller/BrowseController.php
@@ -126,7 +126,7 @@ class BrowseController extends AbstractBase implements
 
         // This is a list of all available browse options:
         $allOptions = [
-            'tag', 'dewey', 'lcc', 'author', 'topic', 'genre', 'region', 'era'
+            'tag', 'dewey', 'lcc', 'author', 'topic', 'genre', 'region', 'era',
         ];
 
         // By default, all options except dewey are turned on if omitted from config:
@@ -274,7 +274,7 @@ class BrowseController extends AbstractBase implements
                 $resultList[] = [
                     'displayText' => $result['displayText'],
                     'value' => $result['value'],
-                    'count' => $result['count']
+                    'count' => $result['count'],
                 ];
             }
             // Don't make a second filter if it would be the same facet
@@ -322,7 +322,7 @@ class BrowseController extends AbstractBase implements
         $view->categoryList = [
             'alphabetical' => 'By Alphabetical',
             'popularity'   => 'By Popularity',
-            'recent'       => 'By Recent'
+            'recent'       => 'By Recent',
         ];
 
         if ($this->params()->fromQuery('findby')) {
@@ -344,7 +344,7 @@ class BrowseController extends AbstractBase implements
                             $tagList[] = [
                                 'displayText' => $tag['tag'],
                                 'value' => $tag['tag'],
-                                'count' => $tag['cnt']
+                                'count' => $tag['cnt'],
                             ];
                         }
                     }
@@ -371,7 +371,7 @@ class BrowseController extends AbstractBase implements
                     $resultList[$i] = [
                         'displayText' => $tag['tag'],
                         'value' => $tag['tag'],
-                        'count'    => $tag['cnt']
+                        'count'    => $tag['cnt'],
                     ];
                 }
                 $view->resultList = $resultList;
@@ -395,7 +395,7 @@ class BrowseController extends AbstractBase implements
         [$view->filter, $view->secondaryList] = $this->getSecondaryList('lcc');
         $view->secondaryParams = [
             'query_field' => 'callnumber-first',
-            'facet_field' => 'callnumber-subject'
+            'facet_field' => 'callnumber-subject',
         ];
         $view->searchParams = ['sort' => 'callnumber-sort'];
         return $this->performSearch($view);
@@ -415,7 +415,7 @@ class BrowseController extends AbstractBase implements
         foreach ($hundredsList as $dewey) {
             $categoryList[$dewey['value']] = [
                 'text' => $dewey['displayText'],
-                'count' => $dewey['count']
+                'count' => $dewey['count'],
             ];
         }
         $view->categoryList = $categoryList;
@@ -437,7 +437,7 @@ class BrowseController extends AbstractBase implements
             $view->secondaryList = $secondaryList;
             $view->secondaryParams = [
                 'query_field' => 'dewey-tens',
-                'facet_field' => 'dewey-ones'
+                'facet_field' => 'dewey-ones',
             ];
             $view->searchParams = ['sort' => 'dewey-sort'];
         }
@@ -464,7 +464,7 @@ class BrowseController extends AbstractBase implements
         if ($findby) {
             $view->secondaryParams = [
                 'query_field' => $this->getCategory($findby),
-                'facet_field' => $this->getCategory($currentAction)
+                'facet_field' => $this->getCategory($currentAction),
             ];
             $view->facetPrefix = $facetPrefix && $findby == 'alphabetical';
             [$view->filter, $view->secondaryList]
@@ -487,7 +487,7 @@ class BrowseController extends AbstractBase implements
             'topic'        => 'By Topic',
             'genre'        => 'By Genre',
             'region'       => 'By Region',
-            'era'          => 'By Era'
+            'era'          => 'By Era',
         ];
 
         return $this->performBrowse('Author', $categoryList, true);
@@ -504,7 +504,7 @@ class BrowseController extends AbstractBase implements
             'alphabetical' => 'By Alphabetical',
             'genre'        => 'By Genre',
             'region'       => 'By Region',
-            'era'          => 'By Era'
+            'era'          => 'By Era',
         ];
 
         return $this->performBrowse('Topic', $categoryList, true);
@@ -521,7 +521,7 @@ class BrowseController extends AbstractBase implements
             'alphabetical' => 'By Alphabetical',
             'topic'        => 'By Topic',
             'region'       => 'By Region',
-            'era'          => 'By Era'
+            'era'          => 'By Era',
         ];
 
         return $this->performBrowse('Genre', $categoryList, true);
@@ -538,7 +538,7 @@ class BrowseController extends AbstractBase implements
             'alphabetical' => 'By Alphabetical',
             'topic'        => 'By Topic',
             'genre'        => 'By Genre',
-            'era'          => 'By Era'
+            'era'          => 'By Era',
         ];
 
         return $this->performBrowse('Region', $categoryList, true);
@@ -555,7 +555,7 @@ class BrowseController extends AbstractBase implements
             'alphabetical' => 'By Alphabetical',
             'topic'        => 'By Topic',
             'genre'        => 'By Genre',
-            'region'       => 'By Region'
+            'region'       => 'By Region',
         ];
 
         return $this->performBrowse('Era', $categoryList, true);
@@ -578,7 +578,7 @@ class BrowseController extends AbstractBase implements
                 return [
                         'dewey-tens', $this->quoteValues(
                             $this->getFacetList('dewey-hundreds', $category, 'index')
-                        )
+                        ),
                     ];
             case 'lcc':
                 return [
@@ -588,31 +588,31 @@ class BrowseController extends AbstractBase implements
                                 $category,
                                 'index'
                             )
-                        )
+                        ),
                     ];
             case 'topic':
                 return [
                         'topic_facet', $this->quoteValues(
                             $this->getFacetList('topic_facet', $category)
-                        )
+                        ),
                     ];
             case 'genre':
                 return [
                         'genre_facet', $this->quoteValues(
                             $this->getFacetList('genre_facet', $category)
-                        )
+                        ),
                     ];
             case 'region':
                 return [
                         'geographic_facet', $this->quoteValues(
                             $this->getFacetList('geographic_facet', $category)
-                        )
+                        ),
                     ];
             case 'era':
                 return [
                         'era_facet', $this->quoteValues(
                             $this->getFacetList('era_facet', $category)
-                        )
+                        ),
                     ];
         }
         throw new \Exception('Unexpected value: ' . $facet);

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -356,7 +356,7 @@ class CartController extends AbstractBase
             $exportType = $export->getBulkExportType($format);
             $params = [
                 'exportType' => $exportType,
-                'format' => $format
+                'format' => $format,
             ];
             if ('post' === $exportType) {
                 $records = $this->getRecordLoader()->loadBatch($ids);
@@ -378,7 +378,7 @@ class CartController extends AbstractBase
                 'msg' => $this->getViewRenderer()->render(
                     'cart/export-success.phtml',
                     $params
-                )
+                ),
             ];
             return $this->redirectToSource('success', $msg);
         }
@@ -477,7 +477,7 @@ class CartController extends AbstractBase
                 'html' => true,
                 'msg' => $this->translate('bulk_save_success') . '. '
                 . '<a href="' . $listUrl . '" class="gotolist">'
-                . $this->translate('go_to_list') . '</a>.'
+                . $this->translate('go_to_list') . '</a>.',
             ];
             $this->flashMessenger()->addMessage($message, 'success');
             return $this->redirect()->toUrl($listUrl);
@@ -487,7 +487,7 @@ class CartController extends AbstractBase
         return $this->createViewModel(
             [
                 'records' => $this->getRecordLoader()->loadBatch($ids),
-                'lists' => $user->getLists()
+                'lists' => $user->getLists(),
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -123,7 +123,7 @@ class CombinedController extends AbstractSearch
                 'showCartControls' => $currentOptions->supportsCart()
                     && $cart->isActive(),
                 'showBulkOptions' => $currentOptions->supportsCart()
-                    && ($general->Site->showBulkOptions ?? false)
+                    && ($general->Site->showBulkOptions ?? false),
             ];
             // Load custom CSS, if necessary:
             $html = ($this->getViewRenderer()->plugin('headLink'))();
@@ -230,7 +230,7 @@ class CombinedController extends AbstractSearch
                 'results' => $results,
                 'supportsCart' => $supportsCart,
                 'supportsCartOptions' => $supportsCartOptions,
-                'showBulkOptions' => $settings->Site->showBulkOptions ?? false
+                'showBulkOptions' => $settings->Site->showBulkOptions ?? false,
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/ConfirmController.php
+++ b/module/VuFind/src/VuFind/Controller/ConfirmController.php
@@ -59,7 +59,7 @@ class ConfirmController extends AbstractBase
                 $flash = (true === is_array($message))
                     ? [
                         'msg' => $message['msg'],
-                        'tokens' => $message['tokens'] ?? []
+                        'tokens' => $message['tokens'] ?? [],
                     ]
                     : $message;
                 $this->flashMessenger()->addMessage($flash, 'info');

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -138,7 +138,7 @@ class FeedbackController extends AbstractBase implements LoggerAwareInterface
             $form->setData(
                 [
                  'name' => $user->firstname . ' ' . $user->lastname,
-                 'email' => $user['email']
+                 'email' => $user['email'],
                 ]
             );
         }

--- a/module/VuFind/src/VuFind/Controller/HierarchyController.php
+++ b/module/VuFind/src/VuFind/Controller/HierarchyController.php
@@ -108,7 +108,7 @@ class HierarchyController extends AbstractBase
 
         $returnArray = [
             "limitReached" => $limitReached,
-            "results" => array_slice($resultIDs, 0, $limit)
+            "results" => array_slice($resultIDs, 0, $limit),
         ];
         return $this->outputJSON(json_encode($returnArray));
     }

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -381,7 +381,7 @@ class HoldsController extends AbstractBase
             );
         }
         $dateValidationResults = [
-            'errors' => []
+            'errors' => [],
         ];
         $frozenThroughValidationResults = [
             'frozenThroughTS' => null,

--- a/module/VuFind/src/VuFind/Controller/HoldsControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsControllerFactory.php
@@ -69,7 +69,7 @@ class HoldsControllerFactory extends AbstractBaseFactory
             $requestedName,
             [
                 $container->get(\VuFind\Validator\CsrfInterface::class),
-                $container->get(\VuFind\Cache\Manager::class)->getCache('object')
+                $container->get(\VuFind\Cache\Manager::class)->getCache('object'),
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -60,7 +60,7 @@ trait HoldsTrait
             'Holds',
             [
                 'id' => $driver->getUniqueID(),
-                'patron' => $patron
+                'patron' => $patron,
             ]
         );
         if (!$checkHolds) {
@@ -197,7 +197,7 @@ trait HoldsTrait
                             ? 'hold_place_success_html'
                             : 'proxy_hold_place_success_html',
                         'tokens' => [
-                            '%%url%%' => $this->url()->fromRoute('holds-list')
+                            '%%url%%' => $this->url()->fromRoute('holds-list'),
                         ],
                     ];
                     $this->flashMessenger()->addMessage($msg, 'success');

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -60,7 +60,7 @@ trait ILLRequestsTrait
             'ILLRequests',
             [
                 'id' => $driver->getUniqueID(),
-                'patron' => $patron
+                'patron' => $patron,
             ]
         );
         if (!$checkRequests) {
@@ -114,7 +114,7 @@ trait ILLRequestsTrait
                     'msg' => 'ill_request_place_success_html',
                     'tokens' => [
                         '%%url%%' => $this->url()
-                            ->fromRoute('myresearch-illrequests')
+                            ->fromRoute('myresearch-illrequests'),
                     ],
                 ];
                 $this->flashMessenger()->addMessage($msg, 'success');

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -131,7 +131,7 @@ class InstallController extends AbstractBase
 
         return [
             'title' => 'Basic Configuration', 'status' => $status,
-            'fix' => 'fixbasicconfig'
+            'fix' => 'fixbasicconfig',
         ];
     }
 
@@ -179,7 +179,7 @@ class InstallController extends AbstractBase
         return [
             'title' => 'Cache',
             'status' => !$cache->hasDirectoryCreationError(),
-            'fix' => 'fixcache'
+            'fix' => 'fixcache',
         ];
     }
 
@@ -216,7 +216,7 @@ class InstallController extends AbstractBase
             $status = false;
         }
         return [
-            'title' => 'Database', 'status' => $status, 'fix' => 'fixdatabase'
+            'title' => 'Database', 'status' => $status, 'fix' => 'fixdatabase',
         ];
     }
 
@@ -254,7 +254,7 @@ class InstallController extends AbstractBase
         return [
             'title' => 'Dependencies',
             'status' => $requiredFunctionsExist && $this->phpVersionIsNewEnough(),
-            'fix' => 'fixdependencies'
+            'fix' => 'fixdependencies',
         ];
     }
 
@@ -682,7 +682,7 @@ class InstallController extends AbstractBase
         return [
             'title' => 'Security',
             'status' => $this->hasSecureDatabase(),
-            'fix' => 'fixsecurity'
+            'fix' => 'fixsecurity',
         ];
     }
 
@@ -811,7 +811,7 @@ class InstallController extends AbstractBase
         }
 
         return [
-            'title' => 'SSL', 'status' => $status, 'fix' => 'fixsslcerts'
+            'title' => 'SSL', 'status' => $status, 'fix' => 'fixsslcerts',
         ];
     }
 

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -800,7 +800,7 @@ class MyResearchController extends AbstractBase
         return $this->createViewModel(
             [
                 'list' => $list, 'deleteIDS' => $ids,
-                'records' => $this->getRecordLoader()->loadBatch($ids)
+                'records' => $this->getRecordLoader()->loadBatch($ids),
             ]
         );
     }
@@ -870,7 +870,7 @@ class MyResearchController extends AbstractBase
                 [
                     'list'  => $list,
                     'mytags'  => $tagParser->parse($tags),
-                    'notes' => $this->params()->fromPost('notes' . $list)
+                    'notes' => $this->params()->fromPost('notes' . $list),
                 ],
                 $user,
                 $driver
@@ -931,7 +931,7 @@ class MyResearchController extends AbstractBase
                 'listId' => $current->list_id,
                 'listTitle' => $current->list_title,
                 'notes' => $current->notes,
-                'tags' => $user->getTagString($id, $current->list_id, $source)
+                'tags' => $user->getTagString($id, $current->list_id, $source),
             ];
         }
 
@@ -1060,7 +1060,7 @@ class MyResearchController extends AbstractBase
             return $this->createViewModel(
                 [
                     'params' => $results->getParams(), 'results' => $results,
-                    'listTags' => $listTags
+                    'listTags' => $listTags,
                 ]
             );
         } catch (ListPermissionException $e) {
@@ -1176,7 +1176,7 @@ class MyResearchController extends AbstractBase
             [
                 'list' => $list,
                 'newList' => $newList,
-                'listTags' => $listTags
+                'listTags' => $listTags,
             ]
         );
     }
@@ -1634,7 +1634,7 @@ class MyResearchController extends AbstractBase
             if ($row['id'] ?? false) {
                 $driversNeeded[$i] = [
                     'id' => $row['id'],
-                    'source' => $row['source'] ?? DEFAULT_SEARCH_BACKEND
+                    'source' => $row['source'] ?? DEFAULT_SEARCH_BACKEND,
                 ];
             }
             // Store by original index so that we can access it when loading record
@@ -1755,7 +1755,7 @@ class MyResearchController extends AbstractBase
                             'library' => $config->Site->title,
                             'url' => $this->getServerUrl('myresearch-verify')
                                 . '?hash='
-                                . $user->verify_hash . '&auth_method=' . $method
+                                . $user->verify_hash . '&auth_method=' . $method,
                         ]
                     );
                     $this->serviceLocator->get(Mailer::class)->send(
@@ -1814,7 +1814,7 @@ class MyResearchController extends AbstractBase
                 'library' => $config->Site->title,
                 'url' => $this->getServerUrl('home'),
                 'email' => $config->Site->email,
-                'newEmail' => $newEmail
+                'newEmail' => $newEmail,
             ]
         );
         // If the user is setting up a new account, use the main email
@@ -1863,7 +1863,7 @@ class MyResearchController extends AbstractBase
                         [
                             'library' => $config->Site->title,
                             'url' => $this->getServerUrl('myresearch-verifyemail')
-                                . '?hash=' . urlencode($user->verify_hash)
+                                . '?hash=' . urlencode($user->verify_hash),
                         ]
                     );
                     // If the user is setting up a new account, use the main email

--- a/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/DbUpgrade.php
@@ -399,7 +399,7 @@ class DbUpgrade extends AbstractPlugin
             $fields = [
                 'fields' => $current->getColumns(),
                 'deleteRule' => $current->getDeleteRule(),
-                'updateRule' => $current->getUpdateRule()
+                'updateRule' => $current->getUpdateRule(),
             ];
             switch ($current->getType()) {
                 case 'FOREIGN KEY':
@@ -785,7 +785,7 @@ class DbUpgrade extends AbstractPlugin
                     'sql' => $sql,
                     'fields' => $this->explodeFields($foreignKeyMatches[2][$i]),
                     'deleteRule' => $deleteRule,
-                    'updateRule' => $updateRule
+                    'updateRule' => $updateRule,
                 ];
             }
 

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -139,7 +139,7 @@ class Holds extends AbstractRequestBase
                         'confirm_hold_cancel_all_text',
                         [
                             'cancelAll' => 1,
-                            'cancelAllIDS' => $params->fromPost('cancelAllIDS')
+                            'cancelAllIDS' => $params->fromPost('cancelAllIDS'),
                         ]
                     );
                 } else {
@@ -151,7 +151,7 @@ class Holds extends AbstractRequestBase
                         [
                             'cancelSelected' => 1,
                             'cancelSelectedIDS' =>
-                                $params->fromPost('cancelSelectedIDS')
+                                $params->fromPost('cancelSelectedIDS'),
                         ]
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/ILLRequests.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ILLRequests.php
@@ -124,7 +124,7 @@ class ILLRequests extends AbstractRequestBase
                         'confirm_ill_request_cancel_all_text',
                         [
                             'cancelAll' => 1,
-                            'cancelAllIDS' => $params->fromPost('cancelAllIDS')
+                            'cancelAllIDS' => $params->fromPost('cancelAllIDS'),
                         ]
                     );
                 } else {
@@ -136,7 +136,7 @@ class ILLRequests extends AbstractRequestBase
                         [
                             'cancelSelected' => 1,
                             'cancelSelectedIDS' =>
-                                $params->fromPost('cancelSelectedIDS')
+                                $params->fromPost('cancelSelectedIDS'),
                         ]
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
@@ -88,7 +88,7 @@ class IlsRecords extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
             function ($current) {
                 return [
                     'id' => $current['id'] ?? '',
-                    'source' => $current['source'] ?? DEFAULT_SEARCH_BACKEND
+                    'source' => $current['source'] ?? DEFAULT_SEARCH_BACKEND,
                 ];
             },
             $records

--- a/module/VuFind/src/VuFind/Controller/Plugin/Reserves.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Reserves.php
@@ -120,7 +120,7 @@ class Reserves extends AbstractPlugin
                     'BIB_ID' => $bib_id,
                     'bib_id' => $bib_id,
                     'course' => $course,
-                    'instructor' => $instructor
+                    'instructor' => $instructor,
                 ];
             }
             return $bibs;

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
@@ -508,7 +508,7 @@ class ResultScroller extends AbstractPlugin
         $retVal = [
             'firstRecord' => null, 'lastRecord' => null,
             'previousRecord' => null, 'nextRecord' => null,
-            'currentPosition' => null, 'resultTotal' => null
+            'currentPosition' => null, 'resultTotal' => null,
         ];
 
         $searchId = $this->searchMemory->getLastSearchId();

--- a/module/VuFind/src/VuFind/Controller/Plugin/StorageRetrievalRequests.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/StorageRetrievalRequests.php
@@ -124,7 +124,7 @@ class StorageRetrievalRequests extends AbstractRequestBase
                         'confirm_storage_retrieval_request_cancel_all_text',
                         [
                             'cancelAll' => 1,
-                            'cancelAllIDS' => $params->fromPost('cancelAllIDS')
+                            'cancelAllIDS' => $params->fromPost('cancelAllIDS'),
                         ]
                     );
                 } else {
@@ -136,7 +136,7 @@ class StorageRetrievalRequests extends AbstractRequestBase
                         [
                             'cancelSelected' => 1,
                             'cancelSelectedIDS' =>
-                                $params->fromPost('cancelSelectedIDS')
+                                $params->fromPost('cancelSelectedIDS'),
                         ]
                     );
                 }

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -253,7 +253,7 @@ class SearchController extends AbstractSolrSearch
         return $this->createViewModel(
             [
                 'fundList' => $this->newItems()->getFundList(),
-                'ranges' => $this->newItems()->getRanges()
+                'ranges' => $this->newItems()->getRanges(),
             ]
         );
     }
@@ -355,7 +355,7 @@ class SearchController extends AbstractSolrSearch
             [
                 'deptList' => $catalog->getDepartments(),
                 'instList' => $catalog->getInstructors(),
-                'courseList' =>  $catalog->getCourses()
+                'courseList' =>  $catalog->getCourses(),
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -60,7 +60,7 @@ trait StorageRetrievalRequestsTrait
             'StorageRetrievalRequests',
             [
                 'id' => $driver->getUniqueID(),
-                'patron' => $patron
+                'patron' => $patron,
             ]
         );
         if (!$checkRequests) {
@@ -133,7 +133,7 @@ trait StorageRetrievalRequestsTrait
                         'msg' => 'storage_retrieval_request_place_success_html',
                         'tokens' => [
                             '%%url%%' => $this->url()
-                                ->fromRoute('myresearch-storageretrievalrequests')
+                                ->fromRoute('myresearch-storageretrievalrequests'),
                         ],
                     ];
                     $this->flashMessenger()->addMessage($msg, 'success');

--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -718,7 +718,7 @@ class UpgradeController extends AbstractBase
 
         return $this->createViewModel(
             [
-                'anonymousTags' => $this->params()->fromQuery('anonymousCnt')
+                'anonymousTags' => $this->params()->fromQuery('anonymousCnt'),
             ]
         );
     }
@@ -950,7 +950,7 @@ class UpgradeController extends AbstractBase
                 'configDir'
                     => dirname($this->getForcedLocalConfigPath('config.ini')),
                 'importDir' => LOCAL_OVERRIDE_DIR . '/import',
-                'oldVersion' => $this->cookie->oldVersion
+                'oldVersion' => $this->cookie->oldVersion,
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Db/Row/Search.php
+++ b/module/VuFind/src/VuFind/Db/Row/Search.php
@@ -153,7 +153,7 @@ class Search extends RowGateway
         $data = [
             'id' => $this->id,
             'user_id' => $user->id,
-            'created' => $user->created
+            'created' => $user->created,
         ];
         return $hmac->generate(array_keys($data), $data);
     }

--- a/module/VuFind/src/VuFind/Db/Row/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Row/Tags.php
@@ -81,7 +81,7 @@ class Tags extends RowGateway implements \VuFind\Db\Table\DbTableAwareInterface
                         'DISTINCT(?)',
                         ['resource.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    ), Select::SQL_STAR
+                    ), Select::SQL_STAR,
                 ]
             );
             $select->join(

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -391,7 +391,7 @@ class User extends RowGateway implements
                         'COUNT(DISTINCT(?))',
                         ['ur.resource_id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -404,7 +404,7 @@ class User extends RowGateway implements
             $select->group(
                 [
                     'user_list.id', 'user_list.user_id', 'title', 'description',
-                    'created', 'public'
+                    'created', 'public',
                 ]
             );
             $select->order(['title']);

--- a/module/VuFind/src/VuFind/Db/Table/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Table/Comments.php
@@ -158,7 +158,7 @@ class Comments extends Gateway
                     ['resource_id'],
                     [Expression::TYPE_IDENTIFIER]
                 ),
-                'total' => new Expression('COUNT(*)')
+                'total' => new Expression('COUNT(*)'),
             ]
         );
         $statement = $this->sql->prepareStatementForSqlObject($select);

--- a/module/VuFind/src/VuFind/Db/Table/Ratings.php
+++ b/module/VuFind/src/VuFind/Db/Table/Ratings.php
@@ -80,7 +80,7 @@ class Ratings extends Gateway
         if (empty($resource)) {
             return [
                 'count' => 0,
-                'rating' => 0
+                'rating' => 0,
             ];
         }
 
@@ -114,7 +114,7 @@ class Ratings extends Gateway
         $result = $this->select($callback)->current();
         return [
             'count' => $result->count,
-            'rating' => $result->rating ?? 0
+            'rating' => $result->rating ?? 0,
         ];
     }
 
@@ -248,7 +248,7 @@ class Ratings extends Gateway
                     ['resource_id'],
                     [Expression::TYPE_IDENTIFIER]
                 ),
-                'total' => new Expression('COUNT(*)')
+                'total' => new Expression('COUNT(*)'),
             ]
         );
         $statement = $this->sql->prepareStatementForSqlObject($select);

--- a/module/VuFind/src/VuFind/Db/Table/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Table/Resource.php
@@ -180,7 +180,7 @@ class Resource extends Gateway
                             'DISTINCT(?)',
                             ['resource.id'],
                             [Expression::TYPE_IDENTIFIER]
-                        ), Select::SQL_STAR
+                        ), Select::SQL_STAR,
                     ]
                 );
                 $s->join(
@@ -303,7 +303,7 @@ class Resource extends Gateway
     {
         // Apply sorting, if necessary:
         $legalSorts = [
-            'title', 'title desc', 'author', 'author desc', 'year', 'year desc'
+            'title', 'title desc', 'author', 'author desc', 'year', 'year desc',
         ];
         if (!empty($sort) && in_array(strtolower($sort), $legalSorts)) {
             // Strip off 'desc' to obtain the raw field name -- we'll need it

--- a/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
@@ -179,7 +179,7 @@ class ResourceTags extends Gateway
                         'DISTINCT(?)',
                         ['resource_tags.resource_id'],
                         [Expression::TYPE_IDENTIFIER]
-                    ), Select::SQL_STAR
+                    ), Select::SQL_STAR,
                 ]
             );
             $select->join(
@@ -241,7 +241,7 @@ class ResourceTags extends Gateway
                 'resource_tags.tag_id = t.id',
                 [
                     'tag' =>
-                        $this->caseSensitive ? 'tag' : new Expression('lower(tag)')
+                        $this->caseSensitive ? 'tag' : new Expression('lower(tag)'),
                 ]
             );
             $select->join(
@@ -322,7 +322,7 @@ class ResourceTags extends Gateway
                     ['resource_id'],
                     [Expression::TYPE_IDENTIFIER]
                 ),
-                'total' => new Expression('COUNT(*)')
+                'total' => new Expression('COUNT(*)'),
             ]
         );
         $statement = $this->sql->prepareStatementForSqlObject($select);
@@ -509,7 +509,7 @@ class ResourceTags extends Gateway
                         'MAX(?)',
                         ['resource_tags.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -570,7 +570,7 @@ class ResourceTags extends Gateway
                         'MAX(?)',
                         ['resource_tags.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -578,7 +578,7 @@ class ResourceTags extends Gateway
                 'resource_tags.tag_id = t.id',
                 [
                     'tag' =>
-                        $this->caseSensitive ? 'tag' : new Expression('lower(tag)')
+                        $this->caseSensitive ? 'tag' : new Expression('lower(tag)'),
                 ]
             );
             if (null !== $userId) {
@@ -634,7 +634,7 @@ class ResourceTags extends Gateway
                         'MAX(?)',
                         ['resource_tags.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -709,7 +709,7 @@ class ResourceTags extends Gateway
             'resource_tags.tag_id = t.id',
             [
                 'tag' =>
-                    $this->caseSensitive ? 'tag' : new Expression('lower(tag)')
+                    $this->caseSensitive ? 'tag' : new Expression('lower(tag)'),
             ]
         );
         $select->join(
@@ -808,7 +808,7 @@ class ResourceTags extends Gateway
                         'MIN(?)',
                         ['id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->group(['resource_id', 'tag_id', 'list_id', 'user_id']);

--- a/module/VuFind/src/VuFind/Db/Table/Search.php
+++ b/module/VuFind/src/VuFind/Db/Table/Search.php
@@ -306,7 +306,7 @@ class Search extends Gateway
         $this->insert(
             [
                 'created' => date('Y-m-d H:i:s'),
-                'checksum' => $normalized->getChecksum()
+                'checksum' => $normalized->getChecksum(),
             ]
         );
         $row = $this->getRowById($this->getLastInsertValue());

--- a/module/VuFind/src/VuFind/Db/Table/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Table/Tags.php
@@ -243,7 +243,7 @@ class Tags extends Gateway
                                 'MAX(?)',
                                 ['subq.tag_id'],
                                 [Expression::TYPE_IDENTIFIER]
-                            )
+                            ),
                         ],
                         Select::JOIN_LEFT
                     );
@@ -258,7 +258,7 @@ class Tags extends Gateway
                             'COUNT(DISTINCT(?))',
                             ["rt.user_id"],
                             [Expression::TYPE_IDENTIFIER]
-                        )
+                        ),
                     ]
                 );
                 $select->join(
@@ -332,7 +332,7 @@ class Tags extends Gateway
                         'COUNT(DISTINCT(?))',
                         ['rt.resource_id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -394,7 +394,7 @@ class Tags extends Gateway
                         [Expression::TYPE_IDENTIFIER]
                     ),
                     'tag' => $this->caseSensitive
-                        ? 'tag' : new Expression('lower(tag)')
+                        ? 'tag' : new Expression('lower(tag)'),
                 ]
             );
             $select->join(
@@ -435,7 +435,7 @@ class Tags extends Gateway
                 [
                     'r.record_id' => $id,
                     'r.source' => $source,
-                    'user_id' => $userToCheck
+                    'user_id' => $userToCheck,
                 ]
             );
         return $sub;
@@ -468,7 +468,7 @@ class Tags extends Gateway
                         'MAX(?)',
                         ['resource_tags.posted'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->join(
@@ -492,7 +492,7 @@ class Tags extends Gateway
                         [
                             'posted DESC',
                             'cnt DESC',
-                            new Expression('lower(tags.tag)')
+                            new Expression('lower(tags.tag)'),
                         ]
                     );
                     break;
@@ -507,7 +507,7 @@ class Tags extends Gateway
         foreach ($this->select($callback) as $t) {
             $tagList[] = [
                 'tag' => $t->tag,
-                'cnt' => $t->cnt
+                'cnt' => $t->cnt,
             ];
         }
         return $tagList;
@@ -558,7 +558,7 @@ class Tags extends Gateway
                         'MIN(?)',
                         ['id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->group(

--- a/module/VuFind/src/VuFind/Db/Table/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserList.php
@@ -139,7 +139,7 @@ class UserList extends Gateway
                         'DISTINCT(?)',
                         ['user_list.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    ), Select::SQL_STAR
+                    ), Select::SQL_STAR,
                 ]
             );
             $select->join(

--- a/module/VuFind/src/VuFind/Db/Table/UserResource.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserResource.php
@@ -89,7 +89,7 @@ class UserResource extends Gateway
                         'DISTINCT(?)',
                         ['user_resource.id'],
                         [Expression::TYPE_IDENTIFIER]
-                    ), Select::SQL_STAR
+                    ), Select::SQL_STAR,
                 ]
             );
             $select->join(
@@ -133,7 +133,7 @@ class UserResource extends Gateway
     ) {
         $params = [
             'resource_id' => $resource_id, 'list_id' => $list_id,
-            'user_id' => $user_id
+            'user_id' => $user_id,
         ];
         $result = $this->select($params)->current();
 
@@ -221,7 +221,7 @@ class UserResource extends Gateway
                     ['resource_id'],
                     [Expression::TYPE_IDENTIFIER]
                 ),
-                'total' => new Expression('COUNT(*)')
+                'total' => new Expression('COUNT(*)'),
             ]
         );
         $statement = $this->sql->prepareStatementForSqlObject($select);
@@ -264,7 +264,7 @@ class UserResource extends Gateway
                         'MIN(?)',
                         ['id'],
                         [Expression::TYPE_IDENTIFIER]
-                    )
+                    ),
                 ]
             );
             $select->group(['resource_id', 'list_id', 'user_id']);

--- a/module/VuFind/src/VuFind/DigitalContent/FakeOverdriveConnector.php
+++ b/module/VuFind/src/VuFind/DigitalContent/FakeOverdriveConnector.php
@@ -310,9 +310,9 @@ class FakeOverdriveConnector extends OverdriveConnector
                 (object)[
                     'reserveId' => 'overdrive1',
                     'expires' => date('Y-m-d'),
-                    'isReturnable' => true
+                    'isReturnable' => true,
                 ],
-            ]
+            ],
         ];
     }
 
@@ -342,7 +342,7 @@ class FakeOverdriveConnector extends OverdriveConnector
                     'numberOfHolds' => 1,
                     'emailAddress' => 'foo@example.com',
                 ],
-            ]
+            ],
         ];
     }
 }

--- a/module/VuFind/src/VuFind/DigitalContent/OverdriveConnector.php
+++ b/module/VuFind/src/VuFind/DigitalContent/OverdriveConnector.php
@@ -737,7 +737,7 @@ class OverdriveConnector implements
             return $result;
         } else {
             $params = [
-                'reserveId' => $overDriveId, 'formatType' => $format
+                'reserveId' => $overDriveId, 'formatType' => $format,
             ];
         }
 
@@ -1185,7 +1185,7 @@ class OverdriveConnector implements
             );
             $headers = [
                 'Content-Type: application/x-www-form-urlencoded;charset=UTF-8',
-                "Authorization: Basic $authHeader"
+                "Authorization: Basic $authHeader",
             ];
 
             try {
@@ -1272,7 +1272,7 @@ class OverdriveConnector implements
             $headers = [
                 "Authorization: $authorizationData",
                 "User-Agent: VuFind",
-                "Content-Type: application/json"
+                "Content-Type: application/json",
             ];
             try {
                 $client = $this->getHttpClient();
@@ -1290,7 +1290,7 @@ class OverdriveConnector implements
                 foreach ($params as $key => $value) {
                     $jsonData['fields'][] = [
                         'name' => $key,
-                        'value' => $value
+                        'value' => $value,
                     ];
                 }
                 $postData = json_encode($jsonData);
@@ -1384,7 +1384,7 @@ class OverdriveConnector implements
             $headers = [
                 "Content-Type: application/x-www-form-urlencoded;charset=UTF-8",
                 "Authorization: Basic $authHeader",
-                "User-Agent: VuFind"
+                "User-Agent: VuFind",
             ];
             try {
                 $client = $this->getHttpClient($url);
@@ -1534,7 +1534,7 @@ class OverdriveConnector implements
         }
         $item = [
             'time' => time(),
-            'entry' => $entry
+            'entry' => $entry,
         ];
         $this->debug("putting item from cache for key $key : $entry");
         $this->cache->setItem($this->getCacheKey($key), $item);
@@ -1571,7 +1571,7 @@ class OverdriveConnector implements
             'status' => $status,
             'msg' => $msg,
             'data' => false,
-            'code' => $code
+            'code' => $code,
         ];
     }
 }

--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -389,7 +389,7 @@ class Form extends \Laminas\Form\Form implements
     {
         return [
             $this->mapRequestParamsToFieldValues($requestParams),
-            'Email/form.phtml'
+            'Email/form.phtml',
         ];
     }
 
@@ -473,16 +473,16 @@ class Form extends \Laminas\Form\Form implements
                 'name' => EmailAddress::class,
                 'options' => [
                     'message' => $this->getValidationMessage('invalid_email'),
-                ]
+                ],
             ],
             'notEmpty' => [
                 'name' => NotEmpty::class,
                 'options' => [
                     'message' => [
                         NotEmpty::IS_EMPTY => $this->getValidationMessage('empty'),
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
 
         $elementObjects = $this->getElements();
@@ -508,8 +508,8 @@ class Form extends \Laminas\Form\Form implements
                                             $value
                                         )
                                     );
-                            }
-                         ]
+                            },
+                         ],
                     ];
                 } elseif ($required) {
                     $fieldValidators[] = [
@@ -517,11 +517,11 @@ class Form extends \Laminas\Form\Form implements
                         'options' => [
                             'message' => [
                                 Identical::MISSING_TOKEN
-                                => $this->getValidationMessage('empty')
+                                => $this->getValidationMessage('empty'),
                             ],
                             'strict' => true,
-                            'token' => array_keys($el['options'])
-                        ]
+                            'token' => array_keys($el['options']),
+                        ],
                     ];
                 }
             }
@@ -542,7 +542,7 @@ class Form extends \Laminas\Form\Form implements
                 [
                     'name' => $el['name'],
                     'required' => $required,
-                    'validators' => $fieldValidators
+                    'validators' => $fieldValidators,
                 ]
             );
         }
@@ -607,7 +607,7 @@ class Form extends \Laminas\Form\Form implements
     {
         $formConfig = [
            'id' => $formId,
-           'title' => !empty($config['name']) ?: $formId
+           'title' => !empty($config['name']) ?: $formId,
         ];
 
         foreach ($this->getFormSettingFields() as $key) {
@@ -630,8 +630,8 @@ class Form extends \Laminas\Form\Form implements
             'label' => $this->translate('feedback_name'),
             'group' => '__sender__',
             'settings' => [
-                'size' => 50
-            ]
+                'size' => 50,
+            ],
         ];
         $senderEmail = [
             'name' => 'email',
@@ -639,8 +639,8 @@ class Form extends \Laminas\Form\Form implements
             'label' => $this->translate('feedback_email'),
             'group' => '__sender__',
             'settings' => [
-                'size' => 254
-            ]
+                'size' => 254,
+            ],
         ];
         if ($formConfig['senderInfoRequired'] ?? false) {
             $senderEmail['required'] = $senderName['required'] = true;
@@ -769,7 +769,7 @@ class Form extends \Laminas\Form\Form implements
         $elements[] = [
             'type' => 'submit',
             'name' => 'submit',
-            'label' => 'Send'
+            'label' => 'Send',
         ];
 
         return $elements;
@@ -799,8 +799,8 @@ class Form extends \Laminas\Form\Form implements
                 'value' => '',
                 'label' => $placeholder,
                 'attributes' => [
-                    'selected' => 'selected', 'disabled' => 'disabled'
-                ]
+                    'selected' => 'selected', 'disabled' => 'disabled',
+                ],
             ];
         }
         $idx = 0;
@@ -810,7 +810,7 @@ class Form extends \Laminas\Form\Form implements
             $label = $option['label'] ?? $option;
             $options["o$idx"] = [
                 'value' => $value,
-                'label' => $label
+                'label' => $label,
             ];
         }
         return $options;
@@ -847,7 +847,7 @@ class Form extends \Laminas\Form\Form implements
             }
             $groups[$group['label']] = [
                 'label' => $group['label'],
-                'options' => $options
+                'options' => $options,
             ];
         }
         return $groups;
@@ -955,7 +955,7 @@ class Form extends \Laminas\Form\Form implements
 
         $attributes = [
             'id' => $this->getElementId($el['name']),
-            'class' => [$el['settings']['class'] ?? null]
+            'class' => [$el['settings']['class'] ?? null],
         ];
 
         if ($type !== 'submit') {
@@ -988,8 +988,8 @@ class Form extends \Laminas\Form\Form implements
                         'label' => $this->translate($item['label']),
                         'value' => $key,
                         'attributes' => [
-                            'id' => $this->getElementId($el['name'] . '_' . $key)
-                        ]
+                            'id' => $this->getElementId($el['name'] . '_' . $key),
+                        ],
                     ];
                 }
                 $conf['options'] = ['value_options' => $optionElements];
@@ -1016,9 +1016,9 @@ class Form extends \Laminas\Form\Form implements
                         'value' => $key,
                         'label_attributes' => ['for' => $elemId],
                         'attributes' => [
-                            'id' => $elemId
+                            'id' => $elemId,
                         ],
-                        'selected' => $first
+                        'selected' => $first,
                     ];
                     $first = false;
                 }

--- a/module/VuFind/src/VuFind/GeoFeatures/MapSelectionConfig.php
+++ b/module/VuFind/src/VuFind/GeoFeatures/MapSelectionConfig.php
@@ -49,7 +49,7 @@ class MapSelectionConfig extends AbstractConfig
     {
         return [
             'default_coordinates' => '-95, 30, 72, 15',
-            'height' => '320'
+            'height' => '320',
         ];
     }
 

--- a/module/VuFind/src/VuFind/GeoFeatures/MapTabConfig.php
+++ b/module/VuFind/src/VuFind/GeoFeatures/MapTabConfig.php
@@ -51,7 +51,7 @@ class MapTabConfig extends AbstractConfig
             'recordMap' => false,
             'displayCoords' => false,
             'mapLabels' => null,
-            'graticule' => false
+            'graticule' => false,
         ];
     }
 

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBasedFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBasedFactory.php
@@ -72,7 +72,7 @@ class ConfigurationBasedFactory
         $configReader = $container->get(\VuFind\Config\PluginManager::class);
         $globalConfig = $configReader->get('config');
         $options = [
-            'enabled' => $globalConfig->Hierarchy->showTree ?? false
+            'enabled' => $globalConfig->Hierarchy->showTree ?? false,
         ];
 
         // Load driver-specific configuration:

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/PluginManager.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/PluginManager.php
@@ -48,7 +48,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $aliases = [
         'default' => HierarchyDefault::class,
         'flat' => HierarchyFlat::class,
-        'search2' => HierarchySearch2::class
+        'search2' => HierarchySearch2::class,
     ];
 
     /**
@@ -59,7 +59,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $factories = [
         HierarchyDefault::class => ConfigurationBasedFactory::class,
         HierarchyFlat::class => ConfigurationBasedFactory::class,
-        HierarchySearch2::class => ConfigurationBasedFactory::class
+        HierarchySearch2::class => ConfigurationBasedFactory::class,
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/Json.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataFormatter/Json.php
@@ -64,7 +64,7 @@ class Json extends AbstractBase
         $raw = [
             'id' => $record->id,
             'type' => $this->isCollection($record) ? 'collection' : 'record',
-            'title' => $this->pickTitle($record, $parentID)
+            'title' => $this->pickTitle($record, $parentID),
         ];
 
         if (isset($this->childMap[$record->id])) {

--- a/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeDataSource/Solr.php
@@ -202,7 +202,7 @@ class Solr extends AbstractBase
                     // Override any default timeAllowed since it cannot be used with
                     // cursorMark
                     'timeAllowed' => -1,
-                    'cursorMark' => $cursorMark
+                    'cursorMark' => $cursorMark,
                 ]
             );
             $command = new RawJsonSearchCommand(

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTree.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/JSTree.php
@@ -100,7 +100,7 @@ class JSTree extends AbstractBase implements \VuFind\I18n\Translator\TranslatorA
                         $hierarchyID,
                         $inHierarchies,
                         $inHierarchiesTitle
-                    )
+                    ),
                 ];
             }
         } else {
@@ -192,13 +192,13 @@ class JSTree extends AbstractBase implements \VuFind\I18n\Translator\TranslatorA
             'id' => preg_replace('/\W/', '-', $node->id),
             'text' => $escaper->escapeHtml($node->title),
             'li_attr' => [
-                'data-recordid' => $node->id
+                'data-recordid' => $node->id,
             ],
             'a_attr' => [
                 'href' => $this->getContextualUrl($node, $context),
-                'title' => $node->title
+                'title' => $node->title,
             ],
-            'type' => $node->type
+            'type' => $node->type,
         ];
         if (isset($node->children)) {
             $ret['children'] = [];
@@ -250,12 +250,12 @@ class JSTree extends AbstractBase implements \VuFind\I18n\Translator\TranslatorA
         if (!isset($cache[$route])) {
             $params = [
                 'id' => '__record_id__',
-                'tab' => 'HierarchyTree'
+                'tab' => 'HierarchyTree',
             ];
             $options = [
                 'query' => [
-                    'recordID' => '__record_id__'
-                ]
+                    'recordID' => '__record_id__',
+                ],
             ];
             $cache[$route] = $this->router->fromRoute(
                 $this->getRouteNameFromDataSource($route),
@@ -366,7 +366,7 @@ class JSTree extends AbstractBase implements \VuFind\I18n\Translator\TranslatorA
             'collectionTitle' => $hierarchyTitle,
             'baseURL' => rtrim($this->router->fromRoute('home'), '/'),
             'context' => $context,
-            'recordID' => $recordID
+            'recordID' => $recordID,
         ];
 
         // Transform the XML

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/PluginManager.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/PluginManager.php
@@ -46,7 +46,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $aliases = [
-        'jstree' => JSTree::class
+        'jstree' => JSTree::class,
     ];
 
     /**
@@ -55,7 +55,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        JSTree::class => JSTreeFactory::class
+        JSTree::class => JSTreeFactory::class,
     ];
 
     /**

--- a/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIniFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/Loader/ExtendedIniFactory.php
@@ -72,7 +72,7 @@ class ExtendedIniFactory implements \Laminas\ServiceManager\Factory\FactoryInter
         }
         $pathStack = [
             APPLICATION_PATH . '/languages',
-            LOCAL_OVERRIDE_DIR . '/languages'
+            LOCAL_OVERRIDE_DIR . '/languages',
         ];
         $settings = $container->get(LocaleSettings::class);
         return new $requestedName($pathStack, $settings->getFallbackLocales());

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -536,7 +536,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
             } else {
                 $cancelParams = [
                     $params ?: [],
-                    $params['patron'] ?? null
+                    $params['patron'] ?? null,
                 ];
                 $check2 = $this->checkCapability(
                     'getCancelStorageRetrievalRequestLink',
@@ -544,7 +544,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                 );
                 if ($check2) {
                     $response = [
-                        'function' => 'getCancelStorageRetrievalRequestLink'
+                        'function' => 'getCancelStorageRetrievalRequestLink',
                     ];
                 }
             }
@@ -623,7 +623,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
             } else {
                 $cancelParams = [
                     $params ?: [],
-                    $params['patron'] ?? null
+                    $params['patron'] ?? null,
                 ];
                 $check2 = $this->checkCapability(
                     'getCancelILLRequestLink',
@@ -631,7 +631,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                 );
                 if ($check2) {
                     $response = [
-                        'function' => 'getCancelILLRequestLink'
+                        'function' => 'getCancelILLRequestLink',
                     ];
                 }
             }
@@ -1040,7 +1040,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
         if (!isset($result['count'])) {
             $result = [
                 'count' => count($result),
-                'records' => $result
+                'records' => $result,
             ];
         }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -259,7 +259,7 @@ class Aleph extends AbstractBase implements
     {
         // Validate config
         $required = [
-            'host', 'bib', 'useradm', 'admlib', 'dlfport', 'available_statuses'
+            'host', 'bib', 'useradm', 'admlib', 'dlfport', 'available_statuses',
         ];
         foreach ($required as $current) {
             if (!isset($this->config['Catalog'][$current])) {
@@ -389,7 +389,7 @@ class Aleph extends AbstractBase implements
                 $url,
                 [
                     'user_name' => $this->wwwuser,
-                    'user_password' => $this->wwwpasswd
+                    'user_password' => $this->wwwpasswd,
                 ]
             );
         }
@@ -445,7 +445,7 @@ class Aleph extends AbstractBase implements
                 "DLF request failed",
                 [
                     'url' => $url, 'reply-code' => $replyCode,
-                    'reply-message' => $replyText
+                    'reply-message' => $replyText,
                 ]
             );
             $ex = new Aleph\RestfulException($replyText, $replyCode);
@@ -630,7 +630,7 @@ class Aleph extends AbstractBase implements
                     'location' => (string)$location[0],
                     'signature' => (string)$signature[0],
                     'reserve' => $reserve,
-                    'callnumber' => (string)$signature[0]
+                    'callnumber' => (string)$signature[0],
                 ];
             }
             $holding[] = $temp;
@@ -729,7 +729,7 @@ class Aleph extends AbstractBase implements
                     'opac'         => 'Y',
                     'request'      => 'C',
                     'desc'         => (string)$z30->{'z30-item-status'},
-                    'sub_lib_desc' => (string)$z30->{'z30-sub-library'}
+                    'sub_lib_desc' => (string)$z30->{'z30-sub-library'},
                 ];
             }
             if ($item_status['opac'] != 'Y') {
@@ -797,7 +797,7 @@ class Aleph extends AbstractBase implements
                 'callnumber_second' => (string)$z30->{'z30-call-no-2'},
                 'sub_lib_desc'      => (string)$item_status['sub_lib_desc'],
                 'no_of_loans'       => (string)$z30->{'$no_of_loans'},
-                'requested'         => (string)$requested
+                'requested'         => (string)$requested,
             ];
         }
         return $holding;
@@ -914,7 +914,7 @@ class Aleph extends AbstractBase implements
 
         return [
             'count' => $totalCount,
-            $key => $transList
+            $key => $transList,
         ];
     }
 
@@ -954,7 +954,7 @@ class Aleph extends AbstractBase implements
             try {
                 $xml = $this->doRestDLFRequest(
                     [
-                        'patron', $patron['id'], 'circulationActions', 'loans', $id
+                        'patron', $patron['id'], 'circulationActions', 'loans', $id,
                     ],
                     null,
                     'POST',
@@ -962,11 +962,11 @@ class Aleph extends AbstractBase implements
                 );
                 $due = (string)current($xml->xpath('//new-due-date'));
                 $result[$id] = [
-                    'success' => true, 'new_date' => $this->parseDate($due)
+                    'success' => true, 'new_date' => $this->parseDate($due),
                 ];
             } catch (Aleph\RestfulException $ex) {
                 $result[$id] = [
-                    'success' => false, 'sysMessage' => $ex->getMessage()
+                    'success' => false, 'sysMessage' => $ex->getMessage(),
                 ];
             }
         }
@@ -1091,7 +1091,7 @@ class Aleph extends AbstractBase implements
                 $result = $this->doRestDLFRequest(
                     [
                         'patron', $patronId, 'circulationActions', 'requests',
-                         'holds', $id
+                         'holds', $id,
                     ],
                     null,
                     "DELETE"
@@ -1206,7 +1206,7 @@ class Aleph extends AbstractBase implements
             "bor-info",
             [
                 'loans' => 'N', 'cash' => 'N', 'hold' => 'N',
-                'library' => $user['college'], 'bor_id' => $user['id']
+                'library' => $user['college'], 'bor_id' => $user['id'],
             ],
             true
         );
@@ -1313,7 +1313,7 @@ class Aleph extends AbstractBase implements
                 'bor-auth',
                 [
                     'library' => $this->useradm, 'bor_id' => $user,
-                    'verification' => $password
+                    'verification' => $password,
                 ],
                 true
             );
@@ -1392,7 +1392,7 @@ class Aleph extends AbstractBase implements
             . substr($date, 0, 4);
         return [
             'pickup-locations' => $locations, 'last-interest-date' => $date,
-            'order' => $requests + 1
+            'order' => $requests + 1,
         ];
     }
 
@@ -1466,7 +1466,7 @@ class Aleph extends AbstractBase implements
         } catch (DateException $de) {
             return [
                 'success'    => false,
-                'sysMessage' => 'hold_date_invalid'
+                'sysMessage' => 'hold_date_invalid',
             ];
         }
         $patronId = $patron['id'];
@@ -1485,7 +1485,7 @@ class Aleph extends AbstractBase implements
             $this->doRestDLFRequest(
                 [
                     'patron', $patronId, 'record', $recordId, 'items', $itemId,
-                    'hold'
+                    'hold',
                 ],
                 null,
                 "PUT",
@@ -1498,7 +1498,7 @@ class Aleph extends AbstractBase implements
             $note = $note[0];
             return [
                 'success' => false,
-                'sysMessage' => "$message ($note)"
+                'sysMessage' => "$message ($note)",
             ];
         }
         return ['success' => true];

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph/Translator.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph/Translator.php
@@ -206,7 +206,7 @@ class Translator
         $key = trim($lib) . "|" . trim($no1) . "|" . trim($no2);
         $tab15[trim($key)] = [
             "desc" => trim($desc), "loan" => $matches[6], "request" => $matches[8],
-            "opac" => $matches[10]
+            "opac" => $matches[10],
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AlephFactory.php
@@ -72,7 +72,7 @@ class AlephFactory extends DriverWithDateConverterFactory
             $requestedName,
             [
                 $container->get(\VuFind\Cache\Manager::class),
-                $container->get(\Laminas\Mvc\I18n\Translator::class)
+                $container->get(\Laminas\Mvc\I18n\Translator::class),
             ]
         );
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -358,7 +358,7 @@ class Alma extends AbstractBase implements
                     'holdtype' => 'auto',
                     'addLink' => $patron ? 'check' : false,
                     // For Alma title-level hold requests
-                    'description' => $description ?? null
+                    'description' => $description ?? null,
                 ];
             }
         }
@@ -542,7 +542,7 @@ class Alma extends AbstractBase implements
         // Check if config params are all set
         $configParams = [
             'recordType', 'userGroup', 'preferredLanguage',
-            'accountType', 'status', 'emailType', 'idType'
+            'accountType', 'status', 'emailType', 'idType',
         ];
         foreach ($configParams as $configParam) {
             if (empty(trim($newUserConfig[$configParam] ?? ''))) {
@@ -657,7 +657,7 @@ class Alma extends AbstractBase implements
             [$response, $status] = $this->makeRequest(
                 '/users/' . rawurlencode($username),
                 [
-                    'view' => 'full'
+                    'view' => 'full',
                 ],
                 [],
                 'GET',
@@ -670,12 +670,12 @@ class Alma extends AbstractBase implements
                 $patron = [
                     'id' => (string)$response->primary_id,
                     'cat_username' => trim($username),
-                    'email' => $this->getPreferredEmail($response)
+                    'email' => $this->getPreferredEmail($response),
                 ];
             } else {
                 // Try to find the user in Alma by unique email address
                 $getParams = [
-                    'q' => 'email~' . $username
+                    'q' => 'email~' . $username,
                 ];
 
                 $response = $this->makeRequest(
@@ -698,7 +698,7 @@ class Alma extends AbstractBase implements
                     $patron = [
                         'id' => (string)$user->primary_id,
                         'cat_username' => trim($username),
-                        'email' => trim($username)
+                        'email' => trim($username),
                     ];
                 }
             }
@@ -712,7 +712,7 @@ class Alma extends AbstractBase implements
             $getParams = [
                 'user_id_type' => 'all_unique',
                 'op' => 'auth',
-                'password' => $password
+                'password' => $password,
             ];
 
             // Try to authenticate the user with Alma
@@ -738,7 +738,7 @@ class Alma extends AbstractBase implements
         $getParams = [
             'user_id_type' => 'all_unique',
             'view' => 'full',
-            'expand' => 'none'
+            'expand' => 'none',
         ];
 
         // Check for patron in Alma
@@ -795,7 +795,7 @@ class Alma extends AbstractBase implements
                 : null,
             'group_code' => (isset($xml->user_group))
                 ? (string)$xml->user_group
-                : null
+                : null,
         ];
         $contact = $xml->contact_info;
         if ($contact) {
@@ -863,7 +863,7 @@ class Alma extends AbstractBase implements
                 "balance"  => round(floatval($fee->balance) * 100),
                 "createdate" => $this->parseDate($created, true),
                 "checkout" => $this->parseDate($checkout, true),
-                "fine"     => $this->getTranslatableString($fee->type)
+                "fine"     => $this->getTranslatableString($fee->type),
             ];
         }
         return $fineList;
@@ -977,7 +977,7 @@ class Alma extends AbstractBase implements
                 $count++;
                 $item[$requestId] = [
                     'success' => true,
-                    'status' => 'hold_cancel_success'
+                    'status' => 'hold_cancel_success',
                 ];
             } catch (ILSException $e) {
                 if (isset($apiResult['xml'])) {
@@ -993,7 +993,7 @@ class Alma extends AbstractBase implements
                     'status' => 'hold_cancel_fail',
                     'sysMessage' => $sysMessage . '. ' .
                          'Alma request ID: ' . $requestId . '. ' .
-                         'Alma error code: ' . $almaErrorCode
+                         'Alma error code: ' . $almaErrorCode,
                 ];
             }
 
@@ -1046,11 +1046,11 @@ class Alma extends AbstractBase implements
                     ?? 'hold_error_fail';
                 $results[$requestId] = [
                     'success' => false,
-                    'status' => (string)$error
+                    'status' => (string)$error,
                 ];
             } else {
                 $results[$requestId] = [
-                    'success' => true
+                    'success' => true,
                 ];
             }
         }
@@ -1182,7 +1182,7 @@ class Alma extends AbstractBase implements
                 ? ($params['page'] - 1) * $pageSize : 0,
             'order_by' => $sortKey,
             'direction' => $direction,
-            'expand' => 'renewable'
+            'expand' => 'renewable',
         ];
 
         // Get user loans from Alma API
@@ -1243,7 +1243,7 @@ class Alma extends AbstractBase implements
 
         return [
             'count' => $totalCount,
-            'records' => $returnArray
+            'records' => $returnArray,
         ];
     }
 
@@ -1301,7 +1301,7 @@ class Alma extends AbstractBase implements
                         true
                     ),
                     'item_id' => (string)$apiResult->loan_id,
-                    'sysMessage' => 'renew_success'
+                    'sysMessage' => 'renew_success',
                 ];
 
                 // Add the renewal to the return array
@@ -1309,7 +1309,7 @@ class Alma extends AbstractBase implements
             } catch (ILSException $ilsEx) {
                 // Add the empty renewal array to the return array
                 $returnArray['details'][$loanId] = [
-                    'success' => false
+                    'success' => false,
                 ];
             }
         }
@@ -1381,7 +1381,7 @@ class Alma extends AbstractBase implements
     {
         if ($function == 'patronLogin') {
             return [
-                'loginMethod' => $this->config['Catalog']['loginMethod'] ?? 'vufind'
+                'loginMethod' => $this->config['Catalog']['loginMethod'] ?? 'vufind',
             ];
         }
         if (isset($this->config[$function])) {
@@ -1402,9 +1402,9 @@ class Alma extends AbstractBase implements
                     'checkout asc' => 'sort_checkout_date_asc',
                     'due desc' => 'sort_due_date_desc',
                     'due asc' => 'sort_due_date_asc',
-                    'title asc' => 'sort_title'
+                    'title asc' => 'sort_title',
                 ],
-                'default_sort' => 'due asc'
+                'default_sort' => 'due asc',
             ];
         } else {
             $functionConfig = false;
@@ -1487,7 +1487,7 @@ class Alma extends AbstractBase implements
         $client->setHeaders(
             [
             'Content-type: application/json',
-            'Accept: application/json'
+            'Accept: application/json',
             ]
         );
 
@@ -1521,7 +1521,7 @@ class Alma extends AbstractBase implements
         return [
             'success' => false,
             'sysMessage' => $error->errorList->error[0]->errorMessage
-                ?? 'hold_error_fail'
+                ?? 'hold_error_fail',
         ];
     }
 
@@ -1553,7 +1553,7 @@ class Alma extends AbstractBase implements
         foreach ($xml as $library) {
             $libraries[] = [
                 'locationID' => (string)$library->code,
-                'locationDisplay' => (string)$library->name
+                'locationDisplay' => (string)$library->name,
             ];
         }
         return $libraries;
@@ -1710,7 +1710,7 @@ class Alma extends AbstractBase implements
         $map = [
             'physical' => 'p_avail',
             'digital' => 'd_avail',
-            'electronic' => 'e_avail'
+            'electronic' => 'e_avail',
         ];
         $types = array_flip($types);
         foreach ($map as $src => $dest) {
@@ -1738,7 +1738,7 @@ class Alma extends AbstractBase implements
         $results = [];
         $params = [
             'mms_id' => implode(',', $ids),
-            'expand' => implode(',', $types)
+            'expand' => implode(',', $types),
         ];
         if ($bibs = $this->makeRequest('/bibs', $params)) {
             foreach ($bibs as $bib) {

--- a/module/VuFind/src/VuFind/ILS/Driver/Amicus.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Amicus.php
@@ -353,7 +353,7 @@ class Amicus extends AbstractBase implements TranslatorAwareInterface
                             'status_array' => [$prestados],
                             'location' => $textoLoc,
                             'reserve' => $reservados,
-                            'callnumber' => $textoSign
+                            'callnumber' => $textoSign,
                         ];
                     } else {
                         $multiple = $row['LOCATION'];
@@ -369,7 +369,7 @@ class Amicus extends AbstractBase implements TranslatorAwareInterface
                             'status_array' => [$prestados],
                             'location' => $multiple,
                             'reserve' => $reservados,
-                            'callnumber' => $row['CALLNUMBER']
+                            'callnumber' => $row['CALLNUMBER'],
                         ];
                     }
                 } else {
@@ -388,7 +388,7 @@ class Amicus extends AbstractBase implements TranslatorAwareInterface
                     'status_array' => [$prestados],
                     'location' => $this->translate("No copies"),
                     'reserve' => $reservados,
-                    'callnumber' => $this->translate("No copies")
+                    'callnumber' => $this->translate("No copies"),
                 ];
                 break;
             }
@@ -506,7 +506,7 @@ class Amicus extends AbstractBase implements TranslatorAwareInterface
                     'returnDate' => false,
                     'number' => count($data) + 1,
                     'item_id' => $row['CPY_ID_NBR'],
-                    'barcode' => $row['BRCDE_NBR']
+                    'barcode' => $row['BRCDE_NBR'],
                 ];
                 $data[] = $currentItem;
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -712,7 +712,7 @@ class DAIA extends AbstractBase implements
         $restructure = function ($array) use (&$restructure) {
             $elements = [
                 'document', 'item', 'available', 'unavailable', 'limitation',
-                'message'
+                'message',
             ];
             foreach ($array as $key => $value) {
                 if (is_array($value)) {

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -165,16 +165,16 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
     protected $locations = [
         [
             'locationID' => 'A',
-            'locationDisplay' => 'Campus A'
+            'locationDisplay' => 'Campus A',
         ],
         [
             'locationID' => 'B',
-            'locationDisplay' => 'Campus B'
+            'locationDisplay' => 'Campus B',
         ],
         [
             'locationID' => 'C',
-            'locationDisplay' => 'Campus C'
-        ]
+            'locationDisplay' => 'Campus C',
+        ],
     ];
 
     /**
@@ -558,7 +558,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     strtotime("now + 30 days")
                 ),
                 "item_id" => $i,
-                "reqnum" => $i
+                "reqnum" => $i,
             ];
             // Inject a random identifier of some sort:
             $currentItem += $this->getRandomItemIdentifier();
@@ -852,7 +852,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         return [
             'total' => count($status),
             'holdings' => $slice ?: $status,
-            'electronic_holdings' => $electronic
+            'electronic_holdings' => $electronic,
         ];
     }
 
@@ -901,7 +901,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             'cat_password' => trim($password),
             'email'        => 'Lib.Rarian@library.not',
             'major'        => null,
-            'college'      => null
+            'college'      => null,
         ];
 
         $loginMethod = $this->config['Catalog']['loginMethod'] ?? 'password';
@@ -950,7 +950,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             'mobile_phone'    => '1234567890',
             'group'           => 'Library Staff',
             'expiration_date' => 'Someday',
-            'birthdate'       => $birthDate->format('Y-m-d')
+            'birthdate'       => $birthDate->format('Y-m-d'),
         ];
         return $patron;
     }
@@ -997,7 +997,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     "duedate"  => $this->dateConverter->convertToDisplayDate(
                         'U',
                         strtotime("now - $day_overdue days")
-                    )
+                    ),
                 ];
                 // Some fines will have no id or title:
                 if (rand() % 3 != 1) {
@@ -1174,7 +1174,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     'institution_id' => 'ill_institution',
                     'institution_name' => 'ILL Library',
                     'institution_dbkey' => 'ill_institution',
-                    'borrowingLocation' => 'ILL Service Desk'
+                    'borrowingLocation' => 'ILL Service Desk',
                 ];
             } else {
                 $transList[$i]['borrowingLocation'] = $this->getFakeLoc();
@@ -1245,7 +1245,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
 
         return [
             'count' => count($session->transactions),
-            'records' => $transactions
+            'records' => $transactions,
         ];
     }
 
@@ -1388,7 +1388,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
 
         return [
             'count' => count($session->historicLoans),
-            'transactions' => $historicLoans
+            'transactions' => $historicLoans,
         ];
     }
 
@@ -1420,7 +1420,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if (($holdDetails['reqnum'] ?? '') == 1) {
             $result[] = [
                 'locationID' => 'D',
-                'locationDisplay' => 'Campus D'
+                'locationDisplay' => 'Campus D',
             ];
         }
 
@@ -1531,12 +1531,12 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         return [
             [
                 'id' => 1,
-                'name' => 'Main Library'
+                'name' => 'Main Library',
             ],
             [
                 'id' => 2,
-                'name' => 'Branch Library'
-            ]
+                'name' => 'Branch Library',
+            ],
         ];
     }
 
@@ -1749,7 +1749,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     $retVal['count']++;
                     $retVal['items'][$current['item_id']] = [
                         'success' => true,
-                        'status' => 'hold_cancel_success'
+                        'status' => 'hold_cancel_success',
                     ];
                 } else {
                     $newHolds->append($current);
@@ -1758,7 +1758,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                         'status' => 'hold_cancel_fail',
                         'sysMessage' =>
                             'Demonstrating failure; keep trying and ' .
-                            'it will work eventually.'
+                            'it will work eventually.',
                     ];
                 }
             }
@@ -1850,7 +1850,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     $retVal['count']++;
                     $retVal['items'][$current['item_id']] = [
                         'success' => true,
-                        'status' => 'storage_retrieval_request_cancel_success'
+                        'status' => 'storage_retrieval_request_cancel_success',
                     ];
                 } else {
                     $newRequests->append($current);
@@ -1859,7 +1859,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                         'status' => 'storage_retrieval_request_cancel_fail',
                         'sysMessage' =>
                             'Demonstrating failure; keep trying and ' .
-                            'it will work eventually.'
+                            'it will work eventually.',
                     ];
                 }
             }
@@ -1907,9 +1907,9 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if ($this->checkRenewBlock()) {
             return [
                 'blocks' => [
-                    'Simulated account block; try again and it will work eventually.'
+                    'Simulated account block; try again and it will work eventually.',
                 ],
-                'details' => []
+                'details' => [],
             ];
         }
 
@@ -1949,7 +1949,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                         "item_id" => $current['item_id'],
                         "sysMessage" =>
                             'Demonstrating failure; keep trying and ' .
-                            'it will work eventually.'
+                            'it will work eventually.',
                     ];
                 }
             }
@@ -2001,12 +2001,12 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             return [
                 'valid' => false,
                 'status' => rand() % 3 != 0
-                    ? 'hold_error_blocked' : 'Demonstrating a custom failure'
+                    ? 'hold_error_blocked' : 'Demonstrating a custom failure',
             ];
         }
         return [
             'valid' => true,
-            'status' => 'request_place_text'
+            'status' => 'request_place_text',
         ];
     }
 
@@ -2030,7 +2030,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 "success" => false,
                 "sysMessage" =>
                     'Demonstrating failure; keep trying and ' .
-                    'it will work eventually.'
+                    'it will work eventually.',
             ];
         }
 
@@ -2126,12 +2126,12 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'valid' => false,
                 'status' => rand() % 3 != 0
                     ? 'storage_retrieval_request_error_blocked'
-                    : 'Demonstrating a custom failure'
+                    : 'Demonstrating a custom failure',
             ];
         }
         return [
             'valid' => true,
-            'status' => 'storage_retrieval_request_place_text'
+            'status' => 'storage_retrieval_request_place_text',
         ];
     }
 
@@ -2152,7 +2152,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if (!$this->storageRetrievalRequests) {
             return [
                 "success" => false,
-                "sysMessage" => 'Storage Retrieval Requests are disabled.'
+                "sysMessage" => 'Storage Retrieval Requests are disabled.',
             ];
         }
 
@@ -2165,7 +2165,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         ) {
             return [
                 'success' => false,
-                'sysMessage' => 'storage_retrieval_request_invalid_pickup'
+                'sysMessage' => 'storage_retrieval_request_invalid_pickup',
             ];
         }
 
@@ -2175,7 +2175,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 "success" => false,
                 "sysMessage" =>
                     'Demonstrating failure; keep trying and ' .
-                    'it will work eventually.'
+                    'it will work eventually.',
             ];
         }
 
@@ -2204,14 +2204,14 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 // Expiration date is invalid
                 return [
                     'success' => false,
-                    'sysMessage' => 'storage_retrieval_request_date_invalid'
+                    'sysMessage' => 'storage_retrieval_request_date_invalid',
                 ];
             }
         }
         if ($expire <= time()) {
             return [
                 'success' => false,
-                'sysMessage' => 'storage_retrieval_request_date_past'
+                'sysMessage' => 'storage_retrieval_request_date_past',
             ];
         }
 
@@ -2227,7 +2227,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'processed' => rand() % 3 == 0
                     ? $this->dateConverter->convertToDisplayDate('U', $expire) : '',
                 'reqnum'   => sprintf('%06d', $nextId),
-                'item_id'  => $nextId
+                'item_id'  => $nextId,
             ]
         );
 
@@ -2256,12 +2256,12 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             return [
                 'valid' => false,
                 'status' => rand() % 3 != 0
-                    ? 'ill_request_error_blocked' : 'Demonstrating a custom failure'
+                    ? 'ill_request_error_blocked' : 'Demonstrating a custom failure',
             ];
         }
         return [
             'valid' => true,
-            'status' => 'ill_request_place_text'
+            'status' => 'ill_request_place_text',
         ];
     }
 
@@ -2282,7 +2282,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if (!$this->ILLRequests) {
             return [
                 'success' => false,
-                'sysMessage' => 'ILL requests are disabled.'
+                'sysMessage' => 'ILL requests are disabled.',
             ];
         }
         // Simulate failure:
@@ -2291,7 +2291,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'success' => false,
                 'sysMessage' =>
                     'Demonstrating failure; keep trying and ' .
-                    'it will work eventually.'
+                    'it will work eventually.',
             ];
         }
 
@@ -2320,14 +2320,14 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 // Expiration Date is invalid
                 return [
                     'success' => false,
-                    'sysMessage' => 'ill_request_date_invalid'
+                    'sysMessage' => 'ill_request_date_invalid',
                 ];
             }
         }
         if ($expire <= time()) {
             return [
                 'success' => false,
-                'sysMessage' => 'ill_request_date_past'
+                'sysMessage' => 'ill_request_date_past',
             ];
         }
 
@@ -2347,7 +2347,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if (!$pickupLocation) {
             return [
                 'success' => false,
-                'sysMessage' => 'ill_request_place_fail_missing'
+                'sysMessage' => 'ill_request_place_fail_missing',
             ];
         }
 
@@ -2363,7 +2363,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'processed' => rand() % 3 == 0
                     ? $this->dateConverter->convertToDisplayDate('U', $expire) : '',
                 'reqnum'   => sprintf('%06d', $nextId),
-                'item_id'  => $nextId
+                'item_id'  => $nextId,
             ]
         );
 
@@ -2394,13 +2394,13 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             [
                 'id' => 1,
                 'name' => 'Main Library',
-                'isDefault' => true
+                'isDefault' => true,
             ],
             [
                 'id' => 2,
                 'name' => 'Branch Library',
-                'isDefault' => false
-            ]
+                'isDefault' => false,
+            ],
         ];
 
         return $details;
@@ -2429,26 +2429,26 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     [
                         'id' => 1,
                         'name' => 'Circulation Desk',
-                        'isDefault' => true
+                        'isDefault' => true,
                     ],
                     [
                         'id' => 2,
                         'name' => 'Reference Desk',
-                        'isDefault' => false
-                    ]
+                        'isDefault' => false,
+                    ],
                 ];
             case 2:
                 return [
                     [
                         'id' => 3,
                         'name' => 'Main Desk',
-                        'isDefault' => false
+                        'isDefault' => false,
                     ],
                     [
                         'id' => 4,
                         'name' => 'Library Bus',
-                        'isDefault' => true
-                    ]
+                        'isDefault' => true,
+                    ],
                 ];
         }
         return [];
@@ -2482,7 +2482,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     $retVal['count']++;
                     $retVal['items'][$current['item_id']] = [
                         'success' => true,
-                        'status' => 'ill_request_cancel_success'
+                        'status' => 'ill_request_cancel_success',
                     ];
                 } else {
                     $newRequests->append($current);
@@ -2491,7 +2491,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                         'status' => 'ill_request_cancel_fail',
                         'sysMessage' =>
                             'Demonstrating failure; keep trying and ' .
-                            'it will work eventually.'
+                            'it will work eventually.',
                     ];
                 }
             }
@@ -2542,7 +2542,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             'success' => false,
             'status' => 'An error has occurred',
             'sysMessage' =>
-                'Demonstrating failure; keep trying and it will work eventually.'
+                'Demonstrating failure; keep trying and it will work eventually.',
         ];
     }
 
@@ -2581,7 +2581,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'HMACKeys' => 'id',
                 'extraFields' => 'comments:pickUpLocation:requiredByDate:item-issue',
                 'helpText' => 'This is a storage retrieval request help text'
-                    . ' with some <span style="color: red">styling</span>.'
+                    . ' with some <span style="color: red">styling</span>.',
             ];
         }
         if ($function == 'ILLRequests' && $this->ILLRequests) {
@@ -2592,7 +2592,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     'comments:pickUpLibrary:pickUpLibraryLocation:requiredByDate',
                 'defaultRequiredDate' => '0:1:0',
                 'helpText' => 'This is an ILL request help text'
-                    . ' with some <span style="color: red">styling</span>.'
+                    . ' with some <span style="color: red">styling</span>.',
             ];
         }
         if ($function == 'changePassword') {
@@ -2610,9 +2610,9 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     'return desc' => 'sort_return_date_desc',
                     'return asc' => 'sort_return_date_asc',
                     'due desc' => 'sort_due_date_desc',
-                    'due asc' => 'sort_due_date_asc'
+                    'due asc' => 'sort_due_date_asc',
                 ],
-                'default_sort' => 'checkout desc'
+                'default_sort' => 'checkout desc',
             ];
             if ($this->config['Loans']['paging'] ?? false) {
                 $config['max_results']
@@ -2629,15 +2629,15 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                 'sort' => [
                     'due desc' => 'sort_due_date_desc',
                     'due asc' => 'sort_due_date_asc',
-                    'title asc' => 'sort_title'
+                    'title asc' => 'sort_title',
                 ],
-                'default_sort' => 'due asc'
+                'default_sort' => 'due asc',
             ];
         }
         if ($function == 'patronLogin') {
             return [
                 'loginMethod'
-                    => $this->config['Catalog']['loginMethod'] ?? 'password'
+                    => $this->config['Catalog']['loginMethod'] ?? 'password',
             ];
         }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DemoFactory.php
@@ -77,7 +77,7 @@ class DemoFactory extends DriverWithDateConverterFactory
             [
                 $container->get(\VuFindSearch\Service::class),
                 $sessionFactory,
-                $container->get('Request')
+                $container->get('Request'),
             ]
         );
         $driver->setSorter($container->get(\VuFind\I18n\Sorter::class));

--- a/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Evergreen.php
@@ -184,7 +184,7 @@ class Evergreen extends AbstractBase implements \Laminas\Log\LoggerAwareInterfac
                 'status' => $row['status'],
                 'location' => $row['location'],
                 'reserve' => $reserve,
-                'callnumber' => $row['callnumber']
+                'callnumber' => $row['callnumber'],
             ];
         }
 
@@ -298,7 +298,7 @@ class Evergreen extends AbstractBase implements \Laminas\Log\LoggerAwareInterfac
                 'callnumber' => $row['callnumber'],
                 'duedate' => $due_date,
                 'number' => $row['copy_number'],
-                'barcode' => $row['barcode']
+                'barcode' => $row['barcode'],
             ];
         }
 
@@ -460,7 +460,7 @@ class Evergreen extends AbstractBase implements \Laminas\Log\LoggerAwareInterfac
                                     'institution_name' => $row['owning_library'],
                                     'borrowingLocation' =>
                                         $row['borrowing_location'],
-                                    'dueStatus' => $dueStatus
+                                    'dueStatus' => $dueStatus,
                                ];
             }
         } catch (PDOException $e) {
@@ -516,7 +516,7 @@ class Evergreen extends AbstractBase implements \Laminas\Log\LoggerAwareInterfac
                     'checkout' => $this->formatDate($row['checkout_time']),
                     'createdate' => $this->formatDate($row['last_billing_ts']),
                     'duedate' => $this->formatDate($row['due_date']),
-                    'id' => $row['record']
+                    'id' => $row['record'],
                 ];
             }
             return $fineList;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -109,7 +109,7 @@ class Folio extends AbstractAPI implements
      */
     protected $defaultInTransitStatuses = [
         'Open - In transit',
-        'Open - Awaiting delivery'
+        'Open - Awaiting delivery',
     ];
 
     /**
@@ -404,7 +404,7 @@ class Folio extends AbstractAPI implements
         $idField = $idType === 'instance' ? 'id' : $idType;
 
         $query = [
-            'query' => '(' . $idField . '=="' . $this->escapeCql($bibId) . '")'
+            'query' => '(' . $idField . '=="' . $this->escapeCql($bibId) . '")',
         ];
         $response = $this->makeRequest('GET', '/instance-storage/instances', $query);
         $instances = json_decode($response->getBody());
@@ -666,7 +666,7 @@ class Folio extends AbstractAPI implements
                 [
                     $item->volume ?? null,
                     $item->enumeration ?? null,
-                    $item->chronology ?? null
+                    $item->chronology ?? null,
                 ]
             )
         );
@@ -699,7 +699,7 @@ class Folio extends AbstractAPI implements
             'location' => $locationName,
             'location_code' => $locationCode,
             'reserve' => 'TODO',
-            'addLink' => true
+            'addLink' => true,
         ];
     }
 
@@ -748,7 +748,7 @@ class Folio extends AbstractAPI implements
         $instance = $this->getInstanceByBibId($bibId);
         $query = [
             'query' => '(instanceId=="' . $instance->id
-                . '" NOT discoverySuppress==true)'
+                . '" NOT discoverySuppress==true)',
         ];
         $items = [];
         $folioItemSort = $this->config['Holdings']['folio_sort'] ?? '';
@@ -1198,7 +1198,7 @@ class Folio extends AbstractAPI implements
         foreach ($renewDetails['details'] ?? [] as $loanId) {
             $requestbody = [
                 'itemId' => $loanId,
-                'userId' => $renewDetails['patron']['id']
+                'userId' => $renewDetails['patron']['id'],
             ];
             try {
                 $response = $this->makeRequest(
@@ -1221,14 +1221,14 @@ class Folio extends AbstractAPI implements
                             $json->dueDate
                         ),
                         'item_id' => $json->itemId,
-                        'sysMessage' => $json->action
+                        'sysMessage' => $json->action,
                     ];
                 } else {
                     $json = json_decode($response->getBody());
                     $sysMessage = $json->errors[0]->message;
                     $renewal = [
                         'success' => false,
-                        'sysMessage' => $sysMessage
+                        'sysMessage' => $sysMessage,
                     ];
                 }
             } catch (Exception $e) {
@@ -1278,7 +1278,7 @@ class Folio extends AbstractAPI implements
         ) {
             $locations[] = [
                 'locationID' => $servicepoint->id,
-                'locationDisplay' => $servicepoint->discoveryDisplayName
+                'locationDisplay' => $servicepoint->discoveryDisplayName,
             ];
         }
         return $locations;
@@ -1432,7 +1432,7 @@ class Folio extends AbstractAPI implements
             $instance = $this->getInstanceByBibId($holdDetails['id']);
             $baseParams = [
                 'instanceId' => $instance->id,
-                'requestLevel' => 'Title'
+                'requestLevel' => 'Title',
             ];
         } else {
             // Note: early Lotus releases require instanceId and holdingsRecordId
@@ -1449,7 +1449,7 @@ class Folio extends AbstractAPI implements
             'requestDate' => date('c'),
             'fulfilmentPreference' => 'Hold Shelf',
             'requestExpirationDate' => $requiredBy,
-            'pickupServicePointId' => $holdDetails['pickUpLocation']
+            'pickupServicePointId' => $holdDetails['pickUpLocation'],
         ];
         if (!empty($holdDetails['proxiedUser'])) {
             $requestBody['requesterId'] = $holdDetails['proxiedUser'];
@@ -1469,14 +1469,14 @@ class Folio extends AbstractAPI implements
             $json = json_decode($response->getBody());
             $result = [
                 'success' => true,
-                'status' => $json->status
+                'status' => $json->status,
             ];
         } else {
             try {
                 $json = json_decode($response->getBody());
                 $result = [
                     'success' => false,
-                    'status' => $json->errors[0]->message
+                    'status' => $json->errors[0]->message,
                 ];
             } catch (Exception $e) {
                 $this->throwAsIlsException($e, $response->getBody());
@@ -1782,7 +1782,7 @@ class Folio extends AbstractAPI implements
                 'status' => $fine->paymentStatus->name,
                 'type' => $fine->feeFineType,
                 'title' => $title,
-                'createdate' => date_format($date, "j M Y")
+                'createdate' => date_format($date, "j M Y"),
             ];
         }
         return $fines;
@@ -1801,7 +1801,7 @@ class Folio extends AbstractAPI implements
             . ' ' . ($user->middleName ?? '');
         $parts = [
             trim($user->lastName ?? ''),
-            trim($firstParts)
+            trim($firstParts),
         ];
         return implode(', ', array_filter($parts));
     }
@@ -1832,7 +1832,7 @@ class Folio extends AbstractAPI implements
     public function getProxiedUsers(array $patron): array
     {
         $query = [
-            'query' => '(proxyUserId=="' . $patron['id'] . '")'
+            'query' => '(proxyUserId=="' . $patron['id'] . '")',
         ];
         $results = [];
         $proxies = $this->getPagedResults('proxiesFor', '/proxiesfor', $query);

--- a/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
@@ -506,7 +506,7 @@ class GeniePlus extends AbstractAPI
             'cat_password' => trim($password),
             'email'        => $email,
             'major'        => null,
-            'college'      => null
+            'college'      => null,
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Horizon.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Horizon.php
@@ -260,13 +260,13 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
         ];
 
         $sqlLeftOuterJoin = [
-           "circ_history ch on ch.item# = i.item#"
+           "circ_history ch on ch.item# = i.item#",
         ];
 
         // Where
         $sqlWhere = [
             "i.bib# = " . addslashes($id),
-            "i.staff_only = 0"
+            "i.staff_only = 0",
         ];
 
         $sqlArray = [
@@ -274,7 +274,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'from' => $sqlFrom,
             'innerJoin' => $sqlInnerJoin,
             'leftOuterJoin' => $sqlLeftOuterJoin,
-            'where' => $sqlWhere
+            'where' => $sqlWhere,
         ];
 
         return $sqlArray;
@@ -388,7 +388,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'status'       => $row['STATUS'],
             'location'     => $row['LOCATION'],
             'reserve'      => $statusValues['reserve'],
-            'callnumber'   => $row['CALLNUMBER']
+            'callnumber'   => $row['CALLNUMBER'],
         ];
 
         return $status;
@@ -448,7 +448,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'expressions' => $sqlExpressions,
             'from'        => $sqlFrom,
             'innerJoin'   => $sqlInnerJoin,
-            'where'       => $sqlWhere
+            'where'       => $sqlWhere,
         ];
 
         return $sqlArray;
@@ -550,7 +550,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
                     'cat_password' => $password,
                     'email' => $row['EMAIL'],
                     'major' => null,
-                    'college' => null
+                    'college' => null,
                 ];
 
                 $this->debug(json_encode($user));
@@ -594,7 +594,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             "convert(varchar(12),dateadd(dd, r.expire_date, '1 jan 1970'))   " .
                              "as REQUEST_EXPIRE",
             "convert(varchar(12),dateadd(dd, r.request_date, '1 jan 1970'))  " .
-                             "as CREATED"
+                             "as CREATED",
         ];
 
         // From
@@ -604,22 +604,22 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
         $sqlJoin = [
             "borrower_barcode bb on bb.borrower# = r.borrower#",
             "location l          on l.location = r.pickup_location",
-            "title t             on t.bib# = r.bib#"
+            "title t             on t.bib# = r.bib#",
         ];
 
         $sqlLeftOuterJoin = [
             "item i             on i.item# = r.item#",
-            "pubdate_inverted p on p.bib# = r.bib#"
+            "pubdate_inverted p on p.bib# = r.bib#",
         ];
 
         // Where
         $sqlWhere = [
-            "bb.bbarcode='" . addslashes($patron['id']) . "'"
+            "bb.bbarcode='" . addslashes($patron['id']) . "'",
         ];
 
         $sqlOrder = [
             "SORT",
-            "t.processed"
+            "t.processed",
         ];
 
         $sqlArray = [
@@ -628,7 +628,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'join'          => $sqlJoin,
             'leftOuterJoin' => $sqlLeftOuterJoin,
             'where'         => $sqlWhere,
-            'order'         => $sqlOrder
+            'order'         => $sqlOrder,
         ];
 
         return $sqlArray;
@@ -687,7 +687,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
                 'item_id'          => $row['ITEM_ID'],
                 'volume'           => $row['VOLUME'],
                 'publication_year' => $row['PUBLICATION_YEAR'],
-                'title'            => $row['TITLE']
+                'title'            => $row['TITLE'],
             ];
         }
         return false;
@@ -812,7 +812,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
                     'createdate' => $row['CREATEDATE'],
                     'duedate'    => $row['DUEDATE'],
                     'id'         => $row['ID'],
-                    'title'      => $row['TITLE']
+                    'title'      => $row['TITLE'],
                 ];
             }
 
@@ -862,7 +862,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
                     'address2' => $row['ADDRESS2'],
                     'zip' => $row['ZIP'],
                     'phone' => $row['PHONE'],
-                    'group' => null
+                    'group' => null,
                 ];
 
                 $this->debug(json_encode($profile));
@@ -917,7 +917,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
         // Left Outer Join
         $sqlLeftOuterJoin = [
             "request r on r.item#=c.item#",
-            "pubdate_inverted p on p.bib# = i.bib#"
+            "pubdate_inverted p on p.bib# = i.bib#",
         ];
 
         // Where
@@ -927,7 +927,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
         // Order by
         $sqlOrder = [
             "i.due_date",
-            "t.processed"
+            "t.processed",
         ];
 
         $sqlArray = [
@@ -936,7 +936,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'join'          => $sqlJoin,
             'leftOuterJoin' => $sqlLeftOuterJoin,
             'where'         => $sqlWhere,
-            'order'         => $sqlOrder
+            'order'         => $sqlOrder,
         ];
 
         return $sqlArray;
@@ -984,7 +984,7 @@ class Horizon extends AbstractBase implements LoggerAwareInterface
             'dueStatus'        => $dueStatus,
             'volume'           => $row['VOLUME'],
             'publication_year' => $row['PUBLICATION_YEAR'],
-            'title'            => $row['TITLE']
+            'title'            => $row['TITLE'],
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
@@ -141,12 +141,12 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
     {
         $itemData = [
             'id' => $row['ITEM_ID'],
-            'level' => 'item'
+            'level' => 'item',
         ];
 
         $holding = parent::processHoldingRow($id, $row, $patron);
         $holding += [
-            'addLink' => $this->checkRequestIsValid($id, $itemData, $patron)
+            'addLink' => $this->checkRequestIsValid($id, $itemData, $patron),
          ];
         return $holding;
     }
@@ -223,7 +223,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             // Select
             $sqlSelect = [
                     "l.location LOCATIONID",
-                    "l.name LOCATIONDISPLAY"
+                    "l.name LOCATIONDISPLAY",
             ];
 
             // From
@@ -233,13 +233,13 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             $sqlJoin = [
                     "location l on l.location = pls.pickup_location",
                     "borrower b on b.location = pls.location",
-                    "borrower_barcode bb on bb.borrower# = b.borrower#"
+                    "borrower_barcode bb on bb.borrower# = b.borrower#",
             ];
 
             // Where
             $sqlWhere = [
                     "pls.display = 1",
-                    "bb.bbarcode=\"" . addslashes($patron['id']) . "\""
+                    "bb.bbarcode=\"" . addslashes($patron['id']) . "\"",
             ];
 
             // Order by
@@ -250,7 +250,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                     'from'        => $sqlFrom,
                     'join'        => $sqlJoin,
                     'where'       => $sqlWhere,
-                    'order'       => $sqlOrder
+                    'order'       => $sqlOrder,
             ];
 
             $sql = $this->buildSqlFromArray($sqlArray);
@@ -261,7 +261,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                 foreach ($sqlStmt as $row) {
                     $pickresponse[] = [
                         'locationID'      => $row['LOCATIONID'],
-                        'locationDisplay' => $row['LOCATIONDISPLAY']
+                        'locationDisplay' => $row['LOCATIONDISPLAY'],
                     ];
                 }
             } catch (\Exception $e) {
@@ -271,7 +271,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             foreach ($this->wsPickUpLocations as $code => $library) {
                 $pickresponse[] = [
                     'locationID' => $code,
-                    'locationDisplay' => $library
+                    'locationDisplay' => $library,
                 ];
             }
         }
@@ -313,7 +313,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                     'expressions' => $sqlSelect,
                     'from'        => $sqlFrom,
                     'join'        => $sqlJoin,
-                    'where'       => $sqlWhere
+                    'where'       => $sqlWhere,
             ];
 
             $sql = $this->buildSqlFromArray($sqlArray);
@@ -400,7 +400,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
     {
         $params = ["profile" => $this->wsProfile,
                         "menu" => "account",
-                        "GetXML" => "true"
+                        "GetXML" => "true",
                         ];
 
         $response = $this->makeRequest($params);
@@ -433,7 +433,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                         "menu" => "account",
                         "sec1" => $userBarcode,
                         "sec2" => $userPassword,
-                        "GetXML" => "true"
+                        "GetXML" => "true",
                         ];
 
         $response = $this->makeRequest($params);
@@ -476,7 +476,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                 "submenu" => "none",
                 "source"  => "~!horizon",
                 "uri"     => "",
-                "GetXML"  => "true"
+                "GetXML"  => "true",
             ];
 
             // set itemkey only if available and level is not title-level
@@ -508,7 +508,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                         "profile" => $this->wsProfile,
                         "menu" => "account",
                         "submenu" => "itemsout",
-                        "GetXML" => "true"
+                        "GetXML" => "true",
                         ];
 
         $response = $this->makeRequest($params);
@@ -538,7 +538,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                         "submenu" => "itemsout",
                         "renewitemkeys" => $items,
                         "renewitems" => "Renew",
-                        "GetXML" => "true"
+                        "GetXML" => "true",
                         ];
 
         $response = $this->makeRequest($params);
@@ -572,7 +572,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                         "submenu" => "none",
                         "source" => "~!horizon",
                         "uri" => "",
-                        "GetXML" => "true"
+                        "GetXML" => "true",
                         ];
 
         // set itemkey only if available
@@ -598,7 +598,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                 "cl" => "PlaceRequestjsp",
                 "pickuplocation" => $requestDetails['pickuplocation'],
                 "notifyby" => $requestDetails['notify'],
-                "GetXML" => "true"
+                "GetXML" => "true",
             ];
 
             $request = $this->makeRequest($confirmParams);
@@ -606,12 +606,12 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             if ($request->request_success) {
                 $response = [
                     'success' => true,
-                    'status' => "hold_success"
+                    'status' => "hold_success",
                 ];
             } else {
                 $response = [
                     'success' => false,
-                    'status' => "hold_error_fail"
+                    'status' => "hold_error_fail",
                 ];
             }
         } else {
@@ -622,7 +622,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             $response = [
                 'success' => false,
                 'status' => "hold_error_fail",
-                'sysMessage' => $sysMessage
+                'sysMessage' => $sysMessage,
             ];
         }
         return $response;
@@ -649,7 +649,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                         "menu"       => "account",
                         "submenu"    => "holds",
                         "cancelhold" => "Cancel Request",
-                        "GetXML"     => "true"
+                        "GetXML"     => "true",
                         ];
 
         $cancelData = [];
@@ -679,7 +679,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                 // If the bib id is matched, the cancel must have failed
                 if (in_array($values['bib_id'], $keys)) {
                     $responseItems[$itemID] = [
-                        'success' => false, 'status' => "hold_cancel_fail"
+                        'success' => false, 'status' => "hold_cancel_fail",
                     ];
                 } else {
                     $responseItems[$itemID] = [
@@ -699,7 +699,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                 $responseItems[$itemID] = [
                     'success' => false,
                     'status' => "hold_cancel_fail",
-                    'sysMessage' => $message
+                    'sysMessage' => $message,
                 ];
             }
         }
@@ -735,7 +735,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
         $requestDetails = [
             'bibId'          => $bibId,
             'pickuplocation' => strtoupper($pickUpLocationID),
-            'notify'         => $notify
+            'notify'         => $notify,
         ];
 
         if ($level != 'title' && $itemId != '') {
@@ -748,7 +748,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             $response = $this->placeRequest($session, $requestDetails);
         } else {
             $response = [
-                'success' => false, 'status' => "authentication_error_admin"
+                'success' => false, 'status' => "authentication_error_admin",
             ];
         }
 
@@ -784,7 +784,7 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
             $response = $this->cancelRequest($session, $cancelIDs);
         } else {
             $response = [
-                'success' => false, 'sysMessage' => "authentication_error_admin"
+                'success' => false, 'sysMessage' => "authentication_error_admin",
             ];
         }
         return $response;
@@ -830,14 +830,14 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
                     $response['details'][$ikey] = [
                         'item_id' => $ikey,
                         'new_date' =>  $dueDate,
-                        'success' => true
+                        'success' => true,
                     ];
                 } else {
                     $response['details'][$ikey] = [
                     'item_id' => $ikey,
                     'new_date' => "",
                         'success'    => false,
-                        'sysMessage' => $renewerror
+                        'sysMessage' => $renewerror,
                     ];
                 }
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -338,7 +338,7 @@ class Koha extends AbstractBase
                     'fine' => (null == $row['FINE']) ? 'Unknown' : $row['FINE'],
                     'balance' => (null == $row['BALANCE']) ? 0 : $row['BALANCE'],
                     'duedate' => $this->displayDate($row['DUEDATE']),
-                    'id' => $row['BIBNO']
+                    'id' => $row['BIBNO'],
                 ];
             }
             return $fineLst;
@@ -378,7 +378,7 @@ class Koha extends AbstractBase
                     'id' => $row['BIBNO'],
                     'location' => $row['BRNAME'],
                     'expire' => $this->displayDate($row['EXDATE']),
-                    'create' => $this->displayDate($row['RSVDATE'])
+                    'create' => $this->displayDate($row['RSVDATE']),
                 ];
             }
         } catch (PDOException $e) {
@@ -418,7 +418,7 @@ class Koha extends AbstractBase
                     'address2' => $row['ADDR2'],
                     'zip' => $row['ZIP'],
                     'phone' => $row['PHONE'],
-                    'group' => $row['GRP']
+                    'group' => $row['GRP'],
                 ];
                 return $profile;
             }
@@ -458,7 +458,7 @@ class Koha extends AbstractBase
                     'duedate' => $this->displayDateTime($row['DUEDATE']),
                     'id' => $row['BIBNO'],
                     'barcode' => $row['BARCODE'],
-                    'renew' => $row['RENEWALS']
+                    'renew' => $row['RENEWALS'],
                 ];
             }
         } catch (PDOException $e) {
@@ -587,7 +587,7 @@ class Koha extends AbstractBase
         }
         return [
             'count' => $totalCount,
-            'transactions' => $historicLoans
+            'transactions' => $historicLoans,
         ];
     }
 
@@ -733,7 +733,7 @@ class Koha extends AbstractBase
                     'cat_password' => $password,
                     'email' => $row['EMAIL'],
                     'major' => null,
-                    'college' => null
+                    'college' => null,
                 ];
 
                 return $patron;
@@ -815,9 +815,9 @@ class Koha extends AbstractBase
                     'return desc' => 'sort_return_date_desc',
                     'return asc' => 'sort_return_date_asc',
                     'due desc' => 'sort_due_date_desc',
-                    'due asc' => 'sort_due_date_asc'
+                    'due asc' => 'sort_due_date_asc',
                 ],
-                'default_sort' => 'checkout desc'
+                'default_sort' => 'checkout desc',
             ];
         }
         return $this->config[$function] ?? false;

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -551,9 +551,9 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
                     'return desc' => 'sort_return_date_desc',
                     'return asc' => 'sort_return_date_asc',
                     'due desc' => 'sort_due_date_desc',
-                    'due asc' => 'sort_due_date_asc'
+                    'due asc' => 'sort_due_date_asc',
                 ],
-                'default_sort' => 'checkout desc'
+                'default_sort' => 'checkout desc',
             ];
         }
         return $this->config[$function] ?? false;
@@ -710,7 +710,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
         } catch (\Exception $e) {
             return [
                 "success" => false,
-                "sysMessage" => "hold_date_invalid"
+                "sysMessage" => "hold_date_invalid",
             ];
         }
 
@@ -735,7 +735,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
             $this->debug("Fatal error: Patron has already reserved this item.");
             return [
                 "success" => false,
-                "sysMessage" => "It seems you have already reserved this item."
+                "sysMessage" => "It seems you have already reserved this item.",
             ];
         }
 
@@ -1079,7 +1079,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
         $rescount = 0;
         foreach ($itemSqlStmt->fetchAll() as $rowItem) {
             $items[] = [
-                'id' => $rowItem['id']
+                'id' => $rowItem['id'],
             ];
             $rescount++;
         }
@@ -1528,7 +1528,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
         }
         return [
             'count' => $totalCount,
-            'transactions' => $historicLoans
+            'transactions' => $historicLoans,
         ];
     }
 
@@ -1563,7 +1563,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
                 "GetServices",
                 [
                     "patron_id" => $id,
-                    "item_id" => $this->getField($loan->{'itemnumber'})
+                    "item_id" => $this->getField($loan->{'itemnumber'}),
                 ]
             );
             $end = microtime(true);
@@ -1990,7 +1990,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
         return [
             'success' => $result,
             'status' => $result ? 'new_password_success'
-                : 'password_error_not_unique'
+                : 'password_error_not_unique',
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -119,7 +119,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      */
     protected $statusRankings = [
         'Charged' => 1,
-        'On Hold' => 2
+        'On Hold' => 2,
     ];
 
     /**
@@ -139,7 +139,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         'ODUE' => 'Overdue',
         'Res' => 'Hold Fee',
         'HE' => 'Hold Expired',
-        'RENT' => 'Rental'
+        'RENT' => 'Rental',
     ];
 
     /**
@@ -157,7 +157,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         'cardlost' => 'renew_card_lost',
         'gonenoaddress' => 'patron_status_address_missing',
         'debarred' => 'patron_status_card_blocked',
-        'debt' => 'renew_debt'
+        'debt' => 'renew_debt',
     ];
 
     /**
@@ -168,7 +168,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     protected $permanentRenewalBlocks = [
         'onsite_checkout',
         'on_reserve',
-        'too_many'
+        'too_many',
     ];
 
     /**
@@ -509,7 +509,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $result = $this->makeRequest(
             [
                 'path' => 'v1/contrib/kohasuomi/coursereserves',
-                'query' => $params
+                'query' => $params,
             ]
         );
         if (200 !== $result['code']) {
@@ -573,7 +573,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             'email' => $result['email'],
             'major' => null,
             'college' => null,
-            'home_library' => $result['library_id']
+            'home_library' => $result['library_id'],
         ];
     }
 
@@ -634,7 +634,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             'city' => $result['city'],
             'country' => $result['country'],
             'expiration_date' => $this->convertDate($result['expiry_date'] ?? null),
-            'birthdate' => $result['date_of_birth'] ?? ''
+            'birthdate' => $result['date_of_birth'] ?? '',
         ];
     }
 
@@ -688,7 +688,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             $result = $this->makeRequest(
                 [
                     'path' => ['v1', 'checkouts', $checkoutId, 'renewal'],
-                    'method' => 'POST'
+                    'method' => 'POST',
                 ]
             );
             if (201 === $result['code']) {
@@ -697,12 +697,12 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 $finalResult['details'][$itemId] = [
                     'item_id' => $itemId,
                     'success' => true,
-                    'new_date' => $newDate
+                    'new_date' => $newDate,
                 ];
             } else {
                 $finalResult['details'][$itemId] = [
                     'item_id' => $itemId,
-                    'success' => false
+                    'success' => false,
                 ];
             }
         }
@@ -747,8 +747,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'query' => [
                     'patron_id' => $patron['id'],
                     '_match' => 'exact',
-                    '_per_page' => -1
-                ]
+                    '_per_page' => -1,
+                ],
             ]
         );
 
@@ -820,21 +820,21 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 [
                     'path' => ['v1', 'holds', $holdId],
                     'method' => 'DELETE',
-                    'errors' => true
+                    'errors' => true,
                 ]
             );
 
             if (200 === $result['code'] || 204 === $result['code']) {
                 $response[$holdId] = [
                     'success' => true,
-                    'status' => 'hold_cancel_success'
+                    'status' => 'hold_cancel_success',
                 ];
                 ++$count;
             } else {
                 $response[$holdId] = [
                     'success' => false,
                     'status' => 'hold_cancel_fail',
-                    'sysMessage' => false
+                    'sysMessage' => false,
                 ];
             }
         }
@@ -883,12 +883,12 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     [
                         'path' => [
                             'v1', 'contrib', 'kohasuomi', 'availability', 'items',
-                            $itemId, 'hold'
+                            $itemId, 'hold',
                         ],
                         'query' => [
                             'patron_id' => (int)$patron['id'],
                             'query_pickup_locations' => 1,
-                        ]
+                        ],
                     ]
                 );
                 if (empty($result['data'])) {
@@ -901,13 +901,13 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     [
                         'path' => [
                             'v1', 'contrib', 'kohasuomi', 'availability', 'biblios',
-                            $bibId, 'hold'
+                            $bibId, 'hold',
                         ],
                         'query' => [
                             'patron_id' => (int)$patron['id'],
                             'query_pickup_locations' => 1,
                             'ignore_patron_holds' => $requestId ? 1 : 0,
-                        ]
+                        ],
                     ]
                 );
                 if (empty($result['data'])) {
@@ -932,7 +932,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             }
             $locations[] = [
                 'locationID' => $code,
-                'locationDisplay' => $library['name']
+                'locationDisplay' => $library['name'],
             ];
         }
 
@@ -1012,20 +1012,20 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 [
                     'path' => [
                         'v1', 'contrib', 'kohasuomi', 'availability', 'biblios', $id,
-                        'hold'
+                        'hold',
                     ],
-                    'query' => ['patron_id' => $patron['id']]
+                    'query' => ['patron_id' => $patron['id']],
                 ]
             );
             if (!empty($result['data']['availability']['available'])) {
                 return [
                     'valid' => true,
-                    'status' => 'title_hold_place'
+                    'status' => 'title_hold_place',
                 ];
             }
             return [
                 'valid' => false,
-                'status' => $this->getHoldBlockReason($result['data'])
+                'status' => $this->getHoldBlockReason($result['data']),
             ];
         }
 
@@ -1038,20 +1038,20 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             [
                 'path' => [
                     'v1', 'contrib', 'kohasuomi', 'availability', 'items',
-                    $data['item_id'], 'hold'
+                    $data['item_id'], 'hold',
                 ],
-                'query' => ['patron_id' => $patron['id']]
+                'query' => ['patron_id' => $patron['id']],
             ]
         );
         if (!empty($result['data']['availability']['available'])) {
             return [
                 'valid' => true,
-                'status' => 'hold_place'
+                'status' => 'hold_place',
             ];
         }
         return [
             'valid' => false,
-            'status' => $this->getHoldBlockReason($result['data'])
+            'status' => $this->getHoldBlockReason($result['data']),
         ];
     }
 
@@ -1106,7 +1106,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'path' => 'v1/holds',
                 'json' => $request,
                 'method' => 'POST',
-                'errors' => true
+                'errors' => true,
             ]
         );
 
@@ -1121,14 +1121,14 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'suspended_until' => \DateTime::createFromFormat(
                     'U',
                     $holdDetails['startDateTS']
-                )->modify('-1 DAY')->format('Y-m-d') . ' 23:59:59'
+                )->modify('-1 DAY')->format('Y-m-d') . ' 23:59:59',
             ];
             $result = $this->makeRequest(
                 [
                     'path' => ['v1', 'holds', $holdId],
                     'json' => $request,
                     'method' => 'PUT',
-                    'errors' => true
+                    'errors' => true,
                 ]
             );
             if ($result['code'] >= 300) {
@@ -1136,7 +1136,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 // about the modification failure:
                 return [
                     'success' => true,
-                    'warningMessage' => 'hold_error_update_failed'
+                    'warningMessage' => 'hold_error_update_failed',
                 ];
             }
         }
@@ -1185,7 +1185,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                                 'path' => ['v1', 'holds', $requestId, 'suspension'],
                                 'method' => 'POST',
                                 'json' => new \stdClass(), // For empty JSON object
-                                'errors' => true
+                                'errors' => true,
                             ]
                         );
                     }
@@ -1195,7 +1195,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                             'path' => ['v1', 'holds', $requestId, 'suspension'],
                             'method' => 'DELETE',
                             'json' => new \stdClass(), // For empty JSON object
-                            'errors' => true
+                            'errors' => true,
                         ]
                     );
                 }
@@ -1214,7 +1214,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                             'path' => ['v1', 'holds', $requestId],
                             'method' => 'PUT',
                             'json' => $updateFields,
-                            'errors' => true
+                            'errors' => true,
                         ]
                     );
                     if ($result['code'] >= 300) {
@@ -1244,7 +1244,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $result = $this->makeRequest(
             [
                 'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id'],
-                'articlerequests'
+                'articlerequests',
             ]
         );
         if (empty($result)) {
@@ -1320,10 +1320,10 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 [
                     'path' => [
                         'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id'],
-                        'articlerequests', $id
+                        'articlerequests', $id,
                     ],
                     'method' => 'DELETE',
-                    'errors' => true
+                    'errors' => true,
                 ]
             );
 
@@ -1331,12 +1331,12 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 $response[$id] = [
                     'success' => false,
                     'status' => 'storage_retrieval_request_cancel_fail',
-                    'sysMessage' => false
+                    'sysMessage' => false,
                 ];
             } else {
                 $response[$id] = [
                     'success' => true,
-                    'status' => 'storage_retrieval_request_cancel_success'
+                    'status' => 'storage_retrieval_request_cancel_success',
                 ];
                 ++$count;
             }
@@ -1371,9 +1371,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 [
                     'path' => [
                         'v1', 'contrib', 'kohasuomi', 'availability', 'biblios', $id,
-                        'articlerequest'
+                        'articlerequest',
                     ],
-                    'query' => ['patron_id' => $patron['id']]
+                    'query' => ['patron_id' => $patron['id']],
                 ]
             );
         } else {
@@ -1381,9 +1381,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 [
                     'path' => [
                         'v1', 'contrib', 'kohasuomi', 'availability', 'items',
-                        $data['item_id'], 'articlerequest'
+                        $data['item_id'], 'articlerequest',
                     ],
-                    'query' => ['patron_id' => $patron['id']]
+                    'query' => ['patron_id' => $patron['id']],
                 ]
             );
         }
@@ -1421,7 +1421,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         ) {
             return [
                 'success' => false,
-                'sysMessage' => 'storage_retrieval_request_invalid_pickup'
+                'sysMessage' => 'storage_retrieval_request_invalid_pickup',
             ];
         }
 
@@ -1441,11 +1441,11 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             [
                 'path' => [
                     'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id'],
-                    'articlerequests'
+                    'articlerequests',
                 ],
                 'json' => $request,
                 'method' => 'POST',
-                'errors' => true
+                'errors' => true,
             ]
         );
 
@@ -1454,12 +1454,12 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 ?? 'storage_retrieval_request_error_fail';
             return [
                 'success' => false,
-                'sysMessage' => $message
+                'sysMessage' => $message,
             ];
         }
         return [
             'success' => true,
-            'status' => 'storage_retrieval_request_place_success'
+            'status' => 'storage_retrieval_request_place_success',
         ];
     }
 
@@ -1528,7 +1528,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $patron = $details['patron'];
         $request = [
             'password' => $details['newPassword'],
-            'password_2' => $details['newPassword']
+            'password_2' => $details['newPassword'],
         ];
 
         $result = $this->makeRequest(
@@ -1536,7 +1536,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'path' => ['v1', 'patrons', $patron['id'], 'password'],
                 'json' => $request,
                 'method' => 'POST',
-                'errors' => true
+                'errors' => true,
             ]
         );
 
@@ -1547,7 +1547,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 $message = 'An error has occurred';
             }
             return [
-                'success' => false, 'status' => $message
+                'success' => false, 'status' => $message,
             ];
         }
         return ['success' => true, 'status' => 'change_password_ok'];
@@ -1580,9 +1580,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     '+checkin_date' => 'sort_return_date_asc',
                     '-due_date' => 'sort_due_date_desc',
                     '+due_date' => 'sort_due_date_asc',
-                    '+title' => 'sort_title'
+                    '+title' => 'sort_title',
                 ],
-                'default_sort' => '-checkout_date'
+                'default_sort' => '-checkout_date',
             ];
         } elseif ('getMyTransactions' === $function) {
             $limit = $this->config['Loans']['max_page_size'] ?? 100;
@@ -1593,9 +1593,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     '+checkout_date' => 'sort_checkout_date_asc',
                     '-due_date' => 'sort_due_date_desc',
                     '+due_date' => 'sort_due_date_asc',
-                    '+title' => 'sort_title'
+                    '+title' => 'sort_title',
                 ],
-                'default_sort' => '+due_date'
+                'default_sort' => '+due_date',
             ];
         }
 
@@ -1700,7 +1700,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         // Handle the simple case of just a path in $request
         if (is_string($request) || !isset($request['path'])) {
             $request = [
-                'path' => $request
+                'path' => $request,
             ];
         }
 
@@ -1863,9 +1863,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             [
                 'path' => [
                     'v1', 'contrib', 'kohasuomi', 'availability', 'biblios', $id,
-                    'search'
+                    'search',
                 ],
-                'errors' => true
+                'errors' => true,
             ]
         );
         if (404 == $result['code']) {
@@ -1910,7 +1910,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'requests_placed' => max(
                     [$item['hold_queue_length'],
                     $result['data']['hold_queue_length']]
-                )
+                ),
             ];
             if (!empty($item['public_notes'])) {
                 $entry['item_notes'] = [$item['public_notes']];
@@ -2201,9 +2201,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             $result = $this->makeRequest(
                 [
                     'path' => [
-                        'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id']
+                        'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id'],
                     ],
-                    'query' => ['query_blocks' => 1]
+                    'query' => ['query_blocks' => 1],
                 ]
             );
             $blockReason = [];
@@ -2309,7 +2309,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         }
         return [
             'success' => false,
-            'sysMessage' => $error
+            'sysMessage' => $error,
         ];
     }
 
@@ -2429,7 +2429,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             'checkout' => 'issuedate',
             'return' => 'returndate',
             'lastrenewed' => 'lastreneweddate',
-            'title' => 'title'
+            'title' => 'title',
         ];
 
         return $params[$key] ?? $default;
@@ -2497,7 +2497,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $queryParams = [
             '_order_by' => $sort,
             '_page' => $params['page'] ?? 1,
-            '_per_page' => $pageSize
+            '_per_page' => $pageSize,
         ];
         if ($checkedIn) {
             $queryParams['checked_in'] = '1';
@@ -2509,9 +2509,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             [
                 'path' => [
                     'v1', 'contrib', 'kohasuomi', 'patrons', $patron['id'],
-                    'checkouts'
+                    'checkouts',
                 ],
-                'query' => $queryParams
+                'query' => $queryParams,
             ]
         );
 
@@ -2522,7 +2522,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         if (empty($result['data'])) {
             return [
                 'count' => 0,
-                $arrayKey => []
+                $arrayKey => [],
             ];
         }
         $transactions = [];
@@ -2578,7 +2578,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 'renew' => $renewals,
                 'renewLimit' => $renewLimit,
                 'renewable' => $renewable,
-                'message' => $message
+                'message' => $message,
             ];
 
             $transactions[] = $transaction;
@@ -2586,7 +2586,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
 
         return [
             'count' => $result['headers']['X-Total-Count'] ?? count($transactions),
-            $arrayKey => $transactions
+            $arrayKey => $transactions,
         ];
     }
 
@@ -2605,7 +2605,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             case 'Hold::MaximumHoldsReached':
                 $params = [
                     '%%blockCount%%' => $details['current_hold_count'],
-                    '%%blockLimit%%' => $details['max_holds_allowed']
+                    '%%blockLimit%%' => $details['max_holds_allowed'],
                 ];
                 break;
             case 'Patron::Debt':

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -243,7 +243,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
                 $driver = $this->getDriver($source);
                 $grouped[$source] = [
                     'driver' => $driver,
-                    'ids' => []
+                    'ids' => [],
                 ];
             }
             $grouped[$source]['ids'][] = $id;
@@ -266,7 +266,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
                     $statuses = array_map(
                         function ($id) {
                             return [
-                                ['id' => $id, 'error' => 'An error has occurred']
+                                ['id' => $id, 'error' => 'An error has occurred'],
                             ];
                         },
                         $localIds
@@ -531,7 +531,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $source = $this->getSource($patron['cat_username']);
         if ($driver = $this->getDriver($source)) {
             $params = [
-                $this->stripIdPrefixes($patron, $source)
+                $this->stripIdPrefixes($patron, $source),
             ];
             if (!$this->driverSupportsMethod($driver, __FUNCTION__, $params)) {
                 // Return empty array if not supported by the driver
@@ -707,7 +707,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
             $params = [
                 $this->stripIdPrefixes($id, $source),
                 $this->stripIdPrefixes($patron, $source),
-                $this->stripIdPrefixes($holdDetails, $source)
+                $this->stripIdPrefixes($holdDetails, $source),
             ];
             if (
                 !$this->driverSupportsSource($source, $id)
@@ -743,7 +743,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         if ($driver = $this->getDriver($source)) {
             $params = [
                 $this->stripIdPrefixes($patron, $source),
-                $this->stripIdPrefixes($holdDetails, $source)
+                $this->stripIdPrefixes($holdDetails, $source),
             ];
             if (!empty($holdDetails)) {
                 if (
@@ -779,7 +779,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
             if (!$this->driverSupportsSource($source, $holdDetails['id'])) {
                 return [
                     'success' => false,
-                    'sysMessage' => 'ILSMessages::hold_wrong_user_institution'
+                    'sysMessage' => 'ILSMessages::hold_wrong_user_institution',
                 ];
             }
             $holdDetails = $this->stripIdPrefixes($holdDetails, $source);
@@ -812,7 +812,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
                 $source,
                 self::HOLD_ID_FIELDS
             ),
-            $this->stripIdPrefixes($patron, $source)
+            $this->stripIdPrefixes($patron, $source),
         ];
         return $this->callMethodIfSupported($source, __FUNCTION__, $params, false);
     }
@@ -839,7 +839,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
             if (!$this->driverSupportsSource($source, $details['id'])) {
                 return [
                     'success' => false,
-                    'sysMessage' => 'ILSMessages::storage_wrong_user_institution'
+                    'sysMessage' => 'ILSMessages::storage_wrong_user_institution',
                 ];
             }
             return $driver->placeStorageRetrievalRequest(
@@ -869,7 +869,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $params = [
             $this->stripIdPrefixes($id, $source),
             $this->stripIdPrefixes($data, $source),
-            $patron
+            $patron,
         ];
         return $this->callMethodIfSupported(
             $source,
@@ -897,7 +897,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         // Patron is not stripped so that the correct library can be determined
         $params = [
             $this->stripIdPrefixes($id, $source, ['id']),
-            $patron
+            $patron,
         ];
         return $this->callMethodIfSupported(
             $source,
@@ -928,7 +928,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $params = [
             $this->stripIdPrefixes($id, $source, ['id']),
             $pickupLib,
-            $patron
+            $patron,
         ];
         return $this->callMethodIfSupported(
             $source,
@@ -979,7 +979,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $source = $this->getSource($patron['cat_username']);
         if ($driver = $this->getDriver($source)) {
             $params = [
-                $this->stripIdPrefixes($patron, $source)
+                $this->stripIdPrefixes($patron, $source),
             ];
             if (!$this->driverSupportsMethod($driver, __FUNCTION__, $params)) {
                 // Return empty array if not supported by the driver
@@ -1008,7 +1008,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $source = $this->getSource($patron['cat_username']);
         if ($driver = $this->getDriver($source)) {
             $params = [
-                $this->stripIdPrefixes($patron, $source)
+                $this->stripIdPrefixes($patron, $source),
             ];
             if (!$this->driverSupportsMethod($driver, __FUNCTION__, $params)) {
                 return false;
@@ -1031,7 +1031,7 @@ class MultiBackend extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $source = $this->getSource($patron['cat_username']);
         if ($driver = $this->getDriver($source)) {
             $params = [
-                $this->stripIdPrefixes($patron, $source)
+                $this->stripIdPrefixes($patron, $source),
             ];
             if (!$this->driverSupportsMethod($driver, __FUNCTION__, $params)) {
                 return false;

--- a/module/VuFind/src/VuFind/ILS/Driver/NewGenLib.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NewGenLib.php
@@ -476,7 +476,7 @@ class NewGenLib extends AbstractBase
             'cat_password' => $password,
             'email' => $row['email'],
             'major' => null,
-            'college' => null
+            'college' => null,
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
@@ -153,8 +153,8 @@ class NoILS extends AbstractBase implements TranslatorAwareInterface
                     'reserve' => $this->config['Status']['reserve'],
                     'callnumber' => $this->translate(
                         $this->config['Status']['callnumber']
-                    )
-                ]
+                    ),
+                ],
             ];
         } elseif ($useStatus == "marc") {
             // Retrieve record from index:
@@ -231,8 +231,8 @@ class NoILS extends AbstractBase implements TranslatorAwareInterface
                     ),
                     'barcode' => $this->config['Holdings']['barcode'],
                     'notes' => $this->config['Holdings']['notes'] ?? [],
-                    'summary' => $this->config['Holdings']['summary'] ?? []
-                ]
+                    'summary' => $this->config['Holdings']['summary'] ?? [],
+                ],
             ];
         } elseif ($useHoldings == "marc") {
             // Retrieve record from index:

--- a/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/PAIA.php
@@ -303,7 +303,7 @@ class PAIA extends DAIA
             $details[] = [
                 'success' => false,
                 'status' => $array_response['error_description'],
-                'sysMessage' => $array_response['error']
+                'sysMessage' => $array_response['error'],
             ];
         } else {
             $elements = $array_response['doc'];
@@ -313,13 +313,13 @@ class PAIA extends DAIA
                     $details[$item_id] = [
                         'success' => false,
                         'status' => $element['error'],
-                        'sysMessage' => 'Cancel request rejected'
+                        'sysMessage' => 'Cancel request rejected',
                     ];
                 } else {
                     $details[$item_id] = [
                         'success' => true,
                         'status' => 'Success',
-                        'sysMessage' => 'Successfully cancelled'
+                        'sysMessage' => 'Successfully cancelled',
                     ];
                     $count++;
 
@@ -365,7 +365,7 @@ class PAIA extends DAIA
             "patron"       => $details['patron']['cat_username'],
             "username"     => $details['patron']['cat_username'],
             "old_password" => $details['oldPassword'],
-            "new_password" => $details['newPassword']
+            "new_password" => $details['newPassword'],
         ];
 
         try {
@@ -376,7 +376,7 @@ class PAIA extends DAIA
         } catch (AuthException $e) {
             return [
                 'success' => false,
-                'status' => 'password_error_auth_old'
+                'status' => 'password_error_auth_old',
             ];
         } catch (\Exception $e) {
             $this->debug($e->getMessage());
@@ -395,7 +395,7 @@ class PAIA extends DAIA
                 'status'     => $array_response['error'],
                 'sysMessage' =>
                     $array_response['error'] ?? ' ' .
-                    $array_response['error_description'] ?? ' '
+                    $array_response['error_description'] ?? ' ',
             ];
         } elseif (
             isset($array_response['patron'])
@@ -404,13 +404,13 @@ class PAIA extends DAIA
             // on success patron_id is returned
             $details = [
                 'success' => true,
-                'status' => 'Successfully changed'
+                'status' => 'Successfully changed',
             ];
         } else {
             $details = [
                 'success' => false,
                 'status' => 'Failure changing password',
-                'sysMessage' => serialize($array_response)
+                'sysMessage' => serialize($array_response),
             ];
         }
         return $details;
@@ -1146,7 +1146,7 @@ class PAIA extends DAIA
         if (isset($array_response['error'])) {
             $details = [
                 'success' => false,
-                'sysMessage' => $array_response['error_description']
+                'sysMessage' => $array_response['error_description'],
             ];
         } else {
             $elements = $array_response['doc'];
@@ -1154,12 +1154,12 @@ class PAIA extends DAIA
                 if (isset($element['error'])) {
                     $details = [
                         'success' => false,
-                        'sysMessage' => $element['error']
+                        'sysMessage' => $element['error'],
                     ];
                 } else {
                     $details = [
                         'success' => true,
-                        'sysMessage' => 'Successfully requested'
+                        'sysMessage' => 'Successfully requested',
                     ];
                     // if caching is enabled for DAIA remove the cached data for the
                     // current item otherwise the changed status will not be shown
@@ -1250,7 +1250,7 @@ class PAIA extends DAIA
         if (isset($array_response['error'])) {
             $details[] = [
                 'success' => false,
-                'sysMessage' => $array_response['error_description']
+                'sysMessage' => $array_response['error_description'],
             ];
         } else {
             $elements = $array_response['doc'];
@@ -1261,7 +1261,7 @@ class PAIA extends DAIA
                     if (isset($element['error'])) {
                         $details[$element['item']] = [
                             'success' => false,
-                            'sysMessage' => $element['error']
+                            'sysMessage' => $element['error'],
                         ];
                     } elseif ($element['status'] == '3') {
                         $details[$element['item']] = [
@@ -1269,7 +1269,7 @@ class PAIA extends DAIA
                             'new_date' => isset($element['endtime'])
                                 ? $this->convertDatetime($element['endtime']) : '',
                             'item_id'  => 0,
-                            'sysMessage' => 'Successfully renewed'
+                            'sysMessage' => 'Successfully renewed',
                         ];
                     } else {
                         $details[$element['item']] = [
@@ -1277,7 +1277,7 @@ class PAIA extends DAIA
                             'item_id'  => 0,
                             'new_date' => isset($element['endtime'])
                                 ? $this->convertDatetime($element['endtime']) : '',
-                            'sysMessage' => 'Request rejected'
+                            'sysMessage' => 'Request rejected',
                         ];
                     }
                 }

--- a/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
@@ -149,7 +149,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
             "Content-type: application/json",
             "Accept: application/json",
             "PolarisDate: $date",
-            "Authorization: $auth_token"
+            "Authorization: $auth_token",
         ];
 
         try {
@@ -485,7 +485,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
             foreach ($this->ws_pickUpLocations as $code => $library) {
                 $locations[] = [
                     'locationID'      => $code,
-                    'locationDisplay' => $library
+                    'locationDisplay' => $library,
                 ];
             }
         } else {
@@ -778,7 +778,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
         }
         $result = [
             'count' => $count, 'details' => $item_response,
-            'blocks' => $item_blocks
+            'blocks' => $item_blocks,
         ];
 
         return $result;
@@ -832,13 +832,13 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
                 $count++;
                 $item_response[$hold_id] = [
                 'success' => true,
-                'status'  => 'hold_cancel_success'
+                'status'  => 'hold_cancel_success',
                 ];
             } else {
                 $item_response[$hold_id] = [
                 'success' => false,
                 'status'  => 'hold_cancel_fail',
-                'sysMessage' => 'Failure calling ILS to cancel hold'
+                'sysMessage' => 'Failure calling ILS to cancel hold',
                 ];
             }
         }
@@ -981,7 +981,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
         foreach ($hold_ids as $hold_id) {
             $jsonrequest = [
                  'UserID' => '1',
-                 'ActivationDate' => "$jsondate"
+                 'ActivationDate' => "$jsondate",
                 ];
 
             $response = $this->makeRequest(
@@ -995,13 +995,13 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
                 $count++;
                 $item_response[$hold_id] = [
                   'success' => true,
-                  'status'  => 'hold_suspend_success'
+                  'status'  => 'hold_suspend_success',
                 ];
             } else {
                 $item_response[$hold_id] = [
                 'success' => false,
                 'status'  => 'hold_suspend_fail',
-                'sysMessage' => 'Failure calling ILS to suspend hold'
+                'sysMessage' => 'Failure calling ILS to suspend hold',
                 ];
             }
         }
@@ -1049,7 +1049,7 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
         foreach ($hold_ids as $hold_id) {
             $jsonrequest = [
                  'UserID' => '1',
-                 'ActivationDate' => "$jsondate"
+                 'ActivationDate' => "$jsondate",
                  ];
 
             $response = $this->makeRequest(
@@ -1063,13 +1063,13 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
                 $count++;
                 $item_response[$hold_id] = [
                   'success' => true,
-                  'status'  => 'hold_reactivate_success'
+                  'status'  => 'hold_reactivate_success',
                 ];
             } else {
                 $item_response[$hold_id] = [
                 'success' => false,
                 'status'  => 'hold_reactivate_fail',
-                'sysMessage' => 'Failure calling ILS to reactivate hold'
+                'sysMessage' => 'Failure calling ILS to reactivate hold',
                 ];
             }
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/Sample.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Sample.php
@@ -79,7 +79,7 @@ class Sample extends AbstractBase
                 'duedate' => '',
                 'number' => 1,
                 'barcode' => '1234567890',
-            ]
+            ],
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -507,7 +507,7 @@ class SierraRest extends AbstractBase implements
             'cat_password' => $password,
             'email' => !empty($patron['emails']) ? $patron['emails'][0] : '',
             'major' => null,
-            'college' => null
+            'college' => null,
         ];
     }
 
@@ -552,7 +552,7 @@ class SierraRest extends AbstractBase implements
         $result = $this->makeRequest(
             [$this->apiBase, 'patrons', $patron['id']],
             [
-                'fields' => 'names,emails,phones,addresses,birthDate,expirationDate'
+                'fields' => 'names,emails,phones,addresses,birthDate,expirationDate',
             ],
             'GET',
             $patron
@@ -596,7 +596,7 @@ class SierraRest extends AbstractBase implements
             'zip' => $zip,
             'city' => $city,
             'birthdate' => $result['birthDate'] ?? '',
-            'expiration_date' => $expirationDate
+            'expiration_date' => $expirationDate,
         ];
     }
 
@@ -624,7 +624,7 @@ class SierraRest extends AbstractBase implements
                 'limit' => $pageSize,
                 'offset' => $offset,
                 'fields' => 'item,dueDate,numberOfRenewals,outDate,recallDate'
-                    . ',callNumber,barcode'
+                    . ',callNumber,barcode',
             ],
             'GET',
             $patron
@@ -632,7 +632,7 @@ class SierraRest extends AbstractBase implements
         if (empty($result['entries'])) {
             return [
                 'count' => $result['total'],
-                'records' => []
+                'records' => [],
             ];
         }
 
@@ -650,7 +650,7 @@ class SierraRest extends AbstractBase implements
                 ),
                 'dueStatus' => $this->getDueStatus($entry),
                 'renew' => $entry['numberOfRenewals'],
-                'renewable' => true // assumption, who knows?
+                'renewable' => true, // assumption, who knows?
             ];
             if (!empty($entry['recallDate'])) {
                 $date = $this->dateConverter->convertToDisplayDate(
@@ -677,7 +677,7 @@ class SierraRest extends AbstractBase implements
 
         return [
             'count' => $result['total'],
-            'records' => $transactions
+            'records' => $transactions,
         ];
     }
 
@@ -724,7 +724,7 @@ class SierraRest extends AbstractBase implements
                 $finalResult['details'][$itemId] = [
                     'item_id' => $itemId,
                     'success' => false,
-                    'sysMessage' => $msg
+                    'sysMessage' => $msg,
                 ];
             } else {
                 $newDate = $this->dateConverter->convertToDisplayDate(
@@ -734,7 +734,7 @@ class SierraRest extends AbstractBase implements
                 $finalResult['details'][$itemId] = [
                     'item_id' => $itemId,
                     'success' => true,
-                    'new_date' => $newDate
+                    'new_date' => $newDate,
                 ];
             }
         }
@@ -767,7 +767,7 @@ class SierraRest extends AbstractBase implements
                 'offset' => $offset,
                 'sortField' => 'outDate',
                 'sortOrder' => $sortOrder,
-                'fields' => 'item,outDate'
+                'fields' => 'item,outDate',
             ],
             'GET',
             $patron
@@ -777,7 +777,7 @@ class SierraRest extends AbstractBase implements
                 'success' => false,
                 'status' => 146 === $result['code']
                     ? 'ils_transaction_history_disabled'
-                    : 'ils_connection_failed'
+                    : 'ils_connection_failed',
             ];
         }
 
@@ -790,7 +790,7 @@ class SierraRest extends AbstractBase implements
                 'checkoutDate' => $this->dateConverter->convertToDisplayDate(
                     'Y-m-d',
                     $entry['outDate']
-                )
+                ),
             ];
             $item = $items[$transaction['item_id']] ?? null;
             $transaction['volume'] = $item ? $this->extractVolume($item) : '';
@@ -810,7 +810,7 @@ class SierraRest extends AbstractBase implements
 
         return [
             'count' => $result['total'] ?? 0,
-            'transactions' => $transactions
+            'transactions' => $transactions,
         ];
     }
 
@@ -848,7 +848,7 @@ class SierraRest extends AbstractBase implements
             [$this->apiBase, 'patrons', $patron['id'], 'holds'],
             [
                 'limit' => 10000,
-                'fields' => $fields
+                'fields' => $fields,
             ],
             'GET',
             $patron
@@ -979,13 +979,13 @@ class SierraRest extends AbstractBase implements
                     'item_id' => $holdId,
                     'success' => false,
                     'status' => 'hold_cancel_fail',
-                    'sysMessage' => $msg
+                    'sysMessage' => $msg,
                 ];
             } else {
                 $response[$holdId] = [
                     'item_id' => $holdId,
                     'success' => true,
-                    'status' => 'hold_cancel_success'
+                    'status' => 'hold_cancel_success',
                 ];
                 ++$count;
             }
@@ -1017,7 +1017,7 @@ class SierraRest extends AbstractBase implements
             $hold = $this->makeRequest(
                 [$this->apiBase, 'patrons', 'holds', $requestId],
                 [
-                    'fields' => $reqFields
+                    'fields' => $reqFields,
                 ],
                 'GET',
                 $patron
@@ -1048,7 +1048,7 @@ class SierraRest extends AbstractBase implements
             if (!$updateFields) {
                 $results[$requestId] = [
                     'success' => false,
-                    'status' => 'hold_error_update_blocked_status'
+                    'status' => 'hold_error_update_blocked_status',
                 ];
             } else {
                 $result = $this->makeRequest(
@@ -1063,16 +1063,16 @@ class SierraRest extends AbstractBase implements
                         'success' => false,
                         'status' => $this->formatErrorMessage(
                             $result['description'] ?? $result['name']
-                        )
+                        ),
                     ];
                 } elseif ($fieldsSkipped) {
                     $results[$requestId] = [
                         'success' => false,
-                        'status' => 'hold_error_update_blocked_status'
+                        'status' => 'hold_error_update_blocked_status',
                     ];
                 } else {
                     $results[$requestId] = [
-                        'success' => true
+                        'success' => true,
                     ];
                 }
             }
@@ -1112,7 +1112,7 @@ class SierraRest extends AbstractBase implements
                     'locationID' => $id,
                     'locationDisplay' => $this->translateLocation(
                         ['code' => $id, 'name' => $location]
-                    )
+                    ),
                 ];
             }
             return $locations;
@@ -1124,7 +1124,7 @@ class SierraRest extends AbstractBase implements
                 'limit' => 10000,
                 'offset' => 0,
                 'fields' => 'code,name',
-                'language' => $this->getTranslatorLocale()
+                'language' => $this->getTranslatorLocale(),
             ],
             'GET',
             $patron
@@ -1147,7 +1147,7 @@ class SierraRest extends AbstractBase implements
                 'locationID' => $entry['code'],
                 'locationDisplay' => $this->translateLocation(
                     ['code' => $entry['code'], 'name' => $entry['name']]
-                )
+                ),
             ];
         }
 
@@ -1281,7 +1281,7 @@ class SierraRest extends AbstractBase implements
             [$this->apiBase, 'patrons', $patron['id'], 'fines'],
             [
                 'fields' => 'item,assessedDate,description,chargeType,itemCharge'
-                    . ',processingFee,billingFee,paidAmount'
+                    . ',processingFee,billingFee,paidAmount',
             ],
             'GET',
             $patron
@@ -1343,7 +1343,7 @@ class SierraRest extends AbstractBase implements
                 ),
                 'checkout' => '',
                 'id' => $this->formatBibId($bibId),
-                'title' => $title
+                'title' => $title,
             ];
         }
         return $fines;
@@ -1373,14 +1373,14 @@ class SierraRest extends AbstractBase implements
         );
         if (null === $patron) {
             return [
-                'success' => false, 'status' => 'authentication_error_invalid'
+                'success' => false, 'status' => 'authentication_error_invalid',
             ];
         }
 
         $newPIN = preg_replace('/[^\d]/', '', trim($details['newPassword']));
         if (strlen($newPIN) != 4) {
             return [
-                'success' => false, 'status' => 'password_error_invalid'
+                'success' => false, 'status' => 'password_error_invalid',
             ];
         }
 
@@ -1398,7 +1398,7 @@ class SierraRest extends AbstractBase implements
                 'success' => false,
                 'status' => $this->formatErrorMessage(
                     $result['description'] ?? $result['name']
-                )
+                ),
             ];
         }
         return ['success' => true, 'status' => 'change_password_ok'];
@@ -1419,7 +1419,7 @@ class SierraRest extends AbstractBase implements
     {
         if ('getMyTransactions' === $function) {
             return [
-                'max_results' => 100
+                'max_results' => 100,
             ];
         }
         if ('getMyTransactionHistory' === $function) {
@@ -1430,9 +1430,9 @@ class SierraRest extends AbstractBase implements
                 'max_results' => 100,
                 'sort' => [
                     'checkout desc' => 'sort_checkout_date_desc',
-                    'checkout asc' => 'sort_checkout_date_asc'
+                    'checkout asc' => 'sort_checkout_date_asc',
                 ],
-                'default_sort' => 'checkout desc'
+                'default_sort' => 'checkout desc',
             ];
         }
         return $this->config[$function] ?? false;
@@ -1689,7 +1689,7 @@ class SierraRest extends AbstractBase implements
         return $returnStatus
             ? [
                 'statusCode' => $response->getStatusCode(),
-                'response' => $decodedResult
+                'response' => $decodedResult,
             ] : $decodedResult;
     }
 
@@ -1803,7 +1803,7 @@ class SierraRest extends AbstractBase implements
             'client_id' => $this->config['Catalog']['client_key'],
             'redirect_uri' => $redirectUri,
             'state' => 'auth',
-            'response_type' => 'code'
+            'response_type' => 'code',
         ];
         $apiUrl = $this->config['Catalog']['host'] . '/authorize'
             . '?' . http_build_query($params);
@@ -2028,7 +2028,7 @@ class SierraRest extends AbstractBase implements
                     'bibIds' => $this->extractBibId($id),
                     //'deleted' => 'false',
                     //'suppressed' => 'false',
-                    'fields' => 'fixedFields,varFields'
+                    'fields' => 'fixedFields,varFields',
                 ],
                 'GET'
             );
@@ -2065,7 +2065,7 @@ class SierraRest extends AbstractBase implements
                     'suppressed' => 'false',
                     'fields' => $fields,
                     'limit' => $limit,
-                    'offset' => $offset
+                    'offset' => $offset,
                 ],
                 'GET'
             );
@@ -2110,7 +2110,7 @@ class SierraRest extends AbstractBase implements
                     'duedate' => $duedate,
                     'number' => $volume,
                     'barcode' => $item['barcode'],
-                    'sort' => $sort--
+                    'sort' => $sort--,
                 ];
                 if ($notes) {
                     $entry['item_notes'] = $notes;
@@ -2161,7 +2161,7 @@ class SierraRest extends AbstractBase implements
                 'availability' => false,
                 'duedate' => '',
                 'barcode' => '',
-                'sort' => $sort--
+                'sort' => $sort--,
             ];
             $entry += $this->getHoldingsData($holdings);
 
@@ -2183,7 +2183,7 @@ class SierraRest extends AbstractBase implements
                 'availability' => false,
                 'duedate' => '',
                 'barcode' => '',
-                'sort' => $sort--
+                'sort' => $sort--,
             ];
         }
 
@@ -2207,7 +2207,7 @@ class SierraRest extends AbstractBase implements
                     'HoldingStatus',
                     1 === $order['copies']
                         ? 'copy_ordered_on_date'
-                        : 'copies_ordered_on_date'
+                        : 'copies_ordered_on_date',
                 ],
                 [
                     '%%copies%%' => $order['copies'],
@@ -2306,8 +2306,8 @@ class SierraRest extends AbstractBase implements
                     $subfields = $field['subfields'] ?? [
                         [
                             'tag' => '',
-                            'content' => $field['content'] ?? ''
-                        ]
+                            'content' => $field['content'] ?? '',
+                        ],
                     ];
                     $line = [];
                     foreach ($subfields as $subfield) {
@@ -2350,7 +2350,7 @@ class SierraRest extends AbstractBase implements
                 ['v4', 'branches'],
                 [
                     'limit' => 10000,
-                    'fields' => 'locations'
+                    'fields' => 'locations',
                 ],
                 'GET'
             );
@@ -2630,7 +2630,7 @@ class SierraRest extends AbstractBase implements
         $msg = $this->formatErrorMessage($msg);
         return [
             'success' => false,
-            'sysMessage' => $msg
+            'sysMessage' => $msg,
         ];
     }
 
@@ -2771,7 +2771,7 @@ class SierraRest extends AbstractBase implements
     ): array {
         $credentials = [
             'cat_username' => $username,
-            'cat_password' => $password
+            'cat_password' => $password,
         ];
         $result = $this->makeRequest(
             [$this->apiBase, 'info', 'token'],
@@ -2889,7 +2889,7 @@ class SierraRest extends AbstractBase implements
             $request = [
                 'barcode' => $username,
                 'pin' => $password,
-                'caseSensitivity' => false
+                'caseSensitivity' => false,
             ];
             try {
                 $result = $this->makeRequest(
@@ -2913,7 +2913,7 @@ class SierraRest extends AbstractBase implements
             [
                 'varFieldTag' => $varField,
                 'varFieldContent' => $username,
-                'fields' => 'names,emails'
+                'fields' => 'names,emails',
             ]
         );
         if (!$result || !empty($result['code'])) {
@@ -2985,7 +2985,7 @@ class SierraRest extends AbstractBase implements
             [$this->apiBase, 'items'],
             [
                 'id' => implode(',', $itemIds),
-                'fields' => 'bibIds,varFields'
+                'fields' => 'bibIds,varFields',
             ],
             'GET',
             $patron
@@ -3003,7 +3003,7 @@ class SierraRest extends AbstractBase implements
             [$this->apiBase, 'bibs'],
             [
                 'id' => implode(',', array_keys($bibIdsToItems)),
-                'fields' => 'title,publishYear'
+                'fields' => 'title,publishYear',
             ],
             'GET',
             $patron

--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -146,7 +146,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
             'showStaffNotes' => true,
             'showFeeType' => 'ALL_FEES',
             'usernameField' => 'userID',
-            'userProfileGroupField' => 'USER_PROFILE_ID'
+            'userProfileGroupField' => 'USER_PROFILE_ID',
         ];
 
         // Initialize cache manager.
@@ -401,7 +401,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
             'current location'       => 'marc|k',
             'home location'          => 'marc|l',
             'item type'              => 'marc|t',
-            'circulate flag'         => 'marc|r'
+            'circulate flag'         => 'marc|r',
         ];
 
         $entryNumber = $this->config['999Holdings']['entry_number'];
@@ -439,7 +439,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     'barcode' => $result['barcode number'],
                     'item_id' => $result['barcode number'],
                     'library' => $library,
-                    'material' => $material
+                    'material' => $material,
                 ];
             }
         }
@@ -703,7 +703,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     'transit_destination_library' =>
                         $transitDestinationLibrary,
                     'transit_reason' => $transitReason,
-                    'transit_date' => $transitDate
+                    'transit_date' => $transitDate,
                 ];
             }
         }
@@ -1103,7 +1103,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 'lookupMyAccountInfo',
                 [
                     'includePatronInfo' => 'true',
-                    'includePatronAddressInfo' => 'true'
+                    'includePatronAddressInfo' => 'true',
                 ],
                 [
                     'login' => $username,
@@ -1180,7 +1180,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 'includePatronInfo' => 'true',
                 'includePatronAddressInfo' => 'true',
                 'includePatronStatusInfo' => 'true',
-                'includeUserGroupInfo'     => 'true'
+                'includeUserGroupInfo'     => 'true',
             ];
 
             $result = $this->makeRequest(
@@ -1189,7 +1189,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 $options,
                 [
                     'login' => $patron['cat_username'],
-                    'password' => $patron['cat_password']
+                    'password' => $patron['cat_password'],
                 ]
             );
 
@@ -1212,7 +1212,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     $options,
                     [
                         'login' => $patron['cat_username'],
-                        'password' => $patron['cat_password']
+                        'password' => $patron['cat_password'],
                     ]
                 )->userProfileID;
             } elseif (strcmp($userProfileGroupField, 'PATRON_LIBRARY_ID') == 0) {
@@ -1233,7 +1233,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 'address2' => $address2,
                 'zip' => $zip,
                 'phone' => $phone,
-                'group' => $group
+                'group' => $group,
             ];
         } catch (\Exception $e) {
             $this->throwAsIlsException($e);
@@ -1264,7 +1264,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 $options,
                 [
                     'login' => $patron['cat_username'],
-                    'password' => $patron['cat_password']
+                    'password' => $patron['cat_password'],
                 ]
             );
 
@@ -1292,7 +1292,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                         'renewable' => $renewable,
                         //'message' => null,
                         'title' => $transaction->title,
-                        'item_id' => $transaction->itemID
+                        'item_id' => $transaction->itemID,
                     ];
                 }
             }
@@ -1324,7 +1324,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 $options,
                 [
                     'login' => $patron['cat_username'],
-                    'password' => $patron['cat_password']
+                    'password' => $patron['cat_password'],
                 ]
             );
 
@@ -1348,7 +1348,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     'item_id' => $hold->itemID,
                     //'volume' => null,
                     //'publication_year' => null,
-                    'title' => $hold->title
+                    'title' => $hold->title,
                 ];
             }
         } catch (SoapFault $e) {
@@ -1382,7 +1382,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 $options,
                 [
                     'login' => $patron['cat_username'],
-                    'password' => $patron['cat_password']
+                    'password' => $patron['cat_password'],
                 ]
             );
 
@@ -1398,7 +1398,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                         'balance' => $fee->amountOutstanding->_ * 100,
                         'createdate' => $fee->dateBilled ?? null,
                         'duedate' => $fee->feeItemInfo->dueDate ?? null,
-                        'id' => $fee->feeItemInfo->titleKey ?? null
+                        'id' => $fee->feeItemInfo->titleKey ?? null,
                     ];
                 }
             }
@@ -1453,20 +1453,20 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     $options,
                     [
                         'login' => $patron['cat_username'],
-                        'password' => $patron['cat_password']
+                        'password' => $patron['cat_password'],
                     ]
                 );
 
                 $count++;
                 $items[$holdKey] = [
                     'success' => true,
-                    'status' => 'hold_cancel_success'
+                    'status' => 'hold_cancel_success',
                 ];
             } catch (\Exception $e) {
                 $items[$holdKey] = [
                     'success' => false,
                     'status' => 'hold_cancel_fail',
-                    'sysMessage' => $e->getMessage()
+                    'sysMessage' => $e->getMessage(),
                 ];
             }
         }
@@ -1548,7 +1548,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     'new_date' => date('j-M-y', strtotime($renewal->dueDate)),
                     'new_time' => date('g:i a', strtotime($renewal->dueDate)),
                     'item_id' => $renewal->itemID,
-                    'sysMessage' => $renewal->message
+                    'sysMessage' => $renewal->message,
                 ];
             } catch (\Exception $e) {
                 $details[$barcode] = [
@@ -1556,7 +1556,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                     'new_date' => false,
                     'new_time' => false,
                     'sysMessage' =>
-                        'We could not renew this item: ' . $e->getMessage()
+                        'We could not renew this item: ' . $e->getMessage(),
                 ];
             }
         }
@@ -1607,20 +1607,20 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
                 $options,
                 [
                     'login' => $patron['cat_username'],
-                    'password' => $patron['cat_password']
+                    'password' => $patron['cat_password'],
                 ]
             );
 
             $result = [
                 'success' => true,
-                'sysMessage' => 'Your hold has been placed.'
+                'sysMessage' => 'Your hold has been placed.',
             ];
             return $result;
         } catch (SoapFault $e) {
             $result = [
                 'success' => false,
                 'sysMessage' =>
-                    'We could not place the hold: ' . $e->getMessage()
+                    'We could not place the hold: ' . $e->getMessage(),
             ];
             return $result;
         }
@@ -1701,7 +1701,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
         foreach ($this->getPolicyList('LIBR') as $key => $library) {
             $libraries[] = [
                 'locationID' => $key,
-                'locationDisplay' => $library
+                'locationDisplay' => $library,
             ];
         }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -184,7 +184,7 @@ class Unicorn extends AbstractBase implements
             [$code, $name] = explode('|', $line);
             $libraries[] = [
                 'locationID' => $code,
-                'locationDisplay' => empty($name) ? $code : $name
+                'locationDisplay' => empty($name) ? $code : $name,
             ];
         }
         return $libraries;
@@ -251,7 +251,7 @@ class Unicorn extends AbstractBase implements
         $params = [
           'query' => 'renew_items', 'chargeKeys' => $chargeKeys,
           'patronId' => $patron['cat_username'], 'pin' => $patron['cat_password'],
-          'library' => $patron['library']
+          'library' => $patron['library'],
         ];
         $response = $this->querySirsi($params);
 
@@ -354,7 +354,7 @@ class Unicorn extends AbstractBase implements
     {
         $statuses = [];
         $params = [
-            'query' => 'multiple', 'ids' => implode("|", array_unique($idList))
+            'query' => 'multiple', 'ids' => implode("|", array_unique($idList)),
         ];
         $response = $this->querySirsi($params);
         if (empty($response)) {
@@ -454,7 +454,7 @@ class Unicorn extends AbstractBase implements
             'comments' => $holdDetails['comment'],
             'holdType' => $holdDetails['level'],
             'callnumber' => $holdDetails['callnumber'],
-            'override' => $holdDetails['override']
+            'override' => $holdDetails['override'],
         ];
         $response = $this->querySirsi($params);
 
@@ -497,7 +497,7 @@ class Unicorn extends AbstractBase implements
     {
         //query sirsi
         $params = [
-            'query' => 'login', 'patronId' => $username, 'pin' => $password
+            'query' => 'login', 'patronId' => $username, 'pin' => $password,
         ];
         $response = $this->querySirsi($params);
 
@@ -537,7 +537,7 @@ class Unicorn extends AbstractBase implements
             'expired' => $expired,
             'number_of_holds' => $holds,
             'status' => $status,
-            'user_key' => $user_key
+            'user_key' => $user_key,
         ];
     }
 
@@ -558,7 +558,7 @@ class Unicorn extends AbstractBase implements
 
         //query sirsi
         $params = [
-            'query' => 'profile', 'patronId' => $username, 'pin' => $password
+            'query' => 'profile', 'patronId' => $username, 'pin' => $password,
         ];
         $response = $this->querySirsi($params);
 
@@ -574,7 +574,7 @@ class Unicorn extends AbstractBase implements
             'phone' => $phone,
             'email' => $email,
             'group' => $profile,
-            'library' => $library
+            'library' => $library,
         ];
     }
 
@@ -595,7 +595,7 @@ class Unicorn extends AbstractBase implements
         $password = $patron['cat_password'];
 
         $params = [
-            'query' => 'fines', 'patronId' => $username, 'pin' => $password
+            'query' => 'fines', 'patronId' => $username, 'pin' => $password,
         ];
         $response = $this->querySirsi($params);
         if (empty($response)) {
@@ -629,7 +629,7 @@ class Unicorn extends AbstractBase implements
                 'fine' => $reason,
                 'checkout' => $this->formatDateTime($date_charged),
                 'duedate' => $this->formatDateTime($duedate),
-                'date_recalled' => $this->formatDateTime($date_recalled)
+                'date_recalled' => $this->formatDateTime($date_recalled),
             ];
         }
 
@@ -653,7 +653,7 @@ class Unicorn extends AbstractBase implements
         $password = $patron['cat_password'];
 
         $params = [
-            'query' => 'getholds', 'patronId' => $username, 'pin' => $password
+            'query' => 'getholds', 'patronId' => $username, 'pin' => $password,
         ];
         $response = $this->querySirsi($params);
         if (empty($response)) {
@@ -676,7 +676,7 @@ class Unicorn extends AbstractBase implements
                 'type' => $type,
                 'location' => $pickup_library,
                 'item_id' => $holdkey,
-                'barcode' => trim($barcode)
+                'barcode' => trim($barcode),
             ];
         }
 
@@ -721,7 +721,7 @@ class Unicorn extends AbstractBase implements
         $params = [
             'query' => 'cancelHolds',
             'patronId' => $patron['cat_username'], 'pin' => $patron['cat_password'],
-            'holdId' => implode('|', $details)
+            'holdId' => implode('|', $details),
         ];
         $response = $this->querySirsi($params);
 
@@ -751,12 +751,12 @@ class Unicorn extends AbstractBase implements
         foreach ($details as $holdKey) {
             if (in_array($holdKey, $failures)) {
                 $items[$holdKey] = [
-                    'success' => false, 'status' => "hold_cancel_fail"
+                    'success' => false, 'status' => "hold_cancel_fail",
                 ];
             } else {
                 $count++;
                 $items[$holdKey] = [
-                  'success' => true, 'status' => "hold_cancel_success"
+                  'success' => true, 'status' => "hold_cancel_success",
                 ];
             }
         }
@@ -782,7 +782,7 @@ class Unicorn extends AbstractBase implements
         $password = $patron['cat_password'];
 
         $params = [
-            'query' => 'transactions', 'patronId' => $username, 'pin' => $password
+            'query' => 'transactions', 'patronId' => $username, 'pin' => $password,
         ];
         $response = $this->querySirsi($params);
         if (empty($response)) {
@@ -825,7 +825,7 @@ class Unicorn extends AbstractBase implements
                 'charge_key' => $charge_key,
                 'item_id' => $charge_key,
                 'callnum' => $callnum,
-                'dueStatus' => $overdue == 'Y' ? 'overdue' : ''
+                'dueStatus' => $overdue == 'Y' ? 'overdue' : '',
             ];
         }
 
@@ -939,22 +939,22 @@ class Unicorn extends AbstractBase implements
         if ($courseId) {
             $params = [
                 'query' => 'reserves', 'course' => $courseId, 'instructor' => '',
-                'desk' => ''
+                'desk' => '',
             ];
         } elseif ($instructorId) {
             $params = [
                 'query' => 'reserves', 'course' => '', 'instructor' => $instructorId,
-                'desk' => ''
+                'desk' => '',
             ];
         } elseif ($departmentId) {
             $params = [
                 'query' => 'reserves', 'course' => '', 'instructor' => '',
-                'desk' => $departmentId
+                'desk' => $departmentId,
             ];
         } else {
             $params = [
                 'query' => 'reserves', 'course' => '', 'instructor' => '',
-                'desk' => ''
+                'desk' => '',
             ];
         }
 
@@ -974,7 +974,7 @@ class Unicorn extends AbstractBase implements
                     'BIB_ID' => $bib_id,
                     'INSTRUCTOR_ID' => $instructor_id,
                     'COURSE_ID' => $course_id,
-                    'DEPARTMENT_ID' => $dept_id
+                    'DEPARTMENT_ID' => $dept_id,
                 ];
             }
         }
@@ -1017,7 +1017,7 @@ class Unicorn extends AbstractBase implements
         foreach ($item_lines as $item) {
             $item = rtrim($item, '|');
             $items[$item] = [
-                'id' => $item
+                'id' => $item,
             ];
             $rescount++;
         }
@@ -1127,7 +1127,7 @@ class Unicorn extends AbstractBase implements
             'circulation_rule' => $circulation_rule,
             'date_recalled' => $this->formatDateTime($date_recalled),
             'item_key' => $itemkey1 . '|' . $itemkey2 . '|' . $itemkey3 . '|',
-            'format' => $format
+            'format' => $format,
             ];
 
         return $item;
@@ -1312,7 +1312,7 @@ class Unicorn extends AbstractBase implements
             'location_code' => $location_code,
             'location'      => $this->mapLocation($location_code),
             'notes'         => $record->getSubfields($field, 'z'),
-            'marc852'       => $field
+            'marc852'       => $field,
         ];
         return $location;
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Virtua.php
@@ -155,7 +155,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     'status'       => null,
                     'location'     => "Toowoomba",
                     'campus'       => "Toowoomba",
-                    'callnumber'   => $result[0]['CALL_NUMBER']
+                    'callnumber'   => $result[0]['CALL_NUMBER'],
                     ];
 
                 switch ($result[0]['CALL_NUMBER']) {
@@ -293,7 +293,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 'location'     => $row['LOCATION'],
                 'reserve'      => $row['RESERVE'],
                 'campus'       => $campus,
-                'callnumber'   => $row['BIB_CALL_NUM']
+                'callnumber'   => $row['BIB_CALL_NUM'],
                 ];
         }
 
@@ -458,7 +458,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 "barcode"       => $row['BARCODE'],
                 "itemclass"     => $row['ITEM_CLASS'],
                 "units"         => $row['UNITS'],
-                "resitemclass"  => $row['RESERVE_ITEM_CLASS']
+                "resitemclass"  => $row['RESERVE_ITEM_CLASS'],
                 ];
 
             // Add to the holdings array
@@ -511,7 +511,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
             '5' => ['US', 'ES', 'PS', 'AS', 'GS', 'TS', 'TAS', 'EPS', 'XVS',
                 'XPS'],
             // 4  => Fraser Coast
-            '4' => ['UF', 'PF', 'AF']
+            '4' => ['UF', 'PF', 'AF'],
             ];
         // Where is the patron from?
         $location = "";
@@ -528,25 +528,25 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
             "5400", // Being Processed
             "5401", // On Display
             "5402", // 24 Hour Hold
-            "5700"  // IN TRANSIT
+            "5700",  // IN TRANSIT
             ];
         // Who can place reservations on available items
         $available_locs = [
             '1' => ['5', '4'],
             '4' => [],
-            '5' => []
+            '5' => [],
             ];
         // Who can place reservations on UNavailable items
         $unavailable_locs = [
             '1' => ['1', '5', '4'],
             '4' => [],
-            '5' => ['5']
+            '5' => ['5'],
             ];
         // Who can place reservations on STATUS items
         $status_locs = [
             '1' => ['1', '5', '4'],
             '4' => [],
-            '5' => ['5']
+            '5' => ['5'],
             ];
 
         // Set a flag for super users, better then
@@ -932,7 +932,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
         if (isset($field['pattern']) && isset($patterns[$field['pattern']])) {
             // Enumeration, Chonology and Other fields
             $enum_chrono = [
-                'a', 'b', 'c', 'd', 'e', 'f', 'i', 'j', 'k', 'l', 'm'
+                'a', 'b', 'c', 'd', 'e', 'f', 'i', 'j', 'k', 'l', 'm',
             ];
             $this_en_ch  = ['pattern' => [], 'data' => []];
             $this_other  = ['pattern' => [], 'data' => []];
@@ -984,7 +984,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 $data_set[$row['FIELD_SEQUENCE']][] = [
                     'tag'  => trim($row['FIELD_TAG']),
                     'code' => trim($row['SUBFIELD_CODE']),
-                    'data' => trim($row['SUBFIELD_DATA'])
+                    'data' => trim($row['SUBFIELD_DATA']),
                 ];
             }
         }
@@ -1011,13 +1011,13 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     // Everything else goes in the data bucket
                     $data[] = [
                         'code' => $subfield['code'],
-                        'data' => $subfield['data']
+                        'data' => $subfield['data'],
                     ];
                 }
             }
             $sort_set[$sort_rule . "." . $sort_order] = [
                 'tag'  => $tag,
-                'data' => $data
+                'data' => $data,
             ];
         }
 
@@ -1035,7 +1035,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
             } else {
                 $holdings_data[] = [
                     'pattern' => $rule[0],
-                    'data'    => $row['data']
+                    'data'    => $row['data'],
                 ];
             }
         }
@@ -1124,7 +1124,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 $data_set[$row['ID'] . "_" . $row['FIELD_SEQUENCE']][] = [
                     'id'   => trim($row['ID']),
                     'code' => trim($row['SUBFIELD_CODE']),
-                    'data' => trim($row['SUBFIELD_DATA'])
+                    'data' => trim($row['SUBFIELD_DATA']),
                     ];
             }
         }
@@ -1235,7 +1235,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 'address2'  => trim($result[0]['STREET_ADDRESS_2']),
                 'zip'       => trim($result[0]['POSTAL_CODE']),
                 'phone'     => trim($result[0]['TELEPHONE_PRIMARY']),
-                'group'     => trim($result[0]['PATRON_TYPE'])
+                'group'     => trim($result[0]['PATRON_TYPE']),
                 ];
 
             if ($result[0]['CITY'] != null) {
@@ -1286,7 +1286,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     "fine"     => $row['DESCRIPTION'],
                     "balance"  => $row['BALANCE'] * 100,
                     "duedate"  => $row['DUE_DATE'],
-                    "id"       => "vtls" . sprintf("%09d", (int)$row['BIB_ID'])
+                    "id"       => "vtls" . sprintf("%09d", (int)$row['BIB_ID']),
                     ];
             }
         }
@@ -1324,7 +1324,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     "location" => $row['PICKUP_LOCATION'],
                     "expire"   => $row['DATE_LAST_NEEDED'],
                     "create"   => $row['DATE_PLACED'],
-                    "reqnum"   => $row['REQUEST_CONTROL_NUMBER']
+                    "reqnum"   => $row['REQUEST_CONTROL_NUMBER'],
                     ];
             }
         }
@@ -1376,7 +1376,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     'renew'   => $row['RENEW_COUNT'],
                     'request' => $row['REQ_COUNT'],
                     // IDs need to show as 'vtls000589589'
-                    'id'      => "vtls" . sprintf("%09d", (int)$row['BIBID'])
+                    'id'      => "vtls" . sprintf("%09d", (int)$row['BIBID']),
                     ];
             }
         }
@@ -1491,7 +1491,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                     date($time_format, strtotime($row['OPEN_TIME'])),
                 'close'  => "$today " .
                     date($time_format, strtotime($row['CLOSE_TIME'])),
-                'status' => $row['STATUS']
+                'status' => $row['STATUS'],
                 ];
         }
 
@@ -1523,7 +1523,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
                 'close'  => "$today "
                     . date($time_format, strtotime($row['CLOSE_TIME'])),
                 'status' => $row['STATUS'],
-                'reason' => $row['REASON']
+                'reason' => $row['REASON'],
             ];
         }
         return $times;
@@ -1559,7 +1559,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
         $allowed_req_levels = [
             'item'   => 0,
             'bib'    => 1,
-            'volume' => 2
+            'volume' => 2,
             ];
         if (!in_array($req_level, array_keys($allowed_req_levels))) {
             return $response;
@@ -1568,7 +1568,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
         $allowed_pickup_locs = [
             'Toowoomba'    => '10000',
             'Fraser Coast' => '40000',
-            'Springfield'  => '50000'
+            'Springfield'  => '50000',
             ];
         if (!in_array($pickup_loc, array_keys($allowed_pickup_locs))) {
             return $response;
@@ -1715,7 +1715,7 @@ class Virtua extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterfa
             "skin" => "homepage",
             "patronid" => $patron['cat_username'],
             "patronpassword" => $patron['cat_password'],
-            "patronhost" => $this->config['Catalog']['patron_host']
+            "patronhost" => $this->config['Catalog']['patron_host'],
         ];
 
         // Get the response

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -398,7 +398,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MFHD_MASTER.DISPLAY_CALL_NO as callnumber",
             "ITEM.TEMP_LOCATION", "ITEM.ITEM_TYPE_ID",
             "ITEM.ITEM_SEQUENCE_NUMBER",
-            $this->getItemSortSequenceSQL('ITEM.PERM_LOCATION')
+            $this->getItemSortSequenceSQL('ITEM.PERM_LOCATION'),
         ];
 
         // From
@@ -407,7 +407,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             $this->dbName . ".ITEM_STATUS_TYPE",
             $this->dbName . ".ITEM_STATUS",
             $this->dbName . ".LOCATION", $this->dbName . ".MFHD_ITEM",
-            $this->dbName . ".MFHD_MASTER"
+            $this->dbName . ".MFHD_MASTER",
         ];
 
         // Where
@@ -419,7 +419,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "LOCATION.LOCATION_ID = ITEM.PERM_LOCATION",
             "MFHD_ITEM.ITEM_ID = ITEM.ITEM_ID",
             "MFHD_MASTER.MFHD_ID = MFHD_ITEM.MFHD_ID",
-            "MFHD_MASTER.SUPPRESS_IN_OPAC='N'"
+            "MFHD_MASTER.SUPPRESS_IN_OPAC='N'",
         ];
 
         // Bind
@@ -461,7 +461,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
         // From
         $sqlFrom = [
             $this->dbName . ".BIB_MFHD", $this->dbName . ".LOCATION",
-            $this->dbName . ".MFHD_MASTER"
+            $this->dbName . ".MFHD_MASTER",
         ];
 
         // Where
@@ -471,7 +471,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MFHD_MASTER.MFHD_ID = BIB_MFHD.MFHD_ID",
             "MFHD_MASTER.SUPPRESS_IN_OPAC='N'",
             "NOT EXISTS (SELECT MFHD_ID FROM {$this->dbName}.MFHD_ITEM " .
-            "WHERE MFHD_ITEM.MFHD_ID=MFHD_MASTER.MFHD_ID)"
+            "WHERE MFHD_ITEM.MFHD_ID=MFHD_MASTER.MFHD_ID)",
         ];
 
         // Bind
@@ -512,7 +512,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
                     'reserve' => $row['ON_RESERVE'],
                     'callnumber' => $row['CALLNUMBER'],
                     'item_sort_seq' => $row['ITEM_SEQUENCE_NUMBER'],
-                    'sort_seq' => $row['SORT_SEQ'] ?? PHP_INT_MAX
+                    'sort_seq' => $row['SORT_SEQ'] ?? PHP_INT_MAX,
                 ];
             } else {
                 $statusFound = in_array(
@@ -593,7 +593,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
         $sqlArrayNoItems = $this->getStatusNoItemsSQL($id);
         $possibleQueries = [
             $this->buildSqlFromArray($sqlArrayItems),
-            $this->buildSqlFromArray($sqlArrayNoItems)
+            $this->buildSqlFromArray($sqlArrayNoItems),
         ];
 
         // Loop through the possible queries and merge results.
@@ -670,7 +670,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "to_char(CIRC_TRANSACTIONS.CURRENT_DUE_DATE, 'MM-DD-YY') as duedate",
             $returnDate,
             "ITEM.ITEM_SEQUENCE_NUMBER",
-            $this->getItemSortSequenceSQL('ITEM.PERM_LOCATION')
+            $this->getItemSortSequenceSQL('ITEM.PERM_LOCATION'),
         ];
 
         // From
@@ -681,7 +681,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             $this->dbName . ".LOCATION", $this->dbName . ".MFHD_ITEM",
             $this->dbName . ".MFHD_MASTER", $this->dbName . ".MFHD_DATA",
             $this->dbName . ".CIRC_TRANSACTIONS",
-            $this->dbName . ".ITEM_BARCODE"
+            $this->dbName . ".ITEM_BARCODE",
         ];
 
         // Where
@@ -696,12 +696,12 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MFHD_ITEM.ITEM_ID = ITEM.ITEM_ID",
             "MFHD_MASTER.MFHD_ID = MFHD_ITEM.MFHD_ID",
             "MFHD_DATA.MFHD_ID = MFHD_ITEM.MFHD_ID",
-            "MFHD_MASTER.SUPPRESS_IN_OPAC='N'"
+            "MFHD_MASTER.SUPPRESS_IN_OPAC='N'",
         ];
 
         // Order
         $sqlOrder = [
-            "ITEM.ITEM_SEQUENCE_NUMBER", "MFHD_DATA.MFHD_ID", "MFHD_DATA.SEQNUM"
+            "ITEM.ITEM_SEQUENCE_NUMBER", "MFHD_DATA.MFHD_ID", "MFHD_DATA.SEQNUM",
         ];
 
         // Bind
@@ -740,13 +740,13 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "null as duedate", "null as RETURNDATE", "0 AS TEMP_LOCATION",
             "0 as PERM_LOCATION",
             "0 as ITEM_SEQUENCE_NUMBER",
-            $this->getItemSortSequenceSQL('LOCATION.LOCATION_ID')
+            $this->getItemSortSequenceSQL('LOCATION.LOCATION_ID'),
         ];
 
         // From
         $sqlFrom = [
             $this->dbName . ".BIB_MFHD", $this->dbName . ".LOCATION",
-            $this->dbName . ".MFHD_MASTER", $this->dbName . ".MFHD_DATA"
+            $this->dbName . ".MFHD_MASTER", $this->dbName . ".MFHD_DATA",
         ];
 
         // Where
@@ -757,7 +757,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MFHD_DATA.MFHD_ID = BIB_MFHD.MFHD_ID",
             "MFHD_MASTER.SUPPRESS_IN_OPAC='N'",
             "NOT EXISTS (SELECT MFHD_ID FROM {$this->dbName}.MFHD_ITEM"
-            . " WHERE MFHD_ITEM.MFHD_ID=MFHD_MASTER.MFHD_ID)"
+            . " WHERE MFHD_ITEM.MFHD_ID=MFHD_MASTER.MFHD_ID)",
         ];
 
         // Order
@@ -1031,7 +1031,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'use_unknown_message' =>
                 in_array('No information available', $sqlRow['STATUS_ARRAY']),
             'item_sort_seq' => $sqlRow['ITEM_SEQUENCE_NUMBER'],
-            'sort_seq' => $sqlRow['SORT_SEQ'] ?? PHP_INT_MAX
+            'sort_seq' => $sqlRow['SORT_SEQ'] ?? PHP_INT_MAX,
         ];
     }
 
@@ -1131,7 +1131,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
                     'number' => $number,
                     'requests_placed' => $requests_placed,
                     'returnDate' => $this->processHoldingReturnDate($row),
-                    'purchase_history' => $purchases
+                    'purchase_history' => $purchases,
                 ];
 
                 // Parse Holding Record
@@ -1375,7 +1375,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MAX(CIRC_TRANSACTIONS.RENEWAL_COUNT) AS RENEWAL_COUNT",
             "MAX(CIRC_POLICY_MATRIX.RENEWAL_COUNT) as RENEWAL_LIMIT",
             "MAX(LOCATION.LOCATION_DISPLAY_NAME) as BORROWING_LOCATION",
-            "MAX(CIRC_POLICY_MATRIX.LOAN_INTERVAL) as LOAN_INTERVAL"
+            "MAX(CIRC_POLICY_MATRIX.LOAN_INTERVAL) as LOAN_INTERVAL",
         ];
 
         // From
@@ -1389,7 +1389,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             $this->dbName . ".MFHD_ITEM",
             $this->dbName . ".BIB_TEXT",
             $this->dbName . ".CIRC_POLICY_MATRIX",
-            $this->dbName . ".LOCATION"
+            $this->dbName . ".LOCATION",
         ];
 
         // Where
@@ -1408,7 +1408,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "(ITEM_BARCODE.BARCODE_STATUS IS NULL OR " .
             "ITEM_BARCODE.BARCODE_STATUS IN (SELECT BARCODE_STATUS_TYPE FROM " .
             "$this->dbName.ITEM_BARCODE_STATUS " .
-            " WHERE BARCODE_STATUS_DESC = 'Active'))"
+            " WHERE BARCODE_STATUS_DESC = 'Active'))",
         ];
 
         // Order
@@ -1423,7 +1423,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'where' => $sqlWhere,
             'order' => $sqlOrder,
             'bind' => $sqlBind,
-            'group' => ['CIRC_TRANSACTIONS.ITEM_ID']
+            'group' => ['CIRC_TRANSACTIONS.ITEM_ID'],
         ];
 
         return $sqlArray;
@@ -1566,13 +1566,13 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "to_char(FINE_FEE.CREATE_DATE, 'MM-DD-YY HH:MI:SS') as CREATEDATE",
             "to_char(FINE_FEE.ORIG_CHARGE_DATE, 'MM-DD-YY') as CHARGEDATE",
             "to_char(FINE_FEE.DUE_DATE, 'MM-DD-YY') as DUEDATE",
-            "BIB_ITEM.BIB_ID"
+            "BIB_ITEM.BIB_ID",
         ];
 
         // From
         $sqlFrom = [
             $this->dbName . ".FINE_FEE", $this->dbName . ".FINE_FEE_TYPE",
-            $this->dbName . ".PATRON", $this->dbName . ".BIB_ITEM"
+            $this->dbName . ".PATRON", $this->dbName . ".BIB_ITEM",
         ];
 
         // Where
@@ -1581,7 +1581,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "FINE_FEE.FINE_FEE_TYPE = FINE_FEE_TYPE.FINE_FEE_TYPE",
             "FINE_FEE.PATRON_ID  = PATRON.PATRON_ID",
             "FINE_FEE.ITEM_ID = BIB_ITEM.ITEM_ID(+)",
-            "FINE_FEE.FINE_FEE_BALANCE > 0"
+            "FINE_FEE.FINE_FEE_BALANCE > 0",
         ];
 
         // Bind
@@ -1591,7 +1591,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         return $sqlArray;
@@ -1700,7 +1700,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "MFHD_ITEM.YEAR",
             "BIB_TEXT.TITLE_BRIEF",
             "BIB_TEXT.TITLE",
-            "REQUEST_GROUP.GROUP_NAME as REQUEST_GROUP_NAME"
+            "REQUEST_GROUP.GROUP_NAME as REQUEST_GROUP_NAME",
         ];
 
         // From
@@ -1710,7 +1710,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             $this->dbName . ".MFHD_ITEM",
             $this->dbName . ".BIB_TEXT",
             $this->dbName . ".VOYAGER_DATABASES",
-            $this->dbName . ".REQUEST_GROUP"
+            $this->dbName . ".REQUEST_GROUP",
         ];
 
         // Where
@@ -1724,7 +1724,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             "(HOLD_RECALL.HOLDING_DB_ID IS NULL OR HOLD_RECALL.HOLDING_DB_ID = 0 " .
             "OR (HOLD_RECALL.HOLDING_DB_ID = " .
             "VOYAGER_DATABASES.DB_ID AND VOYAGER_DATABASES.DB_CODE = 'LOCAL'))",
-            "HOLD_RECALL.REQUEST_GROUP_ID = REQUEST_GROUP.GROUP_ID(+)"
+            "HOLD_RECALL.REQUEST_GROUP_ID = REQUEST_GROUP.GROUP_ID(+)",
         ];
 
         // Bind
@@ -1735,7 +1735,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         return $sqlArray;
@@ -1784,7 +1784,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'volume' => str_replace("v.", "", utf8_encode($sqlRow['ITEM_ENUM'])),
             'publication_year' => $sqlRow['YEAR'],
             'title' => empty($sqlRow['TITLE_BRIEF'])
-                ? $sqlRow['TITLE'] : $sqlRow['TITLE_BRIEF']
+                ? $sqlRow['TITLE'] : $sqlRow['TITLE_BRIEF'],
         ];
     }
 
@@ -1884,7 +1884,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'MFHD_ITEM.ITEM_ENUM',
             'MFHD_ITEM.YEAR',
             'BIB_TEXT.TITLE_BRIEF',
-            'BIB_TEXT.TITLE'
+            'BIB_TEXT.TITLE',
         ];
 
         // From
@@ -1892,7 +1892,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             $this->dbName . '.CALL_SLIP',
             $this->dbName . '.CALL_SLIP_STATUS_TYPE',
             $this->dbName . '.MFHD_ITEM',
-            $this->dbName . '.BIB_TEXT'
+            $this->dbName . '.BIB_TEXT',
         ];
 
         // Where
@@ -1900,7 +1900,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'CALL_SLIP.PATRON_ID = :id',
             'CALL_SLIP.STATUS = CALL_SLIP_STATUS_TYPE.STATUS_TYPE(+)',
             'CALL_SLIP.ITEM_ID = MFHD_ITEM.ITEM_ID(+)',
-            'BIB_TEXT.BIB_ID = CALL_SLIP.BIB_ID'
+            'BIB_TEXT.BIB_ID = CALL_SLIP.BIB_ID',
         ];
 
         if (!empty($this->config['StorageRetrievalRequests']['display_statuses'])) {
@@ -1917,7 +1917,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
 
         // Order by
         $sqlOrderBy = [
-            "to_char(CALL_SLIP.DATE_REQUESTED, 'YYYY-MM-DD HH24:MI:SS')"
+            "to_char(CALL_SLIP.DATE_REQUESTED, 'YYYY-MM-DD HH24:MI:SS')",
         ];
 
         // Bind
@@ -1929,7 +1929,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'from' => $sqlFrom,
             'where' => $sqlWhere,
             'order' => $sqlOrderBy,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         return $sqlArray;
@@ -1992,7 +1992,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
             'issue' => utf8_encode($sqlRow['ITEM_CHRON']),
             'year' => utf8_encode($sqlRow['ITEM_YEAR']),
             'title' => empty($sqlRow['TITLE_BRIEF'])
-                ? $sqlRow['TITLE'] : $sqlRow['TITLE_BRIEF']
+                ? $sqlRow['TITLE'] : $sqlRow['TITLE_BRIEF'],
         ];
     }
 
@@ -2147,7 +2147,7 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
 
         $bindParams = [
             ':enddate' => date('d-m-Y', strtotime('now')),
-            ':startdate' => date('d-m-Y', strtotime("-$daysOld day"))
+            ':startdate' => date('d-m-Y', strtotime("-$daysOld day")),
         ];
 
         $sql = "select count(distinct LINE_ITEM.BIB_ID) as count " .

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -568,7 +568,7 @@ class VoyagerRestful extends Voyager implements
                 'storageRetrievalRequest' => $storageRetrieval,
                 'addStorageRetrievalRequestLink' => $addStorageRetrievalLink,
                 'ILLRequest' => $ILLRequest,
-                'addILLRequestLink' => $addILLRequestLink
+                'addILLRequestLink' => $addILLRequestLink,
             ];
             unset($holding[$i]['_fullRow']);
         }
@@ -705,7 +705,7 @@ class VoyagerRestful extends Voyager implements
             foreach ($this->ws_pickUpLocations as $code => $library) {
                 $pickResponse[] = [
                     'locationID' => $code,
-                    'locationDisplay' => $library
+                    'locationDisplay' => $library,
                 ];
             }
         } else {
@@ -743,7 +743,7 @@ class VoyagerRestful extends Voyager implements
             while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
                 $pickResponse[] = [
                     'locationID' => $row['LOCATION_ID'],
-                    'locationDisplay' => utf8_encode($row['LOCATION_NAME'])
+                    'locationDisplay' => utf8_encode($row['LOCATION_NAME']),
                 ];
             }
         }
@@ -875,7 +875,7 @@ class VoyagerRestful extends Voyager implements
             'rg.GROUP_NAME',
         ];
         $sqlFrom = [
-            "$this->dbName.REQUEST_GROUP rg"
+            "$this->dbName.REQUEST_GROUP rg",
 
         ];
         $sqlWhere = [];
@@ -921,7 +921,7 @@ class VoyagerRestful extends Voyager implements
             $subExpressions = [
                 'sub_rgl.GROUP_ID',
                 'sub_i.ITEM_ID',
-                'max(sub_ist.ITEM_STATUS) as STATUS'
+                'max(sub_ist.ITEM_STATUS) as STATUS',
             ];
 
             $subFrom = [
@@ -930,7 +930,7 @@ class VoyagerRestful extends Voyager implements
                 "$this->dbName.ITEM sub_i",
                 "$this->dbName.REQUEST_GROUP_LOCATION sub_rgl",
                 "$this->dbName.MFHD_ITEM sub_mi",
-                "$this->dbName.MFHD_MASTER sub_mm"
+                "$this->dbName.MFHD_MASTER sub_mm",
             ];
 
             $subWhere = [
@@ -940,12 +940,12 @@ class VoyagerRestful extends Voyager implements
                 'sub_mi.ITEM_ID=sub_i.ITEM_ID',
                 'sub_mm.MFHD_ID=sub_mi.MFHD_ID',
                 'sub_rgl.LOCATION_ID=sub_mm.LOCATION_ID',
-                "sub_mm.SUPPRESS_IN_OPAC='N'"
+                "sub_mm.SUPPRESS_IN_OPAC='N'",
             ];
 
             $subGroup = [
                 'sub_rgl.GROUP_ID',
-                'sub_i.ITEM_ID'
+                'sub_i.ITEM_ID',
             ];
 
             $sqlBind['subBibId'] = $bibId;
@@ -955,7 +955,7 @@ class VoyagerRestful extends Voyager implements
                 'from' => $subFrom,
                 'where' => $subWhere,
                 'group' => $subGroup,
-                'bind' => []
+                'bind' => [],
             ];
 
             $subSql = $this->buildSqlFromArray($subArray);
@@ -988,7 +988,7 @@ class VoyagerRestful extends Voyager implements
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         $sql = $this->buildSqlFromArray($sqlArray);
@@ -1003,7 +1003,7 @@ class VoyagerRestful extends Voyager implements
         while ($row = $sqlStmt->fetch(PDO::FETCH_ASSOC)) {
             $results[] = [
                 'id' => $row['GROUP_ID'],
-                'name' => utf8_encode($row['GROUP_NAME'])
+                'name' => utf8_encode($row['GROUP_NAME']),
             ];
         }
 
@@ -1229,13 +1229,13 @@ class VoyagerRestful extends Voyager implements
             // Build Hierarchy
             $hierarchy = [
                 'patron' =>  $patronId,
-                'patronStatus' => 'blocks'
+                'patronStatus' => 'blocks',
             ];
 
             // Add Required Params
             $params = [
                 'patron_homedb' => $this->ws_patronHomeUbId,
-                'view' => 'full'
+                'view' => 'full',
             ];
 
             $blocks = $this->makeRequest($hierarchy, $params);
@@ -1454,7 +1454,7 @@ class VoyagerRestful extends Voyager implements
             $params = [
                 'patron' => $patronId,
                 'patron_homedb' => $this->ws_patronHomeUbId,
-                'view' => 'full'
+                'view' => 'full',
             ];
 
             $check = $this->makeRequest($hierarchy, $params, 'GET', false);
@@ -1577,7 +1577,7 @@ class VoyagerRestful extends Voyager implements
             if ($message->attributes()->type == 'success') {
                 return [
                     'success' => true,
-                    'status' => 'hold_request_success'
+                    'status' => 'hold_request_success',
                 ];
             }
             if ($message->attributes()->type == 'system') {
@@ -1639,7 +1639,7 @@ class VoyagerRestful extends Voyager implements
     {
         return [
             'success' => false,
-            'sysMessage' => $msg
+            'sysMessage' => $msg,
         ];
     }
 
@@ -1655,18 +1655,18 @@ class VoyagerRestful extends Voyager implements
     protected function isRecordOnLoan($patronId, $bibId, $itemId = null)
     {
         $sqlExpressions = [
-            'count(cta.ITEM_ID) CNT'
+            'count(cta.ITEM_ID) CNT',
         ];
 
         $sqlFrom = [
             "$this->dbName.BIB_ITEM bi",
-            "$this->dbName.CIRC_TRANSACTIONS cta"
+            "$this->dbName.CIRC_TRANSACTIONS cta",
         ];
 
         $sqlWhere = [
             'cta.PATRON_ID=:patronId',
             'bi.BIB_ID=:bibId',
-            'bi.ITEM_ID=cta.ITEM_ID'
+            'bi.ITEM_ID=cta.ITEM_ID',
         ];
 
         if ($this->requestGroupsEnabled) {
@@ -1691,7 +1691,7 @@ class VoyagerRestful extends Voyager implements
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         $sql = $this->buildSqlFromArray($sqlArray);
@@ -1716,14 +1716,14 @@ class VoyagerRestful extends Voyager implements
     protected function itemsExist($bibId, ?int $requestGroupId = null)
     {
         $sqlExpressions = [
-            'count(i.ITEM_ID) CNT'
+            'count(i.ITEM_ID) CNT',
         ];
 
         $sqlFrom = [
             "$this->dbName.BIB_ITEM bi",
             "$this->dbName.ITEM i",
             "$this->dbName.MFHD_ITEM mi",
-            "$this->dbName.MFHD_MASTER mm"
+            "$this->dbName.MFHD_MASTER mm",
         ];
 
         $sqlWhere = [
@@ -1731,7 +1731,7 @@ class VoyagerRestful extends Voyager implements
             'i.ITEM_ID=bi.ITEM_ID',
             'mi.ITEM_ID=i.ITEM_ID',
             'mm.MFHD_ID=mi.MFHD_ID',
-            "mm.SUPPRESS_IN_OPAC='N'"
+            "mm.SUPPRESS_IN_OPAC='N'",
         ];
 
         if ($this->excludedItemLocations) {
@@ -1754,7 +1754,7 @@ class VoyagerRestful extends Voyager implements
             'expressions' => $sqlExpressions,
             'from' => $sqlFrom,
             'where' => $sqlWhere,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         $sql = $this->buildSqlFromArray($sqlArray);
@@ -1780,7 +1780,7 @@ class VoyagerRestful extends Voyager implements
         // Build inner query first
         $sqlExpressions = [
             'i.ITEM_ID',
-            'max(ist.ITEM_STATUS) as STATUS'
+            'max(ist.ITEM_STATUS) as STATUS',
         ];
 
         $sqlFrom = [
@@ -1788,7 +1788,7 @@ class VoyagerRestful extends Voyager implements
             "$this->dbName.BIB_ITEM bi",
             "$this->dbName.ITEM i",
             "$this->dbName.MFHD_ITEM mi",
-            "$this->dbName.MFHD_MASTER mm"
+            "$this->dbName.MFHD_MASTER mm",
         ];
 
         $sqlWhere = [
@@ -1797,7 +1797,7 @@ class VoyagerRestful extends Voyager implements
             'ist.ITEM_ID=i.ITEM_ID',
             'mi.ITEM_ID=i.ITEM_ID',
             'mm.MFHD_ID=mi.MFHD_ID',
-            "mm.SUPPRESS_IN_OPAC='N'"
+            "mm.SUPPRESS_IN_OPAC='N'",
         ];
 
         if ($this->excludedItemLocations) {
@@ -1806,7 +1806,7 @@ class VoyagerRestful extends Voyager implements
         }
 
         $sqlGroup = [
-            'i.ITEM_ID'
+            'i.ITEM_ID',
         ];
 
         $sqlBind = ['bibId' => $bibId];
@@ -1825,7 +1825,7 @@ class VoyagerRestful extends Voyager implements
             'from' => $sqlFrom,
             'where' => $sqlWhere,
             'group' => $sqlGroup,
-            'bind' => $sqlBind
+            'bind' => $sqlBind,
         ];
 
         $sql = $this->buildSqlFromArray($sqlArray);
@@ -1871,7 +1871,7 @@ class VoyagerRestful extends Voyager implements
             "HOLD_RECALL_ITEMS.HOLD_RECALL_STATUS < 3)",
             "HOLD_RECALL.BIB_ID = BIB_TEXT.BIB_ID(+)",
             "HOLD_RECALL.REQUEST_GROUP_ID = REQUEST_GROUP.GROUP_ID(+)",
-            "HOLD_RECALL.HOLDING_DB_ID = VOYAGER_DATABASES.DB_ID(+)"
+            "HOLD_RECALL.HOLDING_DB_ID = VOYAGER_DATABASES.DB_ID(+)",
         ];
 
         return $sqlArray;
@@ -1920,7 +1920,7 @@ class VoyagerRestful extends Voyager implements
             $copyFields = [
                 'id', 'item_id', 'volume', 'publication_year', 'title',
                 'institution_id', 'institution_name',
-                'institution_dbkey', 'in_transit'
+                'institution_dbkey', 'in_transit',
             ];
             $apiHolds = $this->getHoldsFromApi($patron, true);
             foreach ($apiHolds as $apiHold) {
@@ -2063,7 +2063,7 @@ class VoyagerRestful extends Voyager implements
             'bibId' => $bibId,
             'PICK' => $pickUpLocation,
             'REQNNA' => $lastInterestDate,
-            'REQCOMMENTS' => $comment
+            'REQCOMMENTS' => $comment,
         ];
         if ($level == 'copy' && $itemId) {
             $requestData['itemId'] = $itemId;
@@ -2108,13 +2108,13 @@ class VoyagerRestful extends Voyager implements
             $hierarchy = [
                 'patron' => $patron['id'],
                  'circulationActions' => 'requests',
-                 'holds' => $cancelID
+                 'holds' => $cancelID,
             ];
 
             // Add Required Params
             $params = [
                 'patron_homedb' => $this->ws_patronHomeUbId,
-                'view' => 'full'
+                'view' => 'full',
             ];
 
             // Get Data
@@ -2135,7 +2135,7 @@ class VoyagerRestful extends Voyager implements
                 ];
             } else {
                 $response[$itemId] = [
-                    'success' => false, 'status' => 'hold_cancel_fail'
+                    'success' => false, 'status' => 'hold_cancel_fail',
                 ];
             }
         }
@@ -2207,13 +2207,13 @@ class VoyagerRestful extends Voyager implements
         // Build Hierarchy
         $hierarchy = [
             'patron' =>  $patron['id'],
-            'circulationActions' => 'loans'
+            'circulationActions' => 'loans',
         ];
 
         // Add Required Params
         $params = [
             'patron_homedb' => $this->ws_patronHomeUbId,
-            'view' => 'full'
+            'view' => 'full',
         ];
 
         $results = $this->makeRequest($hierarchy, $params);
@@ -2316,13 +2316,13 @@ class VoyagerRestful extends Voyager implements
         $hierarchy = [
             'patron' =>  $patron['id'],
             'circulationActions' => 'requests',
-            'holds' => false
+            'holds' => false,
         ];
 
         // Add Required Params
         $params = [
             'patron_homedb' => $this->ws_patronHomeUbId,
-            'view' => 'full'
+            'view' => 'full',
         ];
 
         $results = $this->makeRequest($hierarchy, $params);
@@ -2380,7 +2380,7 @@ class VoyagerRestful extends Voyager implements
                         'in_transit' => (substr((string)$item->statusText, 0, 13)
                             == 'In transit to')
                           ? substr((string)$item->statusText, 14)
-                          : ''
+                          : '',
                     ];
                 }
             }
@@ -2405,13 +2405,13 @@ class VoyagerRestful extends Voyager implements
         $hierarchy = [
             'patron' =>  $patron['id'],
             'circulationActions' => 'requests',
-            'callslips' => false
+            'callslips' => false,
         ];
 
         // Add Required Params
         $params = [
             'patron_homedb' => $this->ws_patronHomeUbId,
-            'view' => 'full'
+            'view' => 'full',
         ];
 
         $results = $this->makeRequest($hierarchy, $params);
@@ -2474,7 +2474,7 @@ class VoyagerRestful extends Voyager implements
                                 'Y-m-d',
                                 substr((string)$item->statusText, 9)
                             )
-                            : ''
+                            : '',
                     ];
                 }
             }
@@ -2531,7 +2531,7 @@ class VoyagerRestful extends Voyager implements
         $params = [
             'patron' => $patron['id'],
             'patron_homedb' => $this->ws_patronHomeUbId,
-            'view' => 'full'
+            'view' => 'full',
         ];
 
         $xml = [];
@@ -2542,7 +2542,7 @@ class VoyagerRestful extends Voyager implements
                 'reqinput field="2"' => $details['issue'],
                 'reqinput field="3"' => $details['year'],
                 'dbkey' => $this->ws_dbKey,
-                'mfhdId' => $mfhdId
+                'mfhdId' => $mfhdId,
             ];
             if (isset($details['pickUpLocation'])) {
                 $xml['call-slip-title-parameters']['pickup-location']
@@ -2551,7 +2551,7 @@ class VoyagerRestful extends Voyager implements
         } else {
             $xml['call-slip-parameters'] = [
                 'comment' => $comment,
-                'dbkey' => $this->ws_dbKey
+                'dbkey' => $this->ws_dbKey,
             ];
             if (isset($details['pickUpLocation'])) {
                 $xml['call-slip-parameters']['pickup-location']
@@ -2620,13 +2620,13 @@ class VoyagerRestful extends Voyager implements
             $hierarchy = [
                 'patron' => $patron['id'],
                 'circulationActions' => 'requests',
-                'callslips' => $cancelID
+                'callslips' => $cancelID,
             ];
 
             // Add Required Params
             $params = [
                 'patron_homedb' => $this->ws_patronHomeUbId,
-                'view' => 'full'
+                'view' => 'full',
             ];
 
             // Get Data
@@ -2648,7 +2648,7 @@ class VoyagerRestful extends Voyager implements
             } else {
                 $response[$itemId] = [
                     'success' => false,
-                    'status' => 'storage_retrieval_request_cancel_fail'
+                    'status' => 'storage_retrieval_request_cancel_fail',
                 ];
             }
         }
@@ -2842,7 +2842,7 @@ class VoyagerRestful extends Voyager implements
                     foreach ($field->xpath('./req:select/req:option') as $option) {
                         $items[] = [
                             'id' => (string)$option->attributes()->id,
-                            'name' => (string)$option
+                            'name' => (string)$option,
                         ];
                     }
                     break;
@@ -2851,7 +2851,7 @@ class VoyagerRestful extends Voyager implements
                         $libraries[] = [
                             'id' => (string)$option->attributes()->id,
                             'name' => (string)$option,
-                            'isDefault' => $option->attributes()->isDefault == 'Y'
+                            'isDefault' => $option->attributes()->isDefault == 'Y',
                         ];
                     }
                     break;
@@ -2860,7 +2860,7 @@ class VoyagerRestful extends Voyager implements
                         $locations[] = [
                             'id' => (string)$option->attributes()->id,
                             'name' => (string)$option,
-                            'isDefault' => $option->attributes()->isDefault == 'Y'
+                            'isDefault' => $option->attributes()->isDefault == 'Y',
                         ];
                     }
                     break;
@@ -2877,7 +2877,7 @@ class VoyagerRestful extends Voyager implements
             'items' => $items,
             'libraries' => $libraries,
             'locations' => $locations,
-            'requiredBy' => $requiredByDate
+            'requiredBy' => $requiredByDate,
         ];
         $this->putCachedData($cacheId, $results);
         return $results;
@@ -3038,7 +3038,7 @@ class VoyagerRestful extends Voyager implements
             $locations[] = [
                 'id' => (string)$location->attributes()->id,
                 'name' => (string)$location,
-                'isDefault' => $location->attributes()->isDefault == 'Y'
+                'isDefault' => $location->attributes()->isDefault == 'Y',
             ];
         }
         return $locations;
@@ -3108,7 +3108,7 @@ class VoyagerRestful extends Voyager implements
         if (!$pickupLocationValid) {
             return [
                 'success' => false,
-                'sysMessage' => 'ill_request_place_fail_missing'
+                'sysMessage' => 'ill_request_place_fail_missing',
             ];
         }
 
@@ -3182,7 +3182,7 @@ class VoyagerRestful extends Voyager implements
             if ($message->attributes()->type == 'success') {
                 return [
                     'success' => true,
-                    'status' => 'ill_request_place_success'
+                    'status' => 'ill_request_place_success',
                 ];
             }
             if ($message->attributes()->type == 'system') {
@@ -3239,7 +3239,7 @@ class VoyagerRestful extends Voyager implements
             // Build Hierarchy
             $hierarchy = [
                 'patron' => $patron['id'],
-                 'circulationActions' => 'requests'
+                 'circulationActions' => 'requests',
             ];
             // An UB request is
             if ($type == 'C') {
@@ -3251,7 +3251,7 @@ class VoyagerRestful extends Voyager implements
             // Add Required Params
             $params = [
                 'patron_homedb' => $this->ws_patronHomeUbId,
-                'view' => 'full'
+                'view' => 'full',
             ];
 
             // Get Data
@@ -3273,7 +3273,7 @@ class VoyagerRestful extends Voyager implements
             } else {
                 $response[$itemId] = [
                     'success' => false,
-                    'status' => 'ill_request_cancel_fail'
+                    'status' => 'ill_request_cancel_fail',
                 ];
             }
         }
@@ -3364,7 +3364,7 @@ class VoyagerRestful extends Voyager implements
                 || null !== $row['PATRON_PIN']
             ) {
                 return [
-                    'success' => false, 'status' => 'authentication_error_invalid'
+                    'success' => false, 'status' => 'authentication_error_invalid',
                 ];
             }
         }
@@ -3377,7 +3377,7 @@ class VoyagerRestful extends Voyager implements
         );
         if ($newPIN === '') {
             return [
-                'success' => false, 'status' => 'password_error_invalid'
+                'success' => false, 'status' => 'password_error_invalid',
             ];
         }
         $barcode = htmlspecialchars($patron['cat_username'], ENT_COMPAT, 'UTF-8');
@@ -3418,19 +3418,19 @@ class VoyagerRestful extends Voyager implements
             $exceptionNamespace = 'com.endinfosys.voyager.patronpin.PatronPIN.';
             if ($code == $exceptionNamespace . 'ValidateException') {
                 return [
-                    'success' => false, 'status' => 'authentication_error_invalid'
+                    'success' => false, 'status' => 'authentication_error_invalid',
                 ];
             }
             if ($code == $exceptionNamespace . 'ValidateUniqueException') {
                 return [
-                    'success' => false, 'status' => 'password_error_not_unique'
+                    'success' => false, 'status' => 'password_error_not_unique',
                 ];
             }
             if ($code == $exceptionNamespace . 'ValidateLengthException') {
                 // This error may happen even with correct settings if the new PIN
                 // contains invalid characters.
                 return [
-                    'success' => false, 'status' => 'password_error_invalid'
+                    'success' => false, 'status' => 'password_error_invalid',
                 ];
             }
             throw new ILSException((string)$error);

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -152,7 +152,7 @@ class XCNCIP2 extends AbstractBase implements
      * @var string[]
      */
     protected $notHoldableStatuses = [
-        'circulation status undefined', 'not available', 'lost'
+        'circulation status undefined', 'not available', 'lost',
     ];
 
     /**
@@ -419,7 +419,7 @@ class XCNCIP2 extends AbstractBase implements
                 $agencyId = $data[0] . '|' . $data[1];
                 $this->pickupLocations[$agencyId] = [
                     'locationID' => $agencyId,
-                    'locationDisplay' => $data[2]
+                    'locationDisplay' => $data[2],
                 ];
             }
             fclose($handle);
@@ -1255,7 +1255,7 @@ class XCNCIP2 extends AbstractBase implements
                 'fine' => $desc,
                 'duedate' => '',
                 'createdate' => $date,
-                'id' => $id
+                'id' => $id,
             ];
         }
         return $fines;
@@ -2286,7 +2286,7 @@ class XCNCIP2 extends AbstractBase implements
         $desiredElementTypes = [
             'Agency Address Information', 'Agency User Privilege Type',
             'Application Profile Supported Type', 'Authentication Prompt',
-            'Consortium Agreement', 'Organization Name Information'
+            'Consortium Agreement', 'Organization Name Information',
         ];
         foreach ($desiredElementTypes as $elementType) {
             $ret .= $this->element('AgencyElementType', $elementType);
@@ -2758,7 +2758,7 @@ class XCNCIP2 extends AbstractBase implements
     protected function getProblemDescription(
         \SimpleXMLElement $xml,
         array $elements = [
-            'ProblemType', 'ProblemDetail', 'ProblemElement', 'ProblemValue'
+            'ProblemType', 'ProblemDetail', 'ProblemElement', 'ProblemValue',
         ],
         bool $withElementNames = true
     ): string {

--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -127,7 +127,7 @@ class Holds
             $retVal[$groupKey] = [
                 'items' => $items,
                 'location' => $items[0]['location'] ?? '',
-                'locationhref' => $items[0]['locationhref'] ?? ''
+                'locationhref' => $items[0]['locationhref'] ?? '',
             ];
             // Copy all text fields from the item to the holdings level
             foreach ($items as $item) {
@@ -551,7 +551,7 @@ class Holds
         return [
             'action' => $action, 'record' => $details['id'],
             'source' => $details['source'] ?? DEFAULT_SEARCH_BACKEND,
-            'query' => $queryString, 'anchor' => "#tabnav"
+            'query' => $queryString, 'anchor' => "#tabnav",
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
@@ -245,7 +245,7 @@ class TitleHolds
 
         $data = [
             'id' => $id,
-            'level' => 'title'
+            'level' => 'title',
         ];
 
         // Are holds allows?
@@ -314,7 +314,7 @@ class TitleHolds
         // Build Params
         return [
             'action' => 'Hold', 'record' => $data['id'], 'query' => $queryString,
-            'anchor' => '#tabnav'
+            'anchor' => '#tabnav',
         ];
     }
 }

--- a/module/VuFind/src/VuFind/ILS/PaginationHelper.php
+++ b/module/VuFind/src/VuFind/ILS/PaginationHelper.php
@@ -89,7 +89,7 @@ class PaginationHelper
                 $sortList[$key] = [
                     'desc' => $value,
                     'url' => '?sort=' . urlencode($key),
-                    'selected' => $sort == $key
+                    'selected' => $sort == $key,
                 ];
             }
         }

--- a/module/VuFind/src/VuFind/ImageLoader.php
+++ b/module/VuFind/src/VuFind/ImageLoader.php
@@ -89,7 +89,7 @@ class ImageLoader implements \Laminas\Log\LoggerAwareInterface
         "gif" => "image/gif",
         "jpeg" => "image/jpeg", "jpg" => "image/jpeg",
         "png" => "image/png",
-        "tiff" => "image/tiff", "tif" => "image/tiff"
+        "tiff" => "image/tiff", "tif" => "image/tiff",
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -116,7 +116,7 @@ class Logger extends BaseLogger
                         'priority'     => (int)$priority,
                         'priorityName' => $this->priorities[$priority],
                         'message'      => $message,
-                        'extra'        => $extra
+                        'extra'        => $extra,
                     ]
                 );
             }
@@ -211,7 +211,7 @@ class Logger extends BaseLogger
             2 => $baseError . $basicServer,
             3 => $baseError . $basicServer . $basicBacktrace,
             4 => $baseError . $detailedServer . $basicBacktrace,
-            5 => $baseError . $detailedServer . $detailedBacktrace
+            5 => $baseError . $detailedServer . $detailedBacktrace,
         ];
 
         $this->log($this->getSeverityFromException($error), $errorDetails);

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -72,7 +72,7 @@ class LoggerFactory implements FactoryInterface
             'priority' => 'priority',
             'message' => 'message',
             'logtime' => 'timestamp',
-            'ident' => 'ident'
+            'ident' => 'ident',
         ];
 
         // Make Writers

--- a/module/VuFind/src/VuFind/Log/Writer/Slack.php
+++ b/module/VuFind/src/VuFind/Log/Writer/Slack.php
@@ -69,7 +69,7 @@ class Slack extends Post
         ':warning: ',            // WARN
         ':speech_balloon: ',     // NOTICE
         ':information_source: ', // INFO
-        ':beetle: '              // DEBUG
+        ':beetle: ',              // DEBUG
     ];
 
     /**
@@ -104,7 +104,7 @@ class Slack extends Post
             'channel' => $this->channel,
             'username' => $this->username,
             'text' => $this->messageIcons[$event['priority']]
-                . $this->formatter->format($event) . PHP_EOL
+                . $this->formatter->format($event) . PHP_EOL,
         ];
         return json_encode($data);
     }

--- a/module/VuFind/src/VuFind/Mailer/Factory.php
+++ b/module/VuFind/src/VuFind/Mailer/Factory.php
@@ -67,7 +67,7 @@ class Factory implements FactoryInterface
 
         // Create mail transport:
         $settings = [
-            'host' => $config->Mail->host, 'port' => $config->Mail->port
+            'host' => $config->Mail->host, 'port' => $config->Mail->port,
         ];
         if (isset($config->Mail->name)) {
             $settings['name'] = $config->Mail->name;
@@ -76,7 +76,7 @@ class Factory implements FactoryInterface
             $settings['connection_class'] = 'login';
             $settings['connection_config'] = [
                 'username' => $config->Mail->username,
-                'password' => $config->Mail->password
+                'password' => $config->Mail->password,
             ];
             // Set user defined secure connection if provided; otherwise set default
             // secure connection based on configured port number.

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -355,7 +355,7 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
         $body = $view->partial(
             'Email/share-link.phtml',
             [
-                'msgUrl' => $url, 'to' => $to, 'from' => $from, 'message' => $msg
+                'msgUrl' => $url, 'to' => $to, 'from' => $from, 'message' => $msg,
             ]
         );
         $this->send($to, $from, $subject, $body, $cc, $replyTo);
@@ -408,7 +408,7 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
         $body = $view->partial(
             'Email/record.phtml',
             [
-                'driver' => $record, 'to' => $to, 'from' => $from, 'message' => $msg
+                'driver' => $record, 'to' => $to, 'from' => $from, 'message' => $msg,
             ]
         );
         $this->send($to, $from, $subject, $body, $cc, $replyTo);

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -642,7 +642,7 @@ class Server
         if ($this->supportsVuFindMetadata()) {
             $this->metadataFormats['oai_vufind_json'] = [
                 'schema' => 'https://vufind.org/xsd/oai_vufind_json-1.0.xsd',
-                'namespace' => 'http://vufind.org/oai_vufind_json-1.0'
+                'namespace' => 'http://vufind.org/oai_vufind_json-1.0',
             ];
         } else {
             unset($this->metadataFormats['oai_vufind_json']);

--- a/module/VuFind/src/VuFind/Recommend/AuthorFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorFacets.php
@@ -176,7 +176,7 @@ class AuthorFacets implements RecommendInterface
             // false; if we are able to find this information out in the future,
             // we can fill it in here and the templates will display it).
             'count' => false,
-            'list' => $results->getResults()
+            'list' => $results->getResults(),
         ];
     }
 }

--- a/module/VuFind/src/VuFind/Recommend/AuthorityRecommend.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorityRecommend.php
@@ -224,7 +224,7 @@ class AuthorityRecommend implements RecommendInterface
             'type0' => ['Heading'],
             'bool1' => ['NOT'],
             'lookfor1' => [$this->lookfor],
-            'type1' => ['MainHeading']
+            'type1' => ['MainHeading'],
         ];
 
         // loop through records and assign id and headings to separate arrays defined
@@ -244,7 +244,7 @@ class AuthorityRecommend implements RecommendInterface
         // Build a simple "MainHeading" search.
         $params = [
             'lookfor' => [$this->lookfor],
-            'type' => ['MainHeading']
+            'type' => ['MainHeading'],
         ];
 
         // loop through records and assign id and headings to separate arrays defined

--- a/module/VuFind/src/VuFind/Recommend/DPLATerms.php
+++ b/module/VuFind/src/VuFind/Recommend/DPLATerms.php
@@ -197,7 +197,7 @@ class DPLATerms implements RecommendInterface
         $params = [
             'q' => $lookfor,
             'fields' => implode(',', $this->returnFields),
-            'api_key' => $this->apiKey
+            'api_key' => $this->apiKey,
         ];
         foreach ($filters as $field => $filter) {
             if (isset($this->formatMap[$field])) {
@@ -229,7 +229,7 @@ class DPLATerms implements RecommendInterface
                     'provider' => is_array($doc->dataProvider)
                         ? current($doc->dataProvider)
                         : $doc->dataProvider,
-                    'link' => 'http://dp.la/item/' . $doc->id
+                    'link' => 'http://dp.la/item/' . $doc->id,
                 ];
                 if (isset($doc->$desc)) {
                     $results[$i]['desc'] = is_array($doc->$desc)

--- a/module/VuFind/src/VuFind/Recommend/EuropeanaResults.php
+++ b/module/VuFind/src/VuFind/Recommend/EuropeanaResults.php
@@ -240,7 +240,7 @@ class EuropeanaResults implements
                 $resultsProcessed[] = [
                     'title' => $value->getTitle(),
                     'link' => $link,
-                    'enclosure' => $value->getEnclosure()['url'] ?? null
+                    'enclosure' => $value->getEnclosure()['url'] ?? null,
                 ];
             }
             if (count($resultsProcessed) == $this->limit) {
@@ -252,7 +252,7 @@ class EuropeanaResults implements
             $this->results = [
                 'worksArray' => $resultsProcessed,
                 'feedTitle' => $this->searchSite,
-                'sourceLink' => $this->sitePath
+                'sourceLink' => $this->sitePath,
             ];
         } else {
             $this->results = false;

--- a/module/VuFind/src/VuFind/Recommend/MapSelection.php
+++ b/module/VuFind/src/VuFind/Recommend/MapSelection.php
@@ -260,7 +260,7 @@ class MapSelection implements
     {
         return [
             $this->basemapOptions['basemap_url'],
-            $this->basemapOptions['basemap_attribution']
+            $this->basemapOptions['basemap_attribution'],
         ];
     }
 
@@ -322,7 +322,7 @@ class MapSelection implements
             return [
                 $current->id,
                 $current->{$this->geoField},
-                $current->title ?? $defaultTitle
+                $current->title ?? $defaultTitle,
             ];
         };
         return array_map($callback, $response->response->docs);
@@ -365,7 +365,7 @@ class MapSelection implements
                     $recCoords = [$floats[1], $floats[2], $floats[3], $floats[4]];
                 }
                 $results[] = [$recId, $title, $recCoords[0],
-                    $recCoords[1], $recCoords[2], $recCoords[3]
+                    $recCoords[1], $recCoords[2], $recCoords[3],
                 ];
             }
         }

--- a/module/VuFind/src/VuFind/Recommend/OpenLibrarySubjects.php
+++ b/module/VuFind/src/VuFind/Recommend/OpenLibrarySubjects.php
@@ -191,7 +191,7 @@ class OpenLibrarySubjects implements
 
             if (!empty($result)) {
                 $this->result = [
-                    'worksArray' => $result, 'subject' => $this->subject
+                    'worksArray' => $result, 'subject' => $this->subject,
                 ];
             }
         }

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -365,7 +365,7 @@ class SideFacets extends AbstractFacets
             'date' => $this->getDateFacets(),
             'fulldate' => $this->getFullDateFacets(),
             'generic' => $this->getGenericRangeFacets(),
-            'numeric' => $this->getNumericRangeFacets()
+            'numeric' => $this->getNumericRangeFacets(),
         ];
         $processed = [];
         foreach ($raw as $type => $values) {

--- a/module/VuFind/src/VuFind/Recommend/TopFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/TopFacets.php
@@ -82,7 +82,7 @@ class TopFacets extends AbstractFacets
 
         // Load other relevant settings:
         $this->baseSettings = [
-            'rows' => $config->Results_Settings->top_rows
+            'rows' => $config->Results_Settings->top_rows,
         ];
 
         // Load boolean configurations:

--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -157,13 +157,13 @@ class Router
         // Disable path normalization since it can unencode e.g. encoded slashes in
         // record id's
         $options = [
-            'normalize_path' => false
+            'normalize_path' => false,
         ];
 
         return [
             'params' => $params,
             'route' => $routeBase . $routeSuffix,
-            'options' => $options
+            'options' => $options,
         ];
     }
 

--- a/module/VuFind/src/VuFind/Record/SourceAndIdList.php
+++ b/module/VuFind/src/VuFind/Record/SourceAndIdList.php
@@ -75,7 +75,7 @@ class SourceAndIdList
             if (!is_array($details)) {
                 $parts = explode('|', $details, 2);
                 $ids[$i] = $details = [
-                    'source' => $parts[0], 'id' => $parts[1]
+                    'source' => $parts[0], 'id' => $parts[1],
                 ];
             }
             $this->bySource[$details['source']][$details['id']][] = $i;

--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -799,7 +799,7 @@ class DefaultRecord extends AbstractBase
             'ctx_enc' => 'info:ofi/enc:UTF-8',
             'rfr_id' => 'info:sid/' . $this->getCoinsID() . ':generator',
             'rft.title' => $this->getTitle(),
-            'rft.date' => $pubDate
+            'rft.date' => $pubDate,
         ];
     }
 

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -260,7 +260,7 @@ class EDS extends DefaultRecord
                 'Group' => $item['Group'] ?? '',
                 'Name' => $item['Name'] ?? '',
                 'Data'  => isset($item['Data'])
-                    ? $this->toHTML($item['Data'], $item['Group']) : ''
+                    ? $this->toHTML($item['Data'], $item['Group']) : '',
             ];
             if (
                 !$this->itemIsExcluded($nextItem, $context)
@@ -571,7 +571,7 @@ class EDS extends DefaultRecord
                 '<superscript' => '<sup',
                 '</superscript' => '</sup',
                 '<relatesTo'   => '<sup',
-                '</relatesTo'  => '</sup'
+                '</relatesTo'  => '</sup',
         ];
 
         //  The XML data is escaped, let's unescape html entities (e.g. &lt; => <)

--- a/module/VuFind/src/VuFind/RecordDriver/EIT.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EIT.php
@@ -215,7 +215,7 @@ class EIT extends DefaultRecord
     {
         if (isset($this->controlInfo['pubinfo']['dt']['@attributes']['year'])) {
             return [
-                $this->controlInfo['pubinfo']['dt']['@attributes']['year']
+                $this->controlInfo['pubinfo']['dt']['@attributes']['year'],
             ];
         } elseif (isset($this->controlInfo['pubinfo']['dt'])) {
             return [$this->controlInfo['pubinfo']['dt']];

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -63,7 +63,7 @@ trait MarcAdvancedTrait
         '651' => 'geographic',
         '653' => '',
         '655' => 'genre/form',
-        '656' => 'occupation'
+        '656' => 'occupation',
     ];
 
     /**
@@ -81,7 +81,7 @@ trait MarcAdvancedTrait
         '3' => 'nal',
         '4' => 'unknown',
         '5' => 'cash',
-        '6' => 'rvm'
+        '6' => 'rvm',
     ];
 
     /**
@@ -154,7 +154,7 @@ trait MarcAdvancedTrait
                             'heading' => $current,
                             'type' => $fieldType,
                             'source' => $source,
-                            'id' => $this->getSubfield($result, '0')
+                            'id' => $this->getSubfield($result, '0'),
                         ];
                     } else {
                         $retval[] = $current;
@@ -614,7 +614,7 @@ trait MarcAdvancedTrait
         // Which fields/subfields should we check for URLs?
         $fieldsToCheck = [
             '856' => ['y', 'z', '3'],   // Standard URL
-            '555' => ['a']              // Cumulative index/finding aids
+            '555' => ['a'],              // Cumulative index/finding aids
         ];
 
         foreach ($fieldsToCheck as $field => $subfields) {
@@ -782,7 +782,7 @@ trait MarcAdvancedTrait
                     if ($isbn = $this->getSubfield($field, 'z')) {
                         $link = [
                             'type' => 'isn', 'value' => $isbn,
-                            'exclude' => $this->getUniqueId()
+                            'exclude' => $this->getUniqueId(),
                         ];
                     }
                     break;
@@ -790,7 +790,7 @@ trait MarcAdvancedTrait
                     if ($issn = $this->getSubfield($field, 'x')) {
                         $link = [
                             'type' => 'isn', 'value' => $issn,
-                            'exclude' => $this->getUniqueId()
+                            'exclude' => $this->getUniqueId(),
                         ];
                     }
                     break;
@@ -807,7 +807,7 @@ trait MarcAdvancedTrait
         return !isset($link) ? false : [
             'title' => $this->getRecordLinkNote($field),
             'value' => $title,
-            'link'  => $link
+            'link'  => $link,
         ];
     }
 
@@ -889,7 +889,7 @@ trait MarcAdvancedTrait
             $instructions[$key] = [
                 'mode' => $instructionParts[0],
                 'params' => $instructionParts[1] ?? null,
-                'field' => $instructionParts[2] ?? $defaultField
+                'field' => $instructionParts[2] ?? $defaultField,
             ];
         }
 

--- a/module/VuFind/src/VuFind/RecordDriver/Pazpar2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Pazpar2.php
@@ -106,7 +106,7 @@ class Pazpar2 extends DefaultRecord
                     // Convert for multiple children
                     $array[$key] = [
                         $array[$key],
-                        $children
+                        $children,
                     ];
                 }
             }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -64,7 +64,7 @@ class SolrDefault extends DefaultRecord implements
      * @var array
      */
     protected $preferredSnippetFields = [
-        'contents', 'topic'
+        'contents', 'topic',
     ];
 
     /**
@@ -224,7 +224,7 @@ class SolrDefault extends DefaultRecord implements
                 if (isset($this->highlightDetails[$current][0])) {
                     return [
                         'snippet' => $this->highlightDetails[$current][0],
-                        'caption' => $this->getSnippetCaption($current)
+                        'caption' => $this->getSnippetCaption($current),
                     ];
                 }
             }
@@ -238,7 +238,7 @@ class SolrDefault extends DefaultRecord implements
                     if ($value && !in_array($key, $this->forbiddenSnippetFields)) {
                         return [
                             'snippet' => $value[0],
-                            'caption' => $this->getSnippetCaption($key)
+                            'caption' => $this->getSnippetCaption($key),
                         ];
                     }
                 }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrOverdrive.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrOverdrive.php
@@ -439,7 +439,7 @@ class SolrOverdrive extends SolrMarc implements LoggerAwareInterface
         $coverMap = [
             'large' => 'cover300Wide',
             'medium' => 'cover150Wide',
-            'small' => 'thumbnail'
+            'small' => 'thumbnail',
         ];
         $cover = $coverMap[$size] ?? 'cover';
 
@@ -557,7 +557,7 @@ class SolrOverdrive extends SolrMarc implements LoggerAwareInterface
             'action' => 'Hold',
             'record' => $rec_id,
             'query' => "od_id=$od_id&rec_id=$rec_id",
-            'anchor' => ''
+            'anchor' => '',
         ];
         return $urlDetails;
     }

--- a/module/VuFind/src/VuFind/RecordDriver/Summon.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Summon.php
@@ -88,7 +88,7 @@ class Summon extends DefaultRecord implements Feature\PreviousUniqueIdInterface
                     ? [
                         'heading' => [$topic],
                         'type' => $fieldType,
-                        'source' => ''
+                        'source' => '',
                     ] : [$topic];
             }
         }
@@ -186,7 +186,7 @@ class Summon extends DefaultRecord implements Feature\PreviousUniqueIdInterface
         return isset($this->fields['Snippet'][0])
             ? [
                 'snippet' => trim($this->fields['Snippet'][0], '.'),
-                'caption' => ''
+                'caption' => '',
             ]
             : false;
     }
@@ -511,7 +511,7 @@ class Summon extends DefaultRecord implements Feature\PreviousUniqueIdInterface
         if (isset($this->fields['link'])) {
             $msg = $this->hasFullText() ? 'Get full text' : 'Get more information';
             return [
-                ['url' => $this->fields['link'], 'desc' => $this->translate($msg)]
+                ['url' => $this->fields['link'], 'desc' => $this->translate($msg)],
             ];
         }
         $retVal = [];

--- a/module/VuFind/src/VuFind/RecordTab/Map.php
+++ b/module/VuFind/src/VuFind/RecordTab/Map.php
@@ -303,7 +303,7 @@ class Map extends AbstractBase
                 [
                     $geoCoords[$key][0], $geoCoords[$key][1],
                     $geoCoords[$key][2], $geoCoords[$key][3],
-                    $mapLabel, $mapCoords
+                    $mapLabel, $mapCoords,
                 ]
             );
         }

--- a/module/VuFind/src/VuFind/Resolver/Driver/Jop.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Jop.php
@@ -295,7 +295,7 @@ class Jop extends AbstractBase
             '3'  => 'limited',
             '4'  => 'denied',
             '5'  => 'denied',
-            '10' => 'unknown'
+            '10' => 'unknown',
         ];
 
         $i = 0;
@@ -389,7 +389,7 @@ class Jop extends AbstractBase
             '2'  => 'open',
             '3'  => 'limited',
             '4'  => 'denied',
-            '10' => 'unknown'
+            '10' => 'unknown',
         ];
 
         $i = 0;
@@ -400,7 +400,7 @@ class Jop extends AbstractBase
             $resultXP = "/OpenURLResponseXML/Full/PrintData/ResultList/" .
                 "Result[@state={$state}][" . ($i + 1) . "]";
             $resultElements = [
-                'Title', 'Location', 'Signature', 'Period', 'Holding_comment'
+                'Title', 'Location', 'Signature', 'Period', 'Holding_comment',
             ];
             $elements = [];
             foreach ($resultElements as $element) {

--- a/module/VuFind/src/VuFind/Resolver/Driver/PluginManager.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/PluginManager.php
@@ -57,7 +57,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'redi' => Redi::class,
         'threesixtylink' => Threesixtylink::class,
         'generic' => Generic::class,
-        'other' => 'generic'
+        'other' => 'generic',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Route/RouteGenerator.php
+++ b/module/VuFind/src/VuFind/Route/RouteGenerator.php
@@ -82,8 +82,8 @@ class RouteGenerator
                 'defaults' => [
                     'controller' => $controller,
                     'action'     => $actionName,
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -165,8 +165,8 @@ class RouteGenerator
                 'defaults' => [
                     'controller' => $controller,
                     'action'     => 'Home',
-                ]
-            ]
+                ],
+            ],
         ];
         // special non-tab actions that each need their own route:
         foreach (self::$nonTabRecordActions as $action) {
@@ -181,8 +181,8 @@ class RouteGenerator
                     'defaults' => [
                         'controller' => $controller,
                         'action'     => $action,
-                    ]
-                ]
+                    ],
+                ],
             ];
         }
 
@@ -229,8 +229,8 @@ class RouteGenerator
                 'defaults' => [
                     'controller' => $controller,
                     'action'     => $action,
-                ]
-            ]
+                ],
+            ],
         ];
     }
 

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -101,7 +101,7 @@ class Clickatell extends AbstractBase
     public function getCarriers()
     {
         return [
-            'Clickatell' => ['name' => 'Clickatell', 'domain' => null]
+            'Clickatell' => ['name' => 'Clickatell', 'domain' => null],
         ];
     }
 

--- a/module/VuFind/src/VuFind/SMS/Factory.php
+++ b/module/VuFind/src/VuFind/SMS/Factory.php
@@ -77,7 +77,7 @@ class Factory implements FactoryInterface
                 return new Clickatell($smsConfig, ['client' => $client]);
             case 'mailer':
                 $options = [
-                    'mailer' => $container->get(\VuFind\Mailer\Mailer::class)
+                    'mailer' => $container->get(\VuFind\Mailer\Mailer::class),
                 ];
                 if (isset($mainConfig->Site->email)) {
                     $options['defaultFrom'] = $mainConfig->Site->email;

--- a/module/VuFind/src/VuFind/SMS/Mailer.php
+++ b/module/VuFind/src/VuFind/SMS/Mailer.php
@@ -55,7 +55,7 @@ class Mailer extends AbstractBase
         'sprint' => ['name' => 'Sprint', 'domain' => 'messaging.sprintpcs.com'],
         'tmobile' => ['name' => 'T Mobile', 'domain' => 'tmomail.net'],
         'alltel' => ['name' => 'Alltel', 'domain' => 'message.alltel.com'],
-        'Cricket' => ['name' => 'Cricket', 'domain' => 'mms.mycricket.com']
+        'Cricket' => ['name' => 'Cricket', 'domain' => 'mms.mycricket.com'],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1155,7 +1155,7 @@ class Params
                 $translateFormat,
                 [
                     '%%raw%%' => $text,
-                    '%%translated%%' => $translated
+                    '%%translated%%' => $translated,
                 ]
             ) : $translated;
     }
@@ -1726,7 +1726,7 @@ class Params
         foreach ($this->getOptions()->getViewOptions() as $key => $value) {
             $list[$key] = [
                 'desc' => $value,
-                'selected' => ($key == $this->getView())
+                'selected' => ($key == $this->getView()),
             ];
         }
         return $list;
@@ -1746,7 +1746,7 @@ class Params
         foreach ($valid as $limit) {
             $list[$limit] = [
                 'desc' => $limit,
-                'selected' => ($limit == $this->getLimit())
+                'selected' => ($limit == $this->getLimit()),
             ];
         }
         return $list;
@@ -1766,7 +1766,7 @@ class Params
         foreach ($valid as $sort => $desc) {
             $list[$sort] = [
                 'desc' => $desc,
-                'selected' => ($sort == $this->getSort())
+                'selected' => ($sort == $this->getSort()),
             ];
         }
         return $list;

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -823,7 +823,7 @@ abstract class Results
             // Initialize the settings for the current field
             $result[$field] = [
                 'label' => $filter[$field],
-                'list' => []
+                'list' => [],
             ];
             // Should we translate values for the current facet?
             $translate = in_array($field, $translatedFacets);

--- a/module/VuFind/src/VuFind/Search/EDS/Options.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Options.php
@@ -167,7 +167,7 @@ class Options extends \VuFind\Search\Base\Options
         $this->viewOptions = [
             'list|title' => 'Title View',
             'list|brief' => 'Brief View',
-            'list|detailed' => 'Detailed View'
+            'list|detailed' => 'Detailed View',
         ];
         // If we get the API info as a callback, defer until it's actually needed to
         // avoid calling the API:
@@ -568,7 +568,7 @@ class Options extends \VuFind\Search\Base\Options
             if (isset($availCriteria['AvailableSearchModes'])) {
                 foreach ($availCriteria['AvailableSearchModes'] as $mode) {
                     $this->modeOptions[$mode['Mode']] = [
-                        'Label' => $mode['Label'], 'Value' => $mode['Mode']
+                        'Label' => $mode['Label'], 'Value' => $mode['Mode'],
                     ];
                     if (
                         isset($mode['DefaultOn'])
@@ -585,7 +585,7 @@ class Options extends \VuFind\Search\Base\Options
             if (isset($availCriteria['AvailableExpanders'])) {
                 foreach ($availCriteria['AvailableExpanders'] as $expander) {
                     $this->expanderOptions[$expander['Id']] = [
-                        'Label' => $expander['Label'], 'Value' => $expander['Id']
+                        'Label' => $expander['Label'], 'Value' => $expander['Id'],
                     ];
                     if (
                         isset($expander['DefaultOn'])
@@ -636,7 +636,7 @@ class Options extends \VuFind\Search\Base\Options
                 'LimiterValues' => isset($limiterValue['LimiterValues'])
                     ? $this
                         ->populateLimiterValues($limiterValue['LimiterValues'])
-                    : null
+                    : null,
             ];
         }
         return empty($availableLimiterValues) ? null : $availableLimiterValues;
@@ -759,7 +759,7 @@ class Options extends \VuFind\Search\Base\Options
                     'eds_limiter_' . $key,
                     $limiter['Label']
                 ),
-                'selected' => ('y' == $limiter['DefaultOn']) ? true : false
+                'selected' => ('y' == $limiter['DefaultOn']) ? true : false,
             ];
         }
         return $ssLimiterOptions;

--- a/module/VuFind/src/VuFind/Search/EDS/Params.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Params.php
@@ -335,7 +335,7 @@ class Params extends \VuFind\Search\Base\Params
         foreach ($this->getOptions()->getViewOptions() as $key => $value) {
             $list[$key] = [
                 'desc' => $value,
-                'selected' => ($key == $this->getView() . '|' . $this->getEdsView())
+                'selected' => ($key == $this->getView() . '|' . $this->getEdsView()),
             ];
         }
         return $list;

--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -88,7 +88,7 @@ class Results extends \VuFind\Search\Base\Results
                 'fieldName' => 'PublicationDate',
                 'displayName' => 'PublicationDate',
                 'displayText' => 'Publication Date',
-                'counts' => []
+                'counts' => [],
             ];
 
             // Construct record drivers for all the items in the response:

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -137,7 +137,7 @@ class EdsBackendFactory extends AbstractBackendFactory
     {
         $options = [
             'search_http_method' => $this->edsConfig->General->search_http_method
-                ?? 'POST'
+                ?? 'POST',
         ];
         if (isset($this->edsConfig->General->api_url)) {
             $options['api_url'] = $this->edsConfig->General->api_url;

--- a/module/VuFind/src/VuFind/Search/Favorites/Options.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/Options.php
@@ -52,7 +52,7 @@ class Options extends \VuFind\Search\Base\Options
         $this->defaultSort = 'title';
         $this->sortOptions = [
             'title' => 'sort_title', 'author' => 'sort_author',
-            'year DESC' => 'sort_year', 'year' => 'sort_year asc'
+            'year DESC' => 'sort_year', 'year' => 'sort_year asc',
         ];
         $config = $configLoader->get($this->mainIni);
         if (isset($config->Social->lists_default_limit)) {

--- a/module/VuFind/src/VuFind/Search/Favorites/Results.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/Results.php
@@ -138,7 +138,7 @@ class Results extends BaseResults implements AuthorizationServiceAwareInterface
             if (!isset($this->facets[$field])) {
                 $this->facets[$field] = [
                     'label' => $this->getParams()->getFacetLabel($field),
-                    'list' => []
+                    'list' => [],
                 ];
                 switch ($field) {
                     case 'tags':
@@ -153,7 +153,7 @@ class Results extends BaseResults implements AuthorizationServiceAwareInterface
                                 'displayText' => $tag->tag,
                                 'count' => $tag->cnt,
                                 'isApplied' => $this->getParams()
-                                    ->hasFilter("$field:" . $tag->tag)
+                                    ->hasFilter("$field:" . $tag->tag),
                             ];
                         }
                         break;
@@ -225,8 +225,8 @@ class Results extends BaseResults implements AuthorizationServiceAwareInterface
             $recordsToRequest[] = [
                 'id' => $row->record_id, 'source' => $row->source,
                 'extra_fields' => [
-                    'title' => $row->title
-                ]
+                    'title' => $row->title,
+                ],
             ];
         }
 

--- a/module/VuFind/src/VuFind/Search/History.php
+++ b/module/VuFind/src/VuFind/Search/History.php
@@ -149,7 +149,7 @@ class History
         // If custom frequencies are not provided, return defaults:
         if (!isset($this->config->Account->scheduled_search_frequencies)) {
             return [
-                0 => 'schedule_none', 1 => 'schedule_daily', 7 => 'schedule_weekly'
+                0 => 'schedule_none', 1 => 'schedule_daily', 7 => 'schedule_weekly',
             ];
         }
         // If we have a setting, make sure it is properly formatted as an array:

--- a/module/VuFind/src/VuFind/Search/Primo/Params.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Params.php
@@ -152,7 +152,7 @@ class Params extends \VuFind\Search\Base\Params
             }
             $result[$field] = [
                 'facetOp' => $facetOp,
-                'values' => $filter
+                'values' => $filter,
             ];
         }
         return $result;

--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -233,8 +233,8 @@ abstract class QueryAdapter
             return [
                 [
                     'l' => $query->getString(),
-                    'i' => $query->getHandler()
-                ]
+                    'i' => $query->getHandler(),
+                ],
             ];
         }
 
@@ -245,7 +245,7 @@ abstract class QueryAdapter
             if ($topLevel) {
                 $retVal[] = [
                     'g' => self::minify($current, false),
-                    'j' => $operator
+                    'j' => $operator,
                 ];
             } elseif ($current instanceof QueryGroup) {
                 throw new \Exception('Not sure how to minify this query!');
@@ -253,7 +253,7 @@ abstract class QueryAdapter
                 $currentArr = [
                     'f' => $current->getHandler(),
                     'l' => $current->getString(),
-                    'b' => $operator
+                    'b' => $operator,
                 ];
                 if (null !== ($op = $current->getOperator())) {
                     // Some search forms omit the operator for the first element;

--- a/module/VuFind/src/VuFind/Search/Search2/Params.php
+++ b/module/VuFind/src/VuFind/Search/Search2/Params.php
@@ -48,7 +48,7 @@ class Params extends \VuFind\Search\Solr\Params
      */
     protected $defaultFacetLabelSections = [
         'Advanced_Facets', 'HomePage_Facets', 'ResultsTop', 'Results',
-        'ExtraFacetLabels'
+        'ExtraFacetLabels',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/DefaultParametersListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DefaultParametersListener.php
@@ -68,7 +68,7 @@ class DefaultParametersListener
     protected $contextMap = [
         'getIds' => 'search',
         'random' => 'retrieve',
-        'retrieveBatch' => 'retrieve'
+        'retrieveBatch' => 'retrieve',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/Options.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Options.php
@@ -48,7 +48,7 @@ class Options extends \VuFind\Search\Base\Options
      * @var array
      */
     protected $facetSortOptions = [
-        '*' => ['count' => 'sort_count', 'index' => 'sort_alphabetic']
+        '*' => ['count' => 'sort_count', 'index' => 'sort_alphabetic'],
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/SpellingProcessor.php
+++ b/module/VuFind/src/VuFind/Search/Solr/SpellingProcessor.php
@@ -181,7 +181,7 @@ class SpellingProcessor
             ) {
                 $allSuggestions[$term] = [
                     'freq' => $info['origFreq'],
-                    'suggestions' => $suggestions
+                    'suggestions' => $suggestions,
                 ];
             }
         }
@@ -331,7 +331,7 @@ class SpellingProcessor
             // Basic spelling suggestion data
             $returnArray[$targetTerm]['suggestions'][$label] = [
                 'freq' => $freq,
-                'new_term' => $replacement
+                'new_term' => $replacement,
             ];
 
             // Only generate expansions if enabled in config

--- a/module/VuFind/src/VuFind/Search/SolrAuthorFacets/Options.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuthorFacets/Options.php
@@ -55,7 +55,7 @@ class Options extends \VuFind\Search\Solr\Options
         //   is really using facet sorting.
         $this->sortOptions = [
             'relevance' => 'sort_author_relevance',
-            'author' => 'sort_author_author'
+            'author' => 'sort_author_author',
         ];
 
         // No spell check needed in author module:

--- a/module/VuFind/src/VuFind/Search/SolrCollection/Options.php
+++ b/module/VuFind/src/VuFind/Search/SolrCollection/Options.php
@@ -61,7 +61,7 @@ class Options extends \VuFind\Search\Solr\Options
             $this->sortOptions = [
                 'title' => 'sort_title',
                 'year' => 'sort_year', 'year asc' => 'sort_year asc',
-                'author' => 'sort_author'
+                'author' => 'sort_author',
             ];
         }
         $this->defaultSort = key($this->sortOptions);

--- a/module/VuFind/src/VuFind/Search/Summon/Results.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Results.php
@@ -122,7 +122,7 @@ class Results extends \VuFind\Search\Base\Results
                 $this->responseFacets[] = [
                     'fieldName' => $dateFacet,
                     'displayName' => $dateFacet,
-                    'counts' => []
+                    'counts' => [],
                 ];
             }
         }
@@ -287,7 +287,7 @@ class Results extends \VuFind\Search\Base\Results
             $current = $current['suggestion'];
             if (!isset($this->suggestions[$current['originalQuery']])) {
                 $this->suggestions[$current['originalQuery']] = [
-                    'suggestions' => []
+                    'suggestions' => [],
                 ];
             }
             $this->suggestions[$current['originalQuery']]['suggestions'][]
@@ -409,7 +409,7 @@ class Results extends \VuFind\Search\Base\Results
                         'label' => $data['displayName'],
                         'list' => $list,
                     ],
-                    'more' => null
+                    'more' => null,
                 ];
             }
         }

--- a/module/VuFind/src/VuFind/Search/Tags/Options.php
+++ b/module/VuFind/src/VuFind/Search/Tags/Options.php
@@ -76,7 +76,7 @@ class Options extends \VuFind\Search\Base\Options
         $this->defaultSort = 'title';
         $this->sortOptions = [
             'title' => 'sort_title', 'author' => 'sort_author',
-            'year DESC' => 'sort_year', 'year' => 'sort_year asc'
+            'year DESC' => 'sort_year', 'year' => 'sort_year asc',
         ];
         // Load autocomplete preferences:
         $this->configureAutocomplete($searchSettings);

--- a/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
+++ b/module/VuFind/src/VuFind/Service/Feature/RetryTrait.php
@@ -52,7 +52,7 @@ trait RetryTrait
         'subsequentBackoff' => 200,   // backoff (delay) before subsequent retries
                                       // (milliseconds)
         'exponentialBackoff' => true, // whether to use exponential backoff
-        'maximumBackoff' => 1000      // maximum backoff (milliseconds)
+        'maximumBackoff' => 1000,      // maximum backoff (milliseconds)
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Service/MarkdownFactory.php
+++ b/module/VuFind/src/VuFind/Service/MarkdownFactory.php
@@ -76,7 +76,7 @@ class MarkdownFactory implements FactoryInterface
      * @var string[]
      */
     protected static $defaultExtensions = [
-        'Autolink', 'DisallowedRawHtml', 'Strikethrough', 'Table', 'TaskList'
+        'Autolink', 'DisallowedRawHtml', 'Strikethrough', 'Table', 'TaskList',
     ];
 
     /**
@@ -238,7 +238,7 @@ class MarkdownFactory implements FactoryInterface
             'enable_em',
             'enable_strong',
             'use_asterisk',
-            'use_underscore'
+            'use_underscore',
         ];
         foreach ($configOptions as $option) {
             $config['commonmark'][$option]

--- a/module/VuFind/src/VuFind/Sitemap/Generator.php
+++ b/module/VuFind/src/VuFind/Sitemap/Generator.php
@@ -453,7 +453,7 @@ class Generator
             [
                 'baseUrl' => $this->baseUrl,
                 'baseSitemapUrl' => $this->baseSitemapUrl,
-                'verboseMessageCallback' => $verboseCallback
+                'verboseMessageCallback' => $verboseCallback,
             ]
         );
         return $plugin;

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/Index/CursorMarkIdFetcher.php
@@ -134,7 +134,7 @@ class CursorMarkIdFetcher extends AbstractIdFetcher
             $this->defaultParams + [
                 'rows' => $countPerPage,
                 'sort' => $key . ' asc',
-                'cursorMark' => $cursorMark
+                'cursorMark' => $cursorMark,
             ]
         );
         // Apply filters:

--- a/module/VuFind/src/VuFind/Validator/SessionCsrfFactory.php
+++ b/module/VuFind/src/VuFind/Validator/SessionCsrfFactory.php
@@ -79,7 +79,7 @@ class SessionCsrfFactory implements FactoryInterface
         return new $requestedName(
             [
                 'session' => new \Laminas\Session\Container('csrf', $sessionManager),
-                'salt' => $config->Security->HMACkey ?? 'VuFindCsrfSalt'
+                'salt' => $config->Security->HMACkey ?? 'VuFindCsrfSalt',
             ]
         );
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Citation.php
@@ -94,7 +94,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper implements Translator
      * @var string[]
      */
     protected $uncappedPhrases = [
-        'even if', 'if only', 'now that', 'on top of'
+        'even if', 'if only', 'now that', 'on top of',
     ];
 
     /**
@@ -178,7 +178,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper implements Translator
             'pubName' => $publishers[0] ?? null,
             'pubDate' => $pubDates[0] ?? null,
             'edition' => empty($edition) ? [] : [$edition],
-            'journal' => $driver->tryMethod('getContainerTitle')
+            'journal' => $driver->tryMethod('getContainerTitle'),
         ];
 
         return $this;
@@ -290,7 +290,7 @@ class Citation extends \Laminas\View\Helper\AbstractHelper implements Translator
         $apa = [
             'title' => $this->getAPATitle(),
             'authors' => $this->getAPAAuthors(),
-            'edition' => $this->getEdition()
+            'edition' => $this->getEdition(),
         ];
 
         // Show a period after the title if it does not already have punctuation

--- a/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/CookieConsent.php
@@ -172,7 +172,7 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper implements Trans
         foreach ($this->consentConfig['Categories'] ?? [] as $name => $category) {
             if ($serviceNames = $category['ControlVuFindServices'] ?? []) {
                 $controlledVuFindServices[$name] = [
-                    ...$controlledVuFindServices[$name] ?? [], ...$serviceNames
+                    ...$controlledVuFindServices[$name] ?? [], ...$serviceNames,
                 ];
             }
         }
@@ -281,7 +281,7 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper implements Trans
             'name' => $this->consentCookieName,
             'path' => $this->cookieManager->getPath(),
             'expiresAfterDays' => $this->consentCookieExpiration,
-            'sameSite' => $this->cookieManager->getSameSite()
+            'sameSite' => $this->cookieManager->getSameSite(),
         ];
         // Set domain only if we have a value for it to avoid overriding the default
         // (i.e. window.location.hostname):
@@ -349,7 +349,7 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper implements Trans
                                     'description' => $this->translate(
                                         'CookieConsent::category_description_html',
                                         $descriptionPlaceholders
-                                    )
+                                    ),
                                 ],
                             ],
                         ],
@@ -414,7 +414,7 @@ class CookieConsent extends \Laminas\View\Helper\AbstractHelper implements Trans
                     'name' => $name,
                     'domain' => $cookie['Domain'],
                     'desc' => $this->translate($cookie['Description'] ?? ''),
-                    'exp' => $expiration
+                    'exp' => $expiration,
                 ];
             }
             if ($autoClear = $categoryConfig['AutoClearCookies'] ?? []) {

--- a/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Csp.php
@@ -72,7 +72,7 @@ class Csp extends \Laminas\View\Helper\AbstractHelper
         $headers = $this->response->getHeaders();
         $fieldsToCheck = [
             'Content-Security-Policy',
-            'Content-Security-Policy-Report-Only'
+            'Content-Security-Policy-Report-Only',
         ];
         foreach ($fieldsToCheck as $field) {
             if ($cspHeaders = $headers->get($field)) {

--- a/module/VuFind/src/VuFind/View/Helper/Root/DateTime.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DateTime.php
@@ -88,7 +88,7 @@ class DateTime extends \Laminas\View\Helper\AbstractHelper
         $replace = [
             $this->view->translate("date_month_placeholder"),
             $this->view->translate("date_day_placeholder"),
-            $this->view->translate("date_year_placeholder")
+            $this->view->translate("date_year_placeholder"),
         ];
 
         return str_replace($search, $replace, $dueDateHelpString);

--- a/module/VuFind/src/VuFind/View/Helper/Root/IconFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/IconFactory.php
@@ -78,7 +78,7 @@ class IconFactory implements FactoryInterface
         // can disable these problematic checks by setting memory_limit to -1.
         $cacheConfig = [
             'adapter' => \Laminas\Cache\Storage\Adapter\Memory::class,
-            'options' => ['memory_limit' => -1]
+            'options' => ['memory_limit' => -1],
         ];
         $cache = $container->get(\Laminas\Cache\Service\StorageAdapterFactory::class)
             ->createFromArrayConfiguration($cacheConfig);

--- a/module/VuFind/src/VuFind/View/Helper/Root/MakeTag.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/MakeTag.php
@@ -191,7 +191,7 @@ class MakeTag extends \Laminas\View\Helper\AbstractHelper
         'var',
         'video',
         'wbr',
-        'xmp'
+        'xmp',
     ];
 
     /**
@@ -216,7 +216,7 @@ class MakeTag extends \Laminas\View\Helper\AbstractHelper
         'param', // deprecated, but included for back-compatibility
         'source',
         'track',
-        'wbr'
+        'wbr',
     ];
 
     /**
@@ -254,7 +254,7 @@ class MakeTag extends \Laminas\View\Helper\AbstractHelper
         'spacer',
         'strike',
         'tt',
-        'xmp'
+        'xmp',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Matomo.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Matomo.php
@@ -373,7 +373,7 @@ class Matomo extends \Laminas\View\Helper\AbstractHelper
             'Page' => $params->getPage(),
             'Limit' => $params->getLimit(),
             'View' => $params->getView(),
-            'Context' => $this->context ?: 'page'
+            'Context' => $this->context ?: 'page',
         ];
     }
 
@@ -411,7 +411,7 @@ class Matomo extends \Laminas\View\Helper\AbstractHelper
             'Context' => $this->context ?: 'page',
             'RecordFormat' => $formats,
             'RecordData' => "$id|$author|$title",
-            'RecordInstitution' => $institutions
+            'RecordInstitution' => $institutions,
         ];
     }
 
@@ -423,7 +423,7 @@ class Matomo extends \Laminas\View\Helper\AbstractHelper
     protected function getLightboxCustomData(): array
     {
         return [
-            'Context' => $this->context ?: 'page'
+            'Context' => $this->context ?: 'page',
         ];
     }
 
@@ -435,7 +435,7 @@ class Matomo extends \Laminas\View\Helper\AbstractHelper
     protected function getGenericCustomData(): array
     {
         return [
-            'Context' => $this->context ?: 'page'
+            'Context' => $this->context ?: 'page',
         ];
     }
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
@@ -234,7 +234,7 @@ class OpenUrl extends \Laminas\View\Helper\AbstractHelper
             'openUrlGraphicHeight' => empty($this->config->graphic_height)
                 ? false : $this->config->graphic_height,
             'openUrlEmbed' => $embed,
-            'openUrlEmbedAutoLoad' => $embedAutoLoad
+            'openUrlEmbedAutoLoad' => $embedAutoLoad,
         ];
         $this->addImageBasedParams($imagebased, $params);
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -368,7 +368,7 @@ class Piwik extends \Laminas\View\Helper\AbstractHelper
             'Sort' => $params->getSort(),
             'Page' => $params->getPage(),
             'Limit' => $params->getLimit(),
-            'View' => $params->getView()
+            'View' => $params->getView(),
         ];
     }
 
@@ -405,7 +405,7 @@ class Piwik extends \Laminas\View\Helper\AbstractHelper
         return [
             'RecordFormat' => $formats,
             'RecordData' => "$id|$author|$title",
-            'RecordInstitution' => $institutions
+            'RecordInstitution' => $institutions,
         ];
     }
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PiwikFactory.php
@@ -74,7 +74,7 @@ class PiwikFactory implements FactoryInterface
         $settings = [
             'siteId' => $config->Piwik->site_id ?? 1,
             'searchPrefix' => $config->Piwik->searchPrefix ?? null,
-            'disableCookies' => $config->Piwik->disableCookies ?? false
+            'disableCookies' => $config->Piwik->disableCookies ?? false,
         ];
         $customVars = $config->Piwik->custom_variables ?? false;
         $request = $container->get('Request');

--- a/module/VuFind/src/VuFind/View/Helper/Root/Recommend.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Recommend.php
@@ -63,7 +63,7 @@ class Recommend extends \Laminas\View\Helper\AbstractHelper
         $context = [
             'recommend' => $recommend,
             'location' => $location,
-            'configIndex' => $index
+            'configIndex' => $index,
         ];
         return $this->renderClassTemplate($template, $className, $context);
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -239,7 +239,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
                 'driver' => $this->driver,
                 'list' => $list,
                 'user' => $user,
-                'lists' => $lists
+                'lists' => $lists,
             ]
         );
     }
@@ -582,7 +582,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             $extra + ['driver' => $this->driver]
         );
         $qrcode = [
-            "text" => $text, 'level' => $level, 'size' => $size, 'margin' => $margin
+            "text" => $text, 'level' => $level, 'size' => $size, 'margin' => $margin,
         ];
 
         $urlHelper = $this->getView()->plugin('url');

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -124,7 +124,7 @@ class RecordDataFormatterFactory implements FactoryInterface
                             'type' => $type,
                             'schemaLabel' => $schemaLabels[$type],
                             'requiredDataFields' => [
-                                ['name' => 'role', 'prefix' => 'CreatorRoles::']
+                                ['name' => 'role', 'prefix' => 'CreatorRoles::'],
                             ],
                         ],
                     ],

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
@@ -291,7 +291,7 @@ class RecordLinker extends \Laminas\View\Helper\AbstractHelper
 
         $urlParams = [
             'id' => $driver->getUniqueID(),
-            'keys' => $driver->tryMethod('getWorkKeys', [], [])
+            'keys' => $driver->tryMethod('getWorkKeys', [], []),
         ];
 
         $urlHelper = $this->getView()->plugin('url');

--- a/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ResultFeed.php
@@ -148,7 +148,7 @@ class ResultFeed extends AbstractHelper implements TranslatorAwareInterface
                     [
                         '%%start%%' => $results->getStartRecord(),
                         '%%end%%' => $results->getEndRecord(),
-                        '%%total%%' => $results->getResultTotal()
+                        '%%total%%' => $results->getResultTotal(),
                     ]
                 )
             )

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchBox.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchBox.php
@@ -296,7 +296,7 @@ class SearchBox extends \Laminas\View\Helper\AbstractHelper
         foreach ($options->getBasicHandlers() as $searchVal => $searchDesc) {
             $handlers[] = [
                 'value' => $searchVal, 'label' => $searchDesc, 'indent' => false,
-                'selected' => ($activeHandler == $searchVal)
+                'selected' => ($activeHandler == $searchVal),
             ];
         }
         return $handlers;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -273,7 +273,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
                 $this->cachedHiddenFilterParams[$searchClassId]
                     = UrlQueryHelper::buildQueryString(
                         [
-                            'hiddenFilters' => $hiddenFilters
+                            'hiddenFilters' => $hiddenFilters,
                         ]
                     );
             } else {
@@ -300,7 +300,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             'class' => $class,
             'label' => $label,
             'permission' => $permissionName,
-            'selected' => true
+            'selected' => true,
         ];
     }
 
@@ -360,7 +360,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             'label' => $label,
             'permission' => $permissionName,
             'selected' => false,
-            'url' => $newUrl
+            'url' => $newUrl,
         ];
     }
 
@@ -388,7 +388,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             'label' => $label,
             'permission' => $permissionName,
             'selected' => false,
-            'url' => $url
+            'url' => $url,
         ];
     }
 
@@ -423,7 +423,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             'label' => $label,
             'permission' => $permissionName,
             'selected' => false,
-            'url' => $url
+            'url' => $url,
         ];
     }
 
@@ -450,7 +450,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
         if ($hiddenFilters = $params->getHiddenFiltersAsQueryParams()) {
             return $prepend . UrlQueryHelper::buildQueryString(
                 [
-                    'hiddenFilters' => $hiddenFilters
+                    'hiddenFilters' => $hiddenFilters,
                 ]
             );
         }

--- a/module/VuFind/src/VuFind/XSLT/Import/VuFind.php
+++ b/module/VuFind/src/VuFind/XSLT/Import/VuFind.php
@@ -296,10 +296,10 @@ class VuFind
         $descriptorspec = [
             0 => ['pipe', 'r'],
             1 => ['file', $output, 'w'],
-            2 => ['pipe', 'w']
+            2 => ['pipe', 'w'],
         ];
         return [
-            "java -jar $tika $arg -eUTF8 $input", $descriptorspec, []
+            "java -jar $tika $arg -eUTF8 $input", $descriptorspec, [],
         ];
     }
 

--- a/module/VuFind/src/VuFindTest/Feature/AutoRetryTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/AutoRetryTrait.php
@@ -110,7 +110,7 @@ trait AutoRetryTrait
                 if ($this->retriesLeft > 0) {
                     $logMethod = [
                         $this,
-                        $annotations['method']['retryLogMethod'][0] ?? 'logWarning'
+                        $annotations['method']['retryLogMethod'][0] ?? 'logWarning',
                     ];
                     if (is_callable($logMethod)) {
                         $method = get_class($this) . '::' . $this->getName(false);

--- a/module/VuFind/src/VuFindTest/Feature/DemoDriverTestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/DemoDriverTestTrait.php
@@ -66,7 +66,7 @@ trait DemoDriverTestTrait
                     'source' => 'Solr',
                     'item_id' => 0,
                     'renewable' => true,
-                ]
+                ],
             ]
         );
     }

--- a/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
@@ -139,11 +139,11 @@ trait LiveDatabaseTrait
         $checks = [
             [
                 'table' => \VuFind\Db\Table\User::class,
-                'name' => 'users'
+                'name' => 'users',
             ],
             [
                 'table' => \VuFind\Db\Table\Tags::class,
-                'name' => 'tags'
+                'name' => 'tags',
             ],
         ];
         foreach ($checks as $check) {

--- a/module/VuFind/src/VuFindTest/Feature/PathResolverTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/PathResolverTrait.php
@@ -56,13 +56,13 @@ trait PathResolverTrait
             ? [
                 [
                     'directory' => LOCAL_OVERRIDE_DIR,
-                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
-                ]
+                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
+                ],
             ] : [];
         return new \VuFind\Config\PathResolver(
             [
                 'directory' => $baseDirectory ?? APPLICATION_PATH,
-                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
+                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
             ],
             $localDirs
         );

--- a/module/VuFind/src/VuFindTest/Feature/UserCreationTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/UserCreationTrait.php
@@ -58,7 +58,7 @@ trait UserCreationTrait
             'email' => 'username1@ignore.com',
             'username' => 'username1',
             'password' => 'test',
-            'password2' => 'test'
+            'password2' => 'test',
         ];
 
         foreach ($defaults as $field => $default) {

--- a/module/VuFind/src/VuFindTest/Feature/ViewTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/ViewTrait.php
@@ -60,7 +60,7 @@ trait ViewTrait
         $resolver->setPaths(
             [
                 $this->getPathForTheme('root'),
-                $this->getPathForTheme($theme)
+                $this->getPathForTheme($theme),
             ]
         );
         $renderer = new \Laminas\View\Renderer\PhpRenderer();

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -337,7 +337,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     {
         $configs = [
             '.ini' => $this->modifiedConfigs,
-            '.yaml' => $this->modifiedYamlConfigs
+            '.yaml' => $this->modifiedYamlConfigs,
         ];
         foreach ($configs as $extension => $files) {
             foreach ($files as $current) {
@@ -791,7 +791,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $client->setEncType(\Laminas\Http\Client::ENC_FORMDATA);
         $client->setParameterPost(
             [
-                'out' => 'json'
+                'out' => 'json',
             ]
         );
         $page ??= $this->session->getPage();

--- a/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTest.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTest.php
@@ -53,7 +53,7 @@ abstract class AbstractMakeTagTest extends \PHPUnit\Framework\TestCase
             'escapehtml' => new \Laminas\View\Helper\EscapeHtml(),
             'escapehtmlattr' => new \Laminas\View\Helper\EscapeHtmlAttr(),
             'htmlattributes' => new \Laminas\View\Helper\HtmlAttributes(),
-            'maketag' => new \VuFind\View\Helper\Root\MakeTag()
+            'maketag' => new \VuFind\View\Helper\Root\MakeTag(),
         ];
 
         $view = $this->createMock(\Laminas\View\Renderer\PhpRenderer::class);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/DatabaseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/DatabaseTest.php
@@ -118,7 +118,7 @@ final class DatabaseTest extends \PHPUnit\Framework\TestCase
         $post = $overrides + [
             'username' => 'testuser', 'email' => 'user@test.com',
             'password' => 'testpass', 'password2' => 'testpass',
-            'firstname' => 'Test', 'lastname' => 'User'
+            'firstname' => 'Test', 'lastname' => 'User',
         ];
         return $this->getRequest($post);
     }
@@ -134,7 +134,7 @@ final class DatabaseTest extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest($overrides = [])
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass'
+            'username' => 'testuser', 'password' => 'testpass',
         ];
         return $this->getRequest($post);
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
@@ -144,7 +144,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest($overrides = [])
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass'
+            'username' => 'testuser', 'password' => 'testpass',
         ];
         $request = new \Laminas\Http\Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));
@@ -205,7 +205,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
     {
         $response = [
             'cat_username' => 'testuser', 'cat_password' => 'testpass',
-            'email' => 'user@test.com'
+            'email' => 'user@test.com',
         ];
         $driver = $this->getMockDriver();
         $driver->expects($this->once())->method('patronLogin')
@@ -228,7 +228,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
 
         $response = [
             'cat_username' => 'testuser', 'cat_password' => 'testpass',
-            'email' => 'user@test.com'
+            'email' => 'user@test.com',
         ];
         $driver = $this->getMockDriver();
         $driver->expects($this->once())->method('patronLogin')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
@@ -149,7 +149,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
             'login' => 'http://myserver',
             'username' => 'username',
             'email' => 'email',
-            'use_headers' => $useHeaders
+            'use_headers' => $useHeaders,
         ];
         if ($requiredAttributes) {
             $config += [
@@ -218,7 +218,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
     {
         $server = $overrides + [
             'username' => 'testuser', 'email' => 'user@test.com',
-            'password' => 'testpass'
+            'password' => 'testpass',
         ];
         $request = new \Laminas\Http\PhpEnvironment\Request();
         if ($useHeaders) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -171,8 +171,8 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Authentication' => [
                         'change_email' => true,
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
 
@@ -225,7 +225,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
                 ],
                 'config' => [
                     'Catalog' => ['driver' => 'Demo'],
-                ]
+                ],
             ]
         );
 
@@ -240,7 +240,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
             $page,
             [
                 'username' => 'username2',
-                'email' => "username2@ignore.com"
+                'email' => "username2@ignore.com",
             ]
         );
         $this->clickCss($page, '.modal-body .btn.btn-primary');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -74,9 +74,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
                 'Catalog' => ['driver' => 'Demo'],
                 'Authentication' => [
                     'enableAjax' => true,
-                    'enableDropdown' => false
-                ]
-            ]
+                    'enableDropdown' => false,
+                ],
+            ],
             ]
         );
     }
@@ -180,9 +180,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Authentication' => [
                         'enableAjax' => false,
-                        'enableDropdown' => false
-                    ]
-                ]
+                        'enableDropdown' => false,
+                    ],
+                ],
             ]
         );
         $this->login();
@@ -208,9 +208,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Authentication' => [
                         'enableAjax' => false,
-                        'enableDropdown' => true
-                    ]
-                ]
+                        'enableDropdown' => true,
+                    ],
+                ],
             ]
         );
         $this->login();
@@ -236,9 +236,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Authentication' => [
                         'enableAjax' => true,
-                        'enableDropdown' => true
-                    ]
-                ]
+                        'enableDropdown' => true,
+                    ],
+                ],
             ]
         );
         $this->login();
@@ -344,33 +344,33 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'fines' => [
                     'total' => 0,
-                    'display' => 'ZILTCH'
-                ]
+                    'display' => 'ZILTCH',
+                ],
             ],
             // Holds in transit only
             [
                 'holds' => [
                     'in_transit' => 1,
                     'available' => 0,
-                    'other' => 0
-                ]
+                    'other' => 0,
+                ],
             ],
             // ILL Requests in transit only
             [
                 'illRequests' => [
                     'in_transit' => 1,
                     'available' => 0,
-                    'other' => 0
-                ]
+                    'other' => 0,
+                ],
             ],
             // Storage Retrievals in transit only
             [
                 'storageRetrievalRequests' => [
                     'in_transit' => 1,
                     'available' => 0,
-                    'other' => 0
-                ]
-            ]
+                    'other' => 0,
+                ],
+            ],
         ];
         $this->checkIcon($storage, '.account-status-none');
     }
@@ -389,7 +389,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             // ILL Requests available
             ['illRequests' => ['in_transit' => 0, 'available' => 1]],
             // Storage Retrievals available
-            ['storageRetrievalRequests' => ['in_transit' => 0, 'available' => 1]]
+            ['storageRetrievalRequests' => ['in_transit' => 0, 'available' => 1]],
         ];
         $this->checkIcon($storage, '.account-status-good');
     }
@@ -404,7 +404,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $this->login();
         $storage = [
             // Checked out due soon
-            ['checkedOut' => ['warn' => 1]]
+            ['checkedOut' => ['warn' => 1]],
         ];
         $this->checkIcon($storage, '.account-status-warning');
     }
@@ -446,8 +446,8 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             [
                 [
                     'checkedOut' => ['overdue' => 1],
-                    'holds' => ['available' => 1]
-                ]
+                    'holds' => ['available' => 1],
+                ],
             ],
             '.account-status-danger'
         );
@@ -456,8 +456,8 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             [
                 [
                     'checkedOut' => ['warn' => 1],
-                    'holds' => ['available' => 1]
-                ]
+                    'holds' => ['available' => 1],
+                ],
             ],
             '.account-status-warning'
         );
@@ -466,8 +466,8 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             [
                 [
                     'holds' => ['available' => 1],
-                    'fines' => ['total' => 0, 'display' => 'none']
-                ]
+                    'fines' => ['total' => 0, 'display' => 'none'],
+                ],
             ],
             '.account-status-good'
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -298,10 +298,10 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
                 'facets' => [
                     'Advanced_Settings' => [
                         'limitOrderOverride' => [
-                            'format' => 'Book::eBook'
-                        ]
-                    ]
-                ]
+                            'format' => 'Book::eBook',
+                        ],
+                    ],
+                ],
             ]
         );
         $session = $this->getMinkSession();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -69,7 +69,7 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
             'General' => [
                 'default_side_recommend[]'
                     => 'SideFacetsDeferred:Results:CheckboxFacets:Blender',
-            ]
+            ],
         ];
     }
 
@@ -106,12 +106,12 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
         return [
             [
                 ['page' => 1],
-                $expectedFirstPage
+                $expectedFirstPage,
             ],
             [
                 ['page' => 2],
-                $expected
-            ]
+                $expected,
+            ],
         ];
     }
 
@@ -133,9 +133,9 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
                     'SearchTabs' => [
                         'Solr' => 'Catalog',
                         'Blender' => 'Blended',
-                    ]
+                    ],
                 ],
-                'Blender' => $this->getBlenderIniOverrides()
+                'Blender' => $this->getBlenderIniOverrides(),
             ],
             ['Blender']
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CallnumberBrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CallnumberBrowseTest.php
@@ -68,9 +68,9 @@ class CallnumberBrowseTest extends \VuFindTest\Integration\MinkTestCase
                         'multiple_call_nos' => $nos,
                         'multiple_locations' => $locs,
                         'callnumber_handler' => false,
-                        'show_full_status' => $full
-                    ]
-                ]
+                        'show_full_status' => $full,
+                    ],
+                ],
             ]
         );
     }
@@ -103,7 +103,7 @@ class CallnumberBrowseTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
             'config' => [
-                'Catalog' => ['driver' => 'Demo']
+                'Catalog' => ['driver' => 'Demo'],
             ],
             'Demo' => [
                 'StaticHoldings' => [
@@ -112,11 +112,11 @@ class CallnumberBrowseTest extends \VuFindTest\Integration\MinkTestCase
                         ['callnumber' => 'CallNumberOne', 'location' => 'Villanova'],
                         ['callnumber' => 'CallNumberTwo', 'location' => 'Villanova'],
                         ['callnumber' => 'CallNumberThree', 'location' => 'Phobos'],
-                        ['callnumber' => 'CallNumberFour', 'location' => 'Phobos']
+                        ['callnumber' => 'CallNumberFour', 'location' => 'Phobos'],
                         ]
-                    )
-                ]
-            ]
+                    ),
+                ],
+            ],
             ]
         );
     }
@@ -137,8 +137,8 @@ class CallnumberBrowseTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'config' => [
                     'Catalog' => ['driver' => 'Sample'],
-                    'Item_Status' => ['callnumber_handler' => $type]
-                ]
+                    'Item_Status' => ['callnumber_handler' => $type],
+                ],
             ]
         );
         $callnumberSelector = '.callnumber a,.groupCallnumber a,.fullCallnumber a';

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -303,9 +303,9 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Site' => [
                         'showBookBag' => true,
-                        'bookbagTogglesInSearch' => false
-                    ]
-                ]
+                        'bookbagTogglesInSearch' => false,
+                    ],
+                ],
             ]
         );
 
@@ -329,9 +329,9 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Site' => [
                         'showBookBag' => true,
-                        'bookbagTogglesInSearch' => false
-                    ]
-                ]
+                        'bookbagTogglesInSearch' => false,
+                    ],
+                ],
             ]
         );
 
@@ -358,9 +358,9 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
                     'Site' => [
                         'showBookBag' => true,
                         'bookBagMaxSize' => 1,
-                        'bookbagTogglesInSearch' => false
-                    ]
-                ]
+                        'bookbagTogglesInSearch' => false,
+                    ],
+                ],
             ]
         );
 
@@ -495,9 +495,9 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Site' => [
                         'showBookBag' => true,
-                        'bookbagTogglesInSearch' => false
-                    ]
-                ]
+                        'bookbagTogglesInSearch' => false,
+                    ],
+                ],
             ]
         );
         $page = $this->getSearchResultsPage();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChoiceAuthTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChoiceAuthTest.php
@@ -156,7 +156,7 @@ final class ChoiceAuthTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that demo driver expected values are present:
         $texts = [
-            'Lib-catuser', 'Somewhere...', 'Over the Rainbow'
+            'Lib-catuser', 'Somewhere...', 'Over the Rainbow',
         ];
         foreach ($texts as $text) {
             $this->assertTrue($this->hasElementsMatchingText($page, 'td', $text));

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
@@ -80,14 +80,14 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
             [
             'config' => [
                 'Collections' => [
-                    'collections' => true
+                    'collections' => true,
                 ],
             ],
             'HierarchyDefault' => [
                 'Collections' => [
-                    'link_type' => 'Top'
-                ]
-            ]
+                    'link_type' => 'Top',
+                ],
+            ],
             ]
         );
         $page = $this->goToCollection();
@@ -106,14 +106,14 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
             [
             'config' => [
                 'Collections' => [
-                    'collections' => true
+                    'collections' => true,
                 ],
             ],
             'HierarchyDefault' => [
                 'Collections' => [
-                    'link_type' => 'Top'
-                ]
-            ]
+                    'link_type' => 'Top',
+                ],
+            ],
             ]
         );
         $page = $this->goToCollection();
@@ -136,17 +136,17 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
             [
             'config' => [
                 'Hierarchy' => [
-                    'showTree' => true
+                    'showTree' => true,
                 ],
                 'Collections' => [
-                    'collections' => true
+                    'collections' => true,
                 ],
             ],
             'HierarchyDefault' => [
                 'Collections' => [
-                    'link_type' => 'All'
-                ]
-            ]
+                    'link_type' => 'All',
+                ],
+            ],
             ]
         );
         $page = $this->goToCollection();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -58,7 +58,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             'Solr:two' => [
                 'label' => 'Solr Two',
                 'hiddenFilter' => 'building:weird_ids.mrc',
-            ]
+            ],
         ];
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CookieConsentTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CookieConsentTest.php
@@ -58,8 +58,8 @@ final class CookieConsentTest extends \VuFindTest\Integration\MinkTestCase
                 'config' => [
                     'Matomo' => [
                         'url' => $this->getVuFindUrl() . '/Content/faq',
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $page = $this->getStartPage();
@@ -88,8 +88,8 @@ final class CookieConsentTest extends \VuFindTest\Integration\MinkTestCase
                     ],
                     'Matomo' => [
                         'url' => $this->getVuFindUrl() . '/Content/faq',
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         // Make sure the cookie dialog is not hidden from a headless client:
@@ -97,9 +97,9 @@ final class CookieConsentTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'CookieConsent' => [
                     'CookieConsent' => [
-                        'HideFromBots' => false
-                    ]
-                ]
+                        'HideFromBots' => false,
+                    ],
+                ],
             ]
         );
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
@@ -126,7 +126,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         // By default, no OpenURL on record page:
         $page = $this->setupPage(
             [
-                'Captcha' => ['types' => ['demo'], 'forms' => 'feedback']
+                'Captcha' => ['types' => ['demo'], 'forms' => 'feedback'],
             ]
         );
         $this->fillInAndSubmitFeedbackForm($page);
@@ -157,8 +157,8 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
                 'Captcha' => [
                     'types' => ['interval'],
                     'forms' => 'feedback',
-                    'action_interval' => 60
-                ]
+                    'action_interval' => 60,
+                ],
             ]
         );
         // Test that submission is blocked:
@@ -174,8 +174,8 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
                 'Captcha' => [
                     'types' => ['interval'],
                     'forms' => 'feedback',
-                    'action_interval' => 1
-                ]
+                    'action_interval' => 1,
+                ],
             ]
         );
         $this->fillInAndSubmitFeedbackForm($page);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -72,7 +72,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
                 'driver' => 'Demo',
                 'holds_mode' => 'driver',
                 'title_level_holds_mode' => 'driver',
-            ]
+            ],
         ];
     }
 
@@ -287,7 +287,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
             $page,
             [
                 'username' => 'username4',
-                'email' => "username4@ignore.com"
+                'email' => "username4@ignore.com",
             ]
         );
         $this->clickCss($page, 'input.btn.btn-primary');
@@ -734,7 +734,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
             $page,
             [
                 'username' => 'username3',
-                'email' => "username3@ignore.com"
+                'email' => "username3@ignore.com",
             ]
         );
         $this->clickCss($page, 'input.btn.btn-primary');
@@ -769,7 +769,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $demoConfig = $this->getDemoIniOverrides();
         $demoConfig['ProxiedUsers'] = [
             'user1' => 'Proxy User 1',
-            'user2' => 'Proxy User 2'
+            'user2' => 'Proxy User 2',
         ];
         $this->changeConfigs(
             [

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HomePageFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HomePageFacetsTest.php
@@ -52,15 +52,15 @@ class HomePageFacetsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'facets' => [
                     'Results' => [
-                        'hierarchical_facet_str_mv' => 'hierarchy'
+                        'hierarchical_facet_str_mv' => 'hierarchy',
                     ],
                     'SpecialFacets' => [
-                        'hierarchical[]' => 'hierarchical_facet_str_mv'
+                        'hierarchical[]' => 'hierarchical_facet_str_mv',
                     ],
                     'HomePage' => [
-                        'hierarchical_facet_str_mv' => 'Hierarchical'
-                    ]
-                ]
+                        'hierarchical_facet_str_mv' => 'Hierarchical',
+                    ],
+                ],
             ]
         );
         $session = $this->getMinkSession();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -71,7 +71,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
                 'driver' => 'Demo',
                 'holds_mode' => 'driver',   // needed to display login link
                 'renewals_enabled' => true,
-            ]
+            ],
         ];
     }
 
@@ -383,7 +383,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Confirm that demo driver expected values are present:
         $this->waitForPageLoad($page);
         $texts = [
-            'Lib-catuser', 'Somewhere...', 'Over the Rainbow'
+            'Lib-catuser', 'Somewhere...', 'Over the Rainbow',
         ];
         foreach ($texts as $text) {
             $this->assertTrue($this->hasElementsMatchingText($page, 'td', $text));

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
@@ -57,7 +57,7 @@ class LinkResolverTest extends \VuFindTest\Integration\MinkTestCase
                 'resolver' => 'demo',
                 'embed' => '1',
                 'url' => 'https://vufind.org/wiki',
-            ]
+            ],
         ];
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -90,7 +90,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         return [
             'Catalog' => [
                 'driver' => 'Demo',
-            ]
+            ],
         ];
     }
 
@@ -115,8 +115,8 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
                     'redirectUri' => $redirectUri,
                     'isConfidential' => true,
                     'secret' => password_hash('mysecret', PASSWORD_DEFAULT),
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -218,7 +218,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'grant_type' => 'authorization_code',
             'redirect_uri' => $redirectUri,
             'client_id' => 'test',
-            'client_secret' => 'mysecret'
+            'client_secret' => 'mysecret',
         ];
         $http = new \VuFindHttp\HttpService();
         $response = $http->post(
@@ -271,7 +271,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             '',
             [
                 'Authorization' => $tokenResult['token_type'] . ' '
-                . $tokenResult['access_token']
+                . $tokenResult['access_token'],
             ]
         );
         $this->assertEquals(
@@ -471,7 +471,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         $privateKey = openssl_pkey_new(
             [
                 'private_key_bits' => 2048,
-                'private_key_type' => OPENSSL_KEYTYPE_RSA
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
             ]
         );
         if (!$privateKey) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -143,8 +143,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
                 'config' => [
-                    'Captcha' => ['types' => ['demo'], 'forms' => '*']
-                ]
+                    'Captcha' => ['types' => ['demo'], 'forms' => '*'],
+                ],
             ]
         );
         // Go to a record view
@@ -313,8 +313,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
                 'config' => [
-                    'Social' => ['case_sensitive_tags' => 'true']
-                ]
+                    'Social' => ['case_sensitive_tags' => 'true'],
+                ],
             ]
         );
         // Login
@@ -349,7 +349,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'config' => [
                     'Mail' => ['testOnly' => 1],
-                ]
+                ],
             ]
         );
 
@@ -413,7 +413,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'config' => [
                     'Mail' => ['testOnly' => 1],
-                ]
+                ],
             ]
         );
 
@@ -534,8 +534,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
                     'Social' => [
                         'rating' => true,
                         'remove_rating' => $allowRemove,
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $this->removeUsername2And3And4();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
@@ -114,9 +114,9 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         $extraConfigs = [
             'RecordTabs' => [
                 'VuFind\RecordDriver\SolrMarc' => [
-                    'tabs[Versions]' => false
-                ]
-            ]
+                    'tabs[Versions]' => false,
+                ],
+            ],
         ];
         $this->changeConfigs($extraConfigs);
         // Search for an item known to have other versions in test data:
@@ -154,9 +154,9 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         $extraConfigs = [
             'searches' => [
                 'General' => [
-                    'display_versions' => false
-                ]
-            ]
+                    'display_versions' => false,
+                ],
+            ],
         ];
         $this->changeConfigs($extraConfigs);
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -285,7 +285,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
     {
         $this->changeConfigs(
             [
-                'config' => ['Account' => ['schedule_searches' => true]]
+                'config' => ['Account' => ['schedule_searches' => true]],
             ]
         );
         $session = $this->getMinkSession();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -197,8 +197,8 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
                 'searches' => [
                     'General' => [
                         'default_side_recommend[]' => 'SideFacetsDeferred:Results:CheckboxFacets',
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:weird_ids.mrc');
@@ -224,9 +224,9 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
                 'facets' => [
                     'Results_Settings' => [
                         'showMoreInLightbox[*]' => true,
-                        'lightboxLimit' => $limit
-                    ]
-                ]
+                        'lightboxLimit' => $limit,
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:weird_ids.mrc');
@@ -253,9 +253,9 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
                 'facets' => [
                     'Results_Settings' => [
                         'showMoreInLightbox[*]' => 'more',
-                        'lightboxLimit' => $limit
-                    ]
-                ]
+                        'lightboxLimit' => $limit,
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:weird_ids.mrc');
@@ -285,8 +285,8 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
                         'showMoreInLightbox[*]' => true,
                         'lightboxLimit' => $limit,
                         'exclude' => '*',
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:weird_ids.mrc');
@@ -326,12 +326,12 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'facets' => [
                     'Results' => [
-                        'hierarchical_facet_str_mv' => 'hierarchy'
+                        'hierarchical_facet_str_mv' => 'hierarchy',
                     ],
                     'SpecialFacets' => [
-                        'hierarchical[]' => 'hierarchical_facet_str_mv'
-                    ]
-                ]
+                        'hierarchical[]' => 'hierarchical_facet_str_mv',
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:"hierarchy.mrc"');
@@ -349,15 +349,15 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'facets' => [
                     'Results' => [
-                        'hierarchical_facet_str_mv' => 'hierarchy'
+                        'hierarchical_facet_str_mv' => 'hierarchy',
                     ],
                     'SpecialFacets' => [
-                        'hierarchical[]' => 'hierarchical_facet_str_mv'
+                        'hierarchical[]' => 'hierarchical_facet_str_mv',
                     ],
                     'Results_Settings' => [
                         'exclude' => 'hierarchical_facet_str_mv',
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
         $extractCount = function ($str) {
@@ -395,15 +395,15 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'facets' => [
                     'Results' => [
-                        'hierarchical_facet_str_mv' => 'hierarchy'
+                        'hierarchical_facet_str_mv' => 'hierarchy',
                     ],
                     'Results_Settings' => [
-                        'collapsedFacets' => '*'
+                        'collapsedFacets' => '*',
                     ],
                     'SpecialFacets' => [
-                        'hierarchical[]' => 'hierarchical_facet_str_mv'
-                    ]
-                ]
+                        'hierarchical[]' => 'hierarchical_facet_str_mv',
+                    ],
+                ],
             ]
         );
         $page = $this->performSearch('building:"hierarchy.mrc"');
@@ -528,8 +528,8 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
                 'searches' => [
-                    'General' => ['retain_filters_by_default' => false]
-                ]
+                    'General' => ['retain_filters_by_default' => false],
+                ],
             ]
         );
         $page = $this->getFilteredSearch();
@@ -554,8 +554,8 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
                 'searches' => [
-                    'General' => ['default_filters' => ['building:weird_ids.mrc']]
-                ]
+                    'General' => ['default_filters' => ['building:weird_ids.mrc']],
+                ],
             ]
         );
 
@@ -590,8 +590,8 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeConfigs(
             [
                 'facets' => [
-                    'Results_Settings' => ['orFacets' => 'building']
-                ]
+                    'Results_Settings' => ['orFacets' => 'building'],
+                ],
             ]
         );
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
@@ -66,8 +66,8 @@ final class ShibbolethLogoutNotificationTest extends \VuFindTest\Integration\Min
                             '127.0.0.1',
                             '::1',
                         ],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/VisualizationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/VisualizationTest.php
@@ -52,7 +52,7 @@ class VisualizationTest extends \VuFindTest\Integration\MinkTestCase
                 'default_top_recommend' => ['VisualFacets'],
             ],
             'Views' => ['list' => 'List', 'visual' => 'Visual'],
-        ]
+        ],
     ];
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
@@ -76,7 +76,7 @@ class ResultFeedTest extends \PHPUnit\Framework\TestCase
                 [
                     new \VuFind\Record\Router(
                         new \Laminas\Config\Config([])
-                    )
+                    ),
                 ]
             )->getMock();
         $recordLinker->expects($this->any())->method('getUrl')
@@ -99,7 +99,7 @@ class ResultFeedTest extends \PHPUnit\Framework\TestCase
         $translations = [
             'Results for' => 'Results for',
             'showing_results_of_html' => 'Showing <strong>%%start%% - %%end%%'
-                . '</strong> results of <strong>%%total%%</strong>'
+                . '</strong> results of <strong>%%total%%</strong>',
         ];
         $mock = $this->getMockBuilder(\Laminas\I18n\Translator\TranslatorInterface::class)
             ->getMock();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
@@ -151,7 +151,7 @@ class CheckRequestIsValidTest extends \VuFindTest\Unit\AjaxHandlerTest
     {
         $this->assertEquals(
             [
-                ['status' => true, 'msg' => 'storage_retrieval_request_place_text']
+                ['status' => true, 'msg' => 'storage_retrieval_request_place_text'],
             ],
             $this->runSuccessfulTest(
                 'checkStorageRetrievalRequestIsValid',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
@@ -177,11 +177,11 @@ class CommentRecordTest extends \VuFindTest\Unit\AjaxHandlerTest
         $post = [
             'id' => 'foo',
             'comment' => 'bar',
-            'rating' => '100'
+            'rating' => '100',
         ];
         $this->assertEquals(
             [
-                ['commentId' => true]
+                ['commentId' => true],
             ],
             $handler->handleRequest($this->getParamsHelper([], $post))
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
@@ -92,8 +92,8 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                                 'label' => $value,
                                 'icon' => 'remote-icon',
                                 'localIcon' => 'local-icon',
-                            ]
-                        ]
+                            ],
+                        ],
                     ]
                 )
             );
@@ -183,8 +183,8 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                     'DOI' => [
                         'resolver' => 'foo',
                         'new_window' => true,
-                        'proxy_icons' => true
-                    ]
+                        'proxy_icons' => true,
+                    ],
                 ],
                 true,
                 'http://localhost/cover-show?proxy=remote-icon',
@@ -227,9 +227,9 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'newWindow' => $newWindow,
                             'icon' => $remoteIcon,
                             'localIcon' => '(local-icon)',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             $this->getHandlerResults()
         );
@@ -249,7 +249,7 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
         $this->setupPluginManager(
             [
                 'foo' => $this->getMockPlugin('baz'),
-                'foo2' => $this->getMockPlugin('baz2', 'never')
+                'foo2' => $this->getMockPlugin('baz2', 'never'),
             ]
         );
 
@@ -264,9 +264,9 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'newWindow' => false,
                             'icon' => 'remote-icon',
                             'localIcon' => '(local-icon)',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             $this->getHandlerResults()
         );
@@ -288,7 +288,7 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
         $this->setupPluginManager(
             [
                 'foo' => $this->getMockPlugin('baz'),
-                'foo2' => $this->getMockPlugin('baz2', 'never')
+                'foo2' => $this->getMockPlugin('baz2', 'never'),
             ]
         );
 
@@ -303,9 +303,9 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'newWindow' => false,
                             'icon' => 'remote-icon',
                             'localIcon' => '(local-icon)',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             $this->getHandlerResults()
         );
@@ -347,7 +347,7 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'newWindow' => false,
                             'icon' => 'remote-icon',
                             'localIcon' => '(local-icon)',
-                        ]
+                        ],
                     ],
                     'bar2' => [
                         [
@@ -356,9 +356,9 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'newWindow' => false,
                             'icon' => 'remote-icon',
                             'localIcon' => '(local-icon)',
-                        ]
+                        ],
                     ],
-                ]
+                ],
             ],
             $this->getHandlerResults($request)
         );
@@ -380,7 +380,7 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
         $this->setupPluginManager(
             [
                 'foo' => $this->getMockPlugin('baz'),
-                'foo2' => $this->getMockPlugin('baz2')
+                'foo2' => $this->getMockPlugin('baz2'),
             ]
         );
         // Test the handler:
@@ -402,8 +402,8 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
                             'icon' => 'remote-icon',
                             'localIcon' => '(local-icon)',
                         ],
-                    ]
-                ]
+                    ],
+                ],
             ],
             $this->getHandlerResults()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
@@ -154,7 +154,7 @@ class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTest
             [
                 [
                     'html' => 'html',
-                ]
+                ],
             ],
             $handler->handleRequest($params)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
@@ -226,7 +226,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
     ): void {
         $config = new Config(
             [
-                'Authentication' => $authConfig
+                'Authentication' => $authConfig,
             ]
         );
         $db = new Database();
@@ -249,8 +249,8 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
         $config = new Config(
             [
                 'Authentication' => [
-                    'password_pattern' => 'a/'
-                ]
+                    'password_pattern' => 'a/',
+                ],
             ]
         );
         $db = new Database();
@@ -271,7 +271,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
     {
         $defaultConfig = [
             'username_pattern' => "([\\x21\\x23-\\x2B\\x2D-\\x2F\\x3D\\x3F\\x40"
-            . "\\x5E-\\x60\\x7B-\\x7E\\p{L}\\p{Nd}]+)"
+            . "\\x5E-\\x60\\x7B-\\x7E\\p{L}\\p{Nd}]+)",
         ];
         $numericConfig = [
             'minimum_username_length' => 4,
@@ -421,7 +421,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
     ): void {
         $config = new Config(
             [
-                'Authentication' => $authConfig
+                'Authentication' => $authConfig,
             ]
         );
         $db = new Database();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
@@ -77,7 +77,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
                 'host' => 'localhost',
                 'port' => 1234,
                 'basedn' => 'basedn',
-                'username' => 'username'
+                'username' => 'username',
             ],
             true
         );
@@ -184,7 +184,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest($overrides = [])
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass'
+            'username' => 'testuser', 'password' => 'testpass',
         ];
         $request = new \Laminas\Http\Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
@@ -570,7 +570,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $csrf = new \VuFind\Validator\SessionCsrf(
             [
                 'session' => new \Laminas\Session\Container('csrf', $sessionManager),
-                'salt' => 'csrftest'
+                'salt' => 'csrftest',
             ]
         );
         return new Manager(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiAuthTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiAuthTest.php
@@ -72,7 +72,7 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
     {
         $config = new Config(
             [
-                'method_order' => 'Database,ILS'
+                'method_order' => 'Database,ILS',
             ],
             true
         );
@@ -107,7 +107,7 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest(array $overrides = []): \Laminas\Http\Request
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass'
+            'username' => 'testuser', 'password' => 'testpass',
         ];
         $request = new \Laminas\Http\Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
@@ -154,7 +154,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
     {
         $response = [
             'cat_username' => 'testuser', 'cat_password' => 'testpass',
-            'email' => 'user@test.com'
+            'email' => 'user@test.com',
         ];
         $driver = $this->getMockMultiBackend();
         $driver->expects($this->once())->method('patronLogin')
@@ -177,7 +177,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
 
         $response = [
             'cat_username' => 'testuser', 'cat_password' => 'testpass',
-            'email' => 'user@test.com'
+            'email' => 'user@test.com',
         ];
         $driver = $this->getMockMultiBackend();
         $driver->expects($this->once())->method('patronLogin')
@@ -202,7 +202,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest($overrides = [])
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass', 'target' => 'ils1'
+            'username' => 'testuser', 'password' => 'testpass', 'target' => 'ils1',
         ];
         $request = new \Laminas\Http\Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));
@@ -318,7 +318,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
             [
                 $driverClass => [
                     'Drivers' => [
-                        'ils1' => 'Sample'
+                        'ils1' => 'Sample',
                     ],
                     'Login' => [
                         'drivers' => ['ils1'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
@@ -73,7 +73,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
         $config = new Config(
             [
                 'host' => 'my.fake.host',
-                'port' => '6002'
+                'port' => '6002',
             ],
             true
         );
@@ -91,7 +91,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
     protected function getLoginRequest($overrides = [])
     {
         $post = $overrides + [
-            'username' => 'testuser', 'password' => 'testpass'
+            'username' => 'testuser', 'password' => 'testpass',
         ];
         $request = new \Laminas\Http\Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -99,7 +99,7 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(file_exists($expectedFont));
         $expected = [
             'font' => $expectedFont,
-            'imgDir' => $options->getCacheDir()
+            'imgDir' => $options->getCacheDir(),
         ];
         $this->assertEquals($expected, $result->constructorArgs[0]->getOptions());
         $this->assertEquals($expectedCache, $result->constructorArgs[1]);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/IntervalTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/IntervalTest.php
@@ -55,8 +55,8 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $config = new \Laminas\Config\Config(
             [
                 'Captcha' => [
-                    'time_from_session_start' => 20
-                ]
+                    'time_from_session_start' => 20,
+                ],
             ]
         );
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/CartTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/CartTest.php
@@ -61,7 +61,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ->setConstructorArgs(
                 [
                 $this->createMock(\VuFindSearch\Service::class),
-                $this->createMock(\VuFind\RecordDriver\PluginManager::class)
+                $this->createMock(\VuFind\RecordDriver\PluginManager::class),
                 ]
             )->getMock();
     }
@@ -280,7 +280,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
     {
         $cookies = [
             'vufind_cart' => "Aa\tBb\tCc",
-            'vufind_cart_src' => "Solr\tSummon\tWorldCat"
+            'vufind_cart_src' => "Solr\tSummon\tWorldCat",
         ];
         $cart = $this->getCart(100, true, $cookies);
         $this->assertEquals(3, count($cart->getItems()));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/AlphaBrowseTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/AlphaBrowseTest.php
@@ -108,7 +108,7 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
                 'title' => 'nearby_items',
                 'providerId' => 'foo_ProviderId',
                 'links' => [],
-                'token' => 'foo_Id'
+                'token' => 'foo_Id',
             ]];
         $this->assertSame($expectedResult, $alpha->getFromSearch($results));
     }
@@ -167,11 +167,11 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
                            [
                             ['extras' =>
                                 ['title' => [['foo_title']],
-                                 'id' => [['foo_id']]
+                                 'id' => [['foo_id']],
                                 ],
-                            ]
-                           ]
-                        ]
+                            ],
+                           ],
+                        ],
                     ];
 
         $params = new ParamBag(['extras' => 'title:author:isbn:id']);
@@ -262,24 +262,24 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
                 [
                     'label' => 'View Record',
                     'icon' => 'fa-file-text-o',
-                    'url' => 'url_test'
+                    'url' => 'url_test',
                 ],
                 [
                     'label' => 'channel_expand',
                     'icon' => 'fa-search-plus',
-                    'url' => 'channels-record?id=foo_Id&source=foo_Identifier'
+                    'url' => 'channels-record?id=foo_Id&source=foo_Identifier',
                 ],
                 [
                     'label' => 'channel_browse',
                     'icon' => 'fa-list',
-                    'url' => 'alphabrowse-home?source=lcc&from=foo'
-                ]
+                    'url' => 'alphabrowse-home?source=lcc&from=foo',
+                ],
             ],
             'contents' => [[
                 'title' => 'foo_title',
                 'source' => 'Solr',
                 'thumbnail' => false,
-                'id' => 'foo_id']
+                'id' => 'foo_id'],
             ],
         ]];
         return [$alpha, $expectedResult];
@@ -321,7 +321,7 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
             'SourceIdentifier' => 'foo_Identifier',
             'Thumbnail' => 'foo_Thumbnail',
             'UniqueID' => 'foo_Id',
-            'callnumber-raw' => $data['solrField'] ?? null
+            'callnumber-raw' => $data['solrField'] ?? null,
         ];
         $driver->setRawData($data);
         return $driver;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/RandomTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/RandomTest.php
@@ -119,7 +119,7 @@ class RandomTest extends \PHPUnit\Framework\TestCase
                 'thumbnail' => 'foo_Thumbnail',
                 'routeDetails' => 'foo_Route',
                 'id' => 'foo_Id',
-            ]]
+            ]],
         ]];
         $random->setProviderId('foo_ProviderID');
         $coverRouter = $this->getConfiguredCoverRouterMock($recordDriver);
@@ -225,7 +225,7 @@ class RandomTest extends \PHPUnit\Framework\TestCase
             'Title' => 'foo_Title',
             'SourceIdentifier' => 'foo_Identifier',
             'Thumbnail' => 'foo_Thumbnail',
-            'UniqueID' => 'foo_Id'
+            'UniqueID' => 'foo_Id',
         ];
         $driver->setRawData($data);
         return $driver;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/SimilarItemsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/SimilarItemsTest.php
@@ -105,7 +105,7 @@ class SimilarItemsTest extends \PHPUnit\Framework\TestCase
             'title' => 'Similar Items: foo_Breadcrumb',
             'providerId' => 'foo_ProviderId',
             'links' => [],
-            'token' => 'foo_Id'
+            'token' => 'foo_Id',
         ]];
         $similar->setProviderId('foo_ProviderId');
         $this->assertSame($expectedResult, $similar->getFromSearch($results));
@@ -207,20 +207,20 @@ class SimilarItemsTest extends \PHPUnit\Framework\TestCase
                 [
                     'label' => 'View Record',
                     'icon' => 'fa-file-text-o',
-                    'url' => 'url_test'
+                    'url' => 'url_test',
                 ],
                 [
                     'label' => 'channel_expand',
                     'icon' => 'fa-search-plus',
-                    'url' => 'channels-record?id=foo_Id&source=Solr'
-                ]
+                    'url' => 'channels-record?id=foo_Id&source=Solr',
+                ],
             ],
             'contents' => [[
                 'title' => 'foo_Title',
                 'source' => 'Solr',
                 'thumbnail' => false,
                 'routeDetails' => 'foo_Route',
-                'id' => 'foo_Id']
+                'id' => 'foo_Id'],
             ],
 
         ]];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
@@ -65,17 +65,17 @@ class PathResolverTest extends \PHPUnit\Framework\TestCase
         $this->stackedResolver = new PathResolver(
             [
                 'directory' => APPLICATION_PATH,
-                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
+                'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
             ],
             [
                 [
                     'directory' => $fixtureDir . 'secondary',
-                    'defaultConfigSubdir' => 'config/custom'
+                    'defaultConfigSubdir' => 'config/custom',
                 ],
                 [
                     'directory' => $fixtureDir . 'primary',
-                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR
-                ]
+                    'defaultConfigSubdir' => PathResolver::DEFAULT_CONFIG_SUBDIR,
+                ],
             ]
         );
     }
@@ -124,22 +124,22 @@ class PathResolverTest extends \PHPUnit\Framework\TestCase
             [
                 // A file that exists only in the primary path:
                 'only-primary.ini',
-                $fixtureDir . 'primary/config/vufind/only-primary.ini'
+                $fixtureDir . 'primary/config/vufind/only-primary.ini',
             ],
             [
                 // A file that exists both in the primary and secondary paths:
                 'both.ini',
-                $fixtureDir . 'primary/config/vufind/both.ini'
+                $fixtureDir . 'primary/config/vufind/both.ini',
             ],
             [
                 // A file that exists in the secondary path as well as base path:
                 'facets.ini',
-                $fixtureDir . 'secondary/config/custom/facets.ini'
+                $fixtureDir . 'secondary/config/custom/facets.ini',
             ],
             [
                 // A file that exists only in the base path:
                 'config.ini',
-                APPLICATION_PATH . '/config/vufind/config.ini'
+                APPLICATION_PATH . '/config/vufind/config.ini',
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -99,7 +99,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         // theme:
         $expectedWarnings = [
             'The Statistics module has been removed from VuFind. '
-            . 'For usage tracking, please configure Google Analytics or Matomo.'
+            . 'For usage tracking, please configure Google Analytics or Matomo.',
         ];
         if ((float)$version < 1.3) {
             $expectedWarnings[] = "WARNING: This version of VuFind does not support "
@@ -139,7 +139,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
             [
                 'Author' => ['AuthorFacets', 'SpellingSuggestions'],
                 'CallNumber' => ['TopFacets:ResultsTop'],
-                'WorkKeys' => ['']
+                'WorkKeys' => [''],
             ],
             $results['searches.ini']['TopRecommendations']
         );
@@ -189,7 +189,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
             [
                 'institution', 'building', 'format', 'callnumber-first',
                 'author_facet', 'language', 'genre_facet', 'era_facet',
-                'geographic_facet', 'publishDate'
+                'geographic_facet', 'publishDate',
             ],
             array_keys($results['facets.ini']['Results'])
         );
@@ -354,7 +354,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         $adminConfig = [
             'ipRegEx' => '/1\.2\.3\.4|1\.2\.3\.5/',
             'username' => ['username1', 'username2'],
-            'permission' => 'access.AdminModule'
+            'permission' => 'access.AdminModule',
         ];
         $this->assertEquals(
             $adminConfig,
@@ -367,7 +367,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
             'role' => ['loggedin'],
             'ipRegEx' => '/1\.2\.3\.4|1\.2\.3\.5/',
             'boolean' => 'OR',
-            'permission' => 'access.SummonExtendedResults'
+            'permission' => 'access.SummonExtendedResults',
         ];
         $this->assertEquals(
             $summonConfig,
@@ -390,7 +390,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         );
         $expectedRegex = [
             'MEMBER1' => '/^1\.2\..*/',
-            'MEMBER2' => ['/^2\.3\..*/', '/^3\.4\..*/']
+            'MEMBER2' => ['/^2\.3\..*/', '/^3\.4\..*/'],
         ];
         foreach ($expectedRegex as $code => $regex) {
             $perm = "access.PrimoInstitution.$code";
@@ -400,7 +400,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
             );
             $permDetails = [
                 'ipRegEx' => $regex,
-                'permission' => $perm
+                'permission' => $perm,
             ];
             $this->assertEquals($permDetails, $results['permissions.ini'][$perm]);
         }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/WriterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/WriterTest.php
@@ -75,12 +75,12 @@ class WriterTest extends \PHPUnit\Framework\TestCase
                     'settings' => [
                         'key1' => [
                             'before' => "; key head\n",
-                            'inline' => '; key inline'
-                        ]
-                    ]
-                ]
+                            'inline' => '; key inline',
+                        ],
+                    ],
+                ],
             ],
-            'after' => "; the end\n"
+            'after' => "; the end\n",
         ];
         $target = "; section head\n[Test]\t; inline\n; key head\n"
             . "key1             = \"val1\"\t; key inline\n"
@@ -138,7 +138,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     public function testAssocArray()
     {
         $cfg = [
-            'Test' => ['test' => ['key1' => 'val1', 'key2' => 'val2']]
+            'Test' => ['test' => ['key1' => 'val1', 'key2' => 'val2']],
         ];
         $test = new Writer('fake.ini', $cfg);
         $expected = "[Test]\ntest['key1']     = \"val1\"\n"

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
@@ -159,7 +159,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'Overridden' => [
-                    'Original' => 'Not so original'
+                    'Original' => 'Not so original',
                 ],
                 'Other' => [
                     'Merged' => [
@@ -168,12 +168,12 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
                         'Child' => ['Foo', 'Baz'],
                     ],
                     'NonMerged' => [
-                        'Original' => 'Not so original either'
+                        'Original' => 'Not so original either',
                     ],
-                    'ParentOnly' => [true]
+                    'ParentOnly' => [true],
                 ],
                 'ChildOnly' => [
-                    'Child' => 'true'
+                    'Child' => 'true',
                 ],
             ],
             $config

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/KohaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/KohaTest.php
@@ -53,15 +53,15 @@ class KohaTest extends \PHPUnit\Framework\TestCase
             'no id' => [false, [null, 'small', []]],
             'small image' => [
                 'http://base?thumbnail=1&biblionumber=foo',
-                [null, 'small', ['recordid' => 'foo']]
+                [null, 'small', ['recordid' => 'foo']],
             ],
             'medium image' => [
                 'http://base?thumbnail=1&biblionumber=foo',
-                [null, 'medium', ['recordid' => 'foo']]
+                [null, 'medium', ['recordid' => 'foo']],
             ],
             'large image' => [
                 'http://base?biblionumber=foo',
-                [null, 'large', ['recordid' => 'foo']]
+                [null, 'large', ['recordid' => 'foo']],
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/TemplateBasedTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/TemplateBasedTest.php
@@ -154,7 +154,7 @@ class TemplateBasedTest extends \PHPUnit\Framework\TestCase
             [
                 'template' => 'ContentBlock/TemplateBased/markdown',
                 'data' => file_get_contents($file),
-                'pageLocatorDetails' => $details
+                'pageLocatorDetails' => $details,
             ],
             $block->getContext()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/ResultScrollerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Controller/Plugin/ResultScrollerTest.php
@@ -61,7 +61,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => null, 'lastRecord' => null,
             'previousRecord' => null, 'nextRecord' => null,
-            'currentPosition' => null, 'resultTotal' => null
+            'currentPosition' => null, 'resultTotal' => null,
         ];
 
         $this->assertEquals(
@@ -95,7 +95,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => null, 'lastRecord' => null,
             'previousRecord' => null, 'nextRecord' => null,
-            'currentPosition' => null, 'resultTotal' => null
+            'currentPosition' => null, 'resultTotal' => null,
         ];
         $this->assertEquals(
             $expected,
@@ -116,7 +116,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|1',
             'previousRecord' => null, 'nextRecord' => null,
-            'currentPosition' => 1, 'resultTotal' => 1
+            'currentPosition' => 1, 'resultTotal' => 1,
         ];
         $this->assertEquals(
             $expected,
@@ -137,7 +137,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => 'Solr|4', 'nextRecord' => 'Solr|6',
-            'currentPosition' => 5, 'resultTotal' => 10
+            'currentPosition' => 5, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -158,7 +158,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => null, 'nextRecord' => 'Solr|2',
-            'currentPosition' => 1, 'resultTotal' => 10
+            'currentPosition' => 1, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -179,7 +179,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => null, 'nextRecord' => 'Solr|2',
-            'currentPosition' => 1, 'resultTotal' => 10
+            'currentPosition' => 1, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -201,7 +201,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => 'Solr|9', 'nextRecord' => null,
-            'currentPosition' => 10, 'resultTotal' => 10
+            'currentPosition' => 10, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -223,7 +223,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|9',
             'previousRecord' => 'Solr|8', 'nextRecord' => null,
-            'currentPosition' => 9, 'resultTotal' => 9
+            'currentPosition' => 9, 'resultTotal' => 9,
         ];
         $this->assertEquals(
             $expected,
@@ -245,7 +245,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => null, 'lastRecord' => null,
             'previousRecord' => 'Solr|4', 'nextRecord' => 'Solr|6',
-            'currentPosition' => 5, 'resultTotal' => 10
+            'currentPosition' => 5, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -266,7 +266,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => null, 'nextRecord' => 'Solr|2',
-            'currentPosition' => 1, 'resultTotal' => 10
+            'currentPosition' => 1, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -287,7 +287,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|10',
             'previousRecord' => 'Solr|9', 'nextRecord' => null,
-            'currentPosition' => 10, 'resultTotal' => 10
+            'currentPosition' => 10, 'resultTotal' => 10,
         ];
         $this->assertEquals(
             $expected,
@@ -308,7 +308,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|17',
             'previousRecord' => 'Solr|16', 'nextRecord' => null,
-            'currentPosition' => 17, 'resultTotal' => 17
+            'currentPosition' => 17, 'resultTotal' => 17,
         ];
         $this->assertEquals(
             $expected,
@@ -329,7 +329,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|30',
             'previousRecord' => 'Solr|10', 'nextRecord' => 'Solr|12',
-            'currentPosition' => 11, 'resultTotal' => 30
+            'currentPosition' => 11, 'resultTotal' => 30,
         ];
         $this->assertEquals(
             $expected,
@@ -360,7 +360,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|30',
             'previousRecord' => 'Solr|19', 'nextRecord' => 'Solr|21',
-            'currentPosition' => 20, 'resultTotal' => 30
+            'currentPosition' => 20, 'resultTotal' => 30,
         ];
         $this->assertEquals(
             $expected,
@@ -381,7 +381,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'firstRecord' => 'Solr|sorted1', 'lastRecord' => 'Solr|sorted30',
             'previousRecord' => 'Solr|sorted19', 'nextRecord' => 'Solr|sorted21',
-            'currentPosition' => 20, 'resultTotal' => 30
+            'currentPosition' => 20, 'resultTotal' => 30,
         ];
         $this->assertEquals(
             $expected,
@@ -453,7 +453,7 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
             new Container('test'),
             $mockManager,
             $mockMemory,
-            true
+            true,
         ];
         // Create an anonymous class to stub out some behavior:
         $resultScroller = new class (...$params) extends ResultScroller {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/DoiLinker/BrowZineTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/DoiLinker/BrowZineTest.php
@@ -106,9 +106,9 @@ class BrowZineTest extends \PHPUnit\Framework\TestCase
                             'label' => 'PDF Full Text',
                             'icon' => 'https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg',
                             'data' => $rawData['data'],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             [
                 'config' => ['filterType' => 'exclude', 'filter' => ['browzineWebLink']],
@@ -119,9 +119,9 @@ class BrowZineTest extends \PHPUnit\Framework\TestCase
                             'label' => 'PDF Full Text',
                             'icon' => 'https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg',
                             'data' => $rawData['data'],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             [
                 'config' => ['filterType' => 'include', 'filter' => ['browzineWebLink']],
@@ -132,9 +132,9 @@ class BrowZineTest extends \PHPUnit\Framework\TestCase
                             'label' => 'View Complete Issue',
                             'icon' => 'https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg',
                             'data' => $rawData['data'],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/DoiLinker/UnpaywallTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/DoiLinker/UnpaywallTest.php
@@ -75,9 +75,9 @@ class UnpaywallTest extends \PHPUnit\Framework\TestCase
                         [
                             'link' => 'http://sajlis.journals.ac.za/pub/article/download/1434/1332',
                             'label' => 'PDF Full Text',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             [
                 'fixture' => $this->getFixture('unpaywall/goodresponseonline'),
@@ -86,13 +86,13 @@ class UnpaywallTest extends \PHPUnit\Framework\TestCase
                         [
                             'link' => 'https://doi.org/10.7553/66-4-1434',
                             'label' => 'online_resources',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             [
                 'fixture' => $this->getFixture('unpaywall/badresponse'),
-                'response' => []
+                'response' => [],
             ],
         ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
@@ -153,7 +153,7 @@ class ExportTest extends \PHPUnit\Framework\TestCase
     {
         $config = [
             'foo' => ['requiredMethods' => ['getTitle']],
-            'bar' => ['requiredMethods' => ['getThingThatDoesNotExist']]
+            'bar' => ['requiredMethods' => ['getThingThatDoesNotExist']],
         ];
 
         $export = $this->getExport([], $config);
@@ -184,7 +184,7 @@ class ExportTest extends \PHPUnit\Framework\TestCase
         // turned on by default if no main config is passed in.
         $config = [
             'RefWorks' => ['requiredMethods' => ['getTitle']],
-            'EndNote' => ['requiredMethods' => ['getThingThatDoesNotExist']]
+            'EndNote' => ['requiredMethods' => ['getThingThatDoesNotExist']],
         ];
 
         $export = $this->getExport([], $config);
@@ -207,7 +207,7 @@ class ExportTest extends \PHPUnit\Framework\TestCase
         ];
         $exportConfig = [
             'anything' => ['requiredMethods' => ['getTitle']],
-            'marc' => ['requiredMethods' => ['getMarcReader']]
+            'marc' => ['requiredMethods' => ['getMarcReader']],
         ];
         $export = $this->getExport($mainConfig, $exportConfig);
         $solrDefault = new \VuFind\RecordDriver\SolrDefault();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Feed/Writer/Extension/OpenSearch/FeedTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Feed/Writer/Extension/OpenSearch/FeedTest.php
@@ -79,7 +79,7 @@ class FeedTest extends \PHPUnit\Framework\TestCase
                     'role' => 'role',
                     'type' => 'atom',
                     'title' => 'title',
-                ]
+                ],
             ],
             $feed->getOpensearchLinks()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -223,13 +223,13 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $postParams = [
             'message' => 'x',
             'name' => 'y',
-            'email' => 'z@foo.com'
+            'email' => 'z@foo.com',
         ];
 
         $this->assertEquals(
             [
                 $expectedFields,
-                'Email/form.phtml'
+                'Email/form.phtml',
             ],
             $form->formatEmailMessage($postParams)
         );
@@ -381,7 +381,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'label' => 'feedback_email',
                     'settings' => [
                         'size' => 254,
-                        'aria-label' => 'Test label'
+                        'aria-label' => 'Test label',
                     ],
                 ],
                 [
@@ -469,12 +469,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'value' => 'value-1',
-                    'label' => 'label-1'
+                    'label' => 'label-1',
                 ],
                 'o2' => [
                     'value' => 'value-2',
-                    'label' => 'label-2'
-                ]
+                    'label' => 'label-2',
+                ],
             ],
             $el['optionGroups']['group-1']['options']
         );
@@ -485,12 +485,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'value' => 'option-1',
-                    'label' => 'option-1'
+                    'label' => 'option-1',
                 ],
                 'o2' => [
                     'value' => 'option-2',
-                    'label' => 'option-2'
-                ]
+                    'label' => 'option-2',
+                ],
             ],
             $el['optionGroups']['group-1']['options']
         );
@@ -501,12 +501,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'label-1',
-                    'value' => 'value-1'
+                    'value' => 'value-1',
                 ],
                 'o2' => [
                     'label' => 'label-2',
-                    'value' => 'value-2'
-                ]
+                    'value' => 'value-2',
+                ],
             ],
             $el['options']
         );
@@ -517,12 +517,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'option-1',
-                    'value' => 'option-1'
+                    'value' => 'option-1',
                 ],
                 'o2' => [
                     'label' => 'option-2',
-                    'value' => 'option-2'
-                ]
+                    'value' => 'option-2',
+                ],
             ],
             $el['options']
         );
@@ -533,12 +533,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'label-1',
-                    'value' => 'value-1'
+                    'value' => 'value-1',
                 ],
                 'o2' => [
                     'label' => 'label-2',
-                    'value' => 'value-2'
-                ]
+                    'value' => 'value-2',
+                ],
             ],
             $el['options']
         );
@@ -549,12 +549,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'option-1',
-                    'value' => 'option-1'
+                    'value' => 'option-1',
                 ],
                 'o2' => [
                     'label' => 'option-2',
-                    'value' => 'option-2'
-                ]
+                    'value' => 'option-2',
+                ],
             ],
             $el['options']
         );
@@ -565,12 +565,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'label-1',
-                    'value' => 'value-1'
+                    'value' => 'value-1',
                 ],
                 'o2' => [
                     'label' => 'label-2',
-                    'value' => 'value-2'
-                ]
+                    'value' => 'value-2',
+                ],
             ],
             $el['options']
         );
@@ -581,12 +581,12 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'o1' => [
                     'label' => 'option-1',
-                    'value' => 'option-1'
+                    'value' => 'option-1',
                 ],
                 'o2' => [
                     'label' => 'option-2',
-                    'value' => 'option-2'
-                ]
+                    'value' => 'option-2',
+                ],
             ],
             $el['options']
         );
@@ -680,7 +680,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
         // Test checkbox with all options required
         $ids = [
             'TestCheckboxWithAllOptionsRequired',  // options with value
-            'TestCheckboxWithAllOptionsRequired-2' // options with label and value
+            'TestCheckboxWithAllOptionsRequired-2', // options with label and value
         ];
 
         foreach ($ids as $id) {
@@ -710,7 +710,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
         // Test checkbox with one required option
         $ids = [
             'TestCheckboxWithOneOptionRequired',  // options with value
-            'TestCheckboxWithOneOptionRequired-2' // options with label and value
+            'TestCheckboxWithOneOptionRequired-2', // options with label and value
         ];
 
         foreach ($ids as $id) {
@@ -746,7 +746,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             // options with value
             'TestCheckboxWithOneOptionThatIsRequired',
             // options with label and value
-            'TestCheckboxWithOneOptionThatIsRequired-2'
+            'TestCheckboxWithOneOptionThatIsRequired-2',
         ];
 
         foreach ($ids as $id) {
@@ -809,11 +809,11 @@ class FormTest extends \PHPUnit\Framework\TestCase
         return [
             'with placeholders' => [
                 'TestSubjectEmailWithPlaceholders',
-                'Subject One Two option-1'
+                'Subject One Two option-1',
             ],
             'without placeholders' => [
                 'TestSubjectEmailWithoutPlaceholders',
-                'Subject without placeholders'
+                'Subject without placeholders',
             ],
         ];
     }
@@ -837,7 +837,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             [
                 'text1' => 'One',
                 'text2' => 'Two',
-                'checkbox' => ['o1']
+                'checkbox' => ['o1'],
             ]
         );
         $this->assertTrue($form->isValid());

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleDetectorFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleDetectorFactoryTest.php
@@ -76,7 +76,7 @@ class LocaleDetectorFactoryTest extends \PHPUnit\Framework\TestCase
                 LocaleDetectorParamStrategy::class,
                 QueryStrategy::class,
                 LocaleDetectorCookieStrategy::class,
-                HttpAcceptLanguageStrategy::class
+                HttpAcceptLanguageStrategy::class,
             ],
             $this->getStrategyClasses()
         );
@@ -99,7 +99,7 @@ class LocaleDetectorFactoryTest extends \PHPUnit\Framework\TestCase
                 LocaleDetectorParamStrategy::class,
                 QueryStrategy::class,
                 LocaleDetectorCookieStrategy::class,
-                HttpAcceptLanguageStrategy::class
+                HttpAcceptLanguageStrategy::class,
             ],
             $this->getStrategyClasses($mockSettings)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/SorterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/SorterTest.php
@@ -58,7 +58,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => false,
                 ],
-                -1
+                -1,
             ],
             [
                 [
@@ -66,7 +66,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => false,
                 ],
-                0
+                0,
             ],
             [
                 [
@@ -74,7 +74,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => false,
                 ],
-                1
+                1,
             ],
             [
                 [
@@ -82,7 +82,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => false,
                 ],
-                0
+                0,
             ],
             [
                 [
@@ -90,7 +90,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => true,
                 ],
-                -1
+                -1,
             ],
             [
                 [
@@ -98,7 +98,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => true,
                 ],
-                0
+                0,
             ],
             [
                 [
@@ -106,7 +106,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => true,
                 ],
-                1
+                1,
             ],
             [
                 [
@@ -114,7 +114,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'en',
                     'respectLocale' => true,
                 ],
-                0
+                0,
             ],
             [
                 [
@@ -122,7 +122,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'cs',
                     'respectLocale' => false,
                 ],
-                1
+                1,
             ],
             [
                 [
@@ -130,7 +130,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'cs',
                     'respectLocale' => true,
                 ],
-                -1
+                -1,
             ],
             [
                 [
@@ -138,7 +138,7 @@ class SorterTest extends \PHPUnit\Framework\TestCase
                     'locale' => 'cs',
                     'respectLocale' => true,
                 ],
-                0
+                0,
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Translator/Loader/ExtendedIniTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Translator/Loader/ExtendedIniTest.php
@@ -54,7 +54,7 @@ class ExtendedIniTest extends \PHPUnit\Framework\TestCase
     {
         $pathStack = [
             realpath($this->getFixtureDir() . 'language/base'),
-            realpath($this->getFixtureDir() . 'language/overrides')
+            realpath($this->getFixtureDir() . 'language/overrides'),
         ];
         $loader = new ExtendedIni($pathStack);
         $result = $loader->load('en', null);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/DAIATest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/DAIATest.php
@@ -76,7 +76,7 @@ class DAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'addStorageRetrievalRequestLink' => true,
                 'customData' => [],
                 'limitation_types' => [],
-                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081'
+                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081',
             ],
         1 =>
             [
@@ -105,7 +105,7 @@ class DAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'addStorageRetrievalRequestLink' => false,
                 'customData' => [],
                 'limitation_types' => [],
-                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081'
+                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081',
             ],
         2 =>
             [
@@ -134,7 +134,7 @@ class DAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'addStorageRetrievalRequestLink' => false,
                 'customData' => [],
                 'limitation_types' => [],
-                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081'
+                'doc_id' => 'http://uri.gbv.de/document/opac-de-000:ppn:027586081',
             ],
     ];
 
@@ -163,7 +163,7 @@ class DAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                         'baseUrl'            => 'http://daia.gbv.de/',
                         'daiaIdPrefix'       => 'http://uri.gbv.de/document/opac-de-000:ppn:',
                         'daiaResponseFormat' => 'json',
-                    ]
+                    ],
             ]
         );
         $conn->init();
@@ -189,7 +189,7 @@ class DAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                         'baseUrl'            => 'http://daia.gbv.de/',
                         'daiaIdPrefix'       => 'http://uri.gbv.de/document/opac-de-000:ppn:',
                         'daiaResponseFormat' => 'xml',
-                    ]
+                    ],
             ]
         );
         $conn->init();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -57,8 +57,8 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'base_url' => 'localhost',
             'tenant' => 'config_tenant',
             'username' => 'config_username',
-            'password' => 'config_password'
-        ]
+            'password' => 'config_password',
+        ],
     ];
 
     /**
@@ -377,7 +377,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $result = $this->driver->placeHold($details);
         $expected = [
             'success' => false,
-            'status' => 'requestExpirationDate cannot be in the past'
+            'status' => 'requestExpirationDate cannot be in the past',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -403,8 +403,8 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                     'new_date' => '01-01-2022',
                     'new_time' => '00:00',
                     'item_id' => 'record1',
-                ]
-            ]
+                ],
+            ],
         ];
         $this->assertEquals($expected, $result);
     }
@@ -418,7 +418,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-holds-none');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getMyHolds($patron);
         $expected = [];
@@ -434,7 +434,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-holds-available');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getMyHolds($patron);
         $expected[0] = [
@@ -448,7 +448,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'available' => true,
             'in_transit' => false,
             'last_pickup_date' => '12-29-2022',
-            'position' => 1
+            'position' => 1,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -462,7 +462,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-holds-available-proxy');
         $patron = [
-            'id' => 'bar'
+            'id' => 'bar',
         ];
         $result = $this->driver->getMyHolds($patron);
         $expected[0] = [
@@ -491,7 +491,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-holds-in_transit');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getMyHolds($patron);
         $expected[0] = [
@@ -505,7 +505,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'available' => false,
             'in_transit' => true,
             'last_pickup_date' => null,
-            'position' => 1
+            'position' => 1,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -519,7 +519,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-holds-single');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getMyHolds($patron);
         $expected[0] = [
@@ -533,7 +533,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
             'available' => false,
             'in_transit' => false,
             'last_pickup_date' => null,
-            'position' => 3
+            'position' => 3,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -668,7 +668,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-my-profile');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getMyProfile($patron);
         $expected = [
@@ -695,7 +695,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $this->createConnector('get-proxied-users');
         $patron = [
-            'id' => 'foo'
+            'id' => 'foo',
         ];
         $result = $this->driver->getProxiedUsers($patron);
         $expected = ['fakeid' => 'Lastname, Proxity P.'];
@@ -735,7 +735,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                 'location_code' => 'DCOC',
                 'reserve' => 'TODO',
                 'addLink' => true,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $this->driver->getHolding("foo"));
     }
@@ -776,8 +776,8 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                     'location_code' => 'DCOC',
                     'reserve' => 'TODO',
                     'addLink' => true,
-                ]
-            ]
+                ],
+            ],
         ];
         $this->assertEquals($expected, $this->driver->getStatuses(["foo"]));
     }
@@ -815,7 +815,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                 'location_code' => 'DCOC',
                 'reserve' => 'TODO',
                 'addLink' => true,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $this->driver->getHolding("instanceid"));
     }
@@ -851,7 +851,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                 'location_code' => 'DCOC',
                 'reserve' => 'TODO',
                 'addLink' => true,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $this->driver->getHolding("instanceid"));
     }
@@ -912,7 +912,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                 'location_code' => 'DCOC',
                 'reserve' => 'TODO',
                 'addLink' => true,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $this->driver->getHolding("instanceid"));
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/GeniePlusTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/GeniePlusTest.php
@@ -86,7 +86,7 @@ class GeniePlusTest extends \VuFindTest\Unit\ILSDriverTestCase
         [
             'Accept: application/json',
             'Authorization: Bearer fake-token',
-        ]
+        ],
     ];
 
     /**
@@ -279,7 +279,7 @@ class GeniePlusTest extends \VuFindTest\Unit\ILSDriverTestCase
                     [
                         'Accept: application/json',
                         'Authorization: Bearer fake-token',
-                    ]
+                    ],
                 ],
             )->willReturnOnConsecutiveCalls(
                 $response1,
@@ -469,7 +469,7 @@ class GeniePlusTest extends \VuFindTest\Unit\ILSDriverTestCase
                     [
                         'Accept: application/json',
                         'Authorization: Bearer fake-token',
-                    ]
+                    ],
                 ],
             )->willReturnOnConsecutiveCalls(
                 $response1,
@@ -522,7 +522,7 @@ class GeniePlusTest extends \VuFindTest\Unit\ILSDriverTestCase
                     [
                         'Accept: application/json',
                         'Authorization: Bearer fake-token',
-                    ]
+                    ],
                 ],
             )->willReturnOnConsecutiveCalls(
                 $response1,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -134,7 +134,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $driver->setConfig(
             [
                 'General' => ['drivers_config_path' => 'configpath'],
-                'Drivers' => ['d1' => 'Voyager']
+                'Drivers' => ['d1' => 'Voyager'],
             ]
         );
         $driver->init();
@@ -207,21 +207,21 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
 
         $data = [
             'id' => 'record1',
-            'cat_username' => 'record2'
+            'cat_username' => 'record2',
         ];
         $result = $this->callMethod($driver, 'getSourceFromParams', [$data]);
         $this->assertEquals('', $result);
 
         $data = [
             'id' => 'record1',
-            'cat_username' => 'd1.record2'
+            'cat_username' => 'd1.record2',
         ];
         $result = $this->callMethod($driver, 'getSourceFromParams', [$data]);
         $this->assertEquals('d1', $result);
 
         $data = [
             'id' => 'd2.record1',
-            'cat_username' => 'record2'
+            'cat_username' => 'record2',
         ];
         $result = $this->callMethod($driver, 'getSourceFromParams', [$data]);
         $this->assertEquals('d2', $result);
@@ -230,8 +230,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'test' => 'true',
             'patron' => [
                 'id' => 'd2.record1',
-                'cat_username' => 'record2'
-            ]
+                'cat_username' => 'record2',
+            ],
         ];
         $result = $this->callMethod($driver, 'getSourceFromParams', [$data]);
         $this->assertEquals('d2', $result);
@@ -307,11 +307,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
 
         $data = [
             'id' => 'record1',
-            'cat_username' => 'record2'
+            'cat_username' => 'record2',
         ];
         $expected = [
             'id' => "$source.record1",
-            'cat_username' => "$source.record2"
+            'cat_username' => "$source.record2",
         ];
         $result = $this->callMethod($driver, 'addIdPrefixes', [$data, $source]);
         $this->assertEquals($expected, $result);
@@ -319,7 +319,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         // Empty source must not add prefixes
         $expected = [
             'id' => "record1",
-            'cat_username' => "record2"
+            'cat_username' => "record2",
         ];
         $result = $this->callMethod($driver, 'addIdPrefixes', [$data, '']);
         $this->assertEquals($expected, $result);
@@ -330,12 +330,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'id' => 'record2',
                 'cat_username' => [
                     'id' => 'record3',
-                    'cat_username' => 'record4'
+                    'cat_username' => 'record4',
                 ],
                 'cat_info' => 'record5',
-                'other' => 'something'
+                'other' => 'something',
             ],
-            'cat_info' => 'record6'
+            'cat_info' => 'record6',
         ];
         $expected = [
             'id' => "$source.record1",
@@ -343,12 +343,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'id' => "$source.record2",
                 'cat_username' => [
                     'id' => "$source.record3",
-                    'cat_username' => "$source.record4"
+                    'cat_username' => "$source.record4",
                 ],
                 'cat_info' => "$source.record5",
-                'other' => 'something'
+                'other' => 'something',
             ],
-            'cat_info' => "$source.record6"
+            'cat_info' => "$source.record6",
         ];
         $modify = ['id', 'cat_username', 'cat_info'];
         $result = $this->callMethod(
@@ -361,11 +361,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         // Numeric keys are not considered
         $data = [
             'id' => 'record1',
-            'cat_username' => ['foo', 'bar']
+            'cat_username' => ['foo', 'bar'],
         ];
         $expected = [
             'id' => "$source.record1",
-            'cat_username' => ['foo', 'bar']
+            'cat_username' => ['foo', 'bar'],
         ];
         $result = $this->callMethod(
             $driver,
@@ -397,11 +397,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
 
         $expected = [
             'id' => 'record1',
-            'cat_username' => 'record2'
+            'cat_username' => 'record2',
         ];
         $data = [
             'id' => "$source.record1",
-            'cat_username' => "$source.record2"
+            'cat_username' => "$source.record2",
         ];
         $result
             = $this->callMethod($driver, 'stripIdPrefixes', [$data, $source]);
@@ -413,12 +413,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'id' => 'record2',
                 'cat_username' => [
                     'id' => 'record3',
-                    'cat_username' => 'record4'
+                    'cat_username' => 'record4',
                 ],
                 'cat_info' => 'record5',
-                'other' => "$source.something"
+                'other' => "$source.something",
             ],
-            'cat_info' => 'record6'
+            'cat_info' => 'record6',
         ];
         $data = [
             'id' => "$source.record1",
@@ -426,12 +426,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'id' => "$source.record2",
                 'cat_username' => [
                     'id' => "$source.record3",
-                    'cat_username' => "$source.record4"
+                    'cat_username' => "$source.record4",
                 ],
                 'cat_info' => "$source.record5",
-                'other' => "$source.something"
+                'other' => "$source.something",
             ],
-            'cat_info' => "$source.record6"
+            'cat_info' => "$source.record6",
         ];
         $modify = ['id', 'cat_username', 'cat_info'];
         $result = $this->callMethod(
@@ -444,11 +444,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         // Numeric keys are not considered
         $data = [
             'id' => "$source.record1",
-            'test' => ["$source.foo", "$source.bar"]
+            'test' => ["$source.foo", "$source.bar"],
         ];
         $expected = [
             'id' => "record1",
-            'test' => ["$source.foo", "$source.bar"]
+            'test' => ["$source.foo", "$source.bar"],
         ];
         $result = $this->callMethod(
             $driver,
@@ -535,7 +535,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                     [
                         [
                             'id' => '123456',
-                            'status' => 'in'
+                            'status' => 'in',
                         ],
                     ]
                 )
@@ -616,8 +616,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 'Drivers' => [],
                 'Login' => [
-                    'drivers' => ['d2', 'd1']
-                ]
+                    'drivers' => ['d2', 'd1'],
+                ],
             ]
         );
 
@@ -627,7 +627,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $driver->setConfig(
             [
                 'Drivers' => [],
-                'Login' => []
+                'Login' => [],
             ]
         );
         $result = $driver->getDefaultLoginDriver();
@@ -700,17 +700,17 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                         [
                             [
                                 'id' => '123456',
-                                'status' => 'in'
+                                'status' => 'in',
                             ],
                             [
                                 'id' => '123456',
-                                'status' => 'out'
+                                'status' => 'out',
                             ],
                         ],
                         [
                             [
                                 'id' => '098765',
-                                'status' => 'out'
+                                'status' => 'out',
                             ],
                         ],
                     ]
@@ -729,13 +729,13 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                         [
                             [
                                 'id' => '654321',
-                                'status' => 'out'
+                                'status' => 'out',
                             ],
                         ],
                         [
                             [
                                 'id' => '567890',
-                                'status' => 'in'
+                                'status' => 'in',
                             ],
                         ],
                     ]
@@ -775,7 +775,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $this->setProperty($driver, 'drivers', $drivers);
 
         $ids = [
-            'd1.123456', 'd1.098765', 'd2.654321', 'd2.567890'
+            'd1.123456', 'd1.098765', 'd2.654321', 'd2.567890',
         ];
         $expectedReturn = [
             [
@@ -789,8 +789,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 ['id' => "d2.654321", 'status' => 'out'],
             ],
             [
-                ['id' => "d2.567890", 'status' => 'in']
-            ]
+                ['id' => "d2.567890", 'status' => 'in'],
+            ],
         ];
         $return = $driver->getStatuses($ids);
         $this->assertEquals($expectedReturn, $return);
@@ -817,7 +817,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $this->setProperty($driver, 'drivers', $drivers);
 
         $ids = [
-            'd1.123456', 'd1.098765', 'd3.654321', 'd3.567890'
+            'd1.123456', 'd1.098765', 'd3.654321', 'd3.567890',
         ];
         $expectedReturn = [
             [
@@ -832,7 +832,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 ['id' => "d3.567890", 'error' => 'An error has occurred'],
-            ]
+            ],
         ];
         $return = $driver->getStatuses($ids);
         $this->assertEquals($expectedReturn, $return);
@@ -872,7 +872,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $driver = $this->getDriver($sm);
         $drivers = [
             'otherinst' => 'Unicorn',
-            'institution' => 'Voyager'
+            'institution' => 'Voyager',
         ];
         $this->setProperty($driver, 'drivers', $drivers);
 
@@ -934,7 +934,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
     {
         $return = [
             'count' => 2,
-            'results' => [['id' => '1'], ['id' => '2']]
+            'results' => [['id' => '1'], ['id' => '2']],
         ];
 
         $ILS = $this->getMockILS('Voyager', ['getNewItems', 'init']);
@@ -950,7 +950,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
 
         $expected = [
             'count' => 2,
-            'results' => [['id' => 'd1.1'], ['id' => 'd1.2']]
+            'results' => [['id' => 'd1.1'], ['id' => 'd1.2']],
         ];
         $this->setProperty($driver, 'defaultDriver', 'd1');
         $result = $driver->getNewItems(1, 10, 5, 0);
@@ -1098,7 +1098,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'COURSE_ID' => 4,
                 'DEPARTMENT_ID' => 5,
                 'INSTRUCTOR_ID' => 6,
-            ]
+            ],
         ];
 
         $ILS = $this->getMockILS('Voyager', ['findReserves', 'init']);
@@ -1237,14 +1237,14 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
 
         $result = $driver->getRenewDetails(
             [
-                'id' => 'd1.loanid'
+                'id' => 'd1.loanid',
             ]
         );
         $this->assertEquals($expected1, $result);
 
         $result = $driver->getRenewDetails(
             [
-                'id' => 'd2.loanid'
+                'id' => 'd2.loanid',
             ]
         );
         $this->assertEquals($expected2, $result);
@@ -1253,7 +1253,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('No suitable backend driver found');
         $result = $driver->getRenewDetails(
             [
-                'id' => 'invalid.loanid'
+                'id' => 'invalid.loanid',
             ]
         );
     }
@@ -1267,11 +1267,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
     {
         $expected1 = [
             ['id' => 'd1.1'],
-            ['id' => 'd1.2']
+            ['id' => 'd1.2'],
         ];
         $expected2 = [
             ['id' => 'd2.1'],
-            ['id' => 'd2.2']
+            ['id' => 'd2.2'],
         ];
         $driver = $this->initSimpleMethodTest(
             $this->once(),
@@ -1515,7 +1515,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'd1.bibid',
             [
-                'id' => 'd1.itemid'
+                'id' => 'd1.itemid',
             ],
             $this->getPatron('username', 'd1')
         );
@@ -1524,7 +1524,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'd2.bibid',
             [
-                'id' => 'd2.itemid'
+                'id' => 'd2.itemid',
             ],
             $this->getPatron('username', 'd2')
         );
@@ -1534,7 +1534,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'd2.bibid',
             [
-                'id' => 'd2.itemid'
+                'id' => 'd2.itemid',
             ],
             $this->getPatron('username', 'd1')
         );
@@ -1544,7 +1544,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'd1.bibid',
             [
-                'id' => 'd1.itemid'
+                'id' => 'd1.itemid',
             ],
             ['bad patron']
         );
@@ -1553,7 +1553,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'invalid.bibid',
             [
-                'id' => 'invalid.itemid'
+                'id' => 'invalid.itemid',
             ],
             $this->getPatron('username', 'invalid')
         );
@@ -1572,7 +1572,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkRequestIsValid(
             'd1.bibid',
             [
-                'id' => 'd1.itemid'
+                'id' => 'd1.itemid',
             ],
             $this->getPatron('username', 'd2')
         );
@@ -1595,7 +1595,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 'bibid',
                 ['id' => 'itemid'],
-                $this->getPatron('username')
+                $this->getPatron('username'),
             ],
             true,
             false
@@ -1604,7 +1604,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkStorageRetrievalRequestIsValid(
             'd1.bibid',
             [
-                'id' => 'd1.itemid'
+                'id' => 'd1.itemid',
             ],
             $this->getPatron('username', 'd1')
         );
@@ -1613,7 +1613,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkStorageRetrievalRequestIsValid(
             'd2.bibid',
             [
-                'id' => 'd2.itemid'
+                'id' => 'd2.itemid',
             ],
             $this->getPatron('username', 'd2')
         );
@@ -1623,7 +1623,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkStorageRetrievalRequestIsValid(
             'd1.bibid',
             [
-                'id' => 'd1.itemid'
+                'id' => 'd1.itemid',
             ],
             $this->getPatron('username', 'd2')
         );
@@ -1632,7 +1632,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->checkStorageRetrievalRequestIsValid(
             'invalid.bibid',
             [
-                'id' => 'invalid.itemid'
+                'id' => 'invalid.itemid',
             ],
             $this->getPatron('username', 'invalid')
         );
@@ -1654,7 +1654,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'getPickUpLocations',
             [
                 $this->getPatron('username'),
-                ['id' => '1']
+                ['id' => '1'],
             ],
             $expected1,
             $expected2
@@ -1702,7 +1702,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'getDefaultPickUpLocation',
             [
                 $this->getPatron('username'),
-                ['id' => '1']
+                ['id' => '1'],
             ],
             $expected1,
             $expected2
@@ -1750,7 +1750,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'getRequestGroups',
             [
                 '1',
-                $this->getPatron('username')
+                $this->getPatron('username'),
             ],
             $expected1,
             $expected2
@@ -1798,7 +1798,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'getDefaultRequestGroup',
             [
                 $this->getPatron('username'),
-                ['id' => '1']
+                ['id' => '1'],
             ],
             $expected1,
             $expected2
@@ -1840,11 +1840,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
     {
         $expected1 = [
             'success' => true,
-            'status' => ''
+            'status' => '',
         ];
         $expected2 = [
             'success' => false,
-            'status' => 'hold_error_fail'
+            'status' => 'hold_error_fail',
         ];
         $driver = $this->initSimpleMethodTest(
             $this->once(),
@@ -1858,7 +1858,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeHold(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'id' => 'd1.1'
+                'id' => 'd1.1',
             ]
         );
         $this->assertEquals($expected1, $result);
@@ -1866,7 +1866,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeHold(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'id' => 'd2.1'
+                'id' => 'd2.1',
             ]
         );
         $this->assertEquals($expected2, $result);
@@ -1875,13 +1875,13 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeHold(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'id' => 'd1.1'
+                'id' => 'd1.1',
             ]
         );
         $this->assertEquals(
             [
                 'success' => false,
-                'sysMessage' => 'ILSMessages::hold_wrong_user_institution'
+                'sysMessage' => 'ILSMessages::hold_wrong_user_institution',
             ],
             $result
         );
@@ -1891,7 +1891,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeHold(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'id' => 'invalid.1'
+                'id' => 'invalid.1',
             ]
         );
     }
@@ -1906,12 +1906,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $expected = [
             '1' => [
                 'success' => true,
-                'status' => 'hold_cancel_success'
+                'status' => 'hold_cancel_success',
             ],
             '2' => [
                 'success' => false,
-                'status' => 'hold_cancel_fail'
-            ]
+                'status' => 'hold_cancel_fail',
+            ],
 
         ];
         $driver = $this->initSimpleMethodTest(
@@ -1921,8 +1921,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 [
                     'patron' => $this->getPatron('username'),
-                    'details' => ['1', '2']
-                ]
+                    'details' => ['1', '2'],
+                ],
             ],
             $expected,
             $expected
@@ -1931,7 +1931,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelHolds(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -1939,7 +1939,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelHolds(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -1949,7 +1949,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelHolds(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
     }
@@ -2005,11 +2005,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
     {
         $expected1 = [
             'success' => true,
-            'status' => ''
+            'status' => '',
         ];
         $expected2 = [
             'success' => false,
-            'status' => 'storage_retrieval_request_error_blocked'
+            'status' => 'storage_retrieval_request_error_blocked',
         ];
         $driver = $this->initSimpleMethodTest(
             $this->once(),
@@ -2023,7 +2023,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeStorageRetrievalRequest(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'id' => 'd1.1'
+                'id' => 'd1.1',
             ]
         );
         $this->assertEquals($expected1, $result);
@@ -2031,7 +2031,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeStorageRetrievalRequest(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'id' => 'd2.1'
+                'id' => 'd2.1',
             ]
         );
         $this->assertEquals($expected2, $result);
@@ -2040,13 +2040,13 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeStorageRetrievalRequest(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'id' => 'd1.1'
+                'id' => 'd1.1',
             ]
         );
         $this->assertEquals(
             [
                 'success' => false,
-                'sysMessage' => 'ILSMessages::storage_wrong_user_institution'
+                'sysMessage' => 'ILSMessages::storage_wrong_user_institution',
             ],
             $result
         );
@@ -2056,7 +2056,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeStorageRetrievalRequest(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'id' => 'invalid.1'
+                'id' => 'invalid.1',
             ]
         );
     }
@@ -2071,12 +2071,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $expected = [
             '1' => [
                 'success' => true,
-                'status' => 'storage_retrieval_request_cancel_success'
+                'status' => 'storage_retrieval_request_cancel_success',
             ],
             '2' => [
                 'success' => false,
-                'status' => 'storage_retrieval_request_cancel_fail'
-            ]
+                'status' => 'storage_retrieval_request_cancel_fail',
+            ],
 
         ];
         $driver = $this->initSimpleMethodTest(
@@ -2086,8 +2086,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 [
                     'patron' => $this->getPatron('username'),
-                    'details' => ['1', '2']
-                ]
+                    'details' => ['1', '2'],
+                ],
             ],
             $expected,
             $expected
@@ -2096,7 +2096,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelStorageRetrievalRequests(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -2104,7 +2104,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelStorageRetrievalRequests(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -2114,7 +2114,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelStorageRetrievalRequests(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
     }
@@ -2175,7 +2175,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 $this->logicalOr(
                     $this->getPatron('username', 'd1'),
                     $this->getPatron('username', 'd2')
-                )
+                ),
             ],
             true,
             false
@@ -2231,7 +2231,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 $this->logicalOr(
                     $this->getPatron('username', 'd1'),
                     $this->getPatron('username', 'd2')
-                )
+                ),
             ],
             $expected1,
             $expected2
@@ -2276,7 +2276,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 $this->logicalOr(
                     $this->getPatron('username', 'd1'),
                     $this->getPatron('username', 'd2')
-                )
+                ),
             ],
             $expected1,
             $expected2
@@ -2314,11 +2314,11 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
     {
         $expected1 = [
             'success' => true,
-            'status' => ''
+            'status' => '',
         ];
         $expected2 = [
             'success' => false,
-            'status' => 'ill_request_error_fail'
+            'status' => 'ill_request_error_fail',
         ];
         $driver = $this->initSimpleMethodTest(
             $this->once(),
@@ -2328,13 +2328,13 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 $this->logicalOr(
                     [
                         'patron' => $this->getPatron('username', 'd1'),
-                        'id' => 1
+                        'id' => 1,
                     ],
                     [
                         'patron' => $this->getPatron('username', 'd2'),
-                        'id' => 1
+                        'id' => 1,
                     ]
-                )
+                ),
             ],
             $expected1,
             $expected2
@@ -2343,7 +2343,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeILLRequest(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'id' => 'd1.1'
+                'id' => 'd1.1',
             ]
         );
         $this->assertEquals($expected1, $result);
@@ -2351,7 +2351,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeILLRequest(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'id' => 'd2.1'
+                'id' => 'd2.1',
             ]
         );
         $this->assertEquals($expected2, $result);
@@ -2361,7 +2361,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->placeILLRequest(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'id' => 'invalid.1'
+                'id' => 'invalid.1',
             ]
         );
     }
@@ -2411,12 +2411,12 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $expected = [
             '1' => [
                 'success' => true,
-                'status' => 'ill_request_cancel_success'
+                'status' => 'ill_request_cancel_success',
             ],
             '2' => [
                 'success' => false,
-                'status' => 'storage_retrieval_request_cancel_fail'
-            ]
+                'status' => 'storage_retrieval_request_cancel_fail',
+            ],
 
         ];
         $driver = $this->initSimpleMethodTest(
@@ -2426,8 +2426,8 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 [
                     'patron' => $this->getPatron('username'),
-                    'details' => ['1', '2']
-                ]
+                    'details' => ['1', '2'],
+                ],
             ],
             $expected,
             $expected
@@ -2436,7 +2436,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelILLRequests(
             [
                 'patron' => $this->getPatron('username', 'd1'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -2444,7 +2444,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelILLRequests(
             [
                 'patron' => $this->getPatron('username', 'd2'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
         $this->assertEquals($expected, $result);
@@ -2454,7 +2454,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
         $result = $driver->cancelILLRequests(
             [
                 'patron' => $this->getPatron('username', 'invalid'),
-                'details' => ['1', '2']
+                'details' => ['1', '2'],
             ]
         );
     }
@@ -2515,9 +2515,9 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                     ['Holds', ['id' => '123456']],
                     [
                         'Holds',
-                        ['patron' => $this->getPatron('123456')]
+                        ['patron' => $this->getPatron('123456')],
                     ]
-                )
+                ),
             ],
             $expected1,
             $expected2
@@ -2661,7 +2661,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             [
                 'd1' => $voyager,
                 'd2' => $voyager2,
-                'd3' => $dummyILS
+                'd3' => $dummyILS,
             ],
             $this->any()
         );
@@ -2686,7 +2686,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                 'Drivers' => [],
                 'Login' => [
                     'drivers' => ['d1', 'd2'],
-                    'default_driver' => 'd1'
+                    'default_driver' => 'd1',
                 ],
             ]
         );
@@ -2800,7 +2800,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
             'cat_password' => 'password',
             'email' => '',
             'major' => '',
-            'college' => ''
+            'college' => '',
         ];
     }
 
@@ -2842,7 +2842,7 @@ class MultiBackendTest extends \PHPUnit\Framework\TestCase
                     $this->createMock(\VuFindSearch\Service::class),
                     function () use ($session) {
                         return $session;
-                    }
+                    },
                 ]
             )->getMock();
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/NoILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/NoILSTest.php
@@ -67,7 +67,7 @@ class NoILSTest extends \PHPUnit\Framework\TestCase
             ->setConstructorArgs(
                 [
                     $this->createMock(\VuFindSearch\Service::class),
-                    $this->createMock(\VuFind\RecordDriver\PluginManager::class)
+                    $this->createMock(\VuFind\RecordDriver\PluginManager::class),
                 ]
             )->getMock();
         $this->driver = new NoILS($this->loader);
@@ -123,7 +123,7 @@ class NoILSTest extends \PHPUnit\Framework\TestCase
                     'reserve' => 'N',
                     'callnumber' => 'xyzzy',
                     'barcode' => null,
-                ]
+                ],
             ]
         );
         $this->assertTrue($this->driver->hasHoldings('foo'));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/PAIATest.php
@@ -57,7 +57,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
             [
                 'baseUrl'            => 'http://paia.gbv.de/',
                 'grantType'          => 'password',
-            ]
+            ],
     ];
 
     protected $patron = [
@@ -72,10 +72,10 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         'status' => 0,
         'address' => 'No street at all 8, D-21073 Hamburg',
         'type' => [
-            0 => 'de-830:user-type:2'
+            0 => 'de-830:user-type:2',
         ],
         'cat_username' => '08301001001',
-        'cat_password' => 'NOPASSWORD'
+        'cat_password' => 'NOPASSWORD',
     ];
 
     protected $patron_bad = [
@@ -90,10 +90,10 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         'status' => 9,
         'address' => 'No street at all 8, D-21073 Hamburg',
         'type' => [
-            0 => 'de-830:user-type:2'
+            0 => 'de-830:user-type:2',
         ],
         'cat_username' => '08301001011',
-        'cat_password' => 'NOPASSWORD'
+        'cat_password' => 'NOPASSWORD',
     ];
 
     protected $patron_expired = [
@@ -108,10 +108,10 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         'status' => 0,
         'address' => 'No street at all 8, D-21073 Hamburg',
         'type' => [
-            0 => 'de-830:user-type:2'
+            0 => 'de-830:user-type:2',
         ],
         'cat_username' => '08301001111',
-        'cat_password' => 'NOPASSWORD'
+        'cat_password' => 'NOPASSWORD',
     ];
 
     protected $feeTestResult = [
@@ -133,7 +133,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                     . '[open source licensees are free to: use open source software for any purpose, make and'
                     . ' distribute copies, create and distribute derivative works, access and use the source code, '
                     . 'com / Rosen, Lawrence (c 2005)',
-                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$28295402'
+                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$28295402',
             ],
         1 =>
             [
@@ -147,7 +147,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'title' => 'Test framework in action / Allen, Rob (2009)',
                 'feeid' => null,
                 'about' => 'Test framework in action / Allen, Rob (2009)',
-                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$28323471'
+                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$28323471',
             ],
         2 =>
             [
@@ -161,7 +161,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'title' => 'Unsere historischen Gärten / Lutze, Margot (1986)',
                 'feeid' => null,
                 'about' => 'Unsere historischen Gärten / Lutze, Margot (1986)',
-                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$24476416'
+                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$24476416',
             ],
         3 =>
             [
@@ -175,7 +175,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'title' => 'Triumphe des Backsteins = Triumphs of brick / (1992)',
                 'feeid' => null,
                 'about' => 'Triumphe des Backsteins = Triumphs of brick / (1992)',
-                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$33204941'
+                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$33204941',
             ],
         4 =>
             [
@@ -189,7 +189,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'title' => 'Lehrbuch der Botanik / Strasburger, Eduard (2008)',
                 'feeid' => null,
                 'about' => 'Lehrbuch der Botanik / Strasburger, Eduard (2008)',
-                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$26461872'
+                'item' => 'http://uri.gbv.de/document/opac-de-830:bar:830$26461872',
             ],
     ];
 
@@ -291,7 +291,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'available' => false,
                 'create' => '12-22-2011',
                 'cancel_details' => '',
-            ]
+            ],
     ];
 
     protected $renewTestResult = [
@@ -301,19 +301,19 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                 'success' => true,
                 'new_date' => "07-18-2016",
                 'item_id' => 0,
-                'sysMessage' => "Successfully renewed"
-            ]
-        ]
+                'sysMessage' => "Successfully renewed",
+            ],
+        ],
     ];
 
     protected $storageRetrievalTestResult = [
         'success' => true,
-        'sysMessage' => 'Successfully requested'
+        'sysMessage' => 'Successfully requested',
     ];
 
     protected $pwchangeTestResult = [
         'success' => true,
-        'status' => "Successfully changed"
+        'status' => "Successfully changed",
     ];
 
     protected $profileTestResult = [
@@ -329,7 +329,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         'mobile_phone' => null,
         'expires' => "12-31-9999",
         'statuscode' => 0,
-        'canWrite' => true
+        'canWrite' => true,
     ];
 
     /*******************
@@ -369,10 +369,10 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
     {
         $changePasswordTestdata = [
             "patron" => [
-                "cat_username" => "08301001001"
+                "cat_username" => "08301001001",
              ],
              "oldPassword" => "oldsecret",
-             "newPassword" => "newsecret"
+             "newPassword" => "newsecret",
         ];
 
         $conn = $this->createMockConnector('changePassword.json');
@@ -516,8 +516,8 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         $sr_request = [
             "item_id"     => "http://uri.gbv.de/document/opac-de-830:bar:830$24014292",
             "patron" => [
-                "cat_username" => "08301001001"
-            ]
+                "cat_username" => "08301001001",
+            ],
         ];
 
         $conn = $this->createMockConnector('storageretrieval.json');
@@ -535,8 +535,8 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
         $sr_request = [
             "item_id"     => "http://uri.gbv.de/document/opac-de-830:bar:830$24014292",
             "patron" => [
-                "cat_username" => "08301001001"
-            ]
+                "cat_username" => "08301001001",
+            ],
         ];
 
         $conn = $this->createMockConnector('storageretrieval.json');
@@ -553,11 +553,11 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
     {
         $renew_request = [
             "details" => [
-                "item"     => "http://uri.gbv.de/document/opac-de-830:bar:830$22061137"
+                "item"     => "http://uri.gbv.de/document/opac-de-830:bar:830$22061137",
             ],
             "patron" => [
-                "cat_username" => "08301001001"
-            ]
+                "cat_username" => "08301001001",
+            ],
         ];
 
         $conn = $this->createMockConnector('renew_ok.json');
@@ -644,7 +644,7 @@ class PAIATest extends \VuFindTest\Unit\ILSDriverTestCase
                     'change_password',
                     'read_fees',
                     'read_items',
-                    'read_patron'
+                    'read_patron',
                     ]
                 )
             );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
@@ -304,7 +304,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                 'firstname' => '', 'lastname' => 'John Smith Jr.',
                 'address1' => 'Trvalá ulice 123', 'address2' => '12345 Big City',
                 'zip' => '', 'phone' => '', 'group' => '',
-                'expiration_date' => '12-30-2099'
+                'expiration_date' => '12-30-2099',
             ],
         ],
     ];
@@ -493,17 +493,17 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             ],
         ], [
             'file' => 'RequestItemResponseDenied.xml', 'result' => [
-                'success' => false, 'sysMessage' => 'Temporary Processing Failure'
+                'success' => false, 'sysMessage' => 'Temporary Processing Failure',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
             'result' => [
-                'success' => false, 'sysMessage' => 'Temporary Processing Failure'
+                'success' => false, 'sysMessage' => 'Temporary Processing Failure',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
             'result' => [
-                'success' => false, 'sysMessage' => 'User Blocked'
+                'success' => false, 'sysMessage' => 'User Blocked',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedEmpty.xml', 'result' => [
@@ -531,19 +531,19 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         ], [
             'file' => 'RequestItemResponseDenied.xml', 'result' => [
                 'success' => false,
-                'sysMessage' => 'Temporary Processing Failure'
+                'sysMessage' => 'Temporary Processing Failure',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedWithIdentifiers.xml',
             'result' => [
                 'success' => false,
-                'sysMessage' => 'Temporary Processing Failure'
+                'sysMessage' => 'Temporary Processing Failure',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedNotFullProblemElement.xml',
             'result' => [
                 'success' => false,
-                'sysMessage' => 'User Blocked'
+                'sysMessage' => 'User Blocked',
             ],
         ], [
             'file' => 'RequestItemResponseDeniedEmpty.xml', 'result' => [
@@ -637,7 +637,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                 'blocks' => false, 'details' => [
                     'Item1' => [
                         'success' => true, 'new_date' => '09-08-2020',
-                        'new_time' => '20:00', 'item_id' => 'Item1'
+                        'new_time' => '20:00', 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -647,7 +647,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                 'blocks' => false, 'details' => [
                     'Item1' => [
                         'success' => true, 'new_date' => '08-31-2020',
-                        'new_time' => '17:59', 'item_id' => 'Item1'
+                        'new_time' => '17:59', 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -655,7 +655,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'file' => 'RenewItemResponseDenied.xml', 'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -663,7 +663,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'file' => 'RenewItemResponseDeniedInvalidMessage.xml', 'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -681,7 +681,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -690,7 +690,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -698,7 +698,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'file' => 'RenewItemResponseDenied.xml', 'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -706,7 +706,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             'file' => 'RenewItemResponseDeniedInvalidMessage.xml', 'result' => [
                 'blocks' => false, 'details' => [
                     'Item1' => [
-                        'success' => false, 'item_id' => 'Item1'
+                        'success' => false, 'item_id' => 'Item1',
                     ],
                 ],
             ],
@@ -1007,7 +1007,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                 'locationDisplay' => 'Main Circulation Desk',
             ], [
                 'locationID' => 'My University|2', 'locationDisplay' => 'Stacks',
-            ]
+            ],
             ],
             $locations
         );
@@ -1030,7 +1030,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                 ],
                 [
                     'locationID' => 'My library|2', 'locationDisplay' => 'Stacks',
-                ]
+                ],
             ],
             $locations
         );
@@ -1125,7 +1125,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
-                        'patronAgencyId' => 'Test agency', 'id' => '123'
+                        'patronAgencyId' => 'Test agency', 'id' => '123',
                     ], 'details' => [
                         'My University|Request1|Item1',
                     ],
@@ -1154,7 +1154,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                     'patron' => [
                         'cat_username' => 'my_login',
                         'cat_password' => 'my_password',
-                        'patronAgencyId' => 'Test agency', 'id' => '123'
+                        'patronAgencyId' => 'Test agency', 'id' => '123',
                     ], 'details' => [
                         'My University|Request1|Item1',
                     ],
@@ -1221,13 +1221,13 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             ], '3' => [
                 'method' => 'getCancelRequest', 'params' => [
                     '', '', 'patron agency', 'item agency', 'rq1', 'Hold', 'item1',
-                    '12345'
-                ], 'result' => 'CancelRequestItemRequest.xml'
+                    '12345',
+                ], 'result' => 'CancelRequestItemRequest.xml',
             ], '4' => [
                 'method' => 'getCancelRequest', 'params' => [
                     'username', 'password', 'patron agency', 'item agency', 'rq1',
-                    'Hold', 'item1', '12345'
-                ], 'result' => 'CancelRequestItemRequestAuthInput.xml'
+                    'Hold', 'item1', '12345',
+                ], 'result' => 'CancelRequestItemRequestAuthInput.xml',
             ], '4.1' => [
                 'method' => 'getCancelRequest', 'config' => [
                     'Catalog' => [
@@ -1238,12 +1238,12 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                     ], 'NCIP' => [],
                 ], 'params' => [
                     'username', 'password', 'patron agency', '', 'rq1', 'Hold',
-                    'item1', '12345'
-                ], 'result' => 'CancelRequestDefaultItemAgencyRequest.xml'
+                    'item1', '12345',
+                ], 'result' => 'CancelRequestDefaultItemAgencyRequest.xml',
             ], '5' => [
                 'method' => 'getRenewRequest', 'params' => [
-                    'username', 'password', 'item1', 'item agency', 'patron agency'
-                ], 'result' => 'RenewItemRequest.xml'
+                    'username', 'password', 'item1', 'item agency', 'patron agency',
+                ], 'result' => 'RenewItemRequest.xml',
             ], '5.1' => [
                 'method' => 'getRenewRequest', 'config' => [
                     'Catalog' => [
@@ -1254,12 +1254,12 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                     ], 'NCIP' => [],
                 ],
                 'params' => ['username', 'password', 'item1', '', 'patron agency'],
-                'result' => 'RenewItemDefaultAgencyRequest.xml'
+                'result' => 'RenewItemDefaultAgencyRequest.xml',
             ], '5.2' => [
                 'method' => 'getRenewRequest', 'params' => [
                     'username', 'password', 'item1', 'item agency', 'patron agency',
-                    'username'
-                ], 'result' => 'RenewItemWithUserIdRequest.xml'
+                    'username',
+                ], 'result' => 'RenewItemWithUserIdRequest.xml',
             ], '6' => [
                 'method' => 'getRequest', 'config' => [
                     'Catalog' => [
@@ -1270,16 +1270,16 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                     ], 'NCIP' => [],
                 ], 'params' => [
                     'username', '', 'bib1', 'item1', 'patron agency', 'item agency',
-                    'Hold', 'Item', '2020-12-20T00:00:00.000Z', null, 'patron1'
-                ], 'result' => 'RequestItemRequest.xml'
+                    'Hold', 'Item', '2020-12-20T00:00:00.000Z', null, 'patron1',
+                ], 'result' => 'RequestItemRequest.xml',
             ], '7' => [
                 'method' => 'getLookupUserRequest', 'params' => [
                     null, 'password', 'patron agency',
-                    ['<ns1:LoanedItemsDesired />'], 'patron1'
-                ], 'result' => 'LookupUserRequest.xml'
+                    ['<ns1:LoanedItemsDesired />'], 'patron1',
+                ], 'result' => 'LookupUserRequest.xml',
             ], '8' => [
                 'method' => 'getLookupAgencyRequest', 'params' => [null],
-                'result' => 'LookupAgencyRequest.xml'
+                'result' => 'LookupAgencyRequest.xml',
             ], '9' => [
                 'method' => 'getLookupItemRequest', 'config' => [
                     'Catalog' => [
@@ -1289,7 +1289,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
                         'fromAgency' => 'My portal',
                     ], 'NCIP' => [],
                 ], 'params' => ['item1', 'Accession Number'],
-                'result' => 'LookupItemRequest.xml'
+                'result' => 'LookupItemRequest.xml',
             ],
         ];
 
@@ -1337,7 +1337,7 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
             $this->driver,
             [
                 'username', 'password', 'patron agency', 'item agency', '', 'Hold', null,
-                '12345'
+                '12345',
             ]
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/PaginationHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/PaginationHelperTest.php
@@ -56,9 +56,9 @@ class PaginationHelperTest extends \PHPUnit\Framework\TestCase
             'sort' => [
                 '-due_date' => 'sort_due_date_desc',
                 '+due_date' => 'sort_due_date_asc',
-                '+title' => 'sort_title'
+                '+title' => 'sort_title',
             ],
-            'default_sort' => '+due_date'
+            'default_sort' => '+due_date',
         ];
 
         // Typical first page
@@ -74,18 +74,18 @@ class PaginationHelperTest extends \PHPUnit\Framework\TestCase
                 '-due_date' => [
                     'desc' => 'sort_due_date_desc',
                     'url' => '?sort=' . urlencode('-due_date'),
-                    'selected' => false
+                    'selected' => false,
                 ],
                 '+due_date' => [
                     'desc' => 'sort_due_date_asc',
                     'url' => '?sort=' . urlencode('+due_date'),
-                    'selected' => true
+                    'selected' => true,
                 ],
                 '+title' => [
                     'desc' => 'sort_title',
                     'url' => '?sort=' . urlencode('+title'),
-                    'selected' => false
-                ]
+                    'selected' => false,
+                ],
             ],
             $result['sortList']
         );
@@ -103,18 +103,18 @@ class PaginationHelperTest extends \PHPUnit\Framework\TestCase
                 '-due_date' => [
                     'desc' => 'sort_due_date_desc',
                     'url' => '?sort=' . urlencode('-due_date'),
-                    'selected' => false
+                    'selected' => false,
                 ],
                 '+due_date' => [
                     'desc' => 'sort_due_date_asc',
                     'url' => '?sort=' . urlencode('+due_date'),
-                    'selected' => false
+                    'selected' => false,
                 ],
                 '+title' => [
                     'desc' => 'sort_title',
                     'url' => '?sort=' . urlencode('+title'),
-                    'selected' => true
-                ]
+                    'selected' => true,
+                ],
             ],
             $result['sortList']
         );
@@ -132,18 +132,18 @@ class PaginationHelperTest extends \PHPUnit\Framework\TestCase
                 '-due_date' => [
                     'desc' => 'sort_due_date_desc',
                     'url' => '?sort=' . urlencode('-due_date'),
-                    'selected' => false
+                    'selected' => false,
                 ],
                 '+due_date' => [
                     'desc' => 'sort_due_date_asc',
                     'url' => '?sort=' . urlencode('+due_date'),
-                    'selected' => true
+                    'selected' => true,
                 ],
                 '+title' => [
                     'desc' => 'sort_title',
                     'url' => '?sort=' . urlencode('+title'),
-                    'selected' => false
-                ]
+                    'selected' => false,
+                ],
             ],
             $result['sortList']
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Log/LoggerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Log/LoggerTest.php
@@ -106,7 +106,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
                     'REMOTE_ADDR' => '5.6.7.8',
                     'HTTP_USER_AGENT' => 'Fake browser',
                     'HTTP_HOST' => 'localhost:80',
-                    'REQUEST_URI' => '/foo/bar'
+                    'REQUEST_URI' => '/foo/bar',
                 ]
             );
             $logger->logException($e, $fakeServer);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -63,7 +63,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
                 'name' => 'foo',
                 'username' => 'vufinduser',
                 'password' => 'vufindpass',
-            ]
+            ],
         ];
         $cm = $this->getMockConfigPluginManager(compact('config'));
         $sm = new MockContainer($this);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Net/UserIpReaderFactoryTest.php
@@ -128,7 +128,7 @@ class UserIpReaderFactoryTest extends \PHPUnit\Framework\TestCase
                 'Proxy' => [
                     'allow_forwarded_ips' => true,
                     'forwarded_ip_filter' => '1.2.3.4',
-                ]
+                ],
             ]
         );
         $reader = $factory($container, $this->getReaderClass());
@@ -151,7 +151,7 @@ class UserIpReaderFactoryTest extends \PHPUnit\Framework\TestCase
                 'Proxy' => [
                     'allow_forwarded_ips' => true,
                     'forwarded_ip_filter' => ['1.2.3.4', '5.6.7.8'],
-                ]
+                ],
             ]
         );
         $reader = $factory($container, $this->getReaderClass());

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AccessTokenRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AccessTokenRepositoryTest.php
@@ -70,8 +70,8 @@ class AccessTokenRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_access_token',
                     'revoked' => false,
                     'data' => json_encode($token),
-                    'user_id' => '1'
-                ]
+                    'user_id' => '1',
+                ],
             ],
             $this->accessTokenTable
         );
@@ -85,8 +85,8 @@ class AccessTokenRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_access_token',
                     'revoked' => true,
                     'data' => json_encode($token),
-                    'user_id' => '1'
-                ]
+                    'user_id' => '1',
+                ],
             ],
             $this->accessTokenTable
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AuthCodeRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AuthCodeRepositoryTest.php
@@ -64,8 +64,8 @@ class AuthCodeRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_auth_code',
                     'revoked' => false,
                     'data' => json_encode($token),
-                    'user_id' => null
-                ]
+                    'user_id' => null,
+                ],
             ],
             $this->accessTokenTable
         );
@@ -79,8 +79,8 @@ class AuthCodeRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_auth_code',
                     'revoked' => true,
                     'data' => json_encode($token),
-                    'user_id' => null
-                ]
+                    'user_id' => null,
+                ],
             ],
             $this->accessTokenTable
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ClientRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ClientRepositoryTest.php
@@ -62,7 +62,7 @@ class ClientRepositoryTest extends \PHPUnit\Framework\TestCase
                     'redirectUri' => 'http://localhost/secure',
                     'isConfidential' => true,
                 ],
-            ]
+            ],
         ];
         $repo = new ClientRepository($config);
         $this->assertFalse(
@@ -137,7 +137,7 @@ class ClientRepositoryTest extends \PHPUnit\Framework\TestCase
                 'openid_test' => [
                     'name' => 'OpenID Tester',
                 ],
-            ]
+            ],
         ];
         $repo = new ClientRepository($config);
         $this->expectExceptionMessage("OAuth2 client config missing 'redirectUri'");
@@ -156,9 +156,9 @@ class ClientRepositoryTest extends \PHPUnit\Framework\TestCase
                 'openid_test' => [
                     'name' => 'OpenID Tester',
                     'redirectUri' => 'http://localhost/callback',
-                    'secret' => 'this should not be specified'
+                    'secret' => 'this should not be specified',
                 ],
-            ]
+            ],
         ];
         $repo = new ClientRepository($config);
         $this->expectExceptionMessage(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
@@ -225,7 +225,7 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
             ->willReturnMap(
                 [
                     [1, null],
-                    [2, $user]
+                    [2, $user],
                 ]
             );
         return $userTable;
@@ -248,7 +248,7 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
             'cat_password' => 'pass',
             'email'        => 'Lib.Rarian@library.not',
             'major'        => null,
-            'college'      => null
+            'college'      => null,
         ];
 
         $profile = [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/RefreshTokenRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/RefreshTokenRepositoryTest.php
@@ -75,8 +75,8 @@ class RefreshTokenRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_refresh_token',
                     'revoked' => false,
                     'data' => json_encode($token),
-                    'user_id' => '2'
-                ]
+                    'user_id' => '2',
+                ],
             ],
             $this->accessTokenTable
         );
@@ -90,8 +90,8 @@ class RefreshTokenRepositoryTest extends AbstractTokenRepositoryTest
                     'type' => 'oauth2_refresh_token',
                     'revoked' => true,
                     'data' => json_encode($token),
-                    'user_id' => '2'
-                ]
+                    'user_id' => '2',
+                ],
             ],
             $this->accessTokenTable
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
@@ -86,7 +86,7 @@ class ScopeRepositoryTest extends AbstractTokenRepositoryTest
                     'description' => 'Phone',
                     'ils' => true,
                 ],
-            ]
+            ],
         ];
         $repo = new ScopeRepository($config);
 
@@ -114,7 +114,7 @@ class ScopeRepositoryTest extends AbstractTokenRepositoryTest
                 'openid' => [
                     'description' => 'OpenID',
                 ],
-            ]
+            ],
         ];
         $repo = new ScopeRepository($config);
 
@@ -131,7 +131,7 @@ class ScopeRepositoryTest extends AbstractTokenRepositoryTest
         $config = [
             'Scopes' => [
                 'openid' => [],
-            ]
+            ],
         ];
         $repo = new ScopeRepository($config);
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ExpandFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ExpandFacetsTest.php
@@ -68,7 +68,7 @@ class ExpandFacetsTest extends \PHPUnit\Framework\TestCase
                 'Results' => [
                     'format' => 'Format',
                 ],
-            ]
+            ],
         ];
         $results = $this->getMockResults();
         $params = $results->getParams();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/MapSelectionTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/MapSelectionTest.php
@@ -71,7 +71,7 @@ class MapSelectionTest extends \PHPUnit\Framework\TestCase
         ];
         $defaultMapSelectionOptions = [
             'default_coordinates' => '-95, 30, 72, 15',
-            'height' => '320'
+            'height' => '320',
         ];
         return new MapSelection(
             $ss ?? $this->getMockSearchService(),
@@ -125,7 +125,7 @@ class MapSelectionTest extends \PHPUnit\Framework\TestCase
                 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',
                 '<a href="https://wikimediafoundation.org/'
                 . 'wiki/Maps_Terms_of_Use">Wikimedia</a> | &copy; <a '
-                . 'href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                . 'href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             ],
             $this->getMapSelection()->getBasemap()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SideFacetsTest.php
@@ -71,9 +71,9 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                 'facets' => [
                     'SpecialFacets' => [
                         'hierarchical' => ['format'],
-                        'hierarchicalFacetSortOptions' => ['a', 'b', 'c']
-                    ]
-                ]
+                        'hierarchicalFacetSortOptions' => ['a', 'b', 'c'],
+                    ],
+                ],
             ],
             [],
             $this->once()
@@ -102,9 +102,9 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                         'format' => 'Format',
                     ],
                     'SpecialFacets' => [
-                        'hierarchical' => ['format']
-                    ]
-                ]
+                        'hierarchical' => ['format'],
+                    ],
+                ],
             ],
             [],
             $this->once()
@@ -136,8 +136,8 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                     ],
                     'Checkboxes' => [
                         'description' => 'filter',
-                    ]
-                ]
+                    ],
+                ],
             ],
             [],
             $this->once()
@@ -177,7 +177,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                     'Results_Settings' => [
                         'orFacets' => '*',  // test or facet support
                     ],
-                ]
+                ],
             ],
             [],
             $this->once()
@@ -205,7 +205,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                     'Results_Settings' => [
                         'exclude' => '*',  // test or facet support
                     ],
-                ]
+                ],
             ],
             [],
             $this->once()
@@ -229,8 +229,8 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                         'fullDateRange' => ['fullDate'],
                         'genericRange' => ['generic'],
                         'numericRange' => ['numeric'],
-                    ]
-                ]
+                    ],
+                ],
             ],
             [],
             $this->once()
@@ -248,7 +248,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'date' => ['type' => 'date', 'values' => ['1900', '1905']],
             'fullDate' => [
-                'type' => 'fulldate', 'values' => ['1900-01-01', '1905-12-31']
+                'type' => 'fulldate', 'values' => ['1900-01-01', '1905-12-31'],
             ],
             'generic' => ['type' => 'generic', 'values' => ['A', 'Z']],
             'numeric' => ['type' => 'numeric', 'values' => ['1', '9']],
@@ -277,7 +277,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
             [
                 'facets' => [
                     'Results_Settings' => ['collapsedFacets' => '   foo, bar,baz   '],
-                ]
+                ],
             ],
             [],
             $this->once()
@@ -300,7 +300,7 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
                         'format' => 'Format',
                     ],
                     'Results_Settings' => ['collapsedFacets' => '*'],
-                ]
+                ],
             ],
             [],
             $this->once()
@@ -338,8 +338,8 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
         $configLoader = $this->getMockConfigPluginManager(
             [
                 'facets' => [
-                    'Checkboxes' => ['foo' => 'bar']
-                ]
+                    'Checkboxes' => ['foo' => 'bar'],
+                ],
             ],
             [],
             $this->once()
@@ -366,8 +366,8 @@ class SideFacetsTest extends \PHPUnit\Framework\TestCase
         $configLoader = $this->getMockConfigPluginManager(
             [
                 'facets' => [
-                    'Checkboxes' => ['foo' => 'bar']
-                ]
+                    'Checkboxes' => ['foo' => 'bar'],
+                ],
             ],
             [],
             $this->once()

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchQueryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchQueryTest.php
@@ -147,7 +147,7 @@ class SwitchQueryTest extends \PHPUnit\Framework\TestCase
         $sq = $this->getSwitchQuery($results);
         $this->assertEquals(
             [
-                'switchquery_unwantedquotes' => 'my phrase'
+                'switchquery_unwantedquotes' => 'my phrase',
             ],
             $sq->getSuggestions()
         );
@@ -164,7 +164,7 @@ class SwitchQueryTest extends \PHPUnit\Framework\TestCase
         $sq = $this->getSwitchQuery($results, ':wildcard:truncatechar');
         $this->assertEquals(
             [
-                'switchquery_truncatechar' => 'abc'
+                'switchquery_truncatechar' => 'abc',
             ],
             $sq->getSuggestions()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTabTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTabTest.php
@@ -58,7 +58,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label01",
                         "permission" => "permission01",
                         "selected" => true,
-                        "url" => "http://newurl1"
+                        "url" => "http://newurl1",
                     ],
                     [
                         "id" => "A02",
@@ -66,7 +66,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label02",
                         "permission" => "permission02",
                         "selected" => false,
-                        "url" => "http://newurl2"
+                        "url" => "http://newurl2",
                     ],
                 ],
                 [
@@ -75,8 +75,8 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                     "label" => "label01",
                     "permission" => "permission01",
                     "selected" => true,
-                    "url" => "http://newurl1"
-                ]
+                    "url" => "http://newurl1",
+                ],
             ],
             'No tab selected' => [
                 [
@@ -86,7 +86,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label01",
                         "permission" => "permission01",
                         "selected" => false,
-                        "url" => "http://newurl1"
+                        "url" => "http://newurl1",
                     ],
                     [
                         "id" => "A02",
@@ -94,10 +94,10 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label02",
                         "permission" => "permission02",
                         "selected" => false,
-                        "url" => "http://newurl2"
+                        "url" => "http://newurl2",
                     ],
                 ],
-                null
+                null,
             ],
         ];
     }
@@ -134,7 +134,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label01",
                         "permission" => "permission01",
                         "selected" => true,
-                        "url" => "http://newurl1"
+                        "url" => "http://newurl1",
                     ],
                     [
                         "id" => "A02",
@@ -142,7 +142,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label02",
                         "permission" => "permission02",
                         "selected" => false,
-                        "url" => "http://newurl2"
+                        "url" => "http://newurl2",
                     ],
                 ],
                 [
@@ -152,9 +152,9 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
                         "label" => "label02",
                         "permission" => "permission02",
                         "selected" => false,
-                        "url" => "http://newurl2"
-                    ]
-                ]
+                        "url" => "http://newurl2",
+                    ],
+                ],
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/CacheTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/CacheTest.php
@@ -60,19 +60,19 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                 'record_id' => '020645147',
                 'source' => 'Solr',
                 'version' => '2.5',
-                'data' => 's:17:"dummy_solr_record";'
+                'data' => 's:17:"dummy_solr_record";',
             ],
             [
                 'record_id' => '70764764',
                 'source' => 'WorldCat',
                 'version' => '2.5',
-                'data' => 's:21:"dummy_worldcat_record";'
+                'data' => 's:21:"dummy_worldcat_record";',
             ],
             [
                 'record_id' => '00033321',
                 'source' => 'Solr',
                 'version' => '2.5',
-                'data' => 's:19:"dummy_solr_record_2";'
+                'data' => 's:19:"dummy_solr_record_2";',
             ],
         ];
     }
@@ -215,10 +215,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                 'WorldCat' => ['operatingMode' => 'fallback'],
             ],
             'Disabled' => [
-                'Solr' => []
+                'Solr' => [],
             ],
             'Fallback' => [
-                'Solr' => ['operatingMode' => 'fallback']
+                'Solr' => ['operatingMode' => 'fallback'],
             ],
         ];
 
@@ -271,7 +271,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                 'record_id' => $recordId,
                 'source' => $source,
                 'version' => '2.5',
-                'data' => serialize($rawData)
+                'data' => serialize($rawData),
             ];
         };
         $recordTable->method('updateRecord')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/LoaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/LoaderTest.php
@@ -241,7 +241,7 @@ class LoaderTest extends \PHPUnit\Framework\TestCase
         $loader = $this->getLoader($service, $factory);
         $input = [
             ['source' => 'Solr', 'id' => 'test1'],
-            'Solr|test2', 'Summon|test3', 'WorldCat|test4'
+            'Solr|test2', 'Summon|test3', 'WorldCat|test4',
         ];
         $this->assertEquals(
             [$driver1, $driver2, $driver3, $missing],
@@ -293,7 +293,7 @@ class LoaderTest extends \PHPUnit\Framework\TestCase
         $loader = $this->getLoader($service, null, null, $fallbackLoader);
         $input = [
             ['source' => 'Solr', 'id' => 'test1'],
-            'Solr|test2', 'Summon|test3'
+            'Solr|test2', 'Summon|test3',
         ];
         $this->assertEquals(
             [$driver1, $driver2, $driver3],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
@@ -58,8 +58,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test'],
                 'route' => 'record',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getRouteDetails($driver)
         );
@@ -78,8 +78,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test'],
                 'route' => 'summonrecord',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getRouteDetails('Summon|test')
         );
@@ -98,8 +98,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test', 'tab' => 'foo'],
                 'route' => 'summonrecord',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getTabRouteDetails('Summon|test', 'foo')
         );
@@ -119,8 +119,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'route' => 'record',
                 'options' => [
                     'normalize_path' => false,
-                    'query' => ['checkRoute' => 1]
-                ]
+                    'query' => ['checkRoute' => 1],
+                ],
             ],
             $router->getTabRouteDetails('Solr|test', 'foo')
         );
@@ -139,8 +139,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test%2Fsub'],
                 'route' => 'record',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getRouteDetails('Solr|test%2Fsub')
         );
@@ -160,8 +160,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'route' => 'record',
                 'options' => [
                     'normalize_path' => false,
-                    'query' => ['checkRoute' => 1]
-                ]
+                    'query' => ['checkRoute' => 1],
+                ],
             ],
             $router->getTabRouteDetails('test', 'foo')
         );
@@ -185,8 +185,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test', 'tab' => 'foo'],
                 'route' => 'collection',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getTabRouteDetails($driver, 'foo')
         );
@@ -205,8 +205,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test'],
                 'route' => 'record',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getRouteDetails('test')
         );
@@ -226,8 +226,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
                 'params' => ['id' => 'test'],
                 'route' => 'record-sms',
                 'options' => [
-                    'normalize_path' => false
-                ]
+                    'normalize_path' => false,
+                ],
             ],
             $router->getActionRouteDetails($driver, 'SMS')
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -313,8 +313,8 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
             "rft.isbn" => "8820737493",
             "rft_id" => [
                 "info:doi/xxx",
-                "pmid:yyy"
-            ]
+                "pmid:yyy",
+            ],
         ];
 
         $fixture = $this->getJsonFixture('misc/testbug2.json');

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -54,7 +54,7 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     public function testGetUniqueID(): void
     {
         $overrides = [
-            'Header' => ['DbId' => 'TDB123', 'An' => 'TAn456']
+            'Header' => ['DbId' => 'TDB123', 'An' => 'TAn456'],
         ];
         $driver = $this->getDriver($overrides);
         $this->assertEquals('TDB123,TAn456', $driver->getUniqueID());
@@ -351,31 +351,31 @@ class EDSTest extends \PHPUnit\Framework\TestCase
                                         'Identifiers' => [
                                             [
                                                 'Type' => 'issn-electronic',
-                                                'Value' => '1234-5678'
+                                                'Value' => '1234-5678',
                                             ],
                                             [
                                                 'Type' => 'issn-print',
-                                                'Value' => '5678-1234'
+                                                'Value' => '5678-1234',
                                             ],
                                             [
                                                 'Type' => 'isbn-electronic',
-                                                'Value' => '0123456789X'
+                                                'Value' => '0123456789X',
                                             ],
                                             [
                                                 'Type' => 'isbn-print',
-                                                'Value' => 'fakeisbnxxx'
+                                                'Value' => 'fakeisbnxxx',
                                             ],
                                             [
                                                 'Type' => 'meaningless-noise',
-                                                'Value' => 'should never be seen'
+                                                'Value' => 'should never be seen',
                                             ],
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ]
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EITTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EITTest.php
@@ -115,9 +115,9 @@ class EITTest extends \PHPUnit\Framework\TestCase
         $overrides = [
             'header' => [
                 'controlInfo' => [
-                    'pubinfo' => ['pub' => ['TestPublisher']]
-                ]
-            ]
+                    'pubinfo' => ['pub' => ['TestPublisher']],
+                ],
+            ],
         ];
         $driver = $this->getDriver($overrides);
         $this->assertEquals([['TestPublisher']], $driver->getPublishers());

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcAdvancedTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcAdvancedTraitTest.php
@@ -106,7 +106,7 @@ class MarcAdvancedTraitTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 ['name' => 'Development Series &\'><"'],
-                ['name' => 'Development', 'number' => 'no. 2']
+                ['name' => 'Development', 'number' => 'no. 2'],
             ],
             $obj->getSeries()
         );
@@ -123,8 +123,8 @@ class MarcAdvancedTraitTest extends \PHPUnit\Framework\TestCase
             [
                 [
                     'url' => 'https://vufind.org/vufind/',
-                    'desc' => 'VuFind Home Page'
-                ]
+                    'desc' => 'VuFind Home Page',
+                ],
             ],
             $obj->getURLs()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcBasicTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/Feature/MarcBasicTraitTest.php
@@ -60,7 +60,7 @@ class MarcBasicTraitTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 '0000-1111', '1111-2222', '2222-3333', '3333-4444', '4444-5555',
-                '5555-6666', '6666-7777', '7777-8888'
+                '5555-6666', '6666-7777', '7777-8888',
             ],
             $obj->getISSNs()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -66,17 +66,17 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
             [
                 'title' => 'A',
                 'value' => 'Bollettino della Unione matematica italiana',
-                'link' => ['type' => 'bib', 'value' => '000343528']
+                'link' => ['type' => 'bib', 'value' => '000343528'],
             ],
             [
                 'title' => 'B',
                 'value' => 'Bollettino della Unione matematica',
-                'link' => ['type' => 'bib', 'value' => '000343529']
+                'link' => ['type' => 'bib', 'value' => '000343529'],
             ],
             [
                 'title' => 'note_785_8',
                 'value' => 'Bollettino della Unione matematica italiana',
-                'link' => ['type' => 'bib', 'value' => '000394898']
+                'link' => ['type' => 'bib', 'value' => '000394898'],
             ],
         ];
         $this->assertEquals($expected, $record->getAllRecordLinks());
@@ -131,7 +131,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
                     'heading' => ['Matematica', 'Periodici.'],
                     'type' => '',
                     'source' => '',
-                    'id' => ''
+                    'id' => '',
                 ],
             ],
             $record->getAllSubjectHeadings(true)
@@ -229,7 +229,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
                     'default' => 'Bollettino della Unione matematica italiana.',
                     'emptySubfield' => '',
                     'pub' => 'Bologna : Zanichelli, 1922-1975.',
-                ]
+                ],
             ],
             $record->getFormattedMarcDetails('245', $input)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ComponentPartsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ComponentPartsTest.php
@@ -134,7 +134,7 @@ class ComponentPartsTest extends \PHPUnit\Framework\TestCase
                 && $command->getArguments()[2] === 101
                 && $command->getArguments()[3]->getArrayCopy() === [
                     "hl" => ["false"],
-                    "sort" => ["hierarchy_sequence ASC,title ASC"]
+                    "sort" => ["hierarchy_sequence ASC,title ASC"],
                 ];
         };
         $service->expects($this->once())->method('invoke')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/HoldingsILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/HoldingsILSTest.php
@@ -60,7 +60,7 @@ class HoldingsILSTest extends \PHPUnit\Framework\TestCase
         $items2 = [
             ['callnumber' => 'b', 'callnumber_prefix' => ''],
             ['callnumber' => 'b', 'callnumber_prefix' => ''],
-            ['callnumber' => 'b', 'callnumber_prefix' => '']
+            ['callnumber' => 'b', 'callnumber_prefix' => ''],
         ];
         $expected2 = [['callnumber' => 'b', 'display' => 'b', 'prefix' => '']];
         $this->assertSame($expected2, $obj->getUniqueCallNumbers($items2, true));
@@ -69,12 +69,12 @@ class HoldingsILSTest extends \PHPUnit\Framework\TestCase
         $items3 = [
             ['callnumber' => 'a', 'callnumber_prefix' => ''],
             ['callnumber' => 'b', 'callnumber_prefix' => 'c'],
-            ['callnumber' => 'b', 'callnumber_prefix' => '']
+            ['callnumber' => 'b', 'callnumber_prefix' => ''],
         ];
         $expected3 = [
             0 => ['callnumber' => 'a', 'display' => 'a', 'prefix' => ''],
             2 => ['callnumber' => 'b', 'display' => 'b', 'prefix' => ''],
-            1 => ['callnumber' => 'b', 'display' => 'c b', 'prefix' => 'c']
+            1 => ['callnumber' => 'b', 'display' => 'c b', 'prefix' => 'c'],
         ];
         $this->assertSame($expected3, $obj->getUniqueCallNumbers($items3, true));
 
@@ -82,7 +82,7 @@ class HoldingsILSTest extends \PHPUnit\Framework\TestCase
         $items4 = [
             ['callnumber' => 'b', 'callnumber_prefix' => ''],
             ['callnumber' => 'b', 'callnumber_prefix' => 'a'],
-            ['callnumber' => 'b', 'callnumber_prefix' => 'c']
+            ['callnumber' => 'b', 'callnumber_prefix' => 'c'],
         ];
         $expected4 = ['b'];
         $this->assertSame($expected4, $obj->getUniqueCallNumbers($items4, false));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/MapTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/MapTest.php
@@ -52,12 +52,12 @@ class MapTest extends \PHPUnit\Framework\TestCase
         $mapTabDisplay = true;
         $basemapOptions = [
             'basemap_url' => "www.foo.com",
-            'basemap_attribution' => "bar"
+            'basemap_attribution' => "bar",
         ];
         $mapTabOptions = [
             'displayCoords' => true,
             'mapLabels'     => null,
-            'graticule'     => true
+            'graticule'     => true,
         ];
         $obj = new Map($mapTabDisplay, $basemapOptions, $mapTabOptions);
         return $obj;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
@@ -61,7 +61,7 @@ class TabManagerTest extends \PHPUnit\Framework\TestCase
                 'defaultTab' => 'zip',
                 'backgroundLoadedTabs' => ['xyzzy'],
             ],
-        ]
+        ],
     ];
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/VersionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/VersionsTest.php
@@ -81,7 +81,7 @@ class VersionsTest extends \PHPUnit\Framework\TestCase
         return ['Test1' => [true, 1, true],
                 'Test2' => [true, 0, false],
                 'Test3' => [false, 1, false],
-                'Test4' => [true, 0, false]
+                'Test4' => [true, 0, false],
             ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Related/BookplateTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Related/BookplateTest.php
@@ -77,14 +77,14 @@ class BookplateTest extends \PHPUnit\Framework\TestCase
                 'bookplate_full' => 'https://localhost/%%img%%',
                 'bookplate_thumb' => 'https://localhost/%%thumb%%',
                 'bookplate_display_title' => true,
-            ]
+            ],
         ];
         $container = $this->getContainer('config', $config);
         $driver = $this->getTestRecord(
             [
                 'donor_str' => 'Mr. Donor',
                 'donor_image_str' => 'image.jpg',
-                'donor_thumb_str' => 'thumb.jpg'
+                'donor_thumb_str' => 'thumb.jpg',
             ]
         );
         $bookplate = $this->getBookplate($container);
@@ -95,7 +95,7 @@ class BookplateTest extends \PHPUnit\Framework\TestCase
                 'fullUrl' => 'https://localhost/image.jpg',
                 'thumbUrl' => 'https://localhost/thumb.jpg',
                 'displayTitle' => true,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $bookplate->getBookplateDetails());
     }
@@ -116,7 +116,7 @@ class BookplateTest extends \PHPUnit\Framework\TestCase
                 'bookplate_full' => 'https://localhost/%%img%%',
                 'bookplate_thumb' => 'https://localhost/%%thumb%%',
                 'bookplate_display_title' => false,
-            ]
+            ],
         ];
         $container = $this->getContainer('foo', $config);
         $driver = $this->getTestRecord(
@@ -140,7 +140,7 @@ class BookplateTest extends \PHPUnit\Framework\TestCase
                 'fullUrl' => 'https://localhost/image2.jpg',
                 'thumbUrl' => 'https://localhost/thumb2.jpg',
                 'displayTitle' => false,
-            ]
+            ],
         ];
         $this->assertEquals($expected, $bookplate->getBookplateDetails());
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Related/WorldCatSimilarTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Related/WorldCatSimilarTest.php
@@ -57,7 +57,7 @@ class WorldCatSimilarTest extends \PHPUnit\Framework\TestCase
                     'getAllSubjectHeadings',
                     'getTitle',
                     'getUniqueId',
-                    'getSourceIdentifier'
+                    'getSourceIdentifier',
                 ]
             )->getMock();
         $driver->expects($this->once())

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
@@ -73,7 +73,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
             'show_in_record' => false,
             'show_in_holdings' => true,
             'embed' => true,
-            'replace_other_urls' => true
+            'replace_other_urls' => true,
         ],
     ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/JopTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/JopTest.php
@@ -65,7 +65,7 @@ class JopTest extends \PHPUnit\Framework\TestCase
             'show_in_record' => false,
             'show_in_holdings' => true,
             'embed' => true,
-            'replace_other_urls' => true
+            'replace_other_urls' => true,
         ],
     ];
 
@@ -87,35 +87,35 @@ class JopTest extends \PHPUnit\Framework\TestCase
                 'coverage' => 'ab Vol. 31, Iss. 1 (1997)',
                 'access' => 'limited',
                 'href' => 'http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1468-0068',
-                'service_type' => 'getFullTxt'
+                'service_type' => 'getFullTxt',
             ],
             1 => [
                 'title' => 'Noûs (ältere Jahrgänge via JSTOR)',
                 'coverage' => 'ab Vol. 1, Iss. 1 (1967); für die Ausgaben der aktuellen 11 Jahrgänge nicht verfügbar',
                 'access' => 'limited',
                 'href' => 'http://www.jstor.org/action/showPublication?journalCode=nous',
-                'service_type' => 'getFullTxt'
+                'service_type' => 'getFullTxt',
             ],
             2 => [
                 'title' => 'Nous (via EBSCO Host)',
                 'coverage' => 'für die Ausgaben der vergangenen 12 Monate nicht verfügbar',
                 'access' => 'limited',
                 'href' => 'http://search.ebscohost.com/direct.asp?db=aph&jid=D97&scope=site',
-                'service_type' => 'getFullTxt'
+                'service_type' => 'getFullTxt',
             ],
             3 => [
                 'title' => 'Nous (via EBSCO Host)',
                 'coverage' => 'für die Ausgaben der vergangenen 12 Monate nicht verfügbar',
                 'access' => 'limited',
                 'href' => 'http://search.ebscohost.com/direct.asp?db=lfh&jid=D97&scope=site',
-                'service_type' => 'getFullTxt'
+                'service_type' => 'getFullTxt',
             ],
             4 => [
                 'title' => 'Philosophical Perspectives (aktuelle Jahrgänge)',
                 'coverage' => 'ab Vol. 17 (2003)',
                 'access' => 'limited',
                 'href' => 'http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291520-8583',
-                'service_type' => 'getFullTxt'
+                'service_type' => 'getFullTxt',
             ],
             5 => [
                 'title' => 'Print available',
@@ -124,15 +124,15 @@ class JopTest extends \PHPUnit\Framework\TestCase
                 'href' => 'http://dispatch.opac.dnb.de/CHARSET=ISO-8859-1/DB=1.1/CMD'
                     . '?ACT=SRCHA&IKT=8509&SRT=LST_ty&TRM=IDN+011960027+or+IDN+01545794X'
                     . '&HLIB=009030085#009030085',
-                'service_type' => 'getHolding'
+                'service_type' => 'getHolding',
             ],
             6 => [
                 'title' => 'Print available',
                 'coverage' => 'Noûs; Leipzig UB // HB/FH/ Standortsignatur: 96-7-558; '
                     . 'CA 5470 Magazin: 96-7-558; 1.1967 - 27.1993; 30.1996 - 43.2009; Letzten 15 Jg. Freihand',
                 'access' => 'open',
-                'service_type' => 'getHolding'
-            ]
+                'service_type' => 'getHolding',
+            ],
         ];
 
         $this->assertEquals($result, $testResult);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionDeniedManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionDeniedManagerTest.php
@@ -50,24 +50,24 @@ class PermissionDeniedManagerTest extends \PHPUnit\Framework\TestCase
     protected $permissionDeniedConfig = [
         'permissionDeniedTemplate' => [
             'deniedTemplateBehavior' => "showTemplate:record/displayLogicTest:param1=noValue",
-            'deniedControllerBehavior' => "showTemplate:record/ActionTest:param1=noValue"
+            'deniedControllerBehavior' => "showTemplate:record/ActionTest:param1=noValue",
         ],
         'permissionDeniedTemplateNoParams' => [
             'deniedTemplateBehavior' => "showTemplate:record/displayLogicTest",
-            'deniedControllerBehavior' => "showTemplate:record/ActionTest"
+            'deniedControllerBehavior' => "showTemplate:record/ActionTest",
         ],
         'permissionDeniedMessage' => [
             'deniedTemplateBehavior' => "showMessage:dl_translatable_test",
-            'deniedControllerBehavior' => "showTemplate:action_translatable_test"
+            'deniedControllerBehavior' => "showTemplate:action_translatable_test",
         ],
         'permissionDeniedLogin' => [
-            'deniedControllerBehavior' => "promptLogin"
+            'deniedControllerBehavior' => "promptLogin",
         ],
         'permissionDeniedException' => [
-            'deniedControllerBehavior' => "exception:ForbiddenException:exception_message"
+            'deniedControllerBehavior' => "exception:ForbiddenException:exception_message",
         ],
         'permissionDeniedNonExistentException' => [
-            'deniedControllerBehavior' => "exception:NonExistentException:exception_message"
+            'deniedControllerBehavior' => "exception:NonExistentException:exception_message",
         ],
         'permissionDeniedNothing' => [
         ],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionManagerTest.php
@@ -49,16 +49,16 @@ class PermissionManagerTest extends \PHPUnit\Framework\TestCase
      */
     protected $permissionConfig = [
         'permission.all' => [
-            'permission' => "everyone"
+            'permission' => "everyone",
         ],
         'permission.nobody' => [
-            'permission' => "nobody"
+            'permission' => "nobody",
         ],
         'permission.empty' => [
         ],
         'permission.array' => [
-            'permission' => ['everyoneArray', 'everyoneArray2']
-        ]
+            'permission' => ['everyoneArray', 'everyoneArray2'],
+        ],
     ];
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/UserTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/PermissionProvider/UserTest.php
@@ -59,15 +59,15 @@ class UserTest extends \PHPUnit\Framework\TestCase
         [
                 ['username','mbeh'],
                 ['email','markus.beh@ub.uni-freiburg.de'],
-                ['college', 'Albert Ludwigs Universität Freiburg']
+                ['college', 'Albert Ludwigs Universität Freiburg'],
         ],
         'testuser2' =>
         [
                 ['username','mbeh2'],
                 ['email','markus.beh@ub.uni-freiburg.de'],
                 ['college', 'Villanova University'],
-                ['major', 'alumni']
-        ]
+                ['major', 'alumni'],
+        ],
     ];
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -70,7 +70,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
     public function testCarriers()
     {
         $expected = [
-            'Clickatell' => ['name' => 'Clickatell', 'domain' => null]
+            'Clickatell' => ['name' => 'Clickatell', 'domain' => null],
         ];
         $obj = $this->getClickatell();
         $this->assertEquals($expected, $obj->getCarriers());

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/HideFacetValueListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/HideFacetValueListenerTest.php
@@ -76,7 +76,7 @@ class HideFacetValueListenerTest extends \PHPUnit\Framework\TestCase
                 'Book' => 124,
                 'Unknown' => 16,
                 'Fake' => 3,
-            ]
+            ],
         ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Base/ParamsTest.php
@@ -158,7 +158,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'displayText' => 'baz',
                         'field' => 'format',
                         'operator' => 'OR',
-                    ]
+                    ],
                 ],
                 'building_label' => [
                     [
@@ -172,8 +172,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'displayText' => 'sub',
                         'field' => 'building',
                         'operator' => 'NOT',
-                    ]
-                ]
+                    ],
+                ],
             ],
             $params->getFilterList()
         );
@@ -194,8 +194,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'displayText' => 'sub',
                         'field' => 'building',
                         'operator' => 'NOT',
-                    ]
-                ]
+                    ],
+                ],
 
             ],
             $params->getFilterList()
@@ -211,8 +211,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'displayText' => 'sub',
                         'field' => 'building',
                         'operator' => 'NOT',
-                    ]
-                ]
+                    ],
+                ],
 
             ],
             $params->getFilterList()
@@ -272,7 +272,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             $params,
             'facetAliases',
             [
-                'foo_old' => 'foo'
+                'foo_old' => 'foo',
             ]
         );
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
@@ -57,7 +57,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         'Backends' => [
             'Solr' => 'Local',
             'Primo' => 'CDI',
-            'EDS' => 'EBSCO'
+            'EDS' => 'EBSCO',
         ],
         'Blending' => [
             'initialResults' => [
@@ -66,8 +66,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                 'Primo',
                 'EDS',
                 'Primo',
-                'EDS'
-            ]
+                'EDS',
+            ],
         ],
     ];
 
@@ -90,8 +90,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                             'Values' => [
                                 'main' => '0/Main/',
                                 'sub' => '1/Sub/Fiction/',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                 ],
                 'format' => [
@@ -127,7 +127,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'EDS' => [
                             'Field' => 'LIMIT|FT',
                             'Values' => [
-                                'y' => '1'
+                                'y' => '1',
                             ],
                         ],
                     ],
@@ -153,14 +153,14 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'Mappings' => [
                         'Solr' => 'AllFields',
                         'Primo' => 'AllFields',
-                        'EDS' => 'AllFields'
+                        'EDS' => 'AllFields',
                     ],
                 ],
                 'Title' => [
                     'Mappings' => [
                         'Solr' => 'Title',
                         'Primo' => 'Title',
-                        'EDS' => 'TI'
+                        'EDS' => 'TI',
                     ],
                 ],
             ],
@@ -195,8 +195,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             'AvailableSorts' => [
                 [
                     'Id' => 'date',
-                    'Label' => 'Date Newest'
-                ]
+                    'Label' => 'Date Newest',
+                ],
             ],
         ],
     ];
@@ -209,8 +209,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
     protected $edsConfig = [
         'Sorting' => [
             'relevance' => 'relevance',
-            'date' => 'year'
-        ]
+            'date' => 'year',
+        ],
     ];
 
     /**
@@ -221,8 +221,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
     protected $primoConfig = [
         'Sorting' => [
             'relevance' => 'relevance',
-            'scdate' => 'year'
-        ]
+            'scdate' => 'year',
+        ],
     ];
 
     /**
@@ -275,8 +275,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'filter' => 'format:bar',
                     'selected' => false,
                     'alwaysVisible' => false,
-                    'dynamic' => false
-                ]
+                    'dynamic' => false,
+                ],
             ],
             $params->getCheckboxFacets()
         );
@@ -290,8 +290,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'filter' => 'format:bar',
                     'selected' => true,
                     'alwaysVisible' => false,
-                    'dynamic' => false
-                ]
+                    'dynamic' => false,
+                ],
             ],
             $params->getCheckboxFacets()
         );
@@ -301,7 +301,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'format:"bar"',
-                '-blender_backend:"EDS"'
+                '-blender_backend:"EDS"',
             ],
             $backendParams->get('fq')
         );
@@ -319,12 +319,12 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'formatPrimo' => [
                     'facetOp' => 'AND',
-                    'values' => ['barPrimo']
+                    'values' => ['barPrimo'],
                 ],
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -349,7 +349,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'fulltext_boolean:"1"',
                 '{!tag=formatSolr_filter}formatSolr:(formatSolr:"bar"'
-                    . ' OR formatSolr:"baz")'
+                    . ' OR formatSolr:"baz")',
             ],
             $solrParams->get('fq')
         );
@@ -357,15 +357,15 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['false']
+                    'values' => ['false'],
                 ],
                 'formatPrimo' => [
                     'facetOp' => 'OR',
                     'values' => [
                         'barPrimo',
-                        'bazPrimo'
-                    ]
-                ]
+                        'bazPrimo',
+                    ],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -385,7 +385,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['false']
+                    'values' => ['false'],
                 ],
             ],
             $primoParams->get('filterList')
@@ -405,7 +405,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
+                    'values' => ['true'],
                 ],
             ],
             $primoParams->get('filterList')
@@ -426,8 +426,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['false']
-                ]
+                    'values' => ['false'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -456,13 +456,13 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'facetOp' => 'OR',
                     'values' => [
                         'double1',
-                        'double2'
-                    ]
+                        'double2',
+                    ],
                 ],
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -480,13 +480,13 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'facetOp' => 'NOT',
                     'values' => [
                         'double1',
-                        'double2'
-                    ]
+                        'double2',
+                    ],
                 ],
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -501,8 +501,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -522,7 +522,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
+                    'values' => ['true'],
                 ],
             ],
             $primoParams->get('filterList')
@@ -558,11 +558,11 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'creationdate' => [
                     'facetOp' => 'AND',
-                    'values' => ['[2020 TO 2022]']
+                    'values' => ['[2020 TO 2022]'],
                 ],
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
+                    'values' => ['true'],
                 ],
             ],
             $primoParams->get('filterList')
@@ -588,7 +588,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'format:"bar"',
-                '-blender_backend:"EDS"'
+                '-blender_backend:"EDS"',
             ],
             $backendParams->get('fq')
         );
@@ -606,12 +606,12 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'formatPrimo' => [
                     'facetOp' => 'AND',
-                    'values' => ['barPrimo']
+                    'values' => ['barPrimo'],
                 ],
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -648,7 +648,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 '{!tag=blender_backend_filter}blender_backend:('
-                . 'blender_backend:"Primo" OR blender_backend:"EDS")'
+                . 'blender_backend:"Primo" OR blender_backend:"EDS")',
             ],
             $backendParams->get('fq')
         );
@@ -673,7 +673,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'filter' => 'blender_backend:Primo',
                     'selected' => false,
                     'alwaysVisible' => false,
-                    'dynamic' => false
+                    'dynamic' => false,
                 ],
             ],
             $params->getCheckboxFacets()
@@ -688,8 +688,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             [
                 'pcAvailability' => [
                     'facetOp' => 'AND',
-                    'values' => ['true']
-                ]
+                    'values' => ['true'],
+                ],
             ],
             $primoParams->get('filterList')
         );
@@ -709,7 +709,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'format:"bar"',
-                '-blender_backend:"EDS"'
+                '-blender_backend:"EDS"',
             ],
             $backendParams->get('fq')
         );
@@ -717,7 +717,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         // Test ignoring all values:
         $mappings = $this->mappings;
         $mappings['Facets']['Fields']['format']['Mappings']['EDS'] = [
-            'Ignore' => true
+            'Ignore' => true,
         ];
         $params = $this->getParams(null, $mappings);
         $params->addHiddenFilter('format:bar');
@@ -737,8 +737,8 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $mappings = $this->mappings;
         $mappings['Facets']['Fields']['format']['Mappings']['EDS'] = [
             'Ignore' => [
-                'bar'
-            ]
+                'bar',
+            ],
         ];
         $params = $this->getParams(null, $mappings);
         $params->addHiddenFilter('format:bar');
@@ -813,7 +813,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'building:"0/Main/"',
-                '-blender_backend:"Primo"'
+                '-blender_backend:"Primo"',
             ],
             $backendParams->get('fq')
         );
@@ -875,7 +875,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [
                 'building:"0/Sub/"',
-                '-blender_backend:"Primo"'
+                '-blender_backend:"Primo"',
             ],
             $backendParams->get('fq')
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ResultsTest.php
@@ -81,7 +81,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
             new \VuFind\Search\Primo\Params(
                 new \VuFind\Search\Primo\Options($configMgr),
                 $configMgr
-            )
+            ),
         ];
 
         $params = new Params(
@@ -116,7 +116,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
     protected function getConfigManager()
     {
         $configs = [
-            'Primo' => new Config([])
+            'Primo' => new Config([]),
         ];
 
         $callback = function (string $configName) use ($configs) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EDS/ParamsTest.php
@@ -55,12 +55,12 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $limiters = [
-            ['selectedvalue' => 'limitervalue', 'description' => 'limiter']
+            ['selectedvalue' => 'limitervalue', 'description' => 'limiter'],
         ];
         $options->expects($this->once())->method('getSearchScreenLimiters')
             ->will($this->returnValue($limiters));
         $expanders = [
-            ['selectedvalue' => 'expandervalue', 'description' => 'expander']
+            ['selectedvalue' => 'expandervalue', 'description' => 'expander'],
         ];
         $options->expects($this->once())->method('getSearchScreenExpanders')
             ->will($this->returnValue($expanders));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/HistoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/HistoryTest.php
@@ -67,7 +67,7 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
             [
                 'Account' => [
                     'schedule_searches' => false,
-                ]
+                ],
             ]
         );
         $history = $this->getHistory(null, null, $config);
@@ -86,7 +86,7 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
             [
                 'Account' => [
                     'schedule_searches' => true,
-                ]
+                ],
             ]
         );
         $history = $this->getHistory(null, null, $config);
@@ -107,8 +107,8 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
             [
                 'Account' => [
                     'schedule_searches' => true,
-                    'scheduled_search_frequencies' => 'Always'
-                ]
+                    'scheduled_search_frequencies' => 'Always',
+                ],
             ]
         );
         $history = $this->getHistory(null, null, $config);
@@ -127,9 +127,9 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
                 'Account' => [
                     'schedule_searches' => true,
                     'scheduled_search_frequencies' => [
-                        1 => 'One', 2 => 'Two'
-                    ]
-                ]
+                        1 => 'One', 2 => 'Two',
+                    ],
+                ],
             ]
         );
         $history = $this->getHistory(null, null, $config);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/ParamsTest.php
@@ -102,13 +102,13 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'values' => [
                         'foo',
                         'bar',
-                    ]
+                    ],
                 ],
                 'building' => [
                     'facetOp' => 'AND',
                     'values' => [
                         'main',
-                    ]
+                    ],
                 ],
             ],
             $params->getBackendParameters()->get('filterList')
@@ -123,7 +123,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'values' => [
                         'foo',
                         'bar',
-                    ]
+                    ],
                 ],
             ],
             $params->getBackendParameters()->get('filterList')
@@ -139,14 +139,14 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'values' => [
                         'foo',
                         'bar',
-                    ]
+                    ],
                 ],
                 'building' => [
                     'facetOp' => 'AND',
                     'values' => [
                         'sub',
                         'main',
-                    ]
+                    ],
                 ],
             ],
             $params->getBackendParameters()->get('filterList')
@@ -161,7 +161,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'values' => [
                         'sub',
                         'main',
-                    ]
+                    ],
                 ],
             ],
             $params->getBackendParameters()->get('filterList')
@@ -175,7 +175,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'facetOp' => 'AND',
                     'values' => [
                         'sub',
-                    ]
+                    ],
                 ],
             ],
             $params->getBackendParameters()->get('filterList')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/PrimoPermissionHandlerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Primo/PrimoPermissionHandlerTest.php
@@ -58,9 +58,9 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
     protected $primoConfig = [
         'onCampusRule' => [
             'MEMBER' => 'primo.MEMBER',
-            'DEFAULT' => 'primo.defaultRule'
+            'DEFAULT' => 'primo.defaultRule',
         ],
-        'defaultCode' => 'DEFAULT'
+        'defaultCode' => 'DEFAULT',
     ];
 
     /**
@@ -70,8 +70,8 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
      */
     protected $primoConfigWithoutDefault = [
         'onCampusRule' => [
-            'MEMBER' => 'primo.MEMBER'
-        ]
+            'MEMBER' => 'primo.MEMBER',
+        ],
     ];
 
     /**
@@ -82,8 +82,8 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
     protected $primoConfigDefaultOnly = [
         'defaultCode' => 'DEFAULT',
         'onCampusRule' => [
-            'DEFAULT' => 'primo.defaultRule'
-        ]
+            'DEFAULT' => 'primo.defaultRule',
+        ],
     ];
 
     /**
@@ -95,11 +95,11 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
         'defaultCode' => 'DEFAULT',
         'onCampusRule' => [
             'DEFAULT' => 'primo.defaultRule',
-            'MEMBER' => 'primo.isOnCampusAtMEMBER'
+            'MEMBER' => 'primo.isOnCampusAtMEMBER',
         ],
         'institutionCode' => [
-            'MEMBER' => 'primo.isAtMEMBER'
-        ]
+            'MEMBER' => 'primo.isAtMEMBER',
+        ],
     ];
 
     /**
@@ -109,11 +109,11 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
      */
     protected $primoConfigWithoutDefaultWithInstCode = [
         'onCampusRule' => [
-            'MEMBER' => 'primo.isOnCampusAtMEMBER'
+            'MEMBER' => 'primo.isOnCampusAtMEMBER',
         ],
         'institutionCode' => [
-            'MEMBER' => 'primo.isAtMEMBER'
-        ]
+            'MEMBER' => 'primo.isAtMEMBER',
+        ],
     ];
 
     /**
@@ -122,7 +122,7 @@ class PrimoPermissionHandlerTest extends \PHPUnit\Framework\TestCase
      * @var array
      */
     protected $primoConfigDefaultOnlyNoOnCampusRule = [
-        'defaultCode' => 'DEFAULT'
+        'defaultCode' => 'DEFAULT',
     ];
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/QueryAdapterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/QueryAdapterTest.php
@@ -129,7 +129,7 @@ class QueryAdapterTest extends \PHPUnit\Framework\TestCase
         $cases = [
             'basic' => 'john smith',
             'advanced' => '(CallNumber:oranges AND toc:bananas AND ISN:pears) OR '
-                . '(Title:cars OR Subject:trucks) NOT ((AllFields:squid))'
+                . '(Title:cars OR Subject:trucks) NOT ((AllFields:squid))',
         ];
 
         // Create simple closure to fill in for translation callbacks:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/SearchTabsHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/SearchTabsHelperTest.php
@@ -47,17 +47,17 @@ class SearchTabsHelperTest extends \PHPUnit\Framework\TestCase
             'Solr' => 'Local Index',
             'Solr:video' => 'Local Videos',
             'Primo' => 'Primo Central',
-            'Primo:dissertation' => 'Dissertations in Primo Central'
+            'Primo:dissertation' => 'Dissertations in Primo Central',
         ],
         'default_filtered' => [
             'Solr:main' => 'Main Library',
             'Solr:mainvideo' => 'Main Library Videos',
             'Solr:branch' => 'Branch Library',
             'Primo' => 'Primo Central',
-            'Primo:dissertation' => 'Dissertations in Primo Central'
+            'Primo:dissertation' => 'Dissertations in Primo Central',
         ],
         'no_tabs' => [
-        ]
+        ],
     ];
 
     protected $filterConfig = [
@@ -65,7 +65,7 @@ class SearchTabsHelperTest extends \PHPUnit\Framework\TestCase
         'Solr:main' => ['building:main'],
         'Solr:mainvideo' => ['building:main', 'format:video'],
         'Solr:branch' => ['building:branch'],
-        'Primo:dissertation' => ['rtype:Dissertations']
+        'Primo:dissertation' => ['rtype:Dissertations'],
     ];
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -57,7 +57,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     protected static $searchConfig = [
         '0' => '-conditionalFilter.sample|(NOT institution:"MyInst")',
-        '1' => 'conditionalFilter.sample|institution:"MyInst"'
+        '1' => 'conditionalFilter.sample|institution:"MyInst"',
     ];
 
     /**
@@ -304,7 +304,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue',
-            2 => '(NOT institution:"MyInst")'
+            2 => '(NOT institution:"MyInst")',
             ],
             $fq
         );
@@ -339,7 +339,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue',
-            2 => 'institution:"MyInst"'
+            2 => 'institution:"MyInst"',
             ],
             $fq
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/DefaultParametersListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/DefaultParametersListenerTest.php
@@ -75,8 +75,8 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
         $params = new ParamBag(
             [
                 'fq' => [
-                    'foo:value'
-                ]
+                    'foo:value',
+                ],
             ]
         );
 
@@ -86,7 +86,7 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
             $backend,
             [
                 'search' => 'foo=1&foo=2',
-                '*' => 'bar=3&bar'
+                '*' => 'bar=3&bar',
             ]
         );
 
@@ -138,8 +138,8 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
         $params = new ParamBag(
             [
                 'fq' => [
-                    'foo:value'
-                ]
+                    'foo:value',
+                ],
             ]
         );
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/FilterFieldConversionListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/FilterFieldConversionListenerTest.php
@@ -81,7 +81,7 @@ class FilterFieldConversionListenerTest extends \PHPUnit\Framework\TestCase
                     "foo\\:value",
                     'baz:value OR foo:value',
                     '(foo:value)',
-                ]
+                ],
             ]
         );
         $listener = new FilterFieldConversionListener(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HierarchicalFacetHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HierarchicalFacetHelperTest.php
@@ -55,50 +55,50 @@ class HierarchicalFacetHelperTest extends \PHPUnit\Framework\TestCase
             'displayText' => 'Book',
             'count' => 1000,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '0/AV/',
             'displayText' => 'Audiovisual',
             'count' => 600,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '0/Audio/',
             'displayText' => 'Sound',
             'count' => 400,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '1/Book/BookPart/',
             'displayText' => 'Book Part',
             'count' => 300,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '1/Book/Section/',
             'displayText' => 'Book Section',
             'count' => 200,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '1/Audio/Spoken/',
             'displayText' => 'Spoken Text',
             'count' => 100,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => '1/Audio/Music/',
             'displayText' => 'Music',
             'count' => 50,
             'operator' => 'OR',
-            'isApplied' => false
-        ]
+            'isApplied' => false,
+        ],
     ];
 
     /**
@@ -112,21 +112,21 @@ class HierarchicalFacetHelperTest extends \PHPUnit\Framework\TestCase
             'displayText' => 'Book',
             'count' => 1000,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => 'AV',
             'displayText' => 'Audiovisual',
             'count' => 600,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
         [
             'value' => 'Audio',
             'displayText' => 'Sound',
             'count' => 400,
             'operator' => 'OR',
-            'isApplied' => false
+            'isApplied' => false,
         ],
     ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/MultiIndexListenerTest.php
@@ -61,7 +61,7 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
             'QueryFields' => [
                 'A' => [
                     ['onephrase', 500],
-                    ['and', 200]
+                    ['and', 200],
                 ],
                 'B' => [
                     ['and', 100],
@@ -76,12 +76,12 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
                         ['onephrase', 300],
                     ],
                     '-E' => [
-                        ['or', '~']
-                    ]
-                ]
+                        ['or', '~'],
+                    ],
+                ],
             ],
             'FilterQuery' => 'format:Book',
-        ]
+        ],
     ];
 
     /**
@@ -245,15 +245,15 @@ class MultiIndexListenerTest extends \PHPUnit\Framework\TestCase
                           0 => [
                               0 => ['AND', 50],
                               'C' => [
-                                  ['onephrase', 200]
+                                  ['onephrase', 200],
                               ],
                               'D' => [
-                                  ['onephrase', 300]
-                              ]
-                          ]
+                                  ['onephrase', 300],
+                              ],
+                          ],
                       ],
                       'FilterQuery' => 'format:Book',
-                  ]
+                  ],
             ],
             $specs
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
@@ -132,7 +132,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                         'inverted' => 'foo:bar',
                     ],
                 ],
-            ]
+            ],
         ];
         $configManager = $this->getMockConfigPluginManager($config);
         $params = $this->getParams(null, $configManager);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -91,7 +91,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
         $options->setTranslator($mockTranslator);
         $options->setTranslatedFacets(
             [
-                'dewey-raw:DDC23:dewey_format_str'
+                'dewey-raw:DDC23:dewey_format_str',
             ]
         );
         $params = $this->getParams($options);
@@ -102,7 +102,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                 'facet_counts' => [
                     'facet_fields' => [
                         'dewey-raw' => [
-                            ["000", 100]
+                            ["000", 100],
                         ],
                     ],
                 ],
@@ -221,7 +221,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
         $results = $this->getResultsFromResponse(
             [
                 'response' => [
-                    'numFound' => 5
+                    'numFound' => 5,
                 ],
                 'facet_counts' => [
                     'facet_fields' => [
@@ -233,9 +233,9 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             ['0/Main/', 11],
                             ['1/Main/Fiction/', 5],
                             ['0/Sub/', 2],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             $this->getParams(null, $config)
         );
@@ -272,7 +272,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             'isApplied' => false,
                         ],
                     ],
-                ]
+                ],
             ],
             $facets
         );
@@ -300,7 +300,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             'isApplied' => false,
                         ],
                     ],
-                ]
+                ],
             ],
             $facets
         );
@@ -328,7 +328,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             'isApplied' => false,
                         ],
                     ],
-                ]
+                ],
             ],
             $facets
         );
@@ -371,7 +371,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             'isApplied' => false,
                         ],
                     ],
-                ]
+                ],
             ],
             $facets
         );
@@ -407,7 +407,7 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                             'isApplied' => false,
                         ],
                     ],
-                ]
+                ],
             ],
             $facets
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/SpellingProcessorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/SpellingProcessorTest.php
@@ -364,8 +364,8 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                             'freq' => 5735,
                             'new_term' => 'make',
                             'expand_term' => '(lake OR make)',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'geneve' => [
                     'freq' => 662,
@@ -374,9 +374,9 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                             'freq' => 1170,
                             'new_term' => 'geneva',
                             'expand_term' => '(geneve OR geneva)',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ]
         );
     }
@@ -426,18 +426,18 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                     'suggestions' => [
                         '12345678' => [
                             'freq' => 1,
-                            'new_term' => '12345678'
-                        ]
-                    ]
+                            'new_term' => '12345678',
+                        ],
+                    ],
                 ],
                 'sqid' => [
                     'freq' => 0,
                     'suggestions' => [
                         'squid' => [
                             'freq' => 34,
-                            'new_term' => 'squid'
-                        ]
-                    ]
+                            'new_term' => 'squid',
+                        ],
+                    ],
                 ],
             ],
             ['limit' => 1, 'skip_numeric' => false, 'expand' => false]
@@ -459,9 +459,9 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                     'suggestions' => [
                         'squid' => [
                             'freq' => 34,
-                            'new_term' => 'squid'
-                        ]
-                    ]
+                            'new_term' => 'squid',
+                        ],
+                    ],
                 ],
             ],
             ['limit' => 1, 'skip_numeric' => true, 'expand' => false]
@@ -532,7 +532,7 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                 'suggestions' => [
                     'trimble' => 110,
                     'gribble' => 21,
-                    'grimsley' => 24
+                    'grimsley' => 24,
                 ],
             ],
         ];
@@ -559,7 +559,7 @@ class SpellingProcessorTest extends \PHPUnit\Framework\TestCase
                 'suggestions' => [
                     'trimble' => 110,
                     'gribble' => 21,
-                    'grimsley' => 24
+                    'grimsley' => 24,
                 ],
             ],
         ];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V3/ErrorListenerTest.php
@@ -63,7 +63,7 @@ class ErrorListenerTest extends TestCase
         $exception = HttpErrorException::createFromResponse($response);
         $params    = [
             'command'   => $command,
-            'error'     => $exception
+            'error'     => $exception,
         ];
         $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
@@ -85,7 +85,7 @@ class ErrorListenerTest extends TestCase
         $exception = HttpErrorException::createFromResponse($response);
         $params    = [
             'command'   => $command,
-            'error'     => $exception
+            'error'     => $exception,
         ];
         $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/V4/ErrorListenerTest.php
@@ -63,7 +63,7 @@ class ErrorListenerTest extends TestCase
         $exception = HttpErrorException::createFromResponse($response);
         $params    = [
             'command'   => $command,
-            'error'     => $exception
+            'error'     => $exception,
         ];
         $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);
@@ -85,7 +85,7 @@ class ErrorListenerTest extends TestCase
         $exception = HttpErrorException::createFromResponse($response);
         $params    = [
             'command'   => $command,
-            'error'     => $exception
+            'error'     => $exception,
         ];
         $event     = new Event(null, null, $params);
         $listener  = new ErrorListener($backend);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Summon/ParamsTest.php
@@ -61,7 +61,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                     'holdingsOnly:false' => 'add_other_libraries',
                     'queryExpansion:true' => 'include_synonyms',
                 ],
-            ]
+            ],
         ];
         $configManager = $this->getMockConfigPluginManager($config);
         $params = $this->getParams(null, $configManager);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
@@ -164,7 +164,7 @@ class RetryTraitTest extends \PHPUnit\Framework\TestCase
                     'retryableExceptionCallback' => function ($attempt, $exception) {
                         $this->assertInstanceOf(\Exception::class, $exception);
                         return $exception->getMessage() !== 'Fail attempt 3';
-                    }
+                    },
                 ]
             );
         } catch (\Exception $e) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/Index/TermsIdFetcherTest.php
@@ -76,8 +76,8 @@ class TermsIdFetcherTest extends \PHPUnit\Framework\TestCase
         return new Terms(
             [
                 'terms' => [
-                    $this->uniqueKey => $ids
-                ]
+                    $this->uniqueKey => $ids,
+                ],
             ]
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/SitemapTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/SitemapTest.php
@@ -85,17 +85,17 @@ class SitemapTest extends \PHPUnit\Framework\TestCase
             [
                 'url' => 'http://foo',
                 'languages' => [
-                    'en' => 'en', 'en-GB' => 'en-gb', 'fi' => 'fi', 'x-default' => null
-                ]
+                    'en' => 'en', 'en-GB' => 'en-gb', 'fi' => 'fi', 'x-default' => null,
+                ],
             ]
         );
         $sm->addUrl(
             [
                 'url' => 'http://bar?t=1',
                 'languages' => [
-                  'en' => 'en', 'en-GB' => 'en-gb', 'fi' => 'fi', 'x-default' => null
+                  'en' => 'en', 'en-GB' => 'en-gb', 'fi' => 'fi', 'x-default' => null,
                 ],
-                'frequency' => 'daily'
+                'frequency' => 'daily',
             ]
         );
         $sm->addUrl('http://baz');

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/UrlShortener/DatabaseTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/UrlShortener/DatabaseTest.php
@@ -91,7 +91,7 @@ class DatabaseTest extends TestCase
                 [
                     'beginTransaction', 'commit', 'connect', 'getResource',
                     'isConnected', 'getCurrentSchema', 'disconnect', 'rollback',
-                    'execute', 'getLastGeneratedValue'
+                    'execute', 'getLastGeneratedValue',
                 ]
             )->disableOriginalConstructor()
             ->getMock();
@@ -102,7 +102,7 @@ class DatabaseTest extends TestCase
                 [
                     'getConnection', 'getDatabasePlatformName', 'checkEnvironment',
                     'createStatement', 'createResult', 'getPrepareType',
-                    'formatParameterName', 'getLastGeneratedValue'
+                    'formatParameterName', 'getLastGeneratedValue',
                 ]
             )->disableOriginalConstructor()
             ->getMock();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
@@ -60,7 +60,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '',
                 'PlacesOfPublication' => ['St. Louis'],
                 'Publishers' => ['Mosby'],
-                'PublicationDates' => ['1958']
+                'PublicationDates' => ['1958'],
             ],
             'apa' => 'Shafer, K. N. (1958). <i>Medical-surgical nursing</i>. Mosby.',
             'mla' => 'Shafer, Kathleen Newton. <i>Medical-surgical Nursing</i>. Mosby, 1958.',
@@ -74,7 +74,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '7th ed. /',
                 'PlacesOfPublication' => ['St. Louis, Mo.'],
                 'Publishers' => ['Mosby Elsevier'],
-                'PublicationDates' => ['2007']
+                'PublicationDates' => ['2007'],
             ],
             'apa' => 'Lewis, S. (2007). <i>Medical-surgical nursing: Assessment and management of clinical problems</i> (7th ed.). Mosby Elsevier.',
             'mla' => 'Lewis, S.M. <i>Medical-surgical Nursing: Assessment and Management of Clinical Problems</i>. 7th ed. Mosby Elsevier, 2007.',
@@ -102,7 +102,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '1st ed.',
                 'PlacesOfPublication' => ['St. Louis, Mo.'],
                 'Publishers' => ['Mosby Elsevier'],
-                'PublicationDates' => ['2007']
+                'PublicationDates' => ['2007'],
             ],
             'apa' => 'Lewis, S. (2007). <i>Medical-surgical nursing: Assessment and management of clinical problems</i>. Mosby Elsevier.',
             'mla' => 'Lewis, S.M. <i>Medical-surgical Nursing: Assessment and Management of Clinical Problems</i>. Mosby Elsevier, 2007.',
@@ -116,7 +116,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '7th ed.',
                 'PlacesOfPublication' => ['St. Louis, Mo.'],
                 'Publishers' => ['Mosby Elsevier'],
-                'PublicationDates' => ['2007']
+                'PublicationDates' => ['2007'],
             ],
             'apa' => 'Lewis, S. (2007). <i>Medical-surgical nursing: Why?</i> (7th ed.). Mosby Elsevier.',
             'mla' => 'Lewis, S.M. <i>Medical-surgical Nursing: Why?</i> 7th ed. Mosby Elsevier, 2007.',
@@ -130,7 +130,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '1st ed.',
                 'PlacesOfPublication' => ['St. Louis, Mo.'],
                 'Publishers' => ['Mosby Elsevier'],
-                'PublicationDates' => ['2007']
+                'PublicationDates' => ['2007'],
             ],
             'apa' => 'Lewis, S., IV. (2007). <i>Medical-surgical nursing: Why?</i> Mosby Elsevier.',
             'mla' => 'Lewis, S.M., IV. <i>Medical-surgical Nursing: Why?</i> Mosby Elsevier, 2007.',
@@ -144,7 +144,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '',
                 'PlacesOfPublication' => ['New York :'],
                 'Publishers' => ['Holmes & Meier,'],
-                'PublicationDates' => ['1980.']
+                'PublicationDates' => ['1980.'],
             ],
             'apa' => 'Burch, P. H., Jr. (1980). <i>The New Deal to the Carter administration</i>. Holmes &amp; Meier.',
             'mla' => 'Burch, Philip H., Jr. <i>The New Deal to the Carter Administration</i>. Holmes &amp; Meier, 1980.',
@@ -158,7 +158,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '',
                 'PlacesOfPublication' => ['New York :'],
                 'Publishers' => ['Holmes & Meier,'],
-                'PublicationDates' => ['1980.']
+                'PublicationDates' => ['1980.'],
             ],
             'apa' => 'Burch, P. H., Jr., Coauthor, F., &amp; Fakeperson, T., III. (1980). <i>The New Deal to the Carter administration</i>. Holmes &amp; Meier.',
             'mla' => 'Burch, Philip H., Jr., et al. <i>The New Deal to the Carter Administration</i>. Holmes &amp; Meier, 1980.',
@@ -172,7 +172,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Edition' => '',
                 'PlacesOfPublication' => '',
                 'Publishers' => '',
-                'PublicationDates' => ''
+                'PublicationDates' => '',
             ],
             'apa' => 'Burch, P. H., Jr., Coauthor, F., Fakeperson, T., III, Mob, W., &amp; Manypeople, L. <i>The New Deal to the Carter administration</i>.',
             'mla' => 'Burch, Philip H., Jr., et al. <i>The New Deal to the Carter Administration</i>.',
@@ -185,7 +185,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'Subtitle' => '',
                 'Edition' => '',
                 'PlacesOfPublication' => ['New York'],
-                'Publishers' => ['Holmes & Meier']
+                'Publishers' => ['Holmes & Meier'],
             ],
             'apa' => 'Burch, P. H., Jr., Anonymous, &amp; Elseperson, F. <i>The New Deal to the Carter administration</i>. Holmes &amp; Meier.',
             'mla' => 'Burch, Philip H., Jr., et al. <i>The New Deal to the Carter Administration</i>. Holmes &amp; Meier.',
@@ -200,7 +200,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., Six, P., . . . Eight, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -215,7 +215,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., Six, P., . . . Eight, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -230,7 +230,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., Six, P., &amp; Seven, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -245,7 +245,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., &amp; Six, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -260,7 +260,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., &amp; Three, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -275,7 +275,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 19
+                'ContainerEndPage' => 19,
             ],
             'apa' => 'One, P., &amp; Two, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19.',
             'mla' => 'One, Person, and Person Two. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, p. 19.',
@@ -291,7 +291,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 19
+                'ContainerEndPage' => 19,
             ],
             'apa' => 'IBM &amp; Two, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19.',
             'mla' => 'IBM and Person Two. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, p. 19.',
@@ -306,7 +306,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -321,7 +321,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., Six, P., . . . Eight, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -336,7 +336,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'ContainerIssue' => 7,
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
-                'ContainerEndPage' => 21
+                'ContainerEndPage' => 21,
             ],
             'apa' => 'One, P., Two, P., Three, P., Four, P., Five, P., Six, P., . . . Ten, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21.',
             'mla' => 'One, Person, et al. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21.',
@@ -352,12 +352,12 @@ class CitationTest extends \PHPUnit\Framework\TestCase
                 'PublicationDates' => ['1999'],
                 'ContainerStartPage' => 19,
                 'ContainerEndPage' => 21,
-                'CleanDOI' => 'testDOI'
+                'CleanDOI' => 'testDOI',
             ],
             'apa' => 'One, P. (1999). Test Article. <i>Test Journal, 1</i>(7), 19-21. https://doi.org/testDOI',
             'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21, https://doi.org/testDOI.',
             'chicago' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i> 1, no. 7 (1999): 19-21. https://doi.org/testDOI.',
-        ]
+        ],
         // @codingStandardsIgnoreEnd
     ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
@@ -106,7 +106,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
                 'session_name' => 'vufindsession',
                 'consent' => true,
                 'consentCategories' => 'essential,matomo',
-            ]
+            ],
         ];
 
         $cookies = [
@@ -118,7 +118,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
                     'lastConsentTimestamp' => gmdate('Y-m-d\TH:i:s\Z'),
                     'revision' => 0,
                 ]
-            )
+            ),
         ];
         $expectedParams = $this->getExpectedRenderParams(
             'CookieConsent.yaml',
@@ -149,7 +149,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
                 'session_name' => 'vufindsession',
                 'consent' => true,
                 'consentCategories' => 'essential,matomo',
-            ]
+            ],
         ];
 
         $cookies = [
@@ -161,7 +161,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
                     'lastConsentTimestamp' => gmdate('Y-m-d\TH:i:s\Z'),
                     'revision' => -1,
                 ]
-            )
+            ),
         ];
 
         $helper = $this->getCookieConsent($config, $cookies);
@@ -386,7 +386,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
                 'matomo' => [
                     'matomo',
                 ],
-            ]
+            ],
         ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CspTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CspTest.php
@@ -52,14 +52,14 @@ class CspTest extends \PHPUnit\Framework\TestCase
                 'CSP' => [
                     'use_nonce' => true,
                     'enabled' => [
-                        'testing' => true
-                    ]
+                        'testing' => true,
+                    ],
                 ],
                 'Directives' => [
                     'script-src' => [
-                        "'unsafe-inline'"
-                    ]
-                ]
+                        "'unsafe-inline'",
+                    ],
+                ],
             ]
         );
         $nonceGenerator = new \VuFind\Security\NonceGenerator();
@@ -94,14 +94,14 @@ class CspTest extends \PHPUnit\Framework\TestCase
                 'CSP' => [
                     'use_nonce' => true,
                     'enabled' => [
-                        'testing' => 'report_only'
-                    ]
+                        'testing' => 'report_only',
+                    ],
                 ],
                 'Directives' => [
                     'script-src' => [
-                        "'unsafe-inline'"
-                    ]
-                ]
+                        "'unsafe-inline'",
+                    ],
+                ],
             ]
         );
         $nonceGenerator = new \VuFind\Security\NonceGenerator();
@@ -136,14 +136,14 @@ class CspTest extends \PHPUnit\Framework\TestCase
                 'CSP' => [
                     'use_nonce' => true,
                     'enabled' => [
-                        'testing' => false
-                    ]
+                        'testing' => false,
+                    ],
                 ],
                 'Directives' => [
                     'script-src' => [
-                        "'unsafe-inline'"
-                    ]
-                ]
+                        "'unsafe-inline'",
+                    ],
+                ],
             ]
         );
         $nonceGenerator = new \VuFind\Security\NonceGenerator();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/FlashmessagesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/FlashmessagesTest.php
@@ -58,48 +58,48 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 [],
-                ''
+                '',
             ],
             [
                 [
                     'success' => [
-                        'Foo'
-                    ]
+                        'Foo',
+                    ],
                 ],
-                '<div role="alert" class="success">Foo</div>'
+                '<div role="alert" class="success">Foo</div>',
             ],
             [
                 [
                     'error' => [
-                        'Fail'
+                        'Fail',
                     ],
                     'success' => [
-                        'Good'
-                    ]
+                        'Good',
+                    ],
                 ],
                 '<div role="alert" class="error">Fail</div>'
-                    . '<div role="alert" class="success">Good Translation</div>'
-            ],
-            [
-                [
-                    'success' => [
-                        [
-                            'msg' => 'Good'
-                        ]
-                    ]
-                ],
-                '<div role="alert" class="success">Good Translation</div>'
+                    . '<div role="alert" class="success">Good Translation</div>',
             ],
             [
                 [
                     'success' => [
                         [
                             'msg' => 'Good',
-                            'translate' => false
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">Good</div>'
+                '<div role="alert" class="success">Good Translation</div>',
+            ],
+            [
+                [
+                    'success' => [
+                        [
+                            'msg' => 'Good',
+                            'translate' => false,
+                        ],
+                    ],
+                ],
+                '<div role="alert" class="success">Good</div>',
             ],
             [
                 [
@@ -110,10 +110,10 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                             'tokens' => [
                                 '%%ph%%' => 'Good',
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">foo Good</div>'
+                '<div role="alert" class="success">foo Good</div>',
             ],
             [
                 [
@@ -124,11 +124,11 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                             'tokens' => [
                                 '%%ph%%' => 'paragraph',
                             ],
-                            'translateTokens' => true
-                        ]
-                    ]
+                            'translateTokens' => true,
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">foo Tag &lt;p&gt;</div>'
+                '<div role="alert" class="success">foo Tag &lt;p&gt;</div>',
             ],
             [
                 [
@@ -140,11 +140,11 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                             'tokens' => [
                                 '%%ph%%' => 'paragraph',
                             ],
-                            'translateTokens' => true
-                        ]
-                    ]
+                            'translateTokens' => true,
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">foo Tag &lt;p&gt;</div>'
+                '<div role="alert" class="success">foo Tag &lt;p&gt;</div>',
             ],
             [
                 [
@@ -158,10 +158,10 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                             ],
                             'translateTokens' => true,
                             'tokensHtml' => true,
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">foo Tag <p></div>'
+                '<div role="alert" class="success">foo Tag <p></div>',
             ],
             [
                 [
@@ -175,10 +175,10 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                             ],
                             'translateTokens' => false,
                             'tokensHtml' => true,
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">foo <b>bold</b></div>'
+                '<div role="alert" class="success">foo <b>bold</b></div>',
             ],
             [
                 [
@@ -186,10 +186,10 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                         [
                             'msg' => 'Goof',
                             'default' => 'Good',
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
-                '<div role="alert" class="success">Good</div>'
+                '<div role="alert" class="success">Good</div>',
             ],
         ];
     }
@@ -255,7 +255,7 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
                 'Good' => 'Good Translation',
                 'paragraph' => 'Tag <p>',
                 'foo_html' => '<p>Foo</p>',
-                'foo_placeholder' => 'foo %%ph%%'
+                'foo_placeholder' => 'foo %%ph%%',
             ];
             $translated = $strings[$str] ?? $default ?? $str;
             return str_replace(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -80,7 +80,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
         $createJs = "{cookieFlags: 'max-age=7200;secure;samesite=none'}";
         $options = [
             'universal' => true,
-            'create_options_js' => $createJs
+            'create_options_js' => $createJs,
         ];
         $output = $this->renderGA('myfakekey', $options);
         // Confirm that the custom JS appears in the output, and that the

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HtmlSafeJsonEncodeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HtmlSafeJsonEncodeTest.php
@@ -86,7 +86,7 @@ class HtmlSafeJsonEncodeTest extends \PHPUnit\Framework\TestCase
                 => ['<\'">', '"\u003C\u0027\u0022\u003E"'],
             'array of special characters' => [
                 ['<', '"', "'", '>', '&'],
-                '["\u003C","\u0022","\u0027","\u003E","\u0026"]'
+                '["\u003C","\u0022","\u0027","\u003E","\u0026"]',
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -69,7 +69,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
                 'FakeSprite' => [
                     'template' => 'svg-sprite',
                     'src' => 'mysprites.svg',
-                ]
+                ],
             ],
             'aliases' => [
                 'bar' => 'Fugue:baz.png',
@@ -81,7 +81,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
                 'criminal' => 'Alias:illegal',
                 'foolish' => 'Alias:foolish',
                 'classy' => 'FontAwesome:spinner:extraClass',
-                'extraClassy' => 'Fugue:zzz.png:weird:class foo'
+                'extraClassy' => 'Fugue:zzz.png:weird:class foo',
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/JsTranslationsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/JsTranslationsTest.php
@@ -89,7 +89,7 @@ class JsTranslationsTest extends \PHPUnit\Framework\TestCase
                 [
                     '1key' => 'Translation 1&lt;p&gt;',
                     '2key' => '&lt;span&gt;translation&lt;/span&gt;',
-                    '2key_html' => '<span>translation</span>'
+                    '2key_html' => '<span>translation</span>',
                 ]
             ),
             $helper->getJSONFromArray(
@@ -117,8 +117,8 @@ class JsTranslationsTest extends \PHPUnit\Framework\TestCase
                 'default' => [
                     'key1' => 'Translation 1<p>',
                     'key_html' => '<span>translation</span>',
-                    'key2' => 'Translation 2'
-                ]
+                    'key2' => 'Translation 2',
+                ],
             ]
         );
         $translate = new Translate();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
@@ -66,22 +66,22 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
         return [
             'Basic' => [
                 '<button class="btn" id="login">text</button>',
-                ['button', 'text', ['class' => 'btn', 'id' => 'login']]
+                ['button', 'text', ['class' => 'btn', 'id' => 'login']],
             ],
 
             'String' => [
                 '<i class="btn">text</i>',
-                ['i', 'text', 'btn']
+                ['i', 'text', 'btn'],
             ],
 
             'Empty text' => [
                 '<i class="fa&#x20;fa-awesome"></i>',
-                ['i', '', 'fa fa-awesome']
+                ['i', '', 'fa fa-awesome'],
             ],
 
             'Truthy attribute' => [
                 '<a href="&#x2F;login" data-lightbox="1">Login</a>',
-                ['a', 'Login', ['href' => '/login', 'data-lightbox' => true]]
+                ['a', 'Login', ['href' => '/login', 'data-lightbox' => true]],
             ],
         ];
     }
@@ -99,7 +99,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
                 [
                     'button',
                     'This link is <strong>important</strong>',
-                ]
+                ],
             ],
 
             'does not escape innerHTML with option' => [
@@ -108,8 +108,8 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
                     'button',
                     'This link is <strong>important</strong>',
                     [],
-                    ['escapeContent' => false]
-                ]
+                    ['escapeContent' => false],
+                ],
             ],
 
             'escape innerHTML with option' => [
@@ -118,8 +118,8 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
                     'button',
                     'This link is <strong>important</strong>',
                     [],
-                    ['escapeContent' => true]
-                ]
+                    ['escapeContent' => true],
+                ],
             ],
         ];
     }
@@ -137,8 +137,8 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
                 [
                     'img',
                     '',
-                    ['src' => 'book.gif']
-                ]
+                    ['src' => 'book.gif'],
+                ],
             ],
 
             'class only' => [
@@ -146,17 +146,17 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
                 [
                     'br',
                     '',
-                    'sm:hidden'
-                ]
+                    'sm:hidden',
+                ],
             ],
 
             'non-void tag' => [
                 '<span></span>',
                 [
                     'span',
-                    ''
-                ]
-            ]
+                    '',
+                ],
+            ],
         ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/OpenUrlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/OpenUrlTest.php
@@ -63,7 +63,7 @@ class OpenUrlTest extends \PHPUnit\Framework\TestCase
     public function testCheckContextDefaults()
     {
         $config = [
-            'url' => 'http://foo/bar'
+            'url' => 'http://foo/bar',
         ];
         $driver = $this->getMockDriver();
         $openUrl = ($this->getOpenUrl(null, $config))($driver, 'results');

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PermissionTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PermissionTest.php
@@ -54,24 +54,24 @@ class PermissionTest extends \PHPUnit\Framework\TestCase
     protected $permissionDeniedConfig = [
         'permissionDeniedTemplate' => [
             'deniedTemplateBehavior' => "showTemplate:record/displayLogicTest:param1=noValue",
-            'deniedControllerBehavior' => "showTemplate:record/ActionTest:param1=noValue"
+            'deniedControllerBehavior' => "showTemplate:record/ActionTest:param1=noValue",
         ],
         'permissionDeniedTemplateNoParams' => [
             'deniedTemplateBehavior' => "showTemplate:record/displayLogicTest",
-            'deniedControllerBehavior' => "showTemplate:record/ActionTest"
+            'deniedControllerBehavior' => "showTemplate:record/ActionTest",
         ],
         'permissionDeniedMessage' => [
             'deniedTemplateBehavior' => "showMessage:dl_translatable_test",
-            'deniedControllerBehavior' => "showTemplate:action_translatable_test"
+            'deniedControllerBehavior' => "showTemplate:action_translatable_test",
         ],
         'permissionDeniedLogin' => [
-            'deniedControllerBehavior' => "promptLogin"
+            'deniedControllerBehavior' => "promptLogin",
         ],
         'permissionDeniedException' => [
-            'deniedControllerBehavior' => "exception:ForbiddenException:exception_message"
+            'deniedControllerBehavior' => "exception:ForbiddenException:exception_message",
         ],
         'permissionDeniedNonExistentException' => [
-            'deniedControllerBehavior' => "exception:NonExistentException:exception_message"
+            'deniedControllerBehavior' => "exception:NonExistentException:exception_message",
         ],
         'permissionDeniedNothing' => [
         ],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
@@ -68,7 +68,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
         return [
             [ // Set 0
                 [],
-                ''
+                '',
             ],
             [ // Set 1
                 [
@@ -77,14 +77,14 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                 <<<END
                     <span class="term">KeyA:</span> <span class="detail">ValueA</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 2
                 "Value0",
                 <<<END
                     <span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 3
                 [
@@ -93,7 +93,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                 <<<END
                     <span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 4
                 [
@@ -104,7 +104,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     <span class="detail">Value0</span><br/>
                     <span class="detail">Value1</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 5
                 [
@@ -113,7 +113,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                 <<<END
                     <span class="detail">Escaped vals &lt;&gt;&amp;&#039;&quot;</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 6
                 [
@@ -127,7 +127,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;<span class="detail">Value0</span><br/>
                     &ensp;&ensp;<span class="detail">Value1</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 7
                 [
@@ -140,7 +140,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ndash;&ensp;<span class="detail">Value0</span><br/>
                     &ensp;&ensp;<span class="detail">Value1</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 8
                 [
@@ -161,7 +161,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;<span class="term">KeyX:</span> <span class="detail">Value2</span><br/>
                     &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 9
                 [
@@ -182,7 +182,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br/>
                     &ndash;&ensp;<span class="detail">Value4</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 10
                 [
@@ -205,7 +205,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;&ndash;&ensp;<span class="term">KeyY:</span> <span class="detail">Value4</span><br/>
                     &ensp;&ensp;&ensp;&ensp;<span class="term">KeyZ:</span> <span class="detail">Value5</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 11
                 [
@@ -240,7 +240,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;<span class="term">KeyB:</span> <span class="detail">Value6</span><br/>
                     &ensp;&ensp;<span class="term">200:</span> <span class="detail">Value7</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 12
                 [
@@ -264,7 +264,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     <span class="term">003:</span> <span class="detail">Value5</span><br/>
                     <span class="term">100:</span> <span class="detail">Value6</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 13
                 [
@@ -279,7 +279,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ndash;&ensp;<span class="term">049:</span> <span class="detail">Value2</span><br/>
                     &ndash;&ensp;<span class="term">100:</span> <span class="detail">Value3</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 14
                 [
@@ -288,7 +288,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                 <<<END
                     <span class="term">KeyA:</span> <span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 15
                 [
@@ -298,7 +298,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     <span class="term">KeyA:</span><br/>
                     &ensp;&ensp;<span class="term">000:</span> <span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 16
                 [
@@ -308,7 +308,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     <span class="term">KeyA:</span><br/>
                     &ensp;&ensp;<span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 17
                 [
@@ -318,7 +318,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     <span class="term">KeyA:</span><br/>
                     &ensp;&ensp;&ndash;&ensp;&ndash;&ensp;<span class="detail">Value0</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 18
                 [
@@ -334,7 +334,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;<span class="detail">Value1</span><br/>
                     &ensp;&ensp;<span class="detail">Value2</span><br/>
 
-                    END
+                    END,
             ],
             [ // Set 19
                 [
@@ -356,7 +356,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     &ensp;&ensp;&ndash;&ensp;<span class="detail">Value2</span><br/>
                     &ensp;&ensp;&ensp;&ensp;<span class="detail">Value3</span><br/>
 
-                    END
+                    END,
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -120,7 +120,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
     {
         // "Mock out" tag functionality to avoid database access:
         $methods = [
-            'getBuildings', 'getDeduplicatedAuthors', 'getContainerTitle', 'getTags'
+            'getBuildings', 'getDeduplicatedAuthors', 'getContainerTitle', 'getTags',
         ];
         $record = $this->getMockBuilder(\VuFind\RecordDriver\SolrDefault::class)
             ->onlyMethods($methods)
@@ -228,11 +228,11 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
-                'getInvokedSpecs'
+                'getInvokedSpecs',
             ],
             [
-                'getOldSpecs'
-            ]
+                'getOldSpecs',
+            ],
         ];
     }
 
@@ -269,7 +269,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
                         'values' => count($data),
                     ],
                 ];
-            }
+            },
         ];
         $spec['MultiEmptyArrayTest'] = [
             'dataMethod' => true,
@@ -277,7 +277,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'pos' => 2000,
             'multiFunction' => function () {
                 return [];
-            }
+            },
         ];
         $spec['MultiNullTest'] = [
             'dataMethod' => true,
@@ -285,7 +285,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'pos' => 2000,
             'multiFunction' => function () {
                 return null;
-            }
+            },
         ];
         $spec['MultiNullInArrayWithZeroTest'] = [
             'dataMethod' => true,
@@ -301,9 +301,9 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
                     [
                         'label' => 'ZeroBlocked',
                         'values' => 0,
-                    ]
+                    ],
                 ];
-            }
+            },
         ];
         $spec['MultiNullInArrayWithZeroAllowedTest'] = [
             'dataMethod' => true,
@@ -319,9 +319,9 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
                     [
                         'label' => 'ZeroAllowed',
                         'values' => 0,
-                    ]
+                    ],
                 ];
-            }
+            },
         ];
         $spec['MultiWithSortPos'] = [
             'dataMethod' => true,
@@ -332,20 +332,20 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
                     [
                         'label' => 'b',
                         'values' => 'b',
-                        'options' => ['pos' => 3000]
+                        'options' => ['pos' => 3000],
                     ],
                     [
                         'label' => 'a',
                         'values' => 'a',
-                        'options' => ['pos' => 3000]
+                        'options' => ['pos' => 3000],
                     ],
                     [
                         'label' => 'c',
                         'values' => 'c',
-                        'options' => ['pos' => 2999]
+                        'options' => ['pos' => 2999],
                     ],
                 ];
-            }
+            },
         ];
         $expected = [
             'Building' => 'prefix_0',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -211,7 +211,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $user = new \StdClass();
         $user->id = 42;
         $expected = [
-            'driver' => $driver, 'list' => null, 'user' => $user, 'lists' => [1, 2, 3]
+            'driver' => $driver, 'list' => null, 'user' => $user, 'lists' => [1, 2, 3],
         ];
         $context = $this->getMockContext();
         $context->expects($this->once())->method('apply')
@@ -327,11 +327,11 @@ class RecordTest extends \PHPUnit\Framework\TestCase
             ->withConsecutive(
                 [
                     'record/checkbox.phtml',
-                    ['id' => 'Solr|000105196', 'number' => 1, 'prefix' => 'bar', 'formAttr' => 'foo']
+                    ['id' => 'Solr|000105196', 'number' => 1, 'prefix' => 'bar', 'formAttr' => 'foo'],
                 ],
                 [
                     'record/checkbox.phtml',
-                    ['id' => 'Solr|000105196', 'number' => 2, 'prefix' => 'bar', 'formAttr' => 'foo']
+                    ['id' => 'Solr|000105196', 'number' => 2, 'prefix' => 'bar', 'formAttr' => 'foo'],
                 ]
             )
             ->willReturnOnConsecutiveCalls('success', 'success');
@@ -476,8 +476,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $driver->setRawData(
             [
                 'URLs' => [
-                    ['route' => 'fake-route', 'prefix' => 'http://proxy?_=', 'desc' => 'a link']
-                ]
+                    ['route' => 'fake-route', 'prefix' => 'http://proxy?_=', 'desc' => 'a link'],
+                ],
             ]
         );
         $record = $this->getRecord($driver, [], null, 'fake-route', true);
@@ -487,8 +487,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                     'route' => 'fake-route',
                     'prefix' => 'http://proxy?_=',
                     'desc' => 'a link',
-                    'url' => 'http://proxy?_=http://server-foo/baz'
-                ]
+                    'url' => 'http://proxy?_=http://server-foo/baz',
+                ],
             ],
             $record->getLinkDetails()
         );
@@ -508,8 +508,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $driver->setRawData(
             [
                 'URLs' => [
-                    ['bad' => 'junk']
-                ]
+                    ['bad' => 'junk'],
+                ],
             ]
         );
         $record = $this->getRecord($driver);
@@ -519,8 +519,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                     'route' => 'fake-route',
                     'prefix' => 'http://proxy?_=',
                     'desc' => 'a link',
-                    'url' => 'http://proxy?_=http://server-foo/baz'
-                ]
+                    'url' => 'http://proxy?_=http://server-foo/baz',
+                ],
             ],
             $record->getLinkDetails()
         );
@@ -543,8 +543,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                     ['desc' => 'link 1 (alternate description)',
                         'url' => 'http://foo/baz1'],
                     ['url' => 'http://foo/baz3'],
-                    ['url' => 'http://foo/baz3']
-                ]
+                    ['url' => 'http://foo/baz3'],
+                ],
             ]
         );
         $record = $this->getRecord($driver);
@@ -554,7 +554,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
                 ['desc' => 'link 2', 'url' => 'http://foo/baz2'],
                 ['desc' => 'link 1 (alternate description)',
                     'url' => 'http://foo/baz1'],
-                ['desc' => 'http://foo/baz3', 'url' => 'http://foo/baz3']
+                ['desc' => 'http://foo/baz3', 'url' => 'http://foo/baz3'],
             ],
             $record->getLinkDetails()
         );
@@ -571,8 +571,8 @@ class RecordTest extends \PHPUnit\Framework\TestCase
         $driver->setRawData(
             [
                 'URLs' => [
-                    ['route' => 'fake-route', 'prefix' => 'http://proxy?_=', 'desc' => 'a link']
-                ]
+                    ['route' => 'fake-route', 'prefix' => 'http://proxy?_=', 'desc' => 'a link'],
+                ],
             ]
         );
         $record = $this->getRecord($driver, [], null, 'fake-route', true);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
@@ -61,7 +61,7 @@ class SearchTabsTest extends \PHPUnit\Framework\TestCase
                 2,
                 [],
                 1,
-                ''
+                '',
             ],
             [
                 [
@@ -70,7 +70,7 @@ class SearchTabsTest extends \PHPUnit\Framework\TestCase
                 ],
                 1,
                 [
-                    'last' => ['foo']
+                    'last' => ['foo'],
                 ],
                 0,
                 'hiddenFilters%5B%5D=first%3A%22foo%22'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
@@ -181,7 +181,7 @@ class TranslateTest extends \PHPUnit\Framework\TestCase
             $this->getMockTranslator(
                 [
                     'default' => ['foo' => '%%token%%'],
-                    'other' => ['foo' => 'Foo', 'bar' => 'Bar']
+                    'other' => ['foo' => 'Foo', 'bar' => 'Bar'],
                 ]
             )
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslationEmptyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslationEmptyTest.php
@@ -59,7 +59,7 @@ class TranslationEmptyTest extends \PHPUnit\Framework\TestCase
                     'default' => [
                         'foo' => 'bar',
                         'baz' => '',
-                    ]
+                    ],
                 ]
             )
         );

--- a/module/VuFindAdmin/config/module.config.php
+++ b/module/VuFindAdmin/config/module.config.php
@@ -33,7 +33,7 @@ $config = [
                     'defaults' => [
                         'controller' => 'Admin',
                         'action'     => 'Home',
-                    ]
+                    ],
                 ],
                 'may_terminate' => true,
                 'child_routes' => [
@@ -44,8 +44,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'Admin',
                                 'action'     => 'Disabled',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'config' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -54,8 +54,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminConfig',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'feedback' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -64,8 +64,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminFeedback',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'maintenance' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -74,8 +74,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminMaintenance',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'social' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -84,8 +84,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminSocial',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'tags' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -94,8 +94,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminTags',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                     'overdrive' => [
                         'type' => 'Laminas\Router\Http\Segment',
@@ -104,8 +104,8 @@ $config = [
                             'defaults' => [
                                 'controller' => 'AdminOverdrive',
                                 'action'     => 'Home',
-                            ]
-                        ]
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
@@ -130,7 +130,7 @@ class FeedbackController extends AbstractAdmin
         $this->flashMessenger()->addMessage(
             [
                 'msg' => 'feedback_delete_success',
-                'tokens' => ['%%count%%' => $delete]
+                'tokens' => ['%%count%%' => $delete],
             ],
             'success'
         );
@@ -160,8 +160,8 @@ class FeedbackController extends AbstractAdmin
                     'site_url' => $this->getParam('site_url', true),
                     'status' => $this->getParam('status', true),
                     'ids' => $ids,
-                ]
-            ]
+                ],
+            ],
         ];
         return $this->forwardTo('Confirm', 'Confirm', $data);
     }
@@ -190,7 +190,7 @@ class FeedbackController extends AbstractAdmin
         $messages = [];
         $messages[] = [
             'msg' => 'feedback_delete_warning',
-            'tokens' => ['%%count%%' => $count]
+            'tokens' => ['%%count%%' => $count],
         ];
 
         if (array_filter(array_map([$this, 'getParam'], $params))) {
@@ -200,7 +200,7 @@ class FeedbackController extends AbstractAdmin
                     '%%formname%%' => $paramMessages['form_name'],
                     '%%siteurl%%' => $paramMessages['site_url'],
                     '%%status%%' => $paramMessages['status'],
-                ]
+                ],
             ];
         }
         $messages[] = ['msg' => 'confirm_delete'];

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
@@ -177,7 +177,7 @@ class TagsController extends AbstractAdmin
         $this->flashMessenger()->addMessage(
             [
                 'msg' => 'tags_deleted',
-                'tokens' => ['%count%' => $delete]
+                'tokens' => ['%count%' => $delete],
             ],
             'success'
         );
@@ -229,8 +229,8 @@ class TagsController extends AbstractAdmin
         $messages = [
             [
                 'msg' => 'tag_delete_warning',
-                'tokens' => ['%count%' => $count]
-            ]
+                'tokens' => ['%count%' => $count],
+            ],
         ];
         if ($userId || $tagId || $resourceId) {
             $messages[] = [
@@ -238,8 +238,8 @@ class TagsController extends AbstractAdmin
                 'tokens' => [
                     '%username%' => $userMsg,
                     '%tag%' => $tagMsg,
-                    '%resource%' => $resourceMsg
-                ]
+                    '%resource%' => $resourceMsg,
+                ],
             ];
         }
         $messages[] = ['msg' => 'confirm_delete'];
@@ -271,9 +271,9 @@ class TagsController extends AbstractAdmin
                     'user_id' => $this->getParam('user_id'),
                     'tag_id' => $this->getParam('tag_id'),
                     'resource_id' => $this->getParam('resource_id'),
-                    'ids' => $ids
-                ]
-            ]
+                    'ids' => $ids,
+                ],
+            ],
         ];
 
         return $this->forwardTo('Confirm', 'Confirm', $data);
@@ -308,9 +308,9 @@ class TagsController extends AbstractAdmin
                     'user_id' => $this->getParam('user_id'),
                     'tag_id' => $this->getParam('tag_id'),
                     'resource_id' => $this->getParam('resource_id'),
-                    'deleteFilter' => $this->getParam('deleteFilter')
-                ]
-            ]
+                    'deleteFilter' => $this->getParam('deleteFilter'),
+                ],
+            ],
         ];
 
         return $this->forwardTo('Confirm', 'Confirm', $data);

--- a/module/VuFindApi/config/module.config.php
+++ b/module/VuFindApi/config/module.config.php
@@ -33,7 +33,7 @@ $config = [
             \VuFindApi\Controller\SearchApiController::class,
             \VuFindApi\Controller\Search2ApiController::class,
             \VuFindApi\Controller\WebApiController::class,
-        ]
+        ],
     ],
     'router' => [
         'routes' => [
@@ -45,8 +45,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'AdminApi',
                         'action'     => 'clearCache',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'apiHome' => [
                 'type' => 'Laminas\Router\Http\Segment',
@@ -56,7 +56,7 @@ $config = [
                     'defaults' => [
                         'controller' => 'Api',
                         'action'     => 'Index',
-                    ]
+                    ],
                 ],
             ],
             'searchApiv1' => [
@@ -67,8 +67,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'SearchApi',
                         'action'     => 'search',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'recordApiv1' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -78,8 +78,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'SearchApi',
                         'action'     => 'record',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'search2Apiv1' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -89,8 +89,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'Search2Api',
                         'action'     => 'search',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'record2Apiv1' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -100,8 +100,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'Search2Api',
                         'action'     => 'record',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'websearchApiv1' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -111,8 +111,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'WebApi',
                         'action'     => 'search',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'webrecordApiv1' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -122,8 +122,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'WebApi',
                         'action'     => 'record',
-                    ]
-                ]
+                    ],
+                ],
             ],
         ],
     ],

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -131,10 +131,10 @@ class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiI
                         'schema' => [
                             'type' => 'array',
                             'items' => [
-                                'type' => 'string'
-                            ]
+                                'type' => 'string',
+                            ],
                         ],
-                    ]
+                    ],
                 ],
                 'tags' => ['admin'],
                 'responses' => [
@@ -143,22 +143,22 @@ class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiI
                         'content' => [
                             'application/json' => [
                                 'schema' => [
-                                    '$ref' => '#/components/schemas/Success'
-                                ]
-                            ]
-                        ]
+                                    '$ref' => '#/components/schemas/Success',
+                                ],
+                            ],
+                        ],
                     ],
                     'default' => [
                         'description' => 'Error',
                         'content' => [
                             'application/json' => [
                                 'schema' => [
-                                    '$ref' => '#/components/schemas/Error'
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                    '$ref' => '#/components/schemas/Error',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ];
         }
 

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiController.php
@@ -105,7 +105,7 @@ class ApiController extends \VuFind\Controller\AbstractBase
         $config = $this->getConfig();
         $params = [
             'config' => $config,
-            'version' => \VuFind\Config\Version::getBuildVersion()
+            'version' => \VuFind\Config\Version::getBuildVersion(),
         ];
         return $this->getViewRenderer()->render('api/openapi', $params);
     }

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -145,7 +145,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
         // Apply all supported configurations:
         $configKeys = [
-            'recordAccessPermission', 'searchAccessPermission', 'maxLimit'
+            'recordAccessPermission', 'searchAccessPermission', 'maxLimit',
         ];
         foreach ($configKeys as $key) {
             if (isset($settings[$key])) {
@@ -266,7 +266,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         }
 
         $response = [
-            'resultCount' => count($results)
+            'resultCount' => count($results),
         ];
         $requestedFields = $this->getFieldList($request);
         if ($records = $this->recordFormatter->format($results, $requestedFields)) {

--- a/module/VuFindApi/src/VuFindApi/Formatter/FacetFormatter.php
+++ b/module/VuFindApi/src/VuFindApi/Formatter/FacetFormatter.php
@@ -109,7 +109,7 @@ class FacetFormatter extends BaseFormatter
         $result = [];
         $fields = [
             'value', 'displayText', 'count',
-            'children', 'href', 'isApplied'
+            'children', 'href', 'isApplied',
         ];
         foreach ($list as $value) {
             $resultValue = [];

--- a/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatter.php
+++ b/module/VuFindApi/src/VuFindApi/Formatter/RecordFormatter.php
@@ -196,7 +196,7 @@ class RecordFormatter extends BaseFormatter
                     if ($value instanceof TranslatableString) {
                         $value = [
                             'value' => (string)$value,
-                            'translated' => $translator->translate($value)
+                            'translated' => $translator->translate($value),
                         ];
                     } else {
                         $value = (string)$value;

--- a/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/FacetFormatterTest.php
+++ b/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/FacetFormatterTest.php
@@ -70,8 +70,8 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                         'count' => 150,
                         'operator' => 'AND',
                         'isApplied' => true,
-                    ]
-                ]
+                    ],
+                ],
             ],
             'xyzzy' => [
                 'label' => 'Xyzzy Facet',
@@ -96,9 +96,9 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                         'count' => 5,
                         'operator' => 'OR',
                         'isApplied' => true,
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
         if (!$includeOr) {
             unset($data['xyzzy']);
@@ -131,7 +131,7 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                     'count' => 150,
                     'operator' => 'AND',
                     'isApplied' => true,
-                ]
+                ],
             ],
             'hierarchical_xyzzy' => [
                 [
@@ -147,8 +147,8 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                     'count' => 15,
                     'operator' => 'OR',
                     'isApplied' => true,
-                ]
-            ]
+                ],
+            ],
         ];
         if (!$includeOr) {
             unset($data['hierarchical_xyzzy']);
@@ -245,9 +245,9 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                             'count' => 150,
                             'isApplied' => 1,
                             'href' => '?filter%5B%5D=foo%3A%22baz%22',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
         $this->assertEquals($expected, $formatted);
@@ -268,7 +268,7 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                 'hierarchical_foo:1/bar/cookie/',
                 '~xyzzy:val2',
                 '~xyzzy:val3',
-                'hierarchical_xyzzy:1/val1/val2/'
+                'hierarchical_xyzzy:1/val1/val2/',
             ],
             'facetFilter' => ['foo:..z', 'xyzzy:val(2|3)'],
         ];
@@ -333,9 +333,9 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                                 . '&filter%5B%5D=%7Exyzzy%3A%22val2%22'
                                 . '&filter%5B%5D=%7Exyzzy%3A%22val3%22'
                                 . '&filter%5B%5D=hierarchical_xyzzy%3A%221%2Fval1%2Fval2%2F%22',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             'hierarchical_xyzzy' => [
                 [
@@ -357,10 +357,10 @@ class FacetFormatterTest extends \PHPUnit\Framework\TestCase
                                 . '&filter%5B%5D=hierarchical_foo%3A%221%2Fbar%2Fcookie%2F%22'
                                 . '&filter%5B%5D=%7Exyzzy%3A%22val2%22&filter%5B%5D=%7Exyzzy%3A%22val3%22'
                                 . '&filter%5B%5D=hierarchical_xyzzy%3A%221%2Fval1%2Fval2%2F%22',
-                        ]
-                    ]
-                ]
-            ]
+                        ],
+                    ],
+                ],
+            ],
         ];
         $this->assertEquals($expected, $formatted);
     }

--- a/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
+++ b/module/VuFindApi/tests/unit-tests/src/VuFindTest/Formatter/RecordFormatterTest.php
@@ -54,20 +54,20 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
             'cleanDOI' => [
                 'vufind.method' => 'getCleanDOI',
                 'description' => 'First valid DOI',
-                'type' => 'string'
+                'type' => 'string',
             ],
             'dedupIds' => [
                 'vufind.method' => 'Formatter::getDedupIds',
                 'description' => 'IDs of all records deduplicated',
                 'type' => 'array',
-                'items' => ['type' => 'string']
+                'items' => ['type' => 'string'],
             ],
             'fullRecord' => ['vufind.method' => 'Formatter::getFullRecord'],
             'rawData' => ['vufind.method' => 'Formatter::getRawData'],
             'buildings' => ['vufind.method' => 'getBuildings'],
             'recordPage' => ['vufind.method' => 'Formatter::getRecordPage'],
             'subjectsExtended' => [
-                'vufind.method' => 'Formatter::getExtendedSubjectHeadings'
+                'vufind.method' => 'Formatter::getExtendedSubjectHeadings',
             ],
             'authors' => ['vufind.method' => 'getDeduplicatedAuthors'],
         ];
@@ -153,7 +153,7 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
         $expectedRaw = $driver->getRawData();
         unset($expectedRaw['spelling']);
         $expectedRaw['Buildings'] = [
-            'foo', ['value' => 'bar', 'translated' => 'xyzzy']
+            'foo', ['value' => 'bar', 'translated' => 'xyzzy'],
         ];
         $expected = [
             [
@@ -196,12 +196,12 @@ class RecordFormatterTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'cleanDOI' => [
                 'description' => 'First valid DOI',
-                'type' => 'string'
+                'type' => 'string',
             ],
             'dedupIds' => [
                 'description' => 'IDs of all records deduplicated',
                 'type' => 'array',
-                'items' => ['type' => 'string']
+                'items' => ['type' => 'string'],
             ],
             'fullRecord' => [],
             'rawData' => [],

--- a/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
@@ -322,7 +322,7 @@ class InstallCommand extends Command
                 $dir . '/cache',
                 $dir . '/config',
                 $dir . '/harvest',
-                $dir . '/import'
+                $dir . '/import',
             ]
         );
     }
@@ -454,7 +454,7 @@ class InstallCommand extends Command
         $legal = [
             self::MULTISITE_NONE,
             self::MULTISITE_DIR_BASED,
-            self::MULTISITE_HOST_BASED
+            self::MULTISITE_HOST_BASED,
         ];
         while (true) {
             $response = $this->getInput(
@@ -698,7 +698,7 @@ class InstallCommand extends Command
                 $moduleDir,
                 $moduleDir . '/config',
                 $moduleDir . '/src',
-                $moduleDir . '/src/' . $module
+                $moduleDir . '/src/' . $module,
             ]
         );
         if ($dirStatus !== true) {

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/AddUsingTemplateCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/AddUsingTemplateCommand.php
@@ -101,7 +101,7 @@ class AddUsingTemplateCommand extends AbstractCommand
             [$sourceDomain, $sourceKey] = $this->extractTextDomain($key);
             $lookups[$sourceDomain][$current] = [
                 'key' => $sourceKey,
-                'translations' => []
+                'translations' => [],
             ];
         }
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -469,8 +469,8 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
                     $selectedCheckboxes
                 ),
                 'filters' => $params->getFilterList(true),
-                'userInstitution' => $userInstitution
-             ]
+                'userInstitution' => $userInstitution,
+             ],
         ];
         return $this->renderer
             ->render('Email/scheduled-alert.phtml', $viewParams);

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
@@ -157,7 +157,7 @@ class IndexReservesCommand extends AbstractSolrAndIlsCommand
                     'course_id' => $courseId,
                     'course' => $courses[$courseId] ?? '',
                     'department_id' => $departmentId,
-                    'department' => $departments[$departmentId] ?? ''
+                    'department' => $departments[$departmentId] ?? '',
                 ];
             }
             if (!in_array($record['BIB_ID'], $index[$id]['bib_id'])) {

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
@@ -333,7 +333,7 @@ class GeneratorTools
                 );
                 $param1 = [
                     'name' => 'container',
-                    'type' => 'Psr\Container\ContainerInterface'
+                    'type' => 'Psr\Container\ContainerInterface',
                 ];
                 $param2 = [
                     'name' => 'requestedName',
@@ -868,7 +868,7 @@ class GeneratorTools
     {
         $generator = FileGenerator::fromArray(
             [
-                'body' => 'return ' . var_export($config, true) . ';'
+                'body' => 'return ' . var_export($config, true) . ';',
             ]
         );
         if (!file_put_contents($configPath, $generator->generate())) {

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendClassCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendClassCommandTest.php
@@ -90,7 +90,7 @@ class ExtendClassCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'class_name' => 'Foo',
-                'target_module' => 'Bar'
+                'target_module' => 'Bar',
             ]
         );
         $this->assertEquals(0, $commandTester->getStatusCode());
@@ -146,7 +146,7 @@ class ExtendClassCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'class_name' => 'Foo',
-                'target_module' => 'Bar'
+                'target_module' => 'Bar',
             ]
         );
         $this->assertEquals("Foo!\n", $commandTester->getDisplay());

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendServiceCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/ExtendServiceCommandTest.php
@@ -85,7 +85,7 @@ class ExtendServiceCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'config_path' => 'Foo',
-                'target_module' => 'Bar'
+                'target_module' => 'Bar',
             ]
         );
         $this->assertEquals(0, $commandTester->getStatusCode());
@@ -109,7 +109,7 @@ class ExtendServiceCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'config_path' => 'Foo',
-                'target_module' => 'Bar'
+                'target_module' => 'Bar',
             ]
         );
         $this->assertEquals("Foo!\n", $commandTester->getDisplay());

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/NonTabRecordActionCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Generate/NonTabRecordActionCommandTest.php
@@ -90,11 +90,11 @@ class NonTabRecordActionCommandTest extends \PHPUnit\Framework\TestCase
                             'defaults' => [
                                 'controller' => 'Example',
                                 'action'     => 'Foo',
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
         $tools = $this->getMockGeneratorTools(
             ['getModuleConfigPath', 'backUpFile', 'writeModuleConfig']
@@ -123,11 +123,11 @@ class NonTabRecordActionCommandTest extends \PHPUnit\Framework\TestCase
                             'defaults' => [
                                 'controller' => 'Example',
                                 'action'     => 'Home',
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
         $command = new NonTabRecordActionCommand($tools, $config);
         $commandTester = new CommandTester($command);

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/ImportCsvCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/ImportCsvCommandTest.php
@@ -84,7 +84,7 @@ class ImportCsvCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'CSV_file' => 'foo.csv',
-                'ini_file' => 'bar.ini'
+                'ini_file' => 'bar.ini',
             ]
         );
         $this->assertEquals(

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/ImportXslCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/ImportXslCommandTest.php
@@ -84,7 +84,7 @@ class ImportXslCommandTest extends \PHPUnit\Framework\TestCase
         $commandTester->execute(
             [
                 'XML_file' => 'foo.xml',
-                'properties_file' => 'bar.properties'
+                'properties_file' => 'bar.properties',
             ]
         );
         $this->assertEquals(

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/WebCrawlCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Import/WebCrawlCommandTest.php
@@ -74,7 +74,7 @@ class WebCrawlCommandTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('SolrWeb'));
         $config = new Config(
             [
-                'Sitemaps' => ['url' => ['http://foo']]
+                'Sitemaps' => ['url' => ['http://foo']],
             ]
         );
         $command = $this->getMockCommand($importer, $solr, $config);

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
@@ -63,17 +63,17 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
                     $this->isInstanceOf(InputInterface::class),
                     $this->isInstanceOf(OutputInterface::class),
                     'Where would you like to store your local settings? '
-                    . "[$expectedBaseDir/local] "
+                    . "[$expectedBaseDir/local] ",
                 ],
                 [
                     $this->isInstanceOf(InputInterface::class),
                     $this->isInstanceOf(OutputInterface::class),
-                    "\nWhat module name would you like to use? [blank for none] "
+                    "\nWhat module name would you like to use? [blank for none] ",
                 ],
                 [
                     $this->isInstanceOf(InputInterface::class),
                     $this->isInstanceOf(OutputInterface::class),
-                    'What base path should be used in VuFind\'s URL? [/vufind] '
+                    'What base path should be used in VuFind\'s URL? [/vufind] ',
                 ]
             )->willReturnOnConsecutiveCalls($localFixtures, '', '/bar');
         $expectedDirs = [

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Language/CopyStringCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Language/CopyStringCommandTest.php
@@ -142,7 +142,7 @@ class CopyStringCommandTest extends \PHPUnit\Framework\TestCase
             [
                 'source' => 'foo::bar',
                 'target' => 'foo::xyzzy',
-                '--replace' => 'baz/transformed'
+                '--replace' => 'baz/transformed',
             ]
         );
         $this->assertEquals(

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
@@ -74,7 +74,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
         $command = $this->getCommand(
             [
                 'searchTable' => $searchTable,
-                'scheduleOptions' => []
+                'scheduleOptions' => [],
             ]
         );
         $commandTester = new CommandTester($command);
@@ -99,7 +99,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
                         'search_object' => null,
                     ]
                 ),
-                'scheduleOptions' => [1 => 'Daily']
+                'scheduleOptions' => [1 => 'Daily'],
             ]
         );
         $commandTester = new CommandTester($command);
@@ -371,7 +371,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
     protected function getMockSearchResultsSet($record = null)
     {
         return [
-            $record ?? $this->container->createMock(\VuFind\RecordDriver\SolrDefault::class)
+            $record ?? $this->container->createMock(\VuFind\RecordDriver\SolrDefault::class),
         ];
     }
 
@@ -534,7 +534,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
                         'institution' => 'My Institution',
                         'title' => 'My Site',
                         'email' => 'admin@myuniversity.edu',
-                    ]
+                    ],
                 ]
             ),
             $options['mailer'] ?? $this->container->createMock(\VuFind\Mailer\Mailer::class),

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/CreateHierarchyTreesCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/CreateHierarchyTreesCommandTest.php
@@ -85,7 +85,7 @@ class CreateHierarchyTreesCommandTest extends \PHPUnit\Framework\TestCase
         $record->setRawData(
             [
                 'HierarchyType' => 'foo',
-                'HierarchyDriver' => $driver ?? $this->getMockHierarchyDriver()
+                'HierarchyDriver' => $driver ?? $this->getMockHierarchyDriver(),
             ]
         );
         return $record;
@@ -126,10 +126,10 @@ class CreateHierarchyTreesCommandTest extends \PHPUnit\Framework\TestCase
                         [
                             'value' => 'recordid',
                             'count' => 5,
-                        ]
-                    ]
-                ]
-            ]
+                        ],
+                    ],
+                ],
+            ],
         ];
         $results->expects($this->once())->method('getFullFieldFacets')
             ->with($this->equalTo(['hierarchy_top_id']))

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/DedupeCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/DedupeCommandTest.php
@@ -143,12 +143,12 @@ class DedupeCommandTest extends \PHPUnit\Framework\TestCase
                 [
                     $this->isInstanceOf(InputInterface::class),
                     $this->isInstanceOf(OutputInterface::class),
-                    'Please specify an input file: '
+                    'Please specify an input file: ',
                 ],
                 [
                     $this->isInstanceOf(InputInterface::class),
                     $this->isInstanceOf(OutputInterface::class),
-                    'Please specify an output file: '
+                    'Please specify an output file: ',
                 ]
             )->willReturnOnConsecutiveCalls($fixture, $outputFilename);
         $this->setSuccessfulExpectations($command, $outputFilename);

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/IndexReservesCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/IndexReservesCommandTest.php
@@ -232,7 +232,7 @@ class IndexReservesCommandTest extends \PHPUnit\Framework\TestCase
         $ils = $this->getMockIlsConnection();
         $instructors = ['inst1' => 'inst1', 'inst2' => 'inst2', 'inst3' => 'inst3'];
         $courses = [
-            'course1' => 'course1', 'course2' => 'course2', 'course3' => 'course3'
+            'course1' => 'course1', 'course2' => 'course2', 'course3' => 'course3',
         ];
         $departments = ['dept1' => 'dept1', 'dept2' => 'dept2', 'dept3' => 'dept3'];
         $reserves = [

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SuppressedCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SuppressedCommandTest.php
@@ -81,7 +81,7 @@ class SuppressedCommandTest extends \PHPUnit\Framework\TestCase
     {
         $args = [
             $solr ?? $this->getMockSolrWriter(),
-            $ils ?? $this->getMockIlsConnection()
+            $ils ?? $this->getMockIlsConnection(),
         ];
         return $this->getMockBuilder(SuppressedCommand::class)
             ->setConstructorArgs($args)

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
@@ -177,7 +177,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
                     'encrypt_ils_password' => true,
                     'ils_encryption_algo' => $this->encryptionAlgorithm,
                     'ils_encryption_key' => 'bar',
-                ]
+                ],
             ]
         );
         $commandTester = new CommandTester($command);
@@ -229,7 +229,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
                 [
                     'Authentication',
                     'ils_encryption_algo',
-                    $this->encryptionAlgorithm
+                    $this->encryptionAlgorithm,
                 ],
                 ['Authentication', 'ils_encryption_key', 'foo']
             );
@@ -307,7 +307,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
                 [
                     'Authentication',
                     'ils_encryption_algo',
-                    $this->encryptionAlgorithm
+                    $this->encryptionAlgorithm,
                 ],
                 ['Authentication', 'ils_encryption_key', 'foo']
             );

--- a/module/VuFindDevTools/config/module.config.php
+++ b/module/VuFindDevTools/config/module.config.php
@@ -20,8 +20,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'DevTools',
                         'action'     => 'Deminify',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'devtools-home' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -30,8 +30,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'DevTools',
                         'action'     => 'Home',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'devtools-icon' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -40,8 +40,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'DevTools',
                         'action'     => 'Icon',
-                    ]
-                ]
+                    ],
+                ],
             ],
             'devtools-language' => [
                 'type' => 'Laminas\Router\Http\Literal',
@@ -50,8 +50,8 @@ $config = [
                     'defaults' => [
                         'controller' => 'DevTools',
                         'action'     => 'Language',
-                    ]
-                ]
+                    ],
+                ],
             ],
         ],
     ],

--- a/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
@@ -315,7 +315,7 @@ class LanguageHelper
         $main = $this->loadLanguage($mainLanguage, $includeOptional);
         $details = $this->getAllLanguageDetails($main, $includeOptional);
         $dirHelpParts = [
-            APPLICATION_PATH, 'themes', 'root', 'templates', 'HelpTranslations'
+            APPLICATION_PATH, 'themes', 'root', 'templates', 'HelpTranslations',
         ];
         $dirLangParts = [APPLICATION_PATH, 'languages'];
         return compact('details', 'main', 'includeOptional') + [

--- a/module/VuFindDevTools/tests/unit-tests/src/VuFindTest/LanguageHelperTest.php
+++ b/module/VuFindDevTools/tests/unit-tests/src/VuFindTest/LanguageHelperTest.php
@@ -76,7 +76,7 @@ class LanguageHelperTest extends \PHPUnit\Framework\TestCase
             'notInL1' => [4],
             'notInL2' => [1, 3],
             'l1Percent' => '150.00',
-            'l2Percent' => '66.67'
+            'l2Percent' => '66.67',
         ];
         $this->assertEquals($expected, $h->compareLanguages($l1, $l2));
     }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Backend.php
@@ -160,7 +160,7 @@ class Backend extends AbstractBackend
             $backendDetails[$backendId] = [
                 'backend' => $backend,
                 'query' => $params->get("query_$backendId")[0],
-                'params' => $params->get("params_$backendId")[0]
+                'params' => $params->get("params_$backendId")[0],
             ];
         }
         if (!$backendDetails) {
@@ -252,8 +252,8 @@ class Backend extends AbstractBackend
                 [
                     'msg' => 'search_backend_partial_failure',
                     'tokens' => [
-                        '%%sources%%' => implode(', ', $failedBackends)
-                    ]
+                        '%%sources%%' => implode(', ', $failedBackends),
+                    ],
                 ]
             );
         }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Blender/Response/Json/RecordCollection.php
@@ -263,7 +263,7 @@ class RecordCollection extends \VuFindSearch\Backend\Solr\Response\Json\RecordCo
                         'msg' => '%%error%% -- %%label%%',
                         'tokens' => [
                             '%%error%%' => $error,
-                            '%%label%%' => $label
+                            '%%label%%' => $label,
                         ],
                         'translate' => true,
                         'translateTokens' => true,

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Backend.php
@@ -118,7 +118,7 @@ class Backend extends AbstractBackend
             [
                 'offset' => $offset,
                 'recordCount' => count($results),
-                'data' => array_slice($results, $offset, $limit)
+                'data' => array_slice($results, $offset, $limit),
             ]
         );
         $this->injectSourceIdentifier($collection);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -385,7 +385,7 @@ class Backend extends AbstractBackend
         // Most parameters need to be flattened from array format, but a few
         // should remain as arrays:
         $arraySettings = [
-            'query', 'facets', 'filters', 'groupFilters', 'rangeFilters', 'limiters'
+            'query', 'facets', 'filters', 'groupFilters', 'rangeFilters', 'limiters',
         ];
         foreach ($params as $key => $param) {
             $options[$key] = in_array($key, $arraySettings)

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -395,7 +395,7 @@ abstract class Base
         $headers = [
             'Accept' => $this->accept,
             'Content-Type' => $this->contentType,
-            'Accept-Encoding' => 'gzip,deflate'
+            'Accept-Encoding' => 'gzip,deflate',
         ];
         if (null != $headerParams) {
             foreach ($headerParams as $key => $value) {

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Command/AutocompleteCommand.php
@@ -91,7 +91,7 @@ class AutocompleteCommand extends CallMethodCommand
     {
         return [
             $this->getQuery(),
-            $this->getDomain()
+            $this->getDomain(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EIT/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EIT/Connector.php
@@ -125,7 +125,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         return [
             'docs' => $finalDocs,
             'offset' => $offset,
-            'total' => (int)$xml->Hits
+            'total' => (int)$xml->Hits,
         ];
     }
 
@@ -217,7 +217,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         return [
             'docs' => $finalDocs,
             'offset' => 0,
-            'total' => (int)$xml->Hits
+            'total' => (int)$xml->Hits,
         ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Connector.php
@@ -127,7 +127,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                 $result = [
                     'recordCount' => 0,
                     'documents' => [],
-                    'error' => $e->getMessage()
+                    'error' => $e->getMessage(),
                 ];
             } else {
                 throw $e;
@@ -196,7 +196,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
 
         $results = [
             'recordCount' => count($items),
-            'documents' => $items
+            'documents' => $items,
         ];
 
         return $results;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Backend.php
@@ -238,7 +238,7 @@ class Backend extends AbstractBackend
         // Most parameters need to be flattened from array format, but a few
         // should remain as arrays:
         $arraySettings = [
-            'query', 'facets', 'filterList', 'groupFilters', 'rangeFilters'
+            'query', 'facets', 'filterList', 'groupFilters', 'rangeFilters',
         ];
         foreach ($params as $key => $param) {
             $options[$key] = in_array($key, $arraySettings) ? $param : $param[0];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -85,7 +85,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         'recordCount' => 0,
         'documents' => [],
         'facets' => [],
-        'error' => 'empty_search_disallowed'
+        'error' => 'empty_search_disallowed',
     ];
 
     /**
@@ -617,7 +617,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
             'recordCount' => $totalhits,
             'documents' => $items,
             'facets' => $facets,
-            'didYouMean' => $didYouMean
+            'didYouMean' => $didYouMean,
         ];
     }
 
@@ -736,7 +736,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
         $highlightFields = [
             'title' => 'title',
             'creator' => 'author',
-            'description' => 'description'
+            'description' => 'description',
         ];
 
         $hilightDetails = [];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/RawJsonSearchCommand.php
@@ -88,7 +88,7 @@ class RawJsonSearchCommand extends \VuFindSearch\Command\CallMethodCommand
             $this->getQuery(),
             $this->getOffset(),
             $this->getLimit(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Command/WriteDocumentCommand.php
@@ -103,7 +103,7 @@ class WriteDocumentCommand extends \VuFindSearch\Command\CallMethodCommand
             $this->getDocument(),
             $this->getTimeout(),
             $this->getHandler(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SearchHandler.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SearchHandler.php
@@ -54,7 +54,7 @@ class SearchHandler
      */
     protected static $configKeys = [
         'CustomMunge', 'DismaxFields', 'DismaxHandler', 'QueryFields',
-        'DismaxParams', 'FilterQuery', 'DismaxMunge'
+        'DismaxParams', 'FilterQuery', 'DismaxMunge',
     ];
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Backend.php
@@ -173,7 +173,7 @@ class Backend extends AbstractBackend implements RetrieveBatchInterface
                 [
                     'idsToFetch' => $currentPage,
                     'pageNumber' => 1,
-                    'pageSize' => $pageSize
+                    'pageSize' => $pageSize,
                 ]
             );
             try {

--- a/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/Connector.php
@@ -138,7 +138,7 @@ class Connector extends \VuFindSearch\Backend\SRU\Connector
         return [
             'docs' => $error ? [] : [$body],
             'offset' => 0,
-            'total' => $error ? 0 : 1
+            'total' => $error ? 0 : 1,
         ];
     }
 
@@ -169,7 +169,7 @@ class Connector extends \VuFindSearch\Backend\SRU\Connector
         return [
             'docs' => $finalDocs,
             'offset' => $offset,
-            'total' => (int)($xml->numberOfRecords ?? 0)
+            'total' => (int)($xml->numberOfRecords ?? 0),
         ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/AlphabeticBrowseCommand.php
@@ -125,7 +125,7 @@ class AlphabeticBrowseCommand extends CallMethodCommand
             $this->getPage(),
             $this->getLimit(),
             $this->getSearchParameters(),
-            $this->getOffsetDelta()
+            $this->getOffsetDelta(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/GetIdsCommand.php
@@ -90,7 +90,7 @@ class GetIdsCommand extends CallMethodCommand
             $this->getQuery(),
             $this->getOffset(),
             $this->getLimit(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RandomCommand.php
@@ -96,7 +96,7 @@ class RandomCommand extends CallMethodCommand
         return [
             $this->getQuery(),
             $this->getLimit(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveBatchCommand.php
@@ -84,7 +84,7 @@ class RetrieveBatchCommand extends CallMethodCommand
     {
         return [
             $this->getRecordIdentifiers(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/RetrieveCommand.php
@@ -79,7 +79,7 @@ class RetrieveCommand extends CallMethodCommand
     {
         return [
             $this->getRecordIdentifier(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SearchCommand.php
@@ -88,7 +88,7 @@ class SearchCommand extends CallMethodCommand
             $this->getQuery(),
             $this->getOffset(),
             $this->getLimit(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/SimilarCommand.php
@@ -79,7 +79,7 @@ class SimilarCommand extends CallMethodCommand
     {
         return [
             $this->getRecordIdentifier(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/TermsCommand.php
@@ -102,7 +102,7 @@ class TermsCommand extends CallMethodCommand
             $this->getField(),
             $this->getStart(),
             $this->getLimit(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
+++ b/module/VuFindSearch/src/VuFindSearch/Command/WorkExpressionsCommand.php
@@ -91,7 +91,7 @@ class WorkExpressionsCommand extends CallMethodCommand
         return [
             $this->getRecordIdentifier(),
             $this->getWorkKeys(),
-            $this->getSearchParameters()
+            $this->getSearchParameters(),
         ];
     }
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
@@ -67,14 +67,14 @@ class BackendTest extends TestCase
     protected $config = [
         'Backends' => [
             'Solr' => 'Local',
-            'EDS' => 'Electronic Stuff'
+            'EDS' => 'Electronic Stuff',
         ],
         'Blending' => [
             'initialResults' => [
                 'Solr',
                 'Solr',
                 'EDS',
-                'EDS'
+                'EDS',
             ],
             'blockSize' => 7,
         ],
@@ -106,9 +106,9 @@ class BackendTest extends TestCase
                             'Values' => [
                                 'Business Source Premier' => 'Main',
                                 'Communication Abstracts' => '1/Main/Sub/',
-                                'EconLit with Full Text' => '1/Econlit/Foo/'
-                            ]
-                        ]
+                                'EconLit with Full Text' => '1/Econlit/Foo/',
+                            ],
+                        ],
                     ],
                 ],
                 'format' => [
@@ -161,7 +161,7 @@ class BackendTest extends TestCase
                         'EDS' => [
                             'Field' => 'LIMIT|FT',
                             'Values' => [
-                                'y' => '1'
+                                'y' => '1',
                             ],
                         ],
                     ],
@@ -169,10 +169,10 @@ class BackendTest extends TestCase
                 'language' => [
                     'Mappings' => [
                         'EDS' => [
-                            'Field' => ''
-                        ]
-                    ]
-                ]
+                            'Field' => '',
+                        ],
+                    ],
+                ],
             ],
         ],
         'Search' => [
@@ -181,14 +181,14 @@ class BackendTest extends TestCase
                     'Mappings' => [
                         'Solr' => 'AllFields',
                         'Primo' => 'AllFields',
-                        'EDS' => 'AllFields'
+                        'EDS' => 'AllFields',
                     ],
                 ],
                 'Title' => [
                     'Mappings' => [
                         'Solr' => 'Title',
                         'Primo' => 'Title',
-                        'EDS' => 'TI'
+                        'EDS' => 'TI',
                     ],
                 ],
             ],
@@ -240,45 +240,45 @@ class BackendTest extends TestCase
         $solrRecords = [
             [
                 'class' => SolrRecord::class,
-                'title' => 'The test /'
+                'title' => 'The test /',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Of Money and Slashes'
+                'title' => 'Of Money and Slashes',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Movie Quotes Thru The Ages'
+                'title' => 'Movie Quotes Thru The Ages',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => '<HTML> The Basics'
+                'title' => '<HTML> The Basics',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Octothorpes: Why not?'
+                'title' => 'Octothorpes: Why not?',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Questions about Percents'
+                'title' => 'Questions about Percents',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Pluses and Minuses of Pluses and Minuses'
+                'title' => 'Pluses and Minuses of Pluses and Minuses',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'The test of the publication fields.'
+                'title' => 'The test of the publication fields.',
             ],
             [
                 'class' => SolrRecord::class,
-                'title' => 'Dewey browse test'
+                'title' => 'Dewey browse test',
             ],
         ];
         for ($i = 20001; $i <= 20031; $i++) {
             $solrRecords[] =             [
                 'class' => SolrRecord::class,
-                'title' => "Test Publication $i"
+                'title' => "Test Publication $i",
             ];
         }
 
@@ -286,7 +286,7 @@ class BackendTest extends TestCase
         for ($i = 1; $i <= 40; $i++) {
             $edsRecords[] = [
                 'class' => EdsRecord::class,
-                'title' => "Title $i"
+                'title' => "Title $i",
             ];
         }
 
@@ -315,7 +315,7 @@ class BackendTest extends TestCase
         );
         $adaptiveConfig = $this->config;
         $adaptiveConfig['Blending']['adaptiveBlockSizes'] = [
-            '5000-100000:5'
+            '5000-100000:5',
         ];
         $adaptiveConfigWithOrFacet = $adaptiveConfig;
         $adaptiveConfigWithOrFacet['Results_Settings']['orFacets']
@@ -348,49 +348,49 @@ class BackendTest extends TestCase
             [
                 0,
                 0,
-                []
+                [],
             ],
             [
                 0,
                 20,
-                array_slice($expectedRecords, 0, 20)
+                array_slice($expectedRecords, 0, 20),
             ],
             [
                 1,
                 20,
-                array_slice($expectedRecords, 1, 20)
+                array_slice($expectedRecords, 1, 20),
             ],
             [
                 2,
                 20,
-                array_slice($expectedRecords, 2, 20)
+                array_slice($expectedRecords, 2, 20),
             ],
             [
                 3,
                 20,
-                array_slice($expectedRecords, 3, 20)
+                array_slice($expectedRecords, 3, 20),
             ],
             [
                 19,
                 20,
-                array_slice($expectedRecords, 19, 20)
+                array_slice($expectedRecords, 19, 20),
             ],
             [
                 0,
                 40,
-                array_slice($expectedRecords, 0, 40)
+                array_slice($expectedRecords, 0, 40),
             ],
             [
                 0,
                 40,
                 array_slice($expectedRecordsNoBoost, 0, 40),
-                $noBoostConfig
+                $noBoostConfig,
             ],
             [
                 0,
                 40,
                 array_slice($expectedRecordsAdaptive, 0, 40),
-                $adaptiveConfig
+                $adaptiveConfig,
             ],
             [
                 0,
@@ -399,7 +399,7 @@ class BackendTest extends TestCase
                 $adaptiveConfig,
                 ['blender_backend:Solr'],
                 240,
-                null
+                null,
             ],
             [
                 0,
@@ -408,7 +408,7 @@ class BackendTest extends TestCase
                 $adaptiveConfigWithOrFacet,
                 ['-blender_backend:EDS'],
                 240,
-                0
+                0,
             ],
             [
                 0,
@@ -417,7 +417,7 @@ class BackendTest extends TestCase
                 $adaptiveConfigWithOrFacet,
                 ['blender_backend:EDS'],
                 0,
-                65924
+                65924,
             ],
             [
                 0,
@@ -426,8 +426,8 @@ class BackendTest extends TestCase
                 null,
                 [
                     '{!tag=blender_backend_filter}blender_backend:'
-                    . '(blender_backend:"Solr" OR blender_backend:"EDS")'
-                ]
+                    . '(blender_backend:"Solr" OR blender_backend:"EDS")',
+                ],
             ],
             [
                 0,
@@ -436,7 +436,7 @@ class BackendTest extends TestCase
                 null,
                 ['-blender_backend:Solr', '-blender_backend:EDS'],
                 0,
-                0
+                0,
             ],
             [
                 0,
@@ -446,7 +446,7 @@ class BackendTest extends TestCase
                 [],
                 5,
                 65924,
-                new Query('foo', 'Title')
+                new Query('foo', 'Title'),
             ],
             [
                 0,
@@ -456,7 +456,7 @@ class BackendTest extends TestCase
                 [],
                 2,
                 6,
-                new Query('foo', 'Author')
+                new Query('foo', 'Author'),
             ],
         ];
     }
@@ -531,7 +531,7 @@ class BackendTest extends TestCase
                         '0/Main/' => 231,
                         '1/Main/Sub/' => 7,
                         '0/Sub/' => 1,
-                        '1/Sub/Foo/' => 1
+                        '1/Sub/Foo/' => 1,
                     ],
                     'EDS' => [
                         '0/Main/' => 1861 + 2,
@@ -609,7 +609,7 @@ class BackendTest extends TestCase
             )->will($this->returnValue($collection));
 
         $backends = [
-            'EDS' => $eds
+            'EDS' => $eds,
         ];
         $eventManager = new EventManager($this->sharedEventManager);
         $backend = new Backend(
@@ -623,7 +623,7 @@ class BackendTest extends TestCase
         $params = new ParamBag(
             [
                 'query_EDS' => [$query],
-                'params_EDS' => [$edsParams]
+                'params_EDS' => [$edsParams],
             ]
         );
         $backend->search($query, 0, 20, $params);
@@ -681,7 +681,7 @@ class BackendTest extends TestCase
             null,
             [
                 'Solr' => $this->getSolrBackend(),
-                'EDS' => $this->getEDSBackendMock('')
+                'EDS' => $this->getEDSBackendMock(''),
             ]
         );
 
@@ -692,7 +692,7 @@ class BackendTest extends TestCase
                 [
                     'msg' => 'search_backend_partial_failure',
                     'tokens' => ['%%sources%%' => 'Electronic Stuff'],
-                ]
+                ],
             ],
             $result->getErrors()
         );
@@ -718,7 +718,7 @@ class BackendTest extends TestCase
             null,
             [
                 'Solr' => $this->getSolrBackend(''),
-                'EDS' => $this->getEDSBackendMock('')
+                'EDS' => $this->getEDSBackendMock(''),
             ]
         );
 
@@ -756,7 +756,7 @@ class BackendTest extends TestCase
                     ],
                     'translate' => true,
                     'translateTokens' => true,
-                ]
+                ],
             ],
             $result->getErrors()
         );
@@ -774,7 +774,7 @@ class BackendTest extends TestCase
             null,
             [
                 'Solr' => $this->getSolrBackend(),
-                'EDS' => $this->getBackendForFacetsAndErrors([], [])
+                'EDS' => $this->getBackendForFacetsAndErrors([], []),
             ]
         );
 
@@ -899,7 +899,7 @@ class BackendTest extends TestCase
             $postEventParams[$command->getTargetIdentifier()] = [
                 'target' => $event->getTarget(),
                 'params' => $command->getSearchParameters(),
-                'backend' => $event->getParam('backend')
+                'backend' => $event->getParam('backend'),
             ];
         };
 
@@ -1053,7 +1053,7 @@ class BackendTest extends TestCase
                 'query_Solr' => [$query ?? new Query()],
                 'query_EDS' => [$query ?? new Query()],
                 'params_Solr' => [new ParamBag()],
-                'params_EDS' => [new ParamBag()]
+                'params_EDS' => [new ParamBag()],
             ]
         );
     }
@@ -1075,7 +1075,7 @@ class BackendTest extends TestCase
         if (!$backends) {
             $backends = [
                 'Solr' => $this->getSolrBackend(),
-                'EDS' => $this->getEDSBackendMock()
+                'EDS' => $this->getEDSBackendMock(),
             ];
         }
         $eventManager = new EventManager($this->sharedEventManager);
@@ -1138,7 +1138,7 @@ class BackendTest extends TestCase
                     $map,
                     function () {
                         return $this->createMock(\Laminas\Http\Client::class);
-                    }
+                    },
                 ]
             )
             ->getMock();
@@ -1170,15 +1170,15 @@ class BackendTest extends TestCase
             [
                 'Title' => [
                     'DismaxFields' => [
-                        'title'
+                        'title',
                     ],
-                    'DismaxHandler' => 'edismax'
+                    'DismaxHandler' => 'edismax',
                 ],
                 'Author' => [
                     'DismaxFields' => [
-                        'author'
+                        'author',
                     ],
-                    'DismaxHandler' => 'edismax'
+                    'DismaxHandler' => 'edismax',
                 ],
             ]
         );
@@ -1248,7 +1248,7 @@ class BackendTest extends TestCase
             $this->getEDSRecordCollectionFactory(),
             $cache,
             $container,
-            new Config([])
+            new Config([]),
         ];
         $backend = $this->getMockBuilder(\VuFindSearch\Backend\EDS\Backend::class)
             ->onlyMethods(['getAuthenticationToken', 'getSessionToken'])

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
@@ -71,7 +71,7 @@ class BackendTest extends \PHPUnit\Framework\TestCase
             ['getAutocompleteData']
         );
         $autocompleteData = [
-            'custid' => 'foo', 'url' => 'http://foo', 'token' => 'auth1234'
+            'custid' => 'foo', 'url' => 'http://foo', 'token' => 'auth1234',
         ];
         $back->expects($this->any())
             ->method('getAutocompleteData')
@@ -211,8 +211,8 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         $config = [
             'EBSCO_Account' => [
                 'user_name' => 'un', 'password' => 'pw', 'ip_auth' => true,
-                'profile' => 'pr', 'organization_id' => 'oi'
-            ]
+                'profile' => 'pr', 'organization_id' => 'oi',
+            ],
         ];
         $back = $this->getBackend($conn, $fact, null, null, $config);
         $this->assertEquals($fact, $back->getRecordCollectionFactory());

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/ConnectorTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/ConnectorTest.php
@@ -120,7 +120,7 @@ class ConnectorTest extends TestCase
             [
                 'api_url' => 'http://example.tld/',
                 'auth_url' => 'http://example.tld/',
-                'orgid' => 'VuFindTest'
+                'orgid' => 'VuFindTest',
             ],
             $client ?: $this->createClient()
         );

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/QueryBuilderTest.php
@@ -79,7 +79,7 @@ class QueryBuilderTest extends TestCase
                         'field' => null,
                         'bool' => 'AND',
                     ],
-                ]
+                ],
             ],
             $response
         );
@@ -107,9 +107,9 @@ class QueryBuilderTest extends TestCase
                         'term' => 'test',
                         'field' => 'SU',
                         'bool' => 'AND',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
 
         $qb = new QueryBuilder();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EIT/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EIT/QueryBuilderTest.php
@@ -56,7 +56,7 @@ class QueryBuilderTest extends TestCase
         // (queries):
         // @codingStandardsIgnoreStart
         $tests = [
-            ['advanced', '((TX cheese) AND (AU cross)) NOT (((TI expansion)))']
+            ['advanced', '((TX cheese) AND (AU cross)) NOT (((TI expansion)))'],
         ];
         // @codingStandardsIgnoreEnd
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -186,9 +186,9 @@ class BackendTest extends \PHPUnit\Framework\TestCase
             'query' => [
                 [
                     'index' => null,
-                    'lookfor' => 'baz'
-                ]
-            ]
+                    'lookfor' => 'baz',
+                ],
+            ],
         ];
         $conn = $this->getConnectorMock(['query']);
         $conn->expects($this->once())
@@ -212,39 +212,39 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 '',
-                true
+                true,
             ],
             [
                 true,
-                true
+                true,
             ],
             [
                 1,
-                true
+                true,
             ],
             [
                 '1',
-                true
+                true,
             ],
             [
                 'true',
-                true
+                true,
             ],
             [
                 false,
-                false
+                false,
             ],
             [
                 0,
-                false
+                false,
             ],
             [
                 '0',
-                false
+                false,
             ],
             [
                 'false',
-                false
+                false,
             ],
         ];
     }
@@ -266,10 +266,10 @@ class BackendTest extends \PHPUnit\Framework\TestCase
                 'filterList' => [
                     'pcAvailability' => [
                         'values' => [
-                            $value
-                        ]
-                    ]
-                ]
+                            $value,
+                        ],
+                    ],
+                ],
             ]
         );
         $expectedParams = [
@@ -280,9 +280,9 @@ class BackendTest extends \PHPUnit\Framework\TestCase
             'query' => [
                 [
                     'index' => null,
-                    'lookfor' => 'foo'
-                ]
-            ]
+                    'lookfor' => 'foo',
+                ],
+            ],
         ];
         $conn = $this->getConnectorMock(['query']);
         $conn->expects($this->once())

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/QueryBuilderTest.php
@@ -76,7 +76,7 @@ class QueryBuilderTest extends TestCase
         $qb = new QueryBuilder();
         $expected = [
             ['lookfor' => 'query1', 'index' => 'handler1', 'op' => 'OR'],
-            ['lookfor' => 'query2', 'index' => 'handler2', 'op' => 'AND']
+            ['lookfor' => 'query2', 'index' => 'handler2', 'op' => 'AND'],
         ];
         $result = $qb->build($q)->get('query');
         $this->assertEquals($expected, $result);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
@@ -204,7 +204,7 @@ class BackendTest extends TestCase
                     'Adult children of aging parents' => 7,
                     'Automobile drivers\' tests' => 7,
                     'Fathers and daughters' => 7,
-                ]
+                ],
             ],
             $facets
         );
@@ -666,7 +666,7 @@ class BackendTest extends TestCase
                         // If client is provided, return it since it may have test
                         // expectations:
                         return $client ?? new \Laminas\Http\Client();
-                    }
+                    },
                 ]
             )
             ->getMock();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/ConnectorTest.php
@@ -339,7 +339,7 @@ class ConnectorTest extends TestCase
                         // If client is provided, return it since it may have test
                         // expectations:
                         return $client ?? new \Laminas\Http\Client();
-                    }
+                    },
                 ]
             )
             ->getMock();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/HandlerMapTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/HandlerMapTest.php
@@ -133,7 +133,7 @@ class HandlerMapTest extends TestCase
                     'invariants' => ['p1' => 'v1'],
                     'defaults' => ['p2' => 'v2'],
                     'appends' => ['p3' => 'v3'],
-                ]
+                ],
             ]
         );
         $this->assertEquals(
@@ -166,7 +166,7 @@ class HandlerMapTest extends TestCase
                     'invariants' => ['p1' => 'v1'],
                     'defaults' => ['p2' => 'v2'],
                     'appends' => ['p3' => 'v3'],
-                ]
+                ],
             ]
         );
         $this->assertEquals(
@@ -195,7 +195,7 @@ class HandlerMapTest extends TestCase
                 'search' => [
                     'functions' => ['search'],
                     'invariants' => ['p1' => 'v1'],
-                ]
+                ],
             ]
         );
         $map->addParameter('search', 'invariants', 'p2', 'v2');

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -65,7 +65,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             ['apples and oranges (not that)', 'apples AND oranges (NOT that)'],
             [
                 '(this or that) and (apples not oranges)',
-                '(this OR that) AND (apples NOT oranges)'
+                '(this OR that) AND (apples NOT oranges)',
             ],
 
             // do not capitalize inside quotes:
@@ -256,11 +256,11 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             // special case for timestamps:
             [
                 '[1900-01-01t00:00:00z to 1900-12-31t23:59:59z]',
-                '[1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z]'
+                '[1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z]',
             ],
             [
                 '{1900-01-01T00:00:00Z       TO   1900-12-31T23:59:59Z}',
-                '{1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z}'
+                '{1900-01-01T00:00:00Z TO 1900-12-31T23:59:59Z}',
             ],
         ];
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -230,7 +230,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->runQuestionTests(
             [
-                'test' => []
+                'test' => [],
             ],
             'standard'
         );
@@ -245,7 +245,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->runQuestionTests(
             [
-                'test' => ['DismaxHandler' => 'dismax', 'DismaxFields' => ['foo']]
+                'test' => ['DismaxHandler' => 'dismax', 'DismaxFields' => ['foo']],
             ],
             'dismax'
         );
@@ -260,7 +260,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->runQuestionTests(
             [
-                'test' => ['DismaxHandler' => 'edismax', 'DismaxFields' => ['foo']]
+                'test' => ['DismaxHandler' => 'edismax', 'DismaxFields' => ['foo']],
             ],
             'edismax'
         );
@@ -279,9 +279,9 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'test' => [
                     'DismaxFields' => ['a', 'b'],
                     'ExactSettings' => [
-                        'DismaxFields' => ['c', 'd']
-                    ]
-                ]
+                        'DismaxFields' => ['c', 'd'],
+                    ],
+                ],
             ]
         );
 
@@ -307,7 +307,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $qb = new QueryBuilder(
             [
-                'test' => ['DismaxFields' => ['a'], 'FilterQuery' => 'a:filter']
+                'test' => ['DismaxFields' => ['a'], 'FilterQuery' => 'a:filter'],
             ]
         );
         $q = new Query('q', 'test');
@@ -325,7 +325,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $qb = new QueryBuilder(
             [
-                'test' => ['FilterQuery' => 'a:filter']
+                'test' => ['FilterQuery' => 'a:filter'],
             ]
         );
         $q = new Query('q', 'test');
@@ -344,7 +344,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $qb = new QueryBuilder(
             [
-                'test' => ['FilterQuery' => 'a:filter']
+                'test' => ['FilterQuery' => 'a:filter'],
             ]
         );
         $q = new Query('*:*', 'test');
@@ -369,7 +369,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                     'DismaxFields' => ['test'],
                     'DismaxHandler' => 'dismax',
                     'DismaxParams' => [['bq', 'boost']],
-                ]
+                ],
             ]
         );
 
@@ -395,7 +395,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'test' => [
                     'QueryFields' => ['test1' => []],
                     'DismaxFields' => ['test2', 'test3^10000'],
-                ]
+                ],
             ]
         );
 
@@ -435,8 +435,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
             [
                 'test' => [
                     'DismaxFields' => ['test1'],
-                    'DismaxParams' => [['bq', 'boost']]
-                ]
+                    'DismaxParams' => [['bq', 'boost']],
+                ],
             ]
         );
 
@@ -469,7 +469,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
                 'b' => [
                     'DismaxFields' => ['field_b'],
-                ]
+                ],
             ]
         );
 
@@ -499,12 +499,12 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                     'DismaxFields' => ['field_a'],
                     'QueryFields' => [
                         'field_a' => [['and', 100]],
-                        'field_c' => [['and', 200]]
-                    ]
+                        'field_c' => [['and', 200]],
+                    ],
                 ],
                 'b' => [
                     'DismaxFields' => ['field_b'],
-                ]
+                ],
             ]
         );
 
@@ -533,8 +533,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'a' => [
                     'QueryFields' => [
                         'field_a' => [['or', '~']],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
 
@@ -557,8 +557,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'a' => [
                     'QueryFields' => [
                         'field_a' => [['or', '~']],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
 
@@ -581,8 +581,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'a' => [
                     'QueryFields' => [
                         'field_a' => [['or', '~']],
-                    ]
-                ]
+                    ],
+                ],
             ]
         );
 
@@ -616,16 +616,16 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'GlobalExtraParams' => [
                     [
                         'param' => 'bq',
-                        'value' => 'a:foo'
-                    ]
+                        'value' => 'a:foo',
+                    ],
                 ],
                 'expected1' => [
                     'bf' => ['a:filter'],
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
                 'expected2' => [
                     'bf' => null,
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
             'Two values' => [
@@ -634,23 +634,23 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'param' => 'bq',
                         'value' => [
                             'a:foo',
-                            'a:bar'
-                        ]
-                    ]
+                            'a:bar',
+                        ],
+                    ],
                 ],
                 'expected1' => [
                     'bf' => ['a:filter'],
                     'bq' => [
                         'a:foo',
-                        'a:bar'
-                    ]
+                        'a:bar',
+                    ],
                 ],
                 'expected2' => [
                     'bf' => null,
                     'bq' => [
                         'a:foo',
-                        'a:bar'
-                    ]
+                        'a:bar',
+                    ],
                 ],
             ],
             'Value with SearchTypeIn condition' => [
@@ -661,20 +661,20 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'conditions' => [
                             [
                                 'SearchTypeIn' => [
-                                    'test'
-                                ]
-                            ]
-                        ]
-                    ]
+                                    'test',
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected1' => [
                     'bf' => ['a:filter'],
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
                 'expected2' => [
                     'bf' => null,
-                    'bq' => null
-                ]
+                    'bq' => null,
+                ],
             ],
             'Value with SearchTypeNotIn condition' => [
                 'GlobalExtraParams' => [
@@ -684,19 +684,19 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'conditions' => [
                             [
                                 'SearchTypeNotIn' => [
-                                    'test'
-                                ]
-                            ]
-                        ]
-                    ]
+                                    'test',
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected1' => [
                     'bf' => ['a:filter'],
-                    'bq' => null
+                    'bq' => null,
                 ],
                 'expected2' => [
                     'bf' => null,
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
             'Value with NoDisMaxParams = [bf] condition' => [
@@ -706,18 +706,18 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'value' => 'a:foo',
                         'conditions' => [
                             [
-                                'NoDismaxParams' => ['bf']
-                            ]
-                        ]
-                    ]
+                                'NoDismaxParams' => ['bf'],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected1' => [
                     'bf' => ['a:filter'],
-                    'bq' => null
+                    'bq' => null,
                 ],
                 'expected2' => [
                     'bf' => null,
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
         ];
@@ -746,8 +746,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
             'test' => [
                 'DismaxFields' => ['a'],
                 'DismaxParams' => [
-                    ['bf', 'a:filter']
-                ]
+                    ['bf', 'a:filter'],
+                ],
             ],
         ];
         if (!empty($globalExtraParams)) {
@@ -790,13 +790,13 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'value' => 'a:foo',
                         'conditions' => [
                             [
-                                'SearchTypeIn' => ['test']
-                            ]
-                        ]
-                    ]
+                                'SearchTypeIn' => ['test'],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected' => [
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
             'All search types in [test, test2]' => [
@@ -806,13 +806,13 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'value' => 'a:foo',
                         'conditions' => [
                             [
-                                'AllSearchTypesIn' => ['test', 'test2']
-                            ]
-                        ]
-                    ]
+                                'AllSearchTypesIn' => ['test', 'test2'],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected' => [
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
             'All search types in [test, no]' => [
@@ -822,13 +822,13 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'value' => 'a:foo',
                         'conditions' => [
                             [
-                                'AllSearchTypesIn' => ['test', 'no']
-                            ]
-                        ]
-                    ]
+                                'AllSearchTypesIn' => ['test', 'no'],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected' => [
-                    'bq' => null
+                    'bq' => null,
                 ],
             ],
             'All search types in [test, test2, no]' => [
@@ -838,13 +838,13 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         'value' => 'a:foo',
                         'conditions' => [
                             [
-                                'AllSearchTypesIn' => ['test', 'test2', 'no']
-                            ]
-                        ]
-                    ]
+                                'AllSearchTypesIn' => ['test', 'test2', 'no'],
+                            ],
+                        ],
+                    ],
                 ],
                 'expected' => [
-                    'bq' => ['a:foo']
+                    'bq' => ['a:foo'],
                 ],
             ],
         ];
@@ -871,8 +871,8 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
             'test' => [
                 'DismaxFields' => ['a'],
                 'DismaxParams' => [
-                    ['bf', 'a:filter']
-                ]
+                    ['bf', 'a:filter'],
+                ],
             ],
         ];
         if (!empty($globalExtraParams)) {

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/NamedListTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/NamedListTest.php
@@ -98,7 +98,7 @@ class NamedListTest extends TestCase
             [
                 ['first term', 'info'],
                 ['second term', 'info2'],
-                ['third term', 'info3']
+                ['third term', 'info3'],
             ]
         );
         $list->removeKeys(['first term', 'second term']);
@@ -116,7 +116,7 @@ class NamedListTest extends TestCase
             [
                 ['first term', 'info'],
                 ['second term', 'info2'],
-                ['third term', 'info3']
+                ['third term', 'info3'],
             ]
         );
         $list->removeKeys(['first term', 'second term']);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
@@ -91,7 +91,7 @@ class RecordCollectionTest extends TestCase
     {
         $coll = new RecordCollection(
             [
-                'response' => ['numFound' => 10, 'start' => 5]
+                'response' => ['numFound' => 10, 'start' => 5],
             ]
         );
         for ($i = 0; $i < 5; $i++) {
@@ -115,8 +115,8 @@ class RecordCollectionTest extends TestCase
                 'params' => [
                     'spellcheck.q' => 'foo',
                     'q' => 'bar',
-                ]
-            ]
+                ],
+            ],
         ];
         $coll = new RecordCollection($input);
         $this->assertEquals('foo', $coll->getSpellcheck()->getQuery());
@@ -155,8 +155,8 @@ class RecordCollectionTest extends TestCase
                         ],
                     ],
                     ['correctlySpelled', false],
-                ]
-            ]
+                ],
+            ],
         ];
         $coll = new RecordCollection($input);
         $spell = $coll->getSpellcheck();
@@ -219,7 +219,7 @@ class RecordCollectionTest extends TestCase
     {
         $coll = new RecordCollection(
             [
-                'response' => ['numFound' => 10, 'start' => 5]
+                'response' => ['numFound' => 10, 'start' => 5],
             ]
         );
         $record = $this->createMock(\VuFindSearch\Response\RecordInterface::class);
@@ -249,9 +249,9 @@ class RecordCollectionTest extends TestCase
                             ['Book', 123],
                             ['Journal', 234],
                             ['Map', 1],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ]
         );
         $facets = $coll->getFacets();
@@ -260,8 +260,8 @@ class RecordCollectionTest extends TestCase
                 'format' => [
                     'Book' => 123,
                     'Journal' => 234,
-                    'Map' => 1
-                ]
+                    'Map' => 1,
+                ],
             ],
             $facets
         );
@@ -271,8 +271,8 @@ class RecordCollectionTest extends TestCase
             [
                 'format' => [
                     'Book' => 123,
-                    'Map' => 1
-                ]
+                    'Map' => 1,
+                ],
             ],
             $coll->getFacets()
         );

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/SpellcheckTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/SpellcheckTest.php
@@ -65,7 +65,7 @@ class SpellcheckTest extends TestCase
                 ['bar', []],
                 ['foo bar', []],
                 ['1842', []],
-                ['1843', []]
+                ['1843', []],
             ],
             'fake query'
         );

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/TermsTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/TermsTest.php
@@ -55,7 +55,7 @@ class TermsTest extends TestCase
             [
                 'terms' => [
                     'field1' => $field1,
-                ]
+                ],
             ]
         );
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SearchHandlerTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SearchHandlerTest.php
@@ -87,7 +87,7 @@ class SearchHandlerTest extends TestCase
             'DismaxHandler' => 'dismax',
             'QueryFields' => [],
             'FilterQuery' => [],
-            'DismaxMunge' => []
+            'DismaxMunge' => [],
         ];
         $this->assertEquals($spec + $defaults, $hndl->toArray());
     }
@@ -120,14 +120,14 @@ class SearchHandlerTest extends TestCase
                 'callnumber_exact' => [
                     ['uppercase'],
                     ['preg_replace', '/[ "]/', ""],
-                    ['preg_replace', '/\*+$/', ""]
+                    ['preg_replace', '/\*+$/', ""],
                 ],
                 'callnumber_fuzzy' => [
                     ['uppercase'],
                     ['preg_replace', '/[ "]/', ""],
                     ['preg_replace', '/\*+$/', ""],
-                    ['append', '*']
-                ]
+                    ['append', '*'],
+                ],
             ],
             'QueryFields' => [
                 'callnumber' => [
@@ -137,8 +137,8 @@ class SearchHandlerTest extends TestCase
                 'dewey-full' => [
                     ['callnumber_exact', 1000],
                     ['callnumber_fuzzy', '~'],
-                ]
-            ]
+                ],
+            ],
         ];
 
         $hndl = new SearchHandler($spec);
@@ -160,10 +160,10 @@ class SearchHandlerTest extends TestCase
             'DismaxMunge' => [
                 ['uppercase'],
                 ['preg_replace', '/[ "]/', ""],
-                ['preg_replace', '/\*+$/', ""]
+                ['preg_replace', '/\*+$/', ""],
             ],
             'DismaxFields' => ['callnumber'],
-            'DismaxHandler' => 'dismax'
+            'DismaxHandler' => 'dismax',
         ];
 
         $hndl = new SearchHandler($spec);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
@@ -84,8 +84,8 @@ class SimilarBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $config = [
             'MoreLikeThis' => [
-                'count' => 10
-            ]
+                'count' => 10,
+            ],
         ];
         $sb = new SimilarBuilder(new \Laminas\Config\Config($config));
         $response = $sb->build('testrecord');

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Summon/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Summon/QueryBuilderTest.php
@@ -57,7 +57,7 @@ class QueryBuilderTest extends TestCase
         // @codingStandardsIgnoreStart
         $tests = [
             ['basic', 'Author:(john smith)'],
-            ['advanced', '(Title:(bananas)) AND (SubjectTerms:(oranges) OR apples) NOT ((PublicationSeriesTitle:(pears)))']
+            ['advanced', '(Title:(bananas)) AND (SubjectTerms:(oranges) OR apples) NOT ((PublicationSeriesTitle:(pears)))'],
         ];
         // @codingStandardsIgnoreEnd
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/WorldCat/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/WorldCat/QueryBuilderTest.php
@@ -57,7 +57,7 @@ class QueryBuilderTest extends TestCase
         // @codingStandardsIgnoreStart
         $tests = [
             ['basic', '(srw.au all "john smith" OR srw.pn all "john smith" OR srw.cn all "john smith")'],
-            ['advanced', '((srw.ti all "bananas" OR srw.se all "bananas")) AND ((srw.su all "oranges") OR (srw.su all "apples")) NOT (((srw.se all "pears")))']
+            ['advanced', '((srw.ti all "bananas" OR srw.se all "bananas")) AND ((srw.su all "oranges") OR (srw.su all "apples")) NOT (((srw.se all "pears")))'],
         ];
         // @codingStandardsIgnoreEnd
 

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Command/RandomCommandTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Command/RandomCommandTest.php
@@ -123,13 +123,13 @@ class RandomCommandTest extends TestCase
                     $this->equalTo($query),
                     $this->equalTo(0),
                     $this->equalTo(0),
-                    $this->equalTo($params)
+                    $this->equalTo($params),
                 ],
                 [
                     $this->equalTo($query),
                     $this->equalTo(0),
                     $this->equalTo(10),
-                    $this->equalTo($params)
+                    $this->equalTo($params),
                 ]
             )->willReturnOnConsecutiveCalls($this->returnValue($rci), $this->returnValue($rci));
         $this->assertEquals($rci, $command->execute($backend)->getResult());

--- a/module/VuFindTheme/Module.php
+++ b/module/VuFindTheme/Module.php
@@ -87,7 +87,7 @@ class Module
                 // module.config.php configuration.
                 'excluded_theme_prefixes' => ['Laminas'],
                 'extra_theme_prefixes' => [],
-            ]
+            ],
         ];
     }
 

--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -292,7 +292,7 @@ class Initializer
                 if (!empty($name)) {
                     $options[] = [
                         'name' => $name, 'desc' => $desc,
-                        'selected' => ($this->cookieManager->get('ui') == $name)
+                        'selected' => ($this->cookieManager->get('ui') == $name),
                     ];
                 }
             }

--- a/module/VuFindTheme/src/VuFindTheme/ThemeGenerator.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeGenerator.php
@@ -118,7 +118,7 @@ class ThemeGenerator extends AbstractThemeUtility implements GeneratorInterface
         // Enable dropdown
         $settingPrefixes = [
             'bootstrap' => 'bs3',
-            'custom' => strtolower(str_replace(' ', '', $name))
+            'custom' => strtolower(str_replace(' ', '', $name)),
         ];
         // - Set alternate_themes
         $this->writeln("\t\t[Site] > alternate_themes");
@@ -143,7 +143,7 @@ class ThemeGenerator extends AbstractThemeUtility implements GeneratorInterface
         $this->writeln("\t\t[Site] > selectable_themes");
         $dropSetting = [
             $settingPrefixes['bootstrap'] . ':Bootstrap',
-            $settingPrefixes['custom'] . ':' . ucwords($name)
+            $settingPrefixes['custom'] . ':' . ucwords($name),
         ];
         if (isset($config->Site->selectable_themes)) {
             $themes = explode(',', $config->Site->selectable_themes);

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
@@ -79,7 +79,7 @@ class ThemeInfoFactory implements FactoryInterface
         // can disable these problematic checks by setting memory_limit to -1.
         $cacheConfig = [
             'adapter' => \Laminas\Cache\Storage\Adapter\Memory::class,
-            'options' => ['memory_limit' => -1]
+            'options' => ['memory_limit' => -1],
         ];
         $cache = $container->get(\Laminas\Cache\Service\StorageAdapterFactory::class)
             ->createFromArrayConfiguration($cacheConfig);

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ConcatTrait.php
@@ -178,7 +178,7 @@ trait ConcatTrait
             if ($this->isExcludedFromConcat($item)) {
                 $this->groups[] = [
                     'other' => true,
-                    'item' => $item
+                    'item' => $item,
                 ];
                 $groupTypes[] = 'other';
                 continue;
@@ -196,7 +196,7 @@ trait ConcatTrait
                     ? $this->logError($errorMsg) : error_log($errorMsg);
                 $this->groups[] = [
                     'other' => true,
-                    'item' => $item
+                    'item' => $item,
                 ];
                 $groupTypes[] = 'other';
                 continue;
@@ -207,7 +207,7 @@ trait ConcatTrait
             if ($index === false) {
                 $this->groups[] = [
                     'items' => [$item],
-                    'key' => $details['path'] . filemtime($details['path'])
+                    'key' => $details['path'] . filemtime($details['path']),
                 ];
                 $groupTypes[] = $type;
             } else {

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/SetupThemeResources.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/SetupThemeResources.php
@@ -124,7 +124,7 @@ class SetupThemeResources extends \Laminas\View\Helper\AbstractHelper
             $headLink(
                 [
                     'href' => $imageLink($favicon),
-                    'type' => 'image/x-icon', 'rel' => 'shortcut icon'
+                    'type' => 'image/x-icon', 'rel' => 'shortcut icon',
                 ]
             );
         }

--- a/module/VuFindTheme/tests/fixtures/themes/child/theme.config.php
+++ b/module/VuFindTheme/tests/fixtures/themes/child/theme.config.php
@@ -10,6 +10,6 @@ return [
         ],
         'aliases' => [
             'xyzzy' => 'Xyzzy',
-        ]
+        ],
     ],
 ];

--- a/module/VuFindTheme/tests/fixtures/themes/parent/theme.config.php
+++ b/module/VuFindTheme/tests/fixtures/themes/parent/theme.config.php
@@ -7,7 +7,7 @@ return [
         'factories' => [
             'foo' => 'fooFactory',
             'bar' => 'barFactory',
-        ]
+        ],
     ],
     'doctype' => 'HTML5',
 ];

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
@@ -64,7 +64,7 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
     public static function extClassProvider()
     {
         return [
-            ['scss', ScssCompiler::class]
+            ['scss', ScssCompiler::class],
         ];
     }
 

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
@@ -122,7 +122,7 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'aliases' => [
                     'xyzzy' => 'Xyzzy',
-                ]
+                ],
             ],
             'doctype' => 'HTML5',
         ];
@@ -181,7 +181,7 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
                 ],
                 'aliases' => [
                     'xyzzy' => 'Xyzzy',
-                ]
+                ],
             ],
             'doctype' => 'HTML5',
         ];

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
@@ -140,7 +140,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
                 'mixin' => $expectedMixin,
                 'mixin_user' => $expectedMixinUser,
                 'child' => $expectedChild,
-                'parent' => $expectedParent
+                'parent' => $expectedParent,
             ],
             $ti->getThemeInfo()
         );
@@ -174,7 +174,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
         $expected = [
             'theme' => 'parent',
             'path' => $this->fixturePath . '/parent/parent.txt',
-            'relativePath' => 'parent.txt'
+            'relativePath' => 'parent.txt',
         ];
         $this->assertEquals($expected, $ti->findContainingTheme('parent.txt', ThemeInfo::RETURN_ALL_DETAILS));
     }
@@ -204,7 +204,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
         $files = $ti->findInThemes(
             [
                 'templates/content/*.phtml',
-                'templates/content/*.md'
+                'templates/content/*.md',
             ]
         );
         $this->assertIsArray($files);
@@ -400,7 +400,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
                     'not an array',
                 ],
                 [
-                    'mixed' => ['array']
+                    'mixed' => ['array'],
                 ],
             ],
         ];

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInjectTemplateListenerFactoryTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInjectTemplateListenerFactoryTest.php
@@ -60,7 +60,7 @@ class ThemeInjectTemplateListenerFactoryTest extends TestCase
             'vufind' => [
                 'extra_theme_prefixes' => ['Extra/'],
                 'excluded_theme_prefixes' => ['Laminas'],
-            ]
+            ],
         ];
         $container->set('config', $testConfig);
         $modules = ['Laminas\Foo', 'LaminasBar', 'VuFind\Foo', 'VuFind'];

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeResourceContainerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeResourceContainerTest.php
@@ -89,7 +89,7 @@ class ThemeResourceContainerTest extends \PHPUnit\Framework\TestCase
             [
                 'file' => 'http://foo/bar',
                 'position' => 'header',
-                'attributes' => ['conditional' => 'lt IE 7']
+                'attributes' => ['conditional' => 'lt IE 7'],
             ],
         ];
         $this->assertEquals($expectedResult, $container->getJs());
@@ -106,7 +106,7 @@ class ThemeResourceContainerTest extends \PHPUnit\Framework\TestCase
             [
                 'file' => 'http://foo/bar',
                 'position' => 'header',
-                'attributes' => ['conditional' => 'lt IE 7']
+                'attributes' => ['conditional' => 'lt IE 7'],
             ],
         ];
         $this->assertEquals(
@@ -206,7 +206,7 @@ class ThemeResourceContainerTest extends \PHPUnit\Framework\TestCase
         $container = new ResourceContainer();
         $tests = [
             'foo:bar:baz' => ['foo', 'bar', 'baz'],
-            'http://foo/bar:baz:xyzzy' => ['http://foo/bar', 'baz', 'xyzzy']
+            'http://foo/bar:baz:xyzzy' => ['http://foo/bar', 'baz', 'xyzzy'],
         ];
         foreach ($tests as $test => $expected) {
             $this->assertEquals(

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/SetupThemeResourcesTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/SetupThemeResourcesTest.php
@@ -66,7 +66,7 @@ class SetupThemeResourcesTest extends \PHPUnit\Framework\TestCase
     {
         $tests = [
             'foo:bar:baz' => ['foo', 'bar', 'baz'],
-            'http://foo/bar:baz:xyzzy' => ['http://foo/bar', 'baz', 'xyzzy']
+            'http://foo/bar:baz:xyzzy' => ['http://foo/bar', 'baz', 'xyzzy'],
         ];
         foreach ($tests as $test => $expected) {
             $this->assertEquals(

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -6,9 +6,9 @@ $finder->in(__DIR__ . '/../config')
     ->in(__DIR__ . '/../public');
 
 $rules = [
+    '@PHP74Migration' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
-    'array_syntax' => ['syntax' => 'short'],
     'binary_operator_spaces' => [
         'default' => 'single_space',
         'operators' => ['=' => null, '=>' => null],
@@ -20,7 +20,6 @@ $rules = [
     'function_typehint_space' => true,
     'is_null' => true,
     'linebreak_after_opening_tag' => true,
-    'list_syntax' => ['syntax' => 'short'],
     'lowercase_cast' => true,
     'magic_constant_casing' => true,
     'native_function_casing' => true,
@@ -38,7 +37,6 @@ $rules = [
     'no_unneeded_curly_braces' => true,
     'no_unused_imports' => true,
     'no_useless_return' => true,
-    'no_whitespace_before_comma_in_array' => true,
     'no_whitespace_in_blank_line' => true,
     'non_printable_character' => true,
     'ordered_imports' => true,
@@ -50,10 +48,8 @@ $rules = [
     'php_unit_no_expectation_annotation' => true,
     'pow_to_exponentiation' => true,
     'single_line_after_imports' => true,
-    'short_scalar_cast' => true,
     'standardize_not_equals' => true,
     'ternary_operator_spaces' => true,
-    'ternary_to_null_coalescing' => true,
 ];
 
 $cacheDir = __DIR__ . '/../.php_cs_cache';

--- a/tests/vufind_templates.php-cs-fixer.php
+++ b/tests/vufind_templates.php-cs-fixer.php
@@ -5,9 +5,9 @@ $finder->in(__DIR__ . '/../themes')
     ->name('*.phtml');
 
 $rules = [
+    '@PHP74Migration' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
-    'array_syntax' => ['syntax' => 'short'],
     'binary_operator_spaces' => [
         'default' => 'single_space',
     ],
@@ -19,7 +19,6 @@ $rules = [
     'ereg_to_preg' => true,
     'function_typehint_space' => true,
     'is_null' => true,
-    'list_syntax' => ['syntax' => 'short'],
     'lowercase_cast' => true,
     'magic_constant_casing' => true,
     'native_function_casing' => true,
@@ -38,17 +37,14 @@ $rules = [
     'no_unneeded_curly_braces' => true,
     'no_unused_imports' => true,
     'no_useless_return' => true,
-    'no_whitespace_before_comma_in_array' => true,
     'no_whitespace_in_blank_line' => true,
     'non_printable_character' => true,
     'ordered_imports' => true,
     'phpdoc_no_access' => true,
     'pow_to_exponentiation' => true,
     'single_line_after_imports' => true,
-    'short_scalar_cast' => true,
     'standardize_not_equals' => true,
     'ternary_operator_spaces' => true,
-    'ternary_to_null_coalescing' => true,
 ];
 
 $cacheDir = __DIR__ . '/../.php_cs_cache';

--- a/themes/bootprint3/theme.config.php
+++ b/themes/bootprint3/theme.config.php
@@ -194,6 +194,6 @@ return [
             'view-list' => 'Fugue:view_list.png',
             'view-visual' => 'Fugue:view_visual.png',
             'warning' => 'Fugue:error.png',
-        ]
-    ]
+        ],
+    ],
 ];

--- a/themes/bootstrap3/templates/Recommend/AlphaBrowseLink.phtml
+++ b/themes/bootstrap3/templates/Recommend/AlphaBrowseLink.phtml
@@ -7,7 +7,7 @@
             '%%index%%' => $this->transEsc('browse_' . $index),
             '%%from%%' => $this->escapeHtml($from),
             '%%url%%' => $this->url('alphabrowse-home')
-              . '?from=' . urlencode($from) . '&amp;source=' . urlencode($index)
+              . '?from=' . urlencode($from) . '&amp;source=' . urlencode($index),
         ]
     );
 ?>

--- a/themes/bootstrap3/templates/Recommend/MapSelection.phtml
+++ b/themes/bootstrap3/templates/Recommend/MapSelection.phtml
@@ -29,7 +29,7 @@
       json_encode($geoField), json_encode($coordinates),
       json_encode($urlpath), json_encode($baseUrl),
       json_encode($searchParams), json_encode($resultsCoords),
-      json_encode($basemap)
+      json_encode($basemap),
     ];
 
     $jsParams = implode(', ', $params);

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -70,7 +70,7 @@
               [
                   'facet' => $title,
                   'cluster' => $cluster,
-                  'collapsedFacets' => $collapsedFacets
+                  'collapsedFacets' => $collapsedFacets,
               ]
           );
         ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets/facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/facet.phtml
@@ -35,7 +35,7 @@
             'title' => $facet,
             'sortOptions' => $hierarchicalFacetSortOptions[$facet] ?? $hierarchicalFacetSortOptions['*'] ?? null,
             'collapsedFacets' => $this->collapsedFacets,
-            'results' => $this->results
+            'results' => $this->results,
           ]
       );
     ?>
@@ -54,7 +54,7 @@
               'cluster' => $cluster,
               'allowExclude' => $this->recommend->excludeAllowed($facet),
               'facets_before_more' => $this->recommend->getShowMoreSetting($facet),
-              'showMoreInLightbox' => $this->recommend->getShowInLightboxSetting($facet)
+              'showMoreInLightbox' => $this->recommend->getShowInLightboxSetting($facet),
           ]
       );
     ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
@@ -87,7 +87,7 @@
                   'title' => $field,
                   'sortOptions' => $hierarchicalFacetSortOptions[$field] ?? $hierarchicalFacetSortOptions['*'] ?? null,
                   'collapsedFacets' => $collapsedFacets,
-                  'results' => $this->results
+                  'results' => $this->results,
                 ]
             );
           ?>

--- a/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
@@ -40,7 +40,7 @@
           'visual_facet_parent' => 'visual_facet_parent',
           'items' => 'items',
           'more_topics_unescaped' => 'more_topics',
-          'on_topic_unescaped' => 'on_topic'
+          'on_topic_unescaped' => 'on_topic',
         ]
     );
 

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
@@ -45,7 +45,7 @@
           [
             'driver' => $this->driver,
             'defaults' => 'collection-info',
-            'tableId' => 'collectionInfo'
+            'tableId' => 'collectionInfo',
           ]
       );
     ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-record.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-record.phtml
@@ -6,7 +6,7 @@
       'core-fields.phtml',
       [
         'driver' => $this->driver,
-        'defaults' => 'collection-record'
+        'defaults' => 'collection-record',
       ]
   );
 ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
@@ -80,7 +80,7 @@
           'core-fields.phtml',
           [
             'driver' => $this->driver,
-            'defaults' => 'core'
+            'defaults' => 'core',
           ]
       );
     ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/rating.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/rating.phtml
@@ -2,7 +2,7 @@
   $ratingData = $this->driver->getRatingData();
   $translationParams = [
     '%%rating%%' => $this->localizedNumber($ratingData['rating']),
-    '%%count%%' => $this->localizedNumber($ratingData['count'])
+    '%%count%%' => $this->localizedNumber($ratingData['count']),
   ];
   $addUrlEsc = $this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Rating'));
   $countKeys = [

--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/core.phtml
@@ -89,7 +89,7 @@ if ($avail->code == 'od_code_login_for_avail') {
                     "od_hold_queue",
                     [
                         "%%holdPosition%%" => $hold->holdListPosition,
-                        "%%numberOfHolds%%" => $hold->numberOfHolds
+                        "%%numberOfHolds%%" => $hold->numberOfHolds,
                     ]
                 );
             }

--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/hold.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/hold.phtml
@@ -63,7 +63,7 @@
                             "od_hold_queue",
                             [
                                 "%%holdPosition%%" => $result->data->hold->holdListPosition,
-                                "%%numberOfHolds%%" => $result->data->hold->numberOfHolds
+                                "%%numberOfHolds%%" => $result->data->hold->numberOfHolds,
                             ]
                         );
                     endif;?>
@@ -108,7 +108,7 @@
                         "od_hold_queue",
                         [
                             "%%holdPosition%%" => $result->data->hold->holdListPosition,
-                            "%%numberOfHolds%%" => $result->data->hold->numberOfHolds
+                            "%%numberOfHolds%%" => $result->data->hold->numberOfHolds,
                         ]
                     );
                 endif;?>

--- a/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
+++ b/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
@@ -70,7 +70,7 @@
             $transParams = [
               '%%start%%' => $this->localizedNumber($results->getStartRecord()),
               '%%end%%' => $this->localizedNumber($results->getEndRecord()),
-              '%%total%%' => $this->localizedNumber($recordTotal)
+              '%%total%%' => $this->localizedNumber($recordTotal),
             ];
           ?>
           <?php if (!isset($this->skipTotalCount)): ?>

--- a/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
+++ b/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
@@ -6,7 +6,7 @@
   $translations = $this->jsTranslations()->getJSONFromArray(
       [
         'showTree' => 'hierarchy_show_tree',
-        'hideTree' => 'hierarchy_hide_tree'
+        'hideTree' => 'hierarchy_hide_tree',
       ]
   );
 

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -17,7 +17,7 @@
           'electronic_holdings' => [],
           'total' => 0,
           'page' => 0,
-          'itemLimit' => 0
+          'itemLimit' => 0,
         ];
         $offlineMode = 'ils-offline';
     }

--- a/themes/bootstrap3/templates/RecordTab/map.phtml
+++ b/themes/bootstrap3/templates/RecordTab/map.phtml
@@ -10,7 +10,7 @@
   $mapGraticule = $this->tab->getMapGraticule();
   $basemap = $this->tab->getBasemap();
   $params = [
-    json_encode($mapTabData), json_encode($mapGraticule), json_encode($basemap)
+    json_encode($mapTabData), json_encode($mapGraticule), json_encode($basemap),
   ];
   $jsParams = implode(', ', $params);
   $jsLoad = "loadMapTab(" . $jsParams . ");";

--- a/themes/bootstrap3/templates/RecordTab/versions.phtml
+++ b/themes/bootstrap3/templates/RecordTab/versions.phtml
@@ -12,7 +12,7 @@
             [
               '%%start%%' => 1,
               '%%end%%' => count($results),
-              '%%total%%' => $this->localizedNumber($results->getTotal())
+              '%%total%%' => $this->localizedNumber($results->getTotal()),
             ]
         );
       ?>

--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -17,7 +17,7 @@
         'checkboxFilters' => $this->params->getCheckboxFacets(),
         'filterList' => $this->params->getFilterList(true),
         'hasDefaultsApplied' => $this->params->hasDefaultsApplied(),
-        'selectedShards' => $this->params->getSelectedShards()
+        'selectedShards' => $this->params->getSelectedShards(),
       ]
   );
 
@@ -66,7 +66,7 @@
       'combinedResults' => $this->combinedResults,
       'supportsCartOptions' => $this->supportsCartOptions,
       'showCartControls' => $this->showCartControls,
-      'showBulkOptions' => $this->showBulkOptions
+      'showBulkOptions' => $this->showBulkOptions,
     ];
   ?>
   <?=$this->context($this)->renderInContext('combined/stack-' . $placement . '.phtml', $viewParams); ?>

--- a/themes/bootstrap3/templates/combined/stack-distributed.phtml
+++ b/themes/bootstrap3/templates/combined/stack-distributed.phtml
@@ -18,7 +18,7 @@
         // Enable bulk options if appropriate:
         'showBulkOptions' => $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions,
         // Other params
-        'domId' => $currentSearch['domId']
+        'domId' => $currentSearch['domId'],
       ];
       if (isset($currentSearch['ajax'])) {
         $colParams['ajax'] = $currentSearch['ajax'];

--- a/themes/bootstrap3/templates/combined/stack-left.phtml
+++ b/themes/bootstrap3/templates/combined/stack-left.phtml
@@ -10,7 +10,7 @@
           // Enable cart if appropriate:
           'showCartControls' => $this->supportsCartOptions[$columnIndex] && $this->showCartControls,
           // Enable bulk options if appropriate:
-          'showBulkOptions' => $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions
+          'showBulkOptions' => $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions,
         ];
       ?>
       <?php

--- a/themes/bootstrap3/templates/combined/stack-right.phtml
+++ b/themes/bootstrap3/templates/combined/stack-right.phtml
@@ -9,7 +9,7 @@
           // Enable cart if appropriate:
           'showCartControls' => $this->supportsCartOptions[$columnIndex] && $this->showCartControls,
           // Enable bulk options if appropriate:
-          'showBulkOptions' => $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions
+          'showBulkOptions' => $this->supportsCartOptions[$columnIndex] && $this->showBulkOptions,
         ];
       ?>
       <?php

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -81,7 +81,7 @@
                           return $item;
                       },
                       $this->layout()->themeOptions
-                  )
+                  ),
               ]) ?>
           <?php endif; ?>
 

--- a/themes/bootstrap3/templates/layout/js-translations.phtml
+++ b/themes/bootstrap3/templates/layout/js-translations.phtml
@@ -27,7 +27,7 @@ $this->jsTranslations()->addStrings(
         'number_thousands_separator', null, ',',
       ],
       'sms_success' => 'sms_success',
-      'No pickup locations available' => 'No pickup locations available'
+      'No pickup locations available' => 'No pickup locations available',
     ]
 );
 
@@ -81,7 +81,7 @@ if ($account->ajaxEnabled()) {
 if ($this->config()->ajaxCoversEnabled()) {
   $this->jsTranslations()->addStrings(
       [
-        'cover_source_label' => 'cover_source_label'
+        'cover_source_label' => 'cover_source_label',
       ]
   );
 }

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -18,7 +18,7 @@
           [
             '%%pageTitle%%' => $this->headTitle()->renderTitle(),
             '%%siteTitle%%' => $siteConfig->title,
-            '%%titleSeparator%%' => $siteConfig->titleSeparator ?? '::'
+            '%%titleSeparator%%' => $siteConfig->titleSeparator ?? '::',
           ]
       );
       // Enable escaping again for proper output:
@@ -31,7 +31,7 @@
             'href' => $this->url('search-opensearch') . '?method=describe',
             'type' => 'application/opensearchdescription+xml',
             'title' => $this->transEsc('Library Catalog Search'),
-            'rel' => 'search'
+            'rel' => 'search',
           ]
       );
       // We need to generate the icons early, because they may add some stylesheets;

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -31,7 +31,7 @@
             $transParams = [
               '%%start%%' => $this->localizedNumber($paginator->getAbsoluteItemNumber(1)),
               '%%end%%' => $this->localizedNumber($end),
-              '%%total%%' => $this->localizedNumber($paginator->getTotalItemCount())
+              '%%total%%' => $this->localizedNumber($paginator->getTotalItemCount()),
             ];
           ?>
           <?=$this->translate('showing_items_of_html', $transParams); ?>

--- a/themes/bootstrap3/templates/myresearch/historicloans.phtml
+++ b/themes/bootstrap3/templates/myresearch/historicloans.phtml
@@ -26,7 +26,7 @@
             $transParams = [
               '%%start%%' => $this->localizedNumber($this->paginator->getAbsoluteItemNumber(1)),
               '%%end%%' => $this->localizedNumber($end),
-              '%%total%%' => $this->localizedNumber($this->paginator->getTotalItemCount())
+              '%%total%%' => $this->localizedNumber($this->paginator->getTotalItemCount()),
             ];
           ?>
           <?=$this->translate('showing_items_of_html', $transParams); ?>

--- a/themes/bootstrap3/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap3/templates/myresearch/mylist.phtml
@@ -48,7 +48,7 @@
           $transParams = [
             '%%start%%' => $this->localizedNumber($this->results->getStartRecord()),
             '%%end%%' => $this->localizedNumber($this->results->getEndRecord()),
-            '%%total%%' => $this->localizedNumber($recordTotal)
+            '%%total%%' => $this->localizedNumber($recordTotal),
           ];
         ?>
         <?=$this->translate('showing_items_of_html', $transParams); ?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -105,7 +105,7 @@
               $this->transEsc('Phone Number') => 'phone',
               $this->transEsc('Mobile Number') => 'mobile_phone',
               $this->transEsc('Group') => 'group',
-              $this->transEsc('patron_account_expires') => 'expiration_date'
+              $this->transEsc('patron_account_expires') => 'expiration_date',
             ]
         );
       ?>

--- a/themes/bootstrap3/templates/record/prev-next.phtml
+++ b/themes/bootstrap3/templates/record/prev-next.phtml
@@ -34,7 +34,7 @@
 
     <?=$this->transEsc('of_num_results', [
       '%%position%%' => $this->localizedNumber($this->scrollData['currentPosition']),
-      '%%total%%' => $this->localizedNumber($this->scrollData['resultTotal'])
+      '%%total%%' => $this->localizedNumber($this->scrollData['resultTotal']),
     ]) ?>
 
     <?php if ($this->scrollData['nextRecord']): ?>

--- a/themes/bootstrap3/templates/search/controls/showing.phtml
+++ b/themes/bootstrap3/templates/search/controls/showing.phtml
@@ -3,7 +3,7 @@
     '%%start%%' => $this->localizedNumber($this->results->getStartRecord()),
     '%%end%%' => $this->localizedNumber($this->results->getEndRecord()),
     '%%total%%' => $this->localizedNumber($this->recordTotal),
-    '%%lookfor%%' => $this->escapeHtml($this->lookfor)
+    '%%lookfor%%' => $this->escapeHtml($this->lookfor),
   ];
 
   $showingResults = $this->translate(

--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -47,7 +47,7 @@
             'facet' => $item,
             'group' => $this->facet,
             'url' => $this->results->getUrlQuery(),
-            'urlBase' => $searchAction
+            'urlBase' => $searchAction,
           ]) ?>
         <?php endforeach; ?>
       <?php endif; ?>

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -29,7 +29,7 @@
             '%%start%%' => $this->localizedNumber($this->results->getStartRecord()),
             '%%end%%' => $this->localizedNumber($this->results->getEndRecord()),
             '%%total%%' => $this->localizedNumber($recordTotal),
-            '%%lookfor%%' => $this->escapeHtml($reservesLookfor)
+            '%%lookfor%%' => $this->escapeHtml($reservesLookfor),
           ];
         ?>
         <?=$this->translate('showing_results_of_for_html', $transParams); ?><?php if ($qtime): ?>,<?php endif; ?>

--- a/themes/bootstrap3/theme.config.php
+++ b/themes/bootstrap3/theme.config.php
@@ -60,8 +60,8 @@ return [
             'flashmessages' => 'VuFind\View\Helper\Bootstrap3\Flashmessages',
             'highlight' => 'VuFind\View\Helper\Bootstrap3\Highlight',
             'layoutClass' => 'VuFind\View\Helper\Bootstrap3\LayoutClass',
-            'search' => 'VuFind\View\Helper\Bootstrap3\Search'
-        ]
+            'search' => 'VuFind\View\Helper\Bootstrap3\Search',
+        ],
     ],
     'icons' => [
         'defaultSet' => 'FontAwesome',
@@ -280,5 +280,5 @@ return [
             'warning' => 'FontAwesome:exclamation-triangle',
         ],
     ],
-    'doctype' => 'HTML5'
+    'doctype' => 'HTML5',
 ];

--- a/themes/root/templates/Email/new-user-welcome.phtml
+++ b/themes/root/templates/Email/new-user-welcome.phtml
@@ -5,6 +5,6 @@
         '%%firstname%%' => $this->firstname,
         '%%lastname%%' => $this->lastname,
         '%%username%%' => $this->username,
-        '%%url%%' => $this->url
+        '%%url%%' => $this->url,
     ]
 );

--- a/themes/root/templates/api/openapi.phtml
+++ b/themes/root/templates/api/openapi.phtml
@@ -6,7 +6,7 @@
     $basePath = rtrim($this->url('home'), '/') . '/api/v1';
     $info = [
         'title' => $this->config->Site->title,
-        'version' => $this->version
+        'version' => $this->version,
     ];
     if ($description = $this->config->API->description ?? '') {
         $info['description'] = $description;

--- a/themes/root/theme.config.php
+++ b/themes/root/theme.config.php
@@ -173,6 +173,6 @@ return [
             'userlist' => 'VuFind\View\Helper\Root\UserList',
             'usertags' => 'VuFind\View\Helper\Root\UserTags',
             'Laminas\View\Helper\Url' => 'VuFind\View\Helper\Root\Url',
-        ]
+        ],
     ],
 ];


### PR DESCRIPTION
While simplifying and consolidating php-cs-fixer rules, it seemed sensible to simplify the configuration around PHP version compatibility rules. This brings things up to the recommended PHP 7.4 settings, though I think we can safely raise this all the way to 8.2 without breaking backward compatibility. Since there are already a large number of changes (all related to trailing commas inside multi-line arrays), I thought it best to get this merged first and then advance the bar.

TODO
- [x] Run full test suite