### PR TITLE
Fix Lucene query string control character check

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -570,7 +570,7 @@ class LuceneSyntaxHelper
 
         // If the string consists only of control characters and/or BOOLEANs with no
         // other input, wipe it out entirely to prevent weird errors:
-        $operators = ['AND', 'OR', 'NOT', '+', '-', '"', '&', '|'];
+        $operators = ['AND', 'OR', 'NOT', '+', '-', '"', '&&', '||'];
         if (trim(str_replace($operators, '', $input)) == '') {
             return '';
         }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -455,7 +455,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
     public function unquotedNormalizationProvider(): array
     {
         return [
-            // Unquoted ones that need changes:
+            // Unquoted ones that may need changes:
             ['this - that', 'this that'],
             ['this -- that', 'this that'],
             ['- this that', 'this that'],
@@ -480,6 +480,17 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
             ['\\((( this that', '\\( this that'],
             ['\\\\\\((( this that', '\\\\\\( this that'],
             ['\\"((( this that\\"', '\\" this that\\"'],
+            ['&', '&'],
+            ['&&', ''],
+            ['|', '|'],
+            ['||', ''],
+            ['AND', 'and'],
+            ['OR', 'or'],
+            ['NOT', 'not'],
+            ['*:*', ''],
+            [' AND OR', ''],
+            ['AND OR NOT +-"&&||', ''],
+            ['AND OR NOT +-"&&|| &', 'AND OR NOT +-"&&|| &'],
 
             // Quoted ones that must not be affected:
             ['"this - that"', '"this - that"'],


### PR DESCRIPTION
A lone `&` or `|` should not be considered a control sequence in Lucene, while `&&` or `||` should. Adds tests to verify correct behavior.