### PR TITLE
Primo: Replace commas in search terms with spaces instead of pluses.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Connector.php
@@ -244,7 +244,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                 }
 
                 //set the lookfor terms to search
-                $lookfor = preg_replace('/,/', '+', $thisTerm['lookfor']);
+                $lookfor = str_replace(',', ' ', $thisTerm['lookfor']);
 
                 //set precision
                 if (array_key_exists('op', $thisTerm) && !empty($thisTerm['op'])) {
@@ -291,7 +291,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                     }
                     $values = array_map(
                         function ($value) {
-                            return urlencode(preg_replace('/,/', '+', $value));
+                            return urlencode(str_replace(',', ' ', $value));
                         },
                         $values
                     );


### PR DESCRIPTION
Looks like the code has been the same for the past nine years, but perhaps something has changed in Primo to make it less lenient. In any case, this changes the commas to spaces as [documented](https://developers.exlibrisgroup.com/primo/apis/webservices/xservices/search/briefsearch/).