### PR TITLE
Add config setting for custom Solr highlighting params.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -87,6 +87,11 @@ highlighting = true
 ; Solr parameter); default = '*' for all fields:
 ;highlighting_fields = *
 
+; You can use this setting to add additional highlighting parameters to the Solr
+; request when highlighting as active. For all available options, see:
+;   https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
+;extra_hl_params[hl.bs.type] = LINE
+
 ; Set this to true in order to include a text snippet in the search results when
 ; a keyword match is found in a field that is not normally displayed as part of
 ; the listing.  For finer control over which fields are used for snippets, see

--- a/config/vufind/website.ini
+++ b/config/vufind/website.ini
@@ -7,6 +7,7 @@ case_sensitive_bools = true
 default_side_recommend[] = SideFacets:Facets:CheckboxFacets:website
 default_side_recommend[] = CatalogResults
 highlighting = true
+;extra_hl_params[hl.bs.type] = LINE
 snippets = true
 retain_filters_by_default = true
 ;default_record_fields = "*,score"

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -683,7 +683,8 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
         Config $search
     ) {
         $fl = $search->General->highlighting_fields ?? '*';
-        return new InjectHighlightingListener($backend, $fl);
+        $extras = $search->General->extra_hl_params ?? [];
+        return new InjectHighlightingListener($backend, $fl, $extras);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -67,17 +67,26 @@ class InjectHighlightingListener
     protected $fieldList;
 
     /**
+     * Extra Solr highlighting parameters.
+     *
+     * @var array
+     */
+    protected $extraHighlightingParameters;
+
+    /**
      * Constructor.
      *
      * @param BackendInterface $backend   Backend
      * @param string           $fieldList Field(s) to highlight (hl.fl param)
+     * @param array            $extras    Extra Solr highlighting parameters
      *
      * @return void
      */
-    public function __construct(BackendInterface $backend, $fieldList = '*')
+    public function __construct(BackendInterface $backend, $fieldList = '*', $extras = [])
     {
         $this->backend = $backend;
         $this->fieldList = $fieldList;
+        $this->extraHighlightingParameters = $extras;
     }
 
     /**
@@ -118,11 +127,14 @@ class InjectHighlightingListener
             if ($params = $command->getSearchParameters()) {
                 // Set highlighting parameters unless explicitly disabled:
                 $hl = $params->get('hl');
-                if (!isset($hl[0]) || $hl[0] != 'false') {
+                if (($hl[0] ?? 'true') != 'false') {
                     $this->active = true;
                     $params->set('hl', 'true');
                     $params->set('hl.simple.pre', '{{{{START_HILITE}}}}');
                     $params->set('hl.simple.post', '{{{{END_HILITE}}}}');
+                    foreach ($this->extraHighlightingParameters as $key => $val) {
+                        $params->set($key, $val);
+                    }
 
                     // Turn on hl.q generation in query builder:
                     $this->backend->getQueryBuilder()

--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -129,12 +129,14 @@ class InjectHighlightingListener
                 $hl = $params->get('hl');
                 if (($hl[0] ?? 'true') != 'false') {
                     $this->active = true;
-                    $params->set('hl', 'true');
-                    $params->set('hl.simple.pre', '{{{{START_HILITE}}}}');
-                    $params->set('hl.simple.post', '{{{{END_HILITE}}}}');
+                    // Set extra parameters first so they don't override necessary
+                    // core parameters:
                     foreach ($this->extraHighlightingParameters as $key => $val) {
                         $params->set($key, $val);
                     }
+                    $params->set('hl', 'true');
+                    $params->set('hl.simple.pre', '{{{{START_HILITE}}}}');
+                    $params->set('hl.simple.post', '{{{{END_HILITE}}}}');
 
                     // Turn on hl.q generation in query builder:
                     $this->backend->getQueryBuilder()

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/InjectHighlightingListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/InjectHighlightingListenerTest.php
@@ -33,7 +33,6 @@ use Laminas\EventManager\Event;
 use VuFind\Search\Solr\InjectHighlightingListener;
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Backend\Solr\Connector;
-use VuFindSearch\Backend\Solr\HandlerMap;
 use VuFindSearch\Backend\Solr\QueryBuilder;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Service;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/InjectHighlightingListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/InjectHighlightingListenerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Unit tests for inject highlighting listener.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+
+namespace VuFindTest\Search\Solr;
+
+use Laminas\EventManager\Event;
+use VuFind\Search\Solr\InjectHighlightingListener;
+use VuFindSearch\Backend\Solr\Backend;
+use VuFindSearch\Backend\Solr\Connector;
+use VuFindSearch\Backend\Solr\HandlerMap;
+use VuFindSearch\Backend\Solr\QueryBuilder;
+use VuFindSearch\ParamBag;
+use VuFindSearch\Service;
+
+/**
+ * Unit tests for inject highlighting listener.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class InjectHighlightingListenerTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
+    /**
+     * Backend.
+     *
+     * @var BackendInterface
+     */
+    protected $backend;
+
+    /**
+     * Prepare listener.
+     *
+     * @var MultiIndexListener
+     */
+    protected $listener;
+
+    /**
+     * Setup.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->backend = $this->createMock(\VuFindSearch\Backend\Solr\Backend::class);
+        $this->backend->expects($this->any())->method('getIdentifier')->will($this->returnValue('foo'));
+        $this->listener = new InjectHighlightingListener($this->backend, 'bar,baz', ['xyzzy' => 'true']);
+    }
+
+    /**
+     * Test attaching listener.
+     *
+     * @return void
+     */
+    public function testAttach()
+    {
+        $mock = $this->createMock(\Laminas\EventManager\SharedEventManagerInterface::class);
+        $mock->expects($this->exactly(2))->method('attach')->withConsecutive(
+            ['VuFind\Search', 'pre', [$this->listener, 'onSearchPre']],
+            ['VuFind\Search', 'post', [$this->listener, 'onSearchPost']]
+        );
+        $this->listener->attach($mock);
+    }
+
+    /**
+     * Test that appropriate parameters are sent to connector.
+     *
+     * @return void
+     */
+    public function testParameters()
+    {
+        $params = new ParamBag(
+            [
+                'hl' => 'true',
+            ]
+        );
+        $command = $this->getMockSearchCommand(
+            $params,
+            'search',
+            $this->backend->getIdentifier()
+        );
+        $mockQueryBuilder = $this->createMock(QueryBuilder::class);
+        $this->backend->expects($this->once())->method('getQueryBuilder')
+            ->will($this->returnValue($mockQueryBuilder));
+        $mockQueryBuilder->expects($this->once())->method('setFieldsToHighlight')
+            ->with($this->equalTo('bar,baz'));
+        $event = new Event(
+            Service::EVENT_PRE,
+            $this->backend,
+            compact('params', 'command')
+        );
+        $this->listener->onSearchPre($event);
+        $this->assertEquals(
+            [
+                'hl' => ['true'],
+                'xyzzy' => ['true'],
+                'hl.simple.pre' => ['{{{{START_HILITE}}}}'],
+                'hl.simple.post' => ['{{{{END_HILITE}}}}'],
+            ],
+            $params->getArrayCopy()
+        );
+    }
+}


### PR DESCRIPTION
Solr 9.1 has changed some default highlighting behavior, and this new feature makes it easier to override/customize advanced highlighting parameters.

I've also added a test for the InjectHighlightingListener. It's not comprehensive, but it does cover the changed code (and a little more as well).