### PR TITLE
Disable null overrides in RecordDataFormatter options

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter.php
@@ -281,19 +281,28 @@ class RecordDataFormatter extends AbstractHelper
     protected function addOptions($context, $field, $options)
     {
         if ($globalOptions = ($this->config->Global ?? false)) {
+            $options = array_filter($options, function ($val) {
+                return $val !== null;
+            });
             $options = array_merge($globalOptions->toArray(), $options);
         }
 
         $section = 'Field_' . $field;
         if ($fieldOptions = ($this->config->$section ?? false)) {
-            $options = array_merge($options, $fieldOptions->toArray());
+            $fieldOptions = array_filter($fieldOptions->toArray(), function ($val) {
+                return $val !== null;
+            });
+            $options = array_merge($options, $fieldOptions);
         }
 
         $contextSection = $options['overrideContext'][$context] ?? false;
         if (
             $contextOptions = $this->config->$contextSection ?? false
         ) {
-            $options = array_merge($options, $contextOptions->toArray());
+            $contextOptions = array_filter($contextOptions->toArray(), function ($val) {
+                return $val !== null;
+            });
+            $options = array_merge($options, $contextOptions);
         }
 
         return $options;


### PR DESCRIPTION
In the RecordDataFormatter's `addOptions` method options from different sources get merged. Currently, if null values are set they also override other options. This means that for example if you change `renderType` in the `[Global]` section of the config it is not applied when you have something like the following.
```
$spec->setLine(
          'New Title',
          'getNewerTitles',
          null,
          ['recordLink' => 'title']
);
```
Therefore, null values get filtered before merging the options now.