### PR TITLE
Fix hierarchical facet filters in advanced search.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
@@ -178,14 +178,6 @@ class AbstractSolrSearch extends AbstractSearch
                 }
 
                 $tmpList = $list['list'];
-                $sort = $hierarchicalFacetsSortOptions[$facet]
-                    ?? $hierarchicalFacetsSortOptions['*'] ?? 'top';
-
-                $facetHelper->sortFacetList($tmpList, $sort);
-                $tmpList = $facetHelper->buildFacetArray(
-                    $facet,
-                    $tmpList
-                );
                 if ($options->getFilterHierarchicalFacetsInAdvanced()) {
                     $tmpList = $facetHelper->filterFacets(
                         $facet,


### PR DESCRIPTION
I had accidentally left some double-processing of hierarchical facets to the advanced search facets handling code, and this resulted in hierarchical facets only displaying the top level in advanced search filters.