### PR TITLE
Handle OR operator for SortFacetList

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SortFacetList.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SortFacetList.php
@@ -65,7 +65,8 @@ class SortFacetList extends AbstractHelper implements
         $urlHelper = $this->getView()->plugin('url');
         foreach ($list as $value) {
             $url = $urlHelper($searchRoute) . $results->getUrlQuery()
-                ->addFacet($field, $value['value'])->getParams();
+                ->addFacet($field, $value['value'], ($value['operator'] ?? 'AND'))
+                ->getParams();
             $facets[$url] = $value['displayText'];
         }
         $this->getSorter()->natsort($facets);


### PR DESCRIPTION
Recently we noticed, that facet-links on a home page under [HomePage_Settings] defined as orFacets for ContentBlocks don't work. In SortFacetList the addFacet method is called without considering the operator. This should be improved with this PR.