### PR TITLE
Reduce copy and paste in tests.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -703,16 +703,13 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test getHolding with HRID-based lookup
+     * Get expected result of get-holding fixture (shared by multiple tests).
      *
-     * @return void
+     * @return array
      */
-    public function testGetHoldingWithHridLookup(): void
+    protected function getExpectedGetHoldingResult(): array
     {
-        $driverConfig = $this->defaultDriverConfig;
-        $driverConfig['IDs']['type'] = 'hrid';
-        $this->createConnector("get-holding", $driverConfig);
-        $expected = [
+        return [
             [
                 'callnumber_prefix' => '',
                 'callnumber' => 'PS2394 .M643 1883',
@@ -737,7 +734,19 @@ class FolioTest extends \PHPUnit\Framework\TestCase
                 'addLink' => true,
             ],
         ];
-        $this->assertEquals($expected, $this->driver->getHolding("foo"));
+    }
+
+    /**
+     * Test getHolding with HRID-based lookup
+     *
+     * @return void
+     */
+    public function testGetHoldingWithHridLookup(): void
+    {
+        $driverConfig = $this->defaultDriverConfig;
+        $driverConfig['IDs']['type'] = 'hrid';
+        $this->createConnector("get-holding", $driverConfig);
+        $this->assertEquals($this->getExpectedGetHoldingResult(), $this->driver->getHolding("foo"));
     }
 
     /**
@@ -752,34 +761,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $driverConfig = $this->defaultDriverConfig;
         $driverConfig['IDs']['type'] = 'hrid';
         $this->createConnector("get-holding", $driverConfig);
-        $expected = [
-            [
-                [
-                    'callnumber_prefix' => '',
-                    'callnumber' => 'PS2394 .M643 1883',
-                    'id' => 'foo',
-                    'item_id' => 'itemid',
-                    'holding_id' => 'holdingid',
-                    'number' => 1,
-                    'enumchron' => '',
-                    'barcode' => 'barcode-test',
-                    'status' => 'Available',
-                    'duedate' => '',
-                    'availability' => true,
-                    'is_holdable' => true,
-                    'holdings_notes' => null,
-                    'item_notes' => null,
-                    'summary' => ["foo", "bar baz"],
-                    'supplements' => [],
-                    'indexes' => [],
-                    'location' => 'Special Collections',
-                    'location_code' => 'DCOC',
-                    'reserve' => 'TODO',
-                    'addLink' => true,
-                ],
-            ],
-        ];
-        $this->assertEquals($expected, $this->driver->getStatuses(["foo"]));
+        $this->assertEquals([$this->getExpectedGetHoldingResult()], $this->driver->getStatuses(["foo"]));
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
@@ -78,17 +78,14 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
     ];
 
     /**
-     * Test
+     * Support method for testParseLinks and testParseLinksWithoutIgnoredFiltering.
      *
-     * @return void
+     * @param bool $filterSet Should we filter the results for testParseLinksWithoutIgnoredFiltering?
+     *
+     * @return array
      */
-    public function testParseLinks()
+    protected function getExpectedParsedLinks($filterSet = false): array
     {
-        $conn = $this->createConnector('alma.xml');
-
-        $openUrl = "url_ver=Z39.88-2004&ctx_ver=Z39.88-2004";
-        $result = $conn->parseLinks($conn->fetchLinks($openUrl));
-
         $testResult = [
             [
                 'title' => 'Unpaywall',
@@ -170,7 +167,9 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'authentication' => '',
                 'service_type' => 'getWebService',
             ],
-            [
+        ];
+        if (!$filterSet) {
+            $testResult[] = [
                 'title' => 'ProQuest Safari Tech Books Online',
                 'coverage' => '',
                 'access' => 'limited',
@@ -179,10 +178,21 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
                 'notes' => '',
                 'authentication' => '',
                 'service_type' => 'getFullTxt',
-            ],
-        ];
-
-        $this->assertEquals($testResult, $result);
+            ];
+        }
+        return $testResult;
+    }
+    /**
+     * Test
+     *
+     * @return void
+     */
+    public function testParseLinks()
+    {
+        $conn = $this->createConnector('alma.xml');
+        $openUrl = "url_ver=Z39.88-2004&ctx_ver=Z39.88-2004";
+        $result = $conn->parseLinks($conn->fetchLinks($openUrl));
+        $this->assertEquals($this->getExpectedParsedLinks(), $result);
     }
 
     /**
@@ -193,94 +203,9 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
     public function testParseLinksWithoutIgnoredFiltering()
     {
         $conn = $this->createConnector('alma.xml', ['ignoredFilterReasons' => '']);
-
         $openUrl = "url_ver=Z39.88-2004&ctx_ver=Z39.88-2004";
         $result = $conn->parseLinks($conn->fetchLinks($openUrl));
-
-        $testResult = [
-            [
-                'title' => 'Unpaywall',
-                'coverage' => '',
-                'access' => 'open',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=1',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'Ebook override',
-                'coverage' => 'Available from 2019',
-                'access' => 'limited',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861830000561&institutionId=561&customerId=550',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'ebrary Academic Complete Subscription UKI Edition',
-                'coverage' => '',
-                'access' => 'limited',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861800000561&institutionId=561&customerId=550',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'ebrary Science & Technology Subscription',
-                'coverage' => '',
-                'access' => 'limited',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861790000561&institutionId=561&customerId=550',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'EBSCOhost Academic eBook Collection (North America)',
-                'coverage' => '',
-                'access' => 'open',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861770000561&institutionId=561&customerId=550',
-                'notes' => 'notessssssssssss SERVICE LEVEL PUBLIC NOTE',
-                'authentication' => 'collection level auth SERVICE LEVEL AUTHE NOTE',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'EBSCOhost eBook Community College Collection',
-                'coverage' => '',
-                'access' => 'limited',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861780000561&institutionId=561&customerId=550',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getHolding',
-            ],
-            [
-                'title' => 'Elsevier ScienceDirect Books',
-                'coverage' => '',
-                'access' => 'limited',
-                'href' => 'https://na01.alma.exlibrisgroup.com/view/action/uresolver.do'
-                    . '?operation=resolveService&package_service_id=5687861820000561&institutionId=561&customerId=550',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getFullTxt',
-            ],
-            [
-                'title' => 'Request Assistance for this Resource!',
-                'coverage' => '',
-                'access' => '',
-                'href' => 'https://www.google.com/search?Testingrft.oclcnum=437189463'
-                    . '&q=Fundamental+Data+Compression&rft.archive=9942811800561',
-                'notes' => '',
-                'authentication' => '',
-                'service_type' => 'getWebService',
-            ],
-        ];
-
-        $this->assertEquals($testResult, $result);
+        $this->assertEquals($this->getExpectedParsedLinks(true), $result);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Resolver/Driver/AlmaTest.php
@@ -182,6 +182,7 @@ class AlmaTest extends \PHPUnit\Framework\TestCase
         }
         return $testResult;
     }
+
     /**
      * Test
      *

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/WorldCat/ConnectorTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/WorldCat/ConnectorTest.php
@@ -44,22 +44,22 @@ use VuFindSearch\ParamBag;
 class ConnectorTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Test "get holdings"
+     * Get a connector with a mock HTTP client.
      *
-     * @return void
+     * @param string $expectedUri URI expected by client.
+     * @param string $body        Response body returned by client.
+     *
+     * @return Connector
      */
