### PR TITLE
KohaRest: Display expiration date as last pick up date when hold is a…

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -769,6 +769,8 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 ? ''
                 : $requestId;
             $updateDetails = ($available || $inTransit) ? '' : $requestId;
+            // Note: Expiration date is the last interest date until the hold becomes
+            // available for pickup. Then it becomes the last pickup date.
             $expirationDate = $this->convertDate($entry['expiration_date']);
             $holds[] = [
                 'id' => $entry['biblio_id'],

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -769,6 +769,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 ? ''
                 : $requestId;
             $updateDetails = ($available || $inTransit) ? '' : $requestId;
+            $expirationDate = $this->convertDate($entry['expiration_date']);
             $holds[] = [
                 'id' => $entry['biblio_id'],
                 'item_id' => $entry['hold_id'],
@@ -777,9 +778,10 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                     $entry['pickup_library_id'] ?? null
                 ),
                 'create' => $this->convertDate($entry['hold_date'] ?? null),
-                'expire' => $this->convertDate($entry['expiration_date'] ?? null),
+                'expire' => $available ? null : $expirationDate,
                 'position' => $entry['priority'],
                 'available' => $available,
+                'last_pickup_date' => $available ? $expirationDate : null,
                 'frozen' => $frozen,
                 'frozenThrough' => $frozen
                     ? $this->convertDate($entry['suspended_until'] ?? null) : null,


### PR DESCRIPTION
…vailable.

Koha uses the expiration date field for last interest date until the hold becomes available for pick up. This adds the bit of logic to display it properly.