### PR TITLE
Usernames should be consistently case-insensitive.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/User.php
+++ b/module/VuFind/src/VuFind/Db/Table/User.php
@@ -139,7 +139,10 @@ class User extends Gateway
      */
     public function getByUsername($username, $create = true)
     {
-        $row = $this->select(['username' => $username])->current();
+        $callback = function ($select) use ($username) {
+            $select->where->literal('lower(username) = lower(?)', [$username]);
+        };
+        $row = $this->select($callback)->current();
         return ($create && empty($row))
             ? $this->createRowForUsername($username) : $row;
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -71,7 +71,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testChangePassword()
+    public function testChangePassword(): void
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl());
@@ -134,13 +134,38 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test username case-insensitivity.
+     *
+     * @depends testChangePassword
+     *
+     * @return void
+     */
+    public function testCaseInsensitiveUsername(): void
+    {
+        $session = $this->getMinkSession();
+        $page = $session->getPage();
+
+        // Go to profile page:
+        $session->visit($this->getVuFindUrl('/MyResearch/Profile'));
+
+        // Log back in using UPPERCASE version of username (it was created in lowercase above).
+        $this->clickCss($page, '#loginOptions a');
+        $this->fillInLoginForm($page, 'USERNAME1', 'good');
+        $this->clickCss($page, '.modal-body .btn.btn-primary');
+        $this->waitForPageLoad($page);
+
+        // Confirm that we logged in based on the presence of a "change password" link.
+        $this->findAndAssertLink($page, 'Change Password');
+    }
+
+    /**
      * Test that changing email is disabled by default.
      *
      * @depends testChangePassword
      *
      * @return void
      */
-    public function testChangeEmailDisabledByDefault()
+    public function testChangeEmailDisabledByDefault(): void
     {
         // Go to profile page:
         $session = $this->getMinkSession();
@@ -165,7 +190,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testChangeEmail()
+    public function testChangeEmail(): void
     {
         // Turn on email change option:
         $this->changeConfigs(


### PR DESCRIPTION
While reviewing #3027, @sturkel89 observed that usernames are currently case-insensitive in MySQL but case-sensitive in PostgreSQL. Since MySQL is our primary database platform, and I think we should aim for consistency across platforms, this PR adjusts the code to ensure more consistent behavior. It also adds a Mink test to verify the functionality (so we can catch regressions in the future, to ensure that we don't lose this in Doctrine migration, for example).

I'm certainly open to making this behavior configurable if people can think of a compelling reason to do so, but for now I feel pretty comfortable with standardizing things.