### PR TITLE
Fix default sort of hierarchical facets and add tests.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -536,7 +536,7 @@
       </then>
     </if>
 
-    <!-- Add a local translation for tests -->
+    <!-- Add local translations for tests -->
     <if>
       <not>
         <available file="${localdir}/languages" type="dir" />
@@ -545,7 +545,19 @@
         <mkdir dir="${localdir}/languages" />
       </then>
     </if>
+    <if>
+      <not>
+        <available file="${localdir}/languages/Facets" type="dir" />
+      </not>
+      <then>
+        <mkdir dir="${localdir}/languages/Facets" />
+      </then>
+    </if>
     <append destFile="${localdir}/languages/en.ini" text="location_main = Main Library${line.separator}" />
+    <append destFile="${localdir}/languages/Facets/en.ini" text="0/level1a/ = Top Level, Sorted Last${line.separator}" />
+    <append destFile="${localdir}/languages/Facets/en.ini" text="0/level1z/ = Top Level, Sorted First${line.separator}" />
+    <append destFile="${localdir}/languages/Facets/en.ini" text="1/level1z/level2y/ = Second Level, Sorted Last${line.separator}" />
+    <append destFile="${localdir}/languages/Facets/en.ini" text="1/level1z/level2z/ = Second Level, Sorted First${line.separator}" />
   </target>
 
   <target name="setup_database" description="setup demo database">
@@ -768,7 +780,7 @@ ${git_status}
     </delete>
     <delete>
       <fileset dir="${localdir}/languages">
-        <include name="*" />
+        <include name="**/*" />
       </fileset>
     </delete>
     <delete file="${srcdir}/env.bat" />

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -890,7 +890,7 @@ abstract class Results
 
             if ($hierarchical) {
                 $sort = $hierarchicalFacetSortSettings[$field]
-                    ?? $hierarchicalFacetSortSettings['*'] ?? 'top';
+                    ?? $hierarchicalFacetSortSettings['*'] ?? 'count';
                 $this->hierarchicalFacetHelper->sortFacetList($resultList, $sort);
 
                 $resultList

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -507,6 +507,126 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Data provider for testHierarchicalFacetSort
+     *
+     * @return array
+     */
+    public function hierarchicalFacetSortProvider(): array
+    {
+        return [
+            [
+                null,
+                [
+                    [
+                        'value' => 'Top Level, Sorted Last',
+                        'children' => [
+                            'level2a',
+                            'level2b',
+                        ],
+                    ],
+                    [
+                        'value' => 'Top Level, Sorted First',
+                        'children' => [
+                            'Second Level, Sorted Last',
+                            'Second Level, Sorted First',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'top',
+                [
+                    [
+                        'value' => 'Top Level, Sorted First',
+                        'children' => [
+                            'Second Level, Sorted Last',
+                            'Second Level, Sorted First',
+                        ],
+                    ],
+                    [
+                        'value' => 'Top Level, Sorted Last',
+                        'children' => [
+                            'level2a',
+                            'level2b',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'all',
+                [
+                    [
+                        'value' => 'Top Level, Sorted First',
+                        'children' => [
+                            'Second Level, Sorted First',
+                            'Second Level, Sorted Last',
+                        ],
+                    ],
+                    [
+                        'value' => 'Top Level, Sorted Last',
+                        'children' => [
+                            'level2a',
+                            'level2b',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test that hierarchical facet sort options work properly.
+     *
+     * @param ?string $sort     Sort option
+     * @param array   $expected Expected facet values in order
+     *
+     * @dataProvider hierarchicalFacetSortProvider
+     *
+     * @return void
+     */
+    public function testHierarchicalFacetSort(?string $sort, array $expected): void
+    {
+        $facetConfig = [
+            'Results' => [
+                'hierarchical_facet_str_mv' => 'hierarchy',
+            ],
+            'SpecialFacets' => [
+                'hierarchical[]' => 'hierarchical_facet_str_mv',
+            ],
+            'Advanced_Settings' => [
+                'translated_facets[]' => 'hierarchical_facet_str_mv:Facets',
+            ],
+        ];
+        if (null !== $sort) {
+            $facetConfig['SpecialFacets']['hierarchicalFacetSortOptions[hierarchical_facet_str_mv]'] = $sort;
+        }
+        $this->changeConfigs(
+            [
+                'facets' => $facetConfig,
+            ]
+        );
+        $page = $this->performSearch('building:"hierarchy.mrc"');
+        foreach ($expected as $index => $facet) {
+            $topLi = $this->findCss($page, '#side-collapse-hierarchical_facet_str_mv ul.facet-tree > li', null, $index);
+            $item = $this->findCss($topLi, '.facet-value');
+            $this->assertEquals(
+                $facet['value'],
+                $item->getText(),
+                "Hierarchical facet item $index"
+            );
+            foreach ($facet['children'] as $childIndex => $childFacet) {
+                $childLi = $this->findCss($topLi, 'ul > li.facet-tree__parent', null, $childIndex);
+                $childItem = $this->findCss($childLi, '.facet-value');
+                $this->assertEquals(
+                    $childFacet,
+                    $childItem->getText(),
+                    "Hierarchical facet item $index child $childIndex"
+                );
+            }
+        }
+    }
+
+    /**
      * Test that we can persist uncollapsed state of collapsed facets
      *
      * @return void

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ResultsTest.php
@@ -70,6 +70,9 @@ class ResultsTest extends \PHPUnit\Framework\TestCase
                 'hierarchical' => [
                     'building',
                 ],
+                'hierarchicalFacetSortOptions' => [
+                    'building' => 'top',
+                ],
             ],
         ],
     ];


### PR DESCRIPTION
Another fix for sorting of hierarchical facets. The default sort was accidentally set to 'top' instead of 'count' as it used to be and as documented in facets.ini. This fixes it and adds Mink tests.