### PR TITLE
Fix missing searchClassId in layout

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -82,7 +82,7 @@ class AbstractSearch extends AbstractBase
     protected function createViewModel($params = null)
     {
         $view = parent::createViewModel($params);
-        $view->searchClassId = $this->searchClassId;
+        $this->layout()->searchClassId = $view->searchClassId = $this->searchClassId;
         return $view;
     }
 


### PR DESCRIPTION
Hello! Here is a small fix for an issue where our authority search did not recognize the proper searchClassId and routed searches to solr.