### PR TITLE
Add codes to MailExceptions and prevent unnecessary exceptions from being printed

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -32,7 +32,6 @@ namespace VuFind\Controller;
 use VuFind\Exception\BadRequest as BadRequestException;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
-use VuFind\Exception\SMS as SMSException;
 use VuFind\RecordDriver\AbstractBase as AbstractRecordDriver;
 use VuFindSearch\ParamBag;
 
@@ -615,7 +614,7 @@ class AbstractRecord extends AbstractBase
                 $sms->text($view->provider, $view->to, null, $body);
                 $this->flashMessenger()->addMessage('sms_success', 'success');
                 return $this->redirectToRecord();
-            } catch (SMSException $e) {
+            } catch (MailException $e) {
                 $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -549,7 +549,7 @@ class AbstractRecord extends AbstractBase
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                $this->flashMessenger()->addMessage('email_failure', 'error');
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -32,6 +32,7 @@ namespace VuFind\Controller;
 use VuFind\Exception\BadRequest as BadRequestException;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
+use VuFind\Exception\SMS as SMSException;
 use VuFind\RecordDriver\AbstractBase as AbstractRecordDriver;
 use VuFindSearch\ParamBag;
 
@@ -614,7 +615,7 @@ class AbstractRecord extends AbstractBase
                 $sms->text($view->provider, $view->to, null, $body);
                 $this->flashMessenger()->addMessage('sms_success', 'success');
                 return $this->redirectToRecord();
-            } catch (MailException $e) {
+            } catch (SMSException $e) {
                 $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -549,7 +549,10 @@ class AbstractRecord extends AbstractBase
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage('email_failure', 'error');
+                $this->flashMessenger()->addMessage(
+                    $e->getCode() ? $e->getMessage() : 'email_failure',
+                    'error'
+                );
             }
         }
 
@@ -615,7 +618,10 @@ class AbstractRecord extends AbstractBase
                 $this->flashMessenger()->addMessage('sms_success', 'success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                $this->flashMessenger()->addMessage(
+                    $e->getCode() ? $e->getMessage() : 'email_failure',
+                    'error'
+                );
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -549,10 +549,7 @@ class AbstractRecord extends AbstractBase
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage(
-                    $e->getCode() ? $e->getMessage() : 'email_failure',
-                    'error'
-                );
+                $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }
 
@@ -618,10 +615,7 @@ class AbstractRecord extends AbstractBase
                 $this->flashMessenger()->addMessage('sms_success', 'success');
                 return $this->redirectToRecord();
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage(
-                    $e->getCode() ? $e->getMessage() : 'email_failure',
-                    'error'
-                );
+                $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -397,7 +397,7 @@ class AlmaController extends AbstractBase
                 error_log(
                     'Could not send the \'set-password-email\' to user with ' .
                     'primary ID \'' . $user->cat_id . '\' | username \'' .
-                    $user->username . '\': ' . $e->getMessage()
+                    $user->username . '\''
                 );
             }
         }

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -397,7 +397,7 @@ class AlmaController extends AbstractBase
                 error_log(
                     'Could not send the \'set-password-email\' to user with ' .
                     'primary ID \'' . $user->cat_id . '\' | username \'' .
-                    $user->username . '\''
+                    $user->username . '\': ' . $e->getMessage()
                 );
             }
         }

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -290,7 +290,10 @@ class CartController extends AbstractBase
                 );
                 return $this->redirectToSource('success', 'bulk_email_success');
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage('email_failure', 'error');
+                $this->flashMessenger()->addMessage(
+                    $e->getCode() ? $e->getMessage() : 'email_failure',
+                    'error'
+                );
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -290,7 +290,7 @@ class CartController extends AbstractBase
                 );
                 return $this->redirectToSource('success', 'bulk_email_success');
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                $this->flashMessenger()->addMessage('email_failure', 'error');
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -290,10 +290,7 @@ class CartController extends AbstractBase
                 );
                 return $this->redirectToSource('success', 'bulk_email_success');
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage(
-                    $e->getCode() ? $e->getMessage() : 'email_failure',
-                    'error'
-                );
+                $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }
 

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1696,10 +1696,7 @@ class MyResearchController extends AbstractBase
                     $this->flashMessenger()
                         ->addMessage('recovery_email_sent', 'success');
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage(
-                        $e->getCode() ? $e->getMessage() : 'email_failure',
-                        'error'
-                    );
+                    $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
                 }
             }
         }
