### PR TITLE
Fix HTML escaping in autocomplete text.

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -527,7 +527,10 @@ function setupAutocomplete() {
       success: function autocompleteJSON(json) {
         const highlighted = json.data.suggestions.map(
           (item) => ({
-            text: item.replace(query, `<b>${query}</b>`),
+            text: item.replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;")
+              .replaceAll(query, `<b>${query}</b>`),
             value: item,
           })
         );


### PR DESCRIPTION
This fixes a problem discussed in #2979.

BEFORE:

![image](https://github.com/vufind-org/vufind/assets/309069/8a00be24-5d5b-4043-bfc3-9524a4b8c5c6)

AFTER:

![image](https://github.com/vufind-org/vufind/assets/309069/ddbdb39f-6925-41cd-8b23-5694856eeca2)
