### PR TITLE
add list element around collections-bytitle and oai-home breadcrumbs

### DIFF
--- a/themes/bootstrap3/templates/collections/bytitle.phtml
+++ b/themes/bootstrap3/templates/collections/bytitle.phtml
@@ -1,4 +1,4 @@
-<?php $this->layout()->breadcrumbs = '<a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a>'; ?>
+<?php $this->layout()->breadcrumbs = '<li><a href="' . $this->url('collections-home') . '">' . $this->transEsc('Collections') . '</a></li>'; ?>
 <div id="bd">
   <div id="yui-main" class="content">
     <div class="disambiguationDiv" >

--- a/themes/bootstrap3/templates/oai/home.phtml
+++ b/themes/bootstrap3/templates/oai/home.phtml
@@ -1,6 +1,6 @@
 <?php
   $this->headTitle($this->translate('OAI Server'));
-  $this->layout()->breadcrumbs = $this->transEsc('OAI Server');
+  $this->layout()->breadcrumbs = '<li>' . $this->transEsc('OAI Server') . '</li>';
   $baseUrl = $this->url('oai-server');
 ?>
 <div class="<?=$this->layoutClass('mainbody')?>">


### PR DESCRIPTION
In templates `collections/bytitle.phtml` and `oai/home.phtml` are missing the `<li>`-elements around the **breadcrumbs**. 
This PR is adding them.