### PR TITLE
Doi.js: Revert selector target to its previous form

### DIFF
--- a/themes/bootstrap3/js/doi.js
+++ b/themes/bootstrap3/js/doi.js
@@ -67,7 +67,7 @@ VuFind.register('doi', function Doi() {
       VuFind.observerManager.createIntersectionObserver(
         'doiLinks',
         embedDoiLinks,
-        Array.from(container.querySelectorAll('.ajaxItem'))
+        Array.from(container.querySelectorAll('.doiLink'))
       );
     }
   }


### PR DESCRIPTION
Seems like this has accidentally changed when hunt was removed? Or if there is some other reason for the change then im happy to adjust the logic to suit more cases.