### PR TITLE
Enable NFC normalization of test records to avoid warnings.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -674,7 +674,7 @@ ${git_status}
     <append destFile="${localdir}/import/marc-${BASENAME}.properties" text="building=&quot;${BASENAME}&quot;${line.separator}" />
 
     <copy file="${localdir}/import/import.properties" tofile="${localdir}/import/import-${BASENAME}.properties" />
-    <!-- normalize UTF-8 to avoid HTML validation problems -->
+    <!-- normalize Unicode to avoid HTML validation warnings -->
     <append destFile="${localdir}/import/import-${BASENAME}.properties" text="marc.unicode_normalize = C${line.separator}" />
     <reflexive>
       <fileset dir="${localdir}/import">

--- a/build.xml
+++ b/build.xml
@@ -674,6 +674,7 @@ ${git_status}
     <append destFile="${localdir}/import/marc-${BASENAME}.properties" text="building=&quot;${BASENAME}&quot;${line.separator}" />
 
     <copy file="${localdir}/import/import.properties" tofile="${localdir}/import/import-${BASENAME}.properties" />
+    <append destFile="${localdir}/import/import-${BASENAME}.properties" text="marc.unicode_normalize = C${line.separator}" />
     <reflexive>
       <fileset dir="${localdir}/import">
         <include pattern="import-${BASENAME}.properties" />

--- a/build.xml
+++ b/build.xml
@@ -674,6 +674,7 @@ ${git_status}
     <append destFile="${localdir}/import/marc-${BASENAME}.properties" text="building=&quot;${BASENAME}&quot;${line.separator}" />
 
     <copy file="${localdir}/import/import.properties" tofile="${localdir}/import/import-${BASENAME}.properties" />
+    <!-- normalize UTF-8 to avoid HTML validation problems -->
     <append destFile="${localdir}/import/import-${BASENAME}.properties" text="marc.unicode_normalize = C${line.separator}" />
     <reflexive>
       <fileset dir="${localdir}/import">


### PR DESCRIPTION
Non-NFC UNICODE results in the following message from HTML validator in many tests: "Text run is not in Unicode Normalization Form C"