### PR TITLE
Add debug logging of OAuth2 server exceptions.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2022.
+ * Copyright (C) The National Library of Finland 2022-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -227,8 +227,8 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
             $authRequest = $server->validateAuthorizationRequest(
                 Psr7ServerRequest::fromLaminas($this->getRequest())
             );
-        } catch (OAuthServerException $exception) {
-            return $this->convertOAuthServerExceptionToResponse($exception);
+        } catch (OAuthServerException $e) {
+            return $this->handleOAuth2Exception('Authorization request', $e);
         } catch (\Exception $e) {
             return $this->handleException('Authorization request', $e);
         }
@@ -263,10 +263,10 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
                     new \Laminas\Diactoros\Response()
                 );
                 return Psr7Response::toLaminas($response);
-            } catch (OAuthServerException $exception) {
-                return $this->convertOAuthServerExceptionToResponse($exception);
+            } catch (OAuthServerException $e) {
+                return $this->handleOAuth2Exception('Authorization request', $e);
             } catch (\Exception $e) {
-                return $this->handleException('Authorize request', $e);
+                return $this->handleException('Authorization request', $e);
             }
         }
 
@@ -294,8 +294,8 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
             $response = Psr7Response::toLaminas($response);
             $this->addCorsHeaders($response);
             return $response;
-        } catch (OAuthServerException $exception) {
-            return $this->convertOAuthServerExceptionToResponse($exception);
+        } catch (OAuthServerException $e) {
+            return $this->handleOAuth2Exception('Access token request', $e);
         } catch (\Exception $e) {
             return $this->handleException('Access token request', $e);
         }
@@ -317,24 +317,28 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
                 );
             $scopes = $request->getAttribute('oauth_scopes');
             if (!in_array('openid', $scopes)) {
-                throw OAuthServerException::invalidRequest(
-                    'token',
-                    'Not an OpenID request'
+                return $this->handleOAuth2Exception(
+                    'User info request',
+                    OAuthServerException::invalidRequest(
+                        'token',
+                        'Not an OpenID request'
+                    )
                 );
             }
             $userId = $request->getAttribute('oauth_user_id');
             $userEntity = $this->identityRepository
                 ->getUserEntityByIdentifier($userId);
             if (!$userEntity) {
-                return $this->convertOAuthServerExceptionToResponse(
+                return $this->handleOAuth2Exception(
+                    'User info request',
                     OAuthServerException::accessDenied('User does not exist anymore')
                 );
             }
             $result = $this->claimExtractor
                 ->extract($scopes, $userEntity->getClaims());
             return $this->getJsonResponse($result);
-        } catch (OAuthServerException $exception) {
-            return $this->convertOAuthServerExceptionToResponse($exception);
+        } catch (OAuthServerException $e) {
+            return $this->handleOAuth2Exception('User info request', $e);
         } catch (\Exception $e) {
             return $this->handleException('User info request', $e);
         }
@@ -417,5 +421,20 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
         return $this->convertOAuthServerExceptionToResponse(
             OAuthServerException::serverError('Server side issue')
         );
+    }
+
+    /**
+     * Create a server error response from a returnable exception.
+     *
+     * @param string     $function Function description
+     * @param \Exception $e        Exception
+     *
+     * @return Response
+     */
+    protected function handleOAuth2Exception(string $function, \Exception $e): Response
+    {
+        $this->debug("$function exception: " . (string)$e);
+
+        return $this->convertOAuthServerExceptionToResponse($e);
     }
 }


### PR DESCRIPTION
This will help with troubleshooting setup issues. These exceptions are only logged when debug logging is enabled as they are typically caused by a bad request from a client.