### PR TITLE
Exclude FOLIO reserves that have been suppressed from discovery

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -166,6 +166,11 @@ in_transit[] = "Open - Awaiting delivery"
 ; only the name will be displayed:
 displayCourseCodes = false
 
+; If set to true, finding course reserves will include FOLIO instance records
+; even if they are suppressed from discovery; if false, the suppressed records
+; are excluded.
+includeSuppressed = false
+
 [Availability]
 ; The Folio ILS driver needs to make several calls to obtain availability status.
 ; Indicate with showDueDate whether an additional call should be made to obtain the

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1712,11 +1712,16 @@ class Folio extends AbstractAPI implements
     {
         $retVal = [];
 
+        $query = [
+            'query' => 'copiedItem.instanceDiscoverySuppress==false',
+        ];
+
         // Results can be paginated, so let's loop until we've gotten everything:
         foreach (
             $this->getPagedResults(
                 'reserves',
-                '/coursereserves/reserves'
+                '/coursereserves/reserves',
+                $query
             ) as $item
         ) {
             $idProperty = $this->getBibIdType() === 'hrid'

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1711,10 +1711,15 @@ class Folio extends AbstractAPI implements
     public function findReserves($course, $inst, $dept)
     {
         $retVal = [];
+        $query = [];
 
-        $query = [
-            'query' => 'copiedItem.instanceDiscoverySuppress==false',
-        ];
+        $includeSuppressed = $this->config['CourseReserves']['includeSuppressed'] ?? false;
+
+        if (!$includeSuppressed) {
+            $query = [
+                'query' => 'copiedItem.instanceDiscoverySuppress==false',
+            ];
+        }
 
         // Results can be paginated, so let's loop until we've gotten everything:
         foreach (


### PR DESCRIPTION
This change is to exclude course reserves from FOLIO that have instance records marked as suppressed from discovery. We added this to our custom module a while back since it was resulting in a count mis-match (telling the user there were some higher number of course reserves but when they clicked on the reserve result, there were fewer actual reserves because we did not ingest those instance records due to them being suppressed).

The change was added a few years back in the FOLIO API: https://issues.folio.org/browse/MODCR-65 and is documented in their API documentation: https://s3.amazonaws.com/foliodocs/api/mod-courses/r/courses.html#coursereserves_reserves_get.

We thought it would be useful to suggest this change to VuFind, since as a discovery layer, you would expect it to filter suppressed records.