### PR TITLE
Enclose search history label in span to avoid collapsing of white space.

### DIFF
--- a/themes/bootstrap3/templates/search/history-table.phtml
+++ b/themes/bootstrap3/templates/search/history-table.phtml
@@ -18,11 +18,13 @@
       <tr class="<?=$iteration % 2 == 1 ? 'even' : 'odd'?>row">
         <td class="history_time" data-label="<?=$this->transEscAttr('history_time')?>"><?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('U', $info->getStartTime()))?></td>
         <td class="history_search" data-label="<?=$this->transEscAttr('history_search')?>">
-          <?=$this->historylabel($info->getParams()->getSearchClassId())?>
-          <a href="<?=$this->url($info->getOptions()->getSearchAction()) . $info->getUrlQuery()->getParams()?>"><?php
-            $desc = $info->getParams()->getDisplayQuery();
-            echo empty($desc) ? $this->transEsc('history_empty_search') : $this->escapeHtml($desc);
-          ?></a>
+          <span>
+            <?=$this->historylabel($info->getParams()->getSearchClassId())?>
+            <a href="<?=$this->url($info->getOptions()->getSearchAction()) . $info->getUrlQuery()->getParams()?>"><?php
+              $desc = $info->getParams()->getDisplayQuery();
+              echo empty($desc) ? $this->transEsc('history_empty_search') : $this->escapeHtml($desc);
+            ?></a>
+          </span>
         </td>
         <td class="history_limits" data-label="<?=$this->transEscAttr('history_limits')?>">
           <span class="history_limits_field">


### PR DESCRIPTION
Otherwise the history labels and search terms would lose the white space between them on narrow screens.