### PR TITLE
[VUFIND-1638] Improve flexibility of autocomplete autosubmit.

### DIFF
--- a/config/vufind/reserves.ini
+++ b/config/vufind/reserves.ini
@@ -32,6 +32,7 @@ checkboxSections[] = CheckboxFacets
 
 [Autocomplete]
 enabled = true
+auto_submit = true
 formatting_rule[*] = "phrase"
 
 [Autocomplete_Types]

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -591,7 +591,12 @@ function setupAutocomplete() {
           ? event.detail
           : event.detail.value;
         input.value = value;
-        $("#searchForm").trigger("submit");
+        const $form = $searchbox.closest("form");
+        // Try to submit the form:
+        $form.trigger('submit');
+        // If form submit failed (which currently happens for course reserves),
+        // click the input button instead:
+        $form.find('input[type="submit"]').trigger('click');
       });
     }
   });

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -591,12 +591,7 @@ function setupAutocomplete() {
           ? event.detail
           : event.detail.value;
         input.value = value;
-        const $form = $searchbox.closest("form");
-        // Try to submit the form:
-        $form.trigger('submit');
-        // If form submit failed (which currently happens for course reserves),
-        // click the input button instead:
-        $form.find('input[type="submit"]').trigger('click');
+        input.form.submit();
       });
     }
   });

--- a/themes/bootstrap3/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap3/templates/alphabrowse/home.phtml
@@ -63,7 +63,8 @@
         'class' => 'form-control',
       ];
       if ($this->searchbox()->autocompleteEnabled('Solr')) {
-        $searchboxAttributes['class'] .= ' autocomplete';
+        $searchboxAttributes['class'] .= ' autocomplete'
+          . ($this->searchbox()->autocompleteAutoSubmit('SolrReserves') ? ' ac-auto-submit' : '');
         $searchboxAttributes['data-autocomplete-type-field-selector'] = '#alphaBrowseForm_source';
         $searchboxAttributes['data-autocomplete-type-prefix'] = 'alphabrowse_';
         $searchboxAttributes['data-autocomplete-formatting-rules'] = $this->searchbox()->autocompleteFormattingRulesJson('Solr');

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -28,7 +28,7 @@
         $searchboxAttributes['placeholder'] = $placeholder;
       }
       if ($this->searchbox()->autocompleteEnabled('SolrReserves')) {
-        $searchboxAttributes['class'] = ' autocomplete searcher:SolrReserves type:Reserves'
+        $searchboxAttributes['class'] = ' autocomplete form-control searcher:SolrReserves type:Reserves'
           . ($this->searchbox()->autocompleteAutoSubmit('SolrReserves') ? ' ac-auto-submit' : '');
         $searchboxAttributes['data-autocomplete-formatting-rules'] = $this->searchbox()->autocompleteFormattingRulesJson('SolrReserves');
       }

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -34,7 +34,7 @@
       }
     ?>
     <input<?=$this->htmlAttributes($searchboxAttributes)?>>
-    <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Find')?>">
+    <input class="btn btn-primary" type="submit" value="<?=$this->transEscAttr('Find')?>">
   </form>
   <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, "$('#reservesSearchForm_lookfor').focus()", 'SET')?>
 

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -28,7 +28,8 @@
         $searchboxAttributes['placeholder'] = $placeholder;
       }
       if ($this->searchbox()->autocompleteEnabled('SolrReserves')) {
-        $searchboxAttributes['class'] = ' autocomplete searcher:SolrReserves type:Reserves';
+        $searchboxAttributes['class'] = ' autocomplete searcher:SolrReserves type:Reserves'
+          . ($this->searchbox()->autocompleteAutoSubmit('SolrReserves') ? ' ac-auto-submit' : '');
         $searchboxAttributes['data-autocomplete-formatting-rules'] = $this->searchbox()->autocompleteFormattingRulesJson('SolrReserves');
       }
     ?>


### PR DESCRIPTION
This PR addresses [VUFIND-1638](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1638) and adds autocomplete autosubmit support to the course reserves search.

TODO
- [x] Simplify Javascript if possible
- [x] Run full test suite before merging