### PR TITLE
Blender: Fix initialization of filteredFacetCounts.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Blender/Results.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Results.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\Search\Blender;
 
-use VuFindSearch\Command\SearchCommand;
-
 /**
  * Blender aspect of the Search Multi-class (Results)
  *
@@ -57,34 +55,9 @@ class Results extends \VuFind\Search\Solr\Results
      */
     protected function performSearch()
     {
-        $query  = $this->getParams()->getQuery();
-        $limit  = $this->getParams()->getLimit();
-        $offset = $this->getStartRecord() - 1;
-        $params = $this->getParams()->getBackendParameters();
-        $searchService = $this->getSearchService();
-
-        $command = new SearchCommand(
-            $this->backendId,
-            $query,
-            $offset,
-            $limit,
-            $params
-        );
-        $searchService->invoke($command);
-        $collection = $command->getResult();
-
-        $this->responseFacets = $collection->getFacets();
-        $this->resultTotal = $collection->getTotal();
-
-        // Process spelling suggestions
-        $spellcheck = $collection->getSpellcheck();
-        $this->spellingQuery = $spellcheck->getQuery();
-        $this->suggestions = $this->getSpellingProcessor()
-            ->getSuggestions($spellcheck, $this->getParams()->getQuery());
-
-        // Construct record drivers for all the items in the response:
-        $this->results = $collection->getRecords();
-
-        $this->errors = $collection->getErrors();
+        if (null !== $this->getCursorMark()) {
+            throw new \Exception('Blender does not support cursorMark');
+        }
+        parent::performSearch();
     }
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -260,6 +260,9 @@ class Results extends \VuFind\Search\Base\Results
 
         // Construct record drivers for all the items in the response:
         $this->results = $collection->getRecords();
+
+        // Store any errors:
+        $this->errors = $collection->getErrors();
     }
 
     /**


### PR DESCRIPTION
Use Solr's performSearch to ensure that all expected member variables are properly initialized.