### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ import/solrmarc.log*
 lessphp_*.list
 module/VuFind/tests/.phpunit.result.cache
 node_modules
+package-lock.json
 public/swagger-ui
 local/DirLocations.ini
 local/config/vufind/*.ini


### PR DESCRIPTION
This seems like a node.js build artifact just like node_modules.  But that was added to .gitignore 7 years ago so I'm probably missing something.