### PR TITLE
Remove trailing slashes from void elements.

### DIFF
--- a/module/VuFind/src/VuFind/Connection/Wikipedia.php
+++ b/module/VuFind/src/VuFind/Connection/Wikipedia.php
@@ -342,7 +342,7 @@ class Wikipedia implements TranslatorAwareInterface
         // Convert multiple newlines into two breaks
         // We DO want this to be greedy
         $pattern[] = "/\n{2,}/s";
-        $replacement[] = '<br/><br/>';
+        $replacement[] = '<br><br>';
 
         return preg_replace($pattern, $replacement, $body);
     }

--- a/module/VuFind/src/VuFind/Controller/AjaxResponseTrait.php
+++ b/module/VuFind/src/VuFind/Controller/AjaxResponseTrait.php
@@ -185,7 +185,7 @@ trait AjaxResponseTrait
      */
     public static function storeError($errno, $errstr, $errfile, $errline)
     {
-        self::$php_errors[] = "ERROR [$errno] - " . $errstr . "<br />\n"
+        self::$php_errors[] = "ERROR [$errno] - " . $errstr . "<br>\n"
             . " Occurred in " . $errfile . " on line " . $errline . ".";
         return true;
     }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrOverdrive.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrOverdrive.php
@@ -538,7 +538,7 @@ class SolrOverdrive extends SolrMarc implements LoggerAwareInterface
             $c_arr[] = "<strong>{$creator["role"]}<strong>: "
                 . $creator["name"];
         }
-        $data['creators'] = implode("<br/>", $c_arr);
+        $data['creators'] = implode("<br>", $c_arr);
 
         $this->debug("raw data:" . print_r($data, true));
         return $data;

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -589,14 +589,14 @@ class UrlQueryHelper
                     if (!$this->filtered($paramName, $paramValue2, $filter)) {
                         $retVal .= '<input type="hidden" name="' .
                             htmlspecialchars($paramName) . '[]" value="' .
-                            htmlspecialchars($paramValue2) . '" />';
+                            htmlspecialchars($paramValue2) . '">';
                     }
                 }
             } else {
                 if (!$this->filtered($paramName, $paramValue, $filter)) {
                     $retVal .= '<input type="hidden" name="' .
                         htmlspecialchars($paramName) . '" value="' .
-                        htmlspecialchars($paramValue) . '" />';
+                        htmlspecialchars($paramValue) . '">';
                 }
             }
         }

--- a/module/VuFind/src/VuFind/View/Helper/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/View/Helper/AbstractSearch.php
@@ -80,7 +80,7 @@ abstract class AbstractSearch extends AbstractHelper
         $html .= $msg;
         $normalizer = $results->getOptions()->getSpellingNormalizer();
         foreach ($spellingSuggestions as $term => $details) {
-            $html .= '<br/>' . $view->escapeHtml($term) . ' &raquo; ';
+            $html .= '<br>' . $view->escapeHtml($term) . ' &raquo; ';
             $i = 0;
             foreach ($details['suggestions'] as $word => $data) {
                 if ($i++ > 0) {

--- a/module/VuFind/src/VuFind/View/Helper/Root/MakeTag.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/MakeTag.php
@@ -373,7 +373,7 @@ class MakeTag extends \Laminas\View\Helper\AbstractHelper
         $htmlAttrs = $this->getView()->plugin('htmlAttributes')($attrs);
 
         if (empty($contents) && in_array($tagName, $this->voidElements)) {
-            return '<' . $tagName . $htmlAttrs . ' />';
+            return '<' . $tagName . $htmlAttrs . '>';
         }
 
         // Special option: escape content

--- a/module/VuFind/src/VuFind/View/Helper/Root/PrintArrayHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/PrintArrayHtml.php
@@ -81,14 +81,14 @@ class PrintArrayHtml extends AbstractHelper
                     $html .= $makeTag("span", $key . ":", ["class" => "term"])
                              . (
                                  (is_array($value) && !$valueIsSingleKeyList)
-                                 ? "<br/>\n" : " "
+                                 ? "<br>\n" : " "
                              );
                 }
 
                 $html .= $this->__invoke($value, $nextIndentLevel, $nextIndentFirst);
             }
         } else {
-            $html = $makeTag("span", $entry, ["class" => "detail"]) . "<br/>\n";
+            $html = $makeTag("span", $entry, ["class" => "detail"]) . "<br>\n";
         }
         return $html;
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
@@ -388,7 +388,7 @@ class RecordDataFormatter extends AbstractHelper
         $escaper = ($options['translate'] ?? false)
             ? $view->plugin('transEsc') : $view->plugin('escapeHtml');
         $transDomain = $options['translationTextDomain'] ?? '';
-        $separator = $options['separator'] ?? '<br />';
+        $separator = $options['separator'] ?? '<br>';
         $retVal = '';
         $array = (array)$data;
         $remaining = count($array);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/UrlQueryHelperTest.php
@@ -75,7 +75,7 @@ class UrlQueryHelperTest extends \PHPUnit\Framework\TestCase
             $helper->getParamArray()
         );
         $this->assertEquals(
-            '<input type="hidden" name="foo" value="bar" />',
+            '<input type="hidden" name="foo" value="bar">',
             $helper->asHiddenFields(['lookfor' => '/.*/'])
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
@@ -133,7 +133,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
     {
         return [
             'self closing tag' => [
-                '<img src="book.gif" />',
+                '<img src="book.gif">',
                 [
                     'img',
                     '',
@@ -142,7 +142,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
             ],
 
             'class only' => [
-                '<br class="sm&#x3A;hidden" />',
+                '<br class="sm&#x3A;hidden">',
                 [
                     'br',
                     '',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
@@ -75,14 +75,14 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     'KeyA' => "ValueA",
                 ],
                 <<<END
-                    <span class="term">KeyA:</span> <span class="detail">ValueA</span><br/>
+                    <span class="term">KeyA:</span> <span class="detail">ValueA</span><br>
 
                     END,
             ],
             [ // Set 2
                 "Value0",
                 <<<END
-                    <span class="detail">Value0</span><br/>
+                    <span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -91,7 +91,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     0 => "Value0",
                 ],
                 <<<END
-                    <span class="detail">Value0</span><br/>
+                    <span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -101,8 +101,8 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     1 => "Value1",
                 ],
                 <<<END
-                    <span class="detail">Value0</span><br/>
-                    <span class="detail">Value1</span><br/>
+                    <span class="detail">Value0</span><br>
+                    <span class="detail">Value1</span><br>
 
                     END,
             ],
@@ -111,7 +111,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     0 => "Escaped vals <>&'\"",
                 ],
                 <<<END
-                    <span class="detail">Escaped vals &lt;&gt;&amp;&#039;&quot;</span><br/>
+                    <span class="detail">Escaped vals &lt;&gt;&amp;&#039;&quot;</span><br>
 
                     END,
             ],
@@ -123,9 +123,9 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
 
                     END,
             ],
@@ -137,8 +137,8 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    &ndash;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
+                    &ndash;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
 
                     END,
             ],
@@ -154,12 +154,12 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
-                    <span class="term">KeyB:</span><br/>
-                    &ensp;&ensp;<span class="term">KeyX:</span> <span class="detail">Value2</span><br/>
-                    &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
+                    <span class="term">KeyB:</span><br>
+                    &ensp;&ensp;<span class="term">KeyX:</span> <span class="detail">Value2</span><br>
+                    &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br>
 
                     END,
             ],
@@ -176,11 +176,11 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     2 => "Value4",
                 ],
                 <<<END
-                    &ndash;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
-                    &ndash;&ensp;<span class="term">KeyX:</span> <span class="detail">Value2</span><br/>
-                    &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br/>
-                    &ndash;&ensp;<span class="detail">Value4</span><br/>
+                    &ndash;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
+                    &ndash;&ensp;<span class="term">KeyX:</span> <span class="detail">Value2</span><br>
+                    &ensp;&ensp;<span class="term">KeyY:</span> <span class="detail">Value3</span><br>
+                    &ndash;&ensp;<span class="detail">Value4</span><br>
 
                     END,
             ],
@@ -196,14 +196,14 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
-                    <span class="term">KeyB:</span><br/>
-                    &ensp;&ensp;&ndash;&ensp;<span class="term">KeyW:</span> <span class="detail">Value2</span><br/>
-                    &ensp;&ensp;&ensp;&ensp;<span class="term">KeyX:</span> <span class="detail">Value3</span><br/>
-                    &ensp;&ensp;&ndash;&ensp;<span class="term">KeyY:</span> <span class="detail">Value4</span><br/>
-                    &ensp;&ensp;&ensp;&ensp;<span class="term">KeyZ:</span> <span class="detail">Value5</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
+                    <span class="term">KeyB:</span><br>
+                    &ensp;&ensp;&ndash;&ensp;<span class="term">KeyW:</span> <span class="detail">Value2</span><br>
+                    &ensp;&ensp;&ensp;&ensp;<span class="term">KeyX:</span> <span class="detail">Value3</span><br>
+                    &ensp;&ensp;&ndash;&ensp;<span class="term">KeyY:</span> <span class="detail">Value4</span><br>
+                    &ensp;&ensp;&ensp;&ensp;<span class="term">KeyZ:</span> <span class="detail">Value5</span><br>
 
                     END,
             ],
@@ -227,18 +227,18 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
-                    <span class="term">001:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value2</span><br/>
-                    &ensp;&ensp;<span class="detail">Value3</span><br/>
-                    <span class="term">100:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value4</span><br/>
-                    &ensp;&ensp;<span class="detail">Value5</span><br/>
-                    <span class="term">101:</span><br/>
-                    &ensp;&ensp;<span class="term">KeyB:</span> <span class="detail">Value6</span><br/>
-                    &ensp;&ensp;<span class="term">200:</span> <span class="detail">Value7</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
+                    <span class="term">001:</span><br>
+                    &ensp;&ensp;<span class="detail">Value2</span><br>
+                    &ensp;&ensp;<span class="detail">Value3</span><br>
+                    <span class="term">100:</span><br>
+                    &ensp;&ensp;<span class="detail">Value4</span><br>
+                    &ensp;&ensp;<span class="detail">Value5</span><br>
+                    <span class="term">101:</span><br>
+                    &ensp;&ensp;<span class="term">KeyB:</span> <span class="detail">Value6</span><br>
+                    &ensp;&ensp;<span class="term">200:</span> <span class="detail">Value7</span><br>
 
                     END,
             ],
@@ -255,14 +255,14 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     "100" => ["Value6"],
                 ],
                 <<<END
-                    <span class="term">001:</span> <span class="detail">Value0</span><br/>
-                    <span class="term">002:</span><br/>
-                    &ensp;&ensp;<span class="term">020:</span> <span class="detail">Value1</span><br/>
-                    &ensp;&ensp;<span class="term">040:</span> <span class="detail">Value2</span><br/>
-                    &ensp;&ensp;<span class="term">200:</span> <span class="detail">Value3</span><br/>
-                    &ensp;&ensp;<span class="term">201:</span> <span class="detail">Value4</span><br/>
-                    <span class="term">003:</span> <span class="detail">Value5</span><br/>
-                    <span class="term">100:</span> <span class="detail">Value6</span><br/>
+                    <span class="term">001:</span> <span class="detail">Value0</span><br>
+                    <span class="term">002:</span><br>
+                    &ensp;&ensp;<span class="term">020:</span> <span class="detail">Value1</span><br>
+                    &ensp;&ensp;<span class="term">040:</span> <span class="detail">Value2</span><br>
+                    &ensp;&ensp;<span class="term">200:</span> <span class="detail">Value3</span><br>
+                    &ensp;&ensp;<span class="term">201:</span> <span class="detail">Value4</span><br>
+                    <span class="term">003:</span> <span class="detail">Value5</span><br>
+                    <span class="term">100:</span> <span class="detail">Value6</span><br>
 
                     END,
             ],
@@ -274,10 +274,10 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ["100" => ["Value3"]],
                 ],
                 <<<END
-                    &ndash;&ensp;<span class="term">001:</span> <span class="detail">Value0</span><br/>
-                    &ndash;&ensp;<span class="term">002:</span> <span class="detail">Value1</span><br/>
-                    &ndash;&ensp;<span class="term">049:</span> <span class="detail">Value2</span><br/>
-                    &ndash;&ensp;<span class="term">100:</span> <span class="detail">Value3</span><br/>
+                    &ndash;&ensp;<span class="term">001:</span> <span class="detail">Value0</span><br>
+                    &ndash;&ensp;<span class="term">002:</span> <span class="detail">Value1</span><br>
+                    &ndash;&ensp;<span class="term">049:</span> <span class="detail">Value2</span><br>
+                    &ndash;&ensp;<span class="term">100:</span> <span class="detail">Value3</span><br>
 
                     END,
             ],
@@ -286,7 +286,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     "KeyA" => [0 => "Value0"],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span> <span class="detail">Value0</span><br/>
+                    <span class="term">KeyA:</span> <span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -295,8 +295,8 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     "KeyA" => ["000" => "Value0"],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="term">000:</span> <span class="detail">Value0</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="term">000:</span> <span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -305,8 +305,8 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     "KeyA" => [0 => [0 => "Value0"]],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -315,8 +315,8 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     "KeyA" => [0 => [0 => [0 => [0 => "Value0"]]]],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;&ndash;&ensp;&ndash;&ensp;<span class="detail">Value0</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;&ndash;&ensp;&ndash;&ensp;<span class="detail">Value0</span><br>
 
                     END,
             ],
@@ -329,10 +329,10 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;<span class="detail">Value1</span><br/>
-                    &ensp;&ensp;<span class="detail">Value2</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;<span class="detail">Value1</span><br>
+                    &ensp;&ensp;<span class="detail">Value2</span><br>
 
                     END,
             ],
@@ -350,11 +350,11 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
                     ],
                 ],
                 <<<END
-                    <span class="term">KeyA:</span><br/>
-                    &ensp;&ensp;&ndash;&ensp;<span class="detail">Value0</span><br/>
-                    &ensp;&ensp;&ensp;&ensp;<span class="detail">Value1</span><br/>
-                    &ensp;&ensp;&ndash;&ensp;<span class="detail">Value2</span><br/>
-                    &ensp;&ensp;&ensp;&ensp;<span class="detail">Value3</span><br/>
+                    <span class="term">KeyA:</span><br>
+                    &ensp;&ensp;&ndash;&ensp;<span class="detail">Value0</span><br>
+                    &ensp;&ensp;&ensp;&ensp;<span class="detail">Value1</span><br>
+                    &ensp;&ensp;&ndash;&ensp;<span class="detail">Value2</span><br>
+                    &ensp;&ensp;&ensp;&ensp;<span class="detail">Value3</span><br>
 
                     END,
             ],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -388,7 +388,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
         }
         // Check for exact markup in representative example:
         $this->assertEquals(
-            '<span property="availableLanguage" typeof="Language"><span property="name">Italian</span></span><br />'
+            '<span property="availableLanguage" typeof="Language"><span property="name">Italian</span></span><br>'
             . '<span property="availableLanguage" typeof="Language"><span property="name">Latin</span></span>',
             $this->findResult('Language', $results)['value']
         );

--- a/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
@@ -4,7 +4,7 @@
   <form method="post" action="<?=$this->url('myresearch-home')?>" name="loginForm" class="form-login">
     <?=$this->auth()->getLoginFields()?>
     <input type="hidden" name="auth_method" value="<?=$this->escapeHtmlAttr($account->getAuthMethod())?>">
-    <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($account->getCsrfHash())?>" />
+    <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($account->getCsrfHash())?>">
     <div class="form-group">
       <input class="btn btn-primary" type="submit" name="processLogin" value="<?=$this->transEscAttr('Login')?>">
       <?php if ($account->supportsCreation()): ?>

--- a/themes/bootstrap3/templates/Auth/AbstractBase/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/loginfields.phtml
@@ -1,8 +1,8 @@
 <div class="form-group">
   <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Username')?>:</label>
-  <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control" autofocus autocomplete="username"/>
+  <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control" autofocus autocomplete="username">
 </div>
 <div class="form-group">
   <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_password"><?=$this->transEsc('Password')?>:</label>
-  <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control" autocomplete="current-password"/>
+  <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control" autocomplete="current-password">
 </div>

--- a/themes/bootstrap3/templates/Auth/AbstractBase/newpassword.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/newpassword.phtml
@@ -7,7 +7,7 @@
 <?php if (isset($this->verifyold) && $this->verifyold || isset($this->oldpwd)): ?>
   <div class="form-group">
     <label class="control-label" for="oldpwd"><?=$this->transEsc('old_password') ?>:</label>
-    <input type="password" name="oldpwd" id="oldpwd" class="form-control" autocomplete="current-password"/>
+    <input type="password" name="oldpwd" id="oldpwd" class="form-control" autocomplete="current-password">
     <div class="help-block with-errors"></div>
   </div>
 <?php endif; ?>
@@ -25,6 +25,6 @@
 </div>
 <div class="form-group">
   <label class="control-label" for="password2"><?=$this->transEsc('confirm_new_password') ?>:</label>
-  <input type="password" name="password2" id="password2" class="form-control" required aria-required="true" data-match="#password" data-match-error="<?=$this->transEscAttr('Passwords do not match')?>" autocomplete="new-password"/>
+  <input type="password" name="password2" id="password2" class="form-control" required aria-required="true" data-match="#password" data-match-error="<?=$this->transEscAttr('Passwords do not match')?>" autocomplete="new-password">
   <div class="help-block with-errors"></div>
 </div>

--- a/themes/bootstrap3/templates/Auth/Database/create.phtml
+++ b/themes/bootstrap3/templates/Auth/Database/create.phtml
@@ -1,14 +1,14 @@
 <div class="form-group">
   <label class="control-label" for="account_firstname"><?=$this->transEsc('First Name')?>:</label>
-  <input id="account_firstname" type="text" name="firstname" value="<?=$this->escapeHtmlAttr($this->request->get('firstname'))?>" class="form-control"/>
+  <input id="account_firstname" type="text" name="firstname" value="<?=$this->escapeHtmlAttr($this->request->get('firstname'))?>" class="form-control">
 </div>
 <div class="form-group">
   <label class="control-label" for="account_lastname"><?=$this->transEsc('Last Name')?>:</label>
-  <input id="account_lastname" type="text" name="lastname" value="<?=$this->escapeHtmlAttr($this->request->get('lastname'))?>" class="form-control"/>
+  <input id="account_lastname" type="text" name="lastname" value="<?=$this->escapeHtmlAttr($this->request->get('lastname'))?>" class="form-control">
 </div>
 <div class="form-group">
   <label class="control-label" for="account_email"><?=$this->transEsc('Email Address')?>:</label>
-  <input id="account_email" type="email" name="email" required aria-required="true" value="<?=$this->escapeHtmlAttr($this->request->get('email'))?>" class="form-control"/>
+  <input id="account_email" type="email" name="email" required aria-required="true" value="<?=$this->escapeHtmlAttr($this->request->get('email'))?>" class="form-control">
   <div class="help-block with-errors"></div>
 </div>
 <div class="form-group">
@@ -37,6 +37,6 @@
 </div>
 <div class="form-group">
   <label class="control-label" for="account_password2"><?=$this->transEsc('Password Again')?>:</label>
-  <input id="account_password2" type="password" name="password2" required class="form-control" data-match="#account_password" data-match-error="<?=$this->transEscAttr('Passwords do not match')?>"/>
+  <input id="account_password2" type="password" name="password2" required class="form-control" data-match="#account_password" data-match-error="<?=$this->transEscAttr('Passwords do not match')?>">
   <div class="help-block with-errors"></div>
 </div>

--- a/themes/bootstrap3/templates/Auth/Database/recovery.phtml
+++ b/themes/bootstrap3/templates/Auth/Database/recovery.phtml
@@ -1,12 +1,12 @@
 <div class="form-group">
   <label class="control-label" for="recovery_username"><?=$this->transEsc('recovery_by_username') ?>:</label>
-  <input type="text" name="username" class="form-control" id="recovery_username" />
+  <input type="text" name="username" class="form-control" id="recovery_username">
 </div>
 <div class="form-group">
   <label class="control-label" for="recovery_email"><?=$this->transEsc('recovery_by_email') ?>:</label>
-  <input type="email" name="email" class="form-control" id="recovery_email" />
+  <input type="email" name="email" class="form-control" id="recovery_email">
 </div>
 <?=$this->captcha()->html($this->useCaptcha) ?>
 <div class="form-group">
-  <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Recover Account') ?>"/>
+  <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Recover Account') ?>">
 </div>

--- a/themes/bootstrap3/templates/Auth/Email/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/Email/loginfields.phtml
@@ -1,4 +1,4 @@
 <div class="form-group">
   <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Email')?>:</label>
-  <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control"/>
+  <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control">
 </div>

--- a/themes/bootstrap3/templates/Auth/ILS/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/ILS/loginfields.phtml
@@ -2,15 +2,15 @@
 <?php if ('email' === $loginMethod): ?>
   <div class="form-group">
     <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Email')?>:</label>
-    <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control"/>
+    <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control">
   </div>
 <?php else: ?>
   <div class="form-group">
     <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Username')?>:</label>
-    <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control"/>
+    <input type="text" name="username" id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_password"><?=$this->transEsc('Password')?>:</label>
-    <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control"/>
+    <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control">
   </div>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
@@ -16,11 +16,11 @@
 <div class="form-group">
   <label class="control-label password-login" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Username')?>:</label>
   <label class="control-label email-login hidden" for="login_<?=$this->escapeHtmlAttr($topClass)?>_username"><?=$this->transEsc('Email')?>:</label>
-  <input id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" type="text" name="username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control"/>
+  <input id="login_<?=$this->escapeHtmlAttr($topClass)?>_username" type="text" name="username" value="<?=$this->escapeHtmlAttr($this->request->get('username'))?>" class="form-control">
 </div>
 <div class="form-group">
   <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_password"><?=$this->transEsc('Password')?>:</label>
-  <input id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" type="password" name="password" class="form-control"/>
+  <input id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" type="password" name="password" class="form-control">
 </div>
 
 <?php

--- a/themes/bootstrap3/templates/Auth/PasswordAccess/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/PasswordAccess/loginfields.phtml
@@ -1,4 +1,4 @@
 <div class="form-group">
   <label class="control-label" for="login_<?=$this->escapeHtmlAttr($topClass)?>_password"><?=$this->transEsc('Password')?>:</label>
-  <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control"/>
+  <input type="password" name="password" id="login_<?=$this->escapeHtmlAttr($topClass)?>_password" class="form-control">
 </div>

--- a/themes/bootstrap3/templates/Helpers/email-form-fields.phtml
+++ b/themes/bootstrap3/templates/Helpers/email-form-fields.phtml
@@ -1,8 +1,8 @@
 <div class="form-group">
   <label class="control-label" for="email_to"><?=$this->transEsc('To')?>:</label>
-  <input type="<?=$this->maxRecipients != 1 ? 'text' : 'email'?>" id="email_to" class="form-control" name="to" value="<?=$this->escapeHtmlAttr($this->to ?? '')?>"/>
+  <input type="<?=$this->maxRecipients != 1 ? 'text' : 'email'?>" id="email_to" class="form-control" name="to" value="<?=$this->escapeHtmlAttr($this->to ?? '')?>">
   <?php if ($this->maxRecipients != 1): ?>
-    <br />
+    <br>
     <?=$this->transEsc('email_multiple_recipients_note')?>
     <?php if ($this->maxRecipients > 1): ?>
       <?=$this->transEsc('email_maximum_recipients_note', ['%%max%%' => $this->maxRecipients])?>
@@ -12,13 +12,13 @@
 <?php if (!$this->disableFrom): ?>
   <div class="form-group">
     <label class="control-label" for="email_from"><?=$this->transEsc('From')?>:</label>
-    <input type="email" id="email_from" name="from" value="<?=$this->escapeHtmlAttr($this->from ?? '')?>" size="40" class="form-control"/>
+    <input type="email" id="email_from" name="from" value="<?=$this->escapeHtmlAttr($this->from ?? '')?>" size="40" class="form-control">
   </div>
 <?php endif; ?>
 <?php if ($this->editableSubject): ?>
   <div class="form-group">
     <label class="control-label" for="email_subject"><?=$this->transEsc('email_subject')?>:</label>
-    <input type="text" id="email_subject" name="subject" value="<?=$this->escapeHtmlAttr($this->subject ?? '')?>" size="40" class="form-control"/>
+    <input type="text" id="email_subject" name="subject" value="<?=$this->escapeHtmlAttr($this->subject ?? '')?>" size="40" class="form-control">
   </div>
 <?php endif; ?>
 <div class="form-group">
@@ -29,12 +29,12 @@
   <div class="form-group">
     <div class="checkbox">
       <label>
-        <input type="checkbox" name="ccself"/> <?=$this->transEsc('send_email_copy_to_me'); ?>
+        <input type="checkbox" name="ccself"> <?=$this->transEsc('send_email_copy_to_me'); ?>
       </label>
     </div>
   </div>
 <?php endif ?>
 <?=$this->captcha()->html($this->useCaptcha) ?>
 <div class="form-group">
-  <input type="submit" class="btn btn-primary" name="submit" value="<?=$this->transEscAttr('Send')?>"/>
+  <input type="submit" class="btn btn-primary" name="submit" value="<?=$this->transEscAttr('Send')?>">
 </div>

--- a/themes/bootstrap3/templates/Helpers/openurl.phtml
+++ b/themes/bootstrap3/templates/Helpers/openurl.phtml
@@ -29,7 +29,7 @@
           $style .= 'height:' . $this->escapeHtmlAttr($this->openUrlGraphicHeight) . 'px;';
         }
       ?>
-      <img src="<?=$this->escapeHtmlAttr($this->openUrlGraphic)?>" alt="<?=$this->transEscAttr('Get full text')?>" style="<?=$style?>" />
+      <img src="<?=$this->escapeHtmlAttr($this->openUrlGraphic)?>" alt="<?=$this->transEscAttr('Get full text')?>" style="<?=$style?>">
     <?php else: ?>
       <?=$this->transEsc('Get full text')?>
     <?php endif; ?>
@@ -40,7 +40,7 @@
     <?php $ibOpenUrl = $this->openUrlImageBasedOverride ? $this->openUrlImageBasedOverride : $this->openUrl; ?>
     <a href="<?=$this->escapeHtmlAttr($this->openUrlBase . '?' . $ibOpenUrl)?>"<?=$class_ib?>>
       <span title="<?=$this->escapeHtmlAttr($ibOpenUrl)?>" class="openUrl"></span>
-      <img data-recordid="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" src="<?=$this->escapeHtmlAttr($this->openUrlImageBasedSrc)?>" alt="<?=$this->transEscAttr('Get full text')?>" />
+      <img data-recordid="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" src="<?=$this->escapeHtmlAttr($this->openUrlImageBasedSrc)?>" alt="<?=$this->transEscAttr('Get full text')?>">
     </a>
   <?php endif; ?>
 </span>

