### PR TITLE
Fix hierarchy tree search limit default value handling.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HierarchyController.php
+++ b/module/VuFind/src/VuFind/Controller/HierarchyController.php
@@ -84,7 +84,7 @@ class HierarchyController extends AbstractBase
     {
         $this->disableSessionWrites();  // avoid session write timing bug
         $config = $this->getConfig();
-        $limit = $config->Hierarchy->treeSearchLimit ?? -1;
+        $limit = $config->Hierarchy->treeSearchLimit;
         $resultIDs = [];
         $hierarchyID = $this->params()->fromQuery('hierarchyID');
         $source = $this->params()
@@ -96,7 +96,7 @@ class HierarchyController extends AbstractBase
             ->get(\VuFind\Search\Results\PluginManager::class)->get($source);
         $results->getParams()->setBasicSearch($lookfor, $searchType);
         $results->getParams()->addFilter('hierarchy_top_id:' . $hierarchyID);
-        $facets = $results->getFullFieldFacets(['id'], false, $limit + 1);
+        $facets = $results->getFullFieldFacets(['id'], false, null === $limit ? -1 : $limit + 1);
 
         $callback = function ($data) {
             return $data['value'];


### PR DESCRIPTION
The default -1 was passed as 0 to getFullFieldFacets which caused the search to complete but to return no results.