### PR TITLE
Fix CoverController::getImageParams isbn array check

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -88,20 +88,14 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected function getImageParams()
     {
         $params = $this->params();  // shortcut for readability
-        $isbn = null;
+        // Legacy support for "isn", "isbn" param which has been superseded by isbns:
         foreach (['isbns', 'isbn', 'isn'] as $identification) {
-            $isbn = $params()->fromQuery($identification);
-            if (empty($isbn)) {
-                continue;
+            if ($isbns = $params()->fromQuery($identification)) {
+                break;
             }
-            if (is_array($isbn)) {
-                $isbn = reset($isbn);
-            }
-            break;
         }
         return [
-            // Legacy support for "isn" param which has been superseded by isbn:
-            'isbn' => $isbn,
+            'isbns' => (array)$isbns,
             'size' => $params()->fromQuery('size'),
             'type' => $params()->fromQuery('contenttype'),
             'title' => $params()->fromQuery('title'),

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -88,14 +88,16 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected function getImageParams()
     {
         $params = $this->params();  // shortcut for readability
+        $isbns = null;
         // Legacy support for "isn", "isbn" param which has been superseded by isbns:
         foreach (['isbns', 'isbn', 'isn'] as $identification) {
             if ($isbns = $params()->fromQuery($identification)) {
+                $isbns = (array)$isbns;
                 break;
             }
         }
         return [
-            'isbns' => (array)$isbns,
+            'isbns' => $isbns,
             'size' => $params()->fromQuery('size'),
             'type' => $params()->fromQuery('contenttype'),
             'title' => $params()->fromQuery('title'),

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -88,9 +88,20 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected function getImageParams()
     {
         $params = $this->params();  // shortcut for readability
+        $isbn = null;
+        foreach (['isbns', 'isbn', 'isn'] as $identification) {
+            $isbn = $params()->fromQuery($identification);
+            if (empty($isbn)) {
+                continue;
+            }
+            if (is_array($isbn)) {
+                $isbn = reset($isbn);
+            }
+            break;
+        }
         return [
             // Legacy support for "isn" param which has been superseded by isbn:
-            'isbn' => $params()->fromQuery('isbn') ?: $params()->fromQuery('isn'),
+            'isbn' => $isbn,
             'size' => $params()->fromQuery('size'),
             'type' => $params()->fromQuery('contenttype'),
             'title' => $params()->fromQuery('title'),


### PR DESCRIPTION
I think this was forgotten in https://github.com/vufind-org/vufind/pull/2633 but the parameters do not work properly when trying to fetch an image to show.

