### PR TITLE
EPF: Add embargo description

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/EPF/result-list/full-text-links.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/result-list/full-text-links.phtml
@@ -7,7 +7,10 @@ if (isset($holdings) && !empty($holdings)): ?>
         if (!empty($holding)): ?>
           <li>
             <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>"><?=$this->escapeHtml($holding['Name'])?></a>
-            <?=$this->escapeHtml($holding['CoverageStatement'])?>
+            <span class="coverage-statement"><?=$this->escapeHtml($holding['CoverageStatement'])?></span>
+            <?php if (!empty($holding['EmbargoDescription'])): ?>
+              <span class="embargo-description">(<?=$this->escapeHtml($holding['EmbargoDescription'])?>)</span>
+            <?php endif; ?>
           </li>
         <?php endif;
       endforeach; ?>


### PR DESCRIPTION
For EBSCO Publication Finder results, each holding's coverage statement should also display any related embargo.  See "Business Source Complete" example:

![image](https://github.com/vufind-org/vufind/assets/31278545/813db26b-00dd-49db-85c9-542313b4636a)

This formatting (the entire holding info in a single line) mirrors what the native EPF UI does.  However I added two classes in case someone wants to add local CSS to format it.  Similarly someone could hide it with `display: none;` if they really want to.