### PR TITLE
Apply recommended php-cs-fixer rules for PHP 8.1.

### DIFF
--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -296,7 +296,7 @@ class Manager
                 // convert umask from string
                 $umask = octdec($opts['umask']);
                 // validate
-                if ($umask & 0700) {
+                if ($umask & 0o700) {
                     throw new \Exception(
                         'Invalid umask: ' . $opts['umask']
                         . '; need permission to execute, read and write by owner'
@@ -308,7 +308,7 @@ class Manager
                 $dir_perm = octdec($opts['dir_permission']);
             } else {
                 // 0777 is chmod default, use if dir_permission is not explicitly set
-                $dir_perm = 0777;
+                $dir_perm = 0o777;
             }
             // Make sure cache parent directory and directory itself exist:
             $parentDir = dirname($dirName);

--- a/module/VuFind/src/VuFind/Sitemap/AbstractFile.php
+++ b/module/VuFind/src/VuFind/Sitemap/AbstractFile.php
@@ -122,7 +122,7 @@ abstract class AbstractFile
         // if a subfolder was specified that does not exist, make one
         $dirname = dirname($file);
         if (!is_dir($dirname)) {
-            mkdir($dirname, 0755, true);
+            mkdir($dirname, 0o755, true);
         }
         return file_put_contents($file, $this->toString());
     }

--- a/module/VuFind/tests/bootstrap.php
+++ b/module/VuFind/tests/bootstrap.php
@@ -56,5 +56,5 @@ if (!defined('LOCAL_OVERRIDE_DIR')) {
     throw new \Exception('LOCAL_OVERRIDE_DIR must be defined');
 }
 if (!file_exists(LOCAL_OVERRIDE_DIR)) {
-    mkdir(LOCAL_OVERRIDE_DIR, 0777, true);
+    mkdir(LOCAL_OVERRIDE_DIR, 0o777, true);
 }

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
@@ -80,10 +80,10 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
         $temp = sys_get_temp_dir();
         $testDest = $temp . "/vufind_{$ext}_comp_test/";
         // Create directory structure, recursively
-        mkdir($testDest . "themes/child/$ext", 0777, true);
-        mkdir($testDest . 'themes/empty', 0777, true);
-        mkdir($testDest . 'themes/parent/css', 0777, true);
-        mkdir($testDest . "themes/parent/$ext/relative", 0777, true);
+        mkdir($testDest . "themes/child/$ext", 0o777, true);
+        mkdir($testDest . 'themes/empty', 0o777, true);
+        mkdir($testDest . 'themes/parent/css', 0o777, true);
+        mkdir($testDest . "themes/parent/$ext/relative", 0o777, true);
         file_put_contents(
             $testDest . 'themes/empty/theme.config.php',
             '<?php return array("extends"=>false);'

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -6,7 +6,7 @@ $finder->in(__DIR__ . '/../config')
     ->in(__DIR__ . '/../public');
 
 $rules = [
-    '@PHP80Migration' => true,
+    '@PHP81Migration' => true,
     '@PHPUnit84Migration:risky' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,

--- a/tests/vufind_templates.php-cs-fixer.php
+++ b/tests/vufind_templates.php-cs-fixer.php
@@ -5,7 +5,7 @@ $finder->in(__DIR__ . '/../themes')
     ->name('*.phtml');
 
 $rules = [
-    '@PHP80Migration' => true,
+    '@PHP81Migration' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
     'binary_operator_spaces' => [


### PR DESCRIPTION
Now that we have raised our minimum version requirement to 8.1, we can apply new php-cs-fixer recommendations for 8.1; in this instance, the only change is the use of the new explicit octal notation.