### PR TITLE
Add missing container dependency to ChannelsController.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/ChannelsController.php
+++ b/module/VuFind/src/VuFind/Controller/ChannelsController.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Controller;
 
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFind\ChannelProvider\ChannelLoader;
 
 /**
@@ -54,11 +55,14 @@ class ChannelsController extends AbstractBase
     /**
      * Constructor
      *
-     * @param ChannelLoader $loader Channel loader
+     * @param ChannelLoader           $loader Channel loader
+     * @param ServiceLocatorInterface $sm     Top-level service manager (needed for
+     * some AbstractBase behavior)
      */
-    public function __construct(ChannelLoader $loader)
+    public function __construct(ChannelLoader $loader, ServiceLocatorInterface $sm)
     {
         $this->loader = $loader;
+        parent::__construct($sm);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/ChannelsControllerFactory.php
@@ -68,6 +68,6 @@ class ChannelsControllerFactory extends AbstractBaseFactory
             throw new \Exception('Unexpected options sent to factory.');
         }
         $loader = $container->get(\VuFind\ChannelProvider\ChannelLoader::class);
-        return $this->applyPermissions($container, new $requestedName($loader));
+        return $this->applyPermissions($container, new $requestedName($loader, $container));
     }
 }


### PR DESCRIPTION
#2941 revealed a bug in the ChannelsController: even though it extends the AbstractBase controller, it does not inject the top-level service manager that is required/expected by the parent class. This can lead to unexpected failures and problems. This PR adds the missing dependency. This could be viewed as a minor BC break, but I think the fact that it fixes potential bugs overrides that concern and makes it worth including in release 9.0.3. I'm open to discussing this, however!

TODO
- [ ] Add note to changelog