### PR TITLE
Remove unused use statements from Util Commands.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CommitCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CommitCommand.php
@@ -29,7 +29,6 @@
 
 namespace VuFindConsole\Command\Util;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/OptimizeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/OptimizeCommand.php
@@ -29,7 +29,6 @@
 
 namespace VuFindConsole\Command\Util;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommand.php
@@ -29,7 +29,6 @@
 
 namespace VuFindConsole\Command\Util;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFindTheme\ScssCompiler;
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SuppressedCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SuppressedCommand.php
@@ -29,7 +29,6 @@
 
 namespace VuFindConsole\Command\Util;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
Automatic code cleanup tools failed to catch the fact that these use statements were not relevant.