### PR TITLE
Closing lightbox after returning from SSO

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -493,6 +493,7 @@ VuFind.register('lightbox', function Lightbox() {
       // load lightbox
       _currentUrl = lightboxChild;
       var obj = {
+        method: "get",
         url: lightboxChild
       };
       ajax(obj);


### PR DESCRIPTION
Using SSO login and the "Login for hold and recall information" link results in loading the record view inside of the lightbox.

To reproduce one can use the test environment and set 
```
[Catalog]
driver          = Demo
title_level_holds_mode = "driver"

[Authentication]
method         = SimulatedSSO
```
in config.ini. And one has to perform a catalog login and logout first. Then after using the "Login for hold and recall information" in the holdings tab and logging is will result in the error.

The problem is that the condition in line 218 of lightbox.js is false and the lightbox is not closed. A quick fix for this is done in this PR. 

But in my opinion the whole logic of loading a record page inside of a lightbox and closing the lightbox based on an url is not optimal. Maybe the link could directly be a link to an MyResearch action that checks the login and cataloglogin and after that the lightbox is closed.