### PR TITLE
Fix batch-import-marc.sh error if there no files to process

### DIFF
--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -138,7 +138,7 @@ else
 fi
 
 # Process all the files in the target directory:
-find -L $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | sort -z | xargs -0 -n $MAX_BATCH_COUNT | \
+find -L $BASEPATH -maxdepth 1 \( -iname "*.xml" -o -iname "*.mrc" -o -iname "*.marc" \) -type f -print0 | sort -z | xargs -0 -r -n $MAX_BATCH_COUNT | \
   while read -d $'\n' files
 do
   # Logging output handled by log() function


### PR DESCRIPTION
The use of xargs in multi-file processing to batch-import-marc.sh will always output at least one line by default, even if that line is empty. The result is that when no files are available to process (XML or MARC) then the script will attempt to call import-marc.sh with an empty value, resulting in an error.

Adding the -r flag to xargs avoides this error, preventing further commands from running if only blank data was received.