### PR TITLE
Use null coalescing to simplify combined search templates.

### DIFF
--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -15,7 +15,7 @@
     ? $this->url($advancedSearchAction, [], ['query' => ['edit' => $results->getSearchId()]])
     : false;
 ?>
-<?php if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
+<?php if ($currentSearch['more_link'] ?? false): ?>
   <div class="pull-right flip">
     <a href="<?=$moreUrl?>" class="btn btn-link icon-link">
       <?=$this->icon('options', 'icon-link__icon') ?>
@@ -85,7 +85,7 @@
     ];
   ?>
   <?=$this->render('search/list-' . $viewType . '.phtml', $viewParams)?>
-  <?php if (isset($currentSearch['more_link']) && $currentSearch['more_link']): ?>
+  <?php if ($currentSearch['more_link'] ?? false): ?>
     <p class="more_link_bottom">
       <a class="icon-link" href="<?=$moreUrl?>">
         <span class="icon-link__label"><?=$this->transEsc($currentSearch['more_link'])?></span>

--- a/themes/bootstrap3/templates/combined/stack-distributed.phtml
+++ b/themes/bootstrap3/templates/combined/stack-distributed.phtml
@@ -4,9 +4,9 @@
   <?php foreach ($this->combinedResults as $searchClassId => $currentSearch): ?>
     <?php
       if (
-        (!isset($currentSearch['ajax']) || !$currentSearch['ajax'])                    // AJAX column
-        && (isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty']) // set to hide when empty
-        && $currentSearch['view']->results->getResultTotal() == 0                      // and empty
+        !($currentSearch['ajax'] ?? false)                        // AJAX column
+        && ($currentSearch['hide_if_empty'] ?? false)             // set to hide when empty
+        && $currentSearch['view']->results->getResultTotal() == 0 // and empty
       ) {
         continue;
       }
@@ -36,7 +36,7 @@
     <div class="combined-column">
       <?php foreach ($currColumn as $colParams): ?>
         <div id="<?=$this->escapeHtmlAttr($colParams['domId'])?>" class="combined-list">
-          <?php $templateSuffix = (isset($colParams['ajax']) && $colParams['ajax']) ? 'ajax' : 'list'; ?>
+          <?php $templateSuffix = ($colParams['ajax'] ?? false) ? 'ajax' : 'list'; ?>
           <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $colParams)?>
         </div>
       <?php endforeach; ?>

--- a/themes/bootstrap3/templates/combined/stack-left.phtml
+++ b/themes/bootstrap3/templates/combined/stack-left.phtml
@@ -15,9 +15,9 @@
       ?>
       <?php
         if (
-          (!isset($currentSearch['ajax']) || !$currentSearch['ajax'])                    // AJAX column
-          && (isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty']) // set to hide when empty
-          && $currentSearch['view']->results->getResultTotal() == 0                      // and empty
+          !($currentSearch['ajax'] ?? false)                        // AJAX column
+          && ($currentSearch['hide_if_empty'] ?? false)             // set to hide when empty
+          && $currentSearch['view']->results->getResultTotal() == 0 // and empty
         ) {
           continue;
         }
@@ -34,7 +34,7 @@
         }
       ?>
       <div id="<?=$this->escapeHtmlAttr($currentSearch['domId'])?>" class="combined-list">
-        <?php $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
+        <?php $templateSuffix = ($currentSearch['ajax'] ?? false) ? 'ajax' : 'list'; ?>
         <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $viewParams)?>
       </div>
     <?php endforeach; ?>
@@ -42,7 +42,7 @@
   <?php foreach ($rightColumns as $colParams): ?>
     <div class="combined-column">
       <div id="<?=$this->escapeHtmlAttr($colParams['domId'])?>" class="combined-list">
-        <?php $templateSuffix = (isset($colParams['ajax']) && $colParams['ajax']) ? 'ajax' : 'list'; ?>
+        <?php $templateSuffix = ($colParams['ajax'] ?? false) ? 'ajax' : 'list'; ?>
         <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $colParams)?>
       </div>
     </div>

--- a/themes/bootstrap3/templates/combined/stack-right.phtml
+++ b/themes/bootstrap3/templates/combined/stack-right.phtml
@@ -14,15 +14,15 @@
       ?>
       <?php
         if (
-          (!isset($currentSearch['ajax']) || !$currentSearch['ajax'])                    // AJAX column
-          && (isset($currentSearch['hide_if_empty']) && $currentSearch['hide_if_empty']) // set to hide when empty
-          && $currentSearch['view']->results->getResultTotal() == 0                      // and empty
+          !($currentSearch['ajax'] ?? false)                        // AJAX column
+          && ($currentSearch['hide_if_empty'] ?? false)             // set to hide when empty
+          && $currentSearch['view']->results->getResultTotal() == 0 // and empty
         ) {
           continue;
         }
       ?>
       <div id="<?=$this->escapeHtmlAttr($currentSearch['domId'])?>" class="combined-list">
-        <?php $templateSuffix = (isset($currentSearch['ajax']) && $currentSearch['ajax']) ? 'ajax' : 'list'; ?>
+        <?php $templateSuffix = ($currentSearch['ajax'] ?? false) ? 'ajax' : 'list'; ?>
         <?=$this->render('combined/results-' . $templateSuffix . '.phtml', $viewParams)?>
       </div>
       <?php $columnIndex ++; ?>


### PR DESCRIPTION
This applies some simplifications/optimizations that I noticed while reviewing #3077.