### PR TITLE
SierraRest: Trim whitespace from call number and volume.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2271,6 +2271,9 @@ class SierraRest extends AbstractBase implements
                     );
                 }
             }
+            $callNumber = isset($item['callNumber'])
+                ? $this->extractCallNumber($item['callNumber'])
+                : $bibCallNumber;
             $volume = isset($item['varFields']) ? $this->extractVolume($item) : '';
 
             $entry = [
@@ -2280,11 +2283,9 @@ class SierraRest extends AbstractBase implements
                 'availability' => $available,
                 'status' => $status,
                 'reserve' => 'N',
-                'callnumber' => isset($item['callNumber'])
-                    ? preg_replace('/^\|a/', '', $item['callNumber'])
-                    : $bibCallNumber,
+                'callnumber' => trim($callNumber),
                 'duedate' => $duedate,
-                'number' => $volume,
+                'number' => trim($volume),
                 'barcode' => $item['barcode'] ?? '',
                 'sort' => $sort--,
             ];
@@ -2363,6 +2364,18 @@ class SierraRest extends AbstractBase implements
 
         usort($statuses, [$this, 'statusSortFunction']);
         return $statuses;
+    }
+
+    /**
+     * Extract the actual call number from item's call number field
+     *
+     * @param string $callNumber Call number field
+     *
+     * @return string
+     */
+    protected function extractCallNumber(string $callNumber): string
+    {
+        return str_starts_with($callNumber, '|a') ? substr($callNumber, 2) : $callNumber;
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -2350,7 +2350,7 @@ class SierraRest extends AbstractBase implements
                 'id' => $id,
                 'item_id' => "ORDER_{$id}_$locationCode",
                 'location' => $location,
-                'callnumber' => $bibCallNumber,
+                'callnumber' => trim($bibCallNumber),
                 'number' => '',
                 'status' => $this->mapStatusCode('Ordered'),
                 'reserve' => 'N',


### PR DESCRIPTION
Also cleans up the call number extraction code.

Sierra may include some extra spaces in the fields, which leads to apparent duplicate call numbers being displayed.