### PR TITLE
[9.1] Add explicit int casts to cover generator layers.

### DIFF
--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractLayer.php
@@ -72,7 +72,7 @@ abstract class AbstractLayer implements LayerInterface
      * @param resource $im    Image resource being updated
      * @param string   $color Legal color name from HTML4
      *
-     * @return allocated color
+     * @return int allocated color
      */
     protected function getColor($im, $color)
     {

--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractLayer.php
@@ -72,7 +72,7 @@ abstract class AbstractLayer implements LayerInterface
      * @param resource $im    Image resource being updated
      * @param string   $color Legal color name from HTML4
      *
-     * @return int allocated color
+     * @return int|false allocated color
      */
     protected function getColor($im, $color)
     {

--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractTextLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractTextLayer.php
@@ -102,7 +102,7 @@ abstract class AbstractTextLayer extends AbstractLayer
 
         // If the wrap width is smaller than the image width, we want to account
         // for this when right or left aligning to maintain padding on the image.
-        $wrapGap = ($settings->width - $settings->wrapWidth) / 2;
+        $wrapGap = (int)(($settings->width - $settings->wrapWidth) / 2);
 
         $textWidth = $this->textWidth($text, $font, $fontSize);
         if ($textWidth > $settings->width) {
@@ -118,7 +118,7 @@ abstract class AbstractTextLayer extends AbstractLayer
                 break;
             case 'center':
             default:
-                $x = ($settings->width - $textWidth) / 2;
+                $x = (int)(($settings->width - $textWidth) / 2);
         }
 
         // Generate 5 lines of text, 4 offset in a border color
@@ -129,6 +129,6 @@ abstract class AbstractTextLayer extends AbstractLayer
             imagettftext($im, $fontSize, 0, $x - 1, $y, $scolor, $font, $text);
         }
         // 1 centered in main color
-        imagettftext($im, $fontSize, 0, $x, $y, $mcolor, $font, $text);
+        imagettftext($im, $fontSize, 0, $x, (int)$y, $mcolor, $font, $text);
     }
 }

--- a/module/VuFind/src/VuFind/Cover/Layer/GridBackground.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/GridBackground.php
@@ -110,10 +110,10 @@ class GridBackground extends AbstractBackgroundLayer
             $settings->height,
             $this->getColor($im, $settings->baseColor)
         );
-        $halfWidth = $settings->width / 2;
-        $halfHeight = $settings->height / 2;
-        $boxWidth  = $settings->width / 8;
-        $boxHeight = $settings->height / 8;
+        $halfWidth = (int)($settings->width / 2);
+        $halfHeight = (int)($settings->height / 2);
+        $boxWidth  = (int)($settings->width / 8);
+        $boxHeight = (int)($settings->height / 8);
 
         $bc = str_split($pattern);
         for ($k = 0; $k < 4; $k++) {


### PR DESCRIPTION
Fixes some PHP 8.1 deprecation notices.