@@ -1818,10 +1815,7 @@ class MyResearchController extends AbstractBase
                         $this->sendChangeNotificationEmail($user, $to);
                     }
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage(
-                        $e->getCode() ? $e->getMessage() : 'email_failure',
-                        'error'
-                    );
+                    $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
                 }
             }
         }

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1696,7 +1696,7 @@ class MyResearchController extends AbstractBase
                     $this->flashMessenger()
                         ->addMessage('recovery_email_sent', 'success');
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                    $this->flashMessenger()->addMessage('email_failure', 'error');
                 }
             }
         }
@@ -1815,7 +1815,7 @@ class MyResearchController extends AbstractBase
                         $this->sendChangeNotificationEmail($user, $to);
                     }
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                    $this->flashMessenger()->addMessage('email_failure', 'error');
                 }
             }
         }

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1696,7 +1696,10 @@ class MyResearchController extends AbstractBase
                     $this->flashMessenger()
                         ->addMessage('recovery_email_sent', 'success');
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage('email_failure', 'error');
+                    $this->flashMessenger()->addMessage(
+                        $e->getCode() ? $e->getMessage() : 'email_failure',
+                        'error'
+                    );
                 }
             }
         }
@@ -1815,7 +1818,10 @@ class MyResearchController extends AbstractBase
                         $this->sendChangeNotificationEmail($user, $to);
                     }
                 } catch (MailException $e) {
-                    $this->flashMessenger()->addMessage('email_failure', 'error');
+                    $this->flashMessenger()->addMessage(
+                        $e->getCode() ? $e->getMessage() : 'email_failure',
+                        'error'
+                    );
                 }
             }
         }

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -190,7 +190,7 @@ class SearchController extends AbstractSolrSearch
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirect()->toUrl($view->url);
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+                $this->flashMessenger()->addMessage('email_failure', 'error');
             }
         }
         return $view;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -190,10 +190,7 @@ class SearchController extends AbstractSolrSearch
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirect()->toUrl($view->url);
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage(
-                    $e->getCode() ? $e->getMessage() : 'email_failure',
-                    'error'
-                );
+                $this->flashMessenger()->addMessage($e->getDisplayMessage(), 'error');
             }
         }
         return $view;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -190,7 +190,10 @@ class SearchController extends AbstractSolrSearch
                 $this->flashMessenger()->addMessage('email_success', 'success');
                 return $this->redirect()->toUrl($view->url);
             } catch (MailException $e) {
-                $this->flashMessenger()->addMessage('email_failure', 'error');
+                $this->flashMessenger()->addMessage(
+                    $e->getCode() ? $e->getMessage() : 'email_failure',
+                    'error'
+                );
             }
         }
         return $view;

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -45,7 +45,7 @@ class Mail extends \Exception
      *
      * @var int
      */
-    public const ERROR_DEFAULT = 0;
+    public const ERROR_UNKNOWN = 0;
 
     /**
      * Mail recipient address is invalid.
@@ -74,4 +74,18 @@ class Mail extends \Exception
      * @var int
      */
     public const ERROR_TOO_MANY_RECIPIENTS = 4;
+
+    /**
+     * Returns the error message, but excludes too technical messages.
+     *
+     * @return string
+     */
+    public function getDisplayMessage(): string
+    {
+        // If application env is development, we can display too technical messages
+        if ('development' === APPLICATION_ENV || $this->getCode() !== self::ERROR_UNKNOWN) {
+            return $this->getMessage();
+        }
+        return 'email_failure';
+    }
 }

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -76,6 +76,20 @@ class Mail extends \Exception
     public const ERROR_TOO_MANY_RECIPIENTS = 4;
 
     /**
+     * SMS unknow carrier.
+     *
+     * @var int
+     */
+    public const ERROR_UNKNOWN_CARRIER = 5;
+
+    /**
+     * Required extension missing.
+     *
+     * @var int
+     */
+    public const ERROR_EXTENSION_MISSING = 6;
+
+    /**
      * Returns the error message, but excludes too technical messages.
      *
      * @return string

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -76,7 +76,7 @@ class Mail extends \Exception
     public const ERROR_TOO_MANY_RECIPIENTS = 4;
 
     /**
-     * SMS unknow carrier.
+     * SMS unknown carrier.
      *
      * @var int
      */

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -45,33 +45,33 @@ class Mail extends \Exception
      *
      * @var int
      */
