### PR TITLE
Fix broken list tag query (and add test)

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
@@ -230,7 +230,7 @@ class ResourceTags extends Gateway
             $publicOnly,
             $andTags
         ) {
-            $columns = [Select::SQL_STAR];
+            $columns = ['id' => new Expression('min(resource_tags.id)'), 'list_id'];
             if ($andTags) {
                 $columns['tag_cnt'] = new Expression(
                     'COUNT(DISTINCT(?))',
@@ -243,10 +243,7 @@ class ResourceTags extends Gateway
             $select->join(
                 ['t' => 'tags'],
                 'resource_tags.tag_id = t.id',
-                [
-                    'tag' =>
-                        $this->caseSensitive ? 'tag' : new Expression('lower(tag)'),
-                ]
+                []
             );
             $select->join(
                 ['l' => 'user_list'],

--- a/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
@@ -230,15 +230,9 @@ class ResourceTags extends Gateway
             $publicOnly,
             $andTags
         ) {
-            $columns = ['id' => new Expression('min(resource_tags.id)'), 'list_id'];
-            if ($andTags) {
-                $columns['tag_cnt'] = new Expression(
-                    'COUNT(DISTINCT(?))',
-                    ['resource_tags.tag_id'],
-                    [Expression::TYPE_IDENTIFIER]
-                );
-            }
-            $select->columns($columns);
+            $select->columns(
+                ['id' => new Expression('min(resource_tags.id)'), 'list_id']
+            );
 
             $select->join(
                 ['t' => 'tags'],
@@ -291,7 +285,7 @@ class ResourceTags extends Gateway
             if ($tag && $andTags) {
                 // Use AND operator for tags
                 $select->having->literal(
-                    'tag_cnt = ?',
+                    'count(distinct(resource_tags.tag_id)) = ?',
                     count(array_unique($tag))
                 );
             }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -656,6 +656,51 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that a public list can be tagged and displayed as a channel.
+     *
+     * @depends testEmailPublicList
+     *
+     * @return void
+     */
+    public function testListTaggingToDisplayChannel(): void
+    {
+        $this->changeConfigs(
+            [
+                'channels' => [
+                    'General' => [
+                        'cache_home_channels' => false,
+                    ],
+                    'source.Solr' => [
+                        'home' => ['listitems'],
+                    ],
+                    'provider.listitems' => [
+                        'tags' => ['channel'],
+                    ],
+                ],
+                'config' => [
+                    'Social' => [
+                        'listTags' => 'enabled',
+                    ],
+                ],
+            ]
+        );
+        $page = $this->gotoUserAccount();
+        // Click on the first list and make it public:
+        $link = $this->findAndAssertLink($page, 'Test List');
+        $link->click();
+        $button = $this->findAndAssertLink($page, 'Edit List');
+        $button->click();
+        $this->findCssAndSetValue($page, '#list_tags', 'channel');
+        $this->clickCss($page, 'input[name="submit"]'); // submit button
+
+        // Now go to the channel page, where the tagged public list should appear:
+        $this->getMinkSession()->visit($this->getVuFindUrl() . '/Channels');
+        $this->waitForPageLoad($page);
+        $this->assertEquals('Test List', $this->findCss($page, '.channel-title h2')->getText());
+        $this->assertCount(1, $page->findAll('css', '.channel-record'));
+    }
+
+    /**
      * Test that public list indicator appears as expected.
      *
      * @depends testEmailPublicList

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -685,7 +685,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
             ]
         );
         $page = $this->gotoUserAccount();
-        // Click on the first list and make it public:
+        // Click on the first list and tag it:
         $link = $this->findAndAssertLink($page, 'Test List');
         $link->click();
         $button = $this->findAndAssertLink($page, 'Edit List');


### PR DESCRIPTION
While testing @skellamp's work on Doctrine migration, I discovered that the list tag functionality in the current dev branch was broken due to illegal grouping. (It probably worked in the past because MySQL used to have much more tolerant defaults... but I bet it was always broken for PostgreSQL). This PR fixes the grouping problem by removing some unused/unnecessary fields from the select clause and also adds a very basic Mink test to make sure that lists can be tagged, and tagged lists can be retrieved by the ListItems ChannelProvider.

TODO
- [x] Fix PostgreSQL compatibility