### PR TITLE
LibGuides Profile: Remove whitespace if no photo

### DIFF
--- a/themes/bootstrap3/templates/Recommend/LibGuidesProfile.phtml
+++ b/themes/bootstrap3/templates/Recommend/LibGuidesProfile.phtml
@@ -3,7 +3,7 @@
   <div class="libguides-profile">
     <h4><?=$this->transEsc('libguides_profile_suggestion_heading')?></h4>
     <a href="<?=$this->escapeHtmlAttr($account->profile->url)?>" target="_blank">
-      <?php if (!empty($account->profile->image)): ?>
+      <?php if (!empty($account->profile->image->url)): ?>
         <img class="libguides-profile-img" src="<?=$this->escapeHtmlAttr($account->profile->image->url)?>">
       <?php endif; ?>
       <div class="libguides-profile-name"><?=$this->escapeHtml($account->first_name) . ' ' . $this->escapeHtml($account->last_name ?? '')?></div>


### PR DESCRIPTION
This fixes a display bug where there was an attempt to display the profile image even if none was present.  When that happens, $account->profile->image is still defined but ...image->url is an empty string.  