### PR TITLE
Fix tag sorting in PostgreSQL.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Table/Resource.php
@@ -319,11 +319,13 @@ class Resource extends Gateway
             // The title field can't be null, so don't bother with the extra
             // isnull() sort in that case.
             if (strtolower($rawField) != 'title') {
-                $order[] = new Expression(
-                    'isnull(?)',
+                $expression = new Expression(
+                    'case when ? is null then 1 else 0 end',
                     [$alias . '.' . $rawField],
                     [Expression::TYPE_IDENTIFIER]
                 );
+                $query->columns([$expression]);
+                $order[] = $expression;
             }
 
             // Apply the user-specified sort:


### PR DESCRIPTION
Our tag sorting logic relied on a MySQL-specific `isnull` function. This PR switches to use a case statement instead, which works correctly in both MySQL and PostgreSQL.