### PR TITLE
Improve comments about solrmarc.path setting.

### DIFF
--- a/import/import.properties
+++ b/import/import.properties
@@ -11,6 +11,8 @@ solr.hosturl = http://localhost:8983/solr/biblio/update
 # Where to look for properties files, translation maps, and custom scripts.
 # Note that . refers to the directory where the jarfile for SolrMarc is located.
 # You can use a pipe (|) character to create a multi-directory search path.
+# The search path will be searched from left to right, so you should list your
+# override directories FIRST and your default directories LAST.
 # You can use install.php to automatically create and configure your local
 # override of this file for common use cases.
 solrmarc.path = /usr/local/vufind/import

--- a/import/import_auth.properties
+++ b/import/import_auth.properties
@@ -11,6 +11,8 @@ solr.hosturl = http://localhost:8983/solr/authority/update
 # Where to look for properties files, translation maps, and custom scripts.
 # Note that . refers to the directory where the jarfile for SolrMarc is located.
 # You can use a pipe (|) character to create a multi-directory search path.
+# The search path will be searched from left to right, so you should list your
+# override directories FIRST and your default directories LAST.
 # You can use install.php to automatically create and configure your local
 # override of this file for common use cases.
 solrmarc.path = /usr/local/vufind/import


### PR DESCRIPTION
There have been some recent problems where the solution turned out to be changing the order of the SolrMarc search path. This PR adds a comment to make the correct configuration more clear.