### PR TITLE
SierraRest: Add more configuration options for hold availability

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -122,6 +122,10 @@ item_hold_excluded_item_codes = "e"
 ; holds.
 ;item_hold_excluded_item_types = "215:251"
 
+; A colon separated list of bib levels that enable item level holds. If not defined,
+; title_hold_bib_levels is used instead.
+;item_hold_bib_levels = "a:b:m:d"
+
 ; A colon separated list of bib levels that enable title level holds
 title_hold_bib_levels = "a:b:m:d"
 

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -82,11 +82,6 @@ password_field = "pin"
 ; settings. Additional notes about some of these settings are available in the wiki:
 ; https://vufind.org/wiki/configuration:ils:holds
 [Holds]
-; If a colon separated list of item statuses is provided here, only matching items
-; will show hold links.  Skip this setting to allow all statuses.
-; Note that VuFind-style statuses are used here.
-;valid_hold_statuses = 'On Shelf:Charged'
-
 ; HMACKeys - A list of hold form element names that will be analyzed for consistency
 ; during hold form processing. Most users should not need to change this setting.
 HMACKeys = item_id:holdtype:level
@@ -113,16 +108,32 @@ defaultPickUpLocation = ""
 ; By default item holds are enabled. Uncomment this setting to disable item holds.
 ;enableItemHolds = false
 
-; This setting specifies which item codes disable item level holds
-item_hold_excluded_item_codes = e
+; If a colon separated list of item statuses is provided here, only matching items
+; will show hold links.  Skip this setting to allow all statuses.
+; Note that VuFind-style statuses are used here.
+;valid_hold_statuses = 'On Shelf:Charged'
 
-; This setting specifies which bib levels allow title level holds
-title_hold_bib_levels = a:b:m:d
+; A colon separated list of item codes (ICODE2 in Sierra) that disable item level
+; holds.
+item_hold_excluded_item_codes = "e"
 
-; By default a title hold can be placed even when there are no items. Uncomment this
-; to prevent holds if no items exist. If request groups are enabled, item existence
-; is checked only in the selected request group.
-;checkItemsExist = true
+; A colon separated list of item types (I TYPE in Sierra) that disable item level
+; holds.
+;item_hold_excluded_item_types = "215:251"
+
+; A colon separated list of bib levels that enable title level holds
+title_hold_bib_levels = "a:b:m:d"
+
+; If a colon separated list of rules is provided here, title level hold is only
+; displayed for records matching any of the rules.
+; Valid rules are:
+; item                    The title must have at least one item
+; holdable_item           The title must have at least one item that matches the
+;                         item holdability rules (regardless of whether item holds
+;                         are enabled)
+; order                   The title must have at least one active order (order
+;                         record with "ON ORDER" status)
+;title_hold_rules = "holdable_item:order"
 
 ; Fields that can be updated for holds (unless the hold is already in transit or
 ; available for pickup). Supported values are "frozen" and "pickUpLocation".

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -164,7 +164,7 @@ title_hold_bib_levels = "a:b:m:d"
 ;allowCancelingAvailableRequests = true
 
 ; This section allows modification of the default mapping from item status codes to
-; VuFind item statuses. Defaults are
+; VuFind item statuses. Defaults are listed below.
 [ItemStatusMappings]
 ;! = "On Holdshelf"
 ;t = "In Transit"

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -110,7 +110,8 @@ defaultPickUpLocation = ""
 
 ; If a colon separated list of item statuses is provided here, only matching items
 ; will show hold links.  Skip this setting to allow all statuses.
-; Note that VuFind-style statuses are used here.
+; Note that mapped status strings are used here (see the [ItemStatusMappings] for
+; more information).
 ;valid_hold_statuses = 'On Shelf:Charged'
 
 ; A colon separated list of item codes (ICODE2 in Sierra) that disable item level
@@ -127,12 +128,12 @@ title_hold_bib_levels = "a:b:m:d"
 ; If a colon separated list of rules is provided here, title level hold is only
 ; displayed for records matching any of the rules.
 ; Valid rules are:
