### PR TITLE
[release-9.0] Sierra: Fix holdings line number comparison (again).

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2036,7 +2036,7 @@ class SierraRest extends AbstractBase implements
                 $location = '';
                 foreach ($entry['fixedFields'] as $code => $field) {
                     if (
-                        (string)$code === static::HOLDINGS_LINE_NUMBER
+                        (int)$code === static::HOLDINGS_LINE_NUMBER
                         || $field['label'] === 'LOCATION'
                     ) {
                         $location = $field['value'];


### PR DESCRIPTION
Since the const type is different from dev, this needs different comparison.

This will conflict with dev branch and should be resolved so that dev keeps its current version.