### PR TITLE
Hash passwords by default.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -501,9 +501,12 @@ enableAjax = true
 ; account link in the header.
 enableDropdown = false
 
-; Set this to false if you would like to store local passwords in plain text
-; (only applies when method = Database or AlmaDatabase above).
-hash_passwords = false
+; Setting this to false will turn off password hashing and store user passwords
+; in plain text, which is NOT RECOMMENDED, but may be useful if you are in the
+; process of migrating data from a very old VuFind release that predates password
+; hashing. DO NOT CHANGE under other circumstances. Also note that this setting
+; only applies when method = Database or AlmaDatabase above.
+hash_passwords = true
 
 ; Allow users to recover passwords via email (if supported by Auth method)
 ; You can set the subject of recovery emails in your


### PR DESCRIPTION
@lahmann and I reviewed default password hashing configuration and realized that the only reason it was set to false by default was to support migration from VuFind 1.x. This should no longer be a significant concern, so it seems like it's time to change the default to true.