### PR TITLE
Replace strtolower with mb_strtolower to avoid encoding issues.

### DIFF
--- a/module/VuFind/src/VuFind/Normalizer/DefaultSpellingNormalizer.php
+++ b/module/VuFind/src/VuFind/Normalizer/DefaultSpellingNormalizer.php
@@ -55,7 +55,7 @@ class DefaultSpellingNormalizer
         $booleans = ['AND', 'OR', 'NOT'];
         $words = [];
         foreach (preg_split('/\s+/', $stripped) as $word) {
-            $words[] = in_array($word, $booleans) ? $word : strtolower($word);
+            $words[] = in_array($word, $booleans) ? $word : mb_strtolower($word, 'UTF-8');
         }
         return implode(' ', $words);
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Query/QueryTest.php
@@ -146,6 +146,11 @@ class QueryTest extends TestCase
         );
         $q->replaceTerm('test', 'mess', $normalizer);
         $this->assertEquals('this is a mess of things', $q->getString());
+
+        // Test UNICODE characters ("composers" in Northern Sámi):
+        $q = new Query('šuokŋadahkkit');
+        $this->assertTrue($q->containsTerm('šuokŋadahkkit', $normalizer));
+        $this->assertTrue($q->containsTerm('suokŋadahkkit', $normalizer));
     }
 
     /**


### PR DESCRIPTION
Oddly, I couldn't make the test fail, so the failure only occurs under Apache. It could be related to the locale setup somehow, but I couldn't quite find out how. Regardless, the actual change makes a difference and avoids preg_match failing at Query.php line 163 due to invalid UTF-8.