### PR TITLE
Removed prioritizeAlt default from SpecBuilder

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\View\Helper\Root\RecordDataFormatter;
 
-use function array_key_exists;
-
 /**
  * Specification builder for record driver data formatting view helper
  *
@@ -55,11 +53,6 @@ class SpecBuilder
      * @var int
      */
     protected $maxPos = 0;
-
-    /**
-     * If alternative script should be prioritized by combine alt render method
-     */
-    protected $defaultPrioritizeAlt = false;
 
     /**
      * Constructor
@@ -124,10 +117,6 @@ class SpecBuilder
      */
     public function setCombineAltLine($key, $dataMethod, $options = [])
     {
-
-        if ($this->defaultPrioritizeAlt && !array_key_exists('prioritizeAlt', $options)) {
-            $options['prioritizeAlt'] = true;
-        }
         $this->setLine($key, $dataMethod, 'CombineAlt', $options);
     }
 
@@ -145,18 +134,6 @@ class SpecBuilder
     {
         $options['template'] = $template;
         $this->setLine($key, $dataMethod, 'RecordDriverTemplate', $options);
-    }
-
-    /**
-     * Set default prioritize alternative scripts
-     *
-     * @param bool $defaultPeferAlt Default prioritize alt
-     *
-     * @return void
-     */
-    public function setDefaultPrioritizeAlt($defaultPeferAlt)
-    {
-        $this->defaultPrioritizeAlt = $defaultPeferAlt;
     }
 
     /**


### PR DESCRIPTION
Now, that there are configurable defaults we don't need this anymore to set the default for the prioritizeAlt option.
