### PR TITLE
Add support for OCLC numbers to Google cover images and improve medium/large images

### DIFF
--- a/module/VuFind/src/VuFind/Content/Covers/Google.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Google.php
@@ -129,7 +129,11 @@ class Google extends \VuFind\Content\AbstractCover implements \VuFind\Http\Cachi
         // find the first thumbnail URL and process it:
         foreach ((array)$json as $current) {
             if (isset($current['thumbnail_url'])) {
-                return $current['thumbnail_url'];
+                $imageUrl = $current['thumbnail_url'];
+                if ($size == 'medium' || $size == 'large') {
+                    $imageUrl = str_replace('zoom=5', 'zoom=1', $imageUrl);
+                }
+                return $imageUrl;
             }
         }
         return false;

--- a/module/VuFind/src/VuFind/Content/Covers/Google.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Google.php
@@ -51,7 +51,7 @@ class Google extends \VuFind\Content\AbstractCover implements \VuFind\Http\Cachi
      */
     public function __construct()
     {
-        $this->supportsIsbn = true;
+        $this->supportsIsbn = $this->supportsOclc = true;
         $this->cacheOptionsSection = 'GoogleCover';
     }
 
@@ -69,14 +69,21 @@ class Google extends \VuFind\Content\AbstractCover implements \VuFind\Http\Cachi
      */
     public function getUrl($key, $size, $ids)
     {
-        // Don't bother trying if we can't read JSON or ISBN is missing:
-        if (!is_callable('json_decode') || !isset($ids['isbn'])) {
+        // Don't bother trying if we can't read JSON or ISBN and OCLC are missing:
+        if (!is_callable('json_decode') || (!isset($ids['isbn']) && !isset($ids['oclc']))) {
             return false;
         }
 
         // Construct the request URL and make the HTTP request:
+        if (isset($ids['isbn']) && $ids['isbn']->isValid()) {
+            $ident = "ISBN:{$ids['isbn']->get13()}";
+        } elseif (isset($ids['oclc'])) {
+            $ident = "OCLC:{$ids['oclc']}";
+        } else {
+            return false;
+        }
         $url = 'https://books.google.com/books?jscmd=viewapi&' .
-               'bibkeys=ISBN:' . $ids['isbn']->get13() . '&callback=addTheCover';
+               'bibkeys=' . $ident . '&callback=addTheCover';
 
         $decodeCallback = function (\Laminas\Http\Response $response, $url) {
             if (

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/GoogleTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/GoogleTest.php
@@ -50,17 +50,21 @@ class GoogleTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a callback to check the download function call.
      *
-     * @param string $body         Body for mock to return
-     * @param string $expectedISBN ISBN expected in request URL
+     * @param string $body           Body for mock to return
+     * @param string $expectedId     Identifier expected in request URL
+     * @param string $expectedIdType Expected identifier type in request URL
      *
      * @return callable
      */
-    protected function getDownloadCallback(string $body, string $expectedISBN): callable
-    {
-        return function ($url, $params, $callback) use ($body, $expectedISBN) {
+    protected function getDownloadCallback(
+        string $body,
+        string $expectedId,
+        string $expectedIdType = 'ISBN'
+    ): callable {
+        return function ($url, $params, $callback) use ($body, $expectedId, $expectedIdType) {
             $this->assertEquals(
                 'https://books.google.com/books?jscmd=viewapi'
-                . '&bibkeys=ISBN:' . $expectedISBN . '&callback=addTheCover',
+                . '&bibkeys=' . $expectedIdType . ':' . $expectedId . '&callback=addTheCover',
                 $url
             );
             $this->assertEquals([], $params);
@@ -105,6 +109,37 @@ class GoogleTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test cover loading at a larger size
+     *
+     * @return void
+     */
+    public function testValidLargeCoverLoading(): void
+    {
+        $loader = new Google();
+
+        $mockDownloader = $this->getMockBuilder(CachingDownloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $downloadCallback = $this->getDownloadCallback(
+            $this->getFixture('content/covers/google-cover.js'),
+            '9781612917986'
+        );
+        $mockDownloader->expects($this->once())->method('download')
+            ->will($this->returnCallback($downloadCallback));
+        $loader->setCachingDownloader($mockDownloader);
+
+        $this->assertEquals(
+            'https://books.google.com/books/content'
+            . '?id=dEMBBAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl',
+            $loader->getUrl(
+                '',
+                'large',
+                ['isbn' => new ISBN('1612917984')]
+            )
+        );
+    }
+
+    /**
      * Test successful transaction containing no thumbnails.
      *
      * @return void
@@ -129,6 +164,36 @@ class GoogleTest extends \PHPUnit\Framework\TestCase
                 '',
                 'small',
                 ['isbn' => new ISBN('1612917984')]
+            )
+        );
+    }
+
+    /**
+     * Test successful transaction using OCLC number.
+     *
+     * @return void
+     */
+    public function testOCLCLoading(): void
+    {
+        $loader = new Google();
+
+        $mockDownloader = $this->getMockBuilder(CachingDownloader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $downloadCallback = $this->getDownloadCallback(
+            $this->getFixture('content/covers/google-cover-no-thumbnail.js'),
+            '1234',
+            'OCLC'
+        );
+        $mockDownloader->expects($this->once())->method('download')
+            ->will($this->returnCallback($downloadCallback));
+        $loader->setCachingDownloader($mockDownloader);
+
+        $this->assertFalse(
+            $loader->getUrl(
+                '',
+                'small',
+                ['oclc' => '1234']
             )
         );
     }


### PR DESCRIPTION
Current Google cover image implementation only supports ISBN numbers, but the API supports OCLC numbers, so we can use that support. It makes a difference for records that only have an OCLC number.
Also, the zoom in the image URL is modified to get a larger image when the requested size is not small.