### PR TITLE
Optional dataMethod params for RecordDataFormatter

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
@@ -262,14 +262,15 @@ class RecordDataFormatter extends AbstractHelper
 
         if ($useCache = ($options['useCache'] ?? false)) {
             $cacheKey = $this->driver->getUniqueID() . '|'
-                . $this->driver->getSourceIdentifier() . '|' . $method;
+                . $this->driver->getSourceIdentifier() . '|' . $method
+                . (isset($options['dataMethodParams']) ? '|' . serialize($options['dataMethodParams']) : '');
             if (isset($cache[$cacheKey])) {
                 return $cache[$cacheKey];
             }
         }
 
         // Default action: try to extract data from the record driver:
-        $data = $this->driver->tryMethod($method);
+        $data = $this->driver->tryMethod($method, $options['dataMethodParams'] ?? []);
 
         if ($useCache) {
             $cache[$cacheKey] = $data;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -35,6 +35,7 @@ use VuFind\View\Helper\Root\RecordDataFormatter;
 use VuFind\View\Helper\Root\RecordDataFormatterFactory;
 
 use function count;
+use function func_get_args;
 
 /**
  * RecordDataFormatter Test Class
@@ -128,7 +129,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
         $addMethods = [
             'getFullTitle', 'getFullTitleAltScript', 'getAltFullTitle', 'getBuildingsAltScript',
             'getNotExistingAltScript', 'getSummaryAltScript', 'getNewerTitlesAltScript',
-            'getPublicationDetailsAltScript',
+            'getPublicationDetailsAltScript', 'getFunctionWithParams',
         ];
         $record = $this->getMockBuilder(\VuFind\RecordDriver\SolrDefault::class)
             ->onlyMethods($onlyMethods)
@@ -175,6 +176,11 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(['New Title', 'Second New Title']));
         $record->expects($this->any())->method('getNewerTitlesAltScript')
             ->will($this->returnValue(['Alt New Title', 'Second Alt New Title']));
+        $record->expects($this->any())->method('getFunctionWithParams')
+            ->will($this->returnCallback(function () {
+                $args = func_get_args();
+                return implode(' ', $args);
+            }));
 
         // Load record data from fixture file:
         $fixture = $this->getJsonFixture('misc/testbug2.json');
@@ -429,6 +435,12 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'template' => 'data-publicationDetails.phtml',
             'pos' => 4008,
         ];
+        $spec['FunctionWithParams'] = [
+            'dataMethod' => 'getFunctionWithParams',
+            'renderType' => 'Simple',
+            'dataMethodParams' => ['test', 'test2'],
+            'pos' => 5000,
+        ];
         $expected = [
             'Building' => 'prefix_0',
             'Published in' => '0',
@@ -459,6 +471,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'CombineAltNoStdValue' => 'Alternative Summary',
             'CombineAltArray' => 'New TitleSecond New Title Alt New TitleSecond Alt New Title',
             'CombineAltRenderTemplate' => 'Centro di Studi Vichiani, 1992 Alt Place Alt Name Alt Date',
+            'FunctionWithParams' => 'test test2',
         ];
         // Call the method specified by the data provider
         $results = $this->$function($driver, $spec);


### PR DESCRIPTION
Adding the option to add parameters when calling dataMethods in RecordDataFormatter.

I.e. this can be used to call `getAllSubjectHeadings` with `$extended` set to `true`.

TODO:
- [x] Update wiki documentation and changelog when merging