### PR TITLE
Revert confusing Demo driver changes.

### DIFF
--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -138,7 +138,7 @@ updateHolds = 25
 [Holds]
 ; HMACKeys - A list of hold form element names that will be analyzed for consistency
 ; during hold form processing. Most users should not need to change this setting.
-HMACKeys = "record_id:item_id:level"
+HMACKeys = "id:item_id:level"
 
 ; defaultRequiredDate - A colon-separated list used to set the default "not required
 ; after" date for holds in the format days:months:years

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -466,7 +466,6 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         $locationhref = ($location === 'Campus A') ? 'http://campus-a' : false;
         $result = [
             'id'           => $id,
-            'record_id'    => $id, // for hold links to not rely on id from route
             'source'       => $this->getRecordSource(),
             'item_id'      => $number,
             'number'       => $number,
@@ -2081,7 +2080,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         }
         $session->holds->append(
             [
-                'id'       => $holdDetails['record_id'],
+                'id'       => $holdDetails['id'],
                 'source'   => $this->getRecordSource(),
                 'location' => $holdDetails['pickUpLocation'],
                 'expire'   => $expire,
@@ -2562,7 +2561,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         if ($function == 'Holds') {
             return $this->config['Holds']
                 ?? [
-                    'HMACKeys' => 'record_id:item_id:level',
+                    'HMACKeys' => 'id:item_id:level',
                     'extraHoldFields' =>
                         'comments:requestGroup:pickUpLocation:requiredByDate',
                     'defaultRequiredDate' => 'driver:0:2:0',


### PR DESCRIPTION
These changes were made during the testing of #2717, but they do not seem to be necessary, they interfere with simulating title-level holds, and they are generally confusing. Reverting them does not break any tests.