-    public static const ERROR_DEFAULT = 0;
+    public const ERROR_DEFAULT = 0;
 
     /**
      * Mail recipient address is invalid.
      *
      * @var int
      */
-    public static const ERROR_INVALID_RECIPIENT = 1;
+    public const ERROR_INVALID_RECIPIENT = 1;
 
     /**
      * Mail sender address is invalid.
      *
      * @var int
      */
-    public static const ERROR_INVALID_SENDER = 2;
+    public const ERROR_INVALID_SENDER = 2;
 
     /**
      * Mail reply to address is invalid.
      *
      * @var int
      */
-    public static const ERROR_INVALID_REPLY_TO = 3;
+    public const ERROR_INVALID_REPLY_TO = 3;
 
     /**
      * Mail too many recipients.
      *
      * @var int
      */
-    public static const ERROR_TOO_MANY_RECIPIENTS = 4;
+    public const ERROR_TOO_MANY_RECIPIENTS = 4;
 }

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -83,11 +83,11 @@ class Mail extends \Exception
     public const ERROR_UNKNOWN_CARRIER = 5;
 
     /**
-     * Required extension missing.
+     * Response unknown.
      *
      * @var int
      */
-    public const ERROR_EXTENSION_MISSING = 6;
+    public const ERROR_RESPONSE_UNKNOWN = 6;
 
     /**
      * Returns the error message, but excludes too technical messages.

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2011.
+ * Copyright (C) Villanova University 2011-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -42,6 +42,7 @@ class Mail extends \Exception
 {
     /**
      * Default error message when the error is not known exactly.
+     * Will return $defaultDisplayMessage if APPLICATION_ENV is not development.
      *
      * @var int
      */
@@ -76,18 +77,11 @@ class Mail extends \Exception
     public const ERROR_TOO_MANY_RECIPIENTS = 4;
 
     /**
-     * SMS unknown carrier.
+     * Safe error message to return
      *
-     * @var int
+     * @var string
      */
-    public const ERROR_UNKNOWN_CARRIER = 5;
-
-    /**
-     * Response unknown.
-     *
-     * @var int
-     */
-    public const ERROR_RESPONSE_UNKNOWN = 6;
+    protected $defaultDisplayMessage = 'email_failure';
 
     /**
      * Returns the error message, but excludes too technical messages.
@@ -100,6 +94,6 @@ class Mail extends \Exception
         if ('development' === APPLICATION_ENV || $this->getCode() !== self::ERROR_UNKNOWN) {
             return $this->getMessage();
         }
-        return 'email_failure';
+        return $this->defaultDisplayMessage;
     }
 }

--- a/module/VuFind/src/VuFind/Exception/Mail.php
+++ b/module/VuFind/src/VuFind/Exception/Mail.php
@@ -40,4 +40,38 @@ namespace VuFind\Exception;
  */
 class Mail extends \Exception
 {
+    /**
+     * Default error message when the error is not known exactly.
+     *
+     * @var int
+     */
+    public static const ERROR_DEFAULT = 0;
+
+    /**
+     * Mail recipient address is invalid.
+     *
+     * @var int
+     */
+    public static const ERROR_INVALID_RECIPIENT = 1;
+
+    /**
+     * Mail sender address is invalid.
+     *
+     * @var int
+     */
+    public static const ERROR_INVALID_SENDER = 2;
+
+    /**
+     * Mail reply to address is invalid.
+     *
+     * @var int
+     */
+    public static const ERROR_INVALID_REPLY_TO = 3;
+
+    /**
+     * Mail too many recipients.
+     *
+     * @var int
+     */
+    public static const ERROR_TOO_MANY_RECIPIENTS = 4;
 }

