### PR TITLE
Upgrade league/oauth2-server to version 8.4.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "laminas/laminas-validator": "2.25.0",
         "laminas/laminas-view": "2.23.0",
         "league/commonmark": "2.3.9",
-        "league/oauth2-server": "8.4.0",
+        "league/oauth2-server": "8.4.1",
         "lm-commons/lmc-rbac-mvc": "3.3.1",
         "matthiasmullie/minify": "1.3.70",
         "ocramius/proxy-manager": "2.13.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "617acfe40757be40aa64ab2eb2e888c6",
+    "content-hash": "797dd997ae753cadd597c2a01b4173d2",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -4815,16 +4815,16 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "8.4.0",
+            "version": "8.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "539f4340c14eca8d44578fd118f6bdc0ad16d1ce"
+                "reference": "eed31d86d8cc8e6e9c9f58fbb2113494f8b41e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/539f4340c14eca8d44578fd118f6bdc0ad16d1ce",
-                "reference": "539f4340c14eca8d44578fd118f6bdc0ad16d1ce",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/eed31d86d8cc8e6e9c9f58fbb2113494f8b41e24",
+                "reference": "eed31d86d8cc8e6e9c9f58fbb2113494f8b41e24",
                 "shasum": ""
             },
             "require": {
@@ -4891,7 +4891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/oauth2-server/issues",
-                "source": "https://github.com/thephpleague/oauth2-server/tree/8.4.0"
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.4.1"
             },
             "funding": [
                 {
@@ -4899,7 +4899,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-15T16:08:35+00:00"
+            "time": "2023-03-22T11:47:53+00:00"
         },
         {
             "name": "league/uri",


### PR DESCRIPTION
This eliminates PHP 8 deprecation warnings.

Mink tests are passing for me.