### PR TITLE
FOLIO: Remove empty holdings statements

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -608,18 +608,18 @@ class Folio extends AbstractAPI implements
             array_map([$this, 'formatNote'], $holding->notes ?? [])
         );
         $hasHoldingNotes = !empty(implode($holdingNotes));
-        $holdingsStatements = array_map(
+        $holdingsStatements = array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatements ?? []
-        );
-        $holdingsSupplements = array_map(
+        ));
+        $holdingsSupplements = array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatementsForSupplements ?? []
-        );
-        $holdingsIndexes = array_map(
+        ));
+        $holdingsIndexes = array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatementsForIndexes ?? []
-        );
+        ));
         $holdingCallNumber = $holding->callNumber ?? '';
         $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
         return compact(

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -408,7 +408,7 @@ class Folio extends AbstractAPI implements
         ];
         $response = $this->makeRequest('GET', '/instance-storage/instances', $query);
         $instances = json_decode($response->getBody());
-        if (count($instances->instances) == 0) {
+        if (count($instances->instances ?? []) == 0) {
             throw new ILSException("Item Not Found");
         }
         return $instances->instances[0];
@@ -608,18 +608,18 @@ class Folio extends AbstractAPI implements
             array_map([$this, 'formatNote'], $holding->notes ?? [])
         );
         $hasHoldingNotes = !empty(implode($holdingNotes));
