### PR TITLE
Improve icon helper escaping logic

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Icon.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Icon.php
@@ -234,7 +234,7 @@ class Icon extends AbstractHelper
                     array_merge(
                         $this->config['sets'][$set] ?? [],
                         [
-                            'icon' => ($this->esc)($icon),
+                            'icon' => $icon,
                             'attrs' => $this->compileAttrs($attrs),
                             'extra' => $attrs,
                         ]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -137,7 +137,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIcon(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon icon--font fa&#x20;fa-foo" '
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
             . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo')));
     }
@@ -150,7 +150,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIconWithExtraClass(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon icon--font fa&#x20;fa-spinner extraClass" '
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-spinner&#x20;extraClass" '
             . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('classy')));
     }
@@ -163,12 +163,12 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIconWithExtras(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon icon--font fa&#x20;fa-foo" '
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
             . 'bar="baz" role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo', ['bar' => 'baz'])));
 
         // Add class to class
-        $expected = '<span class="icon icon--font fa&#x20;fa-foo foo-bar" role="img" aria-hidden="true"></span>';
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo&#x20;foo-bar" role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo', ['class' => 'foo-bar'])));
 
         // Shortcut
@@ -182,7 +182,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
      */
     public function testCaching(): void
     {
-        $expected = '<span class="icon icon--font fa&#x20;fa-foo" '
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
             . 'bar="baz" role="img" aria-hidden="true"></span>';
         $key = 'foo+c0dc783820069fb9337be7366f7945bf';
 
@@ -212,7 +212,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/baz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon icon--img" src="baz.png" aria-hidden="true"'
+        $expected = '<img class="icon&#x20;icon--img" src="baz.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('bar'));
     }
@@ -227,7 +227,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/zzz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon icon--img weird:class foo" src="zzz.png"'
+        $expected = '<img class="icon&#x20;icon--img&#x20;weird&#x3A;class&#x20;foo" src="zzz.png"'
             . ' aria-hidden="true" alt="">';
         $this->assertEquals($expected, $helper('extraClassy'));
     }
@@ -241,7 +241,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/baz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon icon--img myclass" src="baz.png"'
+        $expected = '<img class="icon&#x20;icon--img&#x20;myclass" src="baz.png"'
             . ' aria-hidden="true" alt="">';
         // Send a string, validating the shortcut where strings are treated as
         // classes, in addition to confirming that extras work for image icons.
@@ -258,14 +258,14 @@ class IconTest extends \PHPUnit\Framework\TestCase
         // RTL exists
         $plugins = ['imageLink' => $this->getMockImageLink('icons/zab.png')];
         $helper = $this->getIconHelper(null, null, $plugins, true);
-        $expected = '<img class="icon icon--img" src="zab.png" aria-hidden="true"'
+        $expected = '<img class="icon&#x20;icon--img" src="zab.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('bar'));
 
         // RTL does not exist
         $plugins = ['imageLink' => $this->getMockImageLink('icons/ltronly.png')];
         $helper = $this->getIconHelper(null, null, $plugins, true);
-        $expected = '<img class="icon icon--img" src="ltronly.png"'
+        $expected = '<img class="icon&#x20;icon--img" src="ltronly.png"'
             . ' aria-hidden="true" alt="">';
         $this->assertEquals($expected, $helper('ltronly'));
     }