-; item                    The title must have at least one item
-; holdable_item           The title must have at least one item that matches the
-;                         item holdability rules (regardless of whether item holds
-;                         are enabled)
-; order                   The title must have at least one active order (order
-;                         record with "ON ORDER" status)
+;   item           The title must have at least one item
+;   holdable_item  The title must have at least one item that matches the
+;                  item holdability rules (regardless of whether item holds are
+;                  enabled)
+;   order          The title must have at least one active order (order record with
+;                  "ON ORDER" status)
 ;title_hold_rules = "holdable_item:order"
 
 ; Fields that can be updated for holds (unless the hold is already in transit or
@@ -159,7 +160,7 @@ title_hold_bib_levels = "a:b:m:d"
 ;allowCancelingAvailableRequests = true
 
 ; This section allows modification of the default mapping from item status codes to
-; VuFind item statuses
+; VuFind item statuses. Defaults are
 [ItemStatusMappings]
 ;! = "On Holdshelf"
 ;t = "In Transit"
@@ -173,9 +174,10 @@ title_hold_bib_levels = "a:b:m:d"
 ;s = "On Search"
 ;d = "In Process"
 ;- = "On Shelf"
-; This is a special case -- not an official Sierra code, but a VuFind-specific way
-; of defining the "checked out" message text:
+; These are special cases -- not official Sierra codes, but a VuFind-specific way
+; of defining the "checked out" and "ordered" message texts:
 ;Charged = "Charged"
+;Ordered = "Ordered"
 
 ; This section allows mapping of patron block codes to VuFind translation strings
 [PatronBlockMappings]

--- a/module/VuFind/src/VuFind/Config/ExplodeSettingTrait.php
+++ b/module/VuFind/src/VuFind/Config/ExplodeSettingTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Trait providing support for converting delimited settings to arrays
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Config
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+
+namespace VuFind\Config;
+
+/**
+ * Trait providing support for converting delimited settings to arrays
+ *
+ * @category VuFind
+ * @package  Config
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+trait ExplodeSettingTrait
+{
+    /**
+     * Explode a delimited setting to an array
+     *
+     * @param string $value     Setting value
+     * @param bool   $trim      Whether to trim the values (disabled by default to
+     * ensure any valid blank entry does not get trimmed, and to avoid doing extra
+     * work on each execution)
+     * @param string $separator Separator
+     *
+     * @return array
+     */
+    protected function explodeSetting(
+        string $value,
+        $trim = false,
+        string $separator = ':'
+    ): array {
+        if ('' === $value) {
+            return [];
+        }
+        $result = explode($separator, $value);
+        if ($trim) {
+            $result = array_map('trim', $result);
+        }
+        return $result;
+    }
+}

--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
@@ -81,4 +81,28 @@ abstract class AbstractBase implements DriverInterface
     ): void {
         throw new ILSException($msg ?? $exception->getMessage(), 0, $exception);
     }
+
+    /**
+     * Explode a delimited setting to an array
+     *
+     * @param string $value     Setting value
+     * @param bool   $trim      Whether to trim the values
+     * @param string $separator Separator
+     *
+     * @return array
+     */
+    protected function explodeSetting(
+        string $value,
+        $trim = false,
+        string $separator = ':'
+    ): array {
+        if ('' === $value) {
+            return [];
+        }
+        $result = explode($separator, $value);
+        if ($trim) {
+            $result = array_map('trim', $result);
+        }
+        return $result;
+    }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
@@ -81,28 +81,4 @@ abstract class AbstractBase implements DriverInterface
     ): void {
         throw new ILSException($msg ?? $exception->getMessage(), 0, $exception);
     }
