### PR TITLE
Fix filtered facet pagination

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/HideFacetValueListener.php
+++ b/module/VuFind/src/VuFind/Search/Base/HideFacetValueListener.php
@@ -34,6 +34,8 @@ use Laminas\EventManager\SharedEventManagerInterface;
 use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\Service;
 
+use function is_callable;
+
 /**
  * Hide single facet values from displaying.
  *

--- a/module/VuFind/src/VuFind/Search/Base/HideFacetValueListener.php
+++ b/module/VuFind/src/VuFind/Search/Base/HideFacetValueListener.php
@@ -139,10 +139,14 @@ class HideFacetValueListener
         }
         $facets = $result->getFacets();
 
+        // Count how many values have been filtered as we go:
+        $filteredFacetCounts = [];
+
         foreach ($this->hideFacets as $facet => $values) {
             foreach ((array)$values as $value) {
                 if (isset($facets[$facet][$value])) {
                     unset($facets[$facet][$value]);
+                    $filteredFacetCounts[$facet] = ($filteredFacetCounts[$facet] ?? 0) + 1;
                 }
             }
         }
@@ -155,9 +159,15 @@ class HideFacetValueListener
                 foreach ($valuesToHide as $valueToHide) {
                     if (isset($facets[$facet][$valueToHide])) {
                         unset($facets[$facet][$valueToHide]);
+                        $filteredFacetCounts[$facet] = ($filteredFacetCounts[$facet] ?? 0) + 1;
                     }
                 }
             }
+        }
+
+        // If the result object is capable of receiving filter counts, send the data:
+        if (is_callable([$result, 'setFilteredFacetCounts'])) {
+            $result->setFilteredFacetCounts($filteredFacetCounts);
         }
 
         $result->setFacets($facets);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -31,6 +31,8 @@
 
 namespace VuFindTest\Mink;
 
+use Behat\Mink\Element\Element;
+
 use function count;
 
 /**
@@ -98,9 +100,9 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Get filtered search
      *
-     * @return \Behat\Mink\Element\Element
+     * @return Element
      */
-    protected function getFilteredSearch()
+    protected function getFilteredSearch(): Element
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Results?filter%5B%5D=building%3A"weird_ids.mrc"');
@@ -110,11 +112,11 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Helper function for simple facet application test
      *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * @param Element $page Mink page object
      *
      * @return void
      */
