### PR TITLE
Accessibility: Use $headTitle as <h1> on results

### DIFF
--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -51,6 +51,7 @@
   $this->headLink()->appendStylesheet('combined-search.css');
 ?>
 <?=$this->flashmessages()?>
+<h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>
 <form id="search-cart-form" class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
   <?php $recs = $combinedResults->getRecommendations('top'); ?>
   <?php if (!empty($recs)): ?>

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -52,6 +52,8 @@
   }
 ?>
 
+<h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>
+
 <div class="<?=$this->layoutClass('mainbody')?>">
   <?php if (($recordTotal = $this->results->getResultTotal()) > 0): // only display these at very top if we have results ?>
     <?php foreach ($this->results->getRecommendations('top') as $index => $current): ?>


### PR DESCRIPTION
On boostrap3 theme there seems to be no `<h1>` element on the search results page.  But there are plenty of `<h2>`s -- each search result title, plus more in the footer or if you have facets enabled.  This is I think a clear accessibility problem.

I'm proposing that the search results title -- effectively the breadcrumb -- be the `<h1>`.  I'm writing it out separately in a `sr-only` element so it doesn't affect layout.