--- a/themes/bootstrap3/templates/Recommend/AuthorFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/AuthorFacets.phtml
@@ -12,11 +12,11 @@
         <?php endif; ?>
         <a href="<?=$this->url('author-home') . '?author=' . urlencode($author['value'])?>"><?=$this->escapeHtml($author['value']) ?><?php /* count disabled -- uncomment to add: echo ' - ' . $this->escapeHtml($author['count']); */ ?></a>
         <?php if ($i + 1 < count($similarAuthors['list'])): ?>
-          <br/>
+          <br>
         <?php endif; ?>
       <?php endforeach; ?>
       </div>
     </div>
-    <br/>
+    <br>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/AuthorInfo.phtml
+++ b/themes/bootstrap3/templates/Recommend/AuthorInfo.phtml
@@ -4,7 +4,7 @@
   <h2><?=$this->info['name'] ?></h2>
 
   <?php if (isset($this->info['image'])): ?>
-    <img class="pull-left flip" src="<?=$this->escapeHtmlAttr($this->info['image']) ?>" alt="<?=$this->escapeHtmlAttr($this->info['altimage']) ?>" width="150px"/>
+    <img class="pull-left flip" src="<?=$this->escapeHtmlAttr($this->info['image']) ?>" alt="<?=$this->escapeHtmlAttr($this->info['altimage']) ?>" width="150px">
   <?php endif; ?>
 
   <?=preg_replace('/___baseurl___/', $this->url('search-results'), $this->info['description']) ?>

--- a/themes/bootstrap3/templates/Recommend/CatalogResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/CatalogResults.phtml
@@ -11,13 +11,13 @@
         <?php $summAuthors = $driver->getPrimaryAuthorsWithHighlighting(); ?>
         <?php if (!empty($summDate) || !empty($summAuthors)): ?>
           <?php if (!empty($summDate)): ?>
-            <br/>
+            <br>
             <span class="small author">
               <?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($summDate[0])?>)
             </span>
           <?php endif; ?>
           <?php if (!empty($summAuthors)): ?>
-            <br/>
+            <br>
             <span class="small"><?=$this->transEsc('By')?></span>
             <a class="small date" href="<?=$this->record($driver)->getLink('author', $this->highlight($summAuthors[0], null, true, false))?>"><?=$this->highlight($summAuthors[0])?></a><?php if (count($summAuthors) > 1): ?><span class="small">, <?=$this->transEsc('more_authors_abbrev')?></span><?php endif; ?>
           <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/DPLATerms.phtml
+++ b/themes/bootstrap3/templates/Recommend/DPLATerms.phtml
@@ -7,9 +7,9 @@
     <div id="side-collapse-dpla" class="collapse<?php if (!$this->recommend->isCollapsed()): ?> in<?php endif ?>">
     <?php foreach ($results as $item): ?>
       <li class="list-group-item">
-        <a href="<?=$this->escapeHtmlAttr($item['link']) ?>" target="_blank"><?=$this->escapeHtml($item['title']) ?></a><br/>
+        <a href="<?=$this->escapeHtmlAttr($item['link']) ?>" target="_blank"><?=$this->escapeHtml($item['title']) ?></a><br>
         <?php if (!empty($item['desc'])): ?>
-          <span class="desc" title="<?=$item['desc'] ?>"><?=$this->escapeHtml($this->truncate($item['desc'], 50)) ?></span><br/>
+          <span class="desc" title="<?=$item['desc'] ?>"><?=$this->escapeHtml($this->truncate($item['desc'], 50)) ?></span><br>
         <?php endif; ?>
         (<span class="from"><?=$this->transEsc('Provider') ?>: <?=$this->escapeHtml($item['provider']) ?></span>)
       </li>

--- a/themes/bootstrap3/templates/Recommend/EuropeanaResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/EuropeanaResults.phtml
@@ -2,7 +2,7 @@
   <div class="sidegroup rssResults">
     <div class="suggestionHeader">
     <a href="http://www.europeana.eu/portal/" title="Europeana.eu" target="_blank">
-      <img src="<?=$this->imageLink(strtolower($data['feedTitle']) . '.png')?>"/>
+      <img src="<?=$this->imageLink(strtolower($data['feedTitle']) . '.png')?>">
     </a>
     </div>
     <div>
@@ -11,7 +11,7 @@
           <li class="list-group-item suggestedResult <?php (++$i % 2) ? 'alt ' : ''?>record<?=$i?>">
             <div class="resultitem clearfix">
               <?php if (isset($work['enclosure'])): ?>
-                <span class="europeanaImg"><img src="<?=$this->escapeHtmlAttr($work['enclosure'])?>" id="europeanaImage<?=$this->escapeHtmlAttr($workKey)?>"/></span>
+                <span class="europeanaImg"><img src="<?=$this->escapeHtmlAttr($work['enclosure'])?>" id="europeanaImage<?=$this->escapeHtmlAttr($workKey)?>"></span>
               <?php endif; ?>
               <a href="<?=$this->escapeHtmlAttr($work['link'])?>" target="_blank">
                 <span><?=$this->escapeHtml($this->truncate($work['title'], 90))?></span>

--- a/themes/bootstrap3/templates/Recommend/OpenLibrarySubjects.phtml
+++ b/themes/bootstrap3/templates/Recommend/OpenLibrarySubjects.phtml
@@ -8,9 +8,9 @@
         <a href="http://openlibrary.org<?=$work['key']?>" title="<?=$this->transEscAttr('Get full text')?>" target="_blank">
           <span class="olSubjectCover">
           <?php if (isset($work['cover_id']) && !empty($work['cover_id'])): ?>
-            <img src="http://covers.openlibrary.org/b/<?=$this->escapeHtmlAttr($work['cover_id_type'])?>/<?=$this->escapeHtmlAttr($work['cover_id'])?>-S.jpg" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>" />
+            <img src="http://covers.openlibrary.org/b/<?=$this->escapeHtmlAttr($work['cover_id_type'])?>/<?=$this->escapeHtmlAttr($work['cover_id'])?>-S.jpg" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>">
           <?php else: ?>
-            <img src="<?=$this->imageLink('noCover2.gif')?>" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>" />
+            <img src="<?=$this->imageLink('noCover2.gif')?>" class="olSubjectImage" alt="<?=$this->escapeHtmlAttr($work['title'])?>">
           <?php endif; ?>
           </span>
           <span><?=$this->escapeHtmlAttr($this->truncate($work['title'], 50))?></span>

--- a/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
@@ -9,26 +9,26 @@
 <div class="facet">
   <form class="facet-range-form" name="<?=$safeBaseId?>Filter" id="<?=$safeBaseId?>Filter">
     <?=$results->getUrlQuery()->asHiddenFields(['page' => "/./", 'filter' => "/^{$this->title}:.*/"])?>
-    <input type="hidden" name="<?=$this->escapeHtmlAttr($this->facet['type'])?>range[]" value="<?=$this->escapeHtmlAttr($this->title)?>"/>
+    <input type="hidden" name="<?=$this->escapeHtmlAttr($this->facet['type'])?>range[]" value="<?=$this->escapeHtmlAttr($this->title)?>">
     <div class="date-fields">
       <?php $extraInputAttribs = ($this->facet['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
       <div class="date-from">
         <label id="<?=$safeBaseId?>from-label" for="<?=$safeBaseId?>from">
           <?=$this->transEsc('date_from')?>:
         </label>
-        <input type="text" class="form-control" name="<?=$safeBaseId?>from" id="<?=$safeBaseId?>from" value="<?=$this->escapeHtmlAttr($cleanValues[0] ?? '')?>" <?=$extraInputAttribs?>/>
+        <input type="text" class="form-control" name="<?=$safeBaseId?>from" id="<?=$safeBaseId?>from" value="<?=$this->escapeHtmlAttr($cleanValues[0] ?? '')?>" <?=$extraInputAttribs?>>
       </div>
       <div class="date-to">
         <label id="<?=$safeBaseId?>to-label" for="<?=$safeBaseId?>to">
           <?=$this->transEsc('date_to')?>:
         </label>
-        <input type="text" class="form-control" name="<?=$safeBaseId?>to" id="<?=$safeBaseId?>to" value="<?=$this->escapeHtmlAttr($cleanValues[1] ?? '')?>" <?=$extraInputAttribs?>/>
+        <input type="text" class="form-control" name="<?=$safeBaseId?>to" id="<?=$safeBaseId?>to" value="<?=$this->escapeHtmlAttr($cleanValues[1] ?? '')?>" <?=$extraInputAttribs?>>
       </div>
     </div>
     <?php if ($this->facet['type'] == 'date'): ?>
-      <div class="slider-container"><input type="text" class="hidden" id="<?=$safeBaseId?><?=$this->escapeHtml($this->facet['type'])?>Slider" aria-label="<?=$this->transEsc('slider_label', ['%%title%%' => $this->translate($this->cluster['label'])])?>"/></div>
+      <div class="slider-container"><input type="text" class="hidden" id="<?=$safeBaseId?><?=$this->escapeHtml($this->facet['type'])?>Slider" aria-label="<?=$this->transEsc('slider_label', ['%%title%%' => $this->translate($this->cluster['label'])])?>"></div>
     <?php endif; ?>
-    <input class="btn btn-default" type="submit" value="<?=$this->transEscAttr('Set')?>"/>
+    <input class="btn btn-default" type="submit" value="<?=$this->transEscAttr('Set')?>">
   </form>
 </div>
 <?php if ($this->facet['type'] == 'date'): ?>

--- a/themes/bootstrap3/templates/Recommend/SummonBestBets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonBestBets.phtml
@@ -7,7 +7,7 @@
       <?php else: ?>
         <b><?=$this->escapeHtml($current['title'])?></b>
       <?php endif; ?>
-      <br/><?=$current['description']?>
+      <br><?=$current['description']?>
     </p>
   <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/Recommend/SummonDatabases.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonDatabases.phtml
@@ -2,7 +2,7 @@
 <div class="authorbox">
   <p><?=$this->transEsc('summon_database_recommendations')?></p>
   <?php foreach ($summonDatabases as $current): ?>
-    <p><a href="<?=$this->escapeHtmlAttr($current['link'])?>"><?=$this->escapeHtml($current['title'])?></a><br/><?=$this->escapeHtml($current['description'])?></p>
+    <p><a href="<?=$this->escapeHtmlAttr($current['link'])?>"><?=$this->escapeHtml($current['title'])?></a><br><?=$this->escapeHtml($current['description'])?></p>
   <?php endforeach; ?>
 </div>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SummonTopics.phtml
+++ b/themes/bootstrap3/templates/Recommend/SummonTopics.phtml
@@ -3,7 +3,7 @@
   <p><b><?=$this->transEsc('Suggested Topics')?></b></p>
   <?php if (isset($summonTopics['title'])): ?>
     <p>
-      <a href="<?=$this->url('summon-search')?>?lookfor=%22<?=urlencode($summonTopics['title'])?>%22"><?=$this->escapeHtml($summonTopics['title'])?></a><br />
+      <a href="<?=$this->url('summon-search')?>?lookfor=%22<?=urlencode($summonTopics['title'])?>%22"><?=$this->escapeHtml($summonTopics['title'])?></a><br>
       <?php if (isset($summonTopics['snippet'])): ?><?=$this->escapeHtml($summonTopics['snippet'])?><?php endif; ?>
       <?php if (isset($summonTopics['sourceLink'])): ?><a href="<?=$this->escapeHtmlAttr($summonTopics['sourceLink'])?>"><?=$this->transEsc('more_ellipsis')?></a><?php endif; ?>
     </p>

--- a/themes/bootstrap3/templates/Recommend/WebResults.phtml
+++ b/themes/bootstrap3/templates/Recommend/WebResults.phtml
@@ -11,9 +11,9 @@
       <?php $snippet = $driver->getHighlightedSnippet(); ?>
       <?php $summary = $driver->getSummary(); ?>
       <?php if (!empty($snippet)): ?>
-        <br /><?=$this->highlight($snippet['snippet'])?>
+        <br><?=$this->highlight($snippet['snippet'])?>
       <?php elseif (!empty($summary)): ?>
-        <br /><?=$this->escapeHtml($summary[0])?>
+        <br><?=$this->escapeHtml($summary[0])?>
       <?php endif; ?>
     </li>
     <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewlink.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewlink.phtml
@@ -38,7 +38,7 @@
                     $title = $this->transEsc('Preview from') . ' ' . $name;
                     $html .= '<div class="' . $divClass . '">'
                         . '<a title="' . $title . '" class="hidden ' . $linkClass . ' ' . $idClasses . '" target="_blank">'
-                        . '<img src="' . $icon . '" alt="' . $this->transEsc('Preview') . '" />'
+                        . '<img src="' . $icon . '" alt="' . $this->transEsc('Preview') . '">'
                         . '</a>'
                         . '</div>';
                 }

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
@@ -16,7 +16,7 @@
       <?php /* Display qrcode if appropriate: */ ?>
       <?php if ($QRCode): ?>
         <span class="hidden-xs">
-          <br/><img alt="<?=$this->transEscAttr('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+          <br><img alt="<?=$this->transEscAttr('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>">
         </span>
       <?php endif; ?>
 

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/core.phtml
@@ -20,7 +20,7 @@
       <?php /* Display qrcode if appropriate: */ ?>
       <?php if ($QRCode): ?>
         <span class="hidden-xs">
-          <br/><img alt="<?=$this->transEscAttr('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>"/>
+          <br><img alt="<?=$this->transEscAttr('QR Code')?>" class="qrcode" src="<?=$this->escapeHtmlAttr($QRCode);?>">
         </span>
       <?php endif; ?>
 

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/cover.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/cover.phtml
@@ -2,14 +2,14 @@
 <?php if ($this->link && !empty($alt)): ?><a href="<?=$this->escapeHtmlAttr($this->link)?>" class="record-cover-link"><?php endif; ?>
 <?php /* Display thumbnail if appropriate: */ ?>
 <?php if ($cover): ?>
-  <img src="<?=$this->escapeHtmlAttr($cover); ?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="<?=$this->escapeHtmlAttr($alt); ?>" />
+  <img src="<?=$this->escapeHtmlAttr($cover); ?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="<?=$this->escapeHtmlAttr($alt); ?>">
 <?php elseif ($cover === false): ?>
-  <img src="<?=$this->url('cover-unavailable')?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="" />
+  <img src="<?=$this->url('cover-unavailable')?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="">
 <?php else: ?>
   <div class="ajaxcover">
     <div class="spinner"><?=$this->icon('spinner') ?> <?=$this->translate('loading_ellipsis')?></div>
     <div class="cover-container">
-      <img <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>data-context="<?=$this->escapeHtmlAttr($this->context)?>" data-recordsource="<?=$this->escapeHtmlAttr($driver->getSourceIdentifier())?>" data-recordid="<?=$this->escapeHtmlAttr($driver->getUniqueID())?>" data-coversize="<?=$this->escapeHtmlAttr($size)?>" class="recordcover ajax" alt="<?=$this->escapeHtmlAttr($alt); ?>" />
+      <img <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>data-context="<?=$this->escapeHtmlAttr($this->context)?>" data-recordsource="<?=$this->escapeHtmlAttr($driver->getSourceIdentifier())?>" data-recordid="<?=$this->escapeHtmlAttr($driver->getUniqueID())?>" data-coversize="<?=$this->escapeHtmlAttr($size)?>" class="recordcover ajax" alt="<?=$this->escapeHtmlAttr($alt); ?>">
     </div>
   </div>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-allRecordLinks.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-allRecordLinks.phtml
@@ -1,11 +1,11 @@
 <?php foreach ($data as $recordLink): ?>
   <?=$this->transEsc($recordLink['title'])?>:
-  <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->related($recordLink['link'], $this->driver->getSourceIdentifier()))?>"><?=$this->escapeHtml($recordLink['value'])?></a><br />
+  <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->related($recordLink['link'], $this->driver->getSourceIdentifier()))?>"><?=$this->escapeHtml($recordLink['value'])?></a><br>
 <?php endforeach; ?>
 <?php /* if we have record links, display relevant explanatory notes */
   $related = $this->driver->getRelationshipNotes();
   if (!empty($related)): ?>
     <?php foreach ($related as $field): ?>
-      <?=$this->escapeHtml($field)?><br/>
+      <?=$this->escapeHtml($field)?><br>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-authorNotes.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-authorNotes.phtml
@@ -2,7 +2,7 @@
 <?php $authorNotes = empty($isbn) ? [] : $this->authorNotes($isbn); if (!empty($authorNotes)): ?>
   <?php foreach ($authorNotes as $provider => $list): ?>
     <?php foreach ($list as $field): ?>
-      <?=$field['Content']?><br />
+      <?=$field['Content']?><br>
     <?php endforeach; ?>
   <?php endforeach; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-onlineAccess.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-onlineAccess.phtml
@@ -7,9 +7,9 @@
   $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
 ?>
 <?php foreach ($urls as $current): ?>
-  <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br/>
+  <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br>
 <?php endforeach; ?>
 <?php if ($openUrlActive): ?>
-  <?=$openUrl->renderTemplate()?><br/>
+  <?=$openUrl->renderTemplate()?><br>
 <?php endif; ?>
 <?php if ($doiActive): ?><?=$doi->renderTemplate()?><?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-publicationDetails.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-publicationDetails.phtml
@@ -12,5 +12,5 @@
   <?php $pubDate = $field->getDate(); if (!empty($pubDate)): ?>
     <span property="datePublished"><?=$this->escapeHtml($pubDate)?></span>
   <?php endif; ?>
-  <br/>
+  <br>
 <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-series.phtml
@@ -8,9 +8,9 @@
       <?php if (!empty($field['number'])): ?>
         <?=$this->escapeHtml($field['number'])?>
       <?php endif; ?>
-      <br/>
+      <br>
     <?php endif; ?>
   <?php else: ?>
-    <a href="<?=$this->record($this->driver)->getLink('series', $field)?>"><?=$this->escapeHtml($field)?></a><br/>
+    <a href="<?=$this->record($this->driver)->getLink('series', $field)?>"><?=$this->escapeHtml($field)?></a><br>
   <?php endif; ?>
 <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-summary.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-summary.phtml
@@ -1,10 +1,10 @@
 <?php foreach ($this->driver->getSummary() as $summary): ?>
-  <?=$this->escapeHtml($summary) ?><br />
+  <?=$this->escapeHtml($summary) ?><br>
 <?php endforeach; ?>
 <?php $isbn = $this->driver->getCleanISBN(); ?>
 <?php foreach ($this->summaries($isbn) as $provider => $content): ?>
   <?php foreach ($content as $summary): ?>
     <?php $htmlContent = substr($summary, 0, 1) == '<' && substr($summary, -1) == '>'; ?>
-    <?=$htmlContent ? $summary : ($this->escapeHtml($summary) . '<br />')?>
+    <?=$htmlContent ? $summary : ($this->escapeHtml($summary) . '<br>')?>
   <?php endforeach; ?>
 <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -24,8 +24,8 @@
     <?php $thumbnail = ob_get_contents(); ?>
     <?php ob_end_clean(); ?>
   <?php endif; ?>
-  <input type="hidden" value="<?=$this->escapeHtmlAttr($id) ?>" class="hiddenId"/>
-  <input type="hidden" value="<?=$this->escapeHtmlAttr($source) ?>" class="hiddenSource"/>
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($id) ?>" class="hiddenId">
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($source) ?>" class="hiddenSource">
   <?=$this->record($this->driver)->getCheckbox()?>
   <div class="media">
     <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
@@ -58,11 +58,11 @@
 
             <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
             <?php if (!empty($journalTitle)): ?>
-              <?=!empty($summAuthor) ? '<br/>' : ''?>
+              <?=!empty($summAuthor) ? '<br>' : ''?>
               <?=/* TODO: handle highlighting more elegantly here */ $this->transEsc('Published in') . ' <a href="' . $this->record($this->driver)->getLink('journaltitle', str_replace(['{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'], '', $journalTitle)) . '">' . $this->highlight($journalTitle) . '</a>';?>
               <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
             <?php elseif (!empty($summDate)): ?>
-              <?=!empty($summAuthor) ? '<br/>' : ''?>
+              <?=!empty($summAuthor) ? '<br>' : ''?>
               <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
             <?php endif; ?>
             <?php $summInCollection = $this->driver->getContainingCollections(); if (false && !empty($summInCollection)): ?>
@@ -88,7 +88,7 @@
                   echo $this->translate(
                       'highlight_snippet_html',
                       ['%%snippet%%' => $this->highlight($snippet['snippet'])]
-                  ) . '<br/>';
+                  ) . '<br>';
                 }
               }
             } ?>
@@ -105,14 +105,14 @@
             <?php foreach ($listTags as $tag): ?>
               <a href="<?=$this->currentPath() . $results->getUrlQuery()->addFacet('tags', $tag->tag)?>"><?=$this->escapeHtml($tag->tag)?></a>
             <?php endforeach; ?>
-            <br/>
+            <br>
           <?php endif; ?>
           <?php $listNotes = $this->driver->getListNotes($list_id, $user_id); ?>
           <?php if (count($listNotes) > 0): ?>
             <strong><?=$this->transEsc('Notes')?>:</strong>
-            <?php if (count($listNotes) > 1): ?><br/><?php endif; ?>
+            <?php if (count($listNotes) > 1): ?><br><?php endif; ?>
             <?php foreach ($listNotes as $note): ?>
-              <?=$this->escapeHtml($note)?><br/>
+              <?=$this->escapeHtml($note)?><br>
             <?php endforeach; ?>
           <?php endif; ?>
 
@@ -121,14 +121,14 @@
               <?php $i = 0;foreach ($this->lists as $current): ?>
                   <a href="<?=$this->url('userList', ['id' => $current->id])?>"><?=$this->escapeHtml($current->title)?></a><?php if ($i++ < count($this->lists) - 1): ?>,<?php endif; ?>
               <?php endforeach; ?>
-              <br/>
+              <br>
           <?php endif; ?>
 
           <div class="callnumAndLocation ajax-availability hidden">
             <?php if ($this->driver->supportsAjaxStatus()): ?>
               <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
               <span class="callnumber ajax-availability hidden">
-                <?=$this->transEsc('loading_ellipsis')?><br/>
+                <?=$this->transEsc('loading_ellipsis')?><br>
               </span>
               <strong><?=$this->transEsc('Located')?>:</strong>
               <span class="location ajax-availability hidden">
@@ -156,12 +156,12 @@
             if ($openUrlActive || $doiActive || !empty($urls)):
           ?>
             <?php if ($openUrlActive): ?>
-              <br/>
+              <br>
               <?=$openUrl->renderTemplate()?>
             <?php endif;?>
 
             <?php if ($doiActive): ?>
-              <br/>
+              <br>
               <?=$doi->renderTemplate()?>
             <?php endif; ?>
 
@@ -175,13 +175,13 @@
                 <?php endforeach; ?>
               <?php endif; ?>
             <?php endif; ?>
-          <br/>
+          <br>
 
           <?=$this->record($this->driver)->getFormatList() ?>
 
           <?php if (!$openUrlActive && empty($urls) && $this->driver->supportsAjaxStatus()): ?>
             <span class="status ajax-availability hidden"><?=$this->transEsc('loading_ellipsis')?></span>
-            <br/><br/>
+            <br><br>
           <?php endif; ?>
           <?=$this->record($this->driver)->getPreviews()?>
         </div>
@@ -191,7 +191,7 @@
         <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool icon-link">
           <?=$this->icon('user-list-entry-edit', 'icon-link__icon') ?>
           <span class="icon-link__label"><?=$this->transEsc('Edit')?></span>
-        </a><br/>
+        </a><br>
         <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
           $deleteUrl = null === $list_id
               ? $this->url('myresearch-favorites')

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-grid.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-grid.phtml
@@ -13,7 +13,7 @@ $recordLinker = $this->recordLinker($this->results);
 ?>
 
 <div class="grid-result<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
-  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
   <?php if (isset($this->showCheckboxes) && $this->showCheckboxes): ?>
     <label class="grid-checkbox">
       <?=$this->record($this->driver)->getCheckbox('', 'search-cart-form') ?>
@@ -33,18 +33,18 @@ $recordLinker = $this->recordLinker($this->results);
         <?=$this->record($this->driver)->getTitleHtml(80)?>
       </a>
       <?php if ($openUrlActive || $doiActive || !empty($urls)): ?>
-        <br/><br/>
+        <br><br>
         <?php if ($openUrlActive): ?>
-          <?=$openUrl->renderTemplate()?><br />
+          <?=$openUrl->renderTemplate()?><br>
         <?php endif; ?>
         <?php if ($doiActive): ?>
-          <?=$doi->renderTemplate()?><br />
+          <?=$doi->renderTemplate()?><br>
         <?php endif; ?>
         <?php if (!is_array($urls)) $urls = []; foreach ($urls as $current): ?>
           <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new">
             <?=$this->icon('external-link') ?>
             <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></a>
-          <br/>
+          <br>
         <?php endforeach; ?>
       <?php endif; ?>
     </div>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list.phtml
@@ -12,8 +12,8 @@
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif; ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
 <div class="media">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
@@ -44,7 +44,7 @@
 
           <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
           <?php if (!empty($journalTitle)): ?>
-            <?=!empty($summAuthor) ? '<br />' : ''?>
+            <?=!empty($summAuthor) ? '<br>' : ''?>
             <?=$this->transEsc('Published in')?>
             <?php $containerSource = $this->driver->getSourceIdentifier(); ?>
             <?php $containerID = $this->driver->getContainerRecordID(); ?>
@@ -52,7 +52,7 @@
             <a href="<?=($containerID ? $this->escapeHtmlAttr($recordLinker->getUrl("$containerSource|$containerID")) : $this->record($this->driver)->getLink('journaltitle', str_replace(['{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'], '', $journalTitle)))?>"><?=$this->highlight($journalTitle) ?></a>
             <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
           <?php elseif (!empty($summDate)): ?>
-            <?=!empty($summAuthor) ? '<br />' : ''?>
+            <?=!empty($summAuthor) ? '<br>' : ''?>
             <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
           <?php endif; ?>
           <?php $summInCollection = $this->driver->getContainingCollections(); if (!empty($summInCollection)): ?>
@@ -74,7 +74,7 @@
             <strong><?=$this->transEsc($snippet['caption']) ?>:</strong>
           <?php endif; ?>
           <?php if (!empty($snippet['snippet'])): ?>
-            <?=$this->translate('highlight_snippet_html', ['%%snippet%%' => $this->highlight($snippet['snippet'])]) ?><br/>
+            <?=$this->translate('highlight_snippet_html', ['%%snippet%%' => $this->highlight($snippet['snippet'])]) ?><br>
           <?php endif; ?>
         <?php endif; ?>
       <?php endif; ?>
@@ -111,7 +111,7 @@
         <?php if ($this->driver->supportsAjaxStatus()): ?>
           <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
           <span class="callnumber ajax-availability hidden">
