### PR TITLE
Fix interpolation of css variables in scss mode.

### DIFF
--- a/themes/bootstrap3/less/components/cookie-consent/abstracts/light-color-scheme.less
+++ b/themes/bootstrap3/less/components/cookie-consent/abstracts/light-color-scheme.less
@@ -1,8 +1,9 @@
 /** Light color-scheme **/
 :root{
+/* #LESS> */
     --cc-bg: @modal-content-bg;
     --cc-primary-color: @text-color;
-    --cc-secondary-color: lighten(@text-color, 10%);;
+    --cc-secondary-color: lighten(@text-color, 10%);
 
     --cc-btn-primary-bg: @btn-primary-bg;
     --cc-btn-primary-color: @btn-primary-color;
@@ -48,4 +49,55 @@
     --cc-footer-bg: @panel-footer-bg;
     --cc-footer-color: @text-color;
     --cc-footer-border-color: @panel-default-border;
+/* #LESS> */
+/* #SCSS>
+    --cc-bg: #{$modal-content-bg};
+    --cc-primary-color: #{$text-color};
+    --cc-secondary-color: #{lighten($text-color, 10%)};
+
+    --cc-btn-primary-bg: #{$btn-primary-bg};
+    --cc-btn-primary-color: #{$btn-primary-color};
+    --cc-btn-primary-border-color: #{$btn-primary-bg};
+    --cc-btn-primary-hover-bg: #{$btn-primary-color};
+    --cc-btn-primary-hover-color: #{$btn-primary-bg};
+    --cc-btn-primary-hover-border-color: #{darken($btn-primary-border, 12%)};
+
+    --cc-btn-secondary-bg: #{$btn-default-bg};
+    --cc-btn-secondary-color: #{$btn-default-color};
+    --cc-btn-secondary-border-color: #{$btn-default-border};
+    --cc-btn-secondary-hover-bg: #{$btn-default-color};
+    --cc-btn-secondary-hover-color: #{$btn-default-bg};
+    --cc-btn-secondary-hover-border-color: #{darken($btn-default-border, 12%)};
+
+    --cc-separator-border-color: #{$well-border};
+
+    --cc-toggle-on-bg: #{$gray-light};
+    --cc-toggle-off-bg: #{lighten($gray-light, 10%)};
+    --cc-toggle-on-knob-bg: #{$body-bg};
+    --cc-toggle-off-knob-bg: #{$body-bg};
+
+    --cc-toggle-enabled-icon-color: #{$modal-content-bg};   // yes (v tick)
+    --cc-toggle-disabled-icon-color: #{$modal-content-bg};  // no (x tick)
+
+    --cc-toggle-readonly-bg: #{lighten($gray-light, 20%)};
+    --cc-toggle-readonly-knob-bg: #{$body-bg};
+    --cc-toggle-readonly-knob-icon-color: lighten($gray-light, 20%);
+
+    --cc-section-category-border: #{$gray-lighter};
+
+    --cc-cookie-category-block-bg: #{$gray-lighter};
+    --cc-cookie-category-block-border: #{$list-group-border};
+    --cc-cookie-category-block-hover-bg: #{darken($gray-lighter, 10%)};
+    --cc-cookie-category-block-hover-border: #{$list-group-border};
+    --cc-cookie-category-expanded-block-bg: #{$gray-lighter};
+    --cc-cookie-category-expanded-block-hover-bg: darken($gray-lighter, 10%);
+
+    --cc-overlay-bg: #{$modal-backdrop-bg};
+    --cc-webkit-scrollbar-bg: #{$gray-lighter};
+    --cc-webkit-scrollbar-hover-bg: #{$btn-primary-color};
+
+    --cc-footer-bg: #{$panel-footer-bg};
+    --cc-footer-color: #{$text-color};
+    --cc-footer-border-color: #{$panel-default-border};
+<#SCSS */
 }

