### PR TITLE
Refactored hold login

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -757,7 +757,7 @@ $staticRoutes = [
     'LibraryCards/ConnectCard', 'LibraryCards/ConnectCardLogin',
     'LibraryCards/DeleteCard',
     'MyResearch/Account', 'MyResearch/ChangeEmail', 'MyResearch/ChangePassword',
-    'MyResearch/CheckedOut', 'MyResearch/Delete', 'MyResearch/DeleteAccount',
+    'MyResearch/CheckedOut', 'MyResearch/CompleteLogin', 'MyResearch/Delete', 'MyResearch/DeleteAccount',
     'MyResearch/DeleteList', 'MyResearch/DeleteUserLoginTokens',
     'MyResearch/DeleteLoginToken', 'MyResearch/Edit',
     'MyResearch/Email', 'MyResearch/EmailNotVerified', 'MyResearch/Favorites',

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -361,6 +361,29 @@ class MyResearchController extends AbstractBase
     }
 
     /**
+     * Complete login - perform a user login followed by a catalog login.
+     *
+     * @return mixed
+     */
+    public function completeLoginAction()
+    {
+        if (!$this->getAuthManager()->isLoggedIn()) {
+            $this->clearFollowupUrl();
+            $this->followup()->store();
+            if ($si = $this->getSessionInitiator()) {
+                return $this->redirect()->toUrl($si);
+            }
+            return $this->forwardTo('MyResearch', 'Login');
+        }
+        if (!is_array($patron = $this->catalogLogin())) {
+            return $patron;
+        }
+        return $this->inLightbox()
+            ? $this->getRefreshResponse()
+            : $this->redirect()->toRoute('home');
+    }
+
+    /**
      * Logout Action
      *
      * @return mixed

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -196,6 +196,8 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Start establishing library catalog profile
         $this->waitForPageLoad($page);
+
+        // Test invalid patron login
         $this->submitCatalogLoginForm($page, 'bad', 'incorrect');
         $this->assertEquals(
             'Invalid Patron Login',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -196,11 +196,6 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Start establishing library catalog profile
         $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.alert.alert-info a');
-        $this->assertEquals('Library Catalog Profile', $element->getText());
-        $element->click();
-
-        // Test invalid patron login
         $this->submitCatalogLoginForm($page, 'bad', 'incorrect');
         $this->assertEquals(
             'Invalid Patron Login',
@@ -277,19 +272,8 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('Login for hold and recall information', $element->getText());
         $element->click();
 
-        // Log in:
-        $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.modal-body .btn');
-        $this->assertEquals('Institutional Login', $element->getText());
-        $element->click();
-
         // Start establishing library catalog profile
         $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.alert.alert-info a');
-        $this->assertEquals('Library Catalog Profile', $element->getText());
-        $element->click();
-
-        // Test valid patron login
         $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
 
         // Create the hold and go to the holds screen:
@@ -332,15 +316,9 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('Login for hold and recall information', $element->getText());
         $element->click();
 
-        // Log in:
-        $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.modal-body .btn');
-        $this->assertEquals('Institutional Login', $element->getText());
-        $element->click();
-        $this->waitForPageLoad($page);
-
         // Check to be sure we don't have a garbled lightbox at this stage; past bugs
         // could cause the whole record to open in the lightbox here.
+        $this->waitForPageLoad($page);
         $this->unFindCss($page, '.modal-body nav');
 
         // Create the hold and go to the holds screen:
@@ -399,9 +377,6 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Start establishing library catalog profile
         $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.alert.alert-info a');
-        $this->assertEquals('Library Catalog Profile', $element->getText());
-        $element->click();
         $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
 
         // Test placing a hold with an invalid "required by" date:
@@ -846,10 +821,6 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Start establishing library catalog profile
         $this->waitForPageLoad($page);
-        $element = $this->findCss($page, '.alert.alert-info a');
-        $this->assertEquals('Library Catalog Profile', $element->getText());
-        $element->click();
-
         $this->submitCatalogLoginForm($page, 'catuser', 'catpass');
 
         // Open the "place hold" dialog and check for error message:

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -493,7 +493,6 @@ VuFind.register('lightbox', function Lightbox() {
       // load lightbox
       _currentUrl = lightboxChild;
       var obj = {
-        method: "get",
         url: lightboxChild
       };
       ajax(obj);

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -39,7 +39,7 @@
   <?php if ($account->loginEnabled() && $offlineMode != 'ils-offline'): ?>
     <?php if (!$user): ?>
       <div class="alert alert-info">
-        <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getTabUrl($this->driver, 'Holdings', ['login' => 'true', 'catalogLogin' => 'true']))?>" data-lightbox><?=$this->transEsc('hold_login')?></a>
+        <a id="hold-login" href="<?=$this->serverUrl($this->url('myresearch-completelogin'))?>" data-lightbox><?=$this->transEsc('hold_login')?></a>
       </div>
     <?php elseif (!$user->cat_username): ?>
       <div class="alert alert-info">


### PR DESCRIPTION
This is a followup PR to #3335. It introduces the new `completeLoginAction` that can be used to perform a login followed by a catalog login in a lightbox and then reload the current page. 

This is used for the hold login. It has the advantage that the record is not loaded again inside of the lightbox only to be closed immediately afterwards. This also removes this dependency on the url checks in lightbox.js. The solution of #3335 can be reverted since it might cause unwanted side effects. 
The catalog login is also being displayed in the lightbox directly after logging in. Hence, the users don't have to click the link in the holdings tab again.