### PR TITLE
Add tests for the getItems function in the EDS driver

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -261,7 +261,7 @@ class EDS extends DefaultRecord
     ) {
         $items = [];
         if (is_array($this->fields['Items'] ?? null)) {
-            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder ?? [];
+            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder->toArray() ?? [];
             $origItems = $this->fields['Items'];
             // Only sort by label if we have a sort config and we're fetching multiple labels:
             if (!empty($itemGlobalOrderConfig) && $labelFilter === null) {
@@ -269,14 +269,13 @@ class EDS extends DefaultRecord
                 $nextPos = max(array_keys((array)$itemGlobalOrderConfig));
                 foreach (array_keys($origItems) as $key) {
                     $label = $origItems[$key]['Label'] ?? '';
-                    $configuredPos = array_search($label, (array)$itemGlobalOrderConfig);
+                    $configuredPos = array_search($label, $itemGlobalOrderConfig);
                     $origItems[$key]['Pos'] = $configuredPos === false
                         ? ++$nextPos : $configuredPos;
                 }
                 $positions = array_column($origItems, 'Pos');
                 array_multisort($positions, SORT_ASC, $origItems);
             }
-
             foreach ($origItems as $item) {
                 $nextItem = [
                     'Label' => $item['Label'] ?? '',

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -261,12 +261,12 @@ class EDS extends DefaultRecord
     ) {
         $items = [];
         if (is_array($this->fields['Items'] ?? null)) {
-            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder->toArray() ?? [];
+            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder?->toArray() ?? [];
             $origItems = $this->fields['Items'];
             // Only sort by label if we have a sort config and we're fetching multiple labels:
             if (!empty($itemGlobalOrderConfig) && $labelFilter === null) {
                 // We want unassigned labels to appear AFTER configured labels:
-                $nextPos = max(array_keys((array)$itemGlobalOrderConfig));
+                $nextPos = max(array_keys($itemGlobalOrderConfig));
                 foreach (array_keys($origItems) as $key) {
                     $label = $origItems[$key]['Label'] ?? '';
                     $configuredPos = array_search($label, $itemGlobalOrderConfig);

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -276,6 +276,7 @@ class EDS extends DefaultRecord
                 $positions = array_column($origItems, 'Pos');
                 array_multisort($positions, SORT_ASC, $origItems);
             }
+
             foreach ($origItems as $item) {
                 $nextItem = [
                     'Label' => $item['Label'] ?? '',

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -261,15 +261,15 @@ class EDS extends DefaultRecord
     ) {
         $items = [];
         if (is_array($this->fields['Items'] ?? null)) {
-            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder?->toArray() ?? [];
+            $itemGlobalOrderConfig = $this->recordConfig?->ItemGlobalOrder ?? [];
             $origItems = $this->fields['Items'];
             // Only sort by label if we have a sort config and we're fetching multiple labels:
             if (!empty($itemGlobalOrderConfig) && $labelFilter === null) {
                 // We want unassigned labels to appear AFTER configured labels:
-                $nextPos = max(array_keys($itemGlobalOrderConfig));
+                $nextPos = max(array_keys((array)$itemGlobalOrderConfig));
                 foreach (array_keys($origItems) as $key) {
                     $label = $origItems[$key]['Label'] ?? '';
-                    $configuredPos = array_search($label, $itemGlobalOrderConfig);
+                    $configuredPos = array_search($label, (array)$itemGlobalOrderConfig);
                     $origItems[$key]['Pos'] = $configuredPos === false
                         ? ++$nextPos : $configuredPos;
                 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -556,9 +556,11 @@ class EDSTest extends \PHPUnit\Framework\TestCase
 
         // Set the private recordConfig property
         // TODO -- is there a better way to set this config?
-        $reflection = new \ReflectionProperty($record::class, 'recordConfig');
-        $reflection->setAccessible(true);
-        $reflection->setValue($record, (object)($config ?? $this->defaultDriverConfig));
+        $this->setProperty(
+            $record,
+            'recordConfig',
+            (object)($config ?? $this->defaultDriverConfig)
+        );
 
         return $record;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -46,8 +46,6 @@ use VuFind\RecordDriver\EDS;
  */
 class EDSTest extends \PHPUnit\Framework\TestCase
 {
-    use \VuFindTest\Feature\ReflectionTrait;
-
     /**
      * Default test configuration
      *
@@ -214,14 +212,11 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     {
         // Change the default order the array data is in and exclude one of the items
         // to ensure it appears at the end
-        $driverConfig = [
-            'ItemGlobalOrder' => [
-                '1' => 'Authors', // note that we used the 'Label' and not the 'Name'
-                '2' => 'Title',
-            ],
-        ];
+        $config = $this->defaultDriverConfig;
+        $config['ItemGlobalOrder']['1'] = 'Authors';
+        $config['ItemGlobalOrder']['2'] = 'Title';
 
-        $driver = $this->getDriverWithItemData($driverConfig);
+        $driver = $this->getDriverWithItemData($config);
         $items = [
             [
                 'Name' => 'Author',
@@ -253,11 +248,11 @@ class EDSTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetItemsWithInvalidConfig(): void
     {
-        $driverConfig = [
-            'ItemGlobalOrder' => 'invalid',
-        ];
+        $config = $this->defaultDriverConfig;
+        $config['ItemGlobalOrder']['invalid'] = null;
 
-        $driver = $this->getDriverWithItemData($driverConfig);
+        $driver = $this->getDriverWithItemData($config);
+
         // items in original order are returned when the config can't be parsed
         $items = [
             [
@@ -551,16 +546,8 @@ class EDSTest extends \PHPUnit\Framework\TestCase
      */
     protected function getDriver($overrides = [], array $config = null): EDS
     {
-        $record = new EDS();
+        $record = new EDS(null, new \Laminas\Config\Config($config ?? $this->defaultDriverConfig));
         $record->setRawData($overrides);
-
-        // Set the private recordConfig property
-        // TODO -- is there a better way to set this config?
-        $this->setProperty(
-            $record,
-            'recordConfig',
-            (object)($config ?? $this->defaultDriverConfig)
-        );
 
         return $record;
     }


### PR DESCRIPTION
This is a follow-up to the new functionality adding in [PR 3284](https://github.com/vufind-org/vufind/pull/3284), which added the ability to sort items returned from EDS. I thought it might be a good idea to have some tests around the `getItems` function for the scenario when there is not configuration set for `ItemGlobalOrder`, when there is an order set, and when invalid data is set.

I was originally trying to get this in as part of that original PR yesterday, but then it ended up being a little more complicated than I hoped because it wasn't as simple as in other places I've written tests to override the config (such as in the Folio driver). What I've done here works and passes, but I don't love it since it uses the `ReflectionTrait` to set the config directly instead of having some access to some sort of `setConfig` class in the record driver. This lead to the minor change in the EDS record driver where I have to remove the `toArray()` call since it might already be an array (when called during the tests) and instead cast to an array when the variable is used lower down in the code. So I'd love feedback if there is a better way to set the config here for testing.

Hopefully if we can get a good framework for testing this function worked out, it will make writing tests for the other functions in the EDS driver easy to fill in.