### PR TITLE
Fix search history behavior when login is disabled.

### DIFF
--- a/themes/bootstrap3/templates/search/history.phtml
+++ b/themes/bootstrap3/templates/search/history.phtml
@@ -2,17 +2,25 @@
   // Set page title.
   $this->headTitle($this->translate('Search History'));
 
+  // Hide the account breadcrumb when login is disabled:
+  $account = $this->auth()->getManager();
+  $parentBreadcrumb = is_object($account) && $account->loginEnabled()
+    ? '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
+    : '';
+
   // Set up breadcrumbs:
-  $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
-    . '<li class="active">' . $this->transEsc('Search History') . '</li>';
+  $this->layout()->breadcrumbs
+    = $parentBreadcrumb . '<li class="active">' . $this->transEsc('Search History') . '</li>';
 
   $saveSupported = $this->accountCapabilities()->getSavedSearchSetting() === 'enabled';
   $loggedInUser = $this->auth()->isLoggedIn();
 ?>
 
-<a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" title="<?=$this->transEsc('sidebar_expand')?>">
-  <?=$this->transEsc('Your Account') ?>
-</a>
+<?php if ($saveSupported): // do not show menu toggle if not showing menu! ?>
+  <a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" title="<?=$this->transEsc('sidebar_expand')?>">
+    <?=$this->transEsc('Your Account') ?>
+  </a>
+<?php endif; ?>
 
 <div class="<?=$this->layoutClass('mainbody')?>">
   <?php if (!empty($this->alertemail)): ?>


### PR DESCRIPTION
When login functionality is disabled (e.g. ILS driver is set to NoILS, and NoILS.ini has hideLogin set to true), the search history page was still displaying login-related functionality. This PR corrects that bug.