### PR TITLE
FOLIO: Fix getStatus() after getHolding() change

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -435,7 +435,8 @@ class Folio extends AbstractAPI implements
      */
     public function getStatus($itemId)
     {
-        return $this->getHolding($itemId);
+        $holding = $this->getHolding($itemId);
+        return $holding['holdings'] ?? [];
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -806,8 +806,10 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $driverConfig = $this->defaultDriverConfig;
         $driverConfig['IDs']['type'] = 'hrid';
         $this->createConnector('get-holding', $driverConfig);
-        $this->assertEquals([$this->getExpectedGetHoldingResult()['holdings']],
-            $this->driver->getStatuses(['foo']));
+        $this->assertEquals(
+            [$this->getExpectedGetHoldingResult()['holdings']],
+            $this->driver->getStatuses(['foo'])
+        );
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -806,7 +806,8 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $driverConfig = $this->defaultDriverConfig;
         $driverConfig['IDs']['type'] = 'hrid';
         $this->createConnector('get-holding', $driverConfig);
-        $this->assertEquals([$this->getExpectedGetHoldingResult()], $this->driver->getStatuses(['foo']));
+        $this->assertEquals([$this->getExpectedGetHoldingResult()['holdings']],
+            $this->driver->getStatuses(['foo']));
     }
 
     /**


### PR DESCRIPTION
In #3094 I changed the FOLIO driver getHolding() function to return an array instead of just $items.  Holds.php is fine either way but I didn't notice that getStatus() is picky and still expects just $items.  This broke the availability check in GetItemStatuses.