### PR TITLE
Combined: Fix scope of search cart form

### DIFF
--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -52,51 +52,51 @@
 ?>
 <?=$this->flashmessages()?>
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>
+<?php $recs = $combinedResults->getRecommendations('top'); ?>
+<?php if (!empty($recs)): ?>
+  <div>
+    <?php foreach ($recs as $current): ?>
+      <?=$this->recommend($current)?>
+    <?php endforeach; ?>
+  </div>
+<?php endif; ?>
+<?php if ($config['Layout']['jump_links'] ?? false): ?>
+  <?=$this->render('combined/jump-links.phtml', ['combinedResults' => $this->combinedResults])?>
+<?php endif; ?>
 <form id="search-cart-form" class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
-  <?php $recs = $combinedResults->getRecommendations('top'); ?>
-  <?php if (!empty($recs)): ?>
-    <div>
-      <?php foreach ($recs as $current): ?>
-        <?=$this->recommend($current)?>
-      <?php endforeach; ?>
-    </div>
-  <?php endif; ?>
-  <?php if ($config['Layout']['jump_links'] ?? false): ?>
-    <?=$this->render('combined/jump-links.phtml', ['combinedResults' => $this->combinedResults])?>
-  <?php endif; ?>
   <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>
-  <?php
-    $viewParams = [
-      'searchClassId' => $searchClassId,
-      'combinedResults' => $this->combinedResults,
-      'supportsCartOptions' => $this->supportsCartOptions,
-      'showCartControls' => $this->showCartControls,
-      'showBulkOptions' => $this->showBulkOptions,
-    ];
-  ?>
-
-  <?php if (!empty($columnSideRecommendations)): ?>
-    <div class="<?=$this->layoutClass('mainbody')?>">
-      <?=$this->context($this)->renderInContext('combined/stack-' . $placement . '.phtml', $viewParams); ?>
-    </div>
-
-    <div class="<?=$this->layoutClass('sidebar')?>" id="search-sidebar">
-      <?php foreach ($columnSideRecommendations as $columnSideRecommendation): ?>
-        <div class="recommendation_container__<?=$columnSideRecommendation?>">
-          <?php // Content is added via JS in results-list.phtml. ?>
-        </div>
-      <?php endforeach; ?>
-    </div>
-  <?php else: ?>
-    <?=$this->context($this)->renderInContext('combined/stack-' . $placement . '.phtml', $viewParams); ?>
-  <?php endif; ?>
-
-  <?php $recs = $combinedResults->getRecommendations('bottom'); ?>
-  <?php if (!empty($recs)): ?>
-    <div>
-      <?php foreach ($recs as $current): ?>
-        <?=$this->recommend($current)?>
-      <?php endforeach; ?>
-    </div>
-  <?php endif; ?>
 </form>
+<?php
+  $viewParams = [
+    'searchClassId' => $searchClassId,
+    'combinedResults' => $this->combinedResults,
+    'supportsCartOptions' => $this->supportsCartOptions,
+    'showCartControls' => $this->showCartControls,
+    'showBulkOptions' => $this->showBulkOptions,
+  ];
+?>
+
+<?php if (!empty($columnSideRecommendations)): ?>
+  <div class="<?=$this->layoutClass('mainbody')?>">
+    <?=$this->context($this)->renderInContext('combined/stack-' . $placement . '.phtml', $viewParams); ?>
+  </div>
+
+  <div class="<?=$this->layoutClass('sidebar')?>" id="search-sidebar">
+    <?php foreach ($columnSideRecommendations as $columnSideRecommendation): ?>
+      <div class="recommendation_container__<?=$columnSideRecommendation?>">
+        <?php // Content is added via JS in results-list.phtml. ?>
+      </div>
+    <?php endforeach; ?>
+  </div>
+<?php else: ?>
+  <?=$this->context($this)->renderInContext('combined/stack-' . $placement . '.phtml', $viewParams); ?>
+<?php endif; ?>
+
+<?php $recs = $combinedResults->getRecommendations('bottom'); ?>
+<?php if (!empty($recs)): ?>
+  <div>
+    <?php foreach ($recs as $current): ?>
+      <?=$this->recommend($current)?>
+    <?php endforeach; ?>
+  </div>
+<?php endif; ?>


### PR DESCRIPTION
In search/results.phtml the form element
`<form id="search-cart-form" ...`
wraps just a single line, the call to render search/bulk-action.buttons.phtml.

In combined/results.phtml, the same form wraps most of the whole file.  It looks like search/results.phtml used to do the same, but was refactored in #802.

This is a problem just now because after #3135 one of the things it wraps is side recommendations, which can include SideFacets.phtml, which can include range-slider.phtml, which defines its own form.  It's invalid HTML to have a form nested within another form, and forces the browser to move the entire sidebar div outside of the search-cart-form.  This in turn messes up the styling assumptions where div.mainbody and div.sidebar are both floated and assumed to be adjacent elements.

This PR changes combined/results.phtml so the form scope mirrors search/results.phtml.