### PR TITLE
Fix display of checkbox filters.

### DIFF
--- a/themes/bootstrap3/templates/search/filters.phtml
+++ b/themes/bootstrap3/templates/search/filters.phtml
@@ -28,25 +28,24 @@
 <?php ob_start(); ?>
   <?php foreach ($this->checkboxFilters as $filter): ?>
     <?php if ($filter['selected']): ?>
-      <span class="filter-value">
-        <?php
-          $removeLink = isset($urlQuery)
-            ? $urlQuery->removeFilter($filter['filter'])
-            : $this->searchMemory()->getEditLink(
-                $this->searchClassId,
-                'removeFilter',
-                $filter['filter']
-            );
-          $desc = $this->translate($filter['desc']);
-          $ariaLabel = $this->translate('Remove filter') . ' ' . $this->escapeHtmlAttr($desc);
-        ?>
-        <?=$desc?>
-        <?php if ($removeLink): ?>
-          <a class="search-filter-remove" aria-label="<?=$ariaLabel?>" href="<?=$removeLink?>">
-            <?=$this->icon('search-filter-remove') ?>
-          </a>
-        <?php endif; ?>
-      </span>
+      <?php
+        $removeLink = isset($urlQuery)
+          ? $urlQuery->removeFilter($filter['filter'])
+          : $this->searchMemory()->getEditLink(
+              $this->searchClassId,
+              'removeFilter',
+              $filter['filter']
+          );
+      ?>
+      <?php if ($removeLink): ?>
+        <a class="filter-value" href="<?=$removeLink?>">
+          <span class="sr-only">
+            <?=$this->translate('Remove filter') ?>
+          </span>
+          <span class="text"><?=$this->transEsc($filter['desc'])?></span>
+          <?=$this->icon('search-filter-remove') ?>
+        </a>
+      <?php endif; ?>
     <?php endif ?>
   <?php endforeach; ?>
 


### PR DESCRIPTION
I noticed that checkbox filters were displaying inconsistently with regular filters. This PR adjusts the markup for checkbox filters to more closely match regular filters, for consistent display and accessibility features.

To reproduce:

1. In facets.ini, uncomment the "First Edition" example under [CheckboxFacets]
2. In search results, apply the "First Edition" checkbox facet, and any other facet.
3. Compare the appearance/behavior of the applied filters above the search results.