-    public function testGetHoldings()
+    protected function getConnectorWithMockClient($expectedUri, $body = '<foo>bar</foo>'): Connector
     {
         $client = $this->createMock(\Laminas\Http\Client::class);
         $connector = new Connector('key', $client);
         $client->expects($this->once())->method('setMethod')
             ->with($this->equalTo('POST'))
             ->will($this->returnValue($client));
-        $expectedUri = 'http://www.worldcat.org/webservices/catalog/content/libraries/baz'
-            . '?wskey=key&servicelevel=full&frbrGrouping=on';
         $client->expects($this->once())->method('setUri')
             ->with($this->equalTo($expectedUri));
-        $body = '<foo>bar</foo>';
         $response = $this->createMock(\Laminas\Http\Response::class);
         $response->expects($this->once())->method('getBody')
             ->will($this->returnValue($body));
@@ -67,6 +67,19 @@ class ConnectorTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(true));
         $client->expects($this->once())->method('send')
             ->will($this->returnValue($response));
+        return $connector;
+    }
+
+    /**
+     * Test "get holdings"
+     *
+     * @return void
+     */
+    public function testGetHoldings()
+    {
+        $expectedUri = 'http://www.worldcat.org/webservices/catalog/content/libraries/baz'
+            . '?wskey=key&servicelevel=full&frbrGrouping=on';
+        $connector = $this->getConnectorWithMockClient($expectedUri);
         $final = $connector->getHoldings('baz');
         $this->assertEquals('bar', (string)$final);
     }