-            <?=$this->transEsc('loading_ellipsis')?><br/>
+            <?=$this->transEsc('loading_ellipsis')?><br>
           </span>
           <strong><?=$this->transEsc('Located')?>:</strong>
           <span class="location ajax-availability hidden">
@@ -136,11 +136,11 @@
 
         if ($openUrlActive || $doiActive || !empty($urls)): ?>
         <?php if ($openUrlActive): ?>
-          <br/>
+          <br>
           <?=$openUrl->renderTemplate()?>
         <?php endif; ?>
         <?php if ($doiActive): ?>
-          <br/>
+          <br>
           <?=$doi->renderTemplate()?>
         <?php endif; ?>
         <?php if (!is_array($urls)) $urls = [];
@@ -149,7 +149,7 @@
               <a class="fulltext icon-link" href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" target="new">
                 <?=$this->icon('external-link', 'icon-link__icon') ?>
                 <span class="icon-link__label"><?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?></span>
-              </a><br/>
+              </a><br>
           <?php endforeach; ?>
         <?php endif; ?>
       <?php endif; ?>
@@ -173,7 +173,7 @@
       <?=$this->record($this->driver)->renderTemplate('controls/qrcode.phtml', ['driver' => $this->driver, 'context' => 'results'])?>
 
       <?php if ($this->cart()->isActiveInSearch() && isset($this->params) && $this->params->getOptions()->supportsCart() && $this->cart()->isActive()): ?>
-        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br/>
+        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br>
       <?php endif; ?>
 
       <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
@@ -182,7 +182,7 @@
           <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" data-lightbox class="save-record result-link icon-link" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
             <?=$this->icon('user-favorites', 'icon-link__icon') ?>
             <span class="result-link-label icon-link__label"><?=$this->transEsc('Add to favorites')?></span>
-          </a><br/>
+          </a><br>
         <?php elseif ($block = $this->permission()->getAlternateContent('feature.Favorites')): ?>
           <?=$block?>
         <?php endif; ?>
@@ -196,7 +196,7 @@
       <?php $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
         <?php foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
           <div class="hierarchyTreeLink">
-            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId" />
+            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId">
             <a class="hierarchyTreeLinkText result-link-label icon-link" data-lightbox href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'HierarchyTree', ['hierarchy' => $hierarchyID]))?>#tabnav" title="<?=$this->transEscAttr('hierarchy_tree')?>" data-lightbox-href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'AjaxTab', ['hierarchy' => $hierarchyID]))?>" data-lightbox-post="tab=hierarchytree">
               <?=$this->icon('tree-context', 'icon-link__icon') ?>
               <span class="icon-link__label"><?=$this->transEsc('hierarchy_view_context')?><?php if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><?php endif; ?></span>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -21,7 +21,7 @@
           <a href="<?=$this->escapeHtmlAttr($pLink)?>">
             <?=$this->transEsc('View in EDS')?>
           </a>
-        </span><br />
+        </span><br>
       <?php endif; ?>
       <?php $ftLink = $this->driver->getLinkedFullTextLink();
           if ($ftLink): ?>
@@ -29,7 +29,7 @@
           <a href="<?=$ftLink?>" class="fulltext">
             <?=$this->transEsc('Linked Full Text')?>
           </a>
-        </span><br />
+        </span><br>
       <?php endif; ?>
       <?php $pdfLink = $this->driver->getPdfLink();
           if ($pdfLink): ?>
@@ -37,7 +37,7 @@
           <a href="<?=$pdfLink?>" class="icon--eds pdf fulltext">
             <?=$this->transEsc('PDF Full Text')?>
           </a>
-        </span><br />
+        </span><br>
       <?php endif; ?>
       <?php $epubLink = $this->driver->getEpubLink();
           if ($epubLink): ?>
@@ -45,14 +45,14 @@
           <a href="<?=$epubLink?>" class="icon--eds epub fulltext">
             <?=$this->transEsc('ePub Full Text')?>
           </a>
-        </span><br />
+        </span><br>
       <?php endif; ?>
       <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
         <span>
           <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver))?>#html" class="icon--eds html fulltext">
             <?=$this->transEsc('HTML Full Text')?>
           </a>
-        </span><br />
+        </span><br>
       <?php endif; ?>
     </div>
   </div>
@@ -111,7 +111,7 @@
         ?>
         <div>
           <a href="<?=$this->escapeHtmlAttr($url)?>" target="_blank" title="<?=$this->escapeHtmlAttr($mot)?>" class="custom-link">
-            <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <?php endif; ?><?=$this->escapeHtml($name)?>
+            <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>"> <?php endif; ?><?=$this->escapeHtml($name)?>
           </a>
         </div>
       <?php endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/cover.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/cover.phtml
@@ -5,7 +5,7 @@
 <?php if ($this->link && !empty($alt)): ?><a href="<?=$this->escapeHtmlAttr($this->link)?>" class="record-cover-link"><?php endif; ?>
 <?php /* Display thumbnail if appropriate: */ ?>
 <?php if ($cover): ?>
-  <img src="<?=$this->escapeHtmlAttr($cover); ?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="<?=$this->escapeHtmlAttr($alt); ?>" />
+  <img src="<?=$this->escapeHtmlAttr($cover); ?>" <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>class="recordcover" alt="<?=$this->escapeHtmlAttr($alt); ?>">
 <?php elseif ($cover === false): ?>
   <span class="recordcover pt-icon pt-<?=$this->driver->getPubTypeId()?>"></span>
   <div><?=$this->driver->getPubType()?></div>
@@ -13,7 +13,7 @@
   <div class="ajaxcover">
     <div class="spinner"><?=$this->icon('spinner') ?> <?=$this->translate('loading_ellipsis')?></div>
     <div class="cover-container">
-      <img <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>data-context="<?=$this->escapeHtmlAttr($this->context)?>" data-recordsource="<?=$this->escapeHtmlAttr($driver->getSourceIdentifier())?>" data-recordid="<?=$this->escapeHtmlAttr($driver->getUniqueID())?>" data-coversize="<?=$this->escapeHtmlAttr($size)?>" class="recordcover ajax" alt="<?=$this->escapeHtmlAttr($alt); ?>" />
+      <img <?php if ($linkPreview): ?>data-linkpreview="true" <?php endif; ?>data-context="<?=$this->escapeHtmlAttr($this->context)?>" data-recordsource="<?=$this->escapeHtmlAttr($driver->getSourceIdentifier())?>" data-recordid="<?=$this->escapeHtmlAttr($driver->getUniqueID())?>" data-coversize="<?=$this->escapeHtmlAttr($size)?>" class="recordcover ajax" alt="<?=$this->escapeHtmlAttr($alt); ?>">
     </div>
   </div>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -17,8 +17,8 @@
   </div>
 <?php $thumbnail = ob_get_contents(); ?>
 <?php ob_end_clean(); ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
 <div class="media<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
@@ -46,7 +46,7 @@
           <div class="resultItemLine1">
             <p>
               <?=$this->transEsc('This result is not displayed to guests')?>
-              <br />
+              <br>
               <a class="login" href="<?=$this->url('myresearch-userlogin')?>">
                 <strong><?=$this->transEsc('Login for full access')?></strong>
               </a>
@@ -66,7 +66,7 @@
             ?>
             <span>
               <a href="<?=$this->escapeHtmlAttr($url)?>" target="_blank" title="<?=$this->escapeHtmlAttr($mot)?>" class="custom-link">
-                <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>" /> <?php endif; ?><?=$this->escapeHtml($name)?>
+                <?php if ($icon): ?><img src="<?=$this->escapeHtmlAttr($icon)?>"> <?php endif; ?><?=$this->escapeHtml($name)?>
               </a>
             </span>
           <?php endforeach; ?>
@@ -111,12 +111,12 @@
       <?=$this->record($this->driver)->renderTemplate('controls/qrcode.phtml', ['driver' => $this->driver, 'context' => 'results'])?>
 
       <?php if ($this->cart()->isActiveInSearch() && $this->params->getOptions()->supportsCart() && $this->cart()->isActive()): ?>
-        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br/>
+        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br>
       <?php endif; ?>
 
       <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
         <?php /* Add to favorites */ ?>
-        <?=$this->icon('user-list-add') ?> <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" class="save-record" data-lightbox id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEscAttr('Add to favorites')?>"><?=$this->transEsc('Add to favorites')?></a><br/>
+        <?=$this->icon('user-list-add') ?> <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" class="save-record" data-lightbox id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEscAttr('Add to favorites')?>"><?=$this->transEsc('Add to favorites')?></a><br>
 
         <?php /* Saved lists */ ?>
         <div class="savedLists alert alert-info hidden">
@@ -128,7 +128,7 @@
       <?php $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
         <?php foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
           <div class="hierarchyTreeLink">
-            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId" />
+            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId">
             <?=$this->icon('tree-context') ?>
             <a class="hierarchyTreeLinkText" data-lightbox href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'HierarchyTree', ['hierarchy' => $hierarchyID]))?>#tabnav" title="<?=$this->transEscAttr('hierarchy_tree')?>">
               <?=$this->transEsc('hierarchy_view_context')?><?php if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/result-list.phtml
@@ -11,8 +11,8 @@
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif; ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId" />
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
 <div class="media<?=$this->driver->supportsAjaxStatus() ? ' ajaxItem' : ''?>">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
@@ -34,11 +34,11 @@
 
       <?php $journalTitle = $this->driver->getContainerTitle(); $summDate = $this->driver->getPublicationDates(); ?>
       <?php if (!empty($journalTitle)): ?>
-        <?=!empty($summAuthor) ? '<br />' : ''?>
+        <?=!empty($summAuthor) ? '<br>' : ''?>
         <?=/* TODO: handle highlighting more elegantly here */ $this->transEsc('Published in') . ' <a href="' . $this->record($this->driver)->getLink('journaltitle', str_replace(['{{{{START_HILITE}}}}', '{{{{END_HILITE}}}}'], '', $journalTitle)) . '">' . $this->highlight($journalTitle) . '</a>';?>
         <?=!empty($summDate) ? ' (' . $this->escapeHtml($summDate[0]) . ')' : ''?>
       <?php elseif (!empty($summDate)): ?>
-        <?=!empty($summAuthor) ? '<br />' : ''?>
+        <?=!empty($summAuthor) ? '<br>' : ''?>
         <?=$this->transEsc('Published') . ' ' . $this->escapeHtml($summDate[0])?>
       <?php endif; ?>
       <?php $summInCollection = $this->driver->getContainingCollections();
@@ -60,7 +60,7 @@
           <strong class="hideIfDetailed"><?=$this->transEsc('Call Number')?>:</strong>
           <span class="callnumber ajax-availability hidden">
             <?=$this->transEsc('loading_ellipsis')?>
-          </span><br class="hideIfDetailed"/>
+          </span><br class="hideIfDetailed">
           <strong><?=$this->transEsc('Located')?>:</strong>
           <span class="location ajax-availability hidden">
             <?=$this->transEsc('loading_ellipsis')?>
@@ -86,11 +86,11 @@
 
         if ($openUrlActive || $doiActive || !empty($urls)): ?>
         <?php if ($openUrlActive): ?>
-          <br/>
+          <br>
           <?=$openUrl->renderTemplate()?>
         <?php endif; ?>
         <?php if ($doiActive): ?>
-          <br/>
+          <br>
           <?=$doi->renderTemplate()?>
         <?php endif; ?>
         <?php if (!is_array($urls)) $urls = [];
@@ -99,7 +99,7 @@
               <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new">
                 <?=$this->icon('external-link') ?>
                 <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?>
-              </a><br/>
+              </a><br>
           <?php endforeach; ?>
         <?php endif; ?>
       <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrAuthDefault/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrAuthDefault/result-list.phtml
@@ -28,18 +28,18 @@
 
     <div class="resultItemLine2">
       <?php if (!empty($seeAlso)): ?>
-        <?=$this->transEsc("See also")?>:<br/>
+        <?=$this->transEsc("See also")?>:<br>
         <?php foreach ($seeAlso as $current): ?>
-          <a href="<?=$this->url('authority-search')?>?lookfor=%22<?=urlencode($current)?>%22&amp;type=MainHeading"><?=$this->escapeHtml($current)?></a><br/>
+          <a href="<?=$this->url('authority-search')?>?lookfor=%22<?=urlencode($current)?>%22&amp;type=MainHeading"><?=$this->escapeHtml($current)?></a><br>
         <?php endforeach; ?>
       <?php endif; ?>
     </div>
 
     <div class="resultItemLine3">
       <?php if (!empty($useFor)): ?>
-        <?=$this->transEsc("Use for")?>:<br/>
+        <?=$this->transEsc("Use for")?>:<br>
         <?php foreach ($useFor as $current): ?>
-          <?=$this->escapeHtml($current)?><br/>
+          <?=$this->escapeHtml($current)?><br>
         <?php endforeach; ?>
       <?php endif; ?>
       <?=$this->record($this->driver)->getLabelList() ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/result-list.phtml
@@ -12,9 +12,9 @@
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif; ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getOverdriveID())?>" class="hiddenId" />
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
-<input type="hidden" value="overdrive" class="handler-name" />
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getOverdriveID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
+<input type="hidden" value="overdrive" class="handler-name">
 <div class="media" data-handler-name="overdrive">
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
@@ -51,7 +51,7 @@
             <strong><?=$this->transEsc($snippet['caption']) ?>:</strong>
           <?php endif; ?>
           <?php if (!empty($snippet['snippet'])): ?>
-            <?=$this->translate('highlight_snippet_html', ['%%snippet%%' => $this->highlight($snippet['snippet'])]) ?><br/>
+            <?=$this->translate('highlight_snippet_html', ['%%snippet%%' => $this->highlight($snippet['snippet'])]) ?><br>
           <?php endif; ?>
         <?php endif; ?>
       <?php endif; ?>
@@ -87,7 +87,7 @@
       <div class="callnumAndLocation ajax-availability hidden">
         <?php if ($this->driver->supportsAjaxStatus()): ?>
           <div class="callnum ajax-availability hidden status">
-            <?=$this->transEsc('loading_ellipsis')?><br/>
+            <?=$this->transEsc('loading_ellipsis')?><br>
           </div>
         <?php elseif ($avail = $this->driver->getOverdriveAvailability()): ?>
           <div class="availability">
@@ -114,11 +114,11 @@
 
         if ($openUrlActive || $doiActive || !empty($urls)): ?>
         <?php if ($openUrlActive): ?>
-          <br/>
+          <br>
           <?=$openUrl->renderTemplate()?>
         <?php endif; ?>
         <?php if ($doiActive): ?>
-          <br/>
+          <br>
           <?=$doi->renderTemplate()?>
         <?php endif; ?>
         <?php if (!is_array($urls)) $urls = [];
@@ -127,7 +127,7 @@
               <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>" class="fulltext" target="new">
                 <?=$this->icon('external-link') ?>
                 <?=($current['url'] == $current['desc']) ? $this->transEsc('Get full text') : $this->escapeHtml($current['desc'])?>
-              </a><br/>
+              </a><br>
           <?php endforeach; ?>
         <?php endif; ?>
       <?php endif; ?>
@@ -142,7 +142,7 @@
       <?=$this->record($this->driver)->renderTemplate('controls/qrcode.phtml', ['driver' => $this->driver, 'context' => 'results'])?>
 
       <?php if ($this->cart()->isActiveInSearch() && isset($this->params) && $this->params->getOptions()->supportsCart() && $this->cart()->isActive()): ?>
-        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br/>
+        <?=$this->render('record/cart-buttons.phtml', ['id' => $this->driver->getUniqueId(), 'source' => $this->driver->getSourceIdentifier()]); ?><br>
       <?php endif; ?>
 
       <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
@@ -151,7 +151,7 @@
           <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" data-lightbox class="save-record" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
             <?=$this->icon('user-favorites') ?>
             <span class="result-link-label"><?=$this->transEsc('Add to favorites')?></span>
-          </a><br/>
+          </a><br>
         <?php elseif ($block = $this->permission()->getAlternateContent('feature.Favorites')): ?>
           <?=$block?>
         <?php endif; ?>
@@ -165,7 +165,7 @@
       <?php $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>
         <?php foreach ($trees as $hierarchyID => $hierarchyTitle): ?>
           <div class="hierarchyTreeLink">
-            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId" />
+            <input type="hidden" value="<?=$this->escapeHtmlAttr($hierarchyID)?>" class="hiddenHierarchyId">
             <?=$this->icon('tree-context') ?>
             <a class="hierarchyTreeLinkText result-link-label" data-lightbox href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'HierarchyTree', ['hierarchy' => $hierarchyID]))?>#tabnav" title="<?=$this->transEscAttr('hierarchy_tree')?>" data-lightbox-href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'AjaxTab', ['hierarchy' => $hierarchyID]))?>" data-lightbox-post="tab=hierarchytree">
               <?=$this->transEsc('hierarchy_view_context')?><?php if (count($trees) > 1): ?>: <?=$this->escapeHtml($hierarchyTitle)?><?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/SolrWeb/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrWeb/result-list.phtml
@@ -22,7 +22,7 @@
     <div class="resultItemLine3">
       <?=$this->escapeHtml($url)?>
       <?php $lastMod = $this->driver->getLastModified(); if (!empty($lastMod)): ?>
-        <br /><?=$this->transEsc('Last Modified')?>: <?=$this->escapeHtml(trim(str_replace(['T', 'Z'], ' ', $lastMod)))?>
+        <br><?=$this->transEsc('Last Modified')?>: <?=$this->escapeHtml(trim(str_replace(['T', 'Z'], ' ', $lastMod)))?>
       <?php endif; ?>
     </div>
   </div>

--- a/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
+++ b/themes/bootstrap3/templates/RecordTab/collectionlist.phtml
@@ -24,11 +24,11 @@
           <input id="keywordFilter_lookfor" type="text" name="lookfor" placeholder="<?=$this->transEscAttr('Search within collection')?>" value="<?=$this->escapeHtmlAttr($params->getDisplayQuery())?>" class="form-control">
           <?php foreach ($filterList as $field => $filters): ?>
             <?php foreach ($filters as $filter): ?>
-              <input type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($filter['field'])?>:&quot;<?=$this->escapeHtmlAttr($filter['value'])?>&quot;" />
+              <input type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($filter['field'])?>:&quot;<?=$this->escapeHtmlAttr($filter['value'])?>&quot;">
             <?php endforeach; ?>
           <?php endforeach; ?>
-          <input type="hidden" name="limit" value="<?=$this->escapeHtmlAttr($params->getLimit()) ?>" />
-          <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($params->getSort()) ?>" />
+          <input type="hidden" name="limit" value="<?=$this->escapeHtmlAttr($params->getLimit()) ?>">
+          <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($params->getSort()) ?>">
           <span class="input-group-btn">
             <button class="btn btn-primary" type="submit" name="submit">
               <span class="sr-only"><?=$this->transEsc('Search')?></span>

--- a/themes/bootstrap3/templates/RecordTab/excerpt.phtml
+++ b/themes/bootstrap3/templates/RecordTab/excerpt.phtml
@@ -10,7 +10,7 @@
     <?php foreach ($list as $excerpt): ?>
       <p class="summary"><?=$excerpt['Content']?></p>
       <?=$excerpt['Copyright'] ?? ''?>
-      <hr/>
+      <hr>
     <?php endforeach; ?>
   <?php endforeach; ?>
 <?php else: ?>

--- a/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
+++ b/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
@@ -45,7 +45,7 @@
           <option value="AllFields"><?=$this->transEsc('All Fields')?></option>
           <option value="Title"><?=$this->transEsc('Title')?></option>
         </select>
-        <input type="submit" class="btn btn-default" value="<?=$this->transEscAttr('Search') ?>"/>
+        <input type="submit" class="btn btn-default" value="<?=$this->transEscAttr('Search') ?>">
         <?=$this->icon('spinner', ['class' => 'hidden', 'id' => 'treeSearchLoadingImg']) ?>
       </div>
       <div id="treeSearchNoResults" class="alert alert-danger hidden"><?=$this->transEsc('nohit_heading')?></div>
@@ -53,10 +53,10 @@
     <?php endif; ?>
     <div id="hierarchyLoading" class="hide"><?=$this->icon('spinner') ?> <?=$this->transEsc('loading_ellipsis')?></div>
     <div id="hierarchyTree" class="hierarchy-tree">
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenRecordId" />
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($activeTree)?>" class="hiddenHierarchyId" />
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenHierarchySource" />
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->treeContext ?? 'Record')?>" class="hiddenContext" />
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenRecordId">
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($activeTree)?>" class="hiddenHierarchyId">
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenHierarchySource">
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->treeContext ?? 'Record')?>" class="hiddenContext">
       <?php if ($this->layout()->getTemplate() != 'layout/lightbox'): ?>
         <noscript>
           <?php if ($this->config()->nonJavascriptSupportEnabled()): ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -58,7 +58,7 @@
   <h3><?=$this->transEsc("Internet")?></h3>
   <?php if (!empty($urls)): ?>
     <?php foreach ($urls as $current): ?>
-      <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br/>
+      <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br>
     <?php endforeach; ?>
   <?php endif; ?>
   <?php if ($openUrlActive): ?><?=$openUrl->renderTemplate()?><?php endif; ?>
@@ -100,7 +100,7 @@
         <?php else: ?>
           <?=$this->escapeHtml($callNo['display'])?>
         <?php endif; ?>
-        <br />
+        <br>
       <?php endforeach; ?>
     </td>
   </tr>
@@ -111,7 +111,7 @@
       <th><?=$textFieldName == 'summary' ? $this->transEsc("Volume Holdings") : $this->transEsc(ucfirst($textFieldName))?>:</th>
       <td>
         <?php foreach ($textFields as $current): ?>
-          <?=$this->linkify($this->escapeHtml($current))?><br/>
+          <?=$this->linkify($this->escapeHtml($current))?><br>
         <?php endforeach; ?>
       </td>
     </tr>
@@ -136,7 +136,7 @@
       <th><?=$this->transEsc("Most Recent Received Issues")?>:</th>
       <td>
         <?php foreach ($holding['purchase_history'] as $current): ?>
-          <?=$this->escapeHtml($current['issue'])?><br/>
+          <?=$this->escapeHtml($current['issue'])?><br>
         <?php endforeach; ?>
       </td>
     </tr>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/extended.phtml
@@ -20,8 +20,8 @@
         </span>
         <span class="holding-field availability">
           <?php if ($holding['reserve'] == "Y"): ?>
-            <link property="availability" href="http://schema.org/InStoreOnly" />
-            <?=$this->transEsc("On Reserve - Ask at Circulation Desk")?><br />
+            <link property="availability" href="http://schema.org/InStoreOnly">
+            <?=$this->transEsc("On Reserve - Ask at Circulation Desk")?><br>
           <?php endif; ?>
 
           <?php if ($holding['use_unknown_message'] ?? false): ?>
@@ -29,10 +29,10 @@
           <?php else: ?>
             <?php if ($holding['availability']): ?>
               <?php /* Begin Available Items (Holds) */ ?>
-              <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock" /></span>
+              <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock"></span>
             <?php else: ?>
               <?php /* Begin Unavailable Items (Recalls) */ ?>
-              <span class="text-danger"><?=$this->transEsc($holding['status'])?><link property="availability" href="http://schema.org/OutOfStock" /></span>
+              <span class="text-danger"><?=$this->transEsc($holding['status'])?><link property="availability" href="http://schema.org/OutOfStock"></span>
               <?php if ($holding['returnDate'] ?? false): ?>
                 <span class="small return-date"><?=$this->escapeHtml($holding['returnDate'])?></span>
               <?php endif; ?>
@@ -97,17 +97,17 @@
       <?php endif; ?>
       <?php /* Embed item structured data: library, barcode, call number */ ?>
       <?php if ($holding['location'] ?? false): ?>
-        <meta property="seller" content="<?=$this->escapeHtmlAttr($holding['location'])?>" />
+        <meta property="seller" content="<?=$this->escapeHtmlAttr($holding['location'])?>">
       <?php endif; ?>
       <?php if ($holding['barcode'] ?? false): ?>
-        <meta property="serialNumber" content="<?=$this->escapeHtmlAttr($holding['barcode'])?>" />
+        <meta property="serialNumber" content="<?=$this->escapeHtmlAttr($holding['barcode'])?>">
       <?php endif; ?>
       <?php if ($holding['callnumber'] ?? false): ?>
-        <meta property="sku" content="<?=$this->escapeHtmlAttr($holding['callnumber'])?>" />
+        <meta property="sku" content="<?=$this->escapeHtmlAttr($holding['callnumber'])?>">
       <?php endif; ?>
       <?php /* Declare that the item is to be borrowed, not for sale */ ?>
-      <link property="businessFunction" href="http://purl.org/goodrelations/v1#LeaseOut" />
-      <link property="itemOffered" href="#record" />
+      <link property="businessFunction" href="http://purl.org/goodrelations/v1#LeaseOut">
+      <link property="itemOffered" href="#record">
     </td>
   </tr>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
@@ -12,15 +12,15 @@
     </th>
     <td>
       <?php if ($holding['reserve'] == "Y"): ?>
-        <link property="availability" href="http://schema.org/InStoreOnly" />
-        <?=$this->transEsc("On Reserve - Ask at Circulation Desk")?><br />
+        <link property="availability" href="http://schema.org/InStoreOnly">
+        <?=$this->transEsc("On Reserve - Ask at Circulation Desk")?><br>
       <?php endif; ?>
       <?php if ($holding['use_unknown_message'] ?? false): ?>
         <span class="text-muted"><?=$this->transEsc("status_unknown_message")?></span>
       <?php else: ?>
         <?php if ($holding['availability'] ?? false): ?>
           <?php /* Begin Available Items (Holds) */ ?>
-           <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock" /></span>
+           <span class="text-success"><?=$this->transEsc("Available")?><link property="availability" href="http://schema.org/InStock"></span>
           <?php if ($holding['link'] ?? false): ?>
             <a class="<?=$check ? 'checkRequest ' : ''?>placehold icon-link" <?php if (!empty($holding['linkLightbox'])): ?>data-lightbox <?php endif; ?>href="<?=$this->escapeHtmlAttr($this->recordLinker()->getRequestUrl($holding['link']))?>">
               <?=$this->icon('place-hold', 'icon-link__icon') ?>
@@ -41,7 +41,7 @@
           <?php endif; ?>
         <?php else: ?>
           <?php /* Begin Unavailable Items (Recalls) */ ?>
-          <span class="text-danger"><?=$this->transEsc($holding['status'])?><link property="availability" href="http://schema.org/OutOfStock" /></span>
+          <span class="text-danger"><?=$this->transEsc($holding['status'])?><link property="availability" href="http://schema.org/OutOfStock"></span>
           <?php if ($holding['returnDate'] ?? false): ?>&ndash; <span class="small"><?=$this->escapeHtml($holding['returnDate'])?></span><?php endif; ?>
           <?php if ($holding['duedate'] ?? false): ?>
             &ndash; <span class="small"><?=$this->transEsc("Due")?>: <?=$this->escapeHtml($holding['duedate'])?></span>
