### PR TITLE
Fix result count for combined search tab

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetResultCountFactory.php
@@ -68,6 +68,7 @@ class GetResultCountFactory implements \Laminas\ServiceManager\Factory\FactoryIn
         }
         return new $requestedName(
             $container->get(\VuFind\Search\Results\PluginManager::class),
+            $container->get(\VuFind\Search\Options\PluginManager::class),
             $container->get(\VuFind\Session\Settings::class)
         );
     }


### PR DESCRIPTION
The result count of the combined search tab is always 0. This PR fixes this by creating a special case in the GetResultsCount ajax handler. Now the tab is displaying the sum of the different combined result counts. 