### PR TITLE
SierraRest: Check holdings also for item statuses by default.

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -250,3 +250,5 @@ title_hold_excluded_item_codes = "e"
 ;sort_by_enum_chron = false
 ; Whether to retrieve and display orders (default is false):
 ;display_orders = false
+; Whether to check holdings records in search results (default is true):
+;check_holdings_in_results = true

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -482,7 +482,7 @@ class SierraRest extends AbstractBase implements
      */
     public function getStatus($id)
     {
-        return $this->getItemStatusesForBib($id, false);
+        return $this->getItemStatusesForBib($id, $this->config['Holdings']['check_holdings_in_results'] ?? true);
     }
 
     /**
@@ -499,7 +499,7 @@ class SierraRest extends AbstractBase implements
     {
         $items = [];
         foreach ($ids as $id) {
-            $items[] = $this->getItemStatusesForBib($id, false);
+            $items[] = $this->getStatus($id);
         }
         return $items;
     }


### PR DESCRIPTION
This fixes a discrepancy between status information on the search results page and record holdings tab. The issue is particularly noticeable for records that only have summary holdings for storage items.