@@ -70,17 +70,17 @@
       <?php endif; ?>
       <?php /* Embed item structured data: library, barcode, call number */ ?>
       <?php if ($holding['location'] ?? false): ?>
-        <meta property="seller" content="<?=$this->escapeHtmlAttr($holding['location'])?>" />
+        <meta property="seller" content="<?=$this->escapeHtmlAttr($holding['location'])?>">
       <?php endif; ?>
       <?php if ($holding['barcode'] ?? false): ?>
-        <meta property="serialNumber" content="<?=$this->escapeHtmlAttr($holding['barcode'])?>" />
+        <meta property="serialNumber" content="<?=$this->escapeHtmlAttr($holding['barcode'])?>">
       <?php endif; ?>
       <?php if ($holding['callnumber'] ?? false): ?>
-        <meta property="sku" content="<?=$this->escapeHtmlAttr($holding['callnumber'])?>" />
+        <meta property="sku" content="<?=$this->escapeHtmlAttr($holding['callnumber'])?>">
       <?php endif; ?>
       <?php /* Declare that the item is to be borrowed, not for sale */ ?>
-      <link property="businessFunction" href="http://purl.org/goodrelations/v1#LeaseOut" />
-      <link property="itemOffered" href="#record" />
+      <link property="businessFunction" href="http://purl.org/goodrelations/v1#LeaseOut">
+      <link property="itemOffered" href="#record">
     </td>
   </tr>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordTab/reviews.phtml
+++ b/themes/bootstrap3/templates/RecordTab/reviews.phtml
@@ -11,7 +11,7 @@
       <?php if (!empty($review['Summary'])): ?>
         <p>
           <?php if (isset($review['Rating'])): ?>
-            <img src="<?=$this->imageLink($review['Rating'] . '.gif')?>" alt="<?=$review['Rating']?>/5 Stars"/>
+            <img src="<?=$this->imageLink($review['Rating'] . '.gif')?>" alt="<?=$review['Rating']?>/5 Stars">
           <?php endif; ?>
           <strong><?=$review['Summary']?></strong>
           <?php
@@ -30,7 +30,7 @@
         <?php endif; ?>
       </p>
       <?=$review['Copyright'] ?? ''?>
-      <hr/>
+      <hr>
     <?php endforeach; ?>
   <?php endforeach; ?>
 <?php else: ?>

--- a/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
@@ -29,10 +29,10 @@
                 <?=$this->icon('format-' . $icon, $format ? ['title' => $format] : []) ?>
                 <b><?=$this->escapeHtml($data->getTitle())?></b>
                 <?php $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
-                  <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
+                  <br><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
                 <?php endif; ?>
                 <?php $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
-                  <br/><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
+                  <br><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
                 <?php endif; ?>
               </div>
             </a>

--- a/themes/bootstrap3/templates/RecordTab/usercomments.phtml
+++ b/themes/bootstrap3/templates/RecordTab/usercomments.phtml
@@ -7,8 +7,8 @@
   <?=$this->render('record/comments-list.phtml')?>
 </div>
 <form class="comment-form" name="commentRecord" action="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'AddComment')) ?>" method="post"<?php if ($this->driver->isRatingAllowed()): ?> data-rating-removal="<?=$this->accountCapabilities()->isRatingRemovalAllowed() ? 'true' : 'false'?>"<?php endif; ?>>
-  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>"/>
-  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>"/>
+  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <label class="comment-label"><?=$this->transEsc("Your Comment")?></label>
   <?php $user = $this->auth()->isLoggedIn() ?>
   <?php if ($user): ?>
@@ -24,7 +24,7 @@
         <?=$this->captcha()->html(true, false) ?>
       <?php endif; ?>
       <div class="clearfix"></div>
-      <input class="btn btn-primary" data-loading-text="<?=$this->transEscAttr('Submitting') ?>" type="submit" value="<?=$this->transEscAttr("Add your comment")?>"/>
+      <input class="btn btn-primary" data-loading-text="<?=$this->transEscAttr('Submitting') ?>" type="submit" value="<?=$this->transEscAttr("Add your comment")?>">
     </div>
   <?php else: ?>
     <?php $singleSignOn = $this->auth()->getManager()->getSessionInitiator($this->serverUrl(true)); ?>

--- a/themes/bootstrap3/templates/Related/Bookplate.phtml
+++ b/themes/bootstrap3/templates/Related/Bookplate.phtml
@@ -9,11 +9,11 @@
       <div class="bookplate-img">
         <?php if ($bpFullUrl && $bpThumbUrl):?>
           <a href="<?=$this->escapeHtmlAttr($bpFullUrl)?>">
-            <img src="<?=$this->escapeHtmlAttr($bpThumbUrl)?>" alt="<?=$this->escapeHtmlAttr($bpAltText)?>" />
+            <img src="<?=$this->escapeHtmlAttr($bpThumbUrl)?>" alt="<?=$this->escapeHtmlAttr($bpAltText)?>">
           </a>
         <?php elseif ($bpFullUrl || $bpThumbUrl):?>
           <?php $bpOneUrl = !empty($bpFullUrl) ? $bpFullUrl : $bpThumbUrl ?>
-          <img src="<?=$this->escapeHtmlAttr($bpOneUrl)?>" alt="<?=$this->escapeHtmlAttr($bpAltText)?>" />
+          <img src="<?=$this->escapeHtmlAttr($bpOneUrl)?>" alt="<?=$this->escapeHtmlAttr($bpAltText)?>">
         <?php endif ?>
       </div>
       <?php if ($bookplate['displayTitle']): ?>

--- a/themes/bootstrap3/templates/Related/Similar.phtml
+++ b/themes/bootstrap3/templates/Related/Similar.phtml
@@ -22,10 +22,10 @@
           <?=$this->escapeHtml($data->getTitle())?>
         </a>
         <?php $authors = $data->getPrimaryAuthors(); if (!empty($authors)): ?>
-          <br/><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
+          <br><?=$this->transEsc('by')?>: <?=$this->escapeHtml($authors[0]);?><?php if (count($authors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?>
         <?php endif; ?>
         <?php $pubDates = $data->getPublicationDates(); if (!empty($pubDates)): ?>
-          <br/><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
+          <br><?=$this->transEsc('Published')?>: (<?=$this->escapeHtml($pubDates[0])?>)
         <?php endif; ?>
       </li>
     <?php endforeach; ?>

--- a/themes/bootstrap3/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap3/templates/admin/feedback/home.phtml
@@ -44,7 +44,7 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
 
       </label>
       <label for="feedbacksubmit">
-        <input type="submit" id="feedbacksubmit" value="<?=$this->transEscAttr('Filter')?>" class="btn btn-primary" />
+        <input type="submit" id="feedbacksubmit" value="<?=$this->transEscAttr('Filter')?>" class="btn btn-primary">
       </label>
       <?php if (('ALL' !== ($this->params['form_name'] ?? 'ALL')) || ('ALL' !== ($this->params['site_url'] ?? 'ALL')) || ('ALL' !== ($this->params['status'] ?? 'ALL'))):?>
         <a class = "btn btn-link" href="<?=$this->url('admin/feedback'); ?>"><?=$this->translate('clear_feedback_filter')?></a>
@@ -58,9 +58,9 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
   <?php $deleteButtons = ob_get_clean(); ?>
   <?php if (count($this->feedback) > 0):?>
     <form action="<?=$this->url('admin/feedback', ['action' => 'Delete'])?>" method="post">
-      <input type="hidden" name="form_name" value="<?=$this->escapeHtmlAttr($this->params['form_name'] ?? '') ?>" />
-      <input type="hidden" name="site_url" value="<?=$this->escapeHtmlAttr($this->params['site_url'] ?? '') ?>" />
-      <input type="hidden" name="status" value="<?=$this->escapeHtmlAttr($this->params['status'] ?? '') ?>" />
+      <input type="hidden" name="form_name" value="<?=$this->escapeHtmlAttr($this->params['form_name'] ?? '') ?>">
+      <input type="hidden" name="site_url" value="<?=$this->escapeHtmlAttr($this->params['site_url'] ?? '') ?>">
+      <input type="hidden" name="status" value="<?=$this->escapeHtmlAttr($this->params['status'] ?? '') ?>">
       <?=$deleteButtons?>
       <table class="table table-striped">
         <tr>
@@ -76,8 +76,8 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
           ?>
           <tr>
             <td>
-              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="checkbox_ui"/>
-              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>" />
+              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="checkbox_ui">
+              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>">
               <?=$this->escapeHtml($feedbackItem->form_name)?>
             </td>
             <td><?=$this->escapeHtml($feedbackItem->site_url)?></td>
@@ -155,11 +155,11 @@ $js = <<<JS
             const id = $(this).closest('tr').find('input[name="ids[]"]').val();
             const new_status = $(this).val();
             const form = $('<form action="$url" method="post">' +
-                '<input type="hidden" name="id" value="' + id + '" />' +
-                '<input type="hidden" name="new_status" value="' + new_status + '" />' +
-                '<input type="hidden" name="form_name" value="$formName" />' +
-                '<input type="hidden" name="site_url" value="$siteUrl" />' +
-                '<input type="hidden" name="status" value="$status" />' +
+                '<input type="hidden" name="id" value="' + id + '">' +
+                '<input type="hidden" name="new_status" value="' + new_status + '">' +
+                '<input type="hidden" name="form_name" value="$formName">' +
+                '<input type="hidden" name="site_url" value="$siteUrl">' +
+                '<input type="hidden" name="status" value="$status">' +
                 '</form>');
             $('body').append(form);
             form.submit();

--- a/themes/bootstrap3/templates/admin/maintenance/home.phtml
+++ b/themes/bootstrap3/templates/admin/maintenance/home.phtml
@@ -9,25 +9,25 @@
   <?=$this->flashmessages()?>
   <form class="form-admin-maintenance expired-searches" method="get" action="<?=$this->url('admin/maintenance', ['action' => 'DeleteExpiredSearches'])?>">
     <label for="del_daysOld">Delete unsaved user search histories older than</label>
-    <input id="del_daysOld" type="number" name="daysOld" size="5" value="2" class="form-control"/> days.
-    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger"/>
+    <input id="del_daysOld" type="number" name="daysOld" size="5" value="2" class="form-control"> days.
+    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger">
   </form>
-  <hr />
+  <hr>
   <form class="form-admin-maintenance expired-sessions" method="get" action="<?=$this->url('admin/maintenance', ['action' => 'DeleteExpiredSessions'])?>">
     <label for="delsess_daysOld">Delete user sessions older than</label>
-    <input id="delsess_daysOld" type="number" name="daysOld" size="5" value="2" class="form-control"/> days.
-    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger"/>
+    <input id="delsess_daysOld" type="number" name="daysOld" size="5" value="2" class="form-control"> days.
+    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger">
   </form>
-  <hr />
+  <hr>
   <form class="form-admin-maintenance clear-cache" method="get" action="<?=$this->url('admin/maintenance', ['action' => 'ClearCache'])?>">
     Clear cache(s):
     <?php foreach ($caches as $cache): ?>
       <label>
-        <input type="checkbox" checked="checked" name="cache[]" value="<?=$this->escapeHtmlAttr($cache)?>" />
+        <input type="checkbox" checked="checked" name="cache[]" value="<?=$this->escapeHtmlAttr($cache)?>">
         <?=$this->escapeHtml($cache) ?>
       </label>
     <?php endforeach; ?>
-    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger"/>
+    <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-danger">
   </form>
 </div>
 

--- a/themes/bootstrap3/templates/admin/tags/checkbox.phtml
+++ b/themes/bootstrap3/templates/admin/tags/checkbox.phtml
@@ -1,7 +1,7 @@
 <div class="checkbox">
   <?php $escId = $this->escapeHtmlAttr($this->prefix . 'checkbox_' . $this->tag['id']); ?>
   <label for="<?=$escId?>">
-    <input id="<?=$escId?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->tag['id'])?>" class="checkbox_ui"/>
-    <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->tag['id'])?>" />
+    <input id="<?=$escId?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->tag['id'])?>" class="checkbox_ui">
+    <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->tag['id'])?>">
   </label>
 </div>

--- a/themes/bootstrap3/templates/admin/tags/list.phtml
+++ b/themes/bootstrap3/templates/admin/tags/list.phtml
@@ -58,10 +58,10 @@
 
   <?php if (count($this->results) > 0):?>
     <form action="<?= $this->url('admin/tags', ['action' => 'Delete'])?>" method="post">
-      <input type="hidden" name="user_id" value="<?=$this->escapeHtmlAttr($this->params['user_id'] ?? '') ?>" />
-      <input type="hidden" name="tag_id" value="<?=$this->escapeHtmlAttr($this->params['tag_id'] ?? '') ?>" />
-      <input type="hidden" name="resource_id" value="<?=$this->escapeHtmlAttr($this->params['resource_id'] ?? '') ?>" />
-      <input type="hidden" name="origin" value="list" />
+      <input type="hidden" name="user_id" value="<?=$this->escapeHtmlAttr($this->params['user_id'] ?? '') ?>">
+      <input type="hidden" name="tag_id" value="<?=$this->escapeHtmlAttr($this->params['tag_id'] ?? '') ?>">
+      <input type="hidden" name="resource_id" value="<?=$this->escapeHtmlAttr($this->params['resource_id'] ?? '') ?>">
+      <input type="hidden" name="origin" value="list">
 
       <table class="table table-striped">
         <tr>
@@ -74,8 +74,8 @@
           <tr>
             <td>
               <label for="<?=$this->prefix?>checkbox_<?=$tag['id']?>">
-                <input id="<?=$this->prefix?>checkbox_<?=$tag['id']?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($tag['id'])?>" class="checkbox_ui"/>
-                <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($tag['id'])?>" />
+                <input id="<?=$this->prefix?>checkbox_<?=$tag['id']?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($tag['id'])?>" class="checkbox_ui">
+                <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($tag['id'])?>">
                 <?=$tag->tag?> (<?= $tag->tag_id?>)
               </label>
             </td>

--- a/themes/bootstrap3/templates/admin/tags/manage.phtml
+++ b/themes/bootstrap3/templates/admin/tags/manage.phtml
@@ -19,14 +19,14 @@
         <option value="tag" <?=("tag" == $this->type) ? ' selected=selected' : ''?>><?=$this->transEsc('Tag')?></option>
         <option value="resource" <?=("resource" == $this->type) ? ' selected=selected' : ''?>><?=$this->transEsc('Title')?></option>
       </select>
-      <input type="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-primary"/>
+      <input type="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-primary">
     </div>
   </form>
 
   <?php if (false !== $this->type):?>
     <form class="form-tags-manage" action="<?= $this->url('admin/tags', ['action' => 'Delete'])?>" method="post">
-      <input type="hidden" name="origin" value="manage" />
-      <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($this->type) ?>" />
+      <input type="hidden" name="origin" value="manage">
+      <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($this->type) ?>">
       <?php if ("user" == $type):?>
         <div class="form-group">
           <label for="user_id" class="control-label"><?=$this->transEsc('Username')?></label>
@@ -37,7 +37,7 @@
               </option>
             <?php endforeach;?>
           </select>
-          <input type="submit"  name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary"/>
+          <input type="submit"  name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary">
         </div>
       <?php elseif ("tag" == $type):?>
         <div class="form-group">
@@ -49,7 +49,7 @@
               </option>
             <?php endforeach;?>
           </select>
-          <input type="submit" name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary"/>
+          <input type="submit" name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary">
         </div>
       <?php elseif ("resource" == $type):?>
         <div class="form-group">
@@ -61,7 +61,7 @@
               </option>
             <?php endforeach;?>
           </select>
-          <input type="submit" name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary"/>
+          <input type="submit" name="deleteFilter" value="<?=$this->transEscAttr('delete_tags')?>" class="btn btn-primary">
         </div>
       <?php endif;?>
     </form>

--- a/themes/bootstrap3/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap3/templates/alphabrowse/home.phtml
@@ -54,8 +54,8 @@
       <?php endforeach; ?>
     </select>
     <label for="alphaBrowseForm_from"><?=$this->transEsc('starting from') ?></label>
-    <input type="text" name="from" id="alphaBrowseForm_from" value="<?=$this->escapeHtmlAttr($this->from) ?>" class="form-control"/>
-    <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Browse') ?>"/>
+    <input type="text" name="from" id="alphaBrowseForm_from" value="<?=$this->escapeHtmlAttr($this->from) ?>" class="form-control">
+    <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Browse') ?>">
   </form>
 <?php endif; ?>
 
@@ -137,7 +137,7 @@
                 endforeach;
                 echo empty($extraDisplayArray)
                   ? '&nbsp;'
-                  : implode('<br />', array_map([$this, 'escapeHtml'], $extraDisplayArray));
+                  : implode('<br>', array_map([$this, 'escapeHtml'], $extraDisplayArray));
               ?>
             </td>
           <?php endforeach; ?>

--- a/themes/bootstrap3/templates/author/home.phtml
+++ b/themes/bootstrap3/templates/author/home.phtml
@@ -7,6 +7,6 @@
 ?>
 <form class="form-inline" method="get" action="<?=$this->url('author-search')?>">
   <label for="author_lookfor"><?=$this->transEsc('Author Results for')?>:</label></br>
-  <input class="form-control" type="text" id="author_lookfor" name="lookfor" />
-  <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Find')?>" />
+  <input class="form-control" type="text" id="author_lookfor" name="lookfor">
+  <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Find')?>">
 </form>

--- a/themes/bootstrap3/templates/cart/cart.phtml
+++ b/themes/bootstrap3/templates/cart/cart.phtml
@@ -8,12 +8,12 @@
 <h2><?=$this->transEsc('Book Bag') ?></h2>
 <?=$this->flashmessages()?>
 <form class="form-inline" action="<?=$this->url('cart-processor')?>" method="post"  name="cartForm" data-lightbox-onsubmit="cartFormHandler">
-  <input type="hidden" id="dropdown_value"/>
+  <input type="hidden" id="dropdown_value">
   <?php if (!$this->cart()->isEmpty()): ?>
     <div class="cart-controls clearfix">
       <div class="checkbox pull-left flip">
         <label>
-          <input type="checkbox" name="selectAll" class="checkbox-select-all"/>
+          <input type="checkbox" name="selectAll" class="checkbox-select-all">
           <?=$this->transEsc('select_page')?>
         </label>
       </div>

--- a/themes/bootstrap3/templates/cart/contents.phtml
+++ b/themes/bootstrap3/templates/cart/contents.phtml
@@ -1,5 +1,5 @@
 <?php $records = $this->cart()->getRecordDetails(); if (!empty($records)): ?>
-  <hr/>
+  <hr>
   <ul class="list-unstyled">
   <?php foreach ($records as $i => $record): ?>
     <li>

--- a/themes/bootstrap3/templates/cart/email.phtml
+++ b/themes/bootstrap3/templates/cart/email.phtml
@@ -11,7 +11,7 @@
 <?=$this->flashmessages()?>
 <form class="form-cart-email" action="<?=$this->url('cart-email')?>" method="post"  name="bulkEmail">
   <?php foreach ($this->records as $current): ?>
-    <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
+    <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>">
   <?php endforeach; ?>
   <div class="form-group">
     <label class="control-label"><?=$this->transEsc('Title')?>:</label>

--- a/themes/bootstrap3/templates/cart/export.phtml
+++ b/themes/bootstrap3/templates/cart/export.phtml
@@ -14,7 +14,7 @@
 <?php if (!empty($this->exportOptions)): ?>
   <form class="form-cart-export" method="post" action="<?=$this->url('cart-export')?>" name="exportForm" title="<?=$this->transEscAttr('Export Items')?>">
     <?php foreach ($this->records as $current): ?>
-      <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
+      <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>">
     <?php endforeach; ?>
     <div class="form-group">
       <label class="control-label"><?=$this->transEsc('Title')?>:</label>
@@ -44,7 +44,7 @@
       </select>
     </div>
     <div class="form-group">
-      <input class="export btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Export')?>"<?php if ($this->export()->needsRedirect($firstOption)): ?> data-lightbox-ignore<?php endif; ?>/>
+      <input class="export btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Export')?>"<?php if ($this->export()->needsRedirect($firstOption)): ?> data-lightbox-ignore<?php endif; ?>>
     </div>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/cart/save.phtml
+++ b/themes/bootstrap3/templates/cart/save.phtml
@@ -14,7 +14,7 @@
   <?php $idParams = []; ?>
   <?php foreach ($this->records as $current): ?>
     <?php $idParams[] = urlencode('ids[]') . '=' . urlencode($current->getSourceIdentifier() . '|' . $current->getUniqueId()) ?>
-    <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>" />
+    <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($current->getSourceIdentifier() . '|' . $current->getUniqueId())?>">
   <?php endforeach; ?>
   <div class="form-group">
     <label class="control-label"><?=$this->transEsc('Title')?>:</label>
@@ -53,12 +53,12 @@
   <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
     <div class="form-group">
       <label class="control-label" for="add_mytags"><?=$this->transEsc('Add Tags') ?></label>
-      <input id="add_mytags" type="text" name="mytags" value="" class="form-control"/>
+      <input id="add_mytags" type="text" name="mytags" value="" class="form-control">
       <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
     </div>
   <?php endif; ?>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>"/>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/channels/channelList.phtml
+++ b/themes/bootstrap3/templates/channels/channelList.phtml
@@ -26,8 +26,8 @@
 <?php if (empty($token)): ?>
   <form action="<?=$this->url('channels-search')?>" class="channel-search form-inline">
     <?=$this->transEsc('channel_searchbox_label')?>
-    <input type="text" name="lookfor" class="form-control" value="<?=$this->escapeHtmlAttr($this->lookfor) ?>"/>
-    <input type="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-default" />
+    <input type="text" name="lookfor" class="form-control" value="<?=$this->escapeHtmlAttr($this->lookfor) ?>">
+    <input type="submit" value="<?=$this->transEscAttr('Submit')?>" class="btn btn-default">
   </form>
 <?php endif; ?>
 

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -45,8 +45,8 @@
 
 <div class="record source<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <div<?php if (!$tree): /* in tree mode, do not constrain width with a class */ ?> class="<?=$this->layoutClass('mainbody') ?> solo"<?php endif; ?>>
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id" />
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id">
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
     <?=$this->flashmessages()?>
     <?=$this->record($this->driver)->getCollectionMetadata()?>
 

--- a/themes/bootstrap3/templates/collections/home.phtml
+++ b/themes/bootstrap3/templates/collections/home.phtml
@@ -46,8 +46,8 @@
           </a>
         </li>
       <?php endif; ?>
-      <input type="submit" class="btn btn-default" value="<?=$this->transEscAttr('Jump to')?>" />
-      <input type="text" name="from" value="<?=$this->escapeHtmlAttr($from)?>" class="form-control" />
+      <input type="submit" class="btn btn-default" value="<?=$this->transEscAttr('Jump to')?>">
+      <input type="text" name="from" value="<?=$this->escapeHtmlAttr($from)?>" class="form-control">
     </ul>
   </form>
 <?php $pageLinks = ob_get_contents(); ?>
@@ -90,5 +90,5 @@
 <?=$pageLinks ?>
 <div class="clearfix">
   <?=$this->render('collections/list.phtml')?>
-</div><br/>
+</div><br>
 <?=$pageLinks ?>

--- a/themes/bootstrap3/templates/confirm/confirm.phtml
+++ b/themes/bootstrap3/templates/confirm/confirm.phtml
@@ -10,17 +10,17 @@
         <?php foreach ($this->extras as $extra => $value): ?>
           <?php if (is_array($value)): ?>
             <?php foreach ($value as $current): ?>
-              <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>[]" value="<?=$this->escapeHtmlAttr($current) ?>" />
+              <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>[]" value="<?=$this->escapeHtmlAttr($current) ?>">
             <?php endforeach; ?>
           <?php else: ?>
-            <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>" value="<?=$this->escapeHtmlAttr($value) ?>" />
+            <input type="hidden" name="<?=$this->escapeHtmlAttr($extra) ?>" value="<?=$this->escapeHtmlAttr($value) ?>">
           <?php endif; ?>
         <?php endforeach; ?>
       <?php endif;?>
-      <input class="btn btn-primary" type="submit" name="confirm" value="<?=$this->transEscAttr('confirm_dialog_yes') ?>" />
+      <input class="btn btn-primary" type="submit" name="confirm" value="<?=$this->transEscAttr('confirm_dialog_yes') ?>">
     </form>
     <form class="pull-left" action="<?=$this->escapeHtmlAttr($this->cancel) ?>" method="post">
-      <input class="btn btn-default" data-lightbox-close type="submit" name="cancel" value="<?=$this->transEscAttr('confirm_dialog_no') ?>" />
+      <input class="btn btn-default" data-lightbox-close type="submit" name="cancel" value="<?=$this->transEscAttr('confirm_dialog_no') ?>">
     </form>
     <div class="clearfix"></div>
   </div>

--- a/themes/bootstrap3/templates/content/faq.phtml
+++ b/themes/bootstrap3/templates/content/faq.phtml
@@ -4,11 +4,11 @@
 
 <?php if ($this->auth()->getManager()->supportsRecovery()): ?>
   <p>
-    Q: How do I reset my password?<br/>
+    Q: How do I reset my password?<br>
     A: Go to the login screen and click the "Forgot password" link. Enter either your user name or email address, and you will get an email containing a link to reset your password.
   </p>
 <?php endif; ?>
 <p>
-  Q: Why does the service use cookies?<br/>
+  Q: Why does the service use cookies?<br>
   A: Cookies are used to manage sessions, which include selected language, last search, book bag contents, any login information, etc.
 </p>

--- a/themes/bootstrap3/templates/devtools/deminify.phtml
+++ b/themes/bootstrap3/templates/devtools/deminify.phtml
@@ -10,7 +10,7 @@
       <label for="min-text">Minified text:</label>
       <textarea class="form-control" id="min-text" name="min" rows="6"></textarea>
     </div>
-    <input class="btn btn-primary" type="submit" />
+    <input class="btn btn-primary" type="submit">
   </form>
 <?php else: ?>
   <h3>Minified Object</h3>

--- a/themes/bootstrap3/templates/devtools/icon.phtml
+++ b/themes/bootstrap3/templates/devtools/icon.phtml
@@ -4,6 +4,6 @@
 
 <table>
   <?php foreach ($aliases as $icon): ?>
-    <?=$this->icon($icon)?>: <?=$this->escapeHtml($icon)?><br />
+    <?=$this->icon($icon)?>: <?=$this->escapeHtml($icon)?><br>
   <?php endforeach; ?>
 </table>

--- a/themes/bootstrap3/templates/devtools/language.phtml
+++ b/themes/bootstrap3/templates/devtools/language.phtml
@@ -13,7 +13,7 @@
 
 <h1><?=$this->escapeHtml($pageTitle)?></h1>
 
