### PR TITLE
Improve coverage of list tagging test.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -656,14 +656,79 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Data provider for testListTaggingToDisplayChannel
+     *
+     * @return array
+     */
+    public function getListTagData(): array
+    {
+        $defaultChannelConfig = ['tags' => ['channel'], 'displayPublicLists' => false];
+        return [
+            'case insensitive channel match' => [
+                'CHANNEL',
+                $defaultChannelConfig,
+                false, // case insensitive
+                true,   // match expected
+            ],
+            'case sensitive channel match' => [
+                'channel',
+                $defaultChannelConfig,
+                true, // case sensitive
+                true,  // match expected
+            ],
+            'case sensitive channel mismatch' => [
+                'Channel',
+                $defaultChannelConfig,
+                true, // case sensitive
+                false, // mismatch expected
+            ],
+            'case sensitive AND mismatch' => [
+                'channel',
+                ['tags' => ['channel', 'banana'], 'displayPublicLists' => false],
+                true, // case sensitive
+                false, // mismatch expected
+            ],
+            'case sensitive AND match' => [
+                'channel banana',
+                ['tags' => ['channel', 'banana'], 'displayPublicLists' => false],
+                true, // case sensitive
+                true,  // match expected
+            ],
+            'case sensitive OR match' => [
+                'channel',
+                ['tags' => ['channel', 'banana'], 'displayPublicLists' => false, 'tagsOperator' => 'OR'],
+                true, // case sensitive
+                true,  // match expected
+            ],
+            'case insensitive OR match' => [
+                'channel',
+                ['tags' => ['chAnnEl', 'banana'], 'displayPublicLists' => false, 'tagsOperator' => 'OR'],
+                false, // case insensitive
+                true,   // match expected
+            ],
+        ];
+    }
+
+    /**
      * Test that a public list can be tagged and displayed as a channel.
+     *
+     * @param string $listTags      Tags to assign to the list
+     * @param array  $channelConfig Config array for listitems channel
+     * @param bool   $caseSensitive Use case sensitive tags?
+     * @param bool   $matchExpected Do we expect the list to show up in channel?
      *
      * @depends testEmailPublicList
      *
+     * @dataProvider getListTagData
+     *
      * @return void
      */
-    public function testListTaggingToDisplayChannel(): void
-    {
+    public function testListTaggingToDisplayChannel(
+        string $listTags,
+        array $channelConfig,
+        bool $caseSensitive,
+        bool $matchExpected
+    ): void {
         $this->changeConfigs(
             [
                 'channels' => [
@@ -673,13 +738,12 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
                     'source.Solr' => [
                         'home' => ['listitems'],
                     ],
-                    'provider.listitems' => [
-                        'tags' => ['channel'],
-                    ],
+                    'provider.listitems' => $channelConfig,
                 ],
                 'config' => [
                     'Social' => [
                         'listTags' => 'enabled',
+                        'case_sensitive_tags' => $caseSensitive,
                     ],
                 ],
             ]
@@ -690,14 +754,18 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $link->click();
         $button = $this->findAndAssertLink($page, 'Edit List');
         $button->click();
-        $this->findCssAndSetValue($page, '#list_tags', 'channel');
+        $this->findCssAndSetValue($page, '#list_tags', $listTags);
         $this->clickCss($page, 'input[name="submit"]'); // submit button
 
         // Now go to the channel page, where the tagged public list should appear:
         $this->getMinkSession()->visit($this->getVuFindUrl() . '/Channels');
         $this->waitForPageLoad($page);
-        $this->assertEquals('Test List', $this->findCss($page, '.channel-title h2')->getText());
-        $this->assertCount(1, $page->findAll('css', '.channel-record'));
+        if ($matchExpected) {
+            $this->assertEquals('Test List', $this->findCss($page, '.channel-title h2')->getText());
+            $this->assertCount(1, $page->findAll('css', '.channel-record'));
+        } else {
+            $this->unfindCss($page, '.channel-title h2');
+        }
     }
 
     /**


### PR DESCRIPTION
This improves the test created in #3067 to cover more edge cases. It is currently passing in my environment, and in the work-in-progress branch that ports tag logic to Doctrine.