### PR TITLE
Sierra: Add mapping of patron block codes to translatable strings.

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -166,6 +166,11 @@ title_hold_bib_levels = a:b:m:d
 ; of defining the "checked out" message text:
 ;Charged = "Charged"
 
+; This section allows mapping of patron block codes to VuFind translation strings
+[PatronBlockMappings]
+;a = patron_status_address_missing
+;b = patron_status_card_blocked
+
 ; Uncomment the following lines to enable password (PIN) change
 ;[changePassword]
 ; PIN change parameters. The default limits are taken from the interface documentation.

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -154,6 +154,11 @@ class SierraRest extends AbstractBase implements
     ];
 
     /**
+     * Mappings from patron block codes to VuFind strings
+     */
+    protected $patronBlockMappings = [];
+
+    /**
      * Status codes indicating that a hold is available for pickup
      *
      * @var array
@@ -321,6 +326,7 @@ class SierraRest extends AbstractBase implements
                 $this->config['ItemStatusMappings']
             );
         }
+        $this->patronBlockMappings = $this->config['PatronBlockMappings'] ?? [];
 
         if (isset($this->config['Catalog']['api_version'])) {
             $this->apiVersion = $this->config['Catalog']['api_version'];
@@ -2566,7 +2572,8 @@ class SierraRest extends AbstractBase implements
                 !empty($result['blockInfo'])
                 && trim($result['blockInfo']['code']) != '-'
             ) {
-                $blockReason = [trim($result['blockInfo']['code'])];
+                $code = trim($result['blockInfo']['code']);
+                $blockReason = [$this->patronBlockMappings[$code] ?? $code];
             } else {
                 $blockReason = [];
             }


### PR DESCRIPTION
The blocks are returned as single character codes. There are no defaults, so every library needs to define their own mappings.