### PR TITLE
Use strict equality in MD5 comparison.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -421,7 +421,7 @@ class Upgrade
         // same, we don't need to copy anything!
         if (
             file_exists($src) && file_exists($raw)
-            && md5(file_get_contents($src)) == md5(file_get_contents($raw))
+            && md5(file_get_contents($src)) === md5(file_get_contents($raw))
         ) {
             return;
         }


### PR DESCRIPTION
It was recommended that we should use strict comparison here, and even though I don't think it's essential, it doesn't hurt to be more specific in this case.