### PR TITLE
Clean up legacy OCI8 logic.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "provide": {
         "ext-memcached": "*",
+        "ext-oci8": "*",
         "ext-soap": "*",
         "ext-sodium": "*"
     },
@@ -93,7 +94,7 @@
         "vufind-org/vufind-marc": "1.0.2",
         "webfontkit/open-sans": "^1.0",
         "wikimedia/composer-merge-plugin": "2.0.1",
-        "yajra/laravel-pdo-via-oci8": "2.4.0 || 3.0.0"
+        "yajra/laravel-pdo-via-oci8": "3.3.1"
     },
     "require-dev": {
         "behat/mink": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15723ac3ffa9b846b14fc1c850193729",
+    "content-hash": "a211822b0fbda947d665a250d0a3b61f",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -764,16 +764,16 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+                "reference": "8cffffb2218e01f3b370bf763e00e81697725259"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/8cffffb2218e01f3b370bf763e00e81697725259",
+                "reference": "8cffffb2218e01f3b370bf763e00e81697725259",
                 "shasum": ""
             },
             "require": {
@@ -801,9 +801,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.0"
             },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-05-29T18:55:17+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -8788,19 +8788,20 @@
         },
         {
             "name": "yajra/laravel-pdo-via-oci8",
-            "version": "v3.0.0",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yajra/pdo-via-oci8.git",
-                "reference": "d9ece35f62fe059c7637b778c1bdc8894dedeecb"
+                "reference": "3483f14fc3b3185525a6f8861dc5cd67423693cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yajra/pdo-via-oci8/zipball/d9ece35f62fe059c7637b778c1bdc8894dedeecb",
-                "reference": "d9ece35f62fe059c7637b778c1bdc8894dedeecb",
+                "url": "https://api.github.com/repos/yajra/pdo-via-oci8/zipball/3483f14fc3b3185525a6f8861dc5cd67423693cd",
+                "reference": "3483f14fc3b3185525a6f8861dc5cd67423693cd",
                 "shasum": ""
             },
             "require": {
+                "ext-oci8": "*",
                 "ext-pdo": "*",
                 "php": "^8.0"
             },
@@ -8831,9 +8832,23 @@
             "description": "PDO userspace driver proxying calls to PHP OCI8 driver",
             "support": {
                 "issues": "https://github.com/yajra/pdo-via-oci8/issues",
-                "source": "https://github.com/yajra/pdo-via-oci8/tree/v3.0.0"
+                "source": "https://github.com/yajra/pdo-via-oci8/tree/v3.3.1"
             },
-            "time": "2020-12-08T12:30:53+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/yajra",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/yajra",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/yajra",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2023-03-15T02:21:45+00:00"
         },
         {
             "name": "zfr/rbac",
@@ -9716,16 +9731,16 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.13.0",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "31be7cd4f305f3f7b52af99c1cb13fc938d1cfad"
+                "reference": "1121d4b04af06e33e9659bac3a6741b91cab1de1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/31be7cd4f305f3f7b52af99c1cb13fc938d1cfad",
-                "reference": "31be7cd4f305f3f7b52af99c1cb13fc938d1cfad",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1121d4b04af06e33e9659bac3a6741b91cab1de1",
+                "reference": "1121d4b04af06e33e9659bac3a6741b91cab1de1",
                 "shasum": ""
             },
             "require": {
@@ -9759,9 +9774,15 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
+            "keywords": [
+                "PHP Depend",
+                "PHP_Depend",
+                "dev",
+                "pdepend"
+            ],
             "support": {
                 "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.13.0"
+                "source": "https://github.com/pdepend/pdepend/tree/2.14.0"
             },
             "funding": [
                 {
@@ -9769,7 +9790,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-28T20:56:15+00:00"
+            "time": "2023-05-26T13:15:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -11907,16 +11928,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.23",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "bb7b7988c898c94f5338e16403c52b5a3cae1d93"
+                "reference": "4645e032d0963fb614969398ca28e47605b1a7da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/bb7b7988c898c94f5338e16403c52b5a3cae1d93",
-                "reference": "bb7b7988c898c94f5338e16403c52b5a3cae1d93",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4645e032d0963fb614969398ca28e47605b1a7da",
+                "reference": "4645e032d0963fb614969398ca28e47605b1a7da",
                 "shasum": ""
             },
             "require": {
@@ -11976,7 +11997,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.23"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -11992,7 +12013,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T15:04:16+00:00"
+            "time": "2023-05-05T14:42:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -12435,16 +12456,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.23",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b842fc4b61609e0a155a114082bd94e31e98287"
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b842fc4b61609e0a155a114082bd94e31e98287",
-                "reference": "4b842fc4b61609e0a155a114082bd94e31e98287",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
                 "shasum": ""
             },
             "require": {
@@ -12477,7 +12498,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.23"
+                "source": "https://github.com/symfony/process/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -12493,7 +12514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-18T13:50:24+00:00"
+            "time": "2023-05-17T11:26:05+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/config/vufind/Voyager.ini
+++ b/config/vufind/Voyager.ini
@@ -29,14 +29,6 @@ login_field = LAST_NAME
 ; status 1 (active) or 4 (expired) are allowed.
 ;allowed_barcode_statuses = 1:4:5
 
-; Force OCI8 support. By default OCI8 is only supported on PHP 7, and you will
-; need to update the the yajra/laravel-pdo-via-oci8 package using the following
-; command before enabling it:
-;
-; php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
-;
-;forceOCI8Support = false
-
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.

--- a/config/vufind/VoyagerRestful.ini
+++ b/config/vufind/VoyagerRestful.ini
@@ -32,14 +32,6 @@ login_field = LAST_NAME
 ; This is the timeout value for making HTTP requests to the Voyager API.
 http_timeout = 30
 
-; Force OCI8 support. By default OCI8 is only supported on PHP 7, and you will
-; need to update the the yajra/laravel-pdo-via-oci8 package using the following
-; command before enabling it:
-;
-; php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
-;
-;forceOCI8Support = false
-
 ; These settings affect the Fund list used as a limiter in the "new items" module:
 [Funds]
 ; Uncomment this line to turn off the fund list entirely.

--- a/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Voyager.php
@@ -189,28 +189,6 @@ class Voyager extends AbstractBase implements TranslatorAwareInterface, \Laminas
                      ')' .
                    ')';
             try {
-                if (
-                    (!defined('PHP_MAJOR_VERSION') || PHP_MAJOR_VERSION >= 8)
-                    && empty($this->config['Catalog']['forceOCI8Support'])
-                ) {
-                    $this->error(
-                        <<<EOT
-                            Voyager connection is only supported on PHP 7 by default. To enable support, you
-                            will need to manually update the yajra/laravel-pdo-via-oci8 package using the
-                            following command:
-
-                            php [path/to/]composer.phar update yajra/laravel-pdo-via-oci8 --ignore-platform-reqs
-
-                            Then force the Voyager driver to connect by adding the following setting to
-                            Voyager.ini or VoyagerRestful.ini:
-
-                            [Catalog]
-                            forceOCI8Support = true
-
-                            EOT
-                    );
-                    throw new ILSException('Unsupported PHP version');
-                }
                 $this->lazyDb = new Oci8(
                     "oci:dbname=$tns;charset=US7ASCII",
                     $this->config['Catalog']['user'],


### PR DESCRIPTION
I'm not sure if anyone is in a position to actually test this anymore now that we've migrated away from Voyager, but this PR cleans out some old PHP7-specific logic now that we're raising our minimum version to PHP8. It also adds a new "provides" setting to composer.json so that the oci8 PHP extension is not mandatory.