### PR TITLE
Display the pickup location of waiting Koha reserves

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2007,6 +2007,16 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
                 $duedate = null;
             }
 
+            if (isset($avail['unavailabilities']['Item::Held']['status'])) {
+                if ($avail['unavailabilities']['Item::Held']['status'] == 'Waiting') {
+                    $libraries           = $this->getLibraries();
+                    $waitingAtCode       = $item['holding_library_id'];
+                    $waitingAtLocation   = isset($libraries[$waitingAtCode]) ?
+                    $libraries[$waitingAtCode]['name'] : $waitingAtCode;
+                    $status              = 'On Reserves Shelf' . ' at ' . $waitingAtLocation;
+                }
+            }
+
             $entry = [
                 'id' => $id,
                 'item_id' => $item['item_id'],


### PR DESCRIPTION
It would be nice if the VuFind search result and record pages should show the location that waiting Koha reserves are currently sitting at awaiting pickup, wording like  'On Reserves Shelf at X' would be helpful for library users. 

I would love some feedback on this change please. I have assumed that if the Koha item has a reserve status of "Waiting" then accessing and displaying the items holding_library_id as the location to pickup the item is a good approach.

I have run the following tests before pushing this change: vendor/bin/phing phpcs-console and vendor/bin/phing phpstan-console

I am unsure where I should be writing unit tests for this change, so if someone could point me in the right direction for that it would be great!

Thank you!