### PR TITLE
Batch import: sort files and follow symlinks

### DIFF
--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -113,7 +113,7 @@ else
 fi
 
 # Process all the files in the target directory:
-find $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | \
+find -L $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | sort -z | \
   while read -d $'\0' file
 do
   # Logging output handled by log() function

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -138,7 +138,7 @@ else
 fi
 
 # Process all the files in the target directory:
-find $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | xargs -0 -n $MAX_BATCH_COUNT | \
+find -L $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | sort -z | xargs -0 -n $MAX_BATCH_COUNT | \
   while read -d $'\n' files
 do
   # Logging output handled by log() function


### PR DESCRIPTION
VuFind 9 started using find for batch import (see [commit](https://github.com/vufind-org/vufind/commit/86e4671b5ef10405faca92c9dee4ee08d002a288)). 2 unintended consequences were that links were not followed anymore, and files were no longer sorted by name (and hence by harvest date). A possible consequence of this is that an older version of a record might get imported after a new one, replacing it. This can happen for instance if files are moved from processed/ to reimport all records.
This PR solves these 2 issues by using a find option to follow symlinks and a sort afterwards to sort files by name (which include a timestamp).