### PR TITLE
Fix account notification check to default to enabled.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/IlsRecords.php
@@ -116,7 +116,7 @@ class IlsRecords extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
     public function collectRequestStats(array $records): ?array
     {
         // Collect up to date stats for ajax account notifications:
-        if (empty($this->config->Authentication->enableAjax)) {
+        if (!($this->config->Authentication->enableAjax ?? true)) {
             return null;
         }
         return $this->getRequestSummary(


### PR DESCRIPTION
This matches the check in module/VuFind/src/VuFind/Auth/Manager.php. This change doesn't require constructor or factory changes, but I intend to post a follow-up for dev branch to make IlsRecords check the setting from Auth Manager.