### PR TITLE
Add more files to clean up in reset_setup task.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -758,8 +758,13 @@ ${git_status}
       <fileset dir="${localdir}/config/vufind">
         <patternset>
           <include name="*.ini" />
-          <include name="*.yaml" />
+          <include name="*.ini.bak" />
           <include name="*.json" />
+          <include name="*.json.bak" />
+          <include name="*.key" />
+          <include name="*.key.bak" />
+          <include name="*.yaml" />
+          <include name="*.yaml.bak" />
         </patternset>
       </fileset>
     </delete>


### PR DESCRIPTION
Removing any .bak files ensures that the tests don't restore obsolete backups. .key files include the OAuth2 server test keys.