### PR TITLE
KohaRest: Add missing permission to .ini comment.

### DIFF
--- a/config/vufind/KohaRest.ini
+++ b/config/vufind/KohaRest.ini
@@ -39,6 +39,7 @@ host = "http://koha-server/api"
 ; - circulate_remaining_permissions
 ; - catalogue
 ; - borrowers
+;   - delete_borrowers
 ;   - edit_borrowers
 ;   - view_borrower_infos_from_any_libraries
 ; - reserveforothers


### PR DESCRIPTION
It has been reported that using the most recent Koha release and most recent KohaRest API plugin as of this writing, VuFind fails when fetching patron blocks if the `delete_borrowers` permission is not assigned, e.g.:

```
{"error":"Authorization failure. Missing required permission(s).","required_permissions":{"borrowers":"1"}}
2023-07-09T22:19:36+05:30 ERR (3): VuFind\ILS\Driver\KohaRest: GET request for 'http://localhost:2001/api/v1/contrib/kohasuomi/patrons/3' with params 'query_blocks=1' and contents '' failed: 403: Forbidden, response content: {"error":"Authorization failure. Missing required permission(s).","required_permissions":{"borrowers":"1"}}
```

This PR adds a note about the missing permission in the .ini file. However, before we merge this, we should consider whether a better solution would be to update the plugin to require more targeted permissions, since I do not believe there is any reason why VuFind should require the specific delete permission that's causing the problem.

I know that @EreMaijala is currently out of office, but I'm opening this PR as a reminder to discuss further upon his return.

TODO
- [x] Discuss before merging