### PR TITLE
Improve delete comment link.

### DIFF
--- a/themes/bootstrap3/templates/record/comments-list.phtml
+++ b/themes/bootstrap3/templates/record/comments-list.phtml
@@ -9,7 +9,7 @@
         <small>
           <?=$this->escapeHtml($comment->created)?>
           <?php if (($user = $this->auth()->isLoggedIn()) && $comment->user_id == $user->id): ?>
-            <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'DeleteComment'))?>?delete=<?=urlencode($comment->id)?>" id="recordComment<?=$this->escapeHtml($comment->id)?>" class="delete"><?=$this->transEsc('Delete')?></a>
+            <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'DeleteComment', ['delete' => $comment->id]))?>" id="recordComment<?=$this->escapeHtml($comment->id)?>" class="delete"><?=$this->transEsc('Delete')?></a>
           <?php endif; ?>
         </small>
       </div>


### PR DESCRIPTION
While testing https://github.com/demiankatz/vufind/pull/12, I ran into a problem where comment delete URLs were being generated incorrectly. The problem that caused this issue has been subsequently fixed in the dev branch (the Doctrine code is a bit behind due to pending updates to libraries), but the code simplification applied here fixes problems in that branch and seems worth including in mainline anyway since it's cleaner regardless of whether or not it's needed to fix a bug.