### PR TITLE
Alma: Revise comment of translationPrefix setting.

### DIFF
--- a/config/vufind/Alma.ini
+++ b/config/vufind/Alma.ini
@@ -23,12 +23,9 @@ http_timeout = 30
 
 ; Translation prefix to use for codes coming from Alma. By default a prefix is not
 ; used, but a prefix may be used to distinguish the codes from any other
-; translations (or other libraries). To use a simple prefix in the default text
-; domain:
-; translationPrefix = "alma_"
-; To use a separate Alma text domain:
-; translationPrefix = "Alma::"
-;translationPrefix = "Alma::"
+; translations (or other libraries). You can use a simple prefix in the default
+; domain (e.g. "alma_") or a custom text domain (e.g. "ILSMessages::").
+;translationPrefix = "ILSMessages::"
 
 ; This section controls hold behavior; note that you must also ensure that Holds are
 ; enabled in the [Catalog] section of config.ini in order to take advantage of these


### PR DESCRIPTION
Follow-up from #3140. I changed the example to "ILSMessages::" because it's an actual existing domain.