### PR TITLE
Fix visual view link and jump to record handling.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -460,10 +460,10 @@ class AbstractSearch extends AbstractBase
         if (
             ($this->getConfig()->Record->jump_to_single_search_result ?? false)
             && $results->getResultTotal() == 1
+            && $recordList = $results->getResults()
         ) {
-            $recordList = $results->getResults();
             return $this->getRedirectForRecord(
-                $recordList[0],
+                reset($recordList),
                 ['sid' => $results->getSearchId()]
             );
         }

--- a/themes/bootstrap3/templates/search/controls/view.phtml
+++ b/themes/bootstrap3/templates/search/controls/view.phtml
@@ -3,7 +3,13 @@
     <?php foreach ($viewList as $viewType => $viewData): ?>
       <?php $viewDesc = $this->translate($viewData['desc']); ?>
       <?php if (!$viewData['selected']): ?>
-        <a class="icon-link" href="<?=$this->results->getUrlQuery()->setViewParam($viewType)?>" title="<?=$this->transEscAttr('switch_view', ['%%view%%' => $viewDesc])?>" >
+        <?php
+          $viewUrl = $this->results->getUrlQuery()->setViewParam($viewType);
+          if ('visual' === $viewType) {
+            $viewUrl = $viewUrl->setPage(1);
+          }
+        ?>
+        <a class="icon-link" href="<?=$viewUrl?>" title="<?=$this->transEscAttr('switch_view', ['%%view%%' => $viewDesc])?>" >
       <?php else: ?>
         <span class="icon-link" title="<?=$this->transEscAttr('view_already_selected', ['%%current%%' => $viewDesc]) ?>">
       <?php endif; ?>


### PR DESCRIPTION
If user jumps to visual view from e.g. the second page, we need to ensure the view url doesn't have a page number. This avoids drilling into visual results from displaying e.g. results 21 to 2 of 2. Also adds a check that a record was returned before trying to jump to it.

I'm not sure how much the visual view is used since it seems a bit raw to me, but at least this prevents an error that could perhaps happen in other circumstances as well, at least with a hand-crafted url if nothing else.