--- a/module/VuFind/src/VuFind/Exception/SMS.php
+++ b/module/VuFind/src/VuFind/Exception/SMS.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SMS Exception
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Exceptions
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Exception;
+
+/**
+ * SMS Exception
+ *
+ * @category VuFind
+ * @package  Exceptions
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class SMS extends \VuFind\Exception\Mail
+{
+    /**
+     * SMS unknown carrier.
+     *
+     * @var int
+     */
+    public const ERROR_UNKNOWN_CARRIER = 5;
+
+    /**
+     * Response unknown.
+     *
+     * @var int
+     */
+    public const ERROR_RESPONSE_UNKNOWN = 6;
+
+    /**
+     * Safe error message to return
+     *
+     * @var string
+     */
+    protected $defaultDisplayMessage = 'sms_failure';
+}

--- a/module/VuFind/src/VuFind/Exception/SMS.php
+++ b/module/VuFind/src/VuFind/Exception/SMS.php
@@ -48,13 +48,6 @@ class SMS extends \VuFind\Exception\Mail
     public const ERROR_UNKNOWN_CARRIER = 5;
 
     /**
-     * Response unknown.
-     *
-     * @var int
-     */
-    public const ERROR_RESPONSE_UNKNOWN = 6;
-
-    /**
      * Safe error message to return
      *
      * @var string

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -48,7 +48,7 @@ use VuFind\Exception\Mail as MailException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Mailer implements 
+class Mailer implements
     \VuFind\I18n\Translator\TranslatorAwareInterface,
     \Laminas\Log\LoggerAwareInterface
 {

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -256,27 +256,42 @@ class Mailer implements
         // Validate email addresses:
         if ($this->maxRecipients > 0) {
             if ($this->maxRecipients < count($recipients)) {
-                throw new MailException('Too Many Email Recipients');
+                throw new MailException(
+                    'Too Many Email Recipients',
+                    MailException::ERROR_TOO_MANY_RECIPIENTS
+                );
             }
         }
         $validator = new \Laminas\Validator\EmailAddress();
         if (count($recipients) == 0) {
-            throw new MailException('Invalid Recipient Email Address');
+            throw new MailException(
+                'Invalid Recipient Email Address',
+                MailException::ERROR_INVALID_RECIPIENT
+            );
         }
         foreach ($recipients as $current) {
             if (!$validator->isValid($current->getEmail())) {
-                throw new MailException('Invalid Recipient Email Address');
+                throw new MailException(
+                    'Invalid Recipient Email Address',
+                    MailException::ERROR_INVALID_RECIPIENT
+                );
             }
         }
         foreach ($replyTo as $current) {
             if (!$validator->isValid($current->getEmail())) {
-                throw new MailException('Invalid Reply-To Email Address');
+                throw new MailException(
+                    'Invalid Reply-To Email Address',
+                    MailException::ERROR_INVALID_REPLY_TO
+                );
             }
         }
         $fromEmail = ($from instanceof Address)
             ? $from->getEmail() : $from;
         if (!$validator->isValid($fromEmail)) {
-            throw new MailException('Invalid Sender Email Address');
+            throw new MailException(
+                'Invalid Sender Email Address',
+                MailException::ERROR_INVALID_SENDER
+            );
         }
 
         if (
@@ -318,7 +333,7 @@ class Mailer implements
             $this->getTransport()->send($message);
         } catch (\Exception $e) {
             $this->logError($e->getMessage());
-            throw new MailException($e->getMessage());
+            throw new MailException($e->getMessage(), MailException::ERROR_DEFAULT);
         }
     }
 

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Mailer;
 
+use Laminas\Log\LoggerAwareInterface;
 use Laminas\Mail\Address;
 use Laminas\Mail\AddressList;
 use Laminas\Mail\Header\ContentType;
@@ -38,6 +39,7 @@ use Laminas\Mime\Message as MimeMessage;
 use Laminas\Mime\Mime;
 use Laminas\Mime\Part as MimePart;
 use VuFind\Exception\Mail as MailException;
+use VuFind\Log\LoggerAwareTrait;
 
 /**
  * VuFind Mailer Class
@@ -51,6 +53,7 @@ use VuFind\Exception\Mail as MailException;
 class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
+    use LoggerAwareTrait;
 
     /**
      * Mail transport
@@ -314,6 +317,7 @@ class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
             }
             $this->getTransport()->send($message);
         } catch (\Exception $e) {
+            $this->logError($e->getMessage());
             throw new MailException($e->getMessage());
         }
     }

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -29,7 +29,6 @@
 
 namespace VuFind\Mailer;
 
-use Laminas\Log\LoggerAwareInterface;
 use Laminas\Mail\Address;
 use Laminas\Mail\AddressList;
 use Laminas\Mail\Header\ContentType;
@@ -39,7 +38,6 @@ use Laminas\Mime\Message as MimeMessage;
 use Laminas\Mime\Mime;
 use Laminas\Mime\Part as MimePart;
 use VuFind\Exception\Mail as MailException;
-use VuFind\Log\LoggerAwareTrait;
 
 /**
  * VuFind Mailer Class
@@ -50,10 +48,12 @@ use VuFind\Log\LoggerAwareTrait;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Mailer implements \VuFind\I18n\Translator\TranslatorAwareInterface
+class Mailer implements 
+    \VuFind\I18n\Translator\TranslatorAwareInterface,
+    \Laminas\Log\LoggerAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
-    use LoggerAwareTrait;
+    use \VuFind\Log\LoggerAwareTrait;
 
     /**
      * Mail transport

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -333,7 +333,7 @@ class Mailer implements
             $this->getTransport()->send($message);
         } catch (\Exception $e) {
             $this->logError($e->getMessage());
-            throw new MailException($e->getMessage(), MailException::ERROR_DEFAULT);
+            throw new MailException($e->getMessage(), MailException::ERROR_UNKNOWN);
         }
     }
 

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -83,7 +83,7 @@ class Clickatell extends AbstractBase
         }
         $response = $result->isSuccess() ? trim($result->getBody()) : '';
         if (empty($response)) {
-            throw new SMSException('Problem sending text.', SMSException::ERROR_RESPONSE_UNKNOWN);
+            throw new SMSException('Problem sending text.', SMSException::ERROR_UNKNOWN);
         }
         if ('ID:' !== substr($response, 0, 3)) {
             throw new SMSException($response, SMSException::ERROR_UNKNOWN);

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -83,7 +83,7 @@ class Clickatell extends AbstractBase
         }
         $response = $result->isSuccess() ? trim($result->getBody()) : '';
         if (empty($response)) {
-            throw new MailException('Problem sending text.', MailException::ERROR_UNKNOWN);
+            throw new MailException('Problem sending text.', MailException::ERROR_RESPONSE_UNKNOWN);
         }
         if ('ID:' !== substr($response, 0, 3)) {
             throw new MailException($response, MailException::ERROR_UNKNOWN);
@@ -173,7 +173,7 @@ class Clickatell extends AbstractBase
         if (!function_exists('iconv')) {
             throw new MailException(
                 'Clickatell requires iconv PHP extension.',
-                MailException::ERROR_EXTENSION_MISSING
+                MailException::ERROR_UNKNOWN
             );
         }
         // Normalize UTF-8 if intl extension is installed:

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\SMS;
 
-use VuFind\Exception\Mail as MailException;
+use VuFind\Exception\SMS as SMSException;
 
 /**
  * Class for text messaging via Clickatell's HTTP API
@@ -79,14 +79,14 @@ class Clickatell extends AbstractBase
         try {
             $result = $this->client->setMethod('GET')->setUri($url)->send();
         } catch (\Exception $e) {
-            throw new MailException($e->getMessage(), MailException::ERROR_UNKNOWN);
+            throw new SMSException($e->getMessage(), SMSException::ERROR_UNKNOWN);
         }
         $response = $result->isSuccess() ? trim($result->getBody()) : '';
         if (empty($response)) {
-            throw new MailException('Problem sending text.', MailException::ERROR_RESPONSE_UNKNOWN);
+            throw new SMSException('Problem sending text.', SMSException::ERROR_RESPONSE_UNKNOWN);
         }
         if ('ID:' !== substr($response, 0, 3)) {
-            throw new MailException($response, MailException::ERROR_UNKNOWN);
+            throw new SMSException($response, SMSException::ERROR_UNKNOWN);
         }
         return true;
     }
@@ -171,9 +171,9 @@ class Clickatell extends AbstractBase
     {
         // Clickatell expects UCS-2 encoding:
         if (!function_exists('iconv')) {
-            throw new MailException(
+            throw new SMSException(
                 'Clickatell requires iconv PHP extension.',
-                MailException::ERROR_UNKNOWN
+                SMSException::ERROR_UNKNOWN
             );
         }
         // Normalize UTF-8 if intl extension is installed:

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -79,14 +79,14 @@ class Clickatell extends AbstractBase
         try {
             $result = $this->client->setMethod('GET')->setUri($url)->send();
         } catch (\Exception $e) {
-            throw new MailException($e->getMessage());
+            throw new MailException($e->getMessage(), MailException::ERROR_UNKNOWN);
         }
         $response = $result->isSuccess() ? trim($result->getBody()) : '';
         if (empty($response)) {
-            throw new MailException('Problem sending text.');
+            throw new MailException('Problem sending text.', MailException::ERROR_UNKNOWN);
         }
         if ('ID:' !== substr($response, 0, 3)) {
-            throw new MailException($response);
+            throw new MailException($response, MailException::ERROR_UNKNOWN);
         }
         return true;
     }
@@ -171,9 +171,10 @@ class Clickatell extends AbstractBase
     {
         // Clickatell expects UCS-2 encoding:
         if (!function_exists('iconv')) {
-            // @codeCoverageIgnoreStart
-            throw new MailException('Clickatell requires iconv PHP extension.');
-            // @codeCoverageIgnoreEnd
+            throw new MailException(
+                'Clickatell requires iconv PHP extension.',
+                MailException::ERROR_EXTENSION_MISSING
+            );
         }
         // Normalize UTF-8 if intl extension is installed:
         if (class_exists('Normalizer')) {

--- a/module/VuFind/src/VuFind/SMS/Mailer.php
+++ b/module/VuFind/src/VuFind/SMS/Mailer.php
@@ -137,7 +137,10 @@ class Mailer extends AbstractBase
     {
         $knownCarriers = array_keys($this->carriers);
         if (empty($provider) || !in_array($provider, $knownCarriers)) {
-            throw new MailException('Unknown Carrier');
+            throw new MailException(
+                'Unknown Carrier',
+                MailException::ERROR_UNKNOWN_CARRIER
+            );
         }
 
         $to = $this->filterPhoneNumber($to)

--- a/module/VuFind/src/VuFind/SMS/Mailer.php
+++ b/module/VuFind/src/VuFind/SMS/Mailer.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\SMS;
 
-use VuFind\Exception\Mail as MailException;
+use VuFind\Exception\SMS as SMSException;
 
 /**
  * VuFind Mailer Class for SMS messages
@@ -130,16 +130,16 @@ class Mailer extends AbstractBase
      * @param string $from     The email address to use as sender
      * @param string $message  The message to send
      *
-     * @throws \VuFind\Exception\Mail
+     * @throws \VuFind\Exception\SMS
      * @return void
      */
     public function text($provider, $to, $from, $message)
     {
         $knownCarriers = array_keys($this->carriers);
         if (empty($provider) || !in_array($provider, $knownCarriers)) {
-            throw new MailException(
+            throw new SMSException(
                 'Unknown Carrier',
-                MailException::ERROR_UNKNOWN_CARRIER
+                SMSException::ERROR_UNKNOWN_CARRIER
             );
         }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -243,6 +243,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Invalid Recipient Email Address');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_INVALID_RECIPIENT);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -258,6 +259,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Invalid Reply-To Email Address');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_INVALID_REPLY_TO);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -280,6 +282,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Invalid Recipient Email Address');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_INVALID_RECIPIENT);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -295,6 +298,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Too Many Email Recipients');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_TOO_MANY_RECIPIENTS);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -310,6 +314,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Invalid Sender Email Address');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_INVALID_SENDER);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -325,6 +330,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Mail::class);
         $this->expectExceptionMessage('Invalid Sender Email Address');
