### PR TITLE
Check for saved lists element before trying to access it.

### DIFF
--- a/themes/bootstrap3/js/check_save_statuses.js
+++ b/themes/bootstrap3/js/check_save_statuses.js
@@ -81,7 +81,8 @@ VuFind.register("saveStatuses", function ItemStatuses() {
   });
 
   function checkSaveStatus(el) {
-    if (!userIsLoggedIn) {
+    const savedListsEl = el.querySelector(".savedLists");
+    if (!userIsLoggedIn || !savedListsEl) {
       VuFind.emit("save-status-done");
 
       return;
@@ -100,7 +101,6 @@ VuFind.register("saveStatuses", function ItemStatuses() {
 
     el.classList.add("js-save-pending");
 
-    const savedListsEl = el.querySelector(".savedLists");
     savedListsEl.classList.remove("loaded", "hidden");
     savedListsEl.innerHTML +=
       '<span class="js-load">' +


### PR DESCRIPTION
This eliminates the JS error "savedListsEl is null" when save status check runs on a page that contains records that don't include the element (e.g. favorites).

The error can be reproduced easily by including the check_save_statuses.js script in theme.config.php (which would be necessary to combine all scripts to a single one with the asset pipeline).