### PR TITLE
Throw exception when full MARC record is missing.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
@@ -81,7 +81,7 @@ trait MarcReaderTrait
                 break;
             }
         }
-        if (!isset($this->fields[$preferredMarcField])) {
+        if (empty($this->fields[$preferredMarcField])) {
             throw new \Exception('Missing MARC data in record ' . $this->getUniqueId());
         }
         return trim($this->fields[$preferredMarcField]);

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcReaderTrait.php
@@ -81,6 +81,9 @@ trait MarcReaderTrait
                 break;
             }
         }
+        if (!isset($this->fields[$preferredMarcField])) {
+            throw new \Exception('Missing MARC data in record ' . $this->getUniqueId());
+        }
         return trim($this->fields[$preferredMarcField]);
     }
 


### PR DESCRIPTION
The `getRawMarcData` method has a flaw where if a record in the Solr index is missing the `fullrecord` field (which can happen, for example, if SolrMarc encounters an exception while attempting to export full record data), it will try to access an undefined array offset. This PR throws an exception when this situation occurs, making it easier to identify the record causing the error.