### PR TITLE
Logging: Add ReferenceId support for username

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1701,6 +1701,13 @@ skip_numeric = true
 ; This setting controls the title on the messages displayed in Office365:
 ;office365_title = "VuFind Log"
 
+; Specify a reference id to inject in all log messages, for use later in querying
+; the logs.  See https://docs.laminas.dev/laminas-log/processors/#referenceid.
+; May be useful in tracking excessive use violations of licensed content.
+; - Default, false, includes no reference id.
+; - 'username' logs the currently logged-in username, if there is one.
+;reference_id = false
+
 ; This section can be used to specify a "parent configuration" from which
 ; the current configuration file will inherit.  You can chain multiple
 ; configurations together if you wish.

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -305,6 +305,18 @@ class LoggerFactory implements FactoryInterface
         if (!$hasWriter) {
             $logger->addWriter(new \Laminas\Log\Writer\Noop());
         }
+
+        // Add ReferenceId processor, if applicable:
+        if ($referenceId = $config->Logging->reference_id ?? false) {
+            if ('username' === $referenceId) {
+                $authManager = $container->get(\VuFind\Auth\Manager::class);
+                if ($user = $authManager->isLoggedIn()) {
+                    $processor = new \Laminas\Log\Processor\ReferenceId();
+                    $processor->setReferenceId($user->username);
+                    $logger->addProcessor($processor);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Log the username (if logged in) as part of each log message.  For example, to track who is responsible for excessive article downloading in violation of license agreements.