### PR TITLE
Fix Cookie SASS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function(grunt) {
             { // Wrap variables in calcs with #{}
               pattern: /calc\([^;]+/gi,
               replacement: function calcVariables(match) {
-                return match.replace(/(\$[^ ]+)/gi, '#{$1}');
+                return match.replace(/(\$[\w\-]+)/gi, '#{$1}');
               },
               order: 4
             },

--- a/themes/bootstrap3/less/bootstrap.less
+++ b/themes/bootstrap3/less/bootstrap.less
@@ -4,9 +4,9 @@ $fa-font-path: "../../bootstrap3/css/fonts";
 <#SCSS */
 /* #LESS> */
 @import "vendor/bootstrap/bootstrap";
-@import "variables";
 
 /* <#LESS */
+@import "variables";
 @import "vendor/font-awesome/font-awesome";
 
 @import "components/accessibility";

--- a/themes/bootstrap3/scss/bootstrap.scss
+++ b/themes/bootstrap3/scss/bootstrap.scss
@@ -4,9 +4,9 @@ $fa-font-path: "../../bootstrap3/css/fonts";
 /* <#SCSS */
 /* #LESS>
 @import "vendor/bootstrap/bootstrap";
-@import "variables";
 
 <#LESS */
+@import "variables";
 @import "vendor/font-awesome/font-awesome";
 
 @import "components/accessibility";

--- a/themes/bootstrap3/scss/components/cookie-consent-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent-modal.scss
@@ -515,7 +515,7 @@ $cc-sections-padding: 1em 1.3em;
         transform: translateY($cc-translate-y);
 
         &--middle{
-            transform: translateY(calc(-50% + #{$cc-translate-y))};
+            transform: translateY(calc(-50% + #{$cc-translate-y}));
         }
 
         &--bar{

--- a/themes/bootstrap3/scss/components/cookie-preferences-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-preferences-modal.scss
@@ -435,7 +435,7 @@ $cc-toggle-border-radius: 4em;
             box-shadow: 0 0 0 1px $cc-toggle-on-bg;
 
             &:after{
-                transform: translateX(calc(#{$cc-toggle-knob-width} - #{$cc-toggle-knob-height))};
+                transform: translateX(calc(#{$cc-toggle-knob-width} - #{$cc-toggle-knob-height}));
                 background-color: $cc-toggle-on-knob-bg;
             }
 
@@ -760,7 +760,7 @@ $cc-toggle-border-radius: 4em;
 
 #cc-main{
     .pm--box{
-        transform: translateY(calc(-50% + #{$cc-translate-y))};
+        transform: translateY(calc(-50% + #{$cc-translate-y}));
     }
 
     .pm--bar{


### PR DESCRIPTION
A poorly constructed regex and a misplaced @import caused SASS errors when converting from LESS.