### PR TITLE
Fix/improve theme selector behavior; add Mink test.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
@@ -164,6 +164,8 @@ class LoginTokenManager implements \VuFind\I18n\Translator\TranslatorAwareInterf
                 // associated with the tokens and send a warning email to user
                 $user = $this->userTable->getById($cookie['user_id']);
                 $this->deleteUserLoginTokens($user->id);
+                // We can't send an email until after the theme has initialized;
+                // if it's not ready yet, save the user for later.
                 if ($this->themeInitialized) {
                     $this->sendLoginTokenWarningEmail($user);
                 } else {
@@ -183,6 +185,7 @@ class LoginTokenManager implements \VuFind\I18n\Translator\TranslatorAwareInterf
     public function themeIsReady(): void
     {
         $this->themeInitialized = true;
+        // If we have queued a user warning, we can send it now!
         if ($this->userToWarn) {
             $this->sendLoginTokenWarningEmail($this->userToWarn);
             $this->userToWarn = null;

--- a/module/VuFind/src/VuFind/Auth/LoginTokenManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManagerFactory.php
@@ -68,15 +68,8 @@ class LoginTokenManagerFactory implements \Laminas\ServiceManager\Factory\Factor
             throw new \Exception('Unexpected options sent to factory.');
         }
 
-        $mainConfig = $container->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
-
-        // We need to initialize the theme so that the view renderer works:
-        $theme = new \VuFindTheme\Initializer($mainConfig->Site, $container);
-        $theme->init();
-
         return new $requestedName(
-            $config = $container->get(\VuFind\Config\PluginManager::class)
+            $container->get(\VuFind\Config\PluginManager::class)
                 ->get('config'),
             $container->get(\VuFind\Db\Table\PluginManager::class)
                 ->get('user'),

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -246,6 +246,20 @@ class Bootstrapper
     }
 
     /**
+     * Send login token warnings after the theme is initialized, if necessary.
+     *
+     * @return void
+     */
+    protected function initLoginTokenManager(): void
+    {
+        $callback = function () {
+            $this->container->get(\VuFind\Auth\LoginTokenManager::class)->themeIsReady();
+        };
+        $this->events->attach('dispatch.error', $callback, 8000);
+        $this->events->attach('dispatch', $callback, 8000);
+    }
+
+    /**
      * Set up custom HTTP status based on exception information.
      *
      * @return void

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -246,7 +246,8 @@ class Bootstrapper
     }
 
     /**
-     * Send login token warnings after the theme is initialized, if necessary.
+     * The login token manager needs to be informed after the theme has been initialized,
+     * so that it can send warning emails if necessary.
      *
      * @return void
      */

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
@@ -46,7 +46,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testHomePage()
+    public function testHomePage(): void
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Home');
@@ -59,7 +59,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testAjaxStatus()
+    public function testAjaxStatus(): void
     {
         // Search for a known record:
         $session = $this->getMinkSession();
@@ -89,7 +89,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testLanguage()
+    public function testLanguage(): void
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Home');
@@ -111,11 +111,51 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test theme switching by checking for a phrase from the example theme
+     *
+     * @return void
+     */
+    public function testThemeSwitcher(): void
+    {
+        // Turn on theme switcher
+        $themeList = 'sandal:sandal,example:local_theme_example';
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Site' => [
+                        'alternate_themes' => $themeList,
+                        'selectable_themes' => $themeList,
+                    ],
+                ],
+            ]
+        );
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Home');
+        $page = $session->getPage();
+        $this->waitForPageLoad($page);
+
+        // Default theme does not have an h1:
+        $this->unfindCss($page, 'h1');
+
+        // Change the theme:
+        $this->clickCss($page, '.theme-selector.dropdown');
+        $this->clickCss($page, '.theme-selector.dropdown li:not(.active) a');
+        $this->waitForPageLoad($page);
+
+        // Check h1 again -- it should exist now
+        $this->assertEquals(
+            'Welcome to your custom theme!',
+            $this->findCss($page, 'h1')->getHTML()
+        );
+    }
+
+    /**
      * Test lightbox jump links
      *
      * @return void
      */
-    public function testLightboxJumps()
+    public function testLightboxJumps(): void
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Home');

--- a/module/VuFindTheme/src/VuFindTheme/Initializer.php
+++ b/module/VuFindTheme/src/VuFindTheme/Initializer.php
@@ -168,7 +168,7 @@ class Initializer
         );
 
         // Determine theme options:
-        $this->sendThemeOptionsToView();
+        $this->sendThemeOptionsToView($currentTheme);
 
         // Make sure the current theme is set correctly in the tools object:
         $error = null;
@@ -260,16 +260,18 @@ class Initializer
     /**
      * Make the theme options available to the view.
      *
+     * @param string $currentTheme Active theme
+     *
      * @return void
      */
-    protected function sendThemeOptionsToView()
+    protected function sendThemeOptionsToView($currentTheme)
     {
         // Get access to the view model:
         if (PHP_SAPI !== 'cli') {
             $viewModel = $this->serviceManager->get('ViewManager')->getViewModel();
 
             // Send down the view options:
-            $viewModel->setVariable('themeOptions', $this->getThemeOptions());
+            $viewModel->setVariable('themeOptions', $this->getThemeOptions($currentTheme));
         }
     }
 
@@ -277,9 +279,11 @@ class Initializer
      * Return an array of information about user-selectable themes. Each entry in
      * the array is an associative array with 'name', 'desc' and 'selected' keys.
      *
+     * @param string $currentTheme Active theme
+     *
      * @return array
      */
-    protected function getThemeOptions()
+    protected function getThemeOptions($currentTheme)
     {
         $options = [];
         if (isset($this->config->selectable_themes)) {
@@ -292,7 +296,7 @@ class Initializer
                 if (!empty($name)) {
                     $options[] = [
                         'name' => $name, 'desc' => $desc,
-                        'selected' => ($this->cookieManager->get('ui') == $name),
+                        'selected' => ($currentTheme == $name),
                     ];
                 }
             }

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -73,6 +73,7 @@
           <?php if (isset($this->layout()->themeOptions) && count($this->layout()->themeOptions) > 1): ?>
               <?=$this->component('menu-button', [
                   'toggleLabel' => 'Theme',
+                  'wrapperClass' => 'theme-selector',
                   'wrapperTag' => 'li',
                   'menuItems' => array_map(
                       function ($item) {


### PR DESCRIPTION
This PR fixes two theme-related problems:

- The recent addition of login token support broke theme selection because a factory class was forcing premature theme initialization.
- The theme selection control only displayed a highlighted theme if a cookie was set; now it also highlights the default value if no cookie is set.

It also adds test coverage for the theme selection control.