### PR TITLE
Fix record redirect to collection to not mess up encoding of record id.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -351,7 +351,11 @@ class AbstractRecord extends AbstractBase
                 if (true === $driver->tryMethod('isCollection')) {
                     $params = $this->params()->fromQuery()
                         + $this->params()->fromRoute();
-                    $options = [];
+                    // Disable path normalization since it can unencode e.g. encoded
+                    // slashes in record id's
+                    $options = [
+                        'normalize_path' => false,
+                    ];
                     if ($sid = $this->getSearchMemory()->getCurrentSearchId()) {
                         $options['query'] = compact('sid');
                     }


### PR DESCRIPTION
Same issue as in other places where `normalize_path` is set to false.