### PR TITLE
Alma: make item status mapping to uncertain work with getStatus call.

### DIFF
--- a/module/VuFind/tests/fixtures/alma/holdings-with-mappings.json
+++ b/module/VuFind/tests/fixtures/alma/holdings-with-mappings.json
@@ -145,18 +145,20 @@
         {
             "id": "1111",
             "source": "Solr",
-            "callnumber": "HB Ab",
+            "callnumber": "",
             "reserve": "N",
             "availability": true,
-            "location": "Central"
+            "location": "Collection Name - Central",
+            "status": null
         },
         {
             "id": "1111",
             "source": "Solr",
-            "callnumber": "HB Ab",
+            "callnumber": "",
             "reserve": "N",
             "availability": false,
-            "location": "Central"
+            "location": "Other Collection - Central",
+            "status": null
         }
     ]
 }

--- a/module/VuFind/tests/fixtures/alma/holdings-without-mappings.json
+++ b/module/VuFind/tests/fixtures/alma/holdings-without-mappings.json
@@ -145,18 +145,20 @@
         {
             "id": "1111",
             "source": "Solr",
-            "callnumber": "HB Ab",
+            "callnumber": "",
             "reserve": "N",
             "availability": true,
-            "location": "Central"
+            "location": "Collection Name - Central",
+            "status": null
         },
         {
             "id": "1111",
             "source": "Solr",
-            "callnumber": "HB Ab",
+            "callnumber": "",
             "reserve": "N",
             "availability": false,
-            "location": "Central"
+            "location": "Other Collection - Central",
+            "status": null
         }
     ]
 }

--- a/module/VuFind/tests/fixtures/alma/responses/get-holding-avail.xml
+++ b/module/VuFind/tests/fixtures/alma/responses/get-holding-avail.xml
@@ -166,37 +166,23 @@
 			<datafield ind1="2" ind2=" " tag="710">
 				<subfield code="a">Mattilan kyläyhdistys.</subfield>
 			</datafield>
-			<datafield ind1=" " ind2=" " tag="AVA">
-				<subfield code="0">1111</subfield>
+			<datafield ind1=" " ind2=" " tag="AVE">
 				<subfield code="8">2221</subfield>
+				<subfield code="c">123456789</subfield>
+				<subfield code="e">Available</subfield>
+				<subfield code="m">Collection Name</subfield>
 				<subfield code="a">358FIN</subfield>
-				<subfield code="b">Central</subfield>
-				<subfield code="c">Central</subfield>
-				<subfield code="d">HB Ab</subfield>
-				<subfield code="e">available</subfield>
-				<subfield code="f">1</subfield>
-				<subfield code="g">0</subfield>
-				<subfield code="i">Campus</subfield>
-				<subfield code="j">general</subfield>
-				<subfield code="k">8</subfield>
-				<subfield code="p">1</subfield>
-				<subfield code="q">Central</subfield>
-			</datafield>
-			<datafield ind1=" " ind2=" " tag="AVA">
 				<subfield code="0">1111</subfield>
-				<subfield code="8">2222</subfield>
-				<subfield code="a">358FIN</subfield>
 				<subfield code="b">Central</subfield>
-				<subfield code="c">Central</subfield>
-				<subfield code="d">HB Ab</subfield>
-				<subfield code="e">unavailable</subfield>
-				<subfield code="f">1</subfield>
-				<subfield code="g">0</subfield>
-				<subfield code="i">Campus</subfield>
-				<subfield code="j">staff</subfield>
-				<subfield code="k">8</subfield>
-				<subfield code="p">1</subfield>
-				<subfield code="q">Central</subfield>
+			</datafield>
+			<datafield ind1=" " ind2=" " tag="AVE">
+				<subfield code="8">2222</subfield>
+				<subfield code="c">123456789</subfield>
+				<subfield code="e">Unavailable</subfield>
+				<subfield code="m">Other Collection</subfield>
+				<subfield code="a">358FIN</subfield>
+				<subfield code="0">1111</subfield>
+				<subfield code="b">Central</subfield>
 			</datafield>
 		</record>
 	</bib>


### PR DESCRIPTION
Previously item status mapping to uncertain based on location type only worked with getHolding.

This also fixes the getHolding test to return proper electronic holdings. The previous mocked response had wrong MARC fields.

To make this work the getItemLocationType had to be moved out from the getItemStatusFromLocationTypeMap method because getStatus only had MARC fields to manage with. This makes for the bulk of the changes.