### PR TITLE
Moving ExplodeSettingTrait to Feature Subdir

### DIFF
--- a/module/VuFind/src/VuFind/Config/Feature/ExplodeSettingTrait.php
+++ b/module/VuFind/src/VuFind/Config/Feature/ExplodeSettingTrait.php
@@ -27,7 +27,7 @@
  * @link     https://vufind.org Main Site
  */
 
-namespace VuFind\Config;
+namespace VuFind\Config\Feature;
 
 /**
  * Trait providing support for converting delimited settings to arrays

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -58,7 +58,7 @@ class SierraRest extends AbstractBase implements
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
     use \VuFind\I18n\HasSorterTrait;
     use \VuFind\Service\Feature\RetryTrait;
-    use \VuFind\Config\ExplodeSettingTrait;
+    use \VuFind\Config\Feature\ExplodeSettingTrait;
 
     /**
      * Fixed field number for location in holdings records


### PR DESCRIPTION
Traits are usually put in a Feature sub-namespace. Hence, the ExplodeSettingsTrait is moved there in this PR as discussed in PR https://github.com/vufind-org/vufind/pull/2947