### PR TITLE
[VUFIND-1610] Fix OAI deleted handling PostgreSQL compatibility.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
@@ -122,7 +122,7 @@ class ChangeTracker extends Gateway
                 ->equalTo('core', $core)
                 ->greaterThanOrEqualTo('deleted', $from)
                 ->lessThanOrEqualTo('deleted', $until);
-            if ($order) {
+            if ($order !== null) {
                 $select->order($order);
             }
             if ($offset > 0) {

--- a/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
@@ -93,6 +93,7 @@ class ChangeTracker extends Gateway
      * @param int    $offset  Record number to retrieve first.
      * @param int    $limit   Retrieval limit (null for no limit)
      * @param array  $columns Columns to retrieve (null for all)
+     * @param string $order   Sort order
      *
      * @return callable
      */
@@ -102,7 +103,8 @@ class ChangeTracker extends Gateway
         $until,
         $offset = 0,
         $limit = null,
-        $columns = null
+        $columns = null,
+        $order = null
     ) {
         return function ($select) use (
             $core,
@@ -110,7 +112,8 @@ class ChangeTracker extends Gateway
             $until,
             $offset,
             $limit,
-            $columns
+            $columns,
+            $order
         ) {
             if ($columns !== null) {
                 $select->columns($columns);
@@ -119,7 +122,9 @@ class ChangeTracker extends Gateway
                 ->equalTo('core', $core)
                 ->greaterThanOrEqualTo('deleted', $from)
                 ->lessThanOrEqualTo('deleted', $until);
-            $select->order('deleted');
+            if ($order) {
+                $select->order($order);
+            }
             if ($offset > 0) {
                 $select->offset($offset);
             }
@@ -173,7 +178,9 @@ class ChangeTracker extends Gateway
             $from,
             $until,
             $offset,
-            $limit
+            $limit,
+            null,
+            'deleted'
         );
         return $this->select($callback);
     }


### PR DESCRIPTION
This PR eliminates an inappropriate ORDER BY clause from being combined with a SELECT COUNT(*) query, which is tolerated by MySQL but which causes a fatal error in PostgreSQL.

TODO
- [ ] Close [VUFIND-1610](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1610) when merging.