### PR TITLE
Fix translation of patron blocks in holdings tab.

### DIFF
--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -29,7 +29,7 @@
 
 <?php if (!empty($holdings['blocks'])):?>
   <div id="account-block-msg" class="alert alert-danger">
-    <?=$this->transEsc('account_block_options_missing', ['%%details%%' => implode('; ', $holdings['blocks'])]) ?>
+    <?=$this->transEsc('account_block_options_missing', ['%%details%%' => implode('; ', array_map([$this, 'translate'], $holdings['blocks']))]) ?>
   </div>
 <?php endif; ?>
 


### PR DESCRIPTION
Blocks were translated when displayed in e.g. the profile page but not when they were displayed as part of the message in the holdings tab.