### PR TITLE
Sierra: Fix PHP error when an item doesn't have a barcode.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2285,7 +2285,7 @@ class SierraRest extends AbstractBase implements
                     : $bibCallNumber,
                 'duedate' => $duedate,
                 'number' => $volume,
-                'barcode' => $item['barcode'],
+                'barcode' => $item['barcode'] ?? '',
                 'sort' => $sort--,
             ];
             if ($notes) {


### PR DESCRIPTION
Apparently Sierra doesn't return the barcode field if an item doesn't have a barcode.