### PR TITLE
Fix JSON syntax error in composer.local.json.dist.

### DIFF
--- a/composer.local.json.dist
+++ b/composer.local.json.dist
@@ -1,7 +1,7 @@
 {
     "__comment__": [
-        "Rename this file from composer.local.json.dist to composer.local.json to"
-        "manage your local dependencies without changing the core composer.json."
+        "Rename this file from composer.local.json.dist to composer.local.json to",
+        "manage your local dependencies without changing the core composer.json.",
         "See https://github.com/wikimedia/composer-merge-plugin for more details."
     ],
     "require": {


### PR DESCRIPTION
I noticed that there was a syntax error (missing commas) in the example JSON in composer.local.json.dist. This PR fixes it.