### PR TITLE
Upgrade php-cs-fixer to version 3.15.1. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "behat/mink-selenium2-driver": "1.6.0",
         "dmore/chrome-mink-driver": "2.9.2",
         "firebase/php-jwt": "6.4.0",
-        "friendsofphp/php-cs-fixer": "3.14.4",
+        "friendsofphp/php-cs-fixer": "3.15.1",
         "phploc/phploc": "7.0.2",
         "phpmd/phpmd": "2.13.0",
         "phpstan/phpstan": "1.10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6e5b9793ac0df3a87114d1fb848aac1",
+    "content-hash": "2585ab1e4800a48b414af861ec0dc192",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -9498,16 +9498,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.14.4",
+            "version": "v3.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "1b3d9dba63d93b8a202c31e824748218781eae6b"
+                "reference": "d48755372a113bddb99f749e34805d83f3acfe04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/1b3d9dba63d93b8a202c31e824748218781eae6b",
-                "reference": "1b3d9dba63d93b8a202c31e824748218781eae6b",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d48755372a113bddb99f749e34805d83f3acfe04",
+                "reference": "d48755372a113bddb99f749e34805d83f3acfe04",
                 "shasum": ""
             },
             "require": {
@@ -9574,9 +9574,15 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.14.4"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.15.1"
             },
             "funding": [
                 {
@@ -9584,7 +9590,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-09T21:49:13+00:00"
+            "time": "2023-03-13T23:26:30+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -12602,5 +12608,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This version supports PHP 8.2 and seems to be a drop-in replacement. Newer versions will require more effort.