### PR TITLE
Add check:scss task and use it in QA to avoid writing out the compile…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,8 +75,12 @@ module.exports = function(grunt) {
     scss: {
       sass: {
         options: {
-          style: 'compress'
+          outputStyle: 'compressed',
         }
+      }
+    },
+    'check:scss': {
+      sass: {
       }
     },
 
@@ -203,35 +207,12 @@ module.exports = function(grunt) {
   });
 
   grunt.registerMultiTask('scss', function sassScan() {
-    var sassConfig = {},
-      path = require('path'),
-      themeList = fs.readdirSync(path.resolve('themes')).filter(function (theme) {
-        return fs.existsSync(path.resolve('themes/' + theme + '/scss/compiled.scss'));
-      });
+    grunt.config.set('sass', getSassConfig(this.data.options, false));
+    grunt.task.run('sass');
+  });
 
-    for (var i in themeList) {
-      var config = {
-        options: {
-          implementation: require("node-sass"),
-          outputStyle: 'compressed'
-        },
-        files: [{
-          expand: true,
-          cwd: path.join('themes', themeList[i], 'scss'),
-          src: ['compiled.scss'],
-          dest: path.join('themes', themeList[i], 'css'),
-          ext: '.css'
-        }]
-      };
-      for (var key in this.data.options) {
-        config.options[key] = this.data.options[key] + '';
-      }
-      config.options.includePaths = getLoadPaths('themes/' + themeList[i] + '/scss/compiled.scss');
-
-      sassConfig[themeList[i]] = config;
-    }
-
-    grunt.config.set('sass', sassConfig);
+  grunt.registerMultiTask('check:scss', function sassCheck() {
+    grunt.config.set('sass', getSassConfig(this.data.options, true));
     grunt.task.run('sass');
   });
 
@@ -241,10 +222,45 @@ module.exports = function(grunt) {
     - grunt less        = compile and compress all themes' LESS files to css.
     - grunt scss        = compile and map all themes' SASS files to css.
     - grunt lessdev     = compile and map all themes' LESS files to css.
+    - grunt check:scss  = check all themes' SASS files.
     - grunt watch:[cmd] = continuous monitor source files and run command when changes are detected.
     - grunt watch:less
     - grunt watch:scss
     - grunt watch:lessdev
     - grunt lessToSass  = transpile all LESS files to SASS.`);
   });
+
+  function getSassConfig(additionalOptions, checkOnly) {
+    var sassConfig = {},
+      path = require('path'),
+      themeList = fs.readdirSync(path.resolve('themes')).filter(function (theme) {
+        return fs.existsSync(path.resolve('themes/' + theme + '/scss/compiled.scss'));
+      });
+
+    for (var i in themeList) {
+      if (Object.prototype.hasOwnProperty.call(themeList, i)) {
+        var config = {
+          options: {
+            implementation: require("node-sass"),
+          },
+          files: [{
+            expand: true,
+            cwd: path.join('themes', themeList[i], 'scss'),
+            src: ['compiled.scss'],
+            dest: checkOnly ? null : path.join('themes', themeList[i], 'css'),
+            ext: '.css'
+          }]
+        };
+        for (var key in additionalOptions) {
+          if (Object.prototype.hasOwnProperty.call(additionalOptions, key)) {
+            config.options[key] = additionalOptions[key];
+          }
+        }
+        config.options.includePaths = getLoadPaths('themes/' + themeList[i] + '/scss/compiled.scss');
+
+        sassConfig[themeList[i]] = config;
+      }
+    }
+    return sassConfig;
+  }
 };

--- a/build.xml
+++ b/build.xml
@@ -201,7 +201,7 @@
 
   <!-- Run Sass build, error if it fails -->
   <target name="checkSassBuild">
-    <exec command="npm run build:scss" checkreturn="true" passthru="true" />
+    <exec command="npm run check:scss" checkreturn="true" passthru="true" />
   </target>
 
   <!-- Run LessToSass, error if there are uncommitted changes (used by continuous integration) -->

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "watch-dev:less": "grunt watch:lessdev",
 
     "build:scss": "grunt scss",
+    "check:scss": "grunt check:scss",
     "watch:scss": "grunt watch:scss",
 
     "lessToSass": "grunt lessToSass",


### PR DESCRIPTION
…d files.

Also moves the `outputStyle` setting to the task-specific settings and removes the `style`option that's not used by the node-sass plugin.