### PR TITLE
Add missing Koha cover configuration line.

### DIFF
--- a/module/VuFind/src/VuFind/Content/Covers/PluginManager.php
+++ b/module/VuFind/src/VuFind/Content/Covers/PluginManager.php
@@ -81,6 +81,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         ContentCafe::class => ContentCafeFactory::class,
         Deprecated::class => InvokableFactory::class,
         Google::class => GoogleFactory::class,
+        Koha::class => KohaFactory::class,
         LibraryThing::class => InvokableFactory::class,
         LocalFile::class => InvokableFactory::class,
         ObalkyKnih::class => ObalkyKnihContentFactory::class,


### PR DESCRIPTION
The Koha cover provider added in release 9.1 did not work due to a missing line of configuration; this PR restores it.