### PR TITLE
Fix searchbox_controls init function if textInput or resetButton are not defined

### DIFF
--- a/themes/bootstrap3/js/searchbox_controls.js
+++ b/themes/bootstrap3/js/searchbox_controls.js
@@ -140,12 +140,13 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
 
   function init(){
     _textInput = document.getElementById('searchForm_lookfor');
-    _resetButton = document.getElementById('searchForm-reset');
 
     if (!_textInput) {
       return;
     }
-  
+
+    _resetButton = document.getElementById('searchForm-reset');
+
     _textInput.addEventListener("input", function resetOnInput(event) {
       _handleInputChange(event.target.value, false);
     });
@@ -155,7 +156,6 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
         _handleInputChange('');
       });
     }
-
 
     if (typeof window.SimpleKeyboard !== 'undefined') {
       _initKeyboard();

--- a/themes/bootstrap3/js/searchbox_controls.js
+++ b/themes/bootstrap3/js/searchbox_controls.js
@@ -144,6 +144,10 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
     _textInput = document.getElementById('searchForm_lookfor');
     _resetButton = document.getElementById('searchForm-reset');
 
+    if (!_textInput || !_resetButton) {
+      return;
+    }
+  
     _textInput.addEventListener("input", function resetOnInput(event) {
       _handleInputChange(event.target.value, false);
     });

--- a/themes/bootstrap3/js/searchbox_controls.js
+++ b/themes/bootstrap3/js/searchbox_controls.js
@@ -20,10 +20,8 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
   function _handleInputChange(input, triggerInputEvent = true) {
     _textInput.value = input;
     _textInput.setAttribute('value', input);
-    if (_textInput.value === '') {
-      _resetButton.classList.add('hidden');
-    } else {
-      _resetButton.classList.remove('hidden');
+    if (_resetButton) {
+      _resetButton.classList.toggle('hidden', _textInput.value === '');
     }
     if ( typeof _keyboard !== 'undefined') {
       _keyboard.setInput(input);
@@ -144,7 +142,7 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
     _textInput = document.getElementById('searchForm_lookfor');
     _resetButton = document.getElementById('searchForm-reset');
 
-    if (!_textInput || !_resetButton) {
+    if (!_textInput) {
       return;
     }
   
@@ -152,9 +150,12 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
       _handleInputChange(event.target.value, false);
     });
 
-    _resetButton.addEventListener('click', function resetOnClick() {
-      _handleInputChange('');
-    });
+    if (_resetButton) {
+      _resetButton.addEventListener('click', function resetOnClick() {
+        _handleInputChange('');
+      });
+    }
+
 
     if (typeof window.SimpleKeyboard !== 'undefined') {
       _initKeyboard();


### PR DESCRIPTION
Added a check that both elements are actually present. Seems like advanced search results does not have those.