@@ -278,7 +278,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testAlias(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon icon--font fa&#x20;fa-foo" '
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
             . 'role="img" aria-hidden="true"></span>';
         // same is an alias for foo!
         $this->assertEquals($expected, $helper('same'));
@@ -316,7 +316,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $plugins = ['imageLink' => $this->getMockImageLink('mysprites.svg')];
         $helper = $this->getIconHelper(null, null, $plugins);
         $expected = <<<EXPECTED
-            <svg class="icon icon--svg" aria-hidden="true">
+            <svg class="icon&#x20;icon--svg" aria-hidden="true">
                 <use xlink:href="mysprites.svg#sprite"></use>
             </svg>
             EXPECTED;
@@ -333,7 +333,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $plugins = ['imageLink' => $this->getMockImageLink('mysprites.svg')];
         $helper = $this->getIconHelper(null, null, $plugins);
         $expected = <<<EXPECTED
-            <svg class="icon icon--svg myclass" data-foo="bar" aria-hidden="true">
+            <svg class="icon&#x20;icon--svg&#x20;myclass" data-foo="bar" aria-hidden="true">
                 <use xlink:href="mysprites.svg#sprite"></use>
             </svg>
             EXPECTED;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -75,6 +75,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
                 'bar' => 'Fugue:baz.png',
                 'bar-rtl' => 'Fugue:zab.png',
                 'ltronly' => 'Fugue:ltronly.png',
+                'quoted' => 'Fugue:"quoted".png',
                 'xyzzy' => 'FakeSprite:sprite',
                 'same' => 'Alias:foo',
                 'illegal' => 'Alias:criminal',
@@ -216,6 +217,20 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $expected = '<img class="icon&#x20;icon--img" src="baz.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('bar'));
+    }
+
+    /**
+     * Test that we can generate an image-based icon where the icon contains a special character.
+     *
+     * @return void
+     */
+    public function testImageIconWithSpecialChars(): void
+    {
+        $plugins = ['imageLink' => $this->getMockImageLink('icons/"quoted".png')];
+        $helper = $this->getIconHelper(null, null, $plugins);
+        $expected = '<img class="icon&#x20;icon--img" src="&quot;quoted&quot;.png" aria-hidden="true"'
+            . ' alt="">';
+        $this->assertEquals($expected, $helper('quoted'));
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -168,7 +168,8 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, trim($helper('foo', ['bar' => 'baz'])));
 
         // Add class to class
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo&#x20;foo-bar" role="img" aria-hidden="true"></span>';
+        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo&#x20;foo-bar" '
+            . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo', ['class' => 'foo-bar'])));
 
         // Shortcut

--- a/themes/root/templates/Helpers/icons/font.phtml
+++ b/themes/root/templates/Helpers/icons/font.phtml
@@ -2,4 +2,4 @@
     $this->headLink()->appendStylesheet($this->src);
     $className = trim('icon icon--font ' . $this->icon . ' ' . ($this->extra['class'] ?? ''));
 ?>
-<span class="<?=$className ?>"<?=$this->attrs ?> role="img" aria-hidden="true"></span>
+<span class="<?=$this->escapeHtmlAttr($className) ?>"<?=$this->attrs ?> role="img" aria-hidden="true"></span>

--- a/themes/root/templates/Helpers/icons/images.phtml
+++ b/themes/root/templates/Helpers/icons/images.phtml
@@ -2,4 +2,4 @@
     $folder = $this->src ?? '';
     $className = trim('icon icon--img ' . ($this->extra['class'] ?? ''));
 ?>
-<img class="<?=$this->escapeHtmlAttr($className) ?>" src="<?=$this->imageLink($folder . '/' . $this->icon) ?>" aria-hidden="true"<?=$this->attrs ?> alt="">
+<img class="<?=$this->escapeHtmlAttr($className) ?>" src="<?=$this->escapeHtmlAttr($this->imageLink($folder . '/' . $this->icon)) ?>" aria-hidden="true"<?=$this->attrs ?> alt="">

--- a/themes/root/templates/Helpers/icons/images.phtml
+++ b/themes/root/templates/Helpers/icons/images.phtml
@@ -2,4 +2,4 @@
     $folder = $this->src ?? '';
     $className = trim('icon icon--img ' . ($this->extra['class'] ?? ''));
 ?>
-<img class="<?=$className ?>" src="<?=$this->imageLink($folder . '/' . $this->icon) ?>" aria-hidden="true"<?=$this->attrs ?> alt="">
+<img class="<?=$this->escapeHtmlAttr($className) ?>" src="<?=$this->imageLink($folder . '/' . $this->icon) ?>" aria-hidden="true"<?=$this->attrs ?> alt="">

--- a/themes/root/templates/Helpers/icons/svg-sprite.phtml
+++ b/themes/root/templates/Helpers/icons/svg-sprite.phtml
@@ -1,6 +1,6 @@
 <?php
     $className = trim('icon icon--svg ' . ($this->extra['class'] ?? ''));
 ?>
-<svg class="<?=$className ?>"<?=$this->attrs ?> aria-hidden="true">
-    <use xlink:href="<?=$this->imageLink($src) ?>#<?=$this->icon ?>"></use>
+<svg class="<?=$this->escapeHtmlAttr($className) ?>"<?=$this->attrs ?> aria-hidden="true">
+    <use xlink:href="<?=$this->imageLink($src) ?>#<?=$this->escapeHtmlAttr($this->icon) ?>"></use>
 </svg>


### PR DESCRIPTION
This PR straightens out icon helper escaping. In some cases, the icon value was being escaped in the helper and should not have been (e.g. images.phtml, where escaping the filename before looking up a file path could result in an invalid image link -- I've added a new test case to cover this scenario); in other cases, class names were not being thoroughly escape. Now, more escaping takes place in the templates to allow for predictable/consistent behavior.

TODO
- [x] Run full test suite
- [ ] Add changelog note when merging