### PR TITLE
Fix problems with Blowfish migration.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/Feature/SecureDatabaseTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/SecureDatabaseTrait.php
@@ -50,7 +50,7 @@ trait SecureDatabaseTrait
     {
         // Make example hash for AES
         $alpha = 'abcdefghijklmnopqrstuvwxyz';
-        $chars = str_repeat($alpha . strtoupper($alpha) . '0123456789,.@#$%^&*', 4);
+        $chars = str_repeat($alpha . strtoupper($alpha) . '0123456789,.@#%^&*', 4);
         return ['aes', substr(str_shuffle($chars), 0, 32)];
     }
 


### PR DESCRIPTION
This PR corrects two issues I discovered with the Blowfish encryption migration while upgrading the Demo server:

1.) If the encryption key includes a dollar sign, it doesn't get parsed correctly on the command line -- I've simply removed $ from the list of encryption key characters for simplicity. (Alternatively, we could escape the character in the message template, but that seems more potentially error prone than just avoiding the problematic character).

2.) If an exception is thrown during the key migration process, we display an error identifying the problem user, rather than aborting the entire process. We also check for null values more carefully. This fixes a problem I encountered when a user's cat_username value was set, but cat_password and cat_pass_enc were both null.