### PR TITLE
php-cs-fixer: Remove disabled braces rule configuration.

### DIFF
--- a/tests/vufind_templates.php-cs-fixer.php
+++ b/tests/vufind_templates.php-cs-fixer.php
@@ -12,7 +12,6 @@ $rules = [
         'default' => 'single_space',
     ],
     'blank_line_after_opening_tag' => false,
-    'braces' => false, // disabled because we don't want to create inconsistent indentation, but useful to normalize control structure spacing
     'cast_spaces' => ['space' => 'none'],
     'class_attributes_separation' => ['elements' => ['method' => 'one', 'property' => 'one']],
     'concat_space' => ['spacing' => 'one'],


### PR DESCRIPTION
The braces rule was disabled for php-cs-fixer template configuration because it was causing problems. However, in newer versions of php-cs-fixer, it is no longer an issue, and the braces rule was causing a deprecation warning. This PR simply removes the offending setting, which does not have an adverse effect on template formatting.