### PR TITLE
More concise flash message code in Admin controllers.

### DIFF
--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
@@ -75,18 +75,16 @@ class ConfigController extends AbstractAdmin
         $writer = new \VuFind\Config\Writer($configFile);
         $writer->set('System', 'autoConfigure', 1);
         if ($writer->save()) {
-            $this->flashMessenger()
-                ->addMessage('Auto-configuration enabled.', 'success');
+            $this->flashMessenger()->addSuccessMessage('Auto-configuration enabled.');
 
             // Reload config now that it has been edited (otherwise, old setting
             // will persist in cache):
             $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
                 ->reload('config');
         } else {
-            $this->flashMessenger()->addMessage(
+            $this->flashMessenger()->addErrorMessage(
                 'Could not enable auto-configuration; check permissions on '
-                . $configFile . '.',
-                'error'
+                . $configFile . '.'
             );
         }
         return $this->forwardTo('AdminConfig', 'Home');

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
@@ -69,7 +69,7 @@ class MaintenanceController extends AbstractAdmin
         // If cache is unset, we didn't go through the loop above, so no message
         // needs to be displayed.
         if (isset($cache)) {
-            $this->flashMessenger()->addMessage('Cache(s) cleared.', 'success');
+            $this->flashMessenger()->addSuccessMessage('Cache(s) cleared.');
         }
         return $this->forwardTo('AdminMaintenance', 'Home');
     }
@@ -122,13 +122,12 @@ class MaintenanceController extends AbstractAdmin
     {
         $daysOld = intval($this->params()->fromQuery('daysOld', $minAge));
         if ($daysOld < $minAge) {
-            $this->flashMessenger()->addMessage(
+            $this->flashMessenger()->addErrorMessage(
                 str_replace(
                     '%%age%%',
                     $minAge,
                     'Expiration age must be at least %%age%% days.'
-                ),
-                'error'
+                )
             );
         } else {
             $search = $this->getTable($table);
@@ -141,7 +140,7 @@ class MaintenanceController extends AbstractAdmin
             } else {
                 $msg = str_replace('%%count%%', $count, $successString);
             }
-            $this->flashMessenger()->addMessage($msg, 'success');
+            $this->flashMessenger()->addSuccessMessage($msg);
         }
         return $this->forwardTo('AdminMaintenance', 'Home');
     }


### PR DESCRIPTION
This makes the flash messenger calls more concise in two of the Admin module's controllers. I didn't make changes to the Form or Tag controllers since those are already being significantly refactored in the Doctrine PR and I didn't want to introduce unnecessary conflicts.