### PR TITLE
Databases: Use LibGuides alternate names field

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -368,6 +368,10 @@ AU = None
 ; Requires configuration in LibGuidesAPI.ini. 
 ;useLibGuides = true
 
+; Find database URLs by the LibGuides alternate names field in addition
+; to the primary name. Default is true. Requires useLibGuides = true. 
+;useLibGuidesAlternateNames = false
+
 ; Map of database name (matching EDS API 'DbLabel' value) to website URL.
 ; These databases are added to any retrieved from LibGuides, and override
 ; the LibGuides URLs if the same name is present here.

--- a/module/VuFind/src/VuFind/Connection/LibGuides.php
+++ b/module/VuFind/src/VuFind/Connection/LibGuides.php
@@ -150,7 +150,7 @@ class LibGuides implements
         }
 
         $result = $this->doGet(
-            $this->baseUrl . '/az'
+            $this->baseUrl . '/az?expand=az_props'
         );
 
         if (isset($result->errorCode)) {

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -332,6 +332,7 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
             $nameToDatabase = [];
             foreach ($databases as $database) {
                 $nameToDatabase[$database->name] = (array)$database;
+                // The alt_names field is single-valued free text
                 if ($this->useLibGuidesAlternateNames && ($database->alt_names ?? false)) {
                     $nameToDatabase[$database->alt_names] = (array)$database;
                 }

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -172,8 +172,8 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
         if (!$databasesConfig) {
             throw new \Exception("Databases config file $databasesConfigFile must have section 'Databases'.");
         }
-        $this->configFileDatabases = isset($databasesConfig->url) ? $databasesConfig->url->toArray()
-            : $this->configFileDatabases;
+        $this->configFileDatabases = $databasesConfig->url?->toArray()
+            ?? $this->configFileDatabases;
         array_walk($this->configFileDatabases, function (&$value, $name) {
             $value = [
                 'name' => $name,
@@ -181,8 +181,7 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
             ];
         });
 
-        $this->resultFacet = isset($databasesConfig->resultFacet)
-            ? $databasesConfig->resultFacet->toArray() : $this->resultFacet;
+        $this->resultFacet = $databasesConfig->resultFacet?->toArray() ?? $this->resultFacet;
         $this->resultFacetNameKey = $databasesConfig->resultFacetNameKey
             ?? $this->resultFacetNameKey;
 

--- a/themes/bootstrap3/templates/Recommend/Databases.phtml
+++ b/themes/bootstrap3/templates/Recommend/Databases.phtml
@@ -6,12 +6,12 @@
       <p><?=$this->transEsc('databases_recommend_intro')?></p>
     <?php endif; ?>
     <div class="list-group">
-      <?php foreach ($databases as $name => $database): ?>
+      <?php foreach ($databases as $database): ?>
         <div class="list-group-item">
           <span>
             <a href="<?=$this->escapeHtmlAttr($this->proxyUrl($database['url']))?>" class="title icon-link" target="_blank">
               <?=$this->icon('external-link', 'icon-link__icon') ?>
-              <span class="icon-link__label"><?=$this->escapeHtml($name)?></span>
+              <span class="icon-link__label"><?=$this->escapeHtml($database['name'])?></span>
             </a>
           </span>
         </div>


### PR DESCRIPTION
LibGuides AZ has an "alternate names" field described as

> Alternate names associated with the database. If a user searches for these words, this database will appear in the results.

If the LibGuides option is enabled for the Databases recommendation module, we should (by default) search for URLs against the alternate names in addition to the primary name.

An example we ran into locally is Oxford Music Online often referred to as Grove Music Online by long-time researchers.  So both "Oxford" and "Grove" should match that database URL.