### PR TITLE
Fix deprecation warnings in tests; make PHPUnit more strict.

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" convertDeprecationsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./bootstrap.php" backupGlobals="false" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">../src/VuFind</directory>

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SummonResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SummonResultsTest.php
@@ -56,6 +56,7 @@ class SummonResultsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $configManager = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
+            ->disableOriginalConstructor()
             ->getMock();
         $obj = new SummonResults($runner, $configManager);
         $this->assertSame('Summon', $method->invoke($obj));

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/WebResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/WebResultsTest.php
@@ -56,6 +56,7 @@ class WebResultsTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $configManager = $this->getMockBuilder(\VuFind\Config\PluginManager::class)
+            ->disableOriginalConstructor()
             ->getMock();
         $obj = new WebResults($runner, $configManager);
 


### PR DESCRIPTION
#3192 introduced some deprecation warnings in the test suite, but they were not caught due to the way PHPUnit was configured. This PR fixes the problems and adjusts the configuration to be more strict about deprecations.