-        $holdingsStatements = array_filter(array_map(
+        $holdingsStatements = array_values(array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatements ?? []
-        ));
-        $holdingsSupplements = array_filter(array_map(
+        )));
+        $holdingsSupplements = array_values(array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatementsForSupplements ?? []
-        ));
-        $holdingsIndexes = array_filter(array_map(
+        )));
+        $holdingsIndexes = array_values(array_filter(array_map(
             $textFormatter,
             $holding->holdingsStatementsForIndexes ?? []
-        ));
+        )));
         $holdingCallNumber = $holding->callNumber ?? '';
         $holdingCallNumberPrefix = $holding->callNumberPrefix ?? '';
         return compact(

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-empty-statements.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-empty-statements.json
@@ -1,0 +1,225 @@
+[
+    {
+        "comment": "Initial token check"
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/instance-storage\/instances",
+        "expectedParams": {
+            "query": "(id==\"instanceid\")"
+        },
+        "body": {
+            "instances": [
+                {
+                    "id": "instanceid",
+                    "_version": 1,
+                    "hrid": "foo",
+                    "source": "MARC",
+                    "title": "The bride of the tomb; or, Lancelot Darling's betrothed \/ By Mrs. Alex. McVeigh Miller.",
+                    "indexTitle": "Bride of the tomb; or, lancelot darling's betrothed",
+                    "editions": [],
+                    "series": [
+                        "Munro's library ; v. 1, no. 2"
+                    ],
+                    "identifiers": [],
+                    "contributors": [
+                        {
+                            "name": "Miller, Alex. McVeigh, Mrs",
+                            "contributorTypeId": "contypeID",
+                            "contributorTypeText": "Contributor",
+                            "contributorNameTypeId": "conNameTypeID",
+                            "primary": true
+                        }
+                    ],
+                    "subjects": [
+                        "Dime novels Specimens",
+                        "Genre: Popular literature Specimens",
+                        "Genre: Mystery and detective fiction"
+                    ],
+                    "classifications": [
+                        {
+                            "classificationNumber": "PS2394 .M643 1883",
+                            "classificationTypeId": "ctypeId"
+                        }
+                    ],
+                    "publication": [
+                        {
+                            "publisher": "Norman L. Munro",
+                            "place": "New York",
+                            "dateOfPublication": "1883"
+                        }
+                    ],
+                    "publicationFrequency": [],
+                    "publicationRange": [],
+                    "publicationPeriod": {
+                        "start": 1883
+                    },
+                    "electronicAccess": [],
+                    "instanceTypeId": "insttypeID",
+                    "instanceFormatIds": [],
+                    "instanceFormats": [],
+                    "physicalDescriptions": [
+                        "144 p.  ; 19 cm."
+                    ],
+                    "languages": [
+                        "eng"
+                    ],
+                    "notes": [],
+                    "modeOfIssuanceId": "moiid",
+                    "previouslyHeld": false,
+                    "staffSuppress": false,
+                    "discoverySuppress": false,
+                    "statisticalCodeIds": [],
+                    "statusUpdatedDate": "2022-12-22T23:34:26.209+0000",
+                    "holdingsRecords2": [],
+                    "natureOfContentTermIds": []
+                }
+            ],
+            "totalRecords": 1,
+            "resultInfo": {
+                "totalRecords": 1,
+                "facets": [],
+                "diagnostics": []
+            }
+        },
+        "bodyType": "json",
+        "code": 200
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/holdings-storage\/holdings",
+        "expectedParams": {
+            "query": "(instanceId==\"instanceid\" NOT discoverySuppress==true)",
+            "offset": 0,
+            "limit": 1000
+        },
+        "body": {
+            "holdingsRecords": [
+                {
+                    "id": "holdingid",
+                    "_version": 1,
+                    "hrid": "hr-holdingid",
+                    "holdingsTypeId": "holdingtypeid",
+                    "instanceId": "instanceid",
+                    "permanentLocationId": "location-id",
+                    "effectiveLocationId": "location-id",
+                    "electronicAccess": [],
+                    "callNumberTypeId": "cntypeid",
+                    "callNumber": "PS2394 .M643 1883",
+                    "administrativeNotes": [],
+                    "notes": [
+                        {
+                            "note": "Fake note"
+                        }
+                    ],
+                    "holdingsStatements": [
+                        {}, {"statement": "summ1"}, {"statement": "summ2"}
+                    ],
+                    "holdingsStatementsForIndexes": [
+                        {"statement": "ind1"}, {"statement": "ind2"}, {}
+                    ],
+                    "holdingsStatementsForSupplements": [
+                        {
+                            "statement": "supp1"
+                        },
+                        {
+                            "statement": ""
+                        },
+                        {
+                            "statement": "supp2"
+                        }
+                    ],
+                    "discoverySuppress": false,
+                    "statisticalCodeIds": [],
+                    "holdingsItems": [],
+                    "bareHoldingsItems": [],
+                    "sourceId": "sourceid"
+                }
+            ],
+            "totalRecords": 1,
+            "resultInfo": {
+                "totalRecords": 1,
+                "facets": [],
+                "diagnostics": []
+            }
+        },
+        "bodyType": "json",
+        "code": 200
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/item-storage\/items",
+        "expectedParams": {
+            "query": "(holdingsRecordId==\"holdingid\" NOT discoverySuppress==true) sortby volume",
+            "offset": 0,
+            "limit": 1000
+        },
+        "body": {
+            "items": [
+                {
+                    "id": "itemid",
+                    "_version": 1,
+                    "hrid": "hr-itemid",
+                    "holdingsRecordId": "holdingid",
+                    "barcode": "barcode-test",
+                    "effectiveShelvingOrder": "PS 42394 M643 41883 11",
+                    "yearCaption": [],
+                    "copyNumber": "1",
+                    "numberOfPieces": "1",
+                    "descriptionOfPieces": "1",
+                    "administrativeNotes": [],
+                    "circulationNotes": [],
+                    "status": {
+                        "name": "Available",
+                        "date": "2022-12-22T20:25:19.050+00:00"
+                    },
+                    "materialTypeId": "materialid",
+                    "permanentLoanTypeId": "loantypeid",
+                    "permanentLocationId": "location-id",
+                    "effectiveLocationId": "location-id",
+                    "electronicAccess": [],
+                    "statisticalCodeIds": []
+                }
+            ],
+            "totalRecords": 1,
+            "resultInfo": {
+                "totalRecords": 1,
+                "facets": [],
+                "diagnostics": []
+            }
+        },
+        "bodyType": "json",
+        "code": 200
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/locations",
+        "expectedParams": {
+            "offset": 0,
+            "limit": 1000
+        },
+        "body": {
+            "locations": [
+                {
+                    "id": "location-id",
+                    "name": "Spec Coll",
+                    "code": "DCOC",
+                    "discoveryDisplayName": "Special Collections",
+                    "isActive": true,
+                    "institutionId": "fakeinst",
+                    "campusId": "fakecamp",
+                    "libraryId": "fakelib",
+                    "details": {},
+                    "primaryServicePoint": "fakepsp",
+                    "servicePointIds": [
+                        "fakepsp"
+                    ],
+                    "servicePoints": []
+                }
+           ],
+            "totalRecords": 1
+        },
+        "bodyType": "json",
+        "code": 200
+    }
+]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -821,6 +821,44 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getHolding filters empty holding statements appropriately.
+     *
+     * @return void
+     */
+    public function testGetHoldingFilteringOfEmptyHoldingStatements(): void
+    {
+        $driverConfig = $this->defaultDriverConfig;
+        $driverConfig['Holdings']['folio_sort'] = 'volume';
+        $this->createConnector("get-holding-empty-statements", $driverConfig);
+        $expected = [
+            [
+                'callnumber_prefix' => '',
+                'callnumber' => 'PS2394 .M643 1883',
+                'id' => 'instanceid',
+                'item_id' => 'itemid',
+                'holding_id' => 'holdingid',
+                'number' => 1,
+                'enumchron' => '',
+                'barcode' => 'barcode-test',
+                'status' => 'Available',
+                'duedate' => '',
+                'availability' => true,
+                'is_holdable' => true,
+                'holdings_notes' => ["Fake note"],
+                'item_notes' => null,
+                'summary' => ['summ1', 'summ2'],
+                'supplements' => ['supp1', 'supp2'],
+                'indexes' => ['ind1', 'ind2'],
+                'location' => 'Special Collections',
+                'location_code' => 'DCOC',
+                'reserve' => 'TODO',
+                'addLink' => true,
+            ],
+        ];
+        $this->assertEquals($expected, $this->driver->getHolding("instanceid"));
+    }
+
+    /**
      * Test getHolding with checked out item.
      *
      * @return void


### PR DESCRIPTION
FOLIO can have an empty object (no key/value) in the holdingsStatements/holdingsStatementsForSupplements/holdingsStatementsForIndexes arrays. It probably shouldn't, but the result in VuFind is empty entries for things like Supplements in the holdings. We can filter out empty strings in the Folio driver to remove them.