### PR TITLE
Simplify and type Auth tests.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
+use Laminas\Http\Request;
 use VuFind\Auth\LDAP;
 
 /**
@@ -48,19 +49,16 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param Config $config Configuration to use (null for default)
+     * @param ?Config $config Configuration to use (null for default)
      *
      * @return LDAP
      */
-    public function getAuthObject($config = null)
+    public function getAuthObject(?Config $config = null): LDAP
     {
         if (null === $config) {
             $config = $this->getAuthConfig();
         }
-        $authManager = new \VuFind\Auth\PluginManager(
-            new \VuFindTest\Container\MockContainer($this)
-        );
-        $obj = $authManager->get('LDAP');
+        $obj = new LDAP();
         $obj->setConfig($config);
         return $obj;
     }
@@ -70,7 +68,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return Config
      */
-    public function getAuthConfig()
+    public function getAuthConfig(): Config
     {
         $ldapConfig = new Config(
             [
@@ -89,7 +87,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithMissingHost()
+    public function testWithMissingHost(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -103,7 +101,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithMissingPort()
+    public function testWithMissingPort(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -117,7 +115,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithMissingBaseDN()
+    public function testWithMissingBaseDN(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -131,7 +129,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithMissingUid()
+    public function testWithMissingUid(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -145,7 +143,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCaseNormalization()
+    public function testCaseNormalization(): void
     {
         $config = $this->getAuthConfig();
         $config->LDAP->username = 'UPPER';
@@ -168,7 +166,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCreateIsDisallowed()
+    public function testCreateIsDisallowed(): void
     {
         $this->assertFalse($this->getAuthObject()->supportsCreation());
     }
@@ -179,14 +177,14 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $overrides Associative array of parameters to override.
      *
-     * @return \Laminas\Http\Request
+     * @return Request
      */
-    protected function getLoginRequest($overrides = [])
+    protected function getLoginRequest(array $overrides = []): Request
     {
         $post = $overrides + [
             'username' => 'testuser', 'password' => 'testpass',
         ];
-        $request = new \Laminas\Http\Request();
+        $request = new Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));
         return $request;
     }
@@ -196,7 +194,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankUsername()
+    public function testLoginWithBlankUsername(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -209,7 +207,7 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankPassword()
+    public function testLoginWithBlankPassword(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
+use \Laminas\Http\Request;
 use VuFind\Auth\SIP2;
 
 /**
@@ -46,19 +47,16 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param Config $config Configuration to use (null for default)
+     * @param ?Config $config Configuration to use (null for default)
      *
-     * @return LDAP
+     * @return SIP2
      */
-    public function getAuthObject($config = null)
+    public function getAuthObject(?Config $config = null): SIP2
     {
         if (null === $config) {
             $config = $this->getAuthConfig();
         }
-        $authManager = new \VuFind\Auth\PluginManager(
-            new \VuFindTest\Container\MockContainer($this)
-        );
-        $obj = $authManager->get('SIP2');
+        $obj = new SIP2();
         $obj->setConfig($config);
         return $obj;
     }
@@ -68,7 +66,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
      *
      * @return Config
      */
-    public function getAuthConfig()
+    public function getAuthConfig(): Config
     {
         $config = new Config(
             [
@@ -86,14 +84,14 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
      *
      * @param array $overrides Associative array of parameters to override.
      *
-     * @return \Laminas\Http\Request
+     * @return Request
      */
-    protected function getLoginRequest($overrides = [])
+    protected function getLoginRequest(array $overrides = []): Request
     {
         $post = $overrides + [
             'username' => 'testuser', 'password' => 'testpass',
         ];
-        $request = new \Laminas\Http\Request();
+        $request = new Request();
         $request->setPost(new \Laminas\Stdlib\Parameters($post));
         return $request;
     }
@@ -103,7 +101,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankUsername()
+    public function testLoginWithBlankUsername(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -116,7 +114,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankPassword()
+    public function testLoginWithBlankPassword(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
@@ -30,7 +30,7 @@
 namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
-use \Laminas\Http\Request;
+use Laminas\Http\Request;
 use VuFind\Auth\SIP2;
 
 /**


### PR DESCRIPTION
PHPUnit 10 revealed that the Auth tests were triggering some PHP warnings due to the strange way objects were being set up via mock containers. This PR simplifies the object initialization and adds some missing typing to modernize the code.