### PR TITLE
Fix more jQuery deprecations.

### DIFF
--- a/themes/bootstrap3/js/embedded_record.js
+++ b/themes/bootstrap3/js/embedded_record.js
@@ -155,7 +155,8 @@ VuFind.register('embedded', function embedded() {
               }
               return ajaxLoadTab(this.id);
             });
-            longNode.find('[id^=usercomment]').find('input[type=submit]').unbind('click').click(
+            longNode.find('[id^=usercomment]').find('input[type=submit]').off("click").on(
+              "click",
               function embeddedComments() {
                 return registerAjaxCommentRecord(longNode);
               }

--- a/themes/bootstrap3/js/openurl.js
+++ b/themes/bootstrap3/js/openurl.js
@@ -45,7 +45,7 @@ VuFind.register('openurl', function OpenUrl() {
   function init(_container) {
     var container = $(_container || 'body');
     // assign action to the openUrlWindow link class
-    container.find('a.openUrlWindow').unbind('click').click(function openUrlWindowClick() {
+    container.find('a.openUrlWindow').off('click').on("click", function openUrlWindowClick() {
       var params = extractClassParams(this);
       var settings = params.window_settings;
       window.open($(this).attr('href'), 'openurl', settings);
@@ -53,7 +53,7 @@ VuFind.register('openurl', function OpenUrl() {
     });
 
     // assign action to the openUrlEmbed link class
-    container.find('.openUrlEmbed a').unbind('click').click(function openUrlEmbedClick() {
+    container.find('.openUrlEmbed a').off('click').on("click", function openUrlEmbedClick() {
       embedOpenUrlLinks(this);
       return false;
     });


### PR DESCRIPTION
This is a follow-up to #2876 which catches a few more deprecated calls that were not adjusted there.

In preparing this, I also noticed that we currently depend on a jQuery plugin that uses many deprecated calls; I have opened [VUFIND-1614](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1614) to remind us to deal with that in the next major release.

Would it also be a good idea to open a ticket about eliminating use of Bootstrap 3 collapsing? @EreMaijala / @crhallberg, do you have any suggested alternatives if we go that route?

TODO
- [x] Run full test suite