### PR TITLE
Reduce test suite's reliance on jQuery.

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -392,7 +392,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $session = $this->getMinkSession();
         $session->wait(
             $timeout,
-            "typeof $ !== 'undefined' && $('$selector').length > $index"
+            "document.querySelectorAll('$selector').length > $index"
         );
         $results = $page->findAll('css', $selector);
         $this->assertIsArray($results, "Selector not found: $selector");
@@ -526,7 +526,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $session = $this->getMinkSession();
         $session->wait(
             $timeout,
-            "typeof $ !== 'undefined' && $('$selector:focusable').length > 0"
+            "document.querySelectorAll('$selector:focusable').length > 0"
         );
         $results = $page->findAll('css', $selector);
         $this->assertIsArray($results, "Selector not found: $selector");
@@ -665,12 +665,12 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         // Make sure any loading spinners are not visible:
         $session->wait(
             $timeout,
-            "typeof $ !== 'undefined' && $('.loading-spinner:visible').length === 0"
+            "document.querySelectorAll('.loading-spinner:visible').length === 0"
         );
         // Make sure nothing is being animated:
         $session->wait(
             $timeout,
-            "typeof $ !== 'undefined' && $(':animated').length === 0"
+            "document.querySelectorAll(':animated').length === 0"
         );
         // Finally, make sure all jQuery ready handlers are done:
         $session->evaluateScript(

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -526,7 +526,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $session = $this->getMinkSession();
         $session->wait(
             $timeout,
-            "document.querySelectorAll('$selector:focusable').length > 0"
+            "typeof $ !== 'undefined' && $('$selector:focusable').length > 0"
         );
         $results = $page->findAll('css', $selector);
         $this->assertIsArray($results, "Selector not found: $selector");
@@ -665,12 +665,12 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         // Make sure any loading spinners are not visible:
         $session->wait(
             $timeout,
-            "document.querySelectorAll('.loading-spinner:visible').length === 0"
+            "typeof $ !== 'undefined' && $('.loading-spinner:visible').length === 0"
         );
         // Make sure nothing is being animated:
         $session->wait(
             $timeout,
-            "document.querySelectorAll(':animated').length === 0"
+            "typeof $ !== 'undefined' && $(':animated').length === 0"
         );
         // Finally, make sure all jQuery ready handlers are done:
         $session->evaluateScript(


### PR DESCRIPTION
Our Mink test suite relies on jQuery for a variety of checks, which is a problem if we want to test a page that does not include jQuery. This PR uses browser-native checks in more places to reduce (but not yet fully eliminate) our reliance on jQuery. Merging this will greatly improve the performance of the tests introduced in #3011.

NOTE: I initially tried to simplify waitForPageLoad as well, but it relies on special jQuery selectors that are not supported by the native browser functionality and needs to remain as-is for now.

TODO
- [x] Run full test suite.