### PR TITLE
Sierra: Fix retrieval of holdings.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2026,8 +2026,8 @@ class SierraRest extends AbstractBase implements
                 ['v5', 'holdings'],
                 [
                     'bibIds' => $this->extractBibId($id),
-                    //'deleted' => 'false',
-                    //'suppressed' => 'false',
+                    'deleted' => 'false',
+                    'suppressed' => 'false',
                     'fields' => 'fixedFields,varFields',
                 ],
                 'GET'
@@ -2036,7 +2036,7 @@ class SierraRest extends AbstractBase implements
                 $location = '';
                 foreach ($entry['fixedFields'] as $code => $field) {
                     if (
-                        $code === static::HOLDINGS_LINE_NUMBER
+                        (string)$code === static::HOLDINGS_LINE_NUMBER
                         || $field['label'] === 'LOCATION'
                     ) {
                         $location = $field['value'];


### PR DESCRIPTION
I was caught off guard by the fact that PHP likes array indexes to be ints.

The exclusion of deleted and suppressed records was commented out since the beginning (see #1338), and I can't think of a reason other than testing something and then forgetting to uncomment them.