### PR TITLE
Fix scoping of dc:subject in OJS import.

### DIFF
--- a/import/xsl/ojs.xsl
+++ b/import/xsl/ojs.xsl
@@ -73,8 +73,8 @@
                     </xsl:for-each>
                 </xsl:if>
                 <!-- SUBJECT -->
-                <xsl:if test="//dc:subject">
-                    <xsl:for-each select="//dc:subject">
+                <xsl:if test="dc:subject">
+                    <xsl:for-each select="dc:subject">
                         <xsl:if test="string-length() > 0">
                             <field name="topic">
                                 <xsl:value-of select="normalize-space()"/>
@@ -82,8 +82,8 @@
                         </xsl:if>
                     </xsl:for-each>
                 </xsl:if>
-                <xsl:if test="//dc:subject">
-                    <xsl:for-each select="//dc:subject">
+                <xsl:if test="dc:subject">
+                    <xsl:for-each select="dc:subject">
                         <xsl:if test="string-length() > 0">
                             <field name="topic_facet">
                                 <xsl:value-of select="normalize-space()"/>


### PR DESCRIPTION
I discovered this bug while working on #2825 -- when importing combined records, each record would include every subject heading from every record, instead of just its own subjects. I've fixed the scoping here and confirmed that it works correctly.

I think in practice this hasn't caused problems because OJS metadata typically doesn't include dc:subject anyway... but now, if it ever does, it will be handled correctly.