### PR TITLE
Disabled session writes for Ajax tabs and getResultCount

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetResultCount.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResultCount.php
@@ -34,6 +34,7 @@ namespace VuFind\AjaxHandler;
 use Laminas\Mvc\Controller\Plugin\Params;
 use Laminas\Stdlib\Parameters;
 use VuFind\Search\Results\PluginManager as ResultsManager;
+use VuFind\Session\Settings as SessionSettings;
 
 /**
  * "Get Result Counts" AJAX Handler
@@ -57,11 +58,13 @@ class GetResultCount extends AbstractBase
     /**
      * Constructor
      *
-     * @param ResultsManager $resultsManager Results Manager
+     * @param ResultsManager  $resultsManager Results Manager
+     * @param SessionSettings $ss             Session settings
      */
-    public function __construct(ResultsManager $resultsManager)
+    public function __construct(ResultsManager $resultsManager, SessionSettings $ss)
     {
         $this->resultsManager = $resultsManager;
+        $this->sessionSettings = $ss;
     }
 
     /**
@@ -73,6 +76,7 @@ class GetResultCount extends AbstractBase
      */
     public function handleRequest(Params $params)
     {
+        $this->disableSessionWrites();
         $queryString = $params->fromQuery('querystring');
         parse_str(parse_url($queryString, PHP_URL_QUERY), $searchParams);
 

--- a/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
@@ -67,7 +67,8 @@ class GetResultCountFactory implements \Laminas\ServiceManager\Factory\FactoryIn
             throw new \Exception('Unexpected options passed to factory.');
         }
         return new $requestedName(
-            $container->get(\VuFind\Search\Results\PluginManager::class)
+            $container->get(\VuFind\Search\Results\PluginManager::class),
+            $container->get(\VuFind\Session\Settings::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -378,6 +378,7 @@ class AbstractRecord extends AbstractBase
      */
     public function ajaxtabAction()
     {
+        $this->disableSessionWrites();
         $this->loadRecord();
         // Set layout to render content only:
         $this->layout()->setTemplate('layout/lightbox');


### PR DESCRIPTION
As discussed in #2941 enabling `loadInitialTabWithAjax` or `show_result_counts` in the config.ini can lead to session conflicts when also using SSO login for bulk actions. This PR fixes this by disabling session writes for these Ajax calls.