### PR TITLE
Eliminate duplicate list object retrieval logic.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
@@ -31,6 +31,7 @@ namespace VuFind\Controller\Plugin;
 
 use VuFind\Db\Row\User;
 use VuFind\Exception\LoginRequired as LoginRequiredException;
+use VuFind\Favorites\FavoritesService;
 use VuFind\Record\Cache;
 use VuFind\Record\Loader;
 use VuFind\Tags;
@@ -68,40 +69,26 @@ class Favorites extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
     protected $tags;
 
     /**
+     * Favorites service
+     *
+     * @var FavoritesService
+     */
+    protected $favoritesService;
+
+    /**
      * Constructor
      *
-     * @param Loader $loader Record loader
-     * @param Cache  $cache  Record cache
-     * @param Tags   $tags   Tag parser
+     * @param Loader           $loader    Record loader
+     * @param Cache            $cache     Record cache
+     * @param Tags             $tags      Tag parser
+     * @param FavoritesService $favorites Favorites service
      */
-    public function __construct(Loader $loader, Cache $cache, Tags $tags)
+    public function __construct(Loader $loader, Cache $cache, Tags $tags, FavoritesService $favorites)
     {
         $this->loader = $loader;
         $this->cache = $cache;
         $this->tags = $tags;
-    }
-
-    /**
-     * Support method for saveBulk() -- get list to save records into. Either
-     * retrieves existing list or creates a new one.
-     *
-     * @param mixed $listId List ID to load (or empty/'NEW' to create new list)
-     * @param User  $user   User object.
-     *
-     * @return \VuFind\Db\Row\UserList
-     */
-    protected function getList($listId, User $user)
-    {
-        $table = $this->getController()->getTable('UserList');
-        if (empty($listId) || $listId == 'NEW') {
-            $list = $table->getNew($user);
-            $list->title = $this->getController()->translate('My Favorites');
-            $list->save($user);
-        } else {
-            $list = $table->getExisting($listId);
-            $list->rememberLastUsed(); // handled by save() in other case
-        }
-        return $list;
+        $this->favoritesService = $favorites;
     }
 
     /**
@@ -150,7 +137,7 @@ class Favorites extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
         }
 
         // Load helper objects needed for the saving process:
-        $list = $this->getList($params['list'] ?? '', $user);
+        $list = $this->favoritesService->getListObject($params['list'] ?? '', $user);
         $this->cache->setContext(Cache::CONTEXT_FAVORITE);
 
         $cacheRecordIds = [];   // list of record IDs to save to cache

--- a/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
@@ -71,7 +71,8 @@ class FavoritesFactory implements FactoryInterface
         return new $requestedName(
             $container->get(\VuFind\Record\Loader::class),
             $container->get(\VuFind\Record\Cache::class),
-            $container->get(\VuFind\Tags::class)
+            $container->get(\VuFind\Tags::class),
+            $container->get(\VuFind\Favorites\FavoritesService::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -96,7 +96,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
      *
      * @throws \VuFind\Exception\ListPermission
      */
-    protected function getListObject($listId, \VuFind\Db\Row\User $user)
+    public function getListObject($listId, \VuFind\Db\Row\User $user)
     {
         if (empty($listId) || $listId == 'NEW') {
             $list = $this->userListTable->getNew($user);


### PR DESCRIPTION
I happened to notice that we had nearly identical logic for obtaining list objects in two different places, and it was easy to consolidate. However, it requires some signature and visibility changes, so this will have to be done in a major release. Perhaps this is our first dev-10.0 branch PR, when we're ready to begin that work?

I also wonder if at some point we should further consolidate so that the Favorites controller plugin is eliminated and all of that logic goes into the FavoritesService... but this seems like a reasonable first step toward consolidation.

TODO
- [x] Update changelog to document backward-breaking changes when merging