### PR TITLE
Add setting to allow deep searching within collections.

### DIFF
--- a/config/vufind/HierarchyDefault.ini
+++ b/config/vufind/HierarchyDefault.ini
@@ -11,7 +11,7 @@ link_type = "Top"
 ; for the 'Top' setting. However, you can override that automatic check with an explicit
 ; field here if needed (this can be useful if you want to do folder-based navigation
 ; normally, but do a deep search into the tree when a user performs a search).
-;search_container_field = "hierarchy_all_parents_str_mv"
+;search_container_id_field = "hierarchy_all_parents_str_mv"
 
 [HierarchyTree]
 ; Are hierarchy trees visible? -- true or false (default false)

--- a/config/vufind/HierarchyDefault.ini
+++ b/config/vufind/HierarchyDefault.ini
@@ -5,6 +5,13 @@
 ;     Top  - any record where is_hierarchy = hierarchy_top
 ;     None - never link to the collection module
 link_type = "Top"
+; When a user searches within a collection, which Solr field should be used to filter
+; the search results using the collection ID? By default, this is automatically set
+; based on link_type -- 'hierarchy_parent_id' for the 'All' setting and 'hierarchy_top_id'
+; for the 'Top' setting. However, you can override that automatic check with an explicit
+; field here if needed (this can be useful if you want to do folder-based navigation
+; normally, but do a deep search into the tree when a user performs a search).
+;search_container_field = "hierarchy_all_parents_str_mv"
 
 [HierarchyTree]
 ; Are hierarchy trees visible? -- true or false (default false)

--- a/config/vufind/HierarchyFlat.ini
+++ b/config/vufind/HierarchyFlat.ini
@@ -11,7 +11,7 @@ link_type = "Top"
 ; for the 'Top' setting. However, you can override that automatic check with an explicit
 ; field here if needed (this can be useful if you want to do folder-based navigation
 ; normally, but do a deep search into the tree when a user performs a search).
-;search_container_field = "hierarchy_all_parents_str_mv"
+;search_container_id_field = "hierarchy_all_parents_str_mv"
 
 [HierarchyTree]
 ; Are hierarchy trees visible? -- true or false (default false)

--- a/config/vufind/HierarchyFlat.ini
+++ b/config/vufind/HierarchyFlat.ini
@@ -5,6 +5,13 @@
 ;     Top  - any record where is_hierarchy = hierarchy_top
 ;     None - never link to the collection module
 link_type = "Top"
