### PR TITLE
Generate useful OpenURL for eBook

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -727,7 +727,7 @@ class DefaultRecord extends AbstractBase
         // If we have multiple formats, Book, Journal and Article are most
         // important...
         $formats = $this->getFormats();
-        if (in_array('Book', $formats)) {
+        if (in_array('Book', $formats) || in_array('eBook', $formats)) {
             return 'Book';
         } elseif (in_array('Article', $formats)) {
             return 'Article';


### PR DESCRIPTION
'eBook' is a recognized out-of-the-box VuFind format defined in import/translation_maps/format_map.properties.  getOpenUrlFormat() currently doesn't recognize it and falls back to 'UnknownFormat'.  I would argue that treating it as a book is more useful.

