### PR TITLE
Switch PHPUnit tests to use static data providers.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
@@ -46,7 +46,7 @@ class AlphabrowseTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function titleSearchNormalizationProvider(): array
+    public static function titleSearchNormalizationProvider(): array
     {
         return [
             'bracket stripping' => ['[arithmetic facts]', 'Arithmetic Facts'],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuthorControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuthorControllerTest.php
@@ -77,7 +77,7 @@ class AuthorControllerTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function authorPathsProvider(): array
+    public static function authorPathsProvider(): array
     {
         return [
             'home page' => ['/Author/Home'],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
@@ -66,7 +66,7 @@ class BasicSearchTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function topPaginationProvider(): array
+    public static function topPaginationProvider(): array
     {
         return [
             [false],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -109,27 +109,23 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function getSearchData(): array
+    public static function getSearchData(): array
     {
         return [
             [
                 ['page' => 1],
-                $this->getExpectedLabels(1),
                 'Blender/Results',
             ],
             [
                 ['page' => 2],
-                $this->getExpectedLabels(2),
                 'Blender/Results',
             ],
             [
                 ['page' => 1],
-                $this->getExpectedLabels(1),
                 'Search/Blended', // legacy path
             ],
             [
                 ['page' => 2],
-                $this->getExpectedLabels(2),
                 'Search/Blended', // legacy path
             ],
         ];
@@ -138,16 +134,16 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Test blended search
      *
-     * @param array  $queryParams    Query parameters
-     * @param array  $expectedLabels Expected labels
-     * @param string $path           URL path
+     * @param array  $queryParams Query parameters
+     * @param string $path        URL path
      *
      * @dataProvider getSearchData
      *
      * @return void
      */
-    public function testSearch(array $queryParams, array $expectedLabels, string $path): void
+    public function testSearch(array $queryParams, string $path): void
     {
+        $expectedLabels = $this->getExpectedLabels($queryParams['page']);
         $this->changeConfigs(
             [
                 'config' => [

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -660,7 +660,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function getListTagData(): array
+    public static function getListTagData(): array
     {
         $defaultChannelConfig = ['tags' => ['channel'], 'displayPublicLists' => false];
         return [

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
@@ -51,7 +51,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function itemStatusAndHoldingsProvider(): array
+    public static function itemStatusAndHoldingsProvider(): array
     {
         $set = [
             [true, 'On Shelf', 'Available', 'success'],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -653,7 +653,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function loanHistoryWithPurgeDisabledProvider(): array
+    public static function loanHistoryWithPurgeDisabledProvider(): array
     {
         return [
             [false, false],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -342,7 +342,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function getTagSearchSortData(): array
+    public static function getTagSearchSortData(): array
     {
         return [
             [1, 'author', 'Fake Record 1 with multiple relators/', 'Dewey browse test'],
@@ -618,7 +618,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function getTestRatingData(): array
+    public static function getTestRatingData(): array
     {
         return [
             [true],

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -530,7 +530,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return array
      */
-    public function hierarchicalFacetSortProvider(): array
+    public static function hierarchicalFacetSortProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
@@ -160,7 +160,7 @@ class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
      *
      * @return array
      */
-    public function getTestSingleLookupData(): array
+    public static function getTestSingleLookupData(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
@@ -96,7 +96,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getTestCreateWithPasswordPolicyData(): array
+    public static function getTestCreateWithPasswordPolicyData(): array
     {
         $numericConfig = [
             'minimum_password_length' => 4,
@@ -267,7 +267,7 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getTestCreateWithUsernamePolicyData(): array
+    public static function getTestCreateWithUsernamePolicyData(): array
     {
         $defaultConfig = [
             'username_pattern' => '([\\x21\\x23-\\x2B\\x2D-\\x2F\\x3D\\x3F\\x40'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Captcha/ImageFactoryTest.php
@@ -112,7 +112,7 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function factoryDataProvider(): array
+    public static function factoryDataProvider(): array
     {
         return [
             'Empty base path' => [],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
@@ -117,29 +117,29 @@ class PathResolverTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getTestPathStackData(): array
+    public static function getTestPathStackData(): array
     {
-        $fixtureDir = $this->getStackedFixtureDir();
         return [
             [
                 // A file that exists only in the primary path:
                 'only-primary.ini',
-                $fixtureDir . 'primary/config/vufind/only-primary.ini',
+                'primary/config/vufind/only-primary.ini',
             ],
             [
                 // A file that exists both in the primary and secondary paths:
                 'both.ini',
-                $fixtureDir . 'primary/config/vufind/both.ini',
+                'primary/config/vufind/both.ini',
             ],
             [
                 // A file that exists in the secondary path as well as base path:
                 'facets.ini',
-                $fixtureDir . 'secondary/config/custom/facets.ini',
+                'secondary/config/custom/facets.ini',
             ],
             [
                 // A file that exists only in the base path:
                 'config.ini',
-                APPLICATION_PATH . '/config/vufind/config.ini',
+                'config/vufind/config.ini',
+                APPLICATION_PATH . '/',
             ],
         ];
     }
@@ -147,17 +147,18 @@ class PathResolverTest extends \PHPUnit\Framework\TestCase
     /**
      * Test stacked path resolution
      *
-     * @param string $filename     Filename to check
-     * @param string $expectedPath Expected result
+     * @param string  $filename         Filename to check
+     * @param string  $expectedFilePath Expected result (minus base path)
+     * @param ?string $expectedBasePath Expected base path in result (null = use default fixture path)
      *
      * @dataProvider getTestPathStackData
      *
      * @return void
      */
-    public function testPathStack($filename, $expectedPath): void
+    public function testPathStack(string $filename, string $expectedFilePath, ?string $expectedBasePath = null): void
     {
         $this->assertEquals(
-            $expectedPath,
+            ($expectedBasePath ?? $this->getStackedFixtureDir()) . $expectedFilePath,
             $this->stackedResolver->getConfigPath($filename)
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/KohaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/KohaTest.php
@@ -47,7 +47,7 @@ class KohaTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getCoverData(): array
+    public static function getCoverData(): array
     {
         return [
             'no id' => [false, [null, 'small', []]],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Crypt/Base62Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Crypt/Base62Test.php
@@ -79,7 +79,7 @@ class Base62Test extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function exampleProvider()
+    public static function exampleProvider()
     {
         // format: base 10 number, base 62 number
         return [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -801,7 +801,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getEmailSubjectsData(): array
+    public static function getEmailSubjectsData(): array
     {
         return [
             'with placeholders' => [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/ExtendedIniNormalizerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/ExtendedIniNormalizerTest.php
@@ -100,7 +100,7 @@ class ExtendedIniNormalizerTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function escapingProvider(): array
+    public static function escapingProvider(): array
     {
         return [
             ['foo = "This is a backslash: \\\\"'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleSettingsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/I18n/Locale/LocaleSettingsTest.php
@@ -151,7 +151,7 @@ class LocaleSettingsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function fallbackLocalConfigsProvider(): array
+    public static function fallbackLocalConfigsProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
@@ -98,7 +98,7 @@ class IdentityRepositoryTest extends AbstractTokenRepositoryTest
      *
      * @return array
      */
-    public function getTestIdentityRepositoryData(): array
+    public static function getTestIdentityRepositoryData(): array
     {
         return [
             [null],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
@@ -47,7 +47,7 @@ class ScopeRepositoryTest extends AbstractTokenRepositoryTest
      *
      * @return array
      */
-    public function getTestScopeRepositoryData(): array
+    public static function getTestScopeRepositoryData(): array
     {
         return [
             ['openid', 'OpenID', false, false],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTabTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTabTest.php
@@ -47,7 +47,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function tabConfigProvider(): array
+    public static function tabConfigProvider(): array
     {
         return [
             'First tab selected' => [
@@ -123,7 +123,7 @@ class SwitchTabTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function inactiveTabConfigProvider(): array
+    public static function inactiveTabConfigProvider(): array
     {
         return [
             'Test1' => [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTypeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/SwitchTypeTest.php
@@ -47,7 +47,7 @@ class SwitchTypeTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function newHandlerNameProvider(): array
+    public static function newHandlerNameProvider(): array
     {
         return ['Test1' => ['foo:bar', 'bar'],
                 'Test2' => ['foo', 'All Fields'],
@@ -76,7 +76,7 @@ class SwitchTypeTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function newHandlerProvider(): array
+    public static function newHandlerProvider(): array
     {
         return ['Test1' => ['foo:bar', 'foo', false],
                 'Test2' => ['', 'foo', 'AllFields'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/DefaultRecordTest.php
@@ -488,7 +488,7 @@ class DefaultRecordTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getCleanISBNsProvider(): array
+    public static function getCleanISBNsProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -655,7 +655,7 @@ class EDSTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getLinkUrlsProvider(): array
+    public static function getLinkUrlsProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ComponentPartsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ComponentPartsTest.php
@@ -72,7 +72,7 @@ class ComponentPartsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['no children' => [0, false], 'children' => [10, true]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/FormatsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/FormatsTest.php
@@ -60,7 +60,7 @@ class FormatsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Not Enabed' => [false, false], 'Enabled' => [true, true]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/HoldingsWorldCatTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/HoldingsWorldCatTest.php
@@ -62,7 +62,7 @@ class HoldingsWorldCatTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Enabed' => ['foo', true], 'Not Enabled' => ['', false]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/PreviewTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/PreviewTest.php
@@ -59,7 +59,7 @@ class PreviewTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Active' => [false, false], 'InActive' => [true, true]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TOCTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TOCTest.php
@@ -59,7 +59,7 @@ class TOCTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Enabled' => ['foo', true], 'Not Enabled' => ['', false]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/UserCommentsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/UserCommentsTest.php
@@ -58,7 +58,7 @@ class UserCommentsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Enabled' => [true, true], 'Not Enabled' => [false, false]];
     }
@@ -84,7 +84,7 @@ class UserCommentsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isCaptchaActiveProvider(): array
+    public static function isCaptchaActiveProvider(): array
     {
         return ['Active' => [true, true], 'InActive' => [false, false]];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/VersionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/VersionsTest.php
@@ -80,7 +80,7 @@ class VersionsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isActiveProvider(): array
+    public static function isActiveProvider(): array
     {
         return ['Test1' => [true, 1, true],
                 'Test2' => [true, 0, false],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/OptionsTest.php
@@ -50,7 +50,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function optionsProvider(): array
+    public static function optionsProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/QueryAdapterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/QueryAdapterTest.php
@@ -52,7 +52,7 @@ class QueryAdapterTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function conversionsProvider(): array
+    public static function conversionsProvider(): array
     {
         return [
             ['basic', true],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
@@ -164,7 +164,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function sortValueProvider(): array
+    public static function sortValueProvider(): array
     {
         return ['Test1' => ['year', 'id', 'publishDateSort desc,id asc'],
                 'Test2' => ['year', 'id desc', 'publishDateSort desc,id desc'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/Feature/RetryTraitTest.php
@@ -178,7 +178,7 @@ class RetryTraitTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function backoffDataProvider(): array
+    public static function backoffDataProvider(): array
     {
         return [
             [0, 0],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/UrlHighlight/VuFindHighlighterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/UrlHighlight/VuFindHighlighterTest.php
@@ -107,7 +107,7 @@ class VuFindHighlighterTest extends \PHPUnit\Framework\TestCase
      *
      * @return array[]
      */
-    public function getHighlightDataProvider(): array
+    public static function getHighlightDataProvider(): array
     {
         return [
             'http' => [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/FlashmessagesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/FlashmessagesTest.php
@@ -53,7 +53,7 @@ class FlashmessagesTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getTestFlashmessageData(): array
+    public static function getTestFlashmessageData(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HoldingsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HoldingsTest.php
@@ -45,7 +45,7 @@ class HoldingsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function barcodeVisibilityBehaviorProvider(): array
+    public static function barcodeVisibilityBehaviorProvider(): array
     {
         return [
             'default' => [[], true, true],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HtmlSafeJsonEncodeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/HtmlSafeJsonEncodeTest.php
@@ -79,7 +79,7 @@ class HtmlSafeJsonEncodeTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getJsonTests(): array
+    public static function getJsonTests(): array
     {
         return [
             'string with special characters'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -189,7 +189,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function unicodeIconProvider(): array
+    public static function unicodeIconProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
@@ -63,7 +63,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
      *
      * @return array
      */
-    public function htmlAttributesTests(): array
+    public static function htmlAttributesTests(): array
     {
         return [
             'Basic' => [
@@ -93,7 +93,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
      *
      * @return array
      */
-    public function helperOptionTests(): array
+    public static function helperOptionTests(): array
     {
         return [
             'escapes innerHTML' => [
@@ -131,7 +131,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
      *
      * @return array
      */
-    public function voidTags(): array
+    public static function voidTags(): array
     {
         return [
             'self closing tag' => [
@@ -189,7 +189,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
      *
      * @return array
      */
-    public function validTags(): array
+    public static function validTags(): array
     {
         return [
             ['SPAN'], // CAPITAL
@@ -228,7 +228,7 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
      *
      * @return array
      */
-    public function invalidTags(): array
+    public static function invalidTags(): array
     {
         return [
             ['nohyphencustom'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
@@ -65,7 +65,7 @@ class PrintArrayHtmlTest extends AbstractMakeTagTest
      *
      * @return array
      */
-    public function getPrintArrayHtmlData(): array
+    public static function getPrintArrayHtmlData(): array
     {
         return [
             [ // Set 0

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -296,7 +296,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getFormattingData(): array
+    public static function getFormattingData(): array
     {
         return [
             [
@@ -580,7 +580,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getFormattingDataWithGlobalOptions(): array
+    public static function getFormattingDataWithGlobalOptions(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordTest.php
@@ -297,7 +297,7 @@ class RecordTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getLinkProvider(): array
+    public static function getLinkProvider(): array
     {
         return [
             'no hidden filters' => ['http://foo', '?', '', 'http://foo'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchMemoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchMemoryTest.php
@@ -108,7 +108,7 @@ class SearchMemoryTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getLastSearchParamsProvider(): array
+    public static function getLastSearchParamsProvider(): array
     {
         return [
             'no parameters' => ['?', []],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
@@ -58,7 +58,7 @@ class SearchTabsTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getCurrentHiddenFilterParamsProvider(): array
+    public static function getCurrentHiddenFilterParamsProvider(): array
     {
         return [
             [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindTest.php
@@ -257,7 +257,7 @@ class VuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function nameProvider(): array
+    public static function nameProvider(): array
     {
         return [
             'single name' => ['foo', 'foo'],
@@ -271,7 +271,7 @@ class VuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function isInvertedNameProvider(): array
+    public static function isInvertedNameProvider(): array
     {
         return [
             ['foo bar', false],
@@ -337,7 +337,7 @@ class VuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function titleSortLowerProvider(): array
+    public static function titleSortLowerProvider(): array
     {
         return [
             'basic lowercasing' => ['ABCDEF', 'abcdef'],

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/PurgeCachedRecordCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/PurgeCachedRecordCommandTest.php
@@ -51,7 +51,7 @@ class PurgeCachedRecordCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function basicOperationProvider(): array
+    public static function basicOperationProvider(): array
     {
         return [
             ['Solr', '123', false, true, null],

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
@@ -68,7 +68,7 @@ class BackendTest extends TestCase
      *
      * @var array
      */
-    protected $config = [
+    protected static $config = [
         'Backends' => [
             'Solr' => 'Local',
             'EDS' => 'Electronic Stuff',
@@ -239,7 +239,7 @@ class BackendTest extends TestCase
      *
      * @return array
      */
-    public function getSearchTestData(): array
+    public static function getSearchTestData(): array
     {
         $solrRecords = [
             [
@@ -317,7 +317,7 @@ class BackendTest extends TestCase
             array_slice($solrRecords, 13, 5),
             array_slice($edsRecords, 17, 5)
         );
-        $adaptiveConfig = $this->config;
+        $adaptiveConfig = static::$config;
         $adaptiveConfig['Blending']['adaptiveBlockSizes'] = [
             '5000-100000:5',
         ];
@@ -333,7 +333,7 @@ class BackendTest extends TestCase
             array_slice($solrRecords, 14, 7),
             array_slice($edsRecords, 14, 5)
         );
-        $noBoostConfig = $this->config;
+        $noBoostConfig = static::$config;
         unset($noBoostConfig['Blending']['initialResults']);
 
         $expectedRecordsTitleSearch = array_merge(
@@ -618,7 +618,7 @@ class BackendTest extends TestCase
         $eventManager = new EventManager($this->sharedEventManager);
         $backend = new Backend(
             $backends,
-            new Config($this->config),
+            new Config(static::$config),
             $this->mappings,
             $eventManager
         );
@@ -642,7 +642,7 @@ class BackendTest extends TestCase
      */
     public function testNonDelimitedBlenderBackendFacet(): void
     {
-        $config = $this->config;
+        $config = static::$config;
         unset($config['Advanced_Settings']);
         $backend = $this->getBackend($config);
         $expectedSolr = 240;
@@ -831,7 +831,7 @@ class BackendTest extends TestCase
      *
      * @return array
      */
-    public function getInvalidBlockSizes(): array
+    public static function getInvalidBlockSizes(): array
     {
         return [
             [
@@ -857,7 +857,7 @@ class BackendTest extends TestCase
      */
     public function testInvalidAdaptiveBlockSize($blockSizes): void
     {
-        $config = $this->config;
+        $config = static::$config;
         $config['Blending']['adaptiveBlockSizes'] = $blockSizes;
         $backend = $this->getBackend($config);
         $params = $this->getSearchParams([]);
@@ -1085,7 +1085,7 @@ class BackendTest extends TestCase
         $eventManager = new EventManager($this->sharedEventManager);
         $backend = new Backend(
             $backends,
-            new Config($config ?? $this->config),
+            new Config($config ?? static::$config),
             $mappings ?? $this->mappings,
             $eventManager
         );

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Primo/BackendTest.php
@@ -207,7 +207,7 @@ class BackendTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getPcAvailabilityData(): array
+    public static function getPcAvailabilityData(): array
     {
         return [
             [

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/LuceneSyntaxHelperTest.php
@@ -49,7 +49,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function capitalizeBooleansProvider(): array
+    public static function capitalizeBooleansProvider(): array
     {
         return [
             ['this not that', 'this NOT that'],        // capitalize not
@@ -227,7 +227,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function capitalizeRangesProvider(): array
+    public static function capitalizeRangesProvider(): array
     {
         return [
             // don't capitalize inside quotes
@@ -367,7 +367,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function colonNormalizationProvider(): array
+    public static function colonNormalizationProvider(): array
     {
         return [
             ['this : that', 'this  that'],
@@ -406,7 +406,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function extractSearchTermsProvider(): array
+    public static function extractSearchTermsProvider(): array
     {
         return [
             ['keyword', 'keyword'],
@@ -452,7 +452,7 @@ class LuceneSyntaxHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function unquotedNormalizationProvider(): array
+    public static function unquotedNormalizationProvider(): array
     {
         return [
             // Unquoted ones that may need changes:

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -594,7 +594,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function globalExtraParamsIndividualQueryDataProvider(): array
+    public static function globalExtraParamsIndividualQueryDataProvider(): array
     {
         return [
             'Single value, no extra params' => [
@@ -776,7 +776,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function globalExtraParamsGroupedQueryDataProvider(): array
+    public static function globalExtraParamsGroupedQueryDataProvider(): array
     {
         return [
             'Search type in [test]' => [

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -7,7 +7,7 @@ $finder->in(__DIR__ . '/../config')
 
 $rules = [
     '@PHP80Migration' => true,
-    '@PHPUnit84Migration:risky' => true,
+    '@PHPUnit100Migration:risky' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
     'binary_operator_spaces' => [


### PR DESCRIPTION
This is a first step toward upgrading to PHPUnit 10, which no longer supports non-static dataProvider methods. Fortunately, the change is straightforward for the vast majority of our tests, though a couple needed slight refactoring to avoid references to `$this` inside dataProvider functions.