### PR TITLE
LibGuidesProfile: Add call number matching strategy

### DIFF
--- a/config/vufind/LibGuidesAPI.ini
+++ b/config/vufind/LibGuidesAPI.ini
@@ -35,12 +35,12 @@ api_base_url = https://lgapi-us.libapps.com/1.2
 ;
 ; Available strategies are:
 ; 
-; call_number
+; CallNumber
 ;       Finds the call number facet with the most matches for
 ;       the given search, then uses the profile_aliases, 
 ;       call_numbers, and call_number_length settings below
 ;       to map that to a profile.
-; subject
+; Subject
 ;       Finds a LibGuides "subject" with the closest string
 ;       match to the query string, and returns a profile 
 ;       "expert" associated with that subject.  Note that this
@@ -49,8 +49,8 @@ api_base_url = https://lgapi-us.libapps.com/1.2
 ;       will be evaluated.
 ;       Re: subjects see see https://ask.springshare.com/libguides/faq/1109 
 ;
-;strategies[] = call_number
-;strategies[] = subject
+;strategies[] = CallNumber
+;strategies[] = Subject
 
 ; For the call_number strategy, truncate any result call number
 ; to the first 'call_number_length' characters to match the

--- a/config/vufind/LibGuidesAPI.ini
+++ b/config/vufind/LibGuidesAPI.ini
@@ -52,6 +52,10 @@ api_base_url = https://lgapi-us.libapps.com/1.2
 ;strategies[] = CallNumber
 ;strategies[] = Subject
 
+; For the call_number strategy, retrieve the call numbers
+; from this facet field.  Default is 'callnumber-first';
+;call_number_field = 'callnumber-first';
+
 ; For the call_number strategy, truncate any result call number
 ; to the first 'call_number_length' characters to match the
 ; call_numbers array keys below.  Default is 3.

--- a/config/vufind/LibGuidesAPI.ini
+++ b/config/vufind/LibGuidesAPI.ini
@@ -37,7 +37,9 @@ api_base_url = https://lgapi-us.libapps.com/1.2
 ; 
 ; call_number
 ;       Finds the call number facet with the most matches for
-;       the given search, then uses the mapping ??????? below to map that to a profile
+;       the given search, then uses the profile_aliases, 
+;       call_numbers, and call_number_length settings below
+;       to map that to a profile.
 ; subject
 ;       Finds a LibGuides "subject" with the closest string
 ;       match to the query string, and returns a profile 

--- a/config/vufind/LibGuidesAPI.ini
+++ b/config/vufind/LibGuidesAPI.ini
@@ -25,3 +25,54 @@ api_base_url = https://lgapi-us.libapps.com/1.2
 [GetAccounts]
 ; Duration (seconds) to cache response data.  Default is 600.
 ;cache_lifetime = 600
