### PR TITLE
Improve npm script verbage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,17 +12,18 @@
   "scripts": {
     "build": "npm run build:css",
     "watch": "npm run watch:css",
-    "dev": "npm run dev:css",
+    "build-dev": "npm run build-dev:css",
+    "watch-dev": "npm run watch-dev:css",
 
     "build:css": "npm run build:less",
     "watch:css": "npm run watch:less",
-    "dev:css": "npm run dev:less",
+    "build-dev:css": "npm run build-dev:less",
+    "watch-dev:css": "npm run watch-dev:less",
 
     "build:less": "grunt less && npm run lessToSass",
-    "build:lessdev": "grunt lessdev",
-    "dev:less": "grunt watch:lessdev && npm run watch:lessToSass",
-    "watch:less": "grunt watch:less",
-    "watch:lessdev": "grunt watch:lessdev",
+    "watch:less": "grunt watch:less && npm run watch:lessToSass",
+    "build-dev:less": "grunt lessdev && npm run lessToSass",
+    "watch-dev:less": "grunt watch:lessdev && npm run watch:lessToSass",
 
     "build:scss": "grunt scss",
     "watch:scss": "grunt watch:scss",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
   "scripts": {
     "build": "npm run build:css",
     "watch": "npm run watch:css",
+    "dev": "npm run dev:css",
 
     "build:css": "npm run build:less",
     "watch:css": "npm run watch:less",
+    "dev:css": "npm run dev:less",
 
     "build:less": "grunt less",
     "build:lessdev": "grunt lessdev",
+    "dev:less": "grunt watch:lessdev && npm run watch:lessToSass",
     "watch:less": "grunt watch:less",
     "watch:lessdev": "grunt watch:lessdev",
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watch:css": "npm run watch:less",
     "dev:css": "npm run dev:less",
 
-    "build:less": "grunt less",
+    "build:less": "grunt less && npm run lessToSass",
     "build:lessdev": "grunt lessdev",
     "dev:less": "grunt watch:lessdev && npm run watch:lessToSass",
     "watch:less": "grunt watch:less",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   },
   "scripts": {
     "build": "npm run build:css",
+    "watch": "npm run watch:css",
 
     "build:css": "npm run build:less",
     "watch:css": "npm run watch:less",
 
     "build:less": "grunt less",
-    "lessdev": "grunt lessdev",
+    "build:lessdev": "grunt lessdev",
     "watch:less": "grunt watch:less",
     "watch:lessdev": "grunt watch:lessdev",
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "watch-dev:css": "npm run watch-dev:less",
 
     "build:less": "grunt less && npm run lessToSass",
-    "watch:less": "grunt watch:less && npm run watch:lessToSass",
+    "watch:less": "grunt watch:less",
     "build-dev:less": "grunt lessdev && npm run lessToSass",
-    "watch-dev:less": "grunt watch:lessdev && npm run watch:lessToSass",
+    "watch-dev:less": "grunt watch:lessdev",
 
     "build:scss": "grunt scss",
     "watch:scss": "grunt watch:scss",


### PR DESCRIPTION
Thanks, @aleksip! I hope this is a step in the right direction. I'd love your feedback on the `watch` verbage. And if there is a good prefix for tools like `lessToSass`. Also `lessdev`, I wanted to go with `dev:less` but that has connotations of watching and serving from other frameworks, so I went with `build:lessdev` for now. Maybe `dev:less` would be better, but how do we explicitly build or watch?

TODO
- [x] Update wiki instructions after merging