### PR TITLE
Bookplates: Fix a small configuration file typo.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1947,7 +1947,7 @@ related[] = "Similar"
 ;bookplate_full = https://your-institution.edu/bookplates/%%img%%-full.jpg
 ;bookplate_thumb = https://your-institution.edu/bookplates/%%thumb%%-thumb.jpg
 
-; Data field with an array of image titles, parallel with bookplate_img_names_field.
+; Data field with an array of image titles, parallel with bookplate_images_field.
 ; Is required for alt text, even if bookplate_display_title is set to false.
 ;bookplate_titles_field = "donor_str_mv"
 


### PR DESCRIPTION
While reviewing config.ini, I noticed a typo in the bookplate-related configuration comments. This PR corrects it.