@@ -102,22 +115,9 @@ class ConnectorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetRecord()
     {
-        $client = $this->createMock(\Laminas\Http\Client::class);
-        $connector = new Connector('key', $client);
-        $client->expects($this->once())->method('setMethod')
-            ->with($this->equalTo('POST'))
-            ->will($this->returnValue($client));
         $expectedUri = 'http://www.worldcat.org/webservices/catalog/content/baz?servicelevel=full&wskey=key';
-        $client->expects($this->once())->method('setUri')
-            ->with($this->equalTo($expectedUri));
         $body = '<foo>bar</foo>';
-        $response = $this->createMock(\Laminas\Http\Response::class);
-        $response->expects($this->once())->method('getBody')
-            ->will($this->returnValue($body));
-        $response->expects($this->any())->method('isSuccess')
-            ->will($this->returnValue(true));
-        $client->expects($this->once())->method('send')
-            ->will($this->returnValue($response));
+        $connector = $this->getConnectorWithMockClient($expectedUri, $body);
         $final = $connector->getRecord('baz');
         $this->assertEquals($body, $final['docs'][0]);
     }
@@ -129,22 +129,9 @@ class ConnectorTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetRecordWithError()
     {
-        $client = $this->createMock(\Laminas\Http\Client::class);
-        $connector = new Connector('key', $client);
-        $client->expects($this->once())->method('setMethod')
-            ->with($this->equalTo('POST'))
-            ->will($this->returnValue($client));
         $expectedUri = 'http://www.worldcat.org/webservices/catalog/content/baz?servicelevel=full&wskey=key';
-        $client->expects($this->once())->method('setUri')
-            ->with($this->equalTo($expectedUri));
         $body = '<foo><diagnostic>bad</diagnostic></foo>';
-        $response = $this->createMock(\Laminas\Http\Response::class);
-        $response->expects($this->once())->method('getBody')
-            ->will($this->returnValue($body));
-        $response->expects($this->any())->method('isSuccess')
-            ->will($this->returnValue(true));
-        $client->expects($this->once())->method('send')
-            ->will($this->returnValue($response));
+        $connector = $this->getConnectorWithMockClient($expectedUri, $body);
         $final = $connector->getRecord('baz');
         $this->assertEquals([], $final['docs']);
     }
@@ -156,24 +143,11 @@ class ConnectorTest extends \PHPUnit\Framework\TestCase
      */
     public function testSearch()
     {
-        $client = $this->createMock(\Laminas\Http\Client::class);
-        $connector = new Connector('key', $client);
-        $client->expects($this->once())->method('setMethod')
-            ->with($this->equalTo('POST'))
-            ->will($this->returnValue($client));
         $expectedUri = 'http://www.worldcat.org/webservices/catalog/search/sru?version=1.1&x=y'
             . '&startRecord=0&maximumRecords=20&servicelevel=full&wskey=key';
-        $client->expects($this->once())->method('setUri')
-            ->with($this->equalTo($expectedUri));
         $body = '<foo>,<numberOfRecords>1</numberOfRecords><records><record><recordData>bar</recordData>'
             . '</record></records></foo>';
-        $response = $this->createMock(\Laminas\Http\Response::class);
-        $response->expects($this->once())->method('getBody')
-            ->will($this->returnValue($body));
-        $response->expects($this->any())->method('isSuccess')
-            ->will($this->returnValue(true));
-        $client->expects($this->once())->method('send')
-            ->will($this->returnValue($response));
+        $connector = $this->getConnectorWithMockClient($expectedUri, $body);
         $final = $connector->search(new ParamBag(['x' => 'y']), 0, 20);
         $this->assertEquals('<recordData>bar</recordData>', $final['docs'][0]);
         $this->assertEquals(1, $final['total']);


### PR DESCRIPTION
Since phpcpd has been discontinued and we will soon likely remove it from our CI processes, I reviewed existing copy and paste reports and made a few changes to reduce code duplication. All changes are in tests, and all tests are passing, so I don't think there's too much risk to merging this.