### PR TITLE
PHPUnit 10 prep: Fix naming of abstract test classes.

### DIFF
--- a/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
@@ -40,7 +40,7 @@ namespace VuFindTest\Unit;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-abstract class AbstractMakeTagTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractMakeTagTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Get makeTag helper with mock view

--- a/module/VuFind/src/VuFindTest/Unit/AjaxHandlerTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AjaxHandlerTestCase.php
@@ -42,7 +42,7 @@ use Laminas\Stdlib\Parameters;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-abstract class AjaxHandlerTest extends \PHPUnit\Framework\TestCase
+abstract class AjaxHandlerTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Mock container

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
@@ -44,7 +44,7 @@ use VuFind\ILS\Connection;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class CheckRequestIsValidTest extends \VuFindTest\Unit\AjaxHandlerTest
+class CheckRequestIsValidTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     /**
      * Set up a CheckRequestIsValid handler for testing.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
@@ -47,7 +47,7 @@ use VuFind\RecordDriver\DefaultRecord;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class CommentRecordTest extends \VuFindTest\Unit\AjaxHandlerTest
+class CommentRecordTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     /**
      * Set up a CommentRecord handler for testing.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/DoiLookupTest.php
@@ -44,7 +44,7 @@ use VuFind\DoiLinker\PluginManager;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTest
+class DoiLookupTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     use \VuFindTest\Feature\ConfigPluginManagerTrait;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
@@ -44,7 +44,7 @@ use VuFind\Session\Settings;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTest
+class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     use \VuFindTest\Feature\ConfigPluginManagerTrait;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/KeepAliveTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/KeepAliveTest.php
@@ -42,7 +42,7 @@ use VuFind\AjaxHandler\KeepAliveFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class KeepAliveTest extends \VuFindTest\Unit\AjaxHandlerTest
+class KeepAliveTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     /**
      * Test the AJAX handler's basic response.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RecommendTest.php
@@ -49,7 +49,7 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class RecommendTest extends \VuFindTest\Unit\AjaxHandlerTest
+class RecommendTest extends \VuFindTest\Unit\AjaxHandlerTestCase
 {
     /**
      * Get a mock params object.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AbstractMultiDriverTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AbstractMultiDriverTestCase.php
@@ -50,7 +50,7 @@ use function in_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-abstract class AbstractMultiDriverTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractMultiDriverTestCase extends \PHPUnit\Framework\TestCase
 {
     use \VuFindTest\Feature\ConfigPluginManagerTrait;
     use \VuFindTest\Feature\ReflectionTrait;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/ComposedDriverTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/ComposedDriverTest.php
@@ -45,7 +45,7 @@ use function call_user_func_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class ComposedDriverTest extends AbstractMultiDriverTest
+class ComposedDriverTest extends AbstractMultiDriverTestCase
 {
     /**
      * Test that driver handles missing main ILS driver configuration properly.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -47,7 +47,7 @@ use function call_user_func_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class MultiBackendTest extends AbstractMultiDriverTest
+class MultiBackendTest extends AbstractMultiDriverTestCase
 {
     /**
      * Test that driver handles missing ILS driver configuration properly.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AbstractTokenRepositoryTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AbstractTokenRepositoryTestCase.php
@@ -43,7 +43,7 @@ use VuFind\OAuth2\Entity\ClientEntity;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-abstract class AbstractTokenRepositoryTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractTokenRepositoryTestCase extends \PHPUnit\Framework\TestCase
 {
     protected $accessTokenTable = [];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AccessTokenRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AccessTokenRepositoryTest.php
@@ -42,7 +42,7 @@ use VuFind\OAuth2\Repository\AuthCodeRepository;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class AccessTokenRepositoryTest extends AbstractTokenRepositoryTest
+class AccessTokenRepositoryTest extends AbstractTokenRepositoryTestCase
 {
     /**
      * Test access token repository

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AuthCodeRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/AuthCodeRepositoryTest.php
@@ -40,7 +40,7 @@ use VuFind\OAuth2\Repository\AuthCodeRepository;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class AuthCodeRepositoryTest extends AbstractTokenRepositoryTest
+class AuthCodeRepositoryTest extends AbstractTokenRepositoryTestCase
 {
     /**
      * Test auth code repository

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
@@ -45,7 +45,7 @@ use VuFind\OAuth2\Repository\IdentityRepository;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class IdentityRepositoryTest extends AbstractTokenRepositoryTest
+class IdentityRepositoryTest extends AbstractTokenRepositoryTestCase
 {
     /**
      * OAuth2 configuration

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/RefreshTokenRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/RefreshTokenRepositoryTest.php
@@ -42,7 +42,7 @@ use VuFind\OAuth2\Repository\RefreshTokenRepository;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class RefreshTokenRepositoryTest extends AbstractTokenRepositoryTest
+class RefreshTokenRepositoryTest extends AbstractTokenRepositoryTestCase
 {
     /**
      * Test refresh token repository

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/ScopeRepositoryTest.php
@@ -40,7 +40,7 @@ use VuFind\OAuth2\Repository\ScopeRepository;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class ScopeRepositoryTest extends AbstractTokenRepositoryTest
+class ScopeRepositoryTest extends AbstractTokenRepositoryTestCase
 {
     /**
      * Data provider for testScopeRepository

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeLinkTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeLinkTest.php
@@ -42,7 +42,7 @@ use VuFind\View\Helper\Root\MakeLink;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class MakeLinkTest extends \VuFindTest\Unit\AbstractMakeTagTest
+class MakeLinkTest extends \VuFindTest\Unit\AbstractMakeTagTestCase
 {
     /**
      * Get MakeLink helper with mock view

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
@@ -44,7 +44,7 @@ use function call_user_func_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTest
+class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTestCase
 {
     /**
      * Get makeTag helper with mock view

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/PrintArrayHtmlTest.php
@@ -30,7 +30,7 @@
 namespace VuFindTest\View\Helper\Root;
 
 use VuFind\View\Helper\Root\PrintArrayHtml;
-use VuFindTest\Unit\AbstractMakeTagTest;
+use VuFindTest\Unit\AbstractMakeTagTestCase;
 
 use function call_user_func;
 
@@ -43,7 +43,7 @@ use function call_user_func;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class PrintArrayHtmlTest extends AbstractMakeTagTest
+class PrintArrayHtmlTest extends AbstractMakeTagTestCase
 {
     use \VuFindTest\Feature\ViewTrait;
 


### PR DESCRIPTION
PHPUnit 10 does not allow abstract test classes whose names end in "Test." This PR renames all such tests to have a "TestCase" suffix for consistency with other existing TestCase classes.