### PR TITLE
Fix SolrAuth typo

### DIFF
--- a/config/vufind/BlenderMappings.yaml
+++ b/config/vufind/BlenderMappings.yaml
@@ -311,7 +311,7 @@ Sorting:
       Mappings:
         Primo: screator
         Solr: author
-        solrAuth: heading
+        SolrAuth: heading
     relevance:
       Mappings:
         EDS: relevance
@@ -321,7 +321,7 @@ Sorting:
       Mappings:
         Primo: title
         Solr: title
-        solrAuth: heading
+        SolrAuth: heading
     year:
       Mappings:
         EDS: date


### PR DESCRIPTION
Looks to me like "S"olrAuth should be capitalized in these uses like the rest of the file?  Not tested.