-Current filter mode: <?=$includeOptional ? "Unfiltered" : "Mandatory strings only"?><br />
+Current filter mode: <?=$includeOptional ? "Unfiltered" : "Mandatory strings only"?><br>
 <a href="?main=<?=urlencode($mainCode)?>&amp;includeOptional=<?=$includeOptional ? 0 : 1?>">
   <?=$includeOptional ? "Exclude optional text domains" : "Include optional text domains"?>
 </a>

--- a/themes/bootstrap3/templates/eds/advanced.phtml
+++ b/themes/bootstrap3/templates/eds/advanced.phtml
@@ -8,21 +8,21 @@
 ?>
 <div id="new_group_template">
   <div class="adv-group eds-adv">
-    <input type="hidden" name="join" value="AND"/>
-    <input type="hidden" name="bool0[]" value="AND"/>
+    <input type="hidden" name="join" value="AND">
+    <input type="hidden" name="bool0[]" value="AND">
     <label class="adv-group-label"><?=$this->transEsc("adv_search_label")?>:</label>
     <?php for ($search = 0; $search < 3; $search++): ?>
       <?php if ($search === 0): ?>
         <div id="new_search_template">
       <?php endif; ?>
       <div class="adv-search">
-        <?php if ($search === 0): ?><input type="hidden" value="AND" class="first-op"/><?php endif; ?>
+        <?php if ($search === 0): ?><input type="hidden" value="AND" class="first-op"><?php endif; ?>
         <select id="search_op0_<?=$search ?>" name="op0[]" class="adv-term-op form-control">
           <option value="AND"><?=$this->transEsc("AND")?></option>
           <option value="OR"><?=$this->transEsc("OR")?></option>
           <option value="NOT"><?=$this->transEsc("NOT")?></option>
         </select>
-        <input id="search_lookfor0_<?=$search ?>" name="lookfor0[]" class="adv-term-input form-control" type="text" value="" aria-label="<?=$this->transEscAttr("search_terms")?>"/>
+        <input id="search_lookfor0_<?=$search ?>" name="lookfor0[]" class="adv-term-input form-control" type="text" value="" aria-label="<?=$this->transEscAttr("search_terms")?>">
         <span class="help-block hidden-xs"><?=$this->transEsc("in")?></span>
         <select id="search_type0_<?=$search ?>" name="type0[]" class="adv-term-type form-control" aria-label="<?=$this->transEscAttr("Search type")?>">
           <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>

--- a/themes/bootstrap3/templates/error/index.phtml
+++ b/themes/bootstrap3/templates/error/index.phtml
@@ -9,7 +9,7 @@
   <p><?=$this->transEsc($this->message)?></p>
   <p>
     <?=$this->transEsc('Please contact the Library Reference Department for assistance')?>
-    <br/>
+    <br>
     <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
     <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
   </p>

--- a/themes/bootstrap3/templates/error/permissiondenied.phtml
+++ b/themes/bootstrap3/templates/error/permissiondenied.phtml
@@ -18,7 +18,7 @@
   </p>
   <p>
     <?=$this->transEsc('Please contact the Library Reference Department for assistance')?>
-    <br/>
+    <br>
     <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
     <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
   </p>

--- a/themes/bootstrap3/templates/error/unavailable.phtml
+++ b/themes/bootstrap3/templates/error/unavailable.phtml
@@ -15,7 +15,7 @@
   </p>
   <p>
     <?=$this->transEsc('Please contact the Library Reference Department for assistance')?>
-    <br/>
+    <br>
     <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
     <a href="mailto:<?=$supportEmail?>"><?=$supportEmail?></a>
   </p>

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -33,7 +33,7 @@
     <?php if (in_array('frozenThrough', $this->fields)): ?>
       <div class="form-group hold-frozen-through">
         <label for="frozen_through" class="control-label"><?=$this->transEsc('hold_edit_frozen_through')?>:</label>
-        <input id="frozen_through" type="text" name="gatheredDetails[frozenThrough]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['frozenThrough'] ?? '')?>" size="10" class="form-control"/>
+        <input id="frozen_through" type="text" name="gatheredDetails[frozenThrough]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['frozenThrough'] ?? '')?>" size="10" class="form-control">
         (<?=$this->dateTime()->getDisplayDateFormat()?>)
       </div>
     <?php endif; ?>
@@ -42,7 +42,7 @@
   <?php if (in_array('startDate', $this->fields)): ?>
     <div class="form-group hold-start-date">
       <label for="start_date" class="control-label"><?=$this->transEsc('hold_start_date')?>:</label>
-      <input id="start_date" type="text" name="gatheredDetails[startDate]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['startDate'] ?? '')?>" size="10" class="form-control"/>
+      <input id="start_date" type="text" name="gatheredDetails[startDate]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['startDate'] ?? '')?>" size="10" class="form-control">
         (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -50,7 +50,7 @@
   <?php if (in_array("requiredByDate", $this->fields)): ?>
     <div class="form-group hold-required-by">
       <label for="required_by_date" class="control-label"><?=$this->transEsc('hold_required_by')?>:</label>
-      <input id="required_by_date" type="text" name="gatheredDetails[requiredBy]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['requiredBy'] ?? '')?>" size="10" class="form-control"/>
+      <input id="required_by_date" type="text" name="gatheredDetails[requiredBy]" value="<?=$this->escapeHtmlAttr($this->gatheredDetails['requiredBy'] ?? '')?>" size="10" class="form-control">
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -78,7 +78,7 @@
   <?php endif; ?>
 
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="updateHolds" value="<?=$this->transEscAttr('Save')?>"/>
+    <input class="btn btn-primary" type="submit" name="updateHolds" value="<?=$this->transEscAttr('Save')?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/holds/list.phtml
+++ b/themes/bootstrap3/templates/holds/list.phtml
@@ -22,12 +22,12 @@
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm || $this->updateForm): ?>
       <form name="updateForm" class="inline" method="post" action="<?=$this->escapeHtmlAttr($this->url('holds-list'))?>" id="update_holds" data-clear-account-cache="holds" data-lightbox>
-        <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
-        <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
+        <input type="hidden" id="submitType" name="cancelSelected" value="1">
+        <input type="hidden" id="cancelConfirm" name="confirm" value="0">
         <div class="toolbar">
           <div class="checkbox">
             <label>
-              <input type="checkbox" name="selectAll" class="checkbox-select-all"/>
+              <input type="checkbox" name="selectAll" class="checkbox-select-all">
               <?=$this->transEsc('select_page')?>
             </label>
             <?php if ($this->updateForm): ?>
@@ -66,7 +66,7 @@
           <?php if (($this->cancelForm && isset($ilsDetails['cancel_details'])) || ($this->updateForm && isset($ilsDetails['updateDetails']))): ?>
             <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['cancel_details'] ?? $ilsDetails['updateDetails']); ?>
             <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
-              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
+              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>">
             <?php endif; ?>
             <div class="checkbox">
               <label>
@@ -112,29 +112,29 @@
                   // Last resort -- indicate that no title could be found.
                   echo $this->transEsc('Title not available');
                 }
-              ?><br/>
+              ?><br>
               <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
                 <?=$this->transEsc('by')?>:
-                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
               <?php endif; ?>
 
               <?php if (count($resource->getFormats()) > 0): ?>
                 <?=$this->record($resource)->getFormatList() ?>
-                <br/>
+                <br>
               <?php endif; ?>
               <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
                 <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
                 <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['requestGroup'])): ?>
                 <strong><?=$this->transEsc('hold_requested_group') ?>:</strong> <?=$this->transEsc('request_group_' . $ilsDetails['requestGroup'], null, $ilsDetails['requestGroup'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
@@ -157,7 +157,7 @@
               <?php if (!empty($pickupDisplay)): ?>
                 <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
                 <?=$pickupTranslate ? $this->transEscWithPrefix('location_', $pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['create'])): ?>
@@ -167,12 +167,12 @@
               <?php if (!empty($ilsDetails['expire'])): ?>
                 <strong><?=$this->transEsc('hold_expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
               <?php endif; ?>
-              <br />
+              <br>
               <?php if (!empty($ilsDetails['proxiedBy'])): ?>
-                <strong><?=$this->transEsc('hold_proxied_by')?>:</strong> <span class="hold-proxied-by"><?=$this->escapeHtml($ilsDetails['proxiedBy'])?></span><br />
+                <strong><?=$this->transEsc('hold_proxied_by')?>:</strong> <span class="hold-proxied-by"><?=$this->escapeHtml($ilsDetails['proxiedBy'])?></span><br>
               <?php endif; ?>
               <?php if (!empty($ilsDetails['proxiedFor'])): ?>
-                <strong><?=$this->transEsc('hold_proxied_for')?>:</strong> <span class="hold-proxied-for"><?=$this->escapeHtml($ilsDetails['proxiedFor'])?></span><br />
+                <strong><?=$this->transEsc('hold_proxied_for')?>:</strong> <span class="hold-proxied-for"><?=$this->escapeHtml($ilsDetails['proxiedFor'])?></span><br>
               <?php endif; ?>
 
               <?php if (isset($ilsDetails['available']) && $ilsDetails['available'] == true): ?>

--- a/themes/bootstrap3/templates/install/fixdatabase.phtml
+++ b/themes/bootstrap3/templates/install/fixdatabase.phtml
@@ -21,40 +21,40 @@
   </div>
   <div class="form-group">
     <label class="control-label" for="dbname">New database name:</label>
-    <input type="text" name="dbname" value="<?=$this->escapeHtmlAttr($this->dbname)?>" class="form-control"/>
+    <input type="text" name="dbname" value="<?=$this->escapeHtmlAttr($this->dbname)?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbuser">New database user:</label>
-    <input type="text" name="dbuser" value="<?=$this->escapeHtmlAttr($this->dbuser)?>" class="form-control"/>
+    <input type="text" name="dbuser" value="<?=$this->escapeHtmlAttr($this->dbuser)?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbpass">New user password:</label>
-    <input type="password" name="dbpass" value="" class="form-control"/>
+    <input type="password" name="dbpass" value="" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbpassconfirm">Confirm new user password:</label>
-    <input type="password" name="dbpassconfirm" value="" class="form-control"/>
+    <input type="password" name="dbpassconfirm" value="" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbhost">MySQL Host:</label>
-    <input type="text" name="dbhost" value="<?=$this->escapeHtmlAttr($this->dbhost)?>" class="form-control"/>
+    <input type="text" name="dbhost" value="<?=$this->escapeHtmlAttr($this->dbhost)?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="vufindhost">VuFind IP/Host (if different from SQL Host):</label>
-    <input type="text" name="vufindhost" value="<?=$this->escapeHtmlAttr($this->vufindhost)?>" class="form-control"/>
+    <input type="text" name="vufindhost" value="<?=$this->escapeHtmlAttr($this->vufindhost)?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbrootuser">MySQL Root User:</label>
-    <input type="text" name="dbrootuser" value="<?=$this->escapeHtmlAttr($this->dbrootuser)?>" class="form-control"/>
+    <input type="text" name="dbrootuser" value="<?=$this->escapeHtmlAttr($this->dbrootuser)?>" class="form-control">
   </div>
   <div class="form-group">
     <label class="control-label" for="dbrootpass">MySQL Root Password:</label>
-    <input type="password" name="dbrootpass" value="" class="form-control"/>
+    <input type="password" name="dbrootpass" value="" class="form-control">
   </div>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>" />
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>">
   </div>
   <div class="form-group">
-    <p class="form-control-static">If you don't have the credentials or you wish to print the SQL out, click here to <input class="btn btn-default" type="submit" name="printsql" value="Skip"/> credentials.</p>
+    <p class="form-control-static">If you don't have the credentials or you wish to print the SQL out, click here to <input class="btn btn-default" type="submit" name="printsql" value="Skip"> credentials.</p>
   </div>
 </form>

--- a/themes/bootstrap3/templates/install/fixils.phtml
+++ b/themes/bootstrap3/templates/install/fixils.phtml
@@ -22,7 +22,7 @@
       </select>
     </div>
     <div class="form-group">
-      <input type="submit" class="btn btn-primary"/>
+      <input type="submit" class="btn btn-primary">
     </div>
   </form>
 

--- a/themes/bootstrap3/templates/install/fixsecurity.phtml
+++ b/themes/bootstrap3/templates/install/fixsecurity.phtml
@@ -15,8 +15,8 @@
   <p><b>Please make a database backup before proceeding.</b></p>
   <p><i>Do you still wish to proceed with enabling enhanced security in the database?</i></p>
   <form method="post" action="<?=$this->url('install-fixsecurity')?>">
-    <input type="submit" name="fix-user-table" value="Yes" class="btn btn-primary"/>
-    <input type="submit" name="fix-user-table" value="No" class="btn btn-default"/>
+    <input type="submit" name="fix-user-table" value="Yes" class="btn btn-primary">
+    <input type="submit" name="fix-user-table" value="No" class="btn btn-default">
   </form>
 <?php else: ?>
   <p>No security problems found.</p>

--- a/themes/bootstrap3/templates/install/showsql.phtml
+++ b/themes/bootstrap3/templates/install/showsql.phtml
@@ -19,13 +19,13 @@
 <textarea class="pre" rows="20" readonly id="sql_text"><?=trim($this->sql) ?></textarea>
 
 <form method="post" action="<?=$this->url('install-showsql')?>">
-    <input type="submit" name="continue" value="Next" class="btn btn-primary"/>
+    <input type="submit" name="continue" value="Next" class="btn btn-primary">
 </form>
 
 <?php
 $script = <<<JS
     $('#sql_text').click(function(e) {
-      this.select();  
+      this.select();
     });
     JS;
 ?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -3,8 +3,8 @@
 <html lang="<?=$this->layout()->userLang?>"<?php if ($this->layout()->rtl): ?> dir="rtl"<?php endif; ?>>
   <head>
     <?php $this->setupThemeResources(); ?>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <?=$this->headMeta()?>
     <?=$this->googleTagManager()->getHeadCode()?>
 

--- a/themes/bootstrap3/templates/librarycards/editcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/editcard.phtml
@@ -14,10 +14,10 @@
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-card" method="post" name="<?=empty($this->card->id) ? 'newCardForm' : 'editCardForm'?>" autocomplete="off" data-clear-account-cache>
-  <input type="hidden" name="id" value="<?=empty($this->card->id) ? 'NEW' : $this->escapeHtmlAttr($this->card->id) ?>"/>
+  <input type="hidden" name="id" value="<?=empty($this->card->id) ? 'NEW' : $this->escapeHtmlAttr($this->card->id) ?>">
   <div class="form-group">
     <label class="control-label" for="card_name"><?=$this->transEsc('Library Card Name'); ?>:</label>
-    <input id="card_name" class="form-control" type="text" name="card_name" value="<?=$this->escapeHtmlAttr($this->cardName)?>"/>
+    <input id="card_name" class="form-control" type="text" name="card_name" value="<?=$this->escapeHtmlAttr($this->cardName)?>">
   </div>
   <?php if ($this->targets !== null): ?>
   <div class="form-group">
@@ -36,16 +36,16 @@
     <?php if (null === $this->loginMethod || 'email' === $this->loginMethod): ?>
       <label class="control-label email-login<?php if (null === $this->loginMethod): ?> hidden<?php endif; ?>" for="login_username"><?=$this->transEsc('Email')?>:</label>
     <?php endif; ?>
-    <input id="login_username" type="text" name="username" value="<?=$this->escapeHtmlAttr($this->username)?>" class="form-control"/>
+    <input id="login_username" type="text" name="username" value="<?=$this->escapeHtmlAttr($this->username)?>" class="form-control">
   </div>
   <?php if (null === $this->loginMethod || 'password' === $this->loginMethod): ?>
     <div class="form-group">
       <label class="control-label" for="login_password"><?=$this->transEsc('Password')?>:</label>
-      <input id="login_password" type="password" name="password" value="" placeholder="<?=!empty($this->card->id) ? $this->transEscAttr('library_card_edit_password_placeholder') : ''?>" class="form-control"/>
+      <input id="login_password" type="password" name="password" value="" placeholder="<?=!empty($this->card->id) ? $this->transEscAttr('library_card_edit_password_placeholder') : ''?>" class="form-control">
     </div>
   <?php endif; ?>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>"/>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -21,7 +21,7 @@
           <option value="<?=$this->escapeHtmlAttr($card->id)?>"<?=strcasecmp($card->cat_username, $this->user->cat_username ?? '') == 0 ? ' selected="selected"' : ''?>><?=$display ?></option>
         <?php endforeach; ?>
       </select>
-      <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+      <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>"></noscript>
     </form>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/account.phtml
+++ b/themes/bootstrap3/templates/myresearch/account.phtml
@@ -15,6 +15,6 @@
     <a class="back-to-login btn btn-link" href="<?=$this->url('myresearch-userlogin') ?>">
       <?=$this->icon('page-prev') ?> <?=$this->transEsc('navigate_back')?>
     </a>
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>"/>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Submit')?>">
   </div>
 </form>

--- a/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
@@ -1,11 +1,11 @@
 <?php if (isset($list)): ?>
-  <input type="hidden" name="listID" value="<?=$this->escapeHtmlAttr($list->id)?>" />
-  <input type="hidden" name="listName" value="<?=$this->escapeHtmlAttr($list->title)?>" />
+  <input type="hidden" name="listID" value="<?=$this->escapeHtmlAttr($list->id)?>">
+  <input type="hidden" name="listName" value="<?=$this->escapeHtmlAttr($list->title)?>">
 <?php endif; ?>
 <?php $user = $this->auth()->isLoggedIn(); ?>
 <nav class="bulkActionButtons">
   <div class="bulk-checkbox">
-    <input type="checkbox" name="selectAll" class="checkbox-select-all" id="myresearchCheckAll"/>
+    <input type="checkbox" name="selectAll" class="checkbox-select-all" id="myresearchCheckAll">
     <label for="myresearchCheckAll"><?=$this->transEsc('select_page')?> | <?=$this->transEsc('with_selected')?>:</label>
   </div>
   <ul class="action-toolbar">

--- a/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
@@ -38,12 +38,12 @@
       <?php if (null === $this->loginMethod || 'email' === $this->loginMethod): ?>
         <label class="control-label email-login<?php if (null === $this->loginMethod): ?> hidden<?php endif; ?>" for="profile_cat_username"><?=$this->transEsc('Email')?>:</label>
       <?php endif; ?>
-      <input id="profile_cat_username" type="<?='email' === $this->loginMethod ? 'email' : 'text'?>" name="cat_username" value="" class="form-control" autocomplete="<?='email' === $this->loginMethod ? 'email' : 'username'?>"/>
+      <input id="profile_cat_username" type="<?='email' === $this->loginMethod ? 'email' : 'text'?>" name="cat_username" value="" class="form-control" autocomplete="<?='email' === $this->loginMethod ? 'email' : 'username'?>">
     </div>
     <?php if (null === $this->loginMethod || 'password' === $this->loginMethod): ?>
       <div class="form-group">
         <label class="control-label" for="profile_cat_password"><?=$this->transEsc('Library Catalog Password')?>:</label>
-        <input id="profile_cat_password" type="password" name="cat_password" value="" class="form-control" autocomplete="current-password"/>
+        <input id="profile_cat_password" type="password" name="cat_password" value="" class="form-control" autocomplete="current-password">
       </div>
     <?php else: ?>
       <input type="hidden" name="cat_password" value="****">

--- a/themes/bootstrap3/templates/myresearch/changeemail.phtml
+++ b/themes/bootstrap3/templates/myresearch/changeemail.phtml
@@ -15,14 +15,14 @@
     <div class="error"><?=$this->transEsc('change_email_disabled') ?></div>
   <?php else: ?>
     <form id="newemail" class="form-new-email" action="<?=$this->url('myresearch-changeemail') ?>" method="post" data-toggle="validator" role="form">
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
       <div class="form-group">
         <label class="control-label"><?=$this->transEsc('Email Address') ?>:</label>
-        <input type="text" name="email" class="form-control" value="<?=$this->escapeHtmlAttr($this->email)?>" />
+        <input type="text" name="email" class="form-control" value="<?=$this->escapeHtmlAttr($this->email)?>">
       </div>
       <?=$this->captcha()->html($this->useCaptcha) ?>
       <div class="form-group">
-        <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Submit')?>" />
+        <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Submit')?>">
       </div>
     </form>
   <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -43,12 +43,12 @@
     </nav>
     <?php if ($this->renewForm): ?>
     <form name="renewals" method="post" id="renewals" data-clear-account-cache="checkedOut" data-disable-on-submit>
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
       <input type="hidden" id="submitType" name="renewSelected" value="1">
       <div class="toolbar">
         <div class="checkbox">
           <label>
-            <input type="checkbox" name="selectAll" class="checkbox-select-all"/>
+            <input type="checkbox" name="selectAll" class="checkbox-select-all">
             <?=$this->transEsc('select_page')?>
           </label>
           <div class="btn-group">
@@ -86,7 +86,7 @@
       <?php endif; ?>
       <?php if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
         <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
-        <input class="pull-left flip" type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
+        <input class="pull-left flip" type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>">
       <?php endif; ?>
     <?php endforeach; ?>
 
@@ -99,10 +99,10 @@
               <?php if (isset($ilsDetails['renewable']) && $ilsDetails['renewable'] && isset($ilsDetails['renew_details'])): ?>
                 <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
                 <label>
-                  <input class="checkbox-select-item" type="checkbox" name="renewSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" id="checkbox_<?=$safeId?>" />
+                  <input class="checkbox-select-item" type="checkbox" name="renewSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" id="checkbox_<?=$safeId?>">
                 </label>
-                <input type="hidden" name="selectAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
-                <input type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" />
+                <input type="hidden" name="selectAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>">
+                <input type="hidden" name="renewAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>">
               <?php else: ?>
                 <label> </label>
               <?php endif; ?>
@@ -141,37 +141,37 @@
                   // Last resort -- indicate that no title could be found.
                   echo $this->transEsc('Title not available');
                 }
-              ?><br/>
+              ?><br>
               <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
                 <?=$this->transEsc('by')?>:
-                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
               <?php endif; ?>
               <?php if (count($resource->getFormats()) > 0): ?>
                 <?=$this->record($resource)->getFormatList() ?>
-                <br/>
+                <br>
               <?php endif; ?>
               <?php if (!empty($ilsDetails['volume'])): ?>
                 <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['publication_year'])): ?>
                 <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
-                <br />
+                <br>
               <?php endif; ?>
               <?php if ($this->displayItemBarcode && !empty($ilsDetails['barcode'])): ?>
                 <strong><?=$this->transEsc('Barcode')?>:</strong> <?=$this->escapeHtml($ilsDetails['barcode'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['institution_name']) && (empty($ilsDetails['borrowingLocation']) || $ilsDetails['institution_name'] != $ilsDetails['borrowingLocation'])): ?>
                 <strong><?=$this->transEscWithPrefix('location_', $ilsDetails['institution_name'])?></strong>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['borrowingLocation'])): ?>
                 <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEscWithPrefix('location_', $ilsDetails['borrowingLocation'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (isset($ilsDetails['renew'])): ?>
@@ -179,7 +179,7 @@
                 <?php if (isset($ilsDetails['renewLimit'])): ?>
                   / <?=$this->transEsc($ilsDetails['renewLimit'])?>
                 <?php endif; ?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php $showStatus = true; ?>

--- a/themes/bootstrap3/templates/myresearch/controls/sort.phtml
+++ b/themes/bootstrap3/templates/myresearch/controls/sort.phtml
@@ -6,6 +6,6 @@
         <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected'] ? ' selected="selected"' : ''?>><?=$this->transEsc($sortData['desc'])?></option>
       <?php endforeach; ?>
     </select>
-    <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+    <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>"></noscript>
   </form>
 </div>

--- a/themes/bootstrap3/templates/myresearch/delete.phtml
+++ b/themes/bootstrap3/templates/myresearch/delete.phtml
@@ -16,11 +16,11 @@
         </li>
       <?php endforeach; ?>
     </ul>
-    <br />
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Delete')?>"/>
+    <br>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Delete')?>">
     <?php foreach ($this->deleteIDS as $deleteID): ?>
-      <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($deleteID)?>" />
+      <input type="hidden" name="ids[]" value="<?=$this->escapeHtmlAttr($deleteID)?>">
     <?php endforeach; ?>
-      <input type="hidden" name="listID" value="<?=$this->list ? $this->escapeHtmlAttr($this->list->id) : ''?>" />
+      <input type="hidden" name="listID" value="<?=$this->list ? $this->escapeHtmlAttr($this->list->id) : ''?>">
   </div>
 </form>

--- a/themes/bootstrap3/templates/myresearch/deleteaccount.phtml
+++ b/themes/bootstrap3/templates/myresearch/deleteaccount.phtml
@@ -13,8 +13,8 @@
   <form id="delete-account" method="post" action="<?=$this->url('myresearch-deleteaccount') ?>" name="deleteAccount">
     <h3><?=$this->transEsc('delete_account_confirm'); ?></h3>
     <p><?=$this->translate('delete_account_description_html'); ?></p>
-    <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" />
-    <input id="delete-account-cancel" class="btn btn-primary" type="submit" name="reset" data-dismiss="modal" value="<?=$this->transEscAttr('confirm_dialog_no'); ?>"/>
-    <input id="delete-account-submit" class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('confirm_dialog_yes'); ?>"/>
+    <input type="hidden" name="csrf" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>">
+    <input id="delete-account-cancel" class="btn btn-primary" type="submit" name="reset" data-dismiss="modal" value="<?=$this->transEscAttr('confirm_dialog_no'); ?>">
+    <input id="delete-account-submit" class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('confirm_dialog_yes'); ?>">
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/edit.phtml
+++ b/themes/bootstrap3/templates/myresearch/edit.phtml
@@ -32,11 +32,11 @@
       <?php foreach ($this->savedData as $i => $current): ?>
         <fieldset class="list-edit-group">
           <h3><?=$this->transEsc('List') ?>: <?=$this->escapeHtml($current['listTitle'])?></h3>
-          <input type="hidden" name="lists[]" value="<?=$this->escapeHtmlAttr($current['listId']) ?>"/>
+          <input type="hidden" name="lists[]" value="<?=$this->escapeHtmlAttr($current['listId']) ?>">
           <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
             <div class="form-group">
               <label class="control-label" for="edit_tags<?=$current['listId'] ?>"><?=$this->transEsc('Tags') ?>:</label>
-              <input type="text" name="tags<?=$current['listId'] ?>" id="edit_tags<?=$current['listId'] ?>" class="form-control" value="<?=$this->escapeHtmlAttr($current['tags'])?>"/>
+              <input type="text" name="tags<?=$current['listId'] ?>" id="edit_tags<?=$current['listId'] ?>" class="form-control" value="<?=$this->escapeHtmlAttr($current['tags'])?>">
               <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
             </div>
           <?php endif; ?>
@@ -53,7 +53,7 @@
     </div>
   <?php endif; ?>
   <?php if (count($this->lists) > 0): ?>
-    <hr/>
+    <hr>
     <div class="form-group">
       <select name="addToList" class="form-control">
         <option value="-1">- <?=$this->transEsc('Add to another list')?> -</option>
@@ -65,7 +65,7 @@
   <?php endif; ?>
   <?php if (!empty($this->savedData) || count($this->lists) > 0): ?>
     <div class="form-group">
-      <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>"/>
+      <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>">
     </div>
   <?php endif; ?>
   </form>

--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -20,10 +20,10 @@
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-list" method="post" name="<?=$this->newList ? 'newList' : 'editListForm'?>">
-  <input type="hidden" name="id" value="<?=empty($this->list->id) ? 'NEW' : $this->escapeHtmlAttr($this->list->id) ?>"/>
+  <input type="hidden" name="id" value="<?=empty($this->list->id) ? 'NEW' : $this->escapeHtmlAttr($this->list->id) ?>">
   <div class="form-group">
     <label class="control-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>
-    <input id="list_title" class="form-control" type="text" name="title" value="<?=isset($this->list['title']) ? $this->escapeHtml($this->list['title']) : ''?>"/>
+    <input id="list_title" class="form-control" type="text" name="title" value="<?=isset($this->list['title']) ? $this->escapeHtml($this->list['title']) : ''?>">
   </div>
   <div class="form-group">
     <label class="control-label" for="list_desc"><?=$this->transEsc('Description') ?></label>
@@ -32,31 +32,31 @@
   <?php if ($this->usertags()->getListMode() === 'enabled'): ?>
     <div class="form-group">
       <label class="control-label" for="list_tags"><?=$this->transEsc('Tags') ?>:</label>
-      <input type="text" name="tags" id="list_tags" class="form-control" value="<?=$this->escapeHtmlAttr($this->listTags)?>"/>
+      <input type="text" name="tags" id="list_tags" class="form-control" value="<?=$this->escapeHtmlAttr($this->listTags)?>">
       <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
     </div>
   <?php endif; ?>
   <?php if ($this->userlist()->getMode() === 'public_only'): ?>
-    <input type="hidden" name="public" value="1" />
+    <input type="hidden" name="public" value="1">
   <?php elseif ($this->userlist()->getMode() === 'private_only'): ?>
-    <input type="hidden" name="public" value="0" />
+    <input type="hidden" name="public" value="0">
   <?php else: ?>
     <div class="form-group">
       <label class="control-label"><?=$this->transEsc('Access') ?></label>
       <div class="radio inline">
         <label>
-          <input id="list_public_1" type="radio" name="public" value="1"<?php if ($this->list->isPublic()): ?> checked="checked"<?php endif; ?>/> <?=$this->transEsc('Public') ?>
+          <input id="list_public_1" type="radio" name="public" value="1"<?php if ($this->list->isPublic()): ?> checked="checked"<?php endif; ?>> <?=$this->transEsc('Public') ?>
         </label>
       </div>
       <div class="radio inline">
         <label>
-          <input id="list_public_0" type="radio" name="public" value="0"<?php if (!$this->list->isPublic()): ?> checked="checked"<?php endif; ?>/> <?=$this->transEsc('Private') ?>
+          <input id="list_public_0" type="radio" name="public" value="0"<?php if (!$this->list->isPublic()): ?> checked="checked"<?php endif; ?>> <?=$this->transEsc('Private') ?>
         </label>
       </div>
     </div>
   <?php endif; ?>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>"/>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>">
   </div>
 </form>
 <?php if ($this->auth()->isLoggedIn() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>

--- a/themes/bootstrap3/templates/myresearch/historicloans.phtml
+++ b/themes/bootstrap3/templates/myresearch/historicloans.phtml
@@ -73,40 +73,40 @@
                   // Last resort -- indicate that no title could be found.
                   echo $this->transEsc('Title not available');
                 }
-              ?><br/>
+              ?><br>
               <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
                 <?=$this->transEsc('by')?>:
-                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
               <?php endif; ?>
               <?php if (count($resource->getFormats()) > 0): ?>
                 <?=$this->record($resource)->getFormatList() ?>
-                <br/>
+                <br>
               <?php endif; ?>
               <?php if (!empty($ilsDetails['volume'])): ?>
                 <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['publication_year'])): ?>
                 <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['institution_name']) && (empty($ilsDetails['borrowingLocation']) || $ilsDetails['institution_name'] != $ilsDetails['borrowingLocation'])): ?>
                 <strong><?=$this->transEscWithPrefix('location_', $ilsDetails['institution_name'])?></strong>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['borrowingLocation'])): ?>
                 <strong><?=$this->transEsc('Borrowing Location')?>:</strong> <?=$this->transEscWithPrefix('location_', $ilsDetails['borrowingLocation'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['checkoutDate'])): ?>
