### PR TITLE
VUFIND-1604: Multiple calls to parentTheme view helper

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplate.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ParentTemplate.php
@@ -71,7 +71,12 @@ class ParentTemplate extends \Laminas\View\Helper\AbstractHelper
     public function __invoke($template, $targetTheme = null)
     {
         $paths = $this->templatePathStack->getPaths();
+
+        // rewind to fix problems with multiple invokes
+        $paths->rewind();
+        // skip current theme
         $paths->next();
+
         while (
             $paths->current() &&
             (!file_exists($paths->current() . $template) ||

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/ParentTemplateTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/ParentTemplateTest.php
@@ -104,6 +104,23 @@ class ParentTemplateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test stack rewinding bug (VUFIND-1604)
+     *
+     * @return void
+     */
+    public function testRepeatCalls()
+    {
+        $helper = $this->getHelper(['parent', 'child']);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertEquals(
+                "{$this->fixturePath}/parent/templates/foo/bar/child.phtml",
+                $helper('foo/bar/child.phtml')
+            );
+        }
+    }
+
+    /**
      * Test deeper parent return
      *
      * @return void


### PR DESCRIPTION
Fixes a found error where multiple calls to the `parentTheme` view helper failed due to reuse of the template path stack.