--- a/themes/bootstrap3/less/components/cookie-consent/abstracts/light-color-scheme.less
+++ b/themes/bootstrap3/less/components/cookie-consent/abstracts/light-color-scheme.less
@@ -49,7 +49,7 @@
     --cc-footer-bg: @panel-footer-bg;
     --cc-footer-color: @text-color;
     --cc-footer-border-color: @panel-default-border;
-/* #LESS> */
+/* <#LESS */
 /* #SCSS>
     --cc-bg: #{$modal-content-bg};
     --cc-primary-color: #{$text-color};

--- a/themes/bootstrap3/less/components/cookie-consent/core/base.less
+++ b/themes/bootstrap3/less/components/cookie-consent/core/base.less
@@ -5,6 +5,7 @@
  */
 
 :root{
+/* #LESS> */
     --cc-font-family: @font-family-base;
     --cc-modal-border-radius: @border-radius-base;
     --cc-btn-border-radius: @btn-border-radius-base;
@@ -12,6 +13,16 @@
     --cc-link-color: @link-color;
     --cc-modal-margin: 1rem;
     --cc-z-index: @zindex-cookie-consent;
+/* #LESS> */
+/* #SCSS>
+    --cc-font-family: #{$font-family-base};
+    --cc-modal-border-radius: #{$border-radius-base};
+    --cc-btn-border-radius: #{$btn-border-radius-base};
+    --cc-modal-transition-duration: .25s;
+    --cc-link-color: #{$link-color};
+    --cc-modal-margin: 1rem;
+    --cc-z-index: #{$zindex-cookie-consent};
+<#SCSS */
 }
 
 #cc-main {

--- a/themes/bootstrap3/less/components/cookie-consent/core/base.less
+++ b/themes/bootstrap3/less/components/cookie-consent/core/base.less
@@ -13,7 +13,7 @@
     --cc-link-color: @link-color;
     --cc-modal-margin: 1rem;
     --cc-z-index: @zindex-cookie-consent;
-/* #LESS> */
+/* <#LESS */
 /* #SCSS>
     --cc-font-family: #{$font-family-base};
     --cc-modal-border-radius: #{$border-radius-base};

--- a/themes/bootstrap3/scss/components/cookie-consent/abstracts/light-color-scheme.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/abstracts/light-color-scheme.scss
@@ -1,8 +1,9 @@
 /** Light color-scheme **/
 :root{
+/* #LESS>
     --cc-bg: $modal-content-bg;
     --cc-primary-color: $text-color;
-    --cc-secondary-color: lighten($text-color, 10%);;
+    --cc-secondary-color: lighten($text-color, 10%);
 
     --cc-btn-primary-bg: $btn-primary-bg;
     --cc-btn-primary-color: $btn-primary-color;
@@ -48,4 +49,55 @@
     --cc-footer-bg: $panel-footer-bg;
     --cc-footer-color: $text-color;
     --cc-footer-border-color: $panel-default-border;
+/* #LESS>
+/* #SCSS> */
+    --cc-bg: #{$modal-content-bg};
+    --cc-primary-color: #{$text-color};
+    --cc-secondary-color: #{lighten($text-color, 10%)};
+
+    --cc-btn-primary-bg: #{$btn-primary-bg};
+    --cc-btn-primary-color: #{$btn-primary-color};
+    --cc-btn-primary-border-color: #{$btn-primary-bg};
+    --cc-btn-primary-hover-bg: #{$btn-primary-color};
+    --cc-btn-primary-hover-color: #{$btn-primary-bg};
+    --cc-btn-primary-hover-border-color: #{darken($btn-primary-border, 12%)};
+
+    --cc-btn-secondary-bg: #{$btn-default-bg};
+    --cc-btn-secondary-color: #{$btn-default-color};
+    --cc-btn-secondary-border-color: #{$btn-default-border};
+    --cc-btn-secondary-hover-bg: #{$btn-default-color};
+    --cc-btn-secondary-hover-color: #{$btn-default-bg};
+    --cc-btn-secondary-hover-border-color: #{darken($btn-default-border, 12%)};
+
+    --cc-separator-border-color: #{$well-border};
+
+    --cc-toggle-on-bg: #{$gray-light};
+    --cc-toggle-off-bg: #{lighten($gray-light, 10%)};
+    --cc-toggle-on-knob-bg: #{$body-bg};
+    --cc-toggle-off-knob-bg: #{$body-bg};
+
+    --cc-toggle-enabled-icon-color: #{$modal-content-bg};   // yes (v tick)
+    --cc-toggle-disabled-icon-color: #{$modal-content-bg};  // no (x tick)
+
+    --cc-toggle-readonly-bg: #{lighten($gray-light, 20%)};
+    --cc-toggle-readonly-knob-bg: #{$body-bg};
+    --cc-toggle-readonly-knob-icon-color: lighten($gray-light, 20%);
+
+    --cc-section-category-border: #{$gray-lighter};
+
+    --cc-cookie-category-block-bg: #{$gray-lighter};
+    --cc-cookie-category-block-border: #{$list-group-border};
+    --cc-cookie-category-block-hover-bg: #{darken($gray-lighter, 10%)};
+    --cc-cookie-category-block-hover-border: #{$list-group-border};
+    --cc-cookie-category-expanded-block-bg: #{$gray-lighter};
+    --cc-cookie-category-expanded-block-hover-bg: darken($gray-lighter, 10%);
+
+    --cc-overlay-bg: #{$modal-backdrop-bg};
+    --cc-webkit-scrollbar-bg: #{$gray-lighter};
+    --cc-webkit-scrollbar-hover-bg: #{$btn-primary-color};
+
+    --cc-footer-bg: #{$panel-footer-bg};
+    --cc-footer-color: #{$text-color};
+    --cc-footer-border-color: #{$panel-default-border};
+/* <#SCSS */
 }