+        $this->expectExceptionCode(\VuFind\Exception\Mail::ERROR_INVALID_SENDER);
 
         $transport = $this->createMock(\Laminas\Mail\Transport\TransportInterface::class);
         $mailer = new Mailer($transport);
@@ -345,6 +351,30 @@ class MailerTest extends \PHPUnit\Framework\TestCase
         $transport->expects($this->once())->method('send')->will($this->throwException(new \Exception('Boom')));
         $mailer = new Mailer($transport);
         $mailer->send('to@example.com', 'from@example.com', 'subject', 'body');
+    }
+
+    /**
+     * Test unknown exception.
+     *
+     * @return void
+     */
+    public function testUnknownException()
+    {
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects(
+            $this->once())->method('send')->will(
+                $this->throwException(
+                    new \VuFind\Exception\Mail(
+                        'Technical message',
+                        \VuFind\Exception\Mail::ERROR_UNKNOWN
+                    )
+                )
+            );
+        try {
+            $mailer->send('to@example.com', 'from@example.com', 'subject', 'body');
+        } catch (\VuFind\Exception\Mail $e) {
+            $this->assertEquals('email_failure', $e->getDisplayMessage());
+        }
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -361,15 +361,14 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     public function testUnknownException()
     {
         $mailer = $this->createMock(Mailer::class);
-        $mailer->expects(
-            $this->once())->method('send')->will(
-                $this->throwException(
-                    new \VuFind\Exception\Mail(
-                        'Technical message',
-                        \VuFind\Exception\Mail::ERROR_UNKNOWN
-                    )
+        $mailer->expects($this->once())->method('send')->will(
+            $this->throwException(
+                new \VuFind\Exception\Mail(
+                    'Technical message',
+                    \VuFind\Exception\Mail::ERROR_UNKNOWN
                 )
-            );
+            )
+        );
         try {
             $mailer->send('to@example.com', 'from@example.com', 'subject', 'body');
         } catch (\VuFind\Exception\Mail $e) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -30,7 +30,6 @@
 namespace VuFindTest\SMS;
 
 use VuFind\SMS\Clickatell;
-use VuFind\XSLT\Import\VuFind;
 
 /**
  * SMS test

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -78,7 +78,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test unexpected carrier error
+     * Test unknown exception message error
      *
      * @return void
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -83,7 +83,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnknownException()
     {
-        $client = $this->getMockClient($this->getMockClient(), []);
+        $client = $this->getMockClient();
         $expectedUri = $this->expectedBaseUri . '&to=1234567890&text=hello';
         $client->expects($this->once())
             ->method('setMethod')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -97,17 +97,17 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
             ->method('send')
             ->will(
                 $this->throwException(
-                    new \VuFind\Exception\Mail(
+                    new \VuFind\Exception\SMS(
                         'Technical message',
-                        \VuFind\Exception\Mail::ERROR_UNKNOWN
+                        \VuFind\Exception\SMS::ERROR_UNKNOWN
                     )
                 )
             );
         $obj = $this->getClickatell($client);
         try {
             $obj->text('Clickatell', '1234567890', 'test@example.com', 'hello');
-        } catch (\VuFind\Exception\Mail $e) {
-            $this->assertEquals('email_failure', $e->getDisplayMessage());
+        } catch (\VuFind\Exception\SMS $e) {
+            $this->assertEquals('sms_failure', $e->getDisplayMessage());
         }
     }
 
@@ -145,7 +145,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnexpectedResponse()
     {
-        $this->expectException(\VuFind\Exception\Mail::class);
+        $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('badbadbad');
 
         $client = $this->getMockClient();
@@ -175,7 +175,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      */
     public function testFailureResponse()
     {
-        $this->expectException(\VuFind\Exception\Mail::class);
+        $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('Problem sending text.');
 
         $client = $this->getMockClient();
@@ -204,7 +204,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      */
     public function testClientException()
     {
-        $this->expectException(\VuFind\Exception\Mail::class);
+        $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('Foo');
 
         $client = $this->getMockClient();


### PR DESCRIPTION
The idea of this pr is to hide too technical errors from the user when i.e a connection can not be established to smtp server.