### PR TITLE
Fix API schema Authors component documentation

### DIFF
--- a/config/vufind/SearchApiRecordFields.yaml
+++ b/config/vufind/SearchApiRecordFields.yaml
@@ -15,11 +15,9 @@ authors:
   vufind.method: getDeduplicatedAuthors
   vufind.default: true
   description: >-
-    Deduplicated author information including main, corporate and secondary
+    Deduplicated author information including primary, corporate and secondary
     authors
-  type: array
-  items:
-    $ref: '#/components/schemas/Authors'
+  $ref: '#/components/schemas/Authors'
 awards:
   vufind.method: getAwards
   description: Award notes

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -235,8 +235,8 @@
             "Authors": {
                 "type": "object",
                 "properties": {
-                    "main": {
-                        "description": "Main authors",
+                    "primary": {
+                        "description": "Primary authors",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/AuthorWithRoles"


### PR DESCRIPTION
Documentation says there are "main" author field, but it is "primary"

Also the authors field of record is defined as "array" but it is object of type "Author"