### PR TITLE
Rename abstract SearchObject class to AbstractSearchObject.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/AbstractSearchObject.php
+++ b/module/VuFind/src/VuFind/Recommend/AbstractSearchObject.php
@@ -6,7 +6,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2010.
+ * Copyright (C) Villanova University 2010-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -42,7 +42,7 @@ use VuFind\Search\SearchRunner;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-abstract class SearchObject implements RecommendInterface
+abstract class AbstractSearchObject implements RecommendInterface
 {
     /**
      * Results object

--- a/module/VuFind/src/VuFind/Recommend/CatalogResults.php
+++ b/module/VuFind/src/VuFind/Recommend/CatalogResults.php
@@ -41,7 +41,7 @@ namespace VuFind\Recommend;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class CatalogResults extends SearchObject
+class CatalogResults extends AbstractSearchObject
 {
     /**
      * Get the search class ID to use for building search objects.

--- a/module/VuFind/src/VuFind/Recommend/EDSResults.php
+++ b/module/VuFind/src/VuFind/Recommend/EDSResults.php
@@ -40,7 +40,7 @@ namespace VuFind\Recommend;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class EDSResults extends SearchObject
+class EDSResults extends AbstractSearchObject
 {
     /**
      * Get the search class ID to use for building search objects.

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesAZResults.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesAZResults.php
@@ -42,7 +42,7 @@ namespace VuFind\Recommend;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class LibGuidesAZResults extends SearchObject
+class LibGuidesAZResults extends AbstractSearchObject
 {
     /**
      * Get the search class ID to use for building search objects.

--- a/module/VuFind/src/VuFind/Recommend/SearchObject.php
+++ b/module/VuFind/src/VuFind/Recommend/SearchObject.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Obsolete Abstract SearchObject Recommendations Module (kept for backward
+ * compatibility only).
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Recommendations
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
+ */
+
+namespace VuFind\Recommend;
+
+/**
+ * Obsolete Abstract SearchObject Recommendations Module (kept for backward
+ * compatibility only).
+ *
+ * @category VuFind
+ * @package  Recommendations
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
+ *
+ * @deprecated Use AbstractSearchObject instead
+ */
+abstract class SearchObject extends AbstractSearchObject
+{
+}

--- a/module/VuFind/src/VuFind/Recommend/SummonResults.php
+++ b/module/VuFind/src/VuFind/Recommend/SummonResults.php
@@ -40,7 +40,7 @@ namespace VuFind\Recommend;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class SummonResults extends SearchObject
+class SummonResults extends AbstractSearchObject
 {
     /**
      * Get the search class ID to use for building search objects.

--- a/module/VuFind/src/VuFind/Recommend/WebResults.php
+++ b/module/VuFind/src/VuFind/Recommend/WebResults.php
@@ -41,7 +41,7 @@ namespace VuFind\Recommend;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:recommendation_modules Wiki
  */
-class WebResults extends SearchObject
+class WebResults extends AbstractSearchObject
 {
     /**
      * Get the search class ID to use for building search objects.


### PR DESCRIPTION
This complements the work in #2966 (as discussed there).

TODO
- [x] When merging, add note to next major version deprecation cleanup ticket to remove SearchObject class.