### PR TITLE
Remove deprecated CSP directive prefetch-src

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -29,7 +29,6 @@ use_nonce = true
 default-src[] = "'self'"
 child-src[] = "'none'"
 object-src[] = "'none'"
-prefetch-src[] = "'none'"
 ; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
 ;   Safari 15.3 and earlier does not support this feature. Since these browser
 ;   versions constitute a significant portion of users, especially mobile users,


### PR DESCRIPTION
Remove deprecated directive `prefetch-src` form `config/vufind/contentsecuritypolicy.ini`.
For more info see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src