### PR TITLE
KohaRest: Fix error in items sorting when serial isssue number is null

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2142,7 +2142,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $result = $this->getSorter()->compare($a['location'], $b['location']);
 
         if (0 === $result && $this->sortItemsBySerialIssue) {
-            $result = strnatcmp($a['number'], $b['number']);
+            $result = strnatcmp($a['number'] ?? '', $b['number'] ?? '');
         }
 
         if (0 === $result) {


### PR DESCRIPTION
Sometimes the number key in status array is null, the sorting number then fails, because  `strnatcmp` function needs arguments to be strings.