### PR TITLE
EPF: Add holdings list to record view

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
@@ -62,18 +62,5 @@
         </tr>
       <?php endif; ?>
     </table>
-
-    <div class="resultItemLine4 holdings-links">
-      <?php $holdings = $this->driver->getFullTextHoldings();
-      if (!empty($holdings)): ?>
-        <?php foreach ($holdings as $holding): ?>
-          <div>
-            <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>" target="_blank" class="full-text-holding">
-              <?=$this->escapeHtml($holding['Name'])?>
-            </a>
-          </div>
-        <?php endforeach; ?>
-      <?php endif; ?>
-    </div>
   </div>
 </div>

--- a/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
@@ -1,0 +1,79 @@
+<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php
+    $items = $this->driver->getItems('core');
+    $accessLevel = $this->driver->getAccessLevel();
+    $coverDetails = $this->record($this->driver)->getCoverDetails('core', 'medium');
+    $cover = $coverDetails['html'];
+?>
+<div class="media" vocab="http://schema.org/" resource="#record" typeof="<?=$this->driver->getSchemaOrgFormats()?> Product">
+  <div class="media-left medium img-col">
+    <?php if ($cover): ?>
+      <?=$cover?>
+    <?php endif; ?>
+
+    <div class="external-links">
+      <?php $pLink = $this->driver->getPLink();
+          if ($pLink): ?>
+        <span>
+          <a href="<?=$this->escapeHtmlAttr($pLink)?>">
+            <?=$this->transEsc('View in EDS')?>
+          </a>
+        </span><br>
+      <?php endif; ?>
+    </div>
+  </div>
+  <div class="media-body info-col">
+    <h1 property="name"><?=$this->driver->getTitle()?></h1>
+
+    <?php if ($this->driver->getExtraDetail('cached_record') && !$this->translationEmpty('cached_record_warning')): ?>
+      <div class="alert alert-warning">
+        <?=$this->transEsc('cached_record_warning')?>
+      </div>
+    <?php endif; ?>
+
+    <table class="table table-striped">
+      <caption class="sr-only"><?=$this->transEsc('Bibliographic Details')?></caption>
+      <?php foreach ($items as $key => $item): ?>
+        <?php if (!empty($item['Data'])): ?>
+        <tr>
+          <th><?=empty($item['Label']) ? '' : $this->transEsc($item['Label']) . ':'?></th>
+          <td class="record__biblio-value"><?=$this->driver->linkUrls($item['Data'])?></td>
+        </tr>
+        <?php endif; ?>
+      <?php endforeach; ?>
+
+      <?php $holdings = $this->driver->getFullTextHoldings();
+      if (isset($holdings) && !empty($holdings)): ?>
+        <tr>
+          <th><?=$this->transEsc('Linked Full Text') . ':'?></th>
+          <td>
+            <ul>
+              <?php
+                foreach($holdings as $holding):
+                  if (!empty($holding)): ?>
+                    <li>
+                      <a href="<?=$holding['URL']?>"><?=$holding['Name']?></a>
+                      <?=$holding['CoverageStatement']?>
+                    </li>
+                  <?php endif;
+                endforeach; ?>
+            </ul>
+          </td>
+        </tr>
+      <?php endif; ?>
+    </table>
+
+    <div class="resultItemLine4 holdings-links">
+      <?php $holdings = $this->driver->getFullTextHoldings();
+      if (!empty($holdings)): ?>
+        <?php foreach ($holdings as $holding): ?>
+          <div>
+            <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>" target="_blank" class="full-text-holding">
+              <?=$this->escapeHtml($holding['Name'])?>
+            </a>
+          </div>
+        <?php endforeach; ?>
+      <?php endif; ?>
+    </div>
+  </div>
+</div>

--- a/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
@@ -52,8 +52,8 @@
                 foreach($holdings as $holding):
                   if (!empty($holding)): ?>
                     <li>
-                      <a href="<?=$holding['URL']?>"><?=$holding['Name']?></a>
-                      <?=$holding['CoverageStatement']?>
+                      <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>"><?=$this->escapeHtml($holding['Name'])?></a>
+                      <?=$this->escapeHtml($holding['CoverageStatement'])?>
                     </li>
                   <?php endif;
                 endforeach; ?>

--- a/themes/bootstrap3/templates/RecordDriver/EPF/result-list/full-text-links.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/result-list/full-text-links.phtml
@@ -6,8 +6,8 @@ if (isset($holdings) && !empty($holdings)): ?>
       foreach($holdings as $holding):
         if (!empty($holding)): ?>
           <li>
-            <a href="<?=$holding['URL']?>"><?=$holding['Name']?></a>
-            <?=$holding['CoverageStatement']?>
+            <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>"><?=$this->escapeHtml($holding['Name'])?></a>
+            <?=$this->escapeHtml($holding['CoverageStatement'])?>
           </li>
         <?php endif;
       endforeach; ?>


### PR DESCRIPTION
Following up on #2973 and specifically [this comment](https://github.com/vufind-org/vufind/pull/2973#pullrequestreview-1506966632).

Provide a core.phtml for EPF instead of relying on the parent record driver (EDS)'s template.
- Remove display logic for the many fields which don't apply to EPF.
- Add a list of full-text holdings.