### PR TITLE
Render combination of standard and alternative script fields in RecordDataFormatter

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
@@ -100,14 +100,15 @@ class RecordDataFormatter extends AbstractHelper
      * Should we allow a value? (Always accepts non-empty values; for empty
      * values, allows zero when configured to do so).
      *
-     * @param mixed $value   Data to check for zero value.
-     * @param array $options Rendering options.
+     * @param mixed $value            Data to check for zero value.
+     * @param array $options          Rendering options.
+     * @param array $ignoreCombineAlt If value should always be allowed when renderType is CombineAlt
      *
      * @return bool
      */
-    protected function allowValue($value, $options)
+    protected function allowValue($value, $options, $ignoreCombineAlt = false)
     {
-        if (!empty($value) || ($options['renderType'] ?? 'Simple') == 'CombineAlt') {
+        if (!empty($value) || ($ignoreCombineAlt && ($options['renderType'] ?? 'Simple') == 'CombineAlt')) {
             return true;
         }
         $allowZero = $options['allowZero'] ?? true;
@@ -126,7 +127,7 @@ class RecordDataFormatter extends AbstractHelper
     protected function render($field, $data, $options)
     {
         // Check whether the data is worth rendering.
-        if (!$this->allowValue($data, $options)) {
+        if (!$this->allowValue($data, $options, true)) {
             return null;
         }
 
@@ -407,6 +408,11 @@ class RecordDataFormatter extends AbstractHelper
         $altData = $this->extractData($altOptions);
 
         $altValue = $altData != null ? $this->$method($altData, $altOptions) : null;
+
+        // check if both values are not allowed
+        if (!$this->allowValue($stdValue, $options) && !$this->allowValue($altValue, $options)) {
+            return null;
+        }
 
         // render both values
         $helper = $this->getView()->plugin('record');

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
@@ -107,6 +107,20 @@ class SpecBuilder
     }
 
     /**
+     * Construct a combine alt template spec line.
+     *
+     * @param string $key        Label to associate with this spec line
+     * @param string $dataMethod Method of data retrieval for rendering element
+     * @param array  $options    Additional options
+     *
+     * @return void
+     */
+    public function setCombineAltLine($key, $dataMethod, $options = [])
+    {
+        $this->setLine($key, $dataMethod, 'CombineAlt', $options);
+    }
+
+    /**
      * Construct a record driver template spec line.
      *
      * @param string $key        Label to associate with this spec line

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\View\Helper\Root\RecordDataFormatter;
 
+use function array_key_exists;
+
 /**
  * Specification builder for record driver data formatting view helper
  *
@@ -53,6 +55,11 @@ class SpecBuilder
      * @var int
      */
     protected $maxPos = 0;
+
+    /**
+     * If alternative script should be prioritized by combine alt render method
+     */
+    protected $defaultPrioritizeAlt = false;
 
     /**
      * Constructor
@@ -117,6 +124,10 @@ class SpecBuilder
      */
     public function setCombineAltLine($key, $dataMethod, $options = [])
     {
+
+        if ($this->defaultPrioritizeAlt && !array_key_exists('prioritizeAlt', $options)) {
+            $options['prioritizeAlt'] = true;
+        }
         $this->setLine($key, $dataMethod, 'CombineAlt', $options);
     }
 
@@ -134,6 +145,18 @@ class SpecBuilder
     {
         $options['template'] = $template;
         $this->setLine($key, $dataMethod, 'RecordDriverTemplate', $options);
+    }
+
+    /**
+     * Set default prioritize alternative scripts
+     *
+     * @param bool $defaultPeferAlt Default prioritize alt
+     *
+     * @return void
+     */
+    public function setDefaultPrioritizeAlt($defaultPeferAlt)
+    {
+        $this->defaultPrioritizeAlt = $defaultPeferAlt;
     }
 
     /**

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -1,0 +1,10 @@
+<div>
+  <bdi>
+    <?= $prioritizeAlt ? $altValue : $stdValue ?>
+  </bdi>
+</div>
+<div>
+  <bdi>
+    <?= $prioritizeAlt ? $stdValue : $altValue ?>
+  </bdi>
+</div>


### PR DESCRIPTION
Adds the option to render standard and alternative script fields together when using the RecordDataFormatter.