-    protected function facetApplyProcedure($page)
+    protected function facetApplyProcedure(Element $page): void
     {
         // Confirm that we have 9 results and no filters to begin with:
         $time = $this->findCss($page, '.search-query-time');
@@ -146,13 +148,13 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Helper function for facets lists
      *
-     * @param \Behat\Mink\Element\Element $page            Mink page object
-     * @param int                         $limit           Configured lightbox length
-     * @param bool                        $exclusionActive Is facet exclusion on?
+     * @param Element $page            Mink page object
+     * @param int     $limit           Configured lightbox length
+     * @param bool    $exclusionActive Is facet exclusion on?
      *
      * @return void
      */
-    protected function facetListProcedure($page, $limit, $exclusionActive = false)
+    protected function facetListProcedure(Element $page, int $limit, bool $exclusionActive = false): void
     {
         $this->waitForPageLoad($page);
         $items = $page->findAll('css', '#modal #facet-list-count .js-facet-item');
@@ -220,7 +222,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testApplyFacet()
+    public function testApplyFacet(): void
     {
         $page = $this->performSearch('building:weird_ids.mrc');
 
@@ -237,7 +239,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testApplyFacetDeferred()
+    public function testApplyFacetDeferred(): void
     {
         $this->changeConfigs(
             [
@@ -263,7 +265,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testFacetLightbox()
+    public function testFacetLightbox(): void
     {
         $limit = 4;
         $this->changeConfigs(
@@ -292,7 +294,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testFacetLightboxMoreSetting()
+    public function testFacetLightboxMoreSetting(): void
     {
         $limit = 4;
         $this->changeConfigs(
@@ -322,7 +324,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testFacetLightboxExclusion()
+    public function testFacetLightboxExclusion(): void
     {
         $limit = 4;
         $this->changeConfigs(
@@ -344,13 +346,60 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Support method to click a hierarchical facet.
-     *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * Test that filtering out facet values does not break lightbox pagination.
      *
      * @return void
      */
-    protected function clickHierarchyFacet($page)
+    public function testFilteredLightboxPagination(): void
+    {
+        $limit = 4;
+        $this->changeConfigs(
+            [
+                'facets' => [
+                    'HideFacetValue' => [
+                        'genre_facet' => [
+                            'Fiction',
+                        ],
+                    ],
+                    'Results_Settings' => [
+                        'showMoreInLightbox[*]' => true,
+                        'lightboxLimit' => $limit,
+                    ],
+                ],
+            ]
+        );
+        $page = $this->performSearch('building:weird_ids.mrc');
+        // Open the genre facet
+        $this->clickCss($page, '#side-collapse-genre_facet .more-facets');
+        $this->waitForPageLoad($page);
+        $items = $page->findAll('css', '#modal #facet-list-count .js-facet-item');
+        $this->assertCount($limit - 1, $items); // (-1 is for the filtered value)
+        // more
+        $this->clickCss($page, '#modal .js-facet-next-page');
+        $this->waitForPageLoad($page);
+        $items = $page->findAll('css', '#modal #facet-list-count .js-facet-item');
+        $this->assertEquals($limit * 2 - 1, count($items));
+        $this->assertEquals(
+            'Weird IDs 9 results 9 '
+            . 'The Study Of P|pes 1 results 1 '
+            . 'The Study and Scor_ng of Dots.and-Dashes:Colons 1 results 1 '
+            . 'The Study of "Important" Things 1 results 1 '
+            . 'The Study of %\'s? 1 results 1 '
+            . 'The Study of +\'s? 1 results 1 '
+            . 'The Study of @Twitter #test 1 results 1 '
+            . 'more…',
+            $this->findCss($page, '#modal #facet-list-count')->getText()
+        );
+    }
+
+    /**
+     * Support method to click a hierarchical facet.
+     *
+     * @param Element $page Mink page object
+     *
+     * @return void
+     */
+    protected function clickHierarchyFacet(Element $page): void
     {
         // Open second level:
         $this->clickCss($page, $this->facetExpandSelector);
@@ -372,7 +421,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testHierarchicalFacets()
+    public function testHierarchicalFacets(): void
     {
         $this->changeConfigs(
             [
@@ -395,7 +444,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testHierarchicalFacetExclude()
+    public function testHierarchicalFacetExclude(): void
     {
         $this->changeConfigs(
             [
@@ -440,7 +489,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testCollapseStatePersistence()
+    public function testCollapseStatePersistence(): void
     {
         $this->changeConfigs(
             [
@@ -476,11 +525,11 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Assert that the filter used by these tests is still applied.
      *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * @param Element $page Mink page object
      *
      * @return void
      */
-    protected function assertFilterIsStillThere($page)
+    protected function assertFilterIsStillThere(Element $page): void
     {
         $filter = $this->findCss($page, $this->activeFilterSelector);
         $this->assertEquals('Remove Filter weird_ids.mrc', $filter->getText());
@@ -489,11 +538,11 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Assert that no filters are applied.
      *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * @param Element $page Mink page object
      *
      * @return void
      */
-    protected function assertNoFilters($page)
+    protected function assertNoFilters(Element $page): void
     {
         $items = $page->findAll('css', $this->activeFilterSelector);
         $this->assertCount(0, $items);
@@ -502,11 +551,11 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Assert that the "reset filters" button is not present.
      *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * @param Element $page Mink page object
      *
      * @return void
      */
-    protected function assertNoResetFiltersButton($page)
+    protected function assertNoResetFiltersButton(Element $page): void
     {
         $reset = $page->findAll('css', '.reset-filters-btn');
         $this->assertCount(0, $reset);
@@ -517,7 +566,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testDefaultRetainFiltersBehavior()
+    public function testDefaultRetainFiltersBehavior(): void
     {
         $page = $this->getFilteredSearch();
         $this->assertFilterIsStillThere($page);
@@ -536,7 +585,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testRetainFiltersOnHomePageBehavior()
+    public function testRetainFiltersOnHomePageBehavior(): void
     {
         $page = $this->getFilteredSearch();
         // Back to home spage:
@@ -555,7 +604,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testFiltersOnRecord()
+    public function testFiltersOnRecord(): void
     {
         $page = $this->getFilteredSearch();
         $this->assertFilterIsStillThere($page);
@@ -574,7 +623,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testNeverRetainFiltersBehavior()
+    public function testNeverRetainFiltersBehavior(): void
     {
         $this->changeConfigs(
             [
@@ -597,7 +646,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testDefaultFiltersWithResetButton()
+    public function testDefaultFiltersWithResetButton(): void
     {
         // Unlike the other tests, which use $this->getFilteredSearch() to set up
         // the weird_ids.mrc filter through a URL parameter, this test sets up the
@@ -636,7 +685,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testOrFacets()
+    public function testOrFacets(): void
     {
         $this->changeConfigs(
             [

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
@@ -80,6 +80,13 @@ class RecordCollection extends AbstractRecordCollection
     protected $facetFields = null;
 
     /**
+     * How many facet values have been filtered out, indexed by field.
+     *
+     * @var array
+     */
+    protected $filteredFacetCounts = [];
+
+    /**
      * Constructor.
      *
      * @param array $response Deserialized SOLR response
@@ -147,6 +154,28 @@ class RecordCollection extends AbstractRecordCollection
             }
         }
         return $this->facetFields;
+    }
+
+    /**
+     * Set filtered facet data.
+     *
+     * @param array $counts Counts of filtered facet values, indexed by field name.
+     *
+     * @return void
+     */
+    public function setFilteredFacetCounts(array $counts): void
+    {
+        $this->filteredFacetCounts = $counts;
+    }
+
+    /**
+     * Get filtered facet data.
+     *
+     * @return array
+     */
+    public function getFilteredFacetCounts(): array
+    {
+        return $this->filteredFacetCounts;
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where applying a facet value filter breaks pagination in the facet lightbox. It also includes a Mink test to cover the problem scenario.