### PR TITLE
Sierra: Add support for statistic group in holds and renewals.

### DIFF
--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -21,6 +21,9 @@ client_secret = "very_secret"
 ;     - patron authentication with global patron data access using a method other
 ;       than "native"
 ;api_version = 6
+; Statistic group to use e.g. when renewing loans or placing holds (requires Sierra
+; 6.0 or later and API version set to 6 or later above):
+;statgroup = 123
 ; Timeout for HTTP requests
 http_timeout = 30
 ; Redirect URL entered in Sierra for patron-specific authentication (does not

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1824,7 +1824,7 @@ class SierraRest extends AbstractBase implements
 
         // Set up the request
         $apiUrl = $this->getApiUrlFromHierarchy($hierarchy);
-        // Add additional query parameters directly to the URL becuase they cannot be
+        // Add additional query parameters directly to the URL because they cannot be
         // added with setParameterGet for POST request:
         if ($queryParams) {
             $apiUrl .= '?' . http_build_query($queryParams);

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -865,9 +865,8 @@ class SierraRest extends AbstractBase implements
 
         foreach ($renewDetails['details'] as $details) {
             [$checkoutId, $itemId] = explode('|', $details);
-            $urlHierarchy = [$this->apiBase, 'patrons', 'checkouts', $checkoutId, 'renewal'];
             $result = $this->makeRequest(
-                $urlHierarchy,
+                [$this->apiBase, 'patrons', 'checkouts', $checkoutId, 'renewal'],
                 [],
                 'POST',
                 $patron,


### PR DESCRIPTION
Sierra 6.0 adds support for statgroup parameter that can be used to specify the "statistic group" to use in Sierra for specific functions (renewal, holds, payments).