### PR TITLE
Introduce results-list template between results and list templates.

### DIFF
--- a/themes/bootstrap3/templates/search/results-list.phtml
+++ b/themes/bootstrap3/templates/search/results-list.phtml
@@ -1,0 +1,9 @@
+<?php
+  // Create a css class for results from the search class:
+  $searchClass = $searchClassCss = $this->params->getSearchClassId();
+  if (!ctype_upper($searchClassCss)) {
+    $searchClassCss = preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $searchClassCss);
+  }
+  $this->resultsClass = 'search-results-' . strtolower($searchClassCss);
+?>
+<?=$this->render('search/list-' . $this->params->getView() . '.phtml')?>

--- a/themes/bootstrap3/templates/search/results-list.phtml
+++ b/themes/bootstrap3/templates/search/results-list.phtml
@@ -1,6 +1,7 @@
 <?php
   // Create a css class for results from the search class:
   $searchClass = $searchClassCss = $this->params->getSearchClassId();
+  // Convert camelCase to hyphenated-text, unless it's all-uppercase, like EDS:
   if (!ctype_upper($searchClassCss)) {
     $searchClassCss = preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $searchClassCss);
   }

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -37,12 +37,6 @@
     && ($this->showBulkOptions || !$this->cart()->isActiveInSearch());
   // Enable bulk options if appropriate:
   $this->showCheckboxes = $this->showCartControls || $this->showBulkOptions;
-  // Create a css class for results from the search class:
-  $searchClass = $this->params->getSearchClassId();
-  if (!ctype_upper($searchClass)) {
-    $searchClass = preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', $searchClass);
-  }
-  $this->resultsClass = 'search-results-' . strtolower($searchClass);
 
   $this->render(
       'search/results-scripts.phtml',
@@ -107,7 +101,7 @@
     <form id="search-cart-form" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>" data-lightbox data-lightbox-onsubmit="bulkFormHandler">
       <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>
     </form>
-    <?=$this->render('search/list-' . $this->params->getView() . '.phtml')?>
+    <?=$this->render('search/results-list.phtml')?>
     <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => 'bottom_', 'formAttr' => 'search-cart-form'])?>
     <?=$this->paginationControl($this->results->getPaginator(), 'Sliding', 'search/pagination.phtml', ['results' => $this->results, 'options' => $this->paginationOptions ?? []])?>
     <?=$this->context($this)->renderInContext('search/controls/results-tools.phtml', ['results' => $this->results])?>


### PR DESCRIPTION
This paves way for extended use (i.e. the possibility of rendering search results without the surrounding controls).

Extracted from #2929.