### PR TITLE
Avoid division by zero when result limit is 0.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -378,8 +378,9 @@ class AbstractSearch extends AbstractBase
         // For page parameter being out of results list, we want to redirect to correct page
         $page = $params->getPage();
         $totalResults = $results->getResultTotal();
-        $lastPage = ceil($totalResults / $params->getLimit());
-        if (($totalResults > 0) && ($page > $lastPage)) {
+        $limit = $params->getLimit();
+        $lastPage = $limit ? ceil($totalResults / $limit) : 1;
+        if ($totalResults > 0 && $page > $lastPage) {
             $queryParams = $request;
             $queryParams['page'] = $lastPage;
             return $this->redirect()->toRoute('search-results', [], [ 'query' => $queryParams ]);


### PR DESCRIPTION
This is a small follow-up to #2940 to avoid a potential division by zero. While I could only trigger the error by adding 0 to `limit_options`, I was a bit worried that there could be a situation such as locally customized code that could trigger it.