### PR TITLE
Fix handling of hierarchical facet sort settings.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -232,6 +232,13 @@ abstract class Options implements TranslatorAwareInterface
     protected $hierarchicalFacetSeparators = [];
 
     /**
+     * Hierarchical facet sort settings
+     *
+     * @var array
+     */
+    protected $hierarchicalFacetSortSettings = [];
+
+    /**
      * Spelling setting
      *
      * @var bool
@@ -806,6 +813,16 @@ abstract class Options implements TranslatorAwareInterface
     public function getHierarchicalFacetSeparators()
     {
         return $this->hierarchicalFacetSeparators;
+    }
+
+    /**
+     * Get hierarchical facet sort settings.
+     *
+     * @return array
+     */
+    public function getHierarchicalFacetSortSettings()
+    {
+        return $this->hierarchicalFacetSortSettings;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/Options.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Options.php
@@ -190,11 +190,12 @@ class Options extends \VuFind\Search\Base\Options
             $this->hierarchicalFacets
                 = $facetSettings->SpecialFacets->hierarchical->toArray();
         }
-
         if (isset($facetSettings->SpecialFacets->hierarchicalFacetSeparators)) {
             $this->hierarchicalFacetSeparators = $facetSettings->SpecialFacets
                 ->hierarchicalFacetSeparators->toArray();
         }
+        $this->hierarchicalFacetSortSettings
+            = $facetSettings?->SpecialFacets?->hierarchicalFacetSortOptions?->toArray() ?? [];
 
         // Load Spelling preferences
         $config = $configLoader->get($this->mainIni);


### PR DESCRIPTION
`VuFind\Search\Base\Results::buildFacetList()` was trying to get settings from Options, but I failed to implement the method for that in #3046.