-
-    /**
-     * Explode a delimited setting to an array
-     *
-     * @param string $value     Setting value
-     * @param bool   $trim      Whether to trim the values
-     * @param string $separator Separator
-     *
-     * @return array
-     */
-    protected function explodeSetting(
-        string $value,
-        $trim = false,
-        string $separator = ':'
-    ): array {
-        if ('' === $value) {
-            return [];
-        }
-        $result = explode($separator, $value);
-        if ($trim) {
-            $result = array_map('trim', $result);
-        }
-        return $result;
-    }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2629,8 +2629,6 @@ class SierraRest extends AbstractBase implements
      * @param array $bib  Bib record from Sierra
      *
      * @return bool
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function isHoldable(array $item, array $bib): bool
     {

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -97,11 +97,18 @@ class SierraRest extends AbstractBase implements
     protected $itemHoldsEnabled;
 
     /**
-     * Item codes for which item level hold is not allowed
+     * Item codes (ICODE2 in Sierra) for which item level hold is not allowed
      *
      * @var array
      */
-    protected $itemHoldExcludedItemCodes;
+    protected $itemHoldExcludedItemCodes = [];
+
+    /**
+     * Item types (I TYPE in Sierra) for which item level hold is not allowed
+     *
+     * @var array
+     */
+    protected $itemHoldExcludedItemTypes = [];
 
     /**
      * Bib levels for which title level hold is allowed
@@ -130,6 +137,13 @@ class SierraRest extends AbstractBase implements
      * @var array
      */
     protected $validHoldStatuses;
+
+    /**
+     * Title hold rules
+     *
+     * @var array
+     */
+    protected $titleHoldRules = [];
 
     /**
      * Mappings from item status codes to VuFind strings
@@ -242,6 +256,23 @@ class SierraRest extends AbstractBase implements
     ];
 
     /**
+     * Bib cache entry life time in seconds
+     *
+     * @var int
+     */
+    protected $bibCacheTTL = 300;
+
+    /**
+     * Life time in seconds for cached items of a bibliographic record
+     *
+     * It is recommended to keep this fairly short to ensure that any recent changes
+     * (such as placing a hold) are reflected correctly in holdings.
+     *
+     * @var int
+     */
+    protected $bibItemsCacheTTL = 10;
+
+    /**
      * Constructor
      *
      * @param \VuFind\Date\Converter $dateConverter  Date converter object
@@ -290,35 +321,23 @@ class SierraRest extends AbstractBase implements
             }
         }
 
-        $this->validHoldStatuses
-            = !empty($this->config['Holds']['valid_hold_statuses'])
-            ? explode(':', $this->config['Holds']['valid_hold_statuses'])
-            : [];
+        $holdCfg = $this->config['Holds'] ?? [];
 
-        $this->itemHoldsEnabled
-            = $this->config['Holds']['enableItemHolds'] ?? true;
-
+        $this->validHoldStatuses = $this->explodeSetting($holdCfg['valid_hold_statuses'] ?? '');
+        $this->itemHoldsEnabled = $holdCfg['enableItemHolds'] ?? true;
         $this->itemHoldExcludedItemCodes
-            = !empty($this->config['Holds']['item_hold_excluded_item_codes'])
-            ? explode(':', $this->config['Holds']['item_hold_excluded_item_codes'])
-            : [];
-
-        $this->titleHoldBibLevels
-            = !empty($this->config['Holds']['title_hold_bib_levels'])
-            ? explode(':', $this->config['Holds']['title_hold_bib_levels'])
-            : ['a', 'b', 'm', 'd'];
-
+            = $this->explodeSetting($holdCfg['item_hold_excluded_item_codes'] ?? '');
+        $this->itemHoldExcludedItemTypes
+            = $this->explodeSetting($holdCfg['item_hold_excluded_item_types'] ?? '');
+        $this->titleHoldBibLevels = $this->explodeSetting($holdCfg['title_hold_bib_levels'] ?? '');
+        $this->titleHoldRules = $this->explodeSetting($holdCfg['title_hold_rules'] ?? '');
         $this->allowCancelingAvailableRequests
-            = $this->config['Holds']['allowCancelingAvailableRequests'] ?? false;
-
-        $this->defaultPickUpLocation
-            = $this->config['Holds']['defaultPickUpLocation'] ?? '';
+            = $holdCfg['allowCancelingAvailableRequests'] ?? false;
+        $this->defaultPickUpLocation = $holdCfg['defaultPickUpLocation'] ?? '';
         if ($this->defaultPickUpLocation === 'user-selected') {
             $this->defaultPickUpLocation = false;
         }
-
-        $this->checkFreezability
-            = !empty($this->config['Holds']['checkFreezability']);
+        $this->checkFreezability = $holdCfg['checkFreezability'] ?? false;
 
         if (!empty($this->config['ItemStatusMappings'])) {
             $this->itemStatusMappings = array_merge(
@@ -405,7 +424,7 @@ class SierraRest extends AbstractBase implements
      */
     public function getHolding($id, array $patron = null, array $options = [])
     {
-        return $this->getItemStatusesForBib($id, true);
+        return $this->getItemStatusesForBib($id, true, $patron);
     }
 
     /**
@@ -945,7 +964,7 @@ class SierraRest extends AbstractBase implements
             }
             if (!empty($bibId)) {
                 // Fetch bib information
-                $bib = $this->getBibRecord($bibId, 'title,publishYear', $patron);
+                $bib = $this->getBibRecord($bibId, ['title', 'publishYear'], $patron);
                 $title = $bib['title'] ?? '';
                 $publicationYear = $bib['publishYear'] ?? '';
             }
@@ -1259,11 +1278,18 @@ class SierraRest extends AbstractBase implements
         }
         $level = $data['level'] ?? 'copy';
         if ('title' === $level) {
-            $bib = $this->getBibRecord($id, 'bibLevel', $patron);
+            $fields = ['bibLevel'];
+            if (in_array('order', $this->titleHoldRules)) {
+                $fields[] = 'orders';
+            }
+            $bib = $this->getBibRecord($id, $fields, $patron);
             if (
                 !isset($bib['bibLevel']['code'])
                 || !in_array($bib['bibLevel']['code'], $this->titleHoldBibLevels)
             ) {
+                return false;
+            }
+            if (!$this->checkTitleHoldRules($bib, $patron)) {
                 return false;
             }
         }
@@ -1392,7 +1418,7 @@ class SierraRest extends AbstractBase implements
                 if (!empty($item['bibIds'])) {
                     $bibId = $item['bibIds'][0];
                     // Fetch bib information
-                    $bib = $this->getBibRecord($bibId, 'title,publishYear', $patron);
+                    $bib = $this->getBibRecord($bibId, null, $patron);
                     $title = $bib['title'] ?? '';
                 }
             }
@@ -2068,22 +2094,23 @@ class SierraRest extends AbstractBase implements
      *
      * @param string $id            The record id to retrieve the holdings for
      * @param bool   $checkHoldings Whether to check holdings records
+     * @param ?array $patron        Patron information, if available
      *
      * @return array An associative array with the following keys:
      * id, availability (boolean), status, location, reserve, callnumber.
      */
-    protected function getItemStatusesForBib($id, $checkHoldings)
+    protected function getItemStatusesForBib(string $id, bool $checkHoldings, ?array $patron = null): array
     {
-        $bibFields = 'bibLevel';
+        $bibFields = ['bibLevel'];
         // If we need to look at bib call numbers, retrieve varFields:
         if (!empty($this->config['CallNumber']['bib_fields'])) {
-            $bibFields .= ',varFields';
+            $bibFields[] = 'varFields';
         }
         // Retrieve orders if needed:
         if (!empty($this->config['Holdings']['display_orders'])) {
-            $bibFields .= ',orders';
+            $bibFields[] = 'orders';
         }
-        $bib = $this->getBibRecord($id, $bibFields);
+        $bib = $this->getBibRecord($id, $bibFields, $patron);
         $bibCallNumber = $this->getBibCallNumber($bib);
         $orders = [];
         foreach ($bib['orders'] ?? [] as $order) {
@@ -2120,91 +2147,59 @@ class SierraRest extends AbstractBase implements
             }
         }
 
-        $offset = 0;
-        $limit = 50;
-        $fields = 'location,status,barcode,callNumber,fixedFields,varFields';
+        $items = $this->getItemsForBibRecord($id, null, $patron);
         $statuses = [];
         $sort = 0;
-        $result = null;
-        while (null === $result || $limit === $result['total']) {
-            $result = $this->makeRequest(
-                [$this->apiBase, 'items'],
-                [
-                    'bibIds' => $this->extractBibId($id),
-                    'deleted' => 'false',
-                    'suppressed' => 'false',
-                    'fields' => $fields,
-                    'limit' => $limit,
-                    'offset' => $offset,
-                ],
-                'GET'
-            );
-            if (empty($result['entries'])) {
-                if (!empty($result['httpStatus']) && 404 !== $result['httpStatus']) {
-                    $msg = "Item status request failed: {$result['httpStatus']}";
-                    if (!empty($result['description'])) {
-                        $msg .= " ({$result['description']})";
-                    }
-                    throw new ILSException($msg);
+        foreach ($items as $item) {
+            $location = $this->translateLocation($item['location']);
+            [$status, $duedate, $notes] = $this->getItemStatus($item);
+            $available = $status == $this->mapStatusCode('-');
+            // OPAC message
+            if (isset($item['fixedFields']['108'])) {
+                $opacMsg = $item['fixedFields']['108'];
+                $trimmedMsg = trim($opacMsg['value']);
+                if (strlen($trimmedMsg) && $trimmedMsg != '-') {
+                    $notes[] = $this->translateOpacMessage(
+                        trim($opacMsg['value'])
+                    );
                 }
-                break;
+            }
+            $volume = isset($item['varFields']) ? $this->extractVolume($item) : '';
+
+            $entry = [
+                'id' => $id,
+                'item_id' => $item['id'],
+                'location' => $location,
+                'availability' => $available,
+                'status' => $status,
+                'reserve' => 'N',
+                'callnumber' => isset($item['callNumber'])
+                    ? preg_replace('/^\|a/', '', $item['callNumber'])
+                    : $bibCallNumber,
+                'duedate' => $duedate,
+                'number' => $volume,
+                'barcode' => $item['barcode'],
+                'sort' => $sort--,
+            ];
+            if ($notes) {
+                $entry['item_notes'] = $notes;
             }
 
-            foreach ($result['entries'] as $item) {
-                $location = $this->translateLocation($item['location']);
-                [$status, $duedate, $notes] = $this->getItemStatus($item);
-                $available = $status == $this->mapStatusCode('-');
-                // OPAC message
-                if (isset($item['fixedFields']['108'])) {
-                    $opacMsg = $item['fixedFields']['108'];
-                    $trimmedMsg = trim($opacMsg['value']);
-                    if (strlen($trimmedMsg) && $trimmedMsg != '-') {
-                        $notes[] = $this->translateOpacMessage(
-                            trim($opacMsg['value'])
-                        );
-                    }
-                }
-                $volume = isset($item['varFields']) ? $this->extractVolume($item)
-                    : '';
-
-                $entry = [
-                    'id' => $id,
-                    'item_id' => $item['id'],
-                    'location' => $location,
-                    'availability' => $available,
-                    'status' => $status,
-                    'reserve' => 'N',
-                    'callnumber' => isset($item['callNumber'])
-                        ? preg_replace('/^\|a/', '', $item['callNumber'])
-                        : $bibCallNumber,
-                    'duedate' => $duedate,
-                    'number' => $volume,
-                    'barcode' => $item['barcode'],
-                    'sort' => $sort--,
-                ];
-                if ($notes) {
-                    $entry['item_notes'] = $notes;
-                }
-
-                if (
-                    $this->isHoldable($item) && $this->itemHoldAllowed($item, $bib)
-                ) {
-                    $entry['is_holdable'] = true;
-                    $entry['level'] = 'copy';
-                    $entry['addLink'] = true;
-                } else {
-                    $entry['is_holdable'] = false;
-                }
-
-                $locationCode = $item['location']['code'] ?? '';
-                if (!empty($holdingsData[$locationCode])) {
-                    $entry += $this->getHoldingsData($holdingsData[$locationCode]);
-                    $holdingsData[$locationCode]['_hasItems'] = true;
-                }
-
-                $statuses[] = $entry;
+            if ($this->itemHoldsEnabled && $this->isHoldable($item, $bib)) {
+                $entry['is_holdable'] = true;
+                $entry['level'] = 'copy';
+                $entry['addLink'] = true;
+            } else {
+                $entry['is_holdable'] = false;
             }
-            $offset += $limit;
+
+            $locationCode = $item['location']['code'] ?? '';
+            if (!empty($holdingsData[$locationCode])) {
+                $entry += $this->getHoldingsData($holdingsData[$locationCode]);
+                $holdingsData[$locationCode]['_hasItems'] = true;
+            }
+
+            $statuses[] = $entry;
         }
 
         // Add holdings that don't have items
@@ -2568,32 +2563,17 @@ class SierraRest extends AbstractBase implements
      * Determine whether an item is holdable
      *
      * @param array $item Item from Sierra
+     * @param array $bib  Bib record from Sierra
      *
      * @return bool
      */
-    protected function isHoldable($item)
+    protected function isHoldable(array $item, array $bib): bool
     {
         if (!empty($this->validHoldStatuses)) {
             [$status] = $this->getItemStatus($item);
             if (!in_array($status, $this->validHoldStatuses)) {
                 return false;
             }
-        }
-        return true;
-    }
-
-    /**
-     * Check if an item is holdable
-     *
-     * @param array $item Item from Sierra
-     * @param array $bib  Bib record from Sierra
-     *
-     * @return bool
-     */
-    protected function itemHoldAllowed($item, $bib)
-    {
-        if (!$this->itemHoldsEnabled) {
-            return false;
         }
         if (
             !empty($this->itemHoldExcludedItemCodes)
@@ -2733,46 +2713,146 @@ class SierraRest extends AbstractBase implements
     }
 
     /**
+     * Get a cached record and check that it has the requested fields
+     *
+     * @param string $cacheId Cache entry ID
+     * @param array  $fields  Fields
+     *
+     * @return array Array with cached data if available, and fields (existing or
+     * required)
+     */
+    protected function getCachedRecordData(string $cacheId, array $fields): array
+    {
+        if ($cached = $this->getCachedData($cacheId)) {
+            if (!array_diff($fields, $cached['fields'])) {
+                // We already have all required fields cached:
+                return $cached;
+            }
+        }
+        $cached = [
+            'data' => [],
+            'fields' => array_unique([...$fields, ...($cached['fields'] ?? [])]),
+        ];
+
+        return $cached;
+    }
+
+    /**
+     * Insert a record and its fields into the cache
+     *
+     * @param string $cacheId Cache entry ID
+     * @param array  $fields  Fields
+     * @param array  $data    Data
+     * @param int    $ttl     Cache entry life time
+     *
+     * @return void
+     */
+    protected function putCachedRecordData(string $cacheId, array $fields, array $data, int $ttl): void
+    {
+        $this->putCachedData($cacheId, compact('data', 'fields'), $ttl);
+    }
+
+    /**
      * Fetch fields for a bib record from Sierra
      *
      * Note: This method can return cached data
      *
-     * @param int    $id     Bib record id
-     * @param string $fields Fields to request
+     * @param string $id     Bib record id
+     * @param ?array $fields Fields to request or null for defaults
      * @param array  $patron Patron information, if available
      *
      * @return array|null
      */
-    protected function getBibRecord($id, $fields, $patron = false)
+    protected function getBibRecord(string $id, ?array $fields, ?array $patron = null): ?array
     {
+        $fields ??= ['title', 'publishYear', 'bibLevel'];
         $cacheId = "bib|$id";
-        $fieldsArray = explode(',', $fields);
-        if ($cached = $this->getCachedData($cacheId)) {
-            if (!array_diff($fieldsArray, $cached['fields'])) {
-                // We already have all required fields cached:
-                return $cached['data'];
-            }
-        } else {
-            $cached = [
-                'fields' => [],
-                'data' => [],
-            ];
+        $cached = $this->getCachedRecordData($cacheId, $fields);
+        if ($cached['data']) {
+            // We already have all required fields cached:
+            return $cached['data'];
         }
         // Fetch requested fields as well as any cached fields to keep everything in
         // sync:
-        $allFields = array_unique([...$fieldsArray, ...$cached['fields']]);
         $result = $this->makeRequest(
             [$this->apiBase, 'bibs', $this->extractBibId($id)],
-            ['fields' => implode(',', $allFields)],
+            ['fields' => implode(',', $cached['fields'])],
             'GET',
             $patron
         );
         if (null !== $result) {
-            $cached['fields'] = $allFields;
-            $cached['data'] = $result;
-            $this->putCachedData($cacheId, $cached, 300);
+            $this->putCachedRecordData($cacheId, $cached['fields'], $result, $this->bibCacheTTL);
         }
         return $result;
+    }
+
+    /**
+     * Get all items for a bib record
+     *
+     * Note: This method can return cached data
+     *
+     * @param string $id     Bib record id
+     * @param ?array $fields Fields to request or null for defaults
+     * @param array  $patron Patron information, if available
+     *
+     * @return array
+     */
+    protected function getItemsForBibRecord(
+        string $id,
+        ?array $fields = null,
+        ?array $patron = null
+    ): array {
+        $fields ??= [
+            'location',
+            'status',
+            'barcode',
+            'callNumber',
+            'fixedFields',
+            'varFields',
+            'itemType',
+        ];
+
+        $cacheId = "items|$id";
+        $cached = $this->getCachedRecordData($cacheId, $fields);
+        if ($cached['data']) {
+            // We already have all required fields cached:
+            return $cached['data'];
+        }
+        $items = [];
+        $offset = 0;
+        $limit = 50;
+        $result = null;
+        while (null === $result || $limit === $result['total']) {
+            // Fetch requested fields as well as any cached fields to keep everything
+            // in sync:
+            $result = $this->makeRequest(
+                [$this->apiBase, 'items'],
+                [
+                    'bibIds' => $this->extractBibId($id),
+                    'deleted' => 'false',
+                    'suppressed' => 'false',
+                    'fields' => implode(',', $cached['fields']),
+                    'limit' => $limit,
+                    'offset' => $offset,
+                ],
+                'GET',
+                $patron
+            );
+            if (empty($result['entries'])) {
+                if (!empty($result['httpStatus']) && 404 !== $result['httpStatus']) {
+                    $msg = "Item status request failed: {$result['httpStatus']}";
+                    if (!empty($result['description'])) {
+                        $msg .= " ({$result['description']})";
+                    }
+                    throw new ILSException($msg);
+                }
+                break;
+            }
+            $items = [...$items, ...$result['entries']];
+            $offset += $limit;
+        }
+        $this->putCachedRecordData($cacheId, $cached['fields'], $items, $this->bibItemsCacheTTL);
+        return $items;
     }
 
     /**
@@ -3085,5 +3165,42 @@ class SierraRest extends AbstractBase implements
         }
 
         return $items;
+    }
+
+    /**
+     * Check if bib matches title hold rules
+     *
+     * @param array $bib    Bibliographic record fields
+     * @param array $patron An array of patron data
+     *
+     * @return bool True if request is valid, false if not
+     */
+    protected function checkTitleHoldRules(array $bib, array $patron): bool
+    {
+        if (!$this->titleHoldRules) {
+            return true;
+        }
+
+        if (
+            in_array('order', $this->titleHoldRules)
+            && !empty($bib['orders'])
+        ) {
+            return true;
+        }
+        if (
+            in_array('item', $this->titleHoldRules)
+            || in_array('holdable_item', $this->titleHoldRules)
+        ) {
+            $items = $this->getItemsForBibRecord($bib['id'], null, $patron);
+            if ($items && in_array('item', $this->titleHoldRules)) {
+                return true;
+            }
+            foreach ($items as $item) {
+                if ($this->isHoldable($item, $bib)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -145,6 +145,13 @@ class SierraRest extends AbstractBase implements
     protected $itemHoldExcludedItemTypes = [];
 
     /**
+     * Bib levels for which item level hold is allowed
+     *
+     * @var array
+     */
+    protected $itemHoldBibLevels;
+
+    /**
      * Bib levels for which title level hold is allowed
      *
      * @var array
@@ -382,6 +389,9 @@ class SierraRest extends AbstractBase implements
             = $this->explodeSetting($holdCfg['item_hold_excluded_item_codes'] ?? '');
         $this->itemHoldExcludedItemTypes
             = $this->explodeSetting($holdCfg['item_hold_excluded_item_types'] ?? '');
+        $this->itemHoldBibLevels = $this->explodeSetting(
+            $holdCfg['item_hold_bib_levels'] ?? $holdCfg['title_hold_bib_levels'] ?? ''
+        );
         $this->titleHoldBibLevels = $this->explodeSetting($holdCfg['title_hold_bib_levels'] ?? '');
         $this->titleHoldRules = $this->explodeSetting($holdCfg['title_hold_rules'] ?? '');
         $this->allowCancelingAvailableRequests
@@ -2624,6 +2634,13 @@ class SierraRest extends AbstractBase implements
      */
     protected function isHoldable(array $item, array $bib): bool
     {
+        if (
+            !isset($bib['bibLevel']['code'])
+            || !in_array($bib['bibLevel']['code'], $this->itemHoldBibLevels)
+        ) {
+            return false;
+        }
+
         if (!empty($this->validHoldStatuses)) {
             [$status] = $this->getItemStatus($item);
             if (!in_array($status, $this->validHoldStatuses)) {

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -63,28 +63,28 @@ class SierraRest extends AbstractBase implements
     /**
      * Fixed field number for location in holdings records
      *
-     * @var int
+     * @var string
      */
     public const HOLDINGS_LOCATION_FIELD = '40';
 
     /**
      * Fixed field number for item code 2 (ICODE2) in item records
      *
-     * @var int
+     * @var string
      */
     public const ITEM_ICODE2_FIELD = '60';
 
     /**
      * Fixed field number for item type (I TYPE) in item records
      *
-     * @var int
+     * @var string
      */
     public const ITEM_ITYPE_FIELD = '61';
 
     /**
      * Fixed field number for item last checkin date (LCHKIN) in item records
      *
-     * @var int
+     * @var string
      */
     public const ITEM_CHECKIN_DATE_FIELD = '68';
 
@@ -297,7 +297,7 @@ class SierraRest extends AbstractBase implements
      *
      * @var int
      */
-    protected $bibItemsCacheTTL = 10;
+    protected $bibItemsCacheTTL = 2;
 
     /**
      * Default list of bib fields to request from Sierra. This list must include
@@ -2818,11 +2818,11 @@ class SierraRest extends AbstractBase implements
      *
      * @param string $id     Bib record id
      * @param ?array $fields Fields to request or null for defaults
-     * @param array  $patron Patron information, if available
+     * @param ?array $patron Patron information, if available
      *
-     * @return array|null
+     * @return ?array
      */
-    protected function getBibRecord(string $id, ?array $fields, ?array $patron = null): ?array
+    protected function getBibRecord(string $id, ?array $fields = null, ?array $patron = null): ?array
     {
         $fields ??= $this->defaultBibFields;
         $cacheId = "bib|$id";
@@ -2852,7 +2852,7 @@ class SierraRest extends AbstractBase implements
      *
      * @param string $id     Bib record id
      * @param ?array $fields Fields to request or null for defaults
-     * @param array  $patron Patron information, if available
+     * @param ?array $patron Patron information, if available
      *
      * @return array
      */
@@ -3238,12 +3238,13 @@ class SierraRest extends AbstractBase implements
         ) {
             return true;
         }
+
         if (
-            in_array('item', $this->titleHoldRules)
+            ($checkForItems = in_array('item', $this->titleHoldRules))
             || in_array('holdable_item', $this->titleHoldRules)
         ) {
             $items = $this->getItemsForBibRecord($bib['id'], null, $patron);
-            if ($items && in_array('item', $this->titleHoldRules)) {
+            if ($checkForItems && $items) {
                 return true;
             }
             foreach ($items as $item) {


### PR DESCRIPTION
New settings have been added to control holdability of items and bibs. Some of the code has been refactored to be reusable and requests to be cacheable.

More specfically, item retrieval has been extracted from getItemStatusesForBiblio, and its results are used in checkRequestIsValid/checkTitleHoldRules as well to avoid requesting the same information multiple times. The items are only cached for 10 seconds by default to avoid displaying stale information. It would be nice to have a shortcut for returning title holdability directly with getHolding, but this is the best I could manage without touching the upper level logic.

The newly added explodeSetting method simplifies initialization of colon separated settings, and I intend to follow up with extended use of it.
