### PR TITLE
Add place of publication to book OpenUrl

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
+++ b/module/VuFind/src/VuFind/RecordDriver/DefaultRecord.php
@@ -825,6 +825,10 @@ class DefaultRecord extends AbstractBase
         if (count($publishers) > 0) {
             $params['rft.pub'] = $publishers[0];
         }
+        $placesOfPublication = $this->getPlacesOfPublication();
+        if (count($placesOfPublication) > 0) {
+            $params['rft.place'] = $placesOfPublication[0];
+        }
         $params['rft.edition'] = $this->getEdition();
         $params['rft.isbn'] = (string)$this->getCleanISBN();
         return $params;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -292,8 +292,9 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
             . 'te=1992&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&rft.genre=book&rft.btitl'
             . 'e=La+congiura+dei+Principi+Napoletani+1701+%3A+%28prima+e+seconda+stesura%29+%2F'
             . '&rft.series=Vico%2C+Giambattista%2C+1668-1744.+Works.+1982+%3B&rft.au=Vico%2C+Gi'
-            . 'ambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.edition=Fiction'
-            . 'al+edition.&rft.isbn=8820737493&rft_id=info%3Adoi%2Fxxx&rft_id=pmid%3Ayyy';
+            . 'ambattista%2C+1668-1744.&rft.pub=Centro+di+Studi+Vichiani%2C&rft.place=Morano+%3A'
+            . '&rft.edition=Fictional+edition.&rft.isbn=8820737493&rft_id=info%3Adoi%2Fxxx'
+            . '&rft_id=pmid%3Ayyy';
 
         // Parameters returned by getBookOpenUrlParams with rft_id added
         $openUrlParams = [
@@ -309,6 +310,7 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
             'rft.series' => 'Vico, Giambattista, 1668-1744. Works. 1982 ;',
             'rft.au' => 'Vico, Giambattista, 1668-1744.',
             'rft.pub' => 'Centro di Studi Vichiani,',
+            'rft.place' => 'Morano :',
             'rft.edition' => 'Fictional edition.',
             'rft.isbn' => '8820737493',
             'rft_id' => [


### PR DESCRIPTION
Because it's useful when sent via COinS as a Zotero citation (according to my librarian colleagues).  

That said I'm not clear on how OpenUrl operates, whether all the fields have to match for the link resolver to surface a result.  I wouldn't want a book to fail to resolve due to a difference in place of publication.