### PR TITLE
Handle lookfor[] array in deferred search object recommendations.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/AbstractSearchObjectDeferred.php
+++ b/module/VuFind/src/VuFind/Recommend/AbstractSearchObjectDeferred.php
@@ -139,6 +139,11 @@ abstract class AbstractSearchObjectDeferred implements RecommendInterface
         $this->lookfor
             = $request->get(empty($settings[0]) ? 'lookfor' : $settings[0], '');
         $settings[0] = 'lookfor';
+
+        // If lookfor has somehow been set as an array, collapse it into a string:
+        if (is_array($this->lookfor)) {
+            $this->lookfor = implode(' ', $this->lookfor);
+        }
     }
 
     /**

--- a/module/VuFind/src/VuFind/Recommend/AbstractSearchObjectDeferred.php
+++ b/module/VuFind/src/VuFind/Recommend/AbstractSearchObjectDeferred.php
@@ -31,6 +31,8 @@
 
 namespace VuFind\Recommend;
 
+use function is_array;
+
 /**
  * Abstract SearchObjectDeferred Recommendations Module (needs to be extended to use
  * a particular search object).

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EDSResultsDeferredTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EDSResultsDeferredTest.php
@@ -57,4 +57,23 @@ class EDSResultsDeferredTest extends \VuFindTest\Unit\RecommendDeferredTestCase
             $mod->getUrlParams()
         );
     }
+
+    /**
+     * Test behavior when lookfor is an array (unexpected, but possible through
+     * query manipulation).
+     *
+     * @return void
+     */
+    public function testLookforArray()
+    {
+        $mod = $this->getRecommend(
+            \VuFind\Recommend\EDSResultsDeferred::class,
+            ':3',
+            new \Laminas\Stdlib\Parameters(['lookfor' => ['foo', 'bar']])
+        );
+        $this->assertEquals(
+            'mod=EDSResults&params=lookfor%3A3&lookfor=foo+bar',
+            $mod->getUrlParams()
+        );
+    }
 }


### PR DESCRIPTION
In reviewing server logs, I found a weird edge case where an external server was making a VuFind request with a lookfor[] array instead of a flat lookfor value, and this was causing errors in the deferred recommendations. This PR offers a workaround. I think that flattening the array into a space-delimited string is probably the closest we can manage to what the non-deferred version does through the search objects.