### PR TITLE
Only update FOLIO location cache data when appropriate.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -523,8 +523,8 @@ class Folio extends AbstractAPI implements
                 $code = $location->code;
                 $locationMap[$location->id] = compact('name', 'code');
             }
+            $this->putCachedData($cacheKey, $locationMap);
         }
-        $this->putCachedData($cacheKey, $locationMap);
         return $locationMap;
     }
 


### PR DESCRIPTION
I happened to notice this bug while reviewing #3145. We don't want to write data to the cache if that data already came from the cache. This is not only inefficient but also potentially prevents appropriate cache expiration.