### PR TITLE
php-cs-fixer: consolidate and update PHPUnit rules.

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -382,8 +382,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $results = $page->findAll('css', $selector);
         $this->assertIsArray($results, "Selector not found: $selector");
         $result = $results[$index] ?? null;
-        $this->assertTrue(
-            is_object($result),
+        $this->assertIsObject($result,
             "Element not found: $selector index $index"
         );
         return $result;
@@ -548,7 +547,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     protected function findAndAssertLink(Element $page, $text)
     {
         $link = $page->findLink($text);
-        $this->assertTrue(is_object($link));
+        $this->assertIsObject($link);
         return $link;
     }
 

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -382,7 +382,8 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $results = $page->findAll('css', $selector);
         $this->assertIsArray($results, "Selector not found: $selector");
         $result = $results[$index] ?? null;
-        $this->assertIsObject($result,
+        $this->assertIsObject(
+            $result,
             "Element not found: $selector index $index"
         );
         return $result;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Connection/SolrAuthTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Connection/SolrAuthTest.php
@@ -71,6 +71,6 @@ class SolrAuthTest extends \PHPUnit\Framework\TestCase
         // Search for a term known to exist in the sample data; request just one
         // record -- we should get a single record back.
         $result = $solr->search(new Query('Dublin Society', 'AllFields'), 0, 1);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Connection/SolrTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Connection/SolrTest.php
@@ -71,7 +71,7 @@ class SolrTest extends \PHPUnit\Framework\TestCase
         $result = $solr->alphabeticBrowse('author', 'Dublin Society', 0, 1, $extras);
         $item = $result['Browse']['items'][0];
         $this->assertEquals($item['count'], count($item['extras']['id']));
-        $this->assertTrue(empty($item['useInstead']));
+        $this->assertEmpty($item['useInstead']);
         $this->assertTrue(in_array(['vtls000013187'], $item['extras']['id']));
         $this->assertTrue(in_array('Royal Dublin Society', $item['seeAlso']));
         $this->assertEquals('Dublin Society', $item['heading']);
@@ -92,7 +92,7 @@ class SolrTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, $item['count']);
         $this->assertEquals($item['count'], count($item['extras']['id']));
         $this->assertEquals('Dublin Society, Royal', $item['heading']);
-        $this->assertTrue(empty($item['seeAlso']));
+        $this->assertEmpty($item['seeAlso']);
         $this->assertTrue(in_array('Royal Dublin Society', $item['useInstead']));
     }
 