+; When a user searches within a collection, which Solr field should be used to filter
+; the search results using the collection ID? By default, this is automatically set
+; based on link_type -- 'hierarchy_parent_id' for the 'All' setting and 'hierarchy_top_id'
+; for the 'Top' setting. However, you can override that automatic check with an explicit
+; field here if needed (this can be useful if you want to do folder-based navigation
+; normally, but do a deep search into the tree when a user performs a search).
+;search_container_field = "hierarchy_all_parents_str_mv"
 
 [HierarchyTree]
 ; Are hierarchy trees visible? -- true or false (default false)

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
@@ -141,8 +141,8 @@ class ConfigurationBased extends AbstractBase
      */
     public function getCollectionField(bool $hasSearch): string
     {
-        if ($hasSearch && !empty($this->config->Collections->search_container_field)) {
-            return $this->config->Collections->search_container_field;
+        if ($hasSearch && !empty($this->config->Collections->search_container_id_field)) {
+            return $this->config->Collections->search_container_id_field;
         }
         return match ($this->getCollectionLinkType()) {
             'All' => 'hierarchy_parent_id',

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
@@ -141,7 +141,7 @@ class ConfigurationBased extends AbstractBase
      */
     public function getCollectionField(bool $hasSearch): string
     {
-        if ($hasSearch && !empty($this->config->Collections->search_container_id_field)) {
+        if ($hasSearch && null !== ($this->config->Collections->search_container_id_field ?? null)) {
             return $this->config->Collections->search_container_id_field;
         }
         return match ($this->getCollectionLinkType()) {

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
@@ -131,4 +131,22 @@ class ConfigurationBased extends AbstractBase
         return isset($this->config->Collections->link_type)
             ? ucwords(strtolower($this->config->Collections->link_type)) : 'All';
     }
+
+    /**
+     * Get the Solr field name used for grouping together collection contents
+     *
+     * @param bool $hasSearch Is the user performing a search?
+     *
+     * @return string
+     */
+    public function getCollectionField(bool $hasSearch): string
+    {
+        if ($hasSearch && !empty($this->config->Collections->search_container_field)) {
+            return $this->config->Collections->search_container_field;
+        }
+        return match ($this->getCollectionLinkType()) {
+            'All' => 'hierarchy_parent_id',
+            'Top' => 'hierarchy_top_id',
+        };
+    }
 }

--- a/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
+++ b/module/VuFind/src/VuFind/Hierarchy/Driver/ConfigurationBased.php
@@ -141,8 +141,8 @@ class ConfigurationBased extends AbstractBase
      */
     public function getCollectionField(bool $hasSearch): string
     {
-        if ($hasSearch && null !== ($this->config->Collections->search_container_id_field ?? null)) {
-            return $this->config->Collections->search_container_id_field;
+        if ($hasSearch && null !== ($field = $this->config->Collections->search_container_id_field ?? null)) {
+            return $field;
         }
         return match ($this->getCollectionLinkType()) {
             'All' => 'hierarchy_parent_id',

--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -129,8 +129,8 @@ class CollectionList extends AbstractBase
             $request = $this->getRequest()->getQuery()->toArray()
                 + $this->getRequest()->getPost()->toArray();
             $rManager = $this->recommendManager;
-            $cb = function ($runner, $params, $searchId) use ($driver, $rManager) {
-                $params->initFromRecordDriver($driver);
+            $cb = function ($runner, $params, $searchId) use ($driver, $rManager, $request) {
+                $params->initFromRecordDriver($driver, strlen($request['lookfor'] ?? '') > 0);
                 $listener = new RecommendListener($rManager, $searchId);
                 $listener->setConfig(
                     $params->getOptions()->getRecommendationSettings()

--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -34,6 +34,8 @@ use VuFind\Search\Memory as SearchMemory;
 use VuFind\Search\RecommendListener;
 use VuFind\Search\SearchRunner;
 
+use function strlen;
+
 /**
  * Collection list tab
  *

--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -34,8 +34,6 @@ use VuFind\Search\Memory as SearchMemory;
 use VuFind\Search\RecommendListener;
 use VuFind\Search\SearchRunner;
 
-use function strlen;
-
 /**
  * Collection list tab
  *
@@ -132,7 +130,7 @@ class CollectionList extends AbstractBase
                 + $this->getRequest()->getPost()->toArray();
             $rManager = $this->recommendManager;
             $cb = function ($runner, $params, $searchId) use ($driver, $rManager, $request) {
-                $params->initFromRecordDriver($driver, strlen($request['lookfor'] ?? '') > 0);
+                $params->initFromRecordDriver($driver, '' !== ($request['lookfor'] ?? ''));
                 $listener = new RecommendListener($rManager, $searchId);
                 $listener->setConfig(
                     $params->getOptions()->getRecommendationSettings()

--- a/module/VuFind/src/VuFind/Search/SolrCollection/Params.php
+++ b/module/VuFind/src/VuFind/Search/SolrCollection/Params.php
@@ -60,22 +60,16 @@ class Params extends \VuFind\Search\Solr\Params
      * Pull the search parameters from the query and set up additional options using
      * a record driver representing a collection.
      *
-     * @param \VuFind\RecordDriver\AbstractBase $driver Record driver
+     * @param \VuFind\RecordDriver\AbstractBase $driver    Record driver
+     * @param bool                              $hasSearch Is the user performing a search?
      *
      * @return void
      */
-    public function initFromRecordDriver($driver)
+    public function initFromRecordDriver($driver, bool $hasSearch = false)
     {
         $this->collectionID = $driver->getUniqueID();
         if ($hierarchyDriver = $driver->getHierarchyDriver()) {
-            switch ($hierarchyDriver->getCollectionLinkType()) {
-                case 'All':
-                    $this->collectionField = 'hierarchy_parent_id';
-                    break;
-                case 'Top':
-                    $this->collectionField = 'hierarchy_top_id';
-                    break;
-            }
+            $this->collectionField = $hierarchyDriver->getCollectionField($hasSearch);
         }
 
         if (null === $this->collectionID) {


### PR DESCRIPTION
This PR is needed to support some improved functionality for Villanova's Digital Library. I'm not sure how likely it is to be useful in other situations, but it at least improves code readability by eliminating a switch statement, so maybe it's worth merging for that alone -- and the extra flexibility it adds is easily ignored.

The situation is this: when "link_type" is set to All in HierarchyDefault.ini and you have a deeply-nested set of collections, you can only see one level of the hierarchy at a time (which is desired -- we want a "drill down" navigation). However, if you use the "search within collection" feature, you also only search within the current level you are looking at, which can be confusing. It would be better to search the current level and also all deeper levels.

This PR adds a setting which allows a different collection filter field to be used when the user inputs a search than when they are viewing the collection without a search.

Note that the desired functionality is not possible with the minimum Solr schema defined in the [documentation](https://vufind.org/wiki/indexing:hierarchies_and_collections). It requires a new hierarchy_all_parents_str_mv field which contains the entire chain of parent IDs, not just the top parent/immediate parent. We already have this field as part of our custom indexing process at Villanova.

You can get a general idea of the functionality I'm proposing (though it will only work at the top level of any given collection tree), you can set up a test like this (using the standard test environment created by Phing):

1.) In HierarchyDefault.ini, set link_type to "All".
2.) In config.ini, set `collections = true` in the [Collections] section.
3.) Navigate to `http://localhost/vufind_test/Collection/topcollection1` -- you will see two items and two subcollections.
4.) Search for "item" in the "Search within collection" box. You will see only two matches -- the items directly within this collection. Even though there are also matching items within the subcollections, they will not be seen.
5.) Now change search_container_field to hierarchy_top_id in HierarchyDefault.ini and repeat the search from step 4. You will see more matches, because the grandchildren are now accessible to the search.

TODO
- [x] Note BC break (changed method signature) when merging
- [x] Note optional _str_mv field in wiki (schema page and hierarchy page)