### PR TITLE
Update Vagrantfile for release 9.0.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://app.vagrantup.com/boxes/search
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y git zip unzip apache2 default-jdk mysql-server
-    apt-get install -y libapache2-mod-php php-mbstring php-pear php php-dev php-gd php-intl php-json php-ldap php-mysql php-soap php-xml php-curl
+    apt-get install -y libapache2-mod-php php-pear php php-curl php-dev php-gd php-intl php-json php-ldap php-mbstring php-mysql php-soap php-xml
 
     # Install composer.
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"


### PR DESCRIPTION
This PR updates the Ubuntu version in the Vagrantfile for compatibility with VuFind 9 dependencies. It also reorganizes some package names for consistency with the .deb file configuration, to make future synchronization/maintenance easier.

TODO
- [x] Test that this actually works