### PR TITLE
Amicus driver: Remove unnecessary require statement

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Amicus.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Amicus.php
@@ -457,8 +457,6 @@ class Amicus extends AbstractBase implements TranslatorAwareInterface
      */
     public function getHolding($id, array $patron = null, array $options = [])
     {
-        include_once 'File/MARC.php';
-
         $items = 'select CPY_ID.BRCDE_NBR, CPY_ID.BIB_ITM_NBR, ' .
             'T_LCTN_NME_BUO.TBL_LNG_ENG_TXT ' .
             'as LOCATION, SHLF_LIST_SRT_FORM as CALLNUMBER, CPY_ID.CPY_ID_NBR as ' .


### PR DESCRIPTION
This code included an include statement related to PEAR code that is no longer used. It should be removed. I am unable to test this driver due to lack of access to Amicus, but this is clearly wrong, and removing it is necessary -- the file no longer exists, and the class being loaded is not actually used anywhere in the code.