### PR TITLE
UrlQueryHelper: Fix passing null to urlencode

### DIFF
--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -626,10 +626,10 @@ class UrlQueryHelper
         foreach ($a as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $current) {
-                    $parts[] = urlencode($key . '[]') . '=' . urlencode($current);
+                    $parts[] = urlencode($key . '[]') . '=' . urlencode($current ?? '');
                 }
             } else {
-                $parts[] = urlencode($key) . '=' . urlencode($value);
+                $parts[] = urlencode($key) . '=' . urlencode($value ?? '');
             }
         }
         $retVal = implode('&', $parts);


### PR DESCRIPTION
Seems like its being deprecated