### PR TITLE
Display errors, notices and alerts in debug mode.

### DIFF
--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -341,10 +341,11 @@ class LoggerFactory implements FactoryInterface
             '<pre>%timestamp% %priorityName%: %message%</pre>' . PHP_EOL
         );
         $writer->setFormatter($formatter);
+        $level = (is_int($debug) ? $debug : '5');
         $this->addWriters(
             $logger,
             $writer,
-            'debug-' . (is_int($debug) ? $debug : '5')
+            "debug-$level,notice-$level,error-$level,alert-$level"
         );
     }
 


### PR DESCRIPTION
There is a significant flaw in the debug setting in config.ini: it ONLY displays debug messages, but not alerts, notices, or errors... thus, turning on debug messages to troubleshoot fatal errors can be a puzzling experience. This PR addresses the problem by displaying ALL log messages when debug mode is turned on.

I imagine there could be debate about whether this should be made more configurable, but my argument is that for complex logging setups, users already have significant flexibility through the [Logging] section of config.ini. If they want to turn on an easy setting to see why something is broken, they should see all available information to get a more complete picture of what is happening.

This PR was inspired by [VUFIND-1599](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1599), because the FOLIO ILS driver logs errors (instead of debug messages) when it encounters permission errors... and these errors were not visible to the end user in debug mode, making them hard to quickly troubleshoot.