### PR TITLE
Fix out-of-sync PHP version comments.

### DIFF
--- a/module/VuFind/src/VuFind/Content/Covers/GoogleFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/GoogleFactory.php
@@ -3,7 +3,7 @@
 /**
  * Google cover loader factory
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2022.
  *

--- a/module/VuFind/src/VuFind/Controller/LibGuidesAZController.php
+++ b/module/VuFind/src/VuFind/Controller/LibGuidesAZController.php
@@ -3,7 +3,7 @@
 /**
  * LibGuides A-Z Databases Controller
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/ILS/Logic/ItemStatus.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/ItemStatus.php
@@ -3,7 +3,7 @@
 /**
  * Item Status Logic Class
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) The National Library of Finland 2023.
  *

--- a/module/VuFind/src/VuFind/RecordDriver/LibGuidesAZ.php
+++ b/module/VuFind/src/VuFind/RecordDriver/LibGuidesAZ.php
@@ -3,7 +3,7 @@
 /**
  * Model for LibGuides A-Z Databases records.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesAZBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesAZBackendFactory.php
@@ -3,7 +3,7 @@
 /**
  * Factory for LibGuides A-Z Databases backends.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/Search/LibGuidesAZ/Options.php
+++ b/module/VuFind/src/VuFind/Search/LibGuidesAZ/Options.php
@@ -3,7 +3,7 @@
 /**
  * LibGuides A-Z Databases aspect of the Search Multi-class (Options)
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/Search/LibGuidesAZ/Params.php
+++ b/module/VuFind/src/VuFind/Search/LibGuidesAZ/Params.php
@@ -3,7 +3,7 @@
 /**
  * LibGuides A-Z Databases aspect of the Search Multi-class (Params)
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/Search/LibGuidesAZ/Results.php
+++ b/module/VuFind/src/VuFind/Search/LibGuidesAZ/Results.php
@@ -3,7 +3,7 @@
 /**
  * LibGuides A-Z Databases aspect of the Search Multi-class (Results)
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/src/VuFind/View/Helper/Root/Session.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Session.php
@@ -3,7 +3,7 @@
 /**
  * Session view helper
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) The National Library of Finland 2023.
  *

--- a/module/VuFind/src/VuFind/View/Helper/Root/SessionFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SessionFactory.php
@@ -3,7 +3,7 @@
 /**
  * Session helper factory.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) The National Library of Finland 2023.
  *

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
@@ -3,7 +3,7 @@
 /**
  * Test class for holdings and item statuses.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) The National Library of Finland 2023.
  *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/GoogleTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/GoogleTest.php
@@ -3,7 +3,7 @@
 /**
  * Unit tests for Google cover loader.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/OrbTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/OrbTest.php
@@ -3,7 +3,7 @@
 /**
  * Unit tests for Orb cover loader.
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AlmaTest.php
@@ -3,7 +3,7 @@
 /**
  * Alma ILS driver test
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  * Copyright (C) The National Library of Finland 2023.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SessionTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SessionTest.php
@@ -3,7 +3,7 @@
 /**
  * Session view helper Test Class
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Villanova University 2023.
  *

--- a/module/VuFindSearch/src/VuFindSearch/Feature/ExtraRequestDetailsInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Feature/ExtraRequestDetailsInterface.php
@@ -4,7 +4,7 @@
  * Optional backend feature: Get some extra details about a search,
  * e.g. the search parameters or request url
  *
- * PHP version 7
+ * PHP version 8
  *
  * Copyright (C) Hebis Verbundzentrale 2023.
  *


### PR DESCRIPTION
Looks like a few PRs merged after we updated to PHP 8 introduced some outdated version comments. This PR brings everything back into sync.