+
+; Configuration for LibGuidesProfile recommendation module
+[Profile]
+; Enable one or more strategies for matching the best profile
+; for the user search.  Strategies are attempted in the order
+; listed; the first to return a match is used.  If no strategies
+; return a match, no profile is displayed.  
+;
+; Available strategies are:
+; 
+; call_number
+;       Finds the call number facet with the most matches for
+;       the given search, then uses the mapping ??????? below to map that to a profile
+; subject
+;       Finds a LibGuides "subject" with the closest string
+;       match to the query string, and returns a profile 
+;       "expert" associated with that subject.  Note that this
+;       strategy will always return a match, so a profile will 
+;       always be displayed and no strategies listed below it 
+;       will be evaluated.
+;       Re: subjects see see https://ask.springshare.com/libguides/faq/1109 
+;
+;strategies[] = call_number
+;strategies[] = subject
+
+; For the call_number strategy, truncate any result call number
+; to the first 'call_number_length' characters to match the
+; call_numbers array keys below.  Default is 3.
+; If a match is not found with this length, the call number will
+; be further truncated to a minimum length of 1 to find a match.
+;call_number_length = 3
+
+; For the call_number strategy, define an alias for each
+; LibGuides account ID (for a profile) to make the call_numbers 
+; mapping below more human-readable.
+;profile_aliases['Alice'] = 1234
+;profile_aliases['Bob'] = 5678
+
+; For the call_number strategy, map a call number substring
+; to an alias defined in profile_aliases above.
+;
+; Example list for LC call numbers:
+;call_numbers['A'] = 'Alice'
+;call_numbers['DB'] = 'Bob'
+;call_numbers['DC'] = 'Alice'
+;call_numbers['P'] = 'Bob'
+;
+; Example list for Dewey call numbers:
+;call_numbers['1'] = 'Bob'
+;call_numbers['51'] = 'Alice'
+;call_numbers['52'] = 'Bob'

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -110,7 +110,7 @@ class LibGuidesProfile implements
 
         $profile = $config->Profile;
         if ($profile) {
-            $this->strategies = $profile->get('strategies', []);
+            $this->strategies = (array) $profile->get('strategies', []);
             $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
             $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];
             $this->callNumberLength = $profile->get('call_number_length', 3);

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -179,6 +179,10 @@ class LibGuidesProfile implements
      */
     public function getResults()
     {
+        if (empty($this->strategies)) {
+            throw new \Exception("LibGuidesAPI.ini must define at least one strategy if LibGuidesProfile is used.");
+        }
+
         // Consider strategies in the order listed in the config file.
         foreach ($this->strategies as $strategy) {
             $method = 'findBestMatchBy' . $strategy;

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -108,8 +108,7 @@ class LibGuidesProfile implements
         // Cache the data related to profiles for up to 10 minutes:
         $this->cacheLifetime = intval($config->GetAccounts->cache_lifetime ?? 600);
 
-        $profile = $config->Profile;
-        if ($profile) {
+        if ($profile = $config->Profile) {
             $this->strategies = $profile->get('strategies', []);
             $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
             $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -110,7 +110,7 @@ class LibGuidesProfile implements
 
         $profile = $config->Profile;
         if ($profile) {
-            $this->strategies = (array) $profile->get('strategies', []);
+            $this->strategies = $profile->get('strategies', []);
             $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
             $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];
             $this->callNumberLength = $profile->get('call_number_length', 3);

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -116,7 +116,9 @@ class LibGuidesProfile implements
         $this->cacheLifetime = intval($config->GetAccounts->cache_lifetime ?? 600);
 
         if ($profile = $config->Profile) {
-            $this->strategies = $profile->get('strategies', []);
+            $strategies = $profile->get('strategies', []);
+            $this->strategies = is_string($strategies) ? [$strategies] : $strategies;
+
             $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
             $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];
             $this->callNumberField = $profile->get('call_number_field', 'callnumber-first');

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -215,7 +215,7 @@ class LibGuidesProfile implements
 
         // For each call number facet.
         $profiles = [];
-        foreach ($facets['callnumber-first']['list'] ?? [] as $current) {
+        foreach ($facets[$this->callNumberField]['list'] ?? [] as $current) {
             $callNumber = trim(substr($current['value'], 0, $this->callNumberLength));
 
             // Find an alias for this call number, or a broader call number if none is found.

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -84,6 +84,13 @@ class LibGuidesProfile implements
     protected $aliasToAccountId;
 
     /**
+     * Facet field name containing the call numbers to match against
+     *
+     * @var string
+     */
+    protected $callNumberField;
+
+    /**
      * Length of the substring at the start of a call number to match against
      *
      * @var int
@@ -112,6 +119,7 @@ class LibGuidesProfile implements
             $this->strategies = $profile->get('strategies', []);
             $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
             $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];
+            $this->callNumberField = $profile->get('call_number_field', 'callnumber-first');
             $this->callNumberLength = $profile->get('call_number_length', 3);
         }
     }
@@ -201,7 +209,7 @@ class LibGuidesProfile implements
 
         // Get the Call Number facet list.
         $filter = [
-            'callnumber-first' => 'Call Number',
+            $this->callNumberField => 'Call Number',
         ];
         $facets = $results->getFacetList($filter);
 

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -185,6 +185,9 @@ class LibGuidesProfile implements
 
         // Consider strategies in the order listed in the config file.
         foreach ($this->strategies as $strategy) {
+            // Sanitize the strategy name.
+            $strategy = preg_replace('/[^\w]/', '', $strategy);
+
             $method = 'findBestMatchBy' . $strategy;
             if (
                 method_exists($this, $method) &&

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -61,13 +61,6 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
     protected $connector;
 
     /**
-     * Config object
-     *
-     * @var Config
-     */
-    protected $config;
-
-    /**
      * Cache adapter object
      *
      * @var CacheAdapter
@@ -96,17 +89,18 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
         $accounts = json_decode(substr($accountsFixture, strpos($accountsFixture, '[')));
         $this->connector->method('getAccounts')->willReturn($accounts);
 
-        // Mock config and caching logic in LibGuidesProfile.
-        // Caching is from a trait, which is not the point of this test suite,
-        // and the config is only used in LibGuidesProfile for caching.
-        $this->config = $this->getMockBuilder(Config::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $config = new Config([], true);
+        $config->Profile = [
+            'strategies' =>  ['subject']
+        ];
+
+        // Mock caching logic in LibGuidesProfile.
+        // Caching is from a trait, which is not the point of this test suite.
         $this->cacheAdapter = $this->getMockBuilder(CacheAdapter::class)->getMock();
 
         // For the target class LibGuidesProfile, only mock the caching methods
         $this->libGuidesProfile = $this->getMockBuilder(LibGuidesProfile::class)
-            ->setConstructorArgs([$this->connector, $this->config, $this->cacheAdapter])
+            ->setConstructorArgs([$this->connector, $config, $this->cacheAdapter])
             ->onlyMethods(['getCachedData', 'putCachedData'])
             ->getMock();
         $this->libGuidesProfile->method('getCachedData')->willReturn(null);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -88,22 +88,6 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
         $accountsFixture = $this->getFixture("libguides/api/accounts");
         $accounts = json_decode(substr($accountsFixture, strpos($accountsFixture, '[')));
         $this->connector->method('getAccounts')->willReturn($accounts);
-
-        $config = new Config([], true);
-        $config->Profile = [
-            'strategies' =>  ['Subject'],
-        ];
-
-        // Mock caching logic in LibGuidesProfile.
-        // Caching is from a trait, which is not the point of this test suite.
-        $this->cacheAdapter = $this->getMockBuilder(CacheAdapter::class)->getMock();
-
-        // For the target class LibGuidesProfile, only mock the caching methods
-        $this->libGuidesProfile = $this->getMockBuilder(LibGuidesProfile::class)
-            ->setConstructorArgs([$this->connector, $config, $this->cacheAdapter])
-            ->onlyMethods(['getCachedData', 'putCachedData'])
-            ->getMock();
-        $this->libGuidesProfile->method('getCachedData')->willReturn(null);
     }
 
     /**
@@ -113,10 +97,14 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      */
     public function testSubjectExactMatch()
     {
-        $queryResults = $this->buildQueryResults('Geography');
-        $this->libGuidesProfile->process($queryResults);
+        $config = new Config([], true);
+        $config->Profile = ['strategies' =>  ['Subject']];
+        $libGuidesProfile = $this->buildProfile($config);
 
-        $account = $this->libGuidesProfile->getResults();
+        $queryResults = $this->buildQueryResults('Geography');
+        $libGuidesProfile->process($queryResults);
+
+        $account = $libGuidesProfile->getResults();
         $this->assertEquals('eratosthenes@alexandria.org', $account->email);
     }
 
@@ -127,11 +115,15 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      */
     public function testSubjectSubstring()
     {
+        $config = new Config([], true);
+        $config->Profile = ['strategies' =>  ['Subject']];
+        $libGuidesProfile = $this->buildProfile($config);
+
         // Exact match would be "Decimal Classification"
         $queryResults = $this->buildQueryResults('Classification');
-        $this->libGuidesProfile->process($queryResults);
+        $libGuidesProfile->process($queryResults);
 
-        $account = $this->libGuidesProfile->getResults();
+        $account = $libGuidesProfile->getResults();
         $this->assertEquals('melvil@dewey.edu', $account->email);
     }
 
@@ -142,12 +134,81 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      */
     public function testSubjectLooseMatch()
     {
+        $config = new Config([], true);
+        $config->Profile = ['strategies' =>  ['Subject']];
+        $libGuidesProfile = $this->buildProfile($config);
+
         // Exact match would be "Music Theory"
         $queryResults = $this->buildQueryResults('Rock Musicians');
-        $this->libGuidesProfile->process($queryResults);
+        $libGuidesProfile->process($queryResults);
 
-        $account = $this->libGuidesProfile->getResults();
+        $account = $libGuidesProfile->getResults();
         $this->assertEquals('eratosthenes@alexandria.org', $account->email);
+    }
+
+    /**
+     * Test call number match
+     *
+     * @return void
+     */
+    public function testCallNumberMatch()
+    {
+        $config = new Config([], true);
+        $config->Profile = [
+            'strategies' =>  ['CallNumber'],
+            'profile_aliases' => [
+                'Dewey' => 1234,
+                'Eratosthenes' => 5678,
+            ],
+            'call_numbers' => [
+                'D' => 'Eratosthenes',
+                'P' => 'Dewey'
+            ],
+        ];
+        $libGuidesProfile = $this->buildProfile($config);
+
+        // D (World History) is the most prominent subject, which matches Eratosthenes
+        $facets = [
+            'callnumber-first' => [
+                'list' => [
+                    [
+                        'value' => 'D - World History',
+                        'count' => 8,
+                    ],
+                    [
+                        'value' => 'P - Language and Literature',
+                        'count' => 7,
+                    ],
+                ],
+            ],
+        ];
+        $queryResults = $this->buildQueryResults('Query does not matter', $facets);
+        $libGuidesProfile->process($queryResults);
+
+        $account = $libGuidesProfile->getResults();
+        $this->assertEquals('eratosthenes@alexandria.org', $account->email);
+    }
+
+    /**
+     * Build a partially mocked LibGuidesProfile object
+     *
+     * @param Config $config The config object
+     *
+     * @return LibGuidesProfile
+     */
+    protected function buildProfile($config)
+    {
+        // Mock caching logic in LibGuidesProfile.
+        // Caching is from a trait, which is not the point of this test suite.
+        $this->cacheAdapter = $this->getMockBuilder(CacheAdapter::class)->getMock();
+
+        // For the target class LibGuidesProfile, only mock the caching methods
+        $libGuidesProfile = $this->getMockBuilder(LibGuidesProfile::class)
+            ->setConstructorArgs([$this->connector, $config, $this->cacheAdapter])
+            ->onlyMethods(['getCachedData', 'putCachedData'])
+            ->getMock();
+        $libGuidesProfile->method('getCachedData')->willReturn(null);
+        return $libGuidesProfile;
     }
 
     /**
@@ -157,7 +218,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return Results The Results object
      */
-    protected function buildQueryResults($queryString)
+    protected function buildQueryResults($queryString, $facets = [])
     {
         // Build query Params
         $queryParams = new Params(
@@ -172,7 +233,9 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
             $this->createStub(\VuFindSearch\Service::class),
             $this->getMockBuilder(\VuFind\Record\Loader::class)
                 ->disableOriginalConstructor()
-                ->getMock()
+                ->getMock(),
+            null,
+            $facets
         );
         return $queryResults;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -91,7 +91,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
 
         $config = new Config([], true);
         $config->Profile = [
-            'strategies' =>  ['subject']
+            'strategies' =>  ['Subject'],
         ];
 
         // Mock caching logic in LibGuidesProfile.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -162,7 +162,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
             ],
             'call_numbers' => [
                 'D' => 'Eratosthenes',
-                'P' => 'Dewey'
+                'P' => 'Dewey',
             ],
         ];
         $libGuidesProfile = $this->buildProfile($config);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -215,6 +215,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      * Build a partially mocked Results object for a given query string
      *
      * @param string $queryString The query string
+     * @param array  $facets      The result facets
      *
      * @return Results The Results object
      */


### PR DESCRIPTION
Expand the LibGuidesProfile recommendation module to use different strategies.

Beyond the original 'subject' matching strategy, this adds a 'call_number' strategy
based on Villanova's custom code.
https://gist.github.com/demiankatz/4600bdfb9af9882ad491f74c406a8a8a

It looks at the call number facet to the search results, finds the most prominent
call number, and maps that to a LibGuides profile.  This mapping happens via
configuration in LibGuidesAPI.ini.  Future enhancements might add other sources 
for that mapping.