### PR TITLE
LoginTokenManager: suppress browscap.ini warnings.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
@@ -212,7 +212,8 @@ class LoginTokenManager implements \VuFind\I18n\Translator\TranslatorAwareInterf
         $browser = '';
         $platform = '';
         try {
-            $userInfo = get_browser(null, true);
+            // Suppress warnings here; we'll throw an exception below if browscap.ini is not set up correctly.
+            $userInfo = @get_browser(null, true);
         } catch (\Exception $e) {
         }
         if (!is_array($userInfo ?? null)) {


### PR DESCRIPTION
PHPUnit 10 complains when tests trigger PHP warnings. Presently, the LoginTokenManager triggers a warning when browscap.ini is not configured, but we also detect this condition and throw an exception. Thus, I think it probably makes sense to suppress the warning to make the test suite happy and eliminate redundant error logging.