### PR TITLE
Summon: throw exception if record not found

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Backend.php
@@ -32,6 +32,7 @@ namespace VuFindSearch\Backend\Summon;
 use SerialsSolutions\Summon\Laminas as Connector;
 use SerialsSolutions_Summon_Exception as SummonException;
 use SerialsSolutions_Summon_Query as SummonQuery;
+use VuFind\Exception\RecordMissing as RecordMissingException;
 use VuFindSearch\Backend\AbstractBackend;
 use VuFindSearch\Backend\Exception\BackendException;
 use VuFindSearch\Feature\RetrieveBatchInterface;
@@ -134,6 +135,7 @@ class Backend extends AbstractBackend implements RetrieveBatchInterface
      * @param ParamBag $params Search backend parameters
      *
      * @return RecordCollectionInterface
+     * @throws RecordMissingException
      */
     public function retrieve($id, ParamBag $params = null)
     {
@@ -148,6 +150,9 @@ class Backend extends AbstractBackend implements RetrieveBatchInterface
                 $e->getCode(),
                 $e
             );
+        }
+        if (empty($response['documents'])) {
+            throw new RecordMissingException('Record does not exist.');
         }
         $collection = $this->createRecordCollection($response);
         $this->injectSourceIdentifier($collection);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
@@ -29,6 +29,7 @@
 
 namespace VuFindSearch\Backend\Summon\Response;
 
+use VuFind\Exception\RecordMissing as RecordMissingException;
 use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
@@ -91,6 +92,7 @@ class RecordCollectionFactory implements RecordCollectionFactoryInterface
      * @param array $response Summon response
      *
      * @return RecordCollection
+     * @throws RecordMissingException
      */
     public function factory($response)
     {
@@ -101,6 +103,9 @@ class RecordCollectionFactory implements RecordCollectionFactoryInterface
                     gettype($response)
                 )
             );
+        }
+        if (empty($response['documents'])) {
+            throw new RecordMissingException('Record does not exist.');
         }
         $collection = new $this->collectionClass($response);
         foreach ($response['documents'] as $doc) {

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
@@ -29,7 +29,6 @@
 
 namespace VuFindSearch\Backend\Summon\Response;
 
-use VuFind\Exception\RecordMissing as RecordMissingException;
 use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
@@ -92,7 +91,6 @@ class RecordCollectionFactory implements RecordCollectionFactoryInterface
      * @param array $response Summon response
      *
      * @return RecordCollection
-     * @throws RecordMissingException
      */
     public function factory($response)
     {
@@ -103,9 +101,6 @@ class RecordCollectionFactory implements RecordCollectionFactoryInterface
                     gettype($response)
                 )
             );
-        }
-        if (empty($response['documents'])) {
-            throw new RecordMissingException('Record does not exist.');
         }
         $collection = new $this->collectionClass($response);
         foreach ($response['documents'] as $doc) {


### PR DESCRIPTION
When somebody tries to access Summon record, which does not exist , it is not handled in vufind. 

Summon api does return normal response but with empty `documents` key. 