### PR TITLE
Record Title labels for checkboxes

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -414,7 +414,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper
             . $this->driver->getUniqueId();
         $context
             = ['id' => $id, 'number' => $number, 'prefix' => $idPrefix,
-               'title' => $this->getTitleHtml()];
+               'titleHtml' => $this->getTitleHtml()];
         if ($formAttr) {
             $context['formAttr'] = $formAttr;
         }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -413,7 +413,8 @@ class Record extends \Laminas\View\Helper\AbstractHelper
         $id = $this->driver->getSourceIdentifier() . '|'
             . $this->driver->getUniqueId();
         $context
-            = ['id' => $id, 'number' => $number, 'prefix' => $idPrefix];
+            = ['id' => $id, 'number' => $number, 'prefix' => $idPrefix,
+               'title' => $this->getTitleHtml()];
         if ($formAttr) {
             $context['formAttr'] = $formAttr;
         }

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -8,8 +8,8 @@
   <span class="checkbox-icon"></span>
   <?php if (strlen($this->number ?? '') > 0): ?>
     <span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span>
-  <?php elseif (strlen($this->title ?? '') > 0): ?>
-    <span class="sr-only"><?=$this->title?></span>
+  <?php elseif (strlen($this->titleHtml ?? '') > 0): ?>
+    <span class="sr-only"><?=$this->titleHtml?></span>
   <?php endif; ?>
 </label>
 <input

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -1,6 +1,6 @@
 <label class="record-checkbox hidden-print">
   <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
   <span class="checkbox-icon"></span>
-  <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?php endif; ?>
+  <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?elseif (strlen($this->title ?? '') > 0): ?><span class="sr-only"><?=$title?></span><?php endif; ?>
 </label>
 <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -1,6 +1,20 @@
 <label class="record-checkbox hidden-print">
-  <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
+  <input
+    class="checkbox-select-item"
+    type="checkbox" name="ids[]"
+    value="<?=$this->escapeHtmlAttr($this->id) ?>"
+    <?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>
+  />
   <span class="checkbox-icon"></span>
-  <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?php elseif (strlen($this->title ?? '') > 0): ?><span class="sr-only"><?=$title?></span><?php endif; ?>
+  <?php if (strlen($this->number ?? '') > 0): ?>
+    <span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span>
+  <?php elseif (strlen($this->title ?? '') > 0): ?>
+    <span class="sr-only"><?=$this->title?></span>
+  <?php endif; ?>
 </label>
-<input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
+<input
+  type="hidden"
+  name="idsAll[]"
+  value="<?=$this->escapeHtmlAttr($this->id) ?>"
+  <?php if (isset($this->formAttr)): ?>form="<?=$this->formAttr ?>"<?php endif; ?>
+/>

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -1,6 +1,6 @@
 <label class="record-checkbox hidden-print">
   <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
   <span class="checkbox-icon"></span>
-  <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?elseif (strlen($this->title ?? '') > 0): ?><span class="sr-only"><?=$title?></span><?php endif; ?>
+  <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?php elseif (strlen($this->title ?? '') > 0): ?><span class="sr-only"><?=$title?></span><?php endif; ?>
 </label>
 <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>


### PR DESCRIPTION
The template `checkbox.phtml`gets called by the Record View Helper and by default only adds some rudimentary info to the template itself, there is also the option to provide a counter for a translated helper text á la "Select entry %X%".

In a recent accessibility report the reporting body noted that it would be better if the checkbox had a label actually referring to the title of the record. In any given fork this can be achieved pretty easily by overwriting the template and creating a variable prior to calling the controller.

I changed the record view helper so it always includes the record `TitleHtml()` (the function is a bit weirdly named as it actually does not give an HTML title but an escaped one. The previous way it worked is preserved and takes precedence over the record title for backwards compatibility. This especially helps catalogues that do not include the number of the record in their number (as many FINC library do for instance). 

There was some discussion regarding this change internally. The title is basically doubled for a screen reader so it bloats the whole thing a bit. Therefore I wanted to broaden the audience for this specific matter.


_side note: why is the checkbox.phtml so horribly compressed. I kept the style as it, but its very _unfun_ to edit_