### PR TITLE
Remove obsolete basemap examples; add more notes.

### DIFF
--- a/config/vufind/geofeatures.ini
+++ b/config/vufind/geofeatures.ini
@@ -8,10 +8,20 @@
 [Basemap]
 ; Configures the basemap that is used to display geographic featuers.
 ; Default basemap configuration is the osm-intl option below, and other
-; open source basemap options are provided.
+; open source basemap options are provided as examples.
+;
+; IMPORTANT: most free map services have significant limitations on
+; usage, so you should consult their terms of service. If you are going to
+; use this feature in production, you may need to consider subscribing to
+; a commercial provider or running your own local tile server.
+;
+; See the Geographic Features wiki page for more details:
+;     https://vufind.org/wiki/configuration:geographic_features
+;
 ; The basemap can be set separately for the MapSelection and MapTab
 ; geographic features by adding the basemap_url and basemap_attribution
 ; to those sections of this file.
+;
 ; Backward compatibility also allows for basemap_url and basemap_attribution
 ; to be set in the config.ini [Content] section where the Geographic Display
 ; settings are located and in the searches.ini [MapSelection] section.
@@ -26,14 +36,6 @@
 ; osm-intl
 basemap_url = https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
 basemap_attribution = "<a href=""https://wikimediafoundation.org/wiki/Maps_Terms_of_Use"">Wikimedia</a> | &copy; <a href=""https://www.openstreetmap.org/copyright"">OpenStreetMap</a>"
-
-; stamen-toner
-;basemap_url = https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.jpg
-;basemap_attribution = 'Map tiles: <a href="http://stamen.com" title="Map tiles by Stamen Design, under CC BY 3.0">Stamen Design</a> | Data: <a href="http://openstreetmap.org" title="Data by OpenStreetMap, under ODbL.">OpenStreetMap</a>'
-
-; stamen-terrain
-;basemap_url = https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg
-;basemap_attribution = 'Map tiles: <a href="http://stamen.com" title="Map tiles by Stamen Design, under CC BY 3.0">Stamen Design</a> | Data: <a href="http://openstreetmap.org" title="Data by OpenStreetMap, under ODbL.">OpenStreetMap</a>'
 
 ; cartocdn-light
 ;basemap_url = http://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png


### PR DESCRIPTION
This pull request removes the Stamen map tile examples, as they are going offline later this month. It also adds a note about licensing and alternative options, with a link to the [Geographic Features](https://vufind.org/wiki/configuration:geographic_features) wiki page. I have updated that page to make it more readable, and to remove a lot of version-specific notes that are very old and likely serve no further purpose. I'm hoping that @EreMaijala and/or @lmgonzales can add a section to the page covering map tiles and map servers, but I wrote my revisions here so that we should be able to merge this whether or not we make other changes there.

TODO
- [x] Add changelog note about stamen map tiles.