### PR TITLE
Make Mink test for record rating more robust.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -640,27 +640,34 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Add comment with rating
         $this->clickCss($page, '.record-tabs .usercomments a');
+        $this->waitForPageLoad($page);
         $this->findCss($page, '.comment-form');
         $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('one');
         $this->clickCss($page, 'form.comment-form div.star-rating label', null, 10);
         // Check that "Clear" link is present before submitting:
         $this->findCss($page, 'form.comment-form a');
         $this->clickCss($page, 'form.comment-form .btn-primary');
-        // Check result
-        $this->waitForPageLoad($page);
-        $inputs = $page->findAll('css', $checked);
-        $this->assertCount(1, $inputs);
-        $this->assertEquals('80', $inputs[0]->getValue());
+        // Check result (wait for the value to update):
+        $this->assertEqualsWithTimeout(
+            [1, '80'],
+            function () use ($page, $checked) {
+                $inputs = $page->findAll('css', $checked);
+                return [count($inputs), $inputs ? $inputs[0]->getValue() : null];
+            }
+        );
         if ($allowRemove) {
             // Clear rating when adding another comment
             $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('two');
             $this->clickCss($page, 'form.comment-form a');
             $this->clickCss($page, 'form.comment-form .btn-primary');
-            // Check result
-            $this->waitForPageLoad($page);
-            $inputs = $page->findAll('css', $checked);
-            $this->assertCount(1, $inputs);
-            $this->assertEquals('70', $inputs[0]->getValue());
+            // Check result (wait for the value to update):
+            $this->assertEqualsWithTimeout(
+                [1, '70'],
+                function () use ($page, $checked) {
+                    $inputs = $page->findAll('css', $checked);
+                    return [count($inputs), $inputs ? $inputs[0]->getValue() : null];
+                }
+            );
         } else {
             // Check that the "Clear" link is no longer available:
             $this->unFindCss($page, 'form.comment-form a');


### PR DESCRIPTION
Uses assertEqualsWithTimeout to check for updated rating since it gets updated asynchronously.