### PR TITLE
Language tool: ISO639-3 text domain should be optional.

### DIFF
--- a/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/LanguageHelper.php
@@ -196,7 +196,7 @@ class LanguageHelper
         if (!$domains) {
             $filter = $includeOptional
                 ? []
-                : ['CallNumberFirst', 'CreatorRoles', 'DDC23'];
+                : ['CallNumberFirst', 'CreatorRoles', 'DDC23', 'ISO639-3'];
             $base = APPLICATION_PATH . '/languages';
             $dir = opendir($base);
             $domains = [];


### PR DESCRIPTION
This PR updates the language file analysis tool to treat the new "ISO639-3" text domain as optional. This seems like the only appropriate choice since every language name has not been translated into every language, and filtering out these extra strings is helpful for identifying the highest-priority translations.

In future, it may also be valuable to enable individual toggling of text domains, but that's a project for another day.