### PR TITLE
FOLIO: do not display credentials in debug messages.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
@@ -125,6 +125,8 @@ abstract class AbstractAPI extends AbstractBase implements
      * @param true|int[]|string $allowedFailureCodes HTTP failure codes that should
      * NOT cause an ILSException to be thrown. May be an array of integers, a regular
      * expression, or boolean true to allow all codes.
+     * @param string|array      $debugParams         Value to use in place of $params
+     * in debug messages (useful for concealing sensitive data, etc.)
      *
      * @return \Laminas\Http\Response
      * @throws ILSException
@@ -134,7 +136,8 @@ abstract class AbstractAPI extends AbstractBase implements
         $path = '/',
         $params = [],
         $headers = [],
-        $allowedFailureCodes = []
+        $allowedFailureCodes = [],
+        $debugParams = null
     ) {
         $client = $this->httpService->createClient(
             $this->config['API']['base_url'] . $path,
@@ -148,7 +151,7 @@ abstract class AbstractAPI extends AbstractBase implements
         [$req_headers, $params] = $this->preRequest($req_headers, $params);
 
         if ($this->logger) {
-            $this->debugRequest($method, $path, $params, $req_headers);
+            $this->debugRequest($method, $path, $debugParams ?? $params, $req_headers);
         }
 
         // Add params

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -254,7 +254,12 @@ class Folio extends AbstractAPI implements
             'username' => $this->config['API']['username'],
             'password' => $this->config['API']['password'],
         ];
-        $response = $this->makeRequest('POST', '/authn/login', json_encode($auth));
+        $response = $this->makeRequest(
+            method: 'POST',
+            path: '/authn/login',
+            params: json_encode($auth),
+            debugParams: '{"username":"...","password":"..."}'
+        );
         $this->token = $response->getHeaders()->get('X-Okapi-Token')
             ->getFieldValue();
         $this->sessionCache->folio_token = $this->token;


### PR DESCRIPTION
This is intended to reduce the chances of accidental disclosure of sensitive information.