### PR TITLE
[dev-10.0] Expose setupQRCodeLinks method.

### DIFF
--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -329,7 +329,8 @@ var VuFind = (function VuFind() {
     updateCspNonce: updateCspNonce,
     getCurrentSearchId: getCurrentSearchId,
     setCurrentSearchId: setCurrentSearchId,
-    initResultScripts: initResultScripts
+    initResultScripts: initResultScripts,
+    setupQRCodeLinks: setupQRCodeLinks
   };
 })();
 


### PR DESCRIPTION
setupQRCodeLinks used to be a global function, and calling it directly could still be needed in customized installations.