### PR TITLE
Fix email-based catalog login from record holdings tab.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/EmailAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/EmailAuthenticator.php
@@ -141,13 +141,13 @@ class EmailAuthenticator implements \VuFind\I18n\Translator\TranslatorAwareInter
      *
      * Stores the required information in the session.
      *
-     * @param string $email     Email address to send the link to
-     * @param array  $data      Information from the authentication request (such as
-     * user details)
-     * @param array  $urlParams Default parameters for the generated URL
-     * @param string $linkRoute The route to use as the base url for the login link
-     * @param string $subject   Email subject
-     * @param string $template  Email message template
+     * @param string $email       Email address to send the link to
+     * @param array  $data        Information from the authentication request (such as user details)
+     * @param array  $urlParams   Default parameters for the generated URL
+     * @param string $linkRoute   The route to use as the base url for the login link
+     * @param array  $routeParams Route parameters
+     * @param string $subject     Email subject
+     * @param string $template    Email message template
      *
      * @return void
      */
@@ -156,6 +156,7 @@ class EmailAuthenticator implements \VuFind\I18n\Translator\TranslatorAwareInter
         $data,
         $urlParams,
         $linkRoute = 'myresearch-home',
+        $routeParams = [],
         $subject = 'email_login_subject',
         $template = 'Email/login-link.phtml'
     ) {
@@ -191,7 +192,7 @@ class EmailAuthenticator implements \VuFind\I18n\Translator\TranslatorAwareInter
         $urlParams['hash'] = $hash;
         $viewParams = $linkData;
         $viewParams['url'] = $serverHelper(
-            $urlHelper($linkRoute, [], ['query' => $urlParams])
+            $urlHelper($linkRoute, $routeParams, ['query' => $urlParams])
         );
         $viewParams['title'] = $this->config->Site->title;
 

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -171,12 +171,14 @@ class ILSAuthenticator
     /**
      * Send email authentication link
      *
-     * @param string $email Email address
-     * @param string $route Route for the login link
+     * @param string $email       Email address
+     * @param string $route       Route for the login link
+     * @param array  $routeParams Route parameters
+     * @param array  $urlParams   URL parameters
      *
      * @return void
      */
-    public function sendEmailLoginLink($email, $route)
+    public function sendEmailLoginLink($email, $route, $routeParams = [], $urlParams = [])
     {
         if (null === $this->emailAuthenticator) {
             throw new \Exception('Email authenticator not set');
@@ -187,8 +189,9 @@ class ILSAuthenticator
             $this->emailAuthenticator->sendAuthenticationLink(
                 $patron['email'],
                 $patron,
-                ['auth_method' => 'ILS'],
-                $route
+                ['auth_method' => 'ILS'] + $urlParams,
+                $route,
+                $routeParams
             );
         }
     }

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -407,7 +407,8 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
                     $routeMatch = $this->getEvent()->getRouteMatch();
                     $routeName = $routeMatch ? $routeMatch->getMatchedRouteName()
                         : 'myresearch-profile';
-                    $ilsAuth->sendEmailLoginLink($username, $routeName);
+                    $routeParams = $routeMatch ? $routeMatch->getParams() : [];
+                    $ilsAuth->sendEmailLoginLink($username, $routeName, $routeParams, ['catalogLogin' => 'true']);
                     $this->flashMessenger()
                         ->addSuccessMessage('email_login_link_sent');
                 } else {


### PR DESCRIPTION
Without route parameters the route doesn't include the record id or current tab. Without the catalogLogin parameter record controller wouldn't process the login request. The issue arises when a user has already logged in to VuFind but doesn't have a library card attached. If they try to add it using the link on the record holdings tab, it would result in a broken link to be sent via email.

This changes the signature of EmailAuthenticator::sendAuthenticationLink, but I believe it's worth it.