### PR TITLE
Add a composer script to update npm dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,7 @@
         "post-install-cmd": "@phing-install-dependencies",
         "post-update-cmd": "@phing-install-dependencies",
         "qa": "phing qa-console -Ddefaultconfigs=true",
-        "install-npm-dependencies": "npm install && phing copynodemodules"
+        "install-npm-dependencies": "npm install && phing copynodemodules",
+        "update-npm-dependencies": "npm update && phing copynodemodules"
     }
 }


### PR DESCRIPTION
Since we don't currently include package-lock.npm in git, this provides a convenient command for updating npm dependencies and copying them to correct places.