--- a/themes/bootstrap3/scss/components/cookie-consent/abstracts/light-color-scheme.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/abstracts/light-color-scheme.scss
@@ -49,7 +49,7 @@
     --cc-footer-bg: $panel-footer-bg;
     --cc-footer-color: $text-color;
     --cc-footer-border-color: $panel-default-border;
-/* #LESS>
+<#LESS */
 /* #SCSS> */
     --cc-bg: #{$modal-content-bg};
     --cc-primary-color: #{$text-color};

--- a/themes/bootstrap3/scss/components/cookie-consent/core/base.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/base.scss
@@ -13,7 +13,7 @@
     --cc-link-color: $link-color;
     --cc-modal-margin: 1rem;
     --cc-z-index: $zindex-cookie-consent;
-/* #LESS>
+<#LESS */
 /* #SCSS> */
     --cc-font-family: #{$font-family-base};
     --cc-modal-border-radius: #{$border-radius-base};

--- a/themes/bootstrap3/scss/components/cookie-consent/core/base.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/base.scss
@@ -5,6 +5,7 @@
  */
 
 :root{
+/* #LESS>
     --cc-font-family: $font-family-base;
     --cc-modal-border-radius: $border-radius-base;
     --cc-btn-border-radius: $btn-border-radius-base;
@@ -12,6 +13,16 @@
     --cc-link-color: $link-color;
     --cc-modal-margin: 1rem;
     --cc-z-index: $zindex-cookie-consent;
+/* #LESS>
+/* #SCSS> */
+    --cc-font-family: #{$font-family-base};
+    --cc-modal-border-radius: #{$border-radius-base};
+    --cc-btn-border-radius: #{$btn-border-radius-base};
+    --cc-modal-transition-duration: .25s;
+    --cc-link-color: #{$link-color};
+    --cc-modal-margin: 1rem;
+    --cc-z-index: #{$zindex-cookie-consent};
+/* <#SCSS */
 }
 
 #cc-main {


### PR DESCRIPTION
Sass needs `#{}` around variables to interpolate them for css variables instead of just outputting the values verbatim. This just add conditional blocks, no fancy conversion magic.