@@ -126,7 +126,7 @@ class SolrTest extends \PHPUnit\Framework\TestCase
     {
         $solr = $this->getBackend();
         $currentPageInfo = $solr->terms('id', 'test', 1)->getFieldTerms('id');
-        $this->assertEquals(1, count($currentPageInfo));
+        $this->assertCount(1, $currentPageInfo);
         foreach ($currentPageInfo as $key => $value) {
             $this->assertEquals('test', substr($key, 0, 4));
         }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Db/Table/ChangeTrackerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Db/Table/ChangeTrackerTest.php
@@ -74,16 +74,16 @@ final class ChangeTrackerTest extends \PHPUnit\Framework\TestCase
         // Create a new row:
         $tracker->index($core, 'test1', 1326833170);
         $row = $tracker->retrieve($core, 'test1');
-        $this->assertTrue(is_object($row));
-        $this->assertTrue(empty($row->deleted));
+        $this->assertIsObject($row);
+        $this->assertEmpty($row->deleted);
         $this->assertEquals($row->first_indexed, $row->last_indexed);
         $this->assertEquals($row->last_record_change, '2012-01-17 20:46:10');
 
         // Try to index an earlier record version -- changes should be ignored:
         $tracker->index($core, 'test1', 1326830000);
         $row = $tracker->retrieve($core, 'test1');
-        $this->assertTrue(is_object($row));
-        $this->assertTrue(empty($row->deleted));
+        $this->assertIsObject($row);
+        $this->assertEmpty($row->deleted);
         $this->assertEquals($row->first_indexed, $row->last_indexed);
         $this->assertEquals($row->last_record_change, '2012-01-17 20:46:10');
         $previousFirstIndexed = $row->first_indexed;
@@ -94,8 +94,8 @@ final class ChangeTrackerTest extends \PHPUnit\Framework\TestCase
         // Index a later record version -- this should lead to changes:
         $tracker->index($core, 'test1', 1326833176);
         $row = $tracker->retrieve($core, 'test1');
-        $this->assertTrue(is_object($row));
-        $this->assertTrue(empty($row->deleted));
+        $this->assertIsObject($row);
+        $this->assertEmpty($row->deleted);
         $this->assertTrue(
             // use <= in case test runs too fast for values to become unequal:
             strtotime($row->first_indexed) <= strtotime($row->last_indexed)
@@ -108,20 +108,20 @@ final class ChangeTrackerTest extends \PHPUnit\Framework\TestCase
         // Delete the record:
         $tracker->markDeleted($core, 'test1');
         $row = $tracker->retrieve($core, 'test1');
-        $this->assertTrue(is_object($row));
+        $this->assertIsObject($row);
         $this->assertTrue(!empty($row->deleted));
 
         // Delete a record that hasn't previously been encountered:
         $tracker->markDeleted($core, 'test2');
         $row = $tracker->retrieve($core, 'test2');
-        $this->assertTrue(is_object($row));
+        $this->assertIsObject($row);
         $this->assertTrue(!empty($row->deleted));
 
         // Index the previously-deleted record and make sure it undeletes properly:
         $tracker->index($core, 'test2', 1326833170);
         $row = $tracker->retrieve($core, 'test2');
-        $this->assertTrue(is_object($row));
-        $this->assertTrue(empty($row->deleted));
+        $this->assertIsObject($row);
+        $this->assertEmpty($row->deleted);
         $this->assertEquals($row->last_record_change, '2012-01-17 20:46:10');
 
         // Clean up after ourselves:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -153,7 +153,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Now confirm that email button is absent:
         $link = $page->findLink('Change Email Address');
-        $this->assertFalse(is_object($link));
+        $this->assertIsNotObject($link);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -159,9 +159,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         // Seed some fines
         $page = $this->setUpFinesEnvironment();
         $menu = $page->findAll('css', '#login-dropdown');
-        $this->assertEquals(0, count($menu));
+        $this->assertCount(0, $menu);
         $stati = $page->findAll('css', '.account-menu .fines-status.hidden');
-        $this->assertEquals(0, count($stati));
+        $this->assertCount(0, $stati);
     }
 
     /**
@@ -188,9 +188,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $this->login();
         $page = $this->setUpFinesEnvironment();
         $menu = $page->findAll('css', '#login-dropdown');
-        $this->assertEquals(0, count($menu));
+        $this->assertCount(0, $menu);
         $stati = $page->findAll('css', '.account-menu .fines-status.hidden');
-        $this->assertEquals(1, count($stati));
+        $this->assertCount(1, $stati);
     }
 
     /**
@@ -216,9 +216,9 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $this->login();
         $page = $this->setUpFinesEnvironment();
         $menu = $page->findAll('css', '#login-dropdown');
-        $this->assertEquals(1, count($menu));
+        $this->assertCount(1, $menu);
         $stati = $page->findAll('css', '.account-menu .fines-status.hidden');
-        $this->assertEquals(2, count($stati)); // one in menu, one in dropdown
+        $this->assertCount(2, $stati); // one in menu, one in dropdown
     }
 
     /**
@@ -244,7 +244,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $this->login();
         $page = $this->setUpFinesEnvironment();
         $menu = $page->findAll('css', '#login-dropdown');
-        $this->assertEquals(1, count($menu));
+        $this->assertCount(1, $menu);
         $this->unFindCss($page, '.account-menu .fines-status.hidden');
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -188,11 +188,11 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $multiSel = $this->findCss($page, '#limit_callnumber-first');
         $multiSel->selectOption('~callnumber-first:"A - General Works"', true);
         $multiSel->selectOption('~callnumber-first:"D - World History"', true);
-        $this->assertEquals(2, count($multiSel->getValue()));
+        $this->assertCount(2, $multiSel->getValue());
 
         $this->findCss($page, '.adv-submit .clear-btn')->press();
         $this->assertEquals('', $this->findCss($page, '#search_lookfor0_0')->getValue());
-        $this->assertEquals(0, count($multiSel->getValue()));
+        $this->assertCount(0, $multiSel->getValue());
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -124,7 +124,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
     protected function checkForLoginMessage(Element $page)
     {
         $warning = $this->findCss($page, '.modal-body .alert-danger');
-        $this->assertTrue(is_object($warning));
+        $this->assertIsObject($warning);
         $this->assertEquals(
             'You must be logged in first',
             $warning->getText()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CallnumberBrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CallnumberBrowseTest.php
@@ -85,7 +85,7 @@ class CallnumberBrowseTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function checkLink($link, $type)
     {
-        $this->assertTrue(is_object($link));
+        $this->assertIsObject($link);
         $href = $link->getAttribute('href');
         $this->assertStringContainsString($type, $href);
         $this->assertNotEquals('', $link->getText());

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -270,7 +270,7 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
     protected function checkForLoginMessage(Element $page)
     {
         $warning = $page->find('css', '.modal-body .alert-danger');
-        $this->assertTrue(is_object($warning));
+        $this->assertIsObject($warning);
         $this->assertEquals(
             'You must be logged in first',
             $warning->getText()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -68,7 +68,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, 'div.channel-wrapper');
         // Check number of channels
         $channels = $page->findAll('css', 'div.channel-wrapper');
-        $this->assertEquals(6, count($channels));
+        $this->assertCount(6, $channels);
         // Make sure search input matches url
         $this->assertEquals(
             'building:"weird_ids.mrc"',
@@ -86,15 +86,15 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->getChannelsPage();
         $channel = $this->findCss($page, 'div.channel-wrapper');
         // Initial counts
-        $this->assertEquals(6, count($page->findAll('css', 'div.channel-wrapper')));
-        $this->assertEquals(8, count($channel->findAll('css', '.channel-add-menu .dropdown-menu li')));
+        $this->assertCount(6, $page->findAll('css', 'div.channel-wrapper'));
+        $this->assertCount(8, $channel->findAll('css', '.channel-add-menu .dropdown-menu li'));
         // Click first add button
         $this->clickCss($channel, '.add-btn');
         // Post count
         $this->waitStatement('$("div.channel-wrapper").length === 8');
         $this->waitStatement('$(".channel-add-menu:first .dropdown-menu li").length === 6');
-        $this->assertEquals(8, count($page->findAll('css', 'div.channel-wrapper')));
-        $this->assertEquals(6, count($channel->findAll('css', '.channel-add-menu .dropdown-menu li')));
+        $this->assertCount(8, $page->findAll('css', 'div.channel-wrapper'));
+        $this->assertCount(6, $channel->findAll('css', '.channel-add-menu .dropdown-menu li'));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
@@ -92,7 +92,7 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
         );
         $page = $this->goToCollection();
         $results = $page->findAll('css', '.result');
-        $this->assertEquals(7, count($results));
+        $this->assertCount(7, $results);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -343,7 +343,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
     protected function clickButtonGroupLink(Element $page, string $text): void
     {
         $link = $this->findCss($page, '.btn-group.open')->findLink($text);
-        $this->assertTrue(is_object($link));
+        $this->assertIsObject($link);
         $link->click();
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -169,7 +169,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     protected function clickButtonGroupLink(Element $page, string $text): void
     {
         $link = $this->findCss($page, '.btn-group.open')->findLink($text);
-        $this->assertTrue(is_object($link));
+        $this->assertIsObject($link);
         $link->click();
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
@@ -192,7 +192,7 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->gotoSearch();
         // Did our result close after not being being in the last search?
         $result = $page->find('css', '.result.embedded');
-        $this->assertFalse(is_object($result));
+        $this->assertIsNotObject($result);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -229,7 +229,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Count tags
         $this->waitForPageLoad($page);
         $tags = $page->findAll('css', '.tagList .tag');
-        $this->assertEquals(4, count($tags));
+        $this->assertCount(4, $tags);
         $tvals = [];
         foreach ($tags as $t) {
             $link = $t->find('css', 'a');
@@ -332,7 +332,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Count tags
         $this->waitForPageLoad($page);
         $tags = $page->findAll('css', '.tagList .tag');
-        $this->assertEquals(6, count($tags));
+        $this->assertCount(6, $tags);
     }
 
     /**
@@ -574,7 +574,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Check result
         $this->waitForPageLoad($page);
         $inputs = $page->findAll('css', $checked);
-        $this->assertEquals(1, count($inputs));
+        $this->assertCount(1, $inputs);
         $this->assertEquals('100', $inputs[0]->getValue());
         // Update rating
         $this->clickCss($page, $ratingLink);
@@ -585,7 +585,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('Rating Saved', $success->getText());
         // Check result
         $inputs = $page->findAll('css', $checked);
-        $this->assertEquals(1, count($inputs));
+        $this->assertCount(1, $inputs);
         $this->assertEquals('50', $inputs[0]->getValue());
 
         if ($allowRemove) {
@@ -595,7 +595,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             $this->waitForPageLoad($page);
             // Check result
             $inputs = $page->findAll('css', $checked);
-            $this->assertEquals(1, count($inputs));
+            $this->assertCount(1, $inputs);
             $this->assertEquals('', $inputs[0]->getValue());
             // Add it back
             $this->clickCss($page, $ratingLink);
@@ -626,7 +626,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Check result
         $this->waitForPageLoad($page);
         $inputs = $page->findAll('css', $checked);
-        $this->assertEquals(1, count($inputs));
+        $this->assertCount(1, $inputs);
         $this->assertEquals('70', $inputs[0]->getValue());
 
         // Login with third account
@@ -647,7 +647,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Check result
         $this->waitForPageLoad($page);
         $inputs = $page->findAll('css', $checked);
-        $this->assertEquals(1, count($inputs));
+        $this->assertCount(1, $inputs);
         $this->assertEquals('80', $inputs[0]->getValue());
         if ($allowRemove) {
             // Clear rating when adding another comment
@@ -657,7 +657,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             // Check result
             $this->waitForPageLoad($page);
             $inputs = $page->findAll('css', $checked);
-            $this->assertEquals(1, count($inputs));
+            $this->assertCount(1, $inputs);
             $this->assertEquals('70', $inputs[0]->getValue());
         } else {
             // Check that the "Clear" link is no longer available:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
@@ -79,7 +79,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCss($page, 'ul.breadcrumb li.active')->getText()
         );
         $results = $page->findAll('css', '.result');
-        $this->assertEquals(4, count($results));
+        $this->assertCount(4, $results);
     }
 
     /**
@@ -139,7 +139,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCss($page, 'ul.breadcrumb li.active')->getText()
         );
         $results = $page->findAll('css', '.result');
-        $this->assertEquals(4, count($results));
+        $this->assertCount(4, $results);
     }
 
     /**
@@ -164,9 +164,9 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performSearch('id:0001732009-0');
 
         // Click on the "other versions" link:
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($page->findAll('css', 'div.record-versions a'))
+            $page->findAll('css', 'div.record-versions a')
         );
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -323,14 +323,14 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
 
         // Now there should be two alert options visible (one in saved, one in
         // unsaved):
-        $this->assertEquals(2, count($page->findAll('css', $scheduleSelector)));
-        $this->assertEquals(
+        $this->assertCount(2, $page->findAll('css', $scheduleSelector));
+        $this->assertCount(
             1,
-            count($page->findAll('css', '#recent-searches ' . $scheduleSelector))
+            $page->findAll('css', '#recent-searches ' . $scheduleSelector)
         );
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($page->findAll('css', '#saved-searches ' . $scheduleSelector))
+            $page->findAll('css', '#saved-searches ' . $scheduleSelector)
         );
 
         // At this point, our journals search should be in the unsaved list; let's
@@ -338,9 +338,9 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         $select = $this->findCss($page, '#recent-searches ' . $scheduleSelector);
         $select->selectOption(7);
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($page->findAll('css', '#saved-searches ' . $scheduleSelector))
+            $page->findAll('css', '#saved-searches ' . $scheduleSelector)
         );
 
         // Now let's delete the saved search and confirm that this clears the
@@ -445,14 +445,14 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
 
         // Now there should be one alert option visible (in unsaved):
         $scheduleSelector = 'select[name="schedule"]';
-        $this->assertEquals(1, count($page->findAll('css', $scheduleSelector)));
-        $this->assertEquals(
+        $this->assertCount(1, $page->findAll('css', $scheduleSelector));
+        $this->assertCount(
             1,
-            count($page->findAll('css', '#recent-searches ' . $scheduleSelector))
+            $page->findAll('css', '#recent-searches ' . $scheduleSelector)
         );
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($page->findAll('css', '#saved-searches ' . $scheduleSelector))
+            $page->findAll('css', '#saved-searches ' . $scheduleSelector)
         );
 
         // Let's set up our search for alerts and make sure it's handled correctly:
@@ -472,9 +472,9 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         // the important one ("employment") should be first, which enables us to
         // safely rely on the final assertion below.
         $this->assertSavedSearchList(["employment", "test"], $page);
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($page->findAll('css', '#saved-searches ' . $scheduleSelector))
+            $page->findAll('css', '#saved-searches ' . $scheduleSelector)
         );
         $this->assertEquals(1, $this->findCss($page, $scheduleSelector)->getValue());
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -77,7 +77,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             $stats->getText()
         );
         $items = $page->findAll('css', $this->activeFilterSelector);
-        $this->assertEquals(0, count($items));
+        $this->assertCount(0, $items);
 
         // Facet to Fiction (after making sure we picked the right link):
         $facetList = $this->findCss($page, '#side-collapse-genre_facet a[data-title="Fiction"]');
@@ -93,7 +93,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             $stats->getText()
         );
         $items = $page->findAll('css', $this->activeFilterSelector);
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
     }
 
     /**
@@ -109,7 +109,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     {
         $this->waitForPageLoad($page);
         $items = $page->findAll('css', '#modal #facet-list-count .js-facet-item');
-        $this->assertEquals($limit, count($items));
+        $this->assertCount($limit, $items);
         $excludes = $page
             ->findAll('css', '#modal #facet-list-count .exclude');
         $this->assertEquals($exclusionActive ? $limit : 0, count($excludes));
@@ -139,7 +139,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '[data-sort="index"]');
         $this->waitForPageLoad($page);
         $items = $page->findAll('css', '#modal #facet-list-index .js-facet-item');
-        $this->assertEquals($limit, count($items)); // reset number of items
+        $this->assertCount($limit, $items); // reset number of items
         $this->assertEquals(
             'Fiction 7 results 7 ' . $excludeControl
             . 'The Study Of P|pes 1 results 1 ' . $excludeControl
@@ -179,7 +179,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that we are NOT using the AJAX sidebar:
         $ajaxContainer = $page->findAll('css', '.side-facets-container-ajax');
-        $this->assertEquals(0, count($ajaxContainer));
+        $this->assertCount(0, $ajaxContainer);
 
         // Now run the body of the test procedure:
         $this->facetApplyProcedure($page);
@@ -205,7 +205,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that we ARE using the AJAX sidebar:
         $ajaxContainer = $page->findAll('css', '.side-facets-container-ajax');
-        $this->assertEquals(1, count($ajaxContainer));
+        $this->assertCount(1, $ajaxContainer);
 
         // Now run the body of the test procedure:
         $this->facetApplyProcedure($page);
@@ -293,7 +293,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         // Open the genre facet
         $this->clickCss($page, '#side-collapse-genre_facet .more-facets');
         $this->facetListProcedure($page, $limit, true);
-        $this->assertEquals(1, count($page->findAll('css', $this->activeFilterSelector)));
+        $this->assertCount(1, $page->findAll('css', $this->activeFilterSelector));
     }
 
     /**
@@ -445,7 +445,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     protected function assertNoFilters($page)
     {
         $items = $page->findAll('css', $this->activeFilterSelector);
-        $this->assertEquals(0, count($items));
+        $this->assertCount(0, $items);
     }
 
     /**
@@ -458,7 +458,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     protected function assertNoResetFiltersButton($page)
     {
         $reset = $page->findAll('css', '.reset-filters-btn');
-        $this->assertEquals(0, count($reset));
+        $this->assertCount(0, $reset);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/View/Helper/Root/ResultFeedTest.php
@@ -138,7 +138,7 @@ class ResultFeedTest extends \PHPUnit\Framework\TestCase
         $helper->setTranslator($this->getMockTranslator());
         $helper->setView($this->getPhpRenderer($this->getPlugins()));
         $feed = $helper($results, '/test/path');
-        $this->assertTrue(is_object($feed));
+        $this->assertIsObject($feed);
         $rss = $feed->export('rss');
 
         // Make sure it's really an RSS feed:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
@@ -513,7 +513,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
         $prototype = $table->getResultSetPrototype()->getArrayObjectPrototype();
         $prototype->expects($this->once())->method('save');
         $user = $db->create($this->getRequest($this->getCreateParams()));
-        $this->assertTrue(is_object($user));
+        $this->assertIsObject($user);
     }
 
     // INTERNAL API

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -96,7 +96,7 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
         $result = $factory($container, get_class($fakeImage));
         $expectedFont = APPLICATION_PATH
         . '/vendor/webfontkit/open-sans/fonts/opensans-regular.ttf';
-        $this->assertTrue(file_exists($expectedFont));
+        $this->assertFileExists($expectedFont);
         $expected = [
             'font' => $expectedFont,
             'imgDir' => $options->getCacheDir(),

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/CartTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/CartTest.php
@@ -265,7 +265,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
     public function testVF1Cookie()
     {
         $cart = $this->getCart(100, true, ['vufind_cart' => "a\tb\tc"]);
-        $this->assertEquals(3, count($cart->getItems()));
+        $this->assertCount(3, $cart->getItems());
         $this->assertTrue($cart->contains('Solr|a'));
         $this->assertTrue($cart->contains('Solr|b'));
         $this->assertTrue($cart->contains('Solr|c'));
@@ -283,7 +283,7 @@ class CartTest extends \PHPUnit\Framework\TestCase
             'vufind_cart_src' => "Solr\tSummon\tWorldCat",
         ];
         $cart = $this->getCart(100, true, $cookies);
-        $this->assertEquals(3, count($cart->getItems()));
+        $this->assertCount(3, $cart->getItems());
         $this->assertTrue($cart->contains('Solr|a'));
         $this->assertTrue($cart->contains('Summon|b'));
         $this->assertTrue($cart->contains('WorldCat|c'));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PluginFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PluginFactoryTest.php
@@ -133,7 +133,7 @@ class PluginFactoryTest extends \PHPUnit\Framework\TestCase
     {
         // Make sure load succeeds:
         $config = $this->getConfig('unit-test-child');
-        $this->assertTrue(is_object($config));
+        $this->assertIsObject($config);
 
         // Make sure Section 1 was overridden; values from parent should not be
         // present.
@@ -162,7 +162,7 @@ class PluginFactoryTest extends \PHPUnit\Framework\TestCase
     {
         // Make sure load succeeds:
         $config = $this->getConfig('unit-test-child2');
-        $this->assertTrue(is_object($config));
+        $this->assertIsObject($config);
 
         // Make sure Section 1 was overridden; values from parent should not be
         // present.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Connection/WorldCatUtilsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Connection/WorldCatUtilsTest.php
@@ -55,8 +55,8 @@ class WorldCatUtilsTest extends \PHPUnit\Framework\TestCase
     {
         $client = $this->getClient('identities');
         $ids = $client->getRelatedIdentities('Clemens, Samuel');
-        $this->assertEquals(9, count($ids));
-        $this->assertEquals(34, count($ids['Twain, Mark, 1835-1910']));
+        $this->assertCount(9, $ids);
+        $this->assertCount(34, $ids['Twain, Mark, 1835-1910']);
         $this->assertTrue(in_array('Conjoined twins', $ids['Twain, Mark, 1835-1910']));
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Cookie/ContainerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Cookie/ContainerTest.php
@@ -84,11 +84,11 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
 
         // Test get/set of array:
         $this->container->testArray = [1, 2];
-        $this->assertEquals(2, count($this->container->testArray));
+        $this->assertCount(2, $this->container->testArray);
 
         // Test getAllValues:
         $all = $this->container->getAllValues();
-        $this->assertEquals(2, count($all));
+        $this->assertCount(2, $all);
         $this->assertTrue(in_array('value', array_keys($all)));
         $this->assertTrue(in_array('testArray', array_keys($all)));
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -84,7 +84,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
             'Laminas\InputFilter\InputFilter',
             get_class($form->getInputFilter())
         );
-        $this->assertEquals(0, count($form->getSecondaryHandlers()));
+        $this->assertCount(0, $form->getSecondaryHandlers());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/SymphonyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/SymphonyTest.php
@@ -79,6 +79,6 @@ class SymphonyTest extends \PHPUnit\Framework\TestCase
         );
         $this->driver->init();
         $pickup = @$this->driver->getPickUpLocations();
-        $this->assertTrue(empty($pickup));
+        $this->assertEmpty($pickup);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/XCNCIP2Test.php
@@ -1543,10 +1543,10 @@ class XCNCIP2Test extends \VuFindTest\Unit\ILSDriverTestCase
         $method->setAccessible(true);
         $this->mockResponse(['lookupItemSetNextItemToken.xml', 'lookupItemSet.xml']);
         $bibs = $method->invokeArgs($this->driver, [['id1'], ['agency1']]);
-        $this->assertEquals(8, count($bibs));
+        $this->assertCount(8, $bibs);
         $this->mockResponse(['lookupItemSetNextItemTokenEmpty.xml','lookupItemSet.xml']);
         $bibs = $method->invokeArgs($this->driver, [['id1'], ['agency1']]);
-        $this->assertEquals(4, count($bibs));
+        $this->assertCount(4, $bibs);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/FallbackLoader/SolrTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/FallbackLoader/SolrTest.php
@@ -100,6 +100,6 @@ class SolrTest extends \PHPUnit\Framework\TestCase
         $resource = $this->getMockBuilder(\VuFind\Db\Table\Resource::class)
             ->disableOriginalConstructor()->getMock();
         $loader = new Solr($resource, $search, null);
-        $this->assertEquals(0, count($loader->load(['oldId'])));
+        $this->assertCount(0, $loader->load(['oldId']));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcRemoteTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcRemoteTest.php
@@ -82,7 +82,7 @@ class SolrMarcRemoteTest extends \PHPUnit\Framework\TestCase
         $driver = $this->getDriver();
         $driver->setHttpService($this->getMockHttpService());
         $driver->setRawData(['id' => 1]);
-        $this->assertEquals(4, count($driver->getTOC()));
+        $this->assertCount(4, $driver->getTOC());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Role/DynamicRoleProviderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Role/DynamicRoleProviderTest.php
@@ -85,7 +85,7 @@ class DynamicRoleProviderTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo([1, 2, 3]))
             ->will($this->returnValue(['role']));
         $result = $this->getDynamicRoleProvider($pm, $config)->getRoles(['role']);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertEquals('role', $result[0]->getName());
         $this->assertTrue($result[0]->hasPermission('perm1'));
         $this->assertFalse($result[0]->hasPermission('perm2'));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -134,8 +134,8 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
     {
         $results = $this->getResults();
         $defaultProcessor = $results->getSpellingProcessor();
-        $this->assertTrue(
-            $defaultProcessor instanceof SpellingProcessor,
+        $this->assertInstanceOf(
+            SpellingProcessor::class, $defaultProcessor,
             'default spelling processor was created'
         );
         $mockProcessor = $this->createMock(SpellingProcessor::class);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -135,7 +135,8 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
         $results = $this->getResults();
         $defaultProcessor = $results->getSpellingProcessor();
         $this->assertInstanceOf(
-            SpellingProcessor::class, $defaultProcessor,
+            SpellingProcessor::class,
+            $defaultProcessor,
             'default spelling processor was created'
         );
         $mockProcessor = $this->createMock(SpellingProcessor::class);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -368,9 +368,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'a' => 'a',
             'b' => 'b',
         ];
-
-        // Check that the function is callable in this test.
-        $this->assertIsCallable([$this, $function]);
+        // Call the method specified by the data provider
         $results = $this->$function($driver, $spec);
         // Check for expected array keys
         $this->assertEquals(array_keys($expected), $this->getLabels($results));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -370,7 +370,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
         ];
 
         // Check that the function is callable in this test.
-        $this->assertTrue(is_callable([$this, $function]));
+        $this->assertIsCallable([$this, $function]);
         $results = $this->$function($driver, $spec);
         // Check for expected array keys
         $this->assertEquals(array_keys($expected), $this->getLabels($results));

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/AbstractExpireCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/AbstractExpireCommandTest.php
@@ -138,7 +138,7 @@ class AbstractExpireCommandTest extends \PHPUnit\Framework\TestCase
         // The response contains date stamps that will vary every time the test
         // runs, so let's split things apart to work around that...
         $parts = explode("\n", trim($response));
-        $this->assertEquals(3, count($parts));
+        $this->assertCount(3, $parts);
         $this->assertEquals(
             "1000 {$this->rowLabel} deleted.",
             explode('] ', $parts[0])[1]
@@ -175,7 +175,7 @@ class AbstractExpireCommandTest extends \PHPUnit\Framework\TestCase
         // The response contains date stamps that will vary every time the test
         // runs, so let's split things apart to work around that...
         $parts = explode("\n", trim($response));
-        $this->assertEquals(1, count($parts));
+        $this->assertCount(1, $parts);
         $this->assertEquals(
             "Total 0 {$this->rowLabel} deleted.",
             explode('] ', $parts[0])[1]

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/BrowZine/Response/RecordCollectionFactoryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/BrowZine/Response/RecordCollectionFactoryTest.php
@@ -53,7 +53,7 @@ class RecordCollectionFactoryTest extends TestCase
         $resp = ['data' => [['id' => 1], ['id' => 2], ['id' => 3]]];
         $fact = new RecordCollectionFactory();
         $coll = $fact->factory($resp);
-        $this->assertEquals(3, count($coll));
+        $this->assertCount(3, $coll);
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
@@ -163,10 +163,10 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(65924, $coll->getTotal());
         $this->assertEquals(0, $coll->getOffset());
         $rawFacets = $coll->getRawFacets();
-        $this->assertEquals(7, count($rawFacets));
+        $this->assertCount(7, $rawFacets);
         $this->assertEquals('SourceType', $rawFacets[0]['Id']);
         $this->assertEquals('Source Type', $rawFacets[0]['Label']);
-        $this->assertEquals(8, count($rawFacets[0]['AvailableFacetValues']));
+        $this->assertCount(8, $rawFacets[0]['AvailableFacetValues']);
         $expected = ['Value' => 'News', 'Count' => '12055', 'AddAction' => 'addfacetfilter(SourceType:News)'];
         $this->assertEquals($expected, $rawFacets[0]['AvailableFacetValues'][0]);
         $facets = $coll->getFacets();

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/LibGuides/Response/RecordCollectionFactoryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/LibGuides/Response/RecordCollectionFactoryTest.php
@@ -53,7 +53,7 @@ class RecordCollectionFactoryTest extends TestCase
         $resp = ['documents' => [[], [], []]];
         $fact = new RecordCollectionFactory();
         $coll = $fact->factory($resp);
-        $this->assertEquals(3, count($coll));
+        $this->assertCount(3, $coll);
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -98,8 +98,8 @@ class BackendTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('crossref10.5755/j01.ss.71.2.544', $recs[2]->recordid);
         $this->assertEquals(5706, $coll->getTotal());
         $facets = $coll->getFacets();
-        $this->assertEquals(9, count($facets));
-        $this->assertEquals(19, count($facets['jtitle']));
+        $this->assertCount(9, $facets);
+        $this->assertCount(19, $facets['jtitle']);
         $this->assertEquals(16, $facets['jtitle']['Remedial and Special Education']);
         $this->assertEquals(0, $coll->getOffset());
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/BackendTest.php
@@ -502,8 +502,8 @@ class BackendTest extends TestCase
         $back = new Backend($conn);
         $query = new Query('foo');
         $result = $back->getIds($query, 0, 10);
-        $this->assertTrue($result instanceof RecordCollection);
-        $this->assertEquals(0, count($result));
+        $this->assertInstanceOf(RecordCollection::class, $result);
+        $this->assertCount(0, $result);
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/NamedListTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/NamedListTest.php
@@ -66,7 +66,7 @@ class NamedListTest extends TestCase
     public function testCountable()
     {
         $list = new NamedList([['first term', 'info'], ['second term', 'info']]);
-        $this->assertEquals(2, count($list));
+        $this->assertCount(2, $list);
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionFactoryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionFactoryTest.php
@@ -53,7 +53,7 @@ class RecordCollectionFactoryTest extends TestCase
         $json = json_encode(['response' => ['start' => 0, 'docs' => [[], [], []]]]);
         $fact = new RecordCollectionFactory();
         $coll = $fact->factory(json_decode($json, true));
-        $this->assertEquals(3, count($coll));
+        $this->assertCount(3, $coll);
     }
 
     /**

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/Response/Json/RecordCollectionTest.php
@@ -160,7 +160,7 @@ class RecordCollectionTest extends TestCase
         ];
         $coll = new RecordCollection($input);
         $spell = $coll->getSpellcheck();
-        $this->assertEquals(1, count($spell));
+        $this->assertCount(1, $spell);
     }
 
     /**
@@ -204,7 +204,7 @@ class RecordCollectionTest extends TestCase
         $coll->add($r3);
         $coll->shuffle();
         $final = $coll->getRecords();
-        $this->assertEquals(3, count($final));
+        $this->assertCount(3, $final);
         $this->assertTrue(in_array($r1, $final));
         $this->assertTrue(in_array($r2, $final));
         $this->assertTrue(in_array($r3, $final));

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/ParamBagTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/ParamBagTest.php
@@ -106,10 +106,10 @@ class ParamBagTest extends TestCase
     public function testCountability()
     {
         $bag = new ParamBag();
-        $this->assertEquals(0, count($bag));
+        $this->assertCount(0, $bag);
         $bag->set('foo', 'bar');
-        $this->assertEquals(1, count($bag));
+        $this->assertCount(1, $bag);
         $bag->set('xyzzy', 'baz');
-        $this->assertEquals(2, count($bag));
+        $this->assertCount(2, $bag);
     }
 }

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
@@ -174,7 +174,7 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
         $this->setupCompiler($ext, $class);
         $this->compiler->compile(['child']);
         $this->assertFileExists($this->testDest . 'themes/child/css/compiled.css');
-        $this->assertFileNotExists($this->testDest . 'themes/parent/css/compiled.css');
+        $this->assertFileDoesNotExist($this->testDest . 'themes/parent/css/compiled.css');
         unlink($this->testDest . 'themes/child/css/compiled.css');
     }
 

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
@@ -173,8 +173,8 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->setupCompiler($ext, $class);
         $this->compiler->compile(['child']);
-        $this->assertTrue(file_exists($this->testDest . 'themes/child/css/compiled.css'));
-        $this->assertFalse(file_exists($this->testDest . 'themes/parent/css/compiled.css'));
+        $this->assertFileExists($this->testDest . 'themes/child/css/compiled.css');
+        $this->assertFileNotExists($this->testDest . 'themes/parent/css/compiled.css');
         unlink($this->testDest . 'themes/child/css/compiled.css');
     }
 
@@ -192,9 +192,9 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
     {
         $this->setupCompiler($ext, $class);
         $this->compiler->compile([]);
-        $this->assertTrue(file_exists($this->testDest . 'themes/child/css/compiled.css'));
-        $this->assertTrue(file_exists($this->testDest . 'themes/parent/css/compiled.css'));
-        $this->assertTrue(file_exists($this->testDest . 'themes/parent/css/relative/relative.css'));
+        $this->assertFileExists($this->testDest . 'themes/child/css/compiled.css');
+        $this->assertFileExists($this->testDest . 'themes/parent/css/compiled.css');
+        $this->assertFileExists($this->testDest . 'themes/parent/css/relative/relative.css');
         unlink($this->testDest . 'themes/child/css/compiled.css');
         unlink($this->testDest . 'themes/parent/css/compiled.css');
         unlink($this->testDest . 'themes/parent/css/relative/relative.css');

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
@@ -217,7 +217,7 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
         // Now recompile with "force" set to true, confirm that this succeeds,
         // and make sure the marker file is now gone:
         $this->assertTrue($compiler->compile('child', 'compiled', true));
-        $this->assertFileNotExists($markerFile);
+        $this->assertFileDoesNotExist($markerFile);
     }
 
     /**

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeCompilerTest.php
@@ -95,9 +95,9 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result);
 
         // Was the target directory created with the expected files?
-        $this->assertTrue(is_dir($this->targetPath));
-        $this->assertTrue(file_exists("{$this->targetPath}/parent.txt"));
-        $this->assertTrue(file_exists("{$this->targetPath}/child.txt"));
+        $this->assertDirectoryExists($this->targetPath);
+        $this->assertFileExists("{$this->targetPath}/parent.txt");
+        $this->assertFileExists("{$this->targetPath}/child.txt");
 
         // Did the right version of the  file that exists in both parent and child
         // get copied over?
@@ -149,10 +149,10 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result);
 
         // Was the target directory created with the expected files?
-        $this->assertTrue(is_dir($this->targetPath));
-        $this->assertTrue(file_exists("{$this->targetPath}/parent.txt"));
-        $this->assertTrue(file_exists("{$this->targetPath}/child.txt"));
-        $this->assertTrue(file_exists("{$this->targetPath}/js/mixin.js"));
+        $this->assertDirectoryExists($this->targetPath);
+        $this->assertFileExists("{$this->targetPath}/parent.txt");
+        $this->assertFileExists("{$this->targetPath}/child.txt");
+        $this->assertFileExists("{$this->targetPath}/js/mixin.js");
 
         // Did the right version of the  file that exists in both parent and child
         // get copied over?
@@ -212,12 +212,12 @@ class ThemeCompilerTest extends \PHPUnit\Framework\TestCase
         // removed when we force a recompile:
         $markerFile = $this->targetPath . '/fake-marker.txt';
         file_put_contents($markerFile, 'junk');
-        $this->assertTrue(file_exists($markerFile));
+        $this->assertFileExists($markerFile);
 
         // Now recompile with "force" set to true, confirm that this succeeds,
         // and make sure the marker file is now gone:
         $this->assertTrue($compiler->compile('child', 'compiled', true));
-        $this->assertFalse(file_exists($markerFile));
+        $this->assertFileNotExists($markerFile);
     }
 
     /**

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
@@ -208,7 +208,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             ]
         );
         $this->assertIsArray($files);
-        $this->assertEquals(3, count($files));
+        $this->assertCount(3, $files);
         $this->assertEquals('parent', $files[0]['theme']);
         $this->assertEquals(
             'templates/content/page1.phtml',

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/SlotTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/SlotTest.php
@@ -51,7 +51,7 @@ class SlotTest extends \PHPUnit\Framework\TestCase
     {
         $helper = $this->getHelper();
         $ret = $helper('test');
-        $this->assertTrue($ret instanceof Slot);
+        $this->assertInstanceOf(Slot::class, $ret);
     }
 
     /**

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -7,6 +7,7 @@ $finder->in(__DIR__ . '/../config')
 
 $rules = [
     '@PHP74Migration' => true,
+    '@PHPUnit84Migration:risky' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
     'binary_operator_spaces' => [
@@ -41,11 +42,7 @@ $rules = [
     'non_printable_character' => true,
     'ordered_imports' => true,
     'phpdoc_no_access' => true,
-    'php_unit_dedicate_assert_internal_type' => true,
-    'php_unit_expectation' => true,
     'php_unit_method_casing' => true,
-    'php_unit_mock' => true,
-    'php_unit_no_expectation_annotation' => true,
     'pow_to_exponentiation' => true,
     'single_line_after_imports' => true,
     'standardize_not_equals' => true,


### PR DESCRIPTION
Another thread of php-cs-fixer cleanup: using the built-in ruleset for PHPUnit to reduce the number of separate rules configured to fix tests, and also bringing that ruleset up to date for the version of PHPUnit we are using. We'll want to raise this to support 10.0 as well in the near future, but I'll address that separately to keep the number of diffs per PR under control.

TODO
- [x] Run full test suite