### PR TITLE
Check exit codes for commands in the browse_build function

### DIFF
--- a/index-alphabetic-browse.bat
+++ b/index-alphabetic-browse.bat
@@ -112,20 +112,24 @@ if "!%3!"=="!1!" goto skipauth
 set args="%bib_index%" "%field%" "%auth_index%" "%browse%.tmp"
 :skipauth
 
-rem Extract lines from Solr
+rem Get the browse headings from Solr
 %JAVA% %jvmopts% -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp %CLASSPATH% PrintBrowseHeadings %args%
 
-rem Sort lines
+rem Sort the browse headings
 sort %browse%.tmp /o sorted-%browse%.tmp /rec 65535
 
 rem Remove duplicate lines
 php %VUFIND_HOME%\util\dedupe.php "sorted-%browse%.tmp" "unique-%browse%.tmp"
 
-rem Build database file
+rem Build the SQLite database
 %JAVA% -Dfile.encoding="UTF-8" -cp %CLASSPATH% CreateBrowseSQLite "unique-%browse%.tmp" "%browse%_browse.db"
 
+rem Clear up temp files
 del /q *.tmp > nul
 
+rem Move the new database to the index directory
 move "%browse%_browse.db" "%index_dir%\%browse%_browse.db-updated" > nul
+
+rem Indicate that the new database is ready for use
 echo OK > "%index_dir%\%browse%_browse.db-ready"
 :end

--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -85,19 +85,48 @@ function build_browse
 
     extra_jvm_opts=$4
 
+    # Get the browse headings
     if [ "$skip_authority" = "1" ]; then
-        $JAVA ${extra_jvm_opts} -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp $CLASSPATH PrintBrowseHeadings "$bib_index" "$field" "${browse}.tmp"
+        if ! output=$($JAVA ${extra_jvm_opts} -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp $CLASSPATH PrintBrowseHeadings "$bib_index" "$field" "${browse}.tmp" 2>&1); then
+            echo "ERROR: Failed to create browse headings for ${browse}. ${output}."
+            exit 1
+        fi
     else
-        $JAVA ${extra_jvm_opts} -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp $CLASSPATH PrintBrowseHeadings "$bib_index" "$field" "$auth_index" "${browse}.tmp"
+        if ! output=$($JAVA ${extra_jvm_opts} -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp $CLASSPATH PrintBrowseHeadings "$bib_index" "$field" "$auth_index" "${browse}.tmp" 2>&1); then
+            echo "ERROR: Failed to create browse headings for ${browse}. ${output}."
+            exit 1
+        fi
     fi
 
-    sort -T /var/tmp -u -t$'\1' -k1 "${browse}.tmp" -o "sorted-${browse}.tmp"
-    $JAVA -Dfile.encoding="UTF-8" -cp $CLASSPATH CreateBrowseSQLite "sorted-${browse}.tmp" "${browse}_browse.db"
+    # Sort the browse headings
+    if ! output=$(sort -T /var/tmp -u -t$'\1' -k1 "${browse}.tmp" -o "sorted-${browse}.tmp" 2>&1); then
+        echo "ERROR: Failed to sort ${browse}. ${output}."
+        exit 1
+    fi
 
-    rm -f *.tmp
+    # Build the SQLite database
+    if ! output=$($JAVA -Dfile.encoding="UTF-8" -cp $CLASSPATH CreateBrowseSQLite "sorted-${browse}.tmp" "${browse}_browse.db" 2>&1); then
+        echo "ERROR: Failed to build the SQLite database for ${browse}. ${output}."
+        exit 1
+    fi
 
-    mv "${browse}_browse.db" "$index_dir/${browse}_browse.db-updated"
-    touch "$index_dir/${browse}_browse.db-ready"
+    # Clear up temp files
+    if ! output=$(rm -f *.tmp 2>&1); then
+        echo "ERROR: Failed to clear out temp files for ${browse}. ${output}."
+        exit 1
+    fi
+
+    # Move the new database to the index directory
+    if ! output=$(mv "${browse}_browse.db" "$index_dir/${browse}_browse.db-updated" 2>&1); then
+        echo "ERROR: Failed to move ${browse}_browse.db database to ${index_dir}/${browse}_browse.db-updated. ${output}."
+        exit 1
+    fi
+
+    # Indicate that the new database is ready for use
+    if ! output=$(touch "$index_dir/${browse}_browse.db-ready" 2>&1); then
+        echo "ERROR: Failed to mark the new ${browse} database as ready for use. ${error}."
+        exit 1
+    fi
 }
 # These parameters should match the ones in solr/vufind/biblio/conf/solrconfig.xml - BrowseRequestHandler
 build_browse "hierarchy" "hierarchy_browse"

--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -85,7 +85,7 @@ function build_browse
 
     extra_jvm_opts=$4
 
-    # Get the browse headings
+    # Get the browse headings from Solr
     if [ "$skip_authority" = "1" ]; then
         if ! output=$($JAVA ${extra_jvm_opts} -Dfile.encoding="UTF-8" -Dfield.preferred=heading -Dfield.insteadof=use_for -cp $CLASSPATH PrintBrowseHeadings "$bib_index" "$field" "${browse}.tmp" 2>&1); then
             echo "ERROR: Failed to create browse headings for ${browse}. ${output}."


### PR DESCRIPTION
We had noticed that it was possibly for the `sort` command in the `browse_build` function in the `index-alphabetic-browse.sh` script to fail, but since it was not checking the exit code of that `sort` command, it was improperly returning an exit code of zero. Instead of just adding the check for that command I thought it wouldn't hurt to have the exit code check on all the commands in that `browse_build` function.

This is particularly useful for us because we have a wrapper script around `index-alphabetic-browse.sh` that will alert us when there are failures (i.e. the script exits with a non-zero exit code).