### PR TITLE
Try to improve robustness of some Mink tests.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AutocompleteTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AutocompleteTest.php
@@ -64,9 +64,9 @@ class AutocompleteTest extends \VuFindTest\Integration\MinkTestCase
         $session->visit($this->getVuFindUrl() . '/Search/Home');
         $page = $session->getPage();
         if ($type) {
-            $this->findCss($page, '#searchForm_type')->setValue($type);
+            $this->findCssAndSetValue($page, '#searchForm_type', $type);
         }
-        $this->findCss($page, '#searchForm_lookfor')->setValue($search);
+        $this->findCssAndSetValue($page, '#searchForm_lookfor', $search);
         $acItem = $this->getAndAssertFirstAutocompleteValue($page, $expected);
         return $acItem;
     }
@@ -144,10 +144,8 @@ class AutocompleteTest extends \VuFindTest\Integration\MinkTestCase
         // Now repeat the same search in Author
         $session = $this->getMinkSession();
         $page = $session->getPage();
-        $this->findCss($page, '#searchForm_type')
-            ->setValue('Author');
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('jsto');
+        $this->findCssAndSetValue($page, '#searchForm_type', 'Author');
+        $this->findCssAndSetValue($page, '#searchForm_lookfor', 'jsto');
         // Make sure we get the right author match, and not a cached All Fields value!
         $acItem = $this->getAndAssertFirstAutocompleteValue($page, 'JSTOR (Organization)');
         $acItem->click();

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
@@ -148,11 +148,13 @@ class BasicSearchTest extends \VuFindTest\Integration\MinkTestCase
 
         $secondPage = $this->findCss($page, '.search-header .pagination-simple .page-next');
         $secondPage->click();
+        $this->waitForPageLoad($page);
         $this->assertShowingResults($page, '21 - 40');
         $this->scrollToResults();
 
         // Prev page now present, click it:
         $this->clickCss($page, '.search-header .pagination-simple .page-prev');
+        $this->waitForPageLoad($page);
         $this->assertShowingResults($page, '1 - 20');
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
@@ -57,6 +57,7 @@ class RecordTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $session->visit($url);
         $page = $session->getPage();
+        $this->waitForPageLoad($page);
         $staffViewTab = $this->findCss($page, '.record-tabs .details a');
         $this->assertEquals('Staff View', $staffViewTab->getText());
         $staffViewTab->click();


### PR DESCRIPTION
This could avoid some retries seen during Mink tests. I couldn't reproduce the test failures myself though, so I couldn't verify the fixes either.