### PR TITLE
Prevent endless redirect loop if library card selection was referred …

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -669,7 +669,7 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
      * separate logic is used for storing followup information when VuFind
      * forces the user to log in from another context.
      *
-     * @param bool $allowCurrentUrl Whether the current URL is a valid for followup
+     * @param bool $allowCurrentUrl Whether the current URL is valid for followup
      *
      * @return void
      */

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -669,9 +669,11 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
      * separate logic is used for storing followup information when VuFind
      * forces the user to log in from another context.
      *
+     * @param bool $allowCurrentUrl Whether the current URL is a valid for followup
+     *
      * @return void
      */
-    protected function setFollowupUrlToReferer()
+    protected function setFollowupUrlToReferer(bool $allowCurrentUrl = true)
     {
         // lbreferer is the stored current url of the lightbox
         // which overrides the url from the server request when present
@@ -708,6 +710,11 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
         $myUserLogin = $this->getServerUrl('myresearch-userlogin');
         $mulNorm = $this->normalizeUrlForComparison($myUserLogin);
         if (0 === strpos($refererNorm, $mulNorm)) {
+            return;
+        }
+
+        // Check that the referer is not current URL if not allowed:
+        if (!$allowCurrentUrl && $this->getRequest()->getUriString() === $referer) {
             return;
         }
 

--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -218,7 +218,7 @@ class LibraryCardsController extends AbstractBase
                 ->addMessage('authentication_error_technical', 'error');
         }
 
-        $this->setFollowupUrlToReferer();
+        $this->setFollowupUrlToReferer(false);
         if ($url = $this->getFollowupUrl()) {
             $this->clearFollowupUrl();
             return $this->redirect()->toUrl($this->adjustCardRedirectUrl($url));


### PR DESCRIPTION
…to by itself.

Steps to reproduce:

1. Open two browser tabs
2. Log in in the first tab
3. Open same address in second tab
4. Switch back to the first tab
5. Make sure the account has at least two library cards
6. Go to e.g. holds page where the library card selection is enabled
7. Log out in the second tab
8. Select another library card in the first tab
9. Log in again