### PR TITLE
Fix double-encoding of hidden filters in advanced search tabs.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -451,7 +451,8 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             return $prepend . UrlQueryHelper::buildQueryString(
                 [
                     'hiddenFilters' => $hiddenFilters,
-                ]
+                ],
+                false
             );
         }
         return '';


### PR DESCRIPTION
This follows the convention of basic search tabs where the remapped url is not encoded by the searchTabs helper.