### PR TITLE
Deprecate custom EDS logging

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -590,6 +590,20 @@ class Backend extends AbstractBackend
     }
 
     /**
+     * Print a message.
+     *
+     * @param string $msg Message to print
+     *
+     * @return void
+     *
+     * @deprecated Use $this->debug directly.
+     */
+    protected function debugPrint($msg)
+    {
+        $this->debug($msg);
+    }
+
+    /**
      * Obtain the session token from the Session container. If it doesn't exist,
      * generate a new one.
      *

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -201,21 +201,21 @@ class Backend extends AbstractBackend
         // process EDS API communication tokens.
         $authenticationToken = $this->getAuthenticationToken();
         $sessionToken = $this->getSessionToken();
-        $this->debugPrint(
+        $this->debug(
             "Authentication Token: $authenticationToken, SessionToken: $sessionToken"
         );
 
         // create query parameters from VuFind data
         $queryString = $query->getAllTerms();
         $paramsStr = implode('&', null !== $params ? $params->request() : []);
-        $this->debugPrint(
+        $this->debug(
             "Query: $queryString, Limit: $limit, Offset: $offset, "
             . "Params: $paramsStr"
         );
 
         $baseParams = $this->getQueryBuilder()->build($query);
         $paramsStr = implode('&', $baseParams->request());
-        $this->debugPrint("BaseParams: $paramsStr ");
+        $this->debug("BaseParams: $paramsStr ");
         if (null !== $params) {
             $baseParams->mergeWith($params);
         }
@@ -225,7 +225,7 @@ class Backend extends AbstractBackend
 
         $searchModel = $this->paramBagToEBSCOSearchModel($baseParams);
         $qs = $searchModel->convertToQueryString();
-        $this->debugPrint("Search Model query string: $qs");
+        $this->debug("Search Model query string: $qs");
         try {
             $response = $this->client
                 ->search($searchModel, $authenticationToken, $sessionToken);
@@ -277,7 +277,7 @@ class Backend extends AbstractBackend
                     break;
             }
         } catch (Exception $e) {
-            $this->debugPrint('Exception found: ' . $e->getMessage());
+            $this->debug('Exception found: ' . $e->getMessage());
             throw new BackendException($e->getMessage(), $e->getCode(), $e);
         }
         $collection = $this->createRecordCollection($response);
@@ -505,7 +505,7 @@ class Backend extends AbstractBackend
         if (isset($authTokenData)) {
             $currentToken = $authTokenData['token'] ?? '';
             $expirationTime = $authTokenData['expiration'] ?? 0;
-            $this->debugPrint(
+            $this->debug(
                 'Cached Authentication data: '
                 . "$currentToken, expiration time: $expirationTime"
             );
@@ -522,7 +522,7 @@ class Backend extends AbstractBackend
         $password = $this->password;
         $orgId = $this->orgId;
         if (!empty($username) && !empty($password)) {
-            $this->debugPrint(
+            $this->debug(
                 'Calling Authenticate with username: '
                 . "$username, password: XXXXXXXX, orgid: $orgId "
             );
@@ -587,18 +587,6 @@ class Backend extends AbstractBackend
             }
         }
         return $autocompleteData;
-    }
-
-    /**
-     * Print a message if debug is enabled.
-     *
-     * @param string $msg Message to print
-     *
-     * @return void
-     */
-    protected function debugPrint($msg)
-    {
-        $this->log('debug', "$msg\n");
     }
 
     /**
@@ -669,7 +657,7 @@ class Backend extends AbstractBackend
         } catch (ApiException $e) {
             $errorCode = $e->getApiErrorCode();
             $desc = $e->getApiErrorDescription();
-            $this->debugPrint(
+            $this->debug(
                 'Error in create session request. Error code: '
                 . "$errorCode, message: $desc, e: $e"
             );

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -45,7 +45,9 @@ use function is_array;
  */
 abstract class Base implements LoggerAwareInterface
 {
-    use \VuFind\Log\LoggerAwareTrait { debug as public debugTrait; }
+    use \VuFind\Log\LoggerAwareTrait {
+        debug as public debugTrait;
+    }
 
     /**
      * A boolean value determining whether to print debug information

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -45,18 +45,7 @@ use function is_array;
  */
 abstract class Base implements LoggerAwareInterface
 {
-    use \VuFind\Log\LoggerAwareTrait {
-        debug as public debugTrait;
-    }
-
-    /**
-     * A boolean value determining whether to print debug information
-     *
-     * @var bool
-     *
-     * @deprecated Set the logging level in the Logging section of config.ini.
-     */
-    protected $debug = false;
+    use \VuFind\Log\LoggerAwareTrait;
 
     /**
      * EDS or EPF API host.
@@ -115,7 +104,6 @@ abstract class Base implements LoggerAwareInterface
      * @param array $settings Associative array of setting to use in
      *                        conjunction with the EDS API
      *    <ul>
-     *      <li>debug - boolean to control debug mode</li>
      *      <li>orgid - Organization making calls to the EDS API </li>
      *      <li>search_http_method - HTTP method for search API calls</li>
      *    </ul>
@@ -133,9 +121,6 @@ abstract class Base implements LoggerAwareInterface
                         break;
                     case 'session_url':
                         $this->sessionHost = $value;
-                        break;
-                    case 'debug':
-                        $this->debug = $value;
                         break;
                     case 'orgid':
                         $this->orgId = $value;
@@ -158,9 +143,7 @@ abstract class Base implements LoggerAwareInterface
      */
     protected function debugPrint($msg)
     {
-        if ($this->debug) {
-            $this->debugTrait($msg);
-        }
+        $this->debug($msg);
     }
 
     /**
@@ -173,7 +156,7 @@ abstract class Base implements LoggerAwareInterface
      */
     public function info($authenticationToken = null, $sessionToken = null)
     {
-        $this->debugTrait('Info');
+        $this->debug('Info');
         $url = $this->apiHost . '/info';
         $headers = $this->setTokens($authenticationToken, $sessionToken);
         return $this->call($url, $headers);
@@ -193,7 +176,7 @@ abstract class Base implements LoggerAwareInterface
         $isGuest = null,
         $authToken = null
     ) {
-        $this->debugTrait(
+        $this->debug(
             'Create Session for profile: '
             . "$profile, guest: $isGuest, authToken: $authToken "
         );
@@ -261,7 +244,7 @@ abstract class Base implements LoggerAwareInterface
         $highlightTerms = null,
         $extraQueryParams = []
     ) {
-        $this->debugTrait(
+        $this->debug(
             "Get Record. an: $an, dbid: $dbId, $highlightTerms: $highlightTerms"
         );
         $qs = $extraQueryParams + ['an' => $an, 'dbid' => $dbId];
@@ -288,7 +271,7 @@ abstract class Base implements LoggerAwareInterface
         $authenticationToken,
         $sessionToken
     ) {
-        $this->debugTrait(
+        $this->debug(
             "Get Record. pubId: $pubId"
         );
         $qs = ['id' => $pubId];
@@ -312,7 +295,7 @@ abstract class Base implements LoggerAwareInterface
         $method = $this->searchHttpMethod;
         $json = $method === 'GET' ? null : $query->convertToSearchRequestJSON();
         $qs = $method === 'GET' ? $query->convertToQueryStringParameterArray() : [];
-        $this->debugTrait(
+        $this->debug(
             'Query: ' . ($method === 'GET' ? print_r($qs, true) : $json)
         );
         $url = $this->apiHost . '/search';
@@ -365,7 +348,7 @@ abstract class Base implements LoggerAwareInterface
 
         $url = $data['url'] . '?' . http_build_query($params);
 
-        $this->debugTrait('Autocomplete URL: ' . $url);
+        $this->debug('Autocomplete URL: ' . $url);
         $response = $this->call($url, null, null, 'GET', null);
         return $raw ? $response : $this->parseAutocomplete($response);
     }
@@ -386,7 +369,7 @@ abstract class Base implements LoggerAwareInterface
         $orgid = null,
         $params = null
     ) {
-        $this->debugTrait(
+        $this->debug(
             "Authenticating: username: $username, password: XXXXXXX, orgid: $orgid"
         );
         $url = $this->authHost . '/uidauth';
@@ -471,7 +454,7 @@ abstract class Base implements LoggerAwareInterface
         // Build Query String Parameters
         $queryParameters = $this->createQSFromArray($params);
         $queryString = implode('&', $queryParameters);
-        $this->debugTrait("Querystring to use: $queryString ");
+        $this->debug("Querystring to use: $queryString ");
         // Build headers
         $headers = [
             'Accept' => $this->accept,

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -30,8 +30,9 @@
 
 namespace VuFindSearch\Backend\EDS;
 
-use function is_array;
 use Laminas\Log\LoggerAwareInterface;
+
+use function is_array;
 
 /**
  * EBSCO Search API abstract base class
@@ -54,7 +55,7 @@ abstract class Base implements LoggerAwareInterface
      * @deprecated Set the logging level in the Logging section of config.ini.
      */
     protected $debug = false;
-    
+
     /**
      * EDS or EPF API host.
      *
@@ -159,7 +160,7 @@ abstract class Base implements LoggerAwareInterface
             $this->debugTrait($msg);
         }
     }
-    
+
     /**
      * Obtain edsapi search critera and application related settings
      *

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Base.php
@@ -44,13 +44,6 @@ use function is_array;
 abstract class Base
 {
     /**
-     * A boolean value determining whether to print debug information
-     *
-     * @var bool
-     */
-    protected $debug = false;
-
-    /**
      * EDS or EPF API host.
      *
      * @var string
@@ -126,9 +119,6 @@ abstract class Base
                     case 'session_url':
                         $this->sessionHost = $value;
                         break;
-                    case 'debug':
-                        $this->debug = $value;
-                        break;
                     case 'orgid':
                         $this->orgId = $value;
                         break;
@@ -136,20 +126,6 @@ abstract class Base
                         $this->searchHttpMethod = $value;
                 }
             }
-        }
-    }
-
-    /**
-     * Print a message if debug is enabled.
-     *
-     * @param string $msg Message to print
-     *
-     * @return void
-     */
-    protected function debugPrint($msg)
-    {
-        if ($this->debug) {
-            echo "<pre>{$msg}</pre>\n";
         }
     }
 
@@ -163,7 +139,7 @@ abstract class Base
      */
     public function info($authenticationToken = null, $sessionToken = null)
     {
-        $this->debugPrint('Info');
+        $this->debug('Info');
         $url = $this->apiHost . '/info';
         $headers = $this->setTokens($authenticationToken, $sessionToken);
         return $this->call($url, $headers);
@@ -183,7 +159,7 @@ abstract class Base
         $isGuest = null,
         $authToken = null
     ) {
-        $this->debugPrint(
+        $this->debug(
             'Create Session for profile: '
             . "$profile, guest: $isGuest, authToken: $authToken "
         );
@@ -251,7 +227,7 @@ abstract class Base
         $highlightTerms = null,
         $extraQueryParams = []
     ) {
-        $this->debugPrint(
+        $this->debug(
             "Get Record. an: $an, dbid: $dbId, $highlightTerms: $highlightTerms"
         );
         $qs = $extraQueryParams + ['an' => $an, 'dbid' => $dbId];
@@ -278,7 +254,7 @@ abstract class Base
         $authenticationToken,
         $sessionToken
     ) {
-        $this->debugPrint(
+        $this->debug(
             "Get Record. pubId: $pubId"
         );
         $qs = ['id' => $pubId];
@@ -302,7 +278,7 @@ abstract class Base
         $method = $this->searchHttpMethod;
         $json = $method === 'GET' ? null : $query->convertToSearchRequestJSON();
         $qs = $method === 'GET' ? $query->convertToQueryStringParameterArray() : [];
-        $this->debugPrint(
+        $this->debug(
             'Query: ' . ($method === 'GET' ? print_r($qs, true) : $json)
         );
         $url = $this->apiHost . '/search';
@@ -355,7 +331,7 @@ abstract class Base
 
         $url = $data['url'] . '?' . http_build_query($params);
 
-        $this->debugPrint('Autocomplete URL: ' . $url);
+        $this->debug('Autocomplete URL: ' . $url);
         $response = $this->call($url, null, null, 'GET', null);
         return $raw ? $response : $this->parseAutocomplete($response);
     }
@@ -376,7 +352,7 @@ abstract class Base
         $orgid = null,
         $params = null
     ) {
-        $this->debugPrint(
+        $this->debug(
             "Authenticating: username: $username, password: XXXXXXX, orgid: $orgid"
         );
         $url = $this->authHost . '/uidauth';
@@ -461,7 +437,7 @@ abstract class Base
         // Build Query String Parameters
         $queryParameters = $this->createQSFromArray($params);
         $queryString = implode('&', $queryParameters);
-        $this->debugPrint("Querystring to use: $queryString ");
+        $this->debug("Querystring to use: $queryString ");
         // Build headers
         $headers = [
             'Accept' => $this->accept,

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Connector.php
@@ -100,7 +100,7 @@ class Connector extends Base implements LoggerAwareInterface
         $messageFormat = 'application/json; charset=utf-8',
         $cacheable = true
     ) {
-        $this->debugPrint("{$method}: {$baseUrl}?{$queryString}");
+        $this->debug("{$method}: {$baseUrl}?{$queryString}");
 
         $this->client->resetParameters();
 
@@ -135,21 +135,5 @@ class Connector extends Base implements LoggerAwareInterface
             $this->putCachedData($cacheKey, $resultBody);
         }
         return $resultBody;
-    }
-
-    /**
-     * Print a message if debug is enabled.
-     *
-     * @param string $msg Message to print
-     *
-     * @return void
-     */
-    protected function debugPrint($msg)
-    {
-        if ($this->logger) {
-            $this->logger->debug("$msg\n");
-        } else {
-            parent::debugPrint($msg);
-        }
     }
 }


### PR DESCRIPTION
It looks like this custom EDS logging code dates to the original EDS implementation.  All of these classes already `use LoggerAwareTrait` (either directly or via inheritance) so logging works fine without it.  Logging actually works better without it, because it inherits the formatting of the logger.  Out-of-the-box this seems to include the class name, which is already a big advantage for grep-ing through to find something.

Example before:
`2023-10-06T13:22:28-04:00 DEBUG (7): POST: https://eds-api.ebscohost.com/edsapi/rest/search?`
after:
`2023-10-06T13:29:07-04:00 DEBUG (7): VuFindSearch\Backend\EDS\Connector: POST: https://eds-api.ebscohost.com/edsapi/rest/search?`
