### PR TITLE
Improve browscap.ini error handling.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
@@ -35,6 +35,8 @@ use Laminas\Session\SessionManager;
 use VuFind\Exception\Auth as AuthException;
 use VuFind\Exception\LoginToken as LoginTokenException;
 
+use function is_array;
+
 /**
  * Class LoginTokenManager
  *

--- a/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
@@ -174,12 +174,14 @@ class LoginTokenManager implements \VuFind\I18n\Translator\TranslatorAwareInterf
         $browser = '';
         $platform = '';
         try {
-            $userInfo = get_browser(null, true) ?? [];
-            $browser = $userInfo['browser'];
-            $platform = $userInfo['platform'];
+            $userInfo = get_browser(null, true);
         } catch (\Exception $e) {
+        }
+        if (!is_array($userInfo ?? null)) {
             throw new AuthException('Problem with browscap.ini');
         }
+        $browser = $userInfo['browser'] ?? '';
+        $platform = $userInfo['platform'] ?? '';
         if ($expires === 0) {
             $lifetime = $this->config->Authentication->persistent_login_lifetime ?? 14;
             $expires = time() + $lifetime * 60 * 60 * 24;


### PR DESCRIPTION
While working on PHPUnit 10 updates, I noticed that there was some unpredictable behavior in the browscap.ini processing logic. This PR attempts to make things a bit more consistent/reliable, by moving more logic outside of the try..catch and making it less likely to attempt to access an undefined array element.

I'm interested in whether @rajaro has any concerns about this.