-                <strong><?=$this->transEsc('Checkout Date')?>:</strong> <?=$this->escapeHtml($ilsDetails['checkoutDate'])?><?php if (isset($ilsDetails['checkoutTime'])): ?> <span class="checkout-time"><?=$this->escapeHtml($ilsDetails['checkoutTime'])?><?php endif; ?></span><br/>
+                <strong><?=$this->transEsc('Checkout Date')?>:</strong> <?=$this->escapeHtml($ilsDetails['checkoutDate'])?><?php if (isset($ilsDetails['checkoutTime'])): ?> <span class="checkout-time"><?=$this->escapeHtml($ilsDetails['checkoutTime'])?><?php endif; ?></span><br>
               <?php endif; ?>
               <?php if (!empty($ilsDetails['returnDate'])): ?>
-                <strong><?=$this->transEsc('Return Date')?>:</strong> <?=$this->escapeHtml($ilsDetails['returnDate'])?><?php if (isset($ilsDetails['returnTime'])): ?> <span class="return-time"><?=$this->escapeHtml($ilsDetails['returnTime'])?><?php endif; ?></span><br/>
+                <strong><?=$this->transEsc('Return Date')?>:</strong> <?=$this->escapeHtml($ilsDetails['returnDate'])?><?php if (isset($ilsDetails['returnTime'])): ?> <span class="return-time"><?=$this->escapeHtml($ilsDetails['returnTime'])?><?php endif; ?></span><br>
               <?php endif; ?>
               <?php if (!empty($ilsDetails['dueDate'])): ?>
                 <strong><?=$this->transEsc('Due Date')?>:</strong> <?=$this->escapeHtml($ilsDetails['dueDate'])?><?php if (isset($ilsDetails['dueTime'])): ?> <span class="due-time"><?=$this->escapeHtml($ilsDetails['dueTime'])?></span><?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/illrequests.phtml
@@ -23,10 +23,10 @@
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm): ?>
       <form name="updateForm" class="inline" method="post" id="cancelILLRequest" data-clear-account-cache="illRequests">
-        <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
-        <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
+        <input type="hidden" id="submitType" name="cancelSelected" value="1">
+        <input type="hidden" id="cancelConfirm" name="confirm" value="0">
         <div class="btn-group">
-          <input id="cancelSelected" name="cancelSelected" type="submit" value="<?=$this->transEscAttr("ill_request_cancel_selected") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown"/>
+          <input id="cancelSelected" name="cancelSelected" type="submit" value="<?=$this->transEscAttr("ill_request_cancel_selected") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <ul class="dropdown-menu">
             <li class="disabled"><a><?=$this->transEsc("confirm_ill_request_cancel_selected_text") ?></a></li>
             <li><a href="#" id="confirm_cancel_selected_yes"><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
@@ -34,7 +34,7 @@
           </ul>
         </div>
         <div class="btn-group">
-          <input id="cancelAll" name="cancelAll" type="submit" value="<?=$this->transEscAttr("ill_request_cancel_all") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown"/>
+          <input id="cancelAll" name="cancelAll" type="submit" value="<?=$this->transEscAttr("ill_request_cancel_all") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <ul class="dropdown-menu">
             <li class="disabled"><a><?=$this->transEsc("confirm_ill_request_cancel_all_text") ?></a></li>
             <li><a href="#" id="confirm_cancel_all_yes"><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
@@ -52,9 +52,9 @@
           <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
             <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
             <div class="checkbox">
-              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
+              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>">
               <label>
-                <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" />
+                <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>">
               </label>
             </div>
           <?php endif; ?>
@@ -91,24 +91,24 @@
                   // Last resort -- indicate that no title could be found.
                   echo $this->transEsc('Title not available');
                 }
-              ?><br/>
+              ?><br>
               <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
                 <?=$this->transEsc('by')?>:
-                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
               <?php endif; ?>
 
               <?php if (count($resource->getFormats()) > 0): ?>
                 <?=$this->record($resource)->getFormatList() ?>
-                <br/>
+                <br>
               <?php endif; ?>
               <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
                 <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
                 <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
@@ -131,7 +131,7 @@
               <?php if (!empty($pickupDisplay)): ?>
                 <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
                 <?=$pickupTranslate ? $this->transEsc($pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['create'])): ?>
@@ -141,7 +141,7 @@
               <?php if (!empty($ilsDetails['expire'])): ?>
                 <strong><?=$this->transEsc('ill_request_expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
               <?php endif; ?>
-              <br />
+              <br>
 
               <?php if (isset($this->cancelResults['items'])): ?>
                 <?php foreach ($this->cancelResults['items'] as $itemId => $cancelResult): ?>

--- a/themes/bootstrap3/templates/myresearch/newpassword.phtml
+++ b/themes/bootstrap3/templates/myresearch/newpassword.phtml
@@ -19,14 +19,14 @@
   <div class="error"><?=$this->transEsc('recovery_user_not_found') ?></div>
 <?php else: ?>
   <form id="newpassword" class="form-new-password" action="<?=$this->url('myresearch-newpassword') ?>" method="post" data-toggle="validator" role="form">
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->hash) ?>" name="hash"/>
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->username) ?>" name="username"/>
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth_method) ?>" name="auth_method"/>
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->hash) ?>" name="hash">
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->username) ?>" name="username">
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth_method) ?>" name="auth_method">
     <?=$this->auth()->getNewPasswordForm() ?>
     <?=$this->captcha()->html($this->useCaptcha) ?>
     <div class="form-group">
-      <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Submit')?>" />
+      <input class="btn btn-primary" name="submit" type="submit" value="<?=$this->transEscAttr('Submit')?>">
     </div>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/odmycontent.phtml
+++ b/themes/bootstrap3/templates/myresearch/odmycontent.phtml
@@ -60,7 +60,7 @@
             <a href="<?=$this->record($resource['record'])->getLink('author', $listAuthors[0])?>">
               <?=$this->escapeHtml($listAuthors[0])?>
             </a>
-            <?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+            <?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
           <?php endif; ?>
 
           <div><?=$this->transEsc('od_expires_on', ['%%due_date%%' => $resource['checkout']->expires])?></div>
@@ -133,7 +133,7 @@
                 if (!empty($listAuthors)): ?>
                   <?=$this->transEsc('by')?>:
                   <a href="<?=$this->record($resource['record'])->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?>
-                <?php endif; ?><br/>
+                <?php endif; ?><br>
                 <?php endif; ?>
 
                 <?=$this->transEsc('od_hold_placed_on', ['%%holdPlacedDate%%' => $resource['hold']->holdPlacedDate]);?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -51,7 +51,7 @@
                   <option value="<?=$this->escapeHtmlAttr($lib['locationID'])?>"<?=($selected == $lib['locationID']) ? ' selected="selected"' : ''?>><?=$this->transEscWithPrefix('location_', $lib['locationDisplay'])?></option>
                 <?php endforeach; ?>
               </select>
-              <input class="btn btn-default" type="submit" value="<?=$this->transEscAttr('Save')?>" />
+              <input class="btn btn-default" type="submit" value="<?=$this->transEscAttr('Save')?>">
             </form>
           <?php else: // case 2: set home library disallowed, but default provided by ILS ?>
             <?=$this->transEscWithPrefix('location_', $this->preferredLibraryDisplay)?>

--- a/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
+++ b/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
@@ -43,7 +43,7 @@
               <option value="<?=$this->escapeHtmlAttr($scheduleValue)?>"<?=($this->search->notification_frequency == $scheduleValue) ? (' selected') : ('')?>><?=$this->transEsc($scheduleLabel)?></option>
             <?php endforeach; ?>
           </select>
-          <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($this->search->id) ?>"/>
+          <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($this->search->id) ?>">
         </form>
       </td>
     </tr>

--- a/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
@@ -22,10 +22,10 @@
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm): ?>
       <form name="updateForm" class="inline" method="post" id="cancelStorageRetrievalRequest" data-clear-account-cache="storageRetrievalRequests">
-        <input type="hidden" id="submitType" name="cancelSelected" value="1"/>
-        <input type="hidden" id="cancelConfirm" name="confirm" value="0"/>
+        <input type="hidden" id="submitType" name="cancelSelected" value="1">
+        <input type="hidden" id="cancelConfirm" name="confirm" value="0">
         <div class="btn-group">
-          <input id="cancelSelected" name="cancelSelected" type="submit" value="<?=$this->transEscAttr("storage_retrieval_request_cancel_selected") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown"/>
+          <input id="cancelSelected" name="cancelSelected" type="submit" value="<?=$this->transEscAttr("storage_retrieval_request_cancel_selected") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <ul class="dropdown-menu">
             <li class="disabled"><a><?=$this->transEsc("confirm_storage_retrieval_request_cancel_selected_text") ?></a></li>
             <li><a id="confirm_cancel_selected_yes" href="#"><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
@@ -33,7 +33,7 @@
           </ul>
         </div>
         <div class="btn-group">
-          <input id="cancelAll" name="cancelAll" type="submit" value="<?=$this->transEscAttr("storage_retrieval_request_cancel_all") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown"/>
+          <input id="cancelAll" name="cancelAll" type="submit" value="<?=$this->transEscAttr("storage_retrieval_request_cancel_all") ?>" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <ul class="dropdown-menu">
             <li class="disabled"><a><?=$this->transEsc("confirm_storage_retrieval_request_cancel_all_text") ?></a></li>
             <li><a href="#" id="confirm_cancel_all_yes"><?=$this->transEsc('confirm_dialog_yes') ?></a></li>
@@ -51,9 +51,9 @@
           <?php if ($this->cancelForm && isset($ilsDetails['cancel_details'])): ?>
             <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
             <div class="checkbox">
-              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" />
+              <input type="hidden" name="cancelAllIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>">
               <label class="pull-left flip">
-                <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" />
+                <input type="checkbox" name="cancelSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>">
               </label>
             </div>
           <?php endif; ?>
@@ -90,24 +90,24 @@
                   // Last resort -- indicate that no title could be found.
                   echo $this->transEsc('Title not available');
                 }
-              ?><br/>
+              ?><br>
               <?php $listAuthors = $resource->getPrimaryAuthors(); if (!empty($listAuthors)): ?>
                 <?=$this->transEsc('by')?>:
-                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br/>
+                <a href="<?=$this->record($resource)->getLink('author', $listAuthors[0])?>"><?=$this->escapeHtml($listAuthors[0])?></a><?php if (count($listAuthors) > 1): ?>, <?=$this->transEsc('more_authors_abbrev')?><?php endif; ?><br>
               <?php endif; ?>
 
               <?php if (count($resource->getFormats()) > 0): ?>
                 <?=$this->record($resource)->getFormatList() ?>
-                <br/>
+                <br>
               <?php endif; ?>
               <?php if (isset($ilsDetails['volume']) && !empty($ilsDetails['volume'])): ?>
                 <strong><?=$this->transEsc('Volume')?>:</strong> <?=$this->escapeHtml($ilsDetails['volume'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (isset($ilsDetails['publication_year']) && !empty($ilsDetails['publication_year'])): ?>
                 <strong><?=$this->transEsc('Year of Publication')?>:</strong> <?=$this->escapeHtml($ilsDetails['publication_year'])?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php /* Depending on the ILS driver, the "location" value may be a string or an ID; figure out the best
@@ -130,7 +130,7 @@
               <?php if (!empty($pickupDisplay)): ?>
                 <strong><?=$this->transEsc('pick_up_location') ?>:</strong>
                 <?=$pickupTranslate ? $this->transEsc($pickupDisplay) : $this->escapeHtml($pickupDisplay)?>
-                <br />
+                <br>
               <?php endif; ?>
 
               <?php if (!empty($ilsDetails['create'])): ?>
@@ -140,7 +140,7 @@
               <?php if (!empty($ilsDetails['expire'])): ?>
                 <strong><?=$this->transEsc('storage_retrieval_request_expires') ?>:</strong> <?=$this->escapeHtml($ilsDetails['expire']) ?>
               <?php endif; ?>
-              <br />
+              <br>
 
               <?php if (isset($this->cancelResults['items'])): ?>
                 <?php foreach ($this->cancelResults['items'] as $itemId => $cancelResult): ?>

--- a/themes/bootstrap3/templates/oai/home.phtml
+++ b/themes/bootstrap3/templates/oai/home.phtml
@@ -7,125 +7,125 @@
   <h2><?=$this->transEsc('OAI Server')?></h2>
   <p>This OAI server is OAI 2.0 compliant.</p>
   <p>The OAI Server URL is: <?=$this->serverUrl($baseUrl)?></p>
-  <hr/>
+  <hr>
   <a name="Identify"></a>
   <h2>Identify</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="Identify"/>
+    <input type="hidden" name="verb" value="Identify">
     <p class="help-block">Returns the Identification information of this OAI Server.</p>
     <p class="help-block">Accepts no additional parameters.</p>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
-  <hr/>
+  <hr>
   <a name="ListIdentifiers"></a>
   <h2>ListIdentifiers</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="ListIdentifiers"/>
+    <input type="hidden" name="verb" value="ListIdentifiers">
     <p class="help-block">Returns a listing of available identifiers</p>
     <div class="form-group">
       <label for="ListIdentifier_from" class="control-label"><?=$this->transEsc('From')?>:</label>
-      <input id="ListIdentifier_from" type="text" name="from" class="form-control"/>
+      <input id="ListIdentifier_from" type="text" name="from" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListIdentifier_until" class="control-label"><?=$this->transEsc('Until')?>:</label>
-      <input id="ListIdentifier_until" type="text" name="until" class="form-control"/>
+      <input id="ListIdentifier_until" type="text" name="until" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListIdentifier_set" class="control-label"><?=$this->transEsc('Set')?>:</label>
-      <input id="ListIdentifier_set" type="text" name="set" class="form-control"/>
+      <input id="ListIdentifier_set" type="text" name="set" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListIdentifier_metadataPrefix" class="control-label"><?=$this->transEsc('Metadata Prefix')?>:</label>
-      <input id="ListIdentifier_metadataPrefix" type="text" name="metadataPrefix" class="form-control"/>
+      <input id="ListIdentifier_metadataPrefix" type="text" name="metadataPrefix" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListIdentifier_resumptionToken" class="control-label"><?=$this->transEsc('Resumption Token')?>:</label>
-      <input id="ListIdentifier_resumptionToken" type="text" name="resumptionToken" class="form-control"/>
+      <input id="ListIdentifier_resumptionToken" type="text" name="resumptionToken" class="form-control">
     </div>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
-  <hr/>
+  <hr>
   <a name="ListMetadataFormats"></a>
   <h2>ListMetadataFormats</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="ListMetadataFormats"/>
+    <input type="hidden" name="verb" value="ListMetadataFormats">
     <p class="help-block">Returns a listing of available metadata formats.</p>
     <div class="form-group">
       <label for="ListMetadataFormats_identifier" class="control-label"><?=$this->transEsc('Identifier')?>:</label>
-      <input id="ListMetadataFormats_identifier" type="text" name="identifier" class="form-control"/>
+      <input id="ListMetadataFormats_identifier" type="text" name="identifier" class="form-control">
     </div>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
-  <hr/>
+  <hr>
   <a name="ListSets"></a>
   <h2>ListSets</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="ListSets"/>
+    <input type="hidden" name="verb" value="ListSets">
     <p class="help-block">Returns a listing of available sets.</p>
     <div class="form-group">
       <label for="ListSets_metadataPrefix" class="control-label"><?=$this->transEsc('Metadata Prefix')?>:</label>
-      <input id="ListSets_metadataPrefix" type="text" name="metadataPrefix" class="form-control"/>
+      <input id="ListSets_metadataPrefix" type="text" name="metadataPrefix" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListSets_resumptionToken" class="control-label"><?=$this->transEsc('Resumption Token')?>:</label>
-      <input id="ListSets_resumptionToken" type="text" name="resumptionToken" class="form-control"/>
+      <input id="ListSets_resumptionToken" type="text" name="resumptionToken" class="form-control">
     </div>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
-  <hr/>
+  <hr>
   <a name="ListRecords"></a>
   <h2>ListRecords</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="ListRecords"/>
+    <input type="hidden" name="verb" value="ListRecords">
     <p class="help-block">Returns a listing of available records.</p>
     <div class="form-group">
       <label for="ListRecord_from" class="control-label"><?=$this->transEsc('From')?>:</label>
-      <input id="ListRecord_from" type="text" name="from" class="form-control"/>
+      <input id="ListRecord_from" type="text" name="from" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListRecord_until" class="control-label"><?=$this->transEsc('Until')?>:</label>
-      <input id="ListRecord_until" type="text" name="until" class="form-control"/>
+      <input id="ListRecord_until" type="text" name="until" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListRecord_set" class="control-label"><?=$this->transEsc('Set')?>:</label>
-      <input id="ListRecord_set" type="text" name="set" class="form-control"/>
+      <input id="ListRecord_set" type="text" name="set" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListRecord_metadataPrefix" class="control-label"><?=$this->transEsc('Metadata Prefix')?>:</label>
-      <input id="ListRecord_metadataPrefix" type="text" name="metadataPrefix" class="form-control"/>
+      <input id="ListRecord_metadataPrefix" type="text" name="metadataPrefix" class="form-control">
     </div>
     <div class="form-group">
       <label for="ListRecord_resumptionToken" class="control-label"><?=$this->transEsc('Resumption Token')?>:</label>
-      <input id="ListRecord_resumptionToken" type="text" name="resumptionToken" class="form-control"/>
+      <input id="ListRecord_resumptionToken" type="text" name="resumptionToken" class="form-control">
     </div>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
-  <hr/>
+  <hr>
   <a name="GetRecord"></a>
   <h2>GetRecord</h2>
   <form class="form-oai-home" method="get" action="<?=$baseUrl?>">
-    <input type="hidden" name="verb" value="GetRecord"/>
+    <input type="hidden" name="verb" value="GetRecord">
     <p class="help-block">Returns a single record.</p>
     <div class="form-group">
       <label for="GetRecord_identifier" class="control-label"><?=$this->transEsc('Identifier')?>:</label>
-      <input id="GetRecord_identifier" type="text" name="identifier" class="form-control"/>
+      <input id="GetRecord_identifier" type="text" name="identifier" class="form-control">
     </div>
     <div class="form-group">
       <label for="GetRecord_metadataPrefix" class="control-label"><?=$this->transEsc('Metadata Token')?>:</label>
-      <input id="GetRecord_metadataPrefix" type="text" name="metadataPrefix" class="form-control"/>
+      <input id="GetRecord_metadataPrefix" type="text" name="metadataPrefix" class="form-control">
     </div>
     <div class="form-group">
-      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>"/>
+      <input class="btn btn-default" type="submit" name="submit" value="<?=$this->transEscAttr('Go')?>">
     </div>
   </form>
 </div>

--- a/themes/bootstrap3/templates/primo/advanced.phtml
+++ b/themes/bootstrap3/templates/primo/advanced.phtml
@@ -24,7 +24,7 @@
     }
 ?>
 <form class="primo-adv-search" id="advSearchForm" name="searchForm"  method="get" action="<?=$this->url($this->options->getSearchAction())?>">
-  <input type="hidden" name="join" value="AND" />
+  <input type="hidden" name="join" value="AND">
   <div class="<?=$this->layoutClass('mainbody')?>">
     <h3><?=$this->transEsc('Advanced Search')?></h3>
     <?php /* fallback to a fixed set of search groups/fields if JavaScript is turned off */ ?>
@@ -36,7 +36,7 @@
       }
     ?>
     <?php for ($i = 0; $i < $numGroups; $i++): ?>
-      <input type="hidden" name="bool<?=$i?>[]" value="AND" />
+      <input type="hidden" name="bool<?=$i?>[]" value="AND">
       <div class="primo adv-group" id="group<?=$i?>">
         <label class="primo-adv-label" id="group<?=$i?>SearchHolder"><?=$this->transEsc("adv_search_label")?>:</label>
         <div class="search-container">
@@ -64,7 +64,7 @@
                   <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getOperator() == $searchVal) ? ' selected="selected"' : ''?>><?=$this->transEsc($searchDesc)?></option>
                 <?php endforeach; ?>
               </select>
-                <input id="search_lookfor<?=$i?>_<?=$j?>" type="text" value="<?=$currRow ? $this->escapeHtmlAttr($currRow->getString()) : ''?>" size="30" name="lookfor<?=$i?>[]" class="form-control primo-adv-input" aria-label="<?=$this->transEscAttr("search_terms")?>"/>
+                <input id="search_lookfor<?=$i?>_<?=$j?>" type="text" value="<?=$currRow ? $this->escapeHtmlAttr($currRow->getString()) : ''?>" size="30" name="lookfor<?=$i?>[]" class="form-control primo-adv-input" aria-label="<?=$this->transEscAttr("search_terms")?>">
             </div>
           <?php endfor; ?>
         </div>
@@ -72,14 +72,14 @@
     <?php endfor; ?>
     <?php $lastSort = $this->searchMemory()->getLastSort($this->options->getSearchClassId()); ?>
     <?php if (!empty($lastSort)): ?>
-      <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>" />
+      <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>">
     <?php endif; ?>
-    <input type="submit" class="btn btn-primary" name="submit" value="<?=$this->transEscAttr("Find")?>"/>
+    <input type="submit" class="btn btn-primary" name="submit" value="<?=$this->transEscAttr("Find")?>">
   </div>
 
   <div class="<?=$this->layoutClass('sidebar')?>">
     <?php if ($hasDefaultsApplied): ?>
-      <input type="hidden" name="dfApplied" value="1" />
+      <input type="hidden" name="dfApplied" value="1">
     <?php endif ?>
     <?php if (!empty($searchFilters)): ?>
       <h4><?=$this->transEsc("adv_search_filters")?></h4>
@@ -88,7 +88,7 @@
           <div class="checkbox">
             <label>
               <?=$this->transEsc("adv_search_select_all")?>
-              <input type="checkbox" checked="checked" class="checkbox-select-all" />
+              <input type="checkbox" checked="checked" class="checkbox-select-all">
             </label>
           </div>
         </li>
@@ -101,7 +101,7 @@
               <li class="list-group-item">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" class="checkbox-select-item" checked="checked" name="filter[]" value='<?=$this->escapeHtmlAttr($value['field'])?>:"<?=$this->escapeHtmlAttr($value['value'])?>"' /> <?=$this->escapeHtml($value['displayText'])?>
+                    <input type="checkbox" class="checkbox-select-item" checked="checked" name="filter[]" value='<?=$this->escapeHtmlAttr($value['field'])?>:"<?=$this->escapeHtmlAttr($value['value'])?>"'> <?=$this->escapeHtml($value['displayText'])?>
                   </label>
                 </div>
               </li>

--- a/themes/bootstrap3/templates/record/addtag.phtml
+++ b/themes/bootstrap3/templates/record/addtag.phtml
@@ -9,15 +9,15 @@
 ?>
 <h2><?=$this->transEsc('Add Tags') ?></h2>
 <form method="post" name="tagRecord" class="form-add-tag" data-lightbox-onclose="refreshTagListCallback">
-  <input type="hidden" name="submit" value="1" />
-  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
-  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
+  <input type="hidden" name="submit" value="1">
+  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <div class="form-group">
     <label class="control-label" for="addtag_tag"><?=$this->transEsc("Tags")?>:</label>
-    <input id="addtag_tag" type="text" name="tag" value="" size="40"  class="form-control"/>
+    <input id="addtag_tag" type="text" name="tag" value="" size="40"  class="form-control">
     <p class="help-block"><?=$this->transEsc("add_tag_note")?></p>
   </div>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save')?>"/>
+    <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save')?>">
   </div>
 </form>

--- a/themes/bootstrap3/templates/record/ajaxview-accordion.phtml
+++ b/themes/bootstrap3/templates/record/ajaxview-accordion.phtml
@@ -19,8 +19,8 @@
       </div>
       <div id="information_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'information'): ?> in<?php endif; ?>">
         <div class="list-tab-content record panel-body">
-          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>" />
-          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource" />
+          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>">
+          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource">
           <?=$coreMetadata ?>
         </div>
       </div>

--- a/themes/bootstrap3/templates/record/ajaxview-tabs.phtml
+++ b/themes/bootstrap3/templates/record/ajaxview-tabs.phtml
@@ -53,8 +53,8 @@
 <div class="tab-content">
   <?php if (!empty($coreMetadata)): ?>
     <div class="list-tab-content record tab-pane<?php if ($this->defaultTab === 'information'): ?> active<?php endif; ?>" id="information_<?=$idSuffixEsc?>-content">
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>" />
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource" />
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>">
+      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource">
       <?=$coreMetadata ?>
     </div>
   <?php endif; ?>

--- a/themes/bootstrap3/templates/record/checkbox.phtml
+++ b/themes/bootstrap3/templates/record/checkbox.phtml
@@ -1,6 +1,6 @@
 <label class="record-checkbox hidden-print">
-  <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
+  <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>>
   <span class="checkbox-icon"></span>
   <?php if (strlen($this->number ?? '') > 0): ?><span class="sr-only"><?=$this->transEsc('result_checkbox_label', ['%%number%%' => $this->number]) ?></span><?php endif; ?>
 </label>
-<input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>/>
+<input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>>

--- a/themes/bootstrap3/templates/record/comments-list.phtml
+++ b/themes/bootstrap3/templates/record/comments-list.phtml
@@ -5,7 +5,7 @@
   <?php foreach ($comments as $comment): ?>
     <div class="comment">
       <div class="comment-name">
-        <strong><?=null === $comment->user_id ? $this->transEsc('comment_anonymous_user') : $this->escapeHtml(trim($comment->firstname . ' ' . $comment->lastname))?></strong><br/>
+        <strong><?=null === $comment->user_id ? $this->transEsc('comment_anonymous_user') : $this->escapeHtml(trim($comment->firstname . ' ' . $comment->lastname))?></strong><br>
         <small>
           <?=$this->escapeHtml($comment->created)?>
           <?php if (($user = $this->auth()->isLoggedIn()) && $comment->user_id == $user->id): ?>

--- a/themes/bootstrap3/templates/record/email.phtml
+++ b/themes/bootstrap3/templates/record/email.phtml
@@ -10,7 +10,7 @@
 <h2><?=$this->transEsc('Email Record') ?>: <span class="title-in-heading"><?=$this->escapeHtml($this->driver->getBreadcrumb())?></span></h2>
 <form class="form-record-email" method="post" action="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Email')) ?>" name="emailRecord">
   <?=$this->flashmessages()?>
-  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
-  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
+  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <?=$this->render('Helpers/email-form-fields.phtml')?>
 </form>

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -26,7 +26,7 @@
   <?php if (in_array('startDate', $this->extraHoldFields)): ?>
     <div class="form-group hold-start-date">
       <label class="control-label"><?=$this->transEsc('hold_start_date')?>:</label>
-      <input id="startDate" type="text" name="gatheredDetails[startDate]" value="<?=!empty($this->gatheredDetails['startDate']) ? $this->escapeHtmlAttr($this->gatheredDetails['startDate']) : $this->escapeHtmlAttr($this->defaultStartDate)?>" size="10" class="form-control"/>
+      <input id="startDate" type="text" name="gatheredDetails[startDate]" value="<?=!empty($this->gatheredDetails['startDate']) ? $this->escapeHtmlAttr($this->gatheredDetails['startDate']) : $this->escapeHtmlAttr($this->defaultStartDate)?>" size="10" class="form-control">
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -34,7 +34,7 @@
   <?php if (in_array("requiredByDate", $this->extraHoldFields) || in_array("requiredByDateOptional", $this->extraHoldFields)): ?>
     <div class="form-group hold-required-by">
       <label class="control-label"><?=$this->transEsc(in_array("requiredByDateOptional", $this->extraHoldFields) ? 'hold_required_by_optional' : 'hold_required_by')?>:</label>
-      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=!empty($this->gatheredDetails['requiredBy']) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="10" class="form-control"/>
+      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=!empty($this->gatheredDetails['requiredBy']) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="10" class="form-control">
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -112,7 +112,7 @@
         </select>
       </div>
     <?php else: ?>
-      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
+      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>">
     <?php endif; ?>
 
     <?php if (!empty($this->proxiedUsers)): ?>
@@ -133,7 +133,7 @@
     <?php endif; ?>
   <?php endif; ?>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="placeHold" value="<?=$this->transEscAttr('request_submit_text')?>"/>
+    <input class="btn btn-primary" type="submit" name="placeHold" value="<?=$this->transEscAttr('request_submit_text')?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/record/illrequest.phtml
+++ b/themes/bootstrap3/templates/record/illrequest.phtml
@@ -47,8 +47,8 @@
         </select>
       <?php else: ?>
         <?php $lib = $this->pickupLibraries[0]; ?>
-        <input type="text" class="form-control" size="40" readonly="readonly" value="<?=$this->transEscAttr('library_' . $lib['name'], null, $lib['name'])?>" />
-        <input type="hidden" id="pickupLibrary" name="gatheredDetails[pickUpLibrary]" value="<?=$this->escapeHtmlAttr($lib['id'])?>" />
+        <input type="text" class="form-control" size="40" readonly="readonly" value="<?=$this->transEscAttr('library_' . $lib['name'], null, $lib['name'])?>">
+        <input type="hidden" id="pickupLibrary" name="gatheredDetails[pickUpLibrary]" value="<?=$this->escapeHtmlAttr($lib['id'])?>">
       <?php endif; ?>
     </div>
   <?php endif; ?>
@@ -86,14 +86,14 @@
         </select>
       </div>
     <?php else: ?>
-      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
+      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>">
     <?php endif; ?>
   <?php endif; ?>
 
   <?php if (in_array("requiredByDate", $this->extraFields)): ?>
     <div class="form-group">
       <label class="control-label"><?=$this->transEsc("hold_required_by")?>:</label>
-      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="8" class="form-control"/>
+      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="8" class="form-control">
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -106,7 +106,7 @@
   <?php endif; ?>
 
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="placeILLRequest" value="<?=$this->transEscAttr('ill_request_submit_text')?>"/>
+    <input class="btn btn-primary" type="submit" name="placeILLRequest" value="<?=$this->transEscAttr('ill_request_submit_text')?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/record/rating.phtml
+++ b/themes/bootstrap3/templates/record/rating.phtml
@@ -40,26 +40,26 @@
 <?php endif; ?>
 <?php if ($this->auth()->isLoggedIn()): ?>
   <form method="post" name="rateRecord" class="form-add-rating">
-    <input type="hidden" name="submit" value="1" />
-    <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
-    <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
+    <input type="hidden" name="submit" value="1">
+    <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+    <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
     <div class="form-group">
       <label class="control-label"><?=$this->transEsc('rating_prompt')?>:</label>
       <?=$this->render('Helpers/star-rating.phtml', ['ratingData' => $this->currentRating, 'inputAttrs' => ['data-submit-on-change']]);?>
     </div>
     <div class="form-group">
-      <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save')?>"/>
+      <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save')?>">
       <?php if ($this->accountCapabilities()->isRatingRemovalAllowed()): ?>
-        <input form="form_remove_rating" class="btn btn-default" type="submit" value="<?=$this->transEscAttr('rating_remove')?>" <?=$this->currentRating['count'] === 0 ? ' disabled' : ''?>/>
+        <input form="form_remove_rating" class="btn btn-default" type="submit" value="<?=$this->transEscAttr('rating_remove')?>" <?=$this->currentRating['count'] === 0 ? ' disabled' : ''?>>
       <?php endif; ?>
     </div>
   </form>
   <?php if ($this->accountCapabilities()->isRatingRemovalAllowed()): ?>
     <form method="post" name="rateRecord" id="form_remove_rating" class="form-remove-rating">
-      <input type="hidden" name="submit" value="1" />
-      <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
-      <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
-      <input type="hidden" name="rating" value="" />
+      <input type="hidden" name="submit" value="1">
+      <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+      <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
+      <input type="hidden" name="rating" value="">
     </form>
   <?php endif; ?>
 <?php else: ?>

--- a/themes/bootstrap3/templates/record/save.phtml
+++ b/themes/bootstrap3/templates/record/save.phtml
@@ -9,15 +9,15 @@
 ?>
 <h2><?=$this->translate("add_to_favorites_html", ['%%title%%' => $this->escapeHtml($this->driver->getBreadcrumb())]) ?></h2>
 <form class="form-record-save" method="post" action="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Save')) ?>" name="saveRecord" data-lightbox-onclose="VuFind.saveStatuses.refresh">
-  <input type="hidden" name="submit" value="1" />
-  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>" />
-  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
+  <input type="hidden" name="submit" value="1">
+  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
+  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <?php if (!empty($this->containingLists)): ?>
     <p><?=$this->transEsc('This item is already part of the following list/lists') ?>:
     <?php foreach ($this->containingLists as $i => $list): ?>
       <a href="<?=$this->url('userList', ['id' => $list['id']]) ?>" data-lightbox-ignore><?=$this->escapeHtml($list['title'])?></a><?php if ($i < count($this->containingLists) - 1): ?>, <?php endif; ?>
     <?php endforeach; ?>
-    </p><hr/>
+    </p><hr>
   <?php endif; ?>
 
   <?php /* Only display the list drop-down if the user has lists that do not contain
@@ -48,7 +48,7 @@
     <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
       <div class="form-group">
         <label class="control-label" for="add_mytags"><?=$this->transEsc('Add Tags') ?></label>
-        <input class="form-control" id="add_mytags" type="text" name="mytags" value=""/>
+        <input class="form-control" id="add_mytags" type="text" name="mytags" value="">
         <span class="help-block"><?=$this->transEsc("add_tag_note") ?></span>
       </div>
     <?php endif; ?>
@@ -57,7 +57,7 @@
       <textarea class="form-control" id="add_notes" name="notes" rows="3"></textarea>
     </div>
     <div class="form-group">
-      <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save') ?>"/>
+      <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Save') ?>">
     </div>
   <?php endif; ?>
 </form>

--- a/themes/bootstrap3/templates/record/sms.phtml
+++ b/themes/bootstrap3/templates/record/sms.phtml
@@ -18,12 +18,12 @@
 <h2><?=$this->transEsc('Text this') ?>: <span class="title-in-heading"><?=$this->escapeHtml($this->driver->getBreadcrumb())?></span></h2>
 <form method="post" name="smsRecord" class="form-record-sms"<?php if (isset($this->validation) && !empty($this->validation)):?> data-lightbox-onsubmit="phoneNumberValidation"<?php endif; ?>>
   <?=$this->flashmessages()?>
-  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" />
-  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" />
-  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf"/>
+  <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
+  <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
   <div class="form-group">
     <label class="control-label" for="sms_to"><?=$this->transEsc('Number')?>:</label>
-    <input id="sms_to" type="tel" name="to" value="<?=$this->escapeHtmlAttr($this->to)?>" placeholder="<?=$this->transEscAttr('sms_phone_number')?>" class="form-control"/>
+    <input id="sms_to" type="tel" name="to" value="<?=$this->escapeHtmlAttr($this->to)?>" placeholder="<?=$this->transEscAttr('sms_phone_number')?>" class="form-control">
     <div class="help-block with-errors"></div>
   </div>
   <?php if (is_array($this->carriers) && count($this->carriers) > 1): ?>
@@ -38,10 +38,10 @@
     </div>
   <?php else: ?>
     <?php $keys = is_array($this->carriers) ? array_keys($this->carriers) : []; ?>
-    <input type="hidden" name="provider" value="<?=$this->escapeHtmlAttr($keys[0] ?? '')?>" />
+    <input type="hidden" name="provider" value="<?=$this->escapeHtmlAttr($keys[0] ?? '')?>">
   <?php endif; ?>
   <?=$this->captcha()->html($this->useCaptcha) ?>
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Send Text')?>"/>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Send Text')?>">
   </div>
 </form>

--- a/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
@@ -33,11 +33,11 @@
     <div class="form-group">
       <div id="storageRetrievalRequestReference" class="storageRetrievalRequestReference">
         <label class="control-label"><?=$this->transEsc('storage_retrieval_request_volume')?>:</label>
-        <input type="text" name="gatheredDetails[volume]" value="<?=isset($this->gatheredDetails['volume']) ? $this->escapeHtmlAttr($this->gatheredDetails['volume']) : ''?>" class="form-control"/><br/>
+        <input type="text" name="gatheredDetails[volume]" value="<?=isset($this->gatheredDetails['volume']) ? $this->escapeHtmlAttr($this->gatheredDetails['volume']) : ''?>" class="form-control"><br>
         <label class="control-label"><?=$this->transEsc('storage_retrieval_request_issue')?>:</label>
-        <input type="text" name="gatheredDetails[issue]" value="<?=isset($this->gatheredDetails['issue']) ? $this->escapeHtmlAttr($this->gatheredDetails['issue']) : ''?>" class="form-control"/><br/>
+        <input type="text" name="gatheredDetails[issue]" value="<?=isset($this->gatheredDetails['issue']) ? $this->escapeHtmlAttr($this->gatheredDetails['issue']) : ''?>" class="form-control"><br>
         <label class="control-label"><?=$this->transEsc('storage_retrieval_request_year')?>:</label>
-        <input type="text" name="gatheredDetails[year]" value="<?=isset($this->gatheredDetails['year']) ? $this->escapeHtmlAttr($this->gatheredDetails['year']) : ''?>" class="form-control"/><br/>
+        <input type="text" name="gatheredDetails[year]" value="<?=isset($this->gatheredDetails['year']) ? $this->escapeHtmlAttr($this->gatheredDetails['year']) : ''?>" class="form-control"><br>
       </div>
     </div>
   <?php endif; ?>
@@ -45,7 +45,7 @@
   <?php if (in_array("requiredByDate", $this->extraFields)): ?>
     <div class="form-group">
       <label class="control-label"><?=$this->transEsc("hold_required_by")?>:</label>
-      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="8" class="form-control"/>
+      <input id="requiredByDate" type="text" name="gatheredDetails[requiredBy]" value="<?=(isset($this->gatheredDetails['requiredBy']) && !empty($this->gatheredDetails['requiredBy'])) ? $this->escapeHtmlAttr($this->gatheredDetails['requiredBy']) : $this->escapeHtmlAttr($this->defaultRequiredDate)?>" size="8" class="form-control">
       (<?=$this->dateTime()->getDisplayDateFormat()?>)
     </div>
   <?php endif; ?>
@@ -83,7 +83,7 @@
         </select>
       </div>
     <?php else: ?>
-      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>" />
+      <input type="hidden" name="gatheredDetails[pickUpLocation]" value="<?=$this->escapeHtmlAttr($this->defaultPickup)?>">
     <?php endif; ?>
   <?php endif; ?>
 
@@ -95,7 +95,7 @@
   <?php endif; ?>
 
   <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="placeStorageRetrievalRequest" value="<?=$this->transEscAttr('storage_retrieval_request_submit_text')?>"/>
+    <input class="btn btn-primary" type="submit" name="placeStorageRetrievalRequest" value="<?=$this->transEscAttr('storage_retrieval_request_submit_text')?>">
   </div>
 </form>
 

--- a/themes/bootstrap3/templates/record/taglist.phtml
+++ b/themes/bootstrap3/templates/record/taglist.phtml
@@ -6,7 +6,7 @@
         <a href="<?=$this->url('tag-home')?>?lookfor=<?=urlencode($tag['tag'])?>"><?=$this->escapeHtml($tag['tag'])?></a>
         <?php if ($loggedin): ?>
           <form method="POST" action="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, $is_me ? 'DeleteTag' : 'AddTag')) ?>" class="tag-form">
-            <input type="hidden" name="tag" value="<?=$this->escapeHtmlAttr($tag['tag'])?>"/>
+            <input type="hidden" name="tag" value="<?=$this->escapeHtmlAttr($tag['tag'])?>">
             <button type="submit" class="badge tag-submit" data-tag="<?=$this->escapeHtmlAttr($tag['tag'])?>" data-selected="<?=$is_me ? 'true' : 'false' ?>"><?=$this->escapeHtml($tag['cnt']) ?>
             <?php if ($is_me): ?>
               <?=$this->icon('tag-remove', ['title' => $this->translate('delete_tag')]) ?>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -36,8 +36,8 @@
 <div class="record source<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <?php $sidebarList = $this->related()->getList($this->driver); ?>
   <div class="<?=$this->layoutClass('mainbody')?><?=count($sidebarList) < 1 ? ' solo' : '' ?>">
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" />
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource" />
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId">
+    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
     <?=$this->flashmessages()?>
     <?=$this->record($this->driver)->getCoreMetadata()?>
 

--- a/themes/bootstrap3/templates/search/advanced/checkbox-filters.phtml
+++ b/themes/bootstrap3/templates/search/advanced/checkbox-filters.phtml
@@ -3,7 +3,7 @@
     <?php foreach ($this->checkboxFacets as $current): ?>
       <div class="checkbox">
         <label>
-          <input type="checkbox" name="filter[]" value="<?=$this->escapeHtmlAttr($current['filter'])?>" id="<?=$this->escapeHtmlAttr(str_replace(' ', '', $current['desc']))?>"<?php if ($current['selected']): ?> checked="checked"<?php endif; ?>/>
+          <input type="checkbox" name="filter[]" value="<?=$this->escapeHtmlAttr($current['filter'])?>" id="<?=$this->escapeHtmlAttr(str_replace(' ', '', $current['desc']))?>"<?php if ($current['selected']): ?> checked="checked"<?php endif; ?>>
           <?=$this->transEsc($current['desc'])?>
         </label>
       </div>

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -29,14 +29,14 @@
     <?php foreach ($this->limiterList as $field => $facet): ?>
       <?php switch($facet['Type']) {
           case 'multiselectvalue': ?>
-            <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>"><?=$this->transEsc($facet['Label'])?></label><br/>
+            <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>"><?=$this->transEsc($facet['Label'])?></label><br>
             <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-control">
               <?php foreach ($facet['LimiterValues'] as $id => $facetValue): ?>
                 <?php $value = $facetValue['Value']; ?>
                 <option value="<?='LIMIT|' . $this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
               <?php endforeach; ?>
             </select>
-            <!-- <br/> -->
+            <!-- <br> -->
             <?php break;
           case 'select':
             $value = $facet['LimiterValues'][0]['Value'] ?>
@@ -75,15 +75,15 @@
 <?php if (isset($this->dateRangeLimit)): ?>
   <fieldset class="eds">
     <legend><?=$this->transEsc('adv_search_year')?></legend>
-    <input type="hidden" name="daterange[]" value="PublicationDate"/>
+    <input type="hidden" name="daterange[]" value="PublicationDate">
     <div class="date-fields">
       <div class="date-from">
         <label for="PublicationDatefrom"><?=$this->transEsc('date_from')?>:</label>
-        <input type="text" name="PublicationDatefrom" id="PublicationDatefrom" value="<?=$this->escapeHtmlAttr($this->dateRangeLimit[0])?>" class="form-control"/>
+        <input type="text" name="PublicationDatefrom" id="PublicationDatefrom" value="<?=$this->escapeHtmlAttr($this->dateRangeLimit[0])?>" class="form-control">
       </div>
       <div class="date-to">
         <label for="PublicationDateto"><?=$this->transEsc('date_to')?>:</label>
-        <input type="text" name="PublicationDateto" id="PublicationDateto" value="<?=$this->escapeHtmlAttr($this->dateRangeLimit[1])?>" class="form-control"/>
+        <input type="text" name="PublicationDateto" id="PublicationDateto" value="<?=$this->escapeHtmlAttr($this->dateRangeLimit[1])?>" class="form-control">
       </div>
     </div>
     <div class="slider-container">

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -70,13 +70,13 @@
   <form name="searchForm" id="advSearchForm" method="get" action="<?=$this->url($this->options->getSearchAction())?>">
     <?php foreach ($hiddenFilters as $key => $filter): ?>
       <?php foreach ($filter as $value): ?>
-        <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr($value)?>" />
+        <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr($value)?>">
       <?php endforeach; ?>
     <?php endforeach; ?>
     <div class="<?=$this->layoutClass('mainbody')?>">
       <?php $lastSort = $this->searchMemory()->getLastSort($this->searchClassId); ?>
       <?php if (!empty($lastSort)): ?>
-        <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>" />
+        <input type="hidden" name="sort" value="<?=$this->escapeHtmlAttr($lastSort)?>">
       <?php endif; ?>
       <div class="clearfix">
         <h2 class="pull-left flip"><?=$this->transEsc('Advanced Search')?></h2>
@@ -168,13 +168,13 @@
 
     <div class="<?=$this->layoutClass('sidebar')?>">
       <?php if ($hasDefaultsApplied): ?>
-        <input type="hidden" name="dfApplied" value="1" />
+        <input type="hidden" name="dfApplied" value="1">
       <?php endif ?>
       <?php if ($checkboxFilters || $searchFilters): ?>
         <h2><?=$this->transEsc("adv_search_filters")?></h2>
         <div class="facet-group">
           <label class="checkbox">
-            <input type="checkbox" checked="checked" class="checkbox-select-all"/>
+            <input type="checkbox" checked="checked" class="checkbox-select-all">
             <?=$this->transEsc("adv_search_select_all")?>
           </label>
         </div>
@@ -183,7 +183,7 @@
           <div class="checkboxFilter">
             <?php foreach ($checkboxFilters as $data): ?>
               <div class="checkbox-filter">
-                <label class="facet checkbox"><input class="checkbox-select-item" type="checkbox" checked="checked" name="filter[]" value="<?=$this->escapeHtmlAttr($data['filter'])?>" /> <?=$this->transEsc($data['desc'])?></label>
+                <label class="facet checkbox"><input class="checkbox-select-item" type="checkbox" checked="checked" name="filter[]" value="<?=$this->escapeHtmlAttr($data['filter'])?>"> <?=$this->transEsc($data['desc'])?></label>
               </div>
             <?php endforeach; ?>
           </div>
@@ -193,7 +193,7 @@
           <div class="facet-group">
             <div class="title"><?=$this->transEsc($field)?></div>
             <?php foreach ($data as $value): ?>
-              <label class="facet checkbox"><input class="checkbox-select-item" type="checkbox" checked="checked" name="filter[]" value='<?=$this->escapeHtmlAttr($value['field'])?>:"<?=$this->escapeHtmlAttr($value['value'])?>"' /> <?=$this->escapeHtml($value['displayText'])?></label>
+              <label class="facet checkbox"><input class="checkbox-select-item" type="checkbox" checked="checked" name="filter[]" value='<?=$this->escapeHtmlAttr($value['field'])?>:"<?=$this->escapeHtmlAttr($value['value'])?>"'> <?=$this->escapeHtml($value['displayText'])?></label>
             <?php endforeach; ?>
           </div>
         <?php endforeach; ?>

--- a/themes/bootstrap3/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap3/templates/search/advanced/ranges.phtml
@@ -4,15 +4,15 @@
     <?php $extraInputAttribs = ($current['type'] == 'date') ? 'maxlength="4" ' : ''; ?>
     <fieldset class="range" id="<?=$escField?>-range-container">
       <legend><?=$this->transEsc($params->getFacetLabel($current['field']))?></legend>
-      <input type="hidden" name="<?=$this->escapeHtmlAttr($current['type'])?>range[]" value="<?=$escField?>"/>
+      <input type="hidden" name="<?=$this->escapeHtmlAttr($current['type'])?>range[]" value="<?=$escField?>">
       <div class="date-fields">
         <div class="date-from">
           <label for="<?=$escField?>from" id="<?=$escField?>from-label"><?=$this->transEsc('date_from')?>:</label>
-          <input type="text" name="<?=$escField?>from" id="<?=$escField?>from" value="<?=isset($current['values'][0]) ? $this->escapeHtmlAttr($current['values'][0]) : ''?>" class="form-control" <?=$extraInputAttribs?>/>
+          <input type="text" name="<?=$escField?>from" id="<?=$escField?>from" value="<?=isset($current['values'][0]) ? $this->escapeHtmlAttr($current['values'][0]) : ''?>" class="form-control" <?=$extraInputAttribs?>>
         </div>
         <div class="date-to">
           <label for="<?=$escField?>to" id="<?=$escField?>to-label"><?=$this->transEsc('date_to')?>:</label>
-          <input type="text" name="<?=$escField?>to" id="<?=$escField?>to" value="<?=isset($current['values'][1]) ? $this->escapeHtmlAttr($current['values'][1]) : ''?>" class="form-control" <?=$extraInputAttribs?>/>
+          <input type="text" name="<?=$escField?>to" id="<?=$escField?>to" value="<?=isset($current['values'][1]) ? $this->escapeHtmlAttr($current['values'][1]) : ''?>" class="form-control" <?=$extraInputAttribs?>>
         </div>
       </div>
       <?php if ($current['type'] == 'date'): ?>

--- a/themes/bootstrap3/templates/search/advanced/solr.phtml
+++ b/themes/bootstrap3/templates/search/advanced/solr.phtml
@@ -62,8 +62,8 @@
   <fieldset class="solr">
     <legend><?=$this->transEsc("Illustrated")?>:</legend>
     <?php foreach ($this->illustratedLimit as $current): ?>
-      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected'] ? ' checked="checked" data-checked-by-default="true"' : ''?>/>
-      <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br/>
+      <input id="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>" type="radio" name="illustration" value="<?=$this->escapeHtmlAttr($current['value'])?>"<?=$current['selected'] ? ' checked="checked" data-checked-by-default="true"' : ''?>>
+      <label for="illustrated_<?=$this->escapeHtmlAttr($current['value'])?>"><?=$this->transEsc($current['text'])?></label><br>
     <?php endforeach; ?>
   </fieldset>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/search/bulk-action-buttons.phtml
@@ -1,7 +1,7 @@
 <?php if (isset($this->showCheckboxes) && $this->showCheckboxes): ?>
   <nav class="bulkActionButtons">
     <div class="bulk-checkbox">
-      <input type="checkbox" class="checkbox-select-all" name="selectAll" id="<?=$this->idPrefix?>addFormCheckboxSelectAll"<?php if ($this->formAttr): ?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>/>
+      <input type="checkbox" class="checkbox-select-all" name="selectAll" id="<?=$this->idPrefix?>addFormCheckboxSelectAll"<?php if ($this->formAttr): ?> form="<?=$this->escapeHtmlAttr($this->formAttr) ?>"<?php endif; ?>>
       <label for="<?=$this->idPrefix?>addFormCheckboxSelectAll">
         <?=$this->transEsc('select_page')?>
         &#124; <?=$this->transEsc('with_selected')?>:

--- a/themes/bootstrap3/templates/search/controls/limit.phtml
+++ b/themes/bootstrap3/templates/search/controls/limit.phtml
@@ -8,6 +8,6 @@
         <option value="<?=$this->escapeHtmlAttr($limitVal)?>"<?=$limitData['selected'] ? ' selected="selected"' : ''?>><?=$this->escapeHtml($limitData['desc'])?></option>
       <?php endforeach; ?>
     </select>
-    <noscript><input type="submit" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+    <noscript><input type="submit" value="<?=$this->transEscAttr("Set")?>"></noscript>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/controls/sort.phtml
+++ b/themes/bootstrap3/templates/search/controls/sort.phtml
@@ -7,6 +7,6 @@
         <option value="<?=$this->escapeHtmlAttr($sortType)?>"<?=$sortData['selected'] ? ' selected="selected"' : ''?>><?=$this->transEsc($sortData['desc'])?></option>
       <?php endforeach; ?>
     </select>
-    <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>" /></noscript>
+    <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr("Set")?>"></noscript>
   </form>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/email.phtml
+++ b/themes/bootstrap3/templates/search/email.phtml
@@ -9,6 +9,6 @@
 <h2><?=$this->transEsc('Email this Search') ?></h2>
 <?=$this->flashmessages()?>
 <form class="form-search-email" method="post" name="emailSearch">
-  <input type="hidden" name="url" value="<?=$this->escapeHtmlAttr($this->url)?>" />
+  <input type="hidden" name="url" value="<?=$this->escapeHtmlAttr($this->url)?>">
   <?=$this->render('Helpers/email-form-fields.phtml')?>
 </form>

--- a/themes/bootstrap3/templates/search/history-table.phtml
+++ b/themes/bootstrap3/templates/search/history-table.phtml
@@ -25,12 +25,12 @@
         <?php foreach ($info->getParams()->getFilterList(true) as $field => $filters): ?>
           <?php foreach ($filters as $i => $filter): ?>
             <?php if ($filter['operator'] == 'NOT') echo $this->transEsc('NOT') . ' '; if ($filter['operator'] == 'OR' && $i > 0) echo $this->transEsc('OR') . ' '; ?>
-            <strong><?=$this->transEsc($field)?></strong>: <?=$this->escapeHtml($filter['displayText'])?><br/>
+            <strong><?=$this->transEsc($field)?></strong>: <?=$this->escapeHtml($filter['displayText'])?><br>
           <?php endforeach; ?>
         <?php endforeach; ?>
         <?php foreach ($info->getParams()->getCheckboxFacets() as $facet): ?>
           <?php if ($facet['selected']): ?>
-            <strong><?=$this->transEsc($facet['desc'])?></strong><br/>
+            <strong><?=$this->transEsc($facet['desc'])?></strong><br>
           <?php endif; ?>
         <?php endforeach; ?>
       </td>
@@ -45,7 +45,7 @@
                   <option value="<?=$this->escapeHtmlAttr($scheduleValue)?>"<?=($schedule == $scheduleValue) ? (' selected') : ('')?>><?=$this->transEsc($scheduleLabel)?></option>
                 <?php endforeach; ?>
               </select>
-              <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($info->getSearchId()) ?>"/>
+              <input type="hidden" name="searchid" value="<?=$this->escapeHtmlAttr($info->getSearchId()) ?>">
             </form>
           <?php else: ?>
             <span class="disable"><?=$this->transEsc("cannot set")?></span>

--- a/themes/bootstrap3/templates/search/list-grid.phtml
+++ b/themes/bootstrap3/templates/search/list-grid.phtml
@@ -4,9 +4,9 @@
     <?=$this->record($current)->getSearchResult('grid', $this->results)?>
     <?php $it++; ?>
     <?php if ($it % 4 === 0): ?>
-      <br class="grid-large-break"/>
+      <br class="grid-large-break">
     <?php elseif ($it % 2 === 0): ?>
-      <br class="grid-small-break"/>
+      <br class="grid-small-break">
     <?php endif; ?>
   <?php endforeach; ?>
 </div>

--- a/themes/bootstrap3/templates/search/newitem.phtml
+++ b/themes/bootstrap3/templates/search/newitem.phtml
@@ -18,7 +18,7 @@
     <div class="btn-group" data-toggle="buttons">
       <?php foreach ($this->ranges as $key => $range): ?>
         <label class="btn btn-primary<?php if ($key == 0): ?> active<?php endif ?>">
-          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked"' : ''?>/>
+          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked"' : ''?>>
           <?=($range == 1) ? $this->transEsc('Yesterday') : $this->transEsc('past_days', ['%%range%%' => $this->escapeHtml($range)])?>
         </label>
       <?php endforeach; ?>
@@ -34,5 +34,5 @@
       </select>
     </div>
   <?php endif; ?>
-  <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>"/>
+  <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>">
 </form>

--- a/themes/bootstrap3/templates/search/reserves.phtml
+++ b/themes/bootstrap3/templates/search/reserves.phtml
@@ -22,7 +22,7 @@
             <option value="<?=$this->escapeHtmlAttr($courseId)?>"><?=$this->escapeHtml($courseName)?></option>
           <?php endforeach; ?>
         </select>
-        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>"/>
+        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>">
       </div>
     <?php endif; ?>
 
@@ -35,7 +35,7 @@
             <option value="<?=$this->escapeHtmlAttr($instId)?>"><?=$this->escapeHtml($instName)?></option>
           <?php endforeach; ?>
         </select>
-        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>"/>
+        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>">
       </div>
     <?php endif; ?>
 
@@ -48,7 +48,7 @@
             <option value="<?=$this->escapeHtmlAttr($deptId)?>"><?=$this->escapeHtml($deptName)?></option>
           <?php endforeach; ?>
         </select>
-        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>"/>
+        <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>">
       </div>
     <?php endif; ?>
   </form>

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -15,8 +15,8 @@
   <h3><?=$this->transEsc('Search For Items on Reserve')?></h3>
   <form class="form-inline" method="get" name="reservesSearchForm">
     <label for="reservesSearchForm_lookfor"><?=$this->transEsc("Your search terms")?></label>
-    <input id="reservesSearchForm_lookfor" type="text" name="lookfor" size="40" value="<?=$this->escapeHtmlAttr($reservesLookfor)?>" <?=$this->searchOptions('SolrReserves')->autocompleteEnabled() ? ' class="autocomplete searcher:SolrReserves type:Reserves"' : ''?> />
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr("Find")?>"/>
+    <input id="reservesSearchForm_lookfor" type="text" name="lookfor" size="40" value="<?=$this->escapeHtmlAttr($reservesLookfor)?>" <?=$this->searchOptions('SolrReserves')->autocompleteEnabled() ? ' class="autocomplete searcher:SolrReserves type:Reserves"' : ''?>>
+    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr("Find")?>">
   </form>
   <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, "$('#reservesSearchForm_lookfor').focus()", 'SET')?>
 

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -70,7 +70,7 @@
   <form id="searchForm" class="searchForm navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" autocomplete="off">
     <?= $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $tabConfig['tabs'], 'showCounts' => $tabConfig['showCounts']]); ?>
     <?php $placeholder = $this->searchbox()->getPlaceholderText($tabConfig['selected']['id'] ?? null); ?>
-    <input id="searchForm_lookfor" class="searchForm_lookfor form-control search-query<?php if ($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><?=$this->searchbox()->autocompleteAutoSubmit($this->searchClassId) ? ' ac-auto-submit' : '' ?><?php endif ?>" type="search" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"<?php if ($placeholder): ?> placeholder="<?=$this->transEscAttr($placeholder) ?>"<?php endif ?> aria-label="<?=$this->transEscAttr("search_terms")?>" />
+    <input id="searchForm_lookfor" class="searchForm_lookfor form-control search-query<?php if ($this->searchbox()->autocompleteEnabled($this->searchClassId)):?> autocomplete searcher:<?=$this->escapeHtmlAttr($this->searchClassId) ?><?=$this->searchbox()->autocompleteAutoSubmit($this->searchClassId) ? ' ac-auto-submit' : '' ?><?php endif ?>" type="search" name="lookfor" value="<?=$this->escapeHtmlAttr($this->lookfor)?>"<?php if ($placeholder): ?> placeholder="<?=$this->transEscAttr($placeholder) ?>"<?php endif ?> aria-label="<?=$this->transEscAttr("search_terms")?>">
     <?php if ($handlerCount > 1): ?>
       <select id="searchForm_type" class="searchForm_type form-control" name="type" data-native-menu="false" aria-label="<?=$this->transEscAttr("Search type")?>">
         <?php $currentGroup = $insideGroup = false; ?>
@@ -96,7 +96,7 @@
         <?php endif; ?>
       </select>
     <?php elseif ($handlerCount == 1): ?>
-      <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($handlers[0]['value'])?>" />
+      <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($handlers[0]['value'])?>">
     <?php endif; ?>
     <button type="submit" class="btn btn-primary"><?=$this->icon('search') ?> <?=$this->transEsc("Find")?></button>
     <?php if ($advSearch): ?>
@@ -114,38 +114,38 @@
       <?php
       $selectedShards = $this->selectedShards ?? $options->getDefaultSelectedShards();
       ?>
-      <br />
+      <br>
       <?php foreach ($shards as $shard => $val): ?>
         <?php $isSelected = empty($selectedShards) || in_array($shard, $selectedShards); ?>
-          <input type="checkbox" <?=$isSelected ? 'checked="checked" ' : ''?>name="shard[]" value='<?=$this->escapeHtmlAttr($shard)?>' /> <?=$this->transEsc($shard)?>
+          <input type="checkbox" <?=$isSelected ? 'checked="checked" ' : ''?>name="shard[]" value='<?=$this->escapeHtmlAttr($shard)?>'> <?=$this->transEsc($shard)?>
       <?php endforeach; ?>
     <?php endif; ?>
     <?php if (($hasDefaultsApplied ?? false) || !empty($filterDetails)): ?>
       <?php if ($options->getRetainFilterSetting()): ?>
         <?php foreach ($filterDetails as $current): ?>
-          <input class="applied-filter" id="<?=$this->escapeHtmlAttr($current['id'])?>" type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($current['value'])?>" />
+          <input class="applied-filter" id="<?=$this->escapeHtmlAttr($current['id'])?>" type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($current['value'])?>">
         <?php endforeach; ?>
         <?php if ($hasDefaultsApplied ?? false): ?>
-          <input class="applied-filter" id="dfApplied" type="hidden" name="dfApplied" value="1" />
+          <input class="applied-filter" id="dfApplied" type="hidden" name="dfApplied" value="1">
         <?php endif; ?>
       <?php endif; ?>
     <?php endif; ?>
     <?php foreach ($hiddenFilters as $key => $filter): ?>
       <?php foreach ($filter as $value): ?>
-        <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr('"' . $value . '"')?>" />
+        <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr('"' . $value . '"')?>">
       <?php endforeach; ?>
     <?php endforeach; ?>
     <?php
       /* Show hidden field for active search class when in combined handler mode. */
       if ($this->searchbox()->combinedHandlersActive()) {
-        echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '" />';
+        echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '">';
       }
       /* Load hidden limit preference from Session */
       if (!empty($lastLimit)) {
-        echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '" />';
+        echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '">';
       }
       if (!empty($lastSort)) {
-        echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '" />';
+        echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '">';
       }
     ?>
     <?=$this->context($this)->renderInContext(

--- a/themes/bootstrap3/templates/upgrade/criticalfixblowfish.phtml
+++ b/themes/bootstrap3/templates/upgrade/criticalfixblowfish.phtml
@@ -61,7 +61,7 @@ activate = 1</pre>
 				<li>Refresh this page or <a href="#conversion">move on to the conversion step below</a>.</li>
 			</ol>
 
-			<hr/>
+			<hr>
 
 			<p>Here is a complete example of the changes you will need to make to your OpenSSL configuration file.</p>
 

--- a/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
@@ -18,11 +18,11 @@ an administrator) to associate with old anonymous tags.</p>
 
 <p>See <a target="_jira" href="https://vufind.org/jira/browse/VUFIND-217">https://vufind.org/jira/browse/VUFIND-217</a> for more details.</p>
 
-<br />
+<br>
 
 <form method="post" action="<?=$this->url('upgrade-fixanonymoustags')?>">
-  <?=$this->transEsc('Username') ?>: <input type="text" name="username" /> <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>" /><br /><br />
-  <input type="submit" name="skip" id="skip" value="<?=$this->transEscAttr('skip_step') ?>." />
+  <?=$this->transEsc('Username') ?>: <input type="text" name="username"> <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>"><br><br>
+  <input type="submit" name="skip" id="skip" value="<?=$this->transEscAttr('skip_step') ?>.">
 </form>
 <?php
 $skipText = $this->transEsc('skip_confirm');

--- a/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
@@ -17,11 +17,11 @@ otherwise, it is recommended that you fix these.  Click Submit to proceed.</p>
 
 <p>See <a target="_jira" href="https://vufind.org/jira/browse/VUFIND-805">https://vufind.org/jira/browse/VUFIND-805</a> and <a target="_jira" href="https://vufind.org/jira/browse/VUFIND-1187">https://vufind.org/jira/browse/VUFIND-1187</a> for more details.</p>
 
-<br />
+<br>
 
 <form method="post" action="<?=$this->url('upgrade-fixduplicatetags')?>">
-  <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>" /><br /><br />
-  <input type="submit" name="skip" value="<?=$this->transEscAttr('skip_step') ?>." id="skip" />
+  <input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>"><br><br>
+  <input type="submit" name="skip" value="<?=$this->transEscAttr('skip_step') ?>." id="skip">
 </form>
 <?php
 $confirmText = $this->transEsc('skip_confirm');

--- a/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
@@ -11,11 +11,11 @@
 <p>Some of the items in your resource table appear to be missing metadata.  Adding this metadata may take some time,
 but it will improve the user experience by allowing proper sorting of favorites and tagged records.</p>
 
-<br />
+<br>
 
 <form method="post" action="<?=$this->url('upgrade-fixmetadata')?>">
-  <input type="submit" name="submit" value="<?=$this->transEscAttr('fix_metadata') ?>." /><br /><br />
-  <input type="submit" name="skip" value="<?=$this->transEscAttr('skip_fix_metadata') ?>." id="skip" />
+  <input type="submit" name="submit" value="<?=$this->transEscAttr('fix_metadata') ?>."><br><br>
+  <input type="submit" name="skip" value="<?=$this->transEscAttr('skip_fix_metadata') ?>." id="skip">
 </form>
 <?php
 $confirmText = $this->transEsc('skip_confirm');

--- a/themes/bootstrap3/templates/upgrade/getdbcredentials.phtml
+++ b/themes/bootstrap3/templates/upgrade/getdbcredentials.phtml
@@ -14,10 +14,10 @@ with permission to alter and create tables.</p>
 <form method="post" action="<?=$this->url('upgrade-getdbcredentials')?>">
   <table>
     <tbody>
-      <tr><td>MySQL Root User: </td><td><input type="text" name="dbrootuser" value="<?=$this->escapeHtmlAttr($this->dbrootuser)?>"/></td></tr>
-      <tr><td>MySQL Root Password: </td><td><input type="password" name="dbrootpass" value=""/></td></tr>
-      <tr><td></td><td><input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>" /></td></tr>
+      <tr><td>MySQL Root User: </td><td><input type="text" name="dbrootuser" value="<?=$this->escapeHtmlAttr($this->dbrootuser)?>"></td></tr>
+      <tr><td>MySQL Root Password: </td><td><input type="password" name="dbrootpass" value=""></td></tr>
+      <tr><td></td><td><input type="submit" name="submit" value="<?=$this->transEscAttr('Submit') ?>"></td></tr>
     </tbody>
   </table>
-  If you don't have the credentials or you wish to print the SQL out : Click here to <input type="submit" name="printsql" value="Skip" /> credentials.
+  If you don't have the credentials or you wish to print the SQL out : Click here to <input type="submit" name="printsql" value="Skip"> credentials.
 </form>

--- a/themes/bootstrap3/templates/upgrade/getsourcedir.phtml
+++ b/themes/bootstrap3/templates/upgrade/getsourcedir.phtml
@@ -10,20 +10,20 @@
 <h3>Option 1: Upgrade from VuFind 1.x</h3>
 <p>Please enter the full path of the directory containing your previous version of VuFind (e.g. /usr/local/vufind):</p>
 <form class="form-inline" method="post" action="<?=$this->url('upgrade-getsourcedir')?>">
-  <input type="text" name="sourcedir" /> <input class="btn btn-primary" type="submit" />
+  <input type="text" name="sourcedir"> <input class="btn btn-primary" type="submit">
 </form>
-<hr />
+<hr>
 <h3>Option 2: Upgrade from VuFind 2.x or newer</h3>
 <form class="form-inline" method="post" action="<?=$this->url('upgrade-getsourceversion')?>">
   <p>
     Please enter the version number you are upgrading from (e.g. 2.0.1):
-    <input type="text" name="sourceversion" />
+    <input type="text" name="sourceversion">
   </p>
-  <p>Options:<br />
+  <p>Options:<br>
   <?php foreach (['config' => 'Configuration', 'database' => 'Database Structure', 'metadata' => 'Stored Metadata'] as $key => $value): ?>
-    <input type="checkbox" name="skip[]" id="skip-<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($key)?>" />
-    <label for="skip-<?=$this->escapeHtmlAttr($key)?>">Skip <?=$this->escapeHtml($value); ?> Upgrade</label><br />
+    <input type="checkbox" name="skip[]" id="skip-<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($key)?>">
+    <label for="skip-<?=$this->escapeHtmlAttr($key)?>">Skip <?=$this->escapeHtml($value); ?> Upgrade</label><br>
   <?php endforeach; ?>
   </p>
-  <input class="btn btn-primary" type="submit" />
+  <input class="btn btn-primary" type="submit">
 </form>

--- a/themes/bootstrap3/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap3/templates/upgrade/showsql.phtml
@@ -19,5 +19,5 @@
 <textarea class="pre" rows="20"><?=trim($this->sql) ?></textarea>
 
 <form method="post" action="<?=$this->url('upgrade-showsql')?>">
-  <input class="btn btn-primary" type="submit" name="continue" value="Next" />
+  <input class="btn btn-primary" type="submit" name="continue" value="Next">
 </form>

--- a/themes/root/templates/Captcha/image.phtml
+++ b/themes/root/templates/Captcha/image.phtml
@@ -3,6 +3,6 @@
   $id = $laminasCaptcha->generate();
 ?>
 <img src="<?=$this->captcha->getCacheBasePath() . $id . $laminasCaptcha->getSuffix();?>">
-<br/><br/>
+<br><br>
 <p><label for="<?=$this->captcha->getHtmlInputId()?>"><?=$this->transEsc('captcha_label_input')?></label> <input name="<?=$this->captcha->getHtmlInputId()?>" id="<?=$this->captcha->getHtmlInputId()?>"></p>
 <input type="hidden" name="<?=$this->captcha->getHtmlInternalId()?>" value="<?=$this->escapeHtmlAttr($id)?>">

--- a/themes/root/templates/HelpTranslations/pl/advsearch.phtml
+++ b/themes/root/templates/HelpTranslations/pl/advsearch.phtml
@@ -10,21 +10,21 @@
   <dd>
     <p>Po pierwszym otwarciu wyszukiwania zaawansowanego ukazuja sie rózne pola wyszukiwawcze. W kazdym polu mozesz wpisac wyrazenie wyszukiwawcze. Dozwolone sa nastepujace:
         <a href="?topic=search#wildcard_searches">operatory wyszukiwawcze</a>.
-      </p><br />
-    <p>Kazde pole posiada rozwijane menu, przy pomocy którego mozesz szczególowo okreslic wyrazenie wyszukiwawcze (np. autor, tytul). Mozesz takze specyfikowac i kombinowac wyszukiwania.</p><br />
+      </p><br>
+    <p>Kazde pole posiada rozwijane menu, przy pomocy którego mozesz szczególowo okreslic wyrazenie wyszukiwawcze (np. autor, tytul). Mozesz takze specyfikowac i kombinowac wyszukiwania.</p><br>
     <p>Przy pomocy ustawienia "zgodnosci" mozesz okreslic, jak maja byc traktowane poszczególne pola wyszukiwawcze.</p>
     <ul>
       <li>Ze WSZYSTKIMI slowami – daje wynik zawierajacy wszystkie podane slowa (odpowiada logicznemu operatorowi AND).</li>
       <li>Z JAKIMKOLWIEK slowem – daje wynik zawierajacy przynajmniej jedno z podanych slów (odpowiada logicznemu opratorowi OR).</li>
       <li>BEZ slów – daje wynik, który nie zawiera podanych slów (odpowiada logicznemu opratorowi NOT).</li>
-    </ul><br />
+    </ul><br>
     <p>Poprzez klikniecie na przycisk "Dodaj pole wyszukiwawcze" mozesz dodac dalsze pola wyszukiwawcze.</p>
   </dd>
 
   <dt><a id="search_groups"></a>Grupy wyszukiwawcze</dt>
   <dd>
-    <p>Niektóre rodzaje wyszukiwania sa bardziej skomplikowane i wyszukiwanie proste nie wystarcza. Przyklad: wyszukiwanie tytulów na temat historii Indii i Chin. Jesli wpiszesz te slowa wyszukiwawcze w pole „Ze WSZYSTKIMI slowami", otrzymasz tylko te tytuly, które opisuja historie Indii i Chin. Jesli uzyjesz pola "Z JAKIMKOLWIEK slowem” otrzymasz takze tytuly, które nie maja nic wspólnego z Chinami i Indiami.</p><br />
-    <p>Za pomoca grup wyszukiwania mozna pola wyszukiwawcze grupowac do jednego wyszukiwania. Za kazdym razem, przy kliknieciu "dodac grupe" dodaje sie nowa grupe z polami wyszukiwawczymi. Grupy mozna tez za pomoca klikniecia "zbiór wyszukiwawczy usunac" z procesu wyszukiwania usunac. Za pomoca klikniecia "WSZYSTKIE" albo "JAKAKOLWIEK" mozna ustalic, czy do wyszukiwania maja byc brane pod uwage wszystkie zbiory, czy jakikolwiek zbiór.<br />
+    <p>Niektóre rodzaje wyszukiwania sa bardziej skomplikowane i wyszukiwanie proste nie wystarcza. Przyklad: wyszukiwanie tytulów na temat historii Indii i Chin. Jesli wpiszesz te slowa wyszukiwawcze w pole „Ze WSZYSTKIMI slowami", otrzymasz tylko te tytuly, które opisuja historie Indii i Chin. Jesli uzyjesz pola "Z JAKIMKOLWIEK slowem” otrzymasz takze tytuly, które nie maja nic wspólnego z Chinami i Indiami.</p><br>
+    <p>Za pomoca grup wyszukiwania mozna pola wyszukiwawcze grupowac do jednego wyszukiwania. Za kazdym razem, przy kliknieciu "dodac grupe" dodaje sie nowa grupe z polami wyszukiwawczymi. Grupy mozna tez za pomoca klikniecia "zbiór wyszukiwawczy usunac" z procesu wyszukiwania usunac. Za pomoca klikniecia "WSZYSTKIE" albo "JAKAKOLWIEK" mozna ustalic, czy do wyszukiwania maja byc brane pod uwage wszystkie zbiory, czy jakikolwiek zbiór.<br>
     </p>
     <p>Do wyzej opisanego przykladu mozna wyszukiwanie za pomoca grup wyszukiwawczych rozwiazac nastepujaco:</p>
     <ul>

--- a/themes/root/templates/search/opensearch-describe.phtml
+++ b/themes/root/templates/search/opensearch-describe.phtml
@@ -6,7 +6,7 @@
   <Description><?=$this->transEsc('Library Catalog Search')?></Description>
   <Image height="16" width="16" type="image/png"><?=$this->serverUrl($this->imageLink('vufind-favicon.png'))?></Image>
   <Contact><?=$this->escapeHtml($this->site->email)?></Contact>
-  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}"/>
-  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss"/>
-  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON"/>
+  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}">
+  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss">
+  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON">
 </OpenSearchDescription>

--- a/themes/root/templates/search/opensearch-describe.phtml
+++ b/themes/root/templates/search/opensearch-describe.phtml
@@ -6,7 +6,7 @@
   <Description><?=$this->transEsc('Library Catalog Search')?></Description>
   <Image height="16" width="16" type="image/png"><?=$this->serverUrl($this->imageLink('vufind-favicon.png'))?></Image>
   <Contact><?=$this->escapeHtml($this->site->email)?></Contact>
-  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}">
-  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss">
-  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON">
+  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}" />
+  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss" />
+  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON" />
 </OpenSearchDescription>

--- a/themes/root/templates/search/opensearch-describe.phtml
+++ b/themes/root/templates/search/opensearch-describe.phtml
@@ -6,7 +6,7 @@
   <Description><?=$this->transEsc('Library Catalog Search')?></Description>
   <Image height="16" width="16" type="image/png"><?=$this->serverUrl($this->imageLink('vufind-favicon.png'))?></Image>
   <Contact><?=$this->escapeHtml($this->site->email)?></Contact>
-  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}" />
-  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss" />
-  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON" />
+  <Url type="text/html" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;page={startPage?}"/>
+  <Url type="application/rss+xml" method="get" template="<?=$searchBase?>?lookfor={searchTerms}&amp;view=rss"/>
+  <Url type="application/x-suggestions+json" method="get" template="<?=$suggestions?>?lookfor={searchTerms}&amp;format=JSON"/>
 </OpenSearchDescription>


### PR DESCRIPTION
This fixes HTML validation warning "Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."

This also improves consistency.