### PR TITLE
Fix record tab heading level

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -291,7 +291,7 @@ function ajaxTagUpdate(_link, tag, _remove) {
 }
 
 function getNewRecordTab(tabid) {
-    return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + tabid + '">' + VuFind.loading() + '</div>');
+    return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + escapeHtmlAttr(tabid) + '">' + VuFind.loading() + '</div>');
 }
 
 function backgroundLoadTab(tabid) {

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -1,4 +1,4 @@
-/*global deparam, getUrlRoot, recaptchaOnLoad, resetCaptcha, syn_get_widget, userIsLoggedIn, VuFind, setupJumpMenus */
+/*global deparam, getUrlRoot, recaptchaOnLoad, resetCaptcha, syn_get_widget, userIsLoggedIn, VuFind, setupJumpMenus, escapeHtmlAttr */
 /*exported ajaxTagUpdate, recordDocReady, refreshTagListCallback, addRecordRating */
 
 /**
@@ -291,7 +291,7 @@ function ajaxTagUpdate(_link, tag, _remove) {
 }
 
 function getNewRecordTab(tabid) {
-    return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + escapeHtmlAttr(tabid) + '">' + VuFind.loading() + '</div>');
+  return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + escapeHtmlAttr(tabid) + '">' + VuFind.loading() + '</div>');
 }
 
 function backgroundLoadTab(tabid) {

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -291,7 +291,7 @@ function ajaxTagUpdate(_link, tag, _remove) {
 }
 
 function getNewRecordTab(tabid) {
-  return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + escapeHtmlAttr(tabid) + '">' + VuFind.loading() + '</div>');
+  return $('<div class="tab-pane ' + escapeHtmlAttr(tabid) + '-tab" aria-labelledby="record-tab-' + escapeHtmlAttr(tabid) + '">' + VuFind.loading() + '</div>');
 }
 
 function backgroundLoadTab(tabid) {

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -291,7 +291,7 @@ function ajaxTagUpdate(_link, tag, _remove) {
 }
 
 function getNewRecordTab(tabid) {
-  return $('<div class="tab-pane ' + tabid + '-tab">' + VuFind.loading() + '</div>');
+    return $('<div class="tab-pane ' + tabid + '-tab" aria-labelledby="record-tab-' + tabid + '">' + VuFind.loading() + '</div>');
 }
 
 function backgroundLoadTab(tabid) {

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -56,7 +56,7 @@
   </a>
 <?php endif; ?>
 <?php if (!empty($urls) || $openUrlActive || $doiActive): ?>
-  <h3><?=$this->transEsc('Internet')?></h3>
+  <h2><?=$this->transEsc('Internet')?></h2>
   <?php if (!empty($urls)): ?>
     <?php foreach ($urls as $current): ?>
       <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($current['url']))?>"><?=$this->escapeHtml($current['desc'])?></a><br>
@@ -76,14 +76,14 @@
 <?php endif; ?>
 
 <?php foreach ($holdings['holdings'] ?? [] as $holding): ?>
-<h3>
+<h2>
   <?php $locationTextEsc = $this->transEscWithPrefix('location_', $holding['location']); ?>
   <?php if ($holding['locationhref'] ?? false): ?>
     <a href="<?=$this->escapeHtmlAttr($holding['locationhref'])?>" target="_blank"><?=$locationTextEsc?></a>
   <?php else: ?>
     <?=$locationTextEsc?>
   <?php endif; ?>
-</h3>
+</h2>
 <?php
   $truncateSettings = [
     'rows' => $this->config()->getHoldingsItemLimit(),
@@ -150,7 +150,7 @@
 <?php endif; ?>
 <?php $history = $this->driver->getRealTimeHistory(); ?>
 <?php if (is_array($history) && !empty($history)): ?>
-  <h3><?=$this->transEsc('Most Recent Received Issues')?></h3>
+  <h2><?=$this->transEsc('Most Recent Received Issues')?></h2>
   <table class="table table-striped">
     <?php foreach ($history as $row): ?>
       <tr><td><?=$this->escapeHtml($row['issue'])?></td></tr>

--- a/themes/bootstrap3/templates/RecordTab/holdingsils/electronic.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/electronic.phtml
@@ -1,4 +1,4 @@
-<h3><?=$this->transEsc('Electronic')?></h3>
+<h2><?=$this->transEsc('Electronic')?></h2>
 <table class="table table-striped">
   <?php foreach ($this->holdings as $item): ?>
     <tr>

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -55,6 +55,7 @@
                   $tabClasses[] = 'active';
                 }
                 $tabClasses[] = 'initiallyActive';
+                $activeTabName = $tabName;
                 $activeTabObj = $obj;
               }
               if (!$obj->isVisible()) {
@@ -64,7 +65,7 @@
                 $tabClasses[] = 'noajax';
               }
             ?>
-            <li class="<?=implode(' ', $tabClasses)?>" role="tab" data-tab="<?=$this->escapeHtmlAttr($tabName)?>"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>>
+            <li id="record-tab-<?=$this->escapeHtmlAttr($tabName)?>" class="<?=implode(' ', $tabClasses)?>" role="tab" data-tab="<?=$this->escapeHtmlAttr($tabName)?>"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>>
               <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getTabUrl($this->driver, $tab))?>#tabnav" data-lightbox-ignore>
                 <?=$this->transEsc($desc)?>
               </a>
@@ -74,7 +75,7 @@
 
         <div class="tab-content">
           <?php if (!$this->loadInitialTabWithAjax || !isset($activeTabObj) || !$activeTabObj->supportsAjax()): ?>
-            <div class="tab-pane active <?=$this->escapeHtmlAttr($this->activeTab) ?>-tab">
+            <div class="tab-pane active <?=$this->escapeHtmlAttr($this->activeTab) ?>-tab" aria-labelledby="record-tab-<?=$this->escapeHtmlAttr($activeTabName)?>">
               <?=isset($activeTabObj) ? $this->record($this->driver)->getTab($activeTabObj) : '' ?>
             </div>
           <?php endif; ?>


### PR DESCRIPTION
From #3039 Accessibility: Moravian Library Report

### Pick up location label

Details from https://docs.google.com/document/d/1qII8IRWOk0eP3er-91C5clhTfQq92yPkUbvAtq3xdNU/edit:

> LH: Only a heading with location name should be 2nd level, just like the "Similar Units" heading, not 3rd.