### PR TITLE
Fix login followup URL for off-site auth

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -155,8 +155,9 @@ class MyResearchController extends AbstractBase
                     if (
                         $this->params()->fromPost('processLogin')
                         && $this->inLightbox()
-                        && empty($this->getFollowupUrl())
                     ) {
+                        // Clear followup and let lightbox handle redirect
+                        $this->clearFollowupUrl();
                         return $this->getRefreshResponse();
                     }
                 }
@@ -298,11 +299,10 @@ class MyResearchController extends AbstractBase
                 : $this->redirect()->toRoute('home');
         }
         $this->clearFollowupUrl();
-        // Set followup only if we're not in lightbox since it has the short-circuit
-        // for reloading current page:
-        if (!$this->inLightbox()) {
-            $this->setFollowupUrlToReferer();
-        }
+        // Lightbox handles reloading current page without a followup, however,
+        // always set a followup as lightbox won't handle page reload if auth
+        // is external. We clear the followup in homeAction if lightbox detected.
+        $this->setFollowupUrlToReferer();
         if ($si = $this->getSessionInitiator()) {
             return $this->redirect()->toUrl($si);
         }


### PR DESCRIPTION
When using a link to an off-site auth system (single-sign-on) in the login lightbox, the followup URL was not being preserved. Lightbox handled reloading the page for direct logins, but that doesn't help if the user leaves the site to authenticate.

This patch makes it so the login followup URL is always set, but then clears that URL on login if the user is inside the lightbox.

This change resolved our issues with login followups. I welcome any insight if there are other considerations that need to be taken into account. Thanks!