### PR TITLE
Sierra: Fix batch retrieval of items and bibs.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -3282,6 +3282,7 @@ class SierraRest extends AbstractBase implements
             [
                 'id' => implode(',', $itemIds),
                 'fields' => 'bibIds,varFields',
+                'limit' => count($itemIds),
             ],
             'GET',
             $patron
@@ -3302,6 +3303,7 @@ class SierraRest extends AbstractBase implements
             [
                 'id' => implode(',', array_keys($bibIdsToItems)),
                 'fields' => 'title,publishYear',
+                'limit' => count($bibIdsToItems),
             ],
             'GET',
             $patron

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -36,6 +36,7 @@ use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFindHttp\HttpServiceAwareInterface;
 
 use function call_user_func_array;
+use function count;
 use function func_get_args;
 use function in_array;
 use function intval;


### PR DESCRIPTION
Turns out Sierra will limit results to 50 records by default even if you ask for a set of identifiers. This will override the default limit with the number of identifiers requested. There'll be another PR to further tweak the mechanism so this is a minimal one to fix the issue.