### PR TITLE
Tweak Mink tests, part 2

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/AutoRetryTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/AutoRetryTrait.php
@@ -119,7 +119,7 @@ trait AutoRetryTrait
                     if (is_callable($logMethod)) {
                         $method = get_class($this) . '::' . $this->getName(false);
                         $msg = "RETRY TEST $method ({$this->retriesLeft} left)"
-                            . ' after exception: ' . $e->getMessage() . '.';
+                            . ' after exception: ' . (string)$e . '.';
                         call_user_func(
                             $logMethod,
                             $msg . ' See PHP error log for details.',

--- a/module/VuFind/src/VuFindTest/Feature/DemoDriverTestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/DemoDriverTestTrait.php
@@ -204,8 +204,8 @@ trait DemoDriverTestTrait
         string $username,
         string $password
     ): void {
-        $this->findCss($page, '#profile_cat_username')->setValue($username);
-        $this->findCss($page, '#profile_cat_password')->setValue($password);
+        $this->findCssAndSetValue($page, '#profile_cat_username', $username);
+        $this->findCssAndSetValue($page, '#profile_cat_password', $password);
         $this->clickCss($page, 'input.btn.btn-primary');
     }
 }

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -516,11 +516,12 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      * Set a value within an element selected via CSS; retry if set fails
      * due to browser bugs.
      *
-     * @param Element $page     Page element
-     * @param string  $selector CSS selector
-     * @param string  $value    Value to set
-     * @param int     $timeout  Wait timeout for CSS selection (in ms)
-     * @param int     $retries  Retry count for set loop
+     * @param Element $page        Page element
+     * @param string  $selector    CSS selector
+     * @param string  $value       Value to set
+     * @param int     $timeout     Wait timeout for CSS selection (in ms)
+     * @param int     $retries     Retry count for set loop
+     * @param bool    $verifyValue Whether to verify that the value was written
      *
      * @return mixed
      */
@@ -529,7 +530,8 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $selector,
         $value,
         $timeout = null,
-        $retries = 6
+        $retries = 6,
+        $verifyValue = true
     ) {
         $timeout ??= $this->getDefaultTimeout();
 
@@ -539,6 +541,9 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             try {
                 $field = $this->findCss($page, $selector, $timeout, 0);
                 $field->setValue($value);
+                if (!$verifyValue) {
+                    return;
+                }
 
                 // Did it work? If so, we're done and can leave....
                 if ($field->getValue() === $value) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -355,7 +355,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         // Change the default and verify:
-        $this->findCss($page, '#home_library')->setValue('B');
+        $this->findCssAndSetValue($page, '#home_library', 'B');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
         $this->assertEquals('B', $this->findCss($page, '#home_library')->getValue());
@@ -365,7 +365,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         // Change to "Always ask me":
-        $this->findCss($page, '#home_library')->setValue(' ** ');
+        $this->findCssAndSetValue($page, '#home_library', ' ** ');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
         $this->assertEquals(
@@ -375,7 +375,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertNull($userTable->getByUsername('username2')->home_library);
 
         // Back to default:
-        $this->findCss($page, '#home_library')->setValue('');
+        $this->findCssAndSetValue($page, '#home_library', '');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
         $this->assertEquals(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -139,13 +139,13 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '#search1_0 .adv-term-remove:not(.hidden)');
 
         // Enter search for bride of the tomb
-        $this->findCss($page, '#search_lookfor0_0')->setValue('bride');
-        $this->findCss($page, '#search_lookfor0_1')->setValue('tomb');
+        $this->findCssAndSetValue($page, '#search_lookfor0_0', 'bride');
+        $this->findCssAndSetValue($page, '#search_lookfor0_1', 'tomb');
         $this->findCss($page, '#search_type0_1')->selectOption('Title');
-        $this->findCss($page, '#search_lookfor0_2')->setValue('garbage');
-        $this->findCss($page, '#search_lookfor0_3')->setValue('1883');
+        $this->findCssAndSetValue($page, '#search_lookfor0_2', 'garbage');
+        $this->findCssAndSetValue($page, '#search_lookfor0_3', '1883');
         $this->findCss($page, '#search_type0_3')->selectOption('year');
-        $this->findCss($page, '#search_lookfor1_0')->setValue('miller');
+        $this->findCssAndSetValue($page, '#search_lookfor1_0', 'miller');
 
         // Submit search form
         $this->findCss($page, '[type=submit]')->press();
@@ -217,9 +217,9 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '#group1');
 
         // Enter search criteria
-        $this->findCss($page, '#search_lookfor0_0')->setValue('building:"journals.mrc"');
+        $this->findCssAndSetValue($page, '#search_lookfor0_0', 'building:"journals.mrc"');
         $this->findCss($page, '#search_type1_0')->selectOption('Title');
-        $this->findCss($page, '#search_lookfor1_0')->setValue('rational');
+        $this->findCssAndSetValue($page, '#search_lookfor1_0', 'rational');
         $this->findCss($page, '#search_bool1')->selectOption('NOT');
 
         // Submit search form
@@ -248,7 +248,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
 
         // Enter search criteria
         $this->findCss($page, '#search_type0_0')->selectOption('Title');
-        $this->findCss($page, '#search_lookfor0_0')->setValue('rational');
+        $this->findCssAndSetValue($page, '#search_lookfor0_0', 'rational');
         $this->findCss($page, '#search_bool0')->selectOption('NOT');
 
         // Submit search form

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ApiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ApiTest.php
@@ -57,7 +57,7 @@ class ApiTest extends \VuFindTest\Integration\MinkTestCase
         $page = $session->getPage();
         $this->clickCss($page, '#operations-Record-get_record button');
         $this->clickCss($page, '#operations-Record-get_record .try-out button');
-        $this->findCss($page, '#operations-Record-get_record input[type="text"]')->setValue($id);
+        $this->findCssAndSetValue($page, '#operations-Record-get_record input[type="text"]', $id);
         $this->clickCss($page, '#operations-Record-get_record .execute-wrapper button');
         return $page;
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
@@ -92,7 +92,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
     protected function fillInAndSubmitFeedbackForm($page)
     {
         $this->clickCss($page, '#feedbackLink');
-        $this->findCss($page, '#modal .form-control[name="name"]')->setValue('Me');
+        $this->findCssAndSetValue($page, '#modal .form-control[name="name"]', 'Me');
         $this->findCss($page, '#modal .form-control[name="email"]')
             ->setValue('test@test.com');
         $this->findCss($page, '#modal #form_FeedbackSite_message')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -138,7 +138,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         // Add extra form field values:
         $this->waitForPageLoad($page);
         foreach ($extras as $selector => $value) {
-            $this->findCss($page, $selector)->setValue($value);
+            $this->findCssAndSetValue($page, $selector, $value);
         }
         $this->clickCss($page, '.modal-body .btn.btn-primary');
     }
@@ -597,8 +597,8 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.hold-edit');
 
         // Release the hold and change the pickup location
-        $this->findCss($page, '#frozen')->setValue('0');
-        $this->findCss($page, '#pickup_location')->setValue('A');
+        $this->findCssAndSetValue($page, '#frozen', '0');
+        $this->findCssAndSetValue($page, '#pickup_location', 'A');
         $this->findCss($page, '#modal .btn.btn-primary')->click();
 
         // Confirm that the values have changed
@@ -652,7 +652,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Change the first hold to location C so it matches the second one:
         $this->clickCss($page, '.hold-edit');
-        $this->findCss($page, '#pickup_location')->setValue('C');
+        $this->findCssAndSetValue($page, '#pickup_location', 'C');
         $this->findCss($page, '#modal .btn.btn-primary')->click();
 
         // Locations should now match:
@@ -669,7 +669,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.checkbox-select-item', 1000, 0);
         $this->clickCss($page, '.checkbox-select-item', 1000, 2);
         $this->clickCss($page, '#update_selected');
-        $this->findCss($page, '#pickup_location')->setValue('C');
+        $this->findCssAndSetValue($page, '#pickup_location', 'C');
         $this->findCss($page, '#modal .btn.btn-primary')->click();
 
         // Confirm that it worked:
@@ -703,8 +703,8 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Revise the freeze date:
         $futureDate = date('m-d-Y', strtotime('+3 days'));
-        $this->findCss($page, '#frozen')->setValue('1');
-        $this->findCss($page, '#frozen_through')->setValue($futureDate);
+        $this->findCssAndSetValue($page, '#frozen', '1');
+        $this->findCssAndSetValue($page, '#frozen_through', $futureDate);
         $this->findCss($page, '#modal .btn.btn-primary')->click();
 
         // Confirm that the values have changed
@@ -771,7 +771,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         // Set pickup location to a non-default value so we can confirm that
         // the element is being passed through correctly, then submit form:
         $this->waitForPageLoad($page);
-        $this->findCss($page, '#pickUpLocation')->setValue('B');
+        $this->findCssAndSetValue($page, '#pickUpLocation', 'B');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
 
         // If successful, we should now have a link to review the hold:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -107,9 +107,9 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Set pickup location to a non-default value so we can confirm that
         // the element is being passed through correctly, then submit form:
-        $this->findCss($page, '#pickupLibrary')->setValue('2');
+        $this->findCssAndSetValue($page, '#pickupLibrary', '2');
         $this->waitForPageLoad($page);
-        $this->findCss($page, '#pickupLibraryLocation')->setValue('3');
+        $this->findCssAndSetValue($page, '#pickupLibraryLocation', '3');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
 
         // If successful, we should now have a link to review the request:
@@ -143,7 +143,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Set pickup location to a non-default value so we can confirm that
         // the element is being passed through correctly, then submit form:
-        $this->findCss($page, '.modal-body select')->setValue('C');
+        $this->findCssAndSetValue($page, '.modal-body select', 'C');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
 
         // If successful, we should now have a link to review the request:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
@@ -222,9 +222,9 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCss($page, '.catalog-profile tr:nth-child(1) td:nth-child(2)')->getText()
         );
 
-        // Switch to the second card; we can't currently use findCssAndSetValue() here because
-        // it conflicts with the behavior of jumpMenu.
-        $this->findCssAndSetValue($page, '#library_card', $card2Value);
+        // Switch to the second card; don't try to verify the set value because it
+        // conflicts with the behavior of jumpMenu.
+        $this->findCssAndSetValue($page, '#library_card', $card2Value, null, 6, false);
         $this->waitForPageLoad($page);
 
         // Check that the appropriate username is reflected in the output:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
@@ -224,7 +224,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Switch to the second card; we can't currently use findCssAndSetValue() here because
         // it conflicts with the behavior of jumpMenu.
-        $this->findCss($page, '#library_card')->setValue($card2Value);
+        $this->findCssAndSetValue($page, '#library_card', $card2Value);
         $this->waitForPageLoad($page);
 
         // Check that the appropriate username is reflected in the output:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
@@ -152,8 +152,8 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
         $this->submitLoginForm($page);
         // Make list
         $this->clickCss($page, '#make-list');
-        $this->findCss($page, '#list_title')->setValue('Test List');
-        $this->findCss($page, '#list_desc')->setValue('Just. THE BEST.');
+        $this->findCssAndSetValue($page, '#list_title', 'Test List');
+        $this->findCssAndSetValue($page, '#list_desc', 'Just. THE BEST.');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Save to list
         $this->clickCss($page, '.modal-body .btn.btn-primary');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -134,7 +134,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, 'form.comment-form .btn-primary');
         $this->unFindCss($page, '.comment');
         // Add comment
-        $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('one');
+        $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'one');
         $this->clickCss($page, 'form.comment-form .btn-primary');
         $this->findCss($page, '.comment');
         // Remove comment
@@ -188,7 +188,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, 'form.comment-form .btn-primary');
         $this->unFindCss($page, '.comment');
         // Add comment without CAPTCHA
-        $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('one');
+        $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'one');
         $this->clickCss($page, 'form.comment-form .btn-primary');
         $this->assertEquals(
             'CAPTCHA not passed',
@@ -229,7 +229,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
             $this->submitLoginForm($page);
         }
         // Add tags
-        $this->findCss($page, '.modal #addtag_tag')->setValue($tags);
+        $this->findCssAndSetValue($page, '.modal #addtag_tag', $tags);
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page);
         $success = $this->findCss($page, '.modal-body .alert-success');
@@ -435,7 +435,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLoginForm($page, 'username2', 'test');
         $this->submitLoginForm($page);
         // Add tags
-        $this->findCss($page, '.modal #addtag_tag')->setValue('one ONE "new tag" ONE "THREE 4"');
+        $this->findCssAndSetValue($page, '.modal #addtag_tag', 'one ONE "new tag" ONE "THREE 4"');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page);
         $success = $this->findCss($page, '.modal-body .alert-success');
@@ -475,11 +475,11 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Make sure Lightbox redirects to email view
         $this->findCss($page, '.modal #email_to');
         // Type invalid email
-        $this->findCss($page, '.modal #email_to')->setValue('blargarsaurus');
-        $this->findCss($page, '.modal #email_from')->setValue('asdf@asdf.com');
-        $this->findCss($page, '.modal #email_message')->setValue('message');
+        $this->findCssAndSetValue($page, '.modal #email_to', 'blargarsaurus');
+        $this->findCssAndSetValue($page, '.modal #email_from', 'asdf@asdf.com');
+        $this->findCssAndSetValue($page, '.modal #email_message', 'message');
         // Send text to false email
-        $this->findCss($page, '.modal #email_to')->setValue('asdf@vufind.org');
+        $this->findCssAndSetValue($page, '.modal #email_to', 'asdf@vufind.org');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message
         $this->findCss($page, '.modal .alert-success');
@@ -503,8 +503,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.mail-record');
         $this->findCss($page, '.modal #email_to');
         // Send text to false email
-        $this->findCss($page, '.modal #email_to')->setValue('asdf@vufind.org');
-        $this->findCss($page, '.modal #email_from')->setValue('asdf@vufind.org');
+        $this->findCssAndSetValue($page, '.modal #email_to', 'asdf@vufind.org');
+        $this->findCssAndSetValue($page, '.modal #email_from', 'asdf@vufind.org');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message and close lightbox
         $this->findCss($page, '.modal .alert-success');
@@ -535,36 +535,36 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.sms-record');
         // Type invalid phone numbers
         // - too empty
-        $this->findCss($page, '.modal #sms_to')->setValue('');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->findCss($page, '.modal .sms-error');
         // - too short
-        $this->findCss($page, '.modal #sms_to')->setValue('123');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '123');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->findCss($page, '.modal .sms-error');
         // - too long
-        $this->findCss($page, '.modal #sms_to')->setValue('12345678912345678912345679');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '12345678912345678912345679');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->findCss($page, '.modal .sms-error');
         // - too lettery
-        $this->findCss($page, '.modal #sms_to')->setValue('123abc');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '123abc');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->findCss($page, '.modal .sms-error');
         // - just right
-        $this->findCss($page, '.modal #sms_to')->setValue('8005555555');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '8005555555');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page); // wait for form submission to catch missing carrier
         $this->assertNull($page->find('css', '.modal .sms-error'));
 
         $this->unFindCss($page, '.modal .sms-error');
         // - pretty just right
-        $this->findCss($page, '.modal #sms_to')->setValue('(800) 555-5555');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '(800) 555-5555');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page); // wait for form submission to catch missing carrier
         $this->assertNull($page->find('css', '.modal .sms-error'));
         $this->unFindCss($page, '.modal .sms-error');
         // Send text to false number
-        $this->findCss($page, '.modal #sms_to')->setValue('(800) 555-5555');
+        $this->findCssAndSetValue($page, '.modal #sms_to', '(800) 555-5555');
         $optionElement = $this->findCss($page, '.modal #sms_provider option');
         $page->selectFieldOption('sms_provider', 'verizon');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
@@ -583,7 +583,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Home');
         $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')->setValue('Dewey');
+        $this->findCssAndSetValue($page, '#searchForm_lookfor', 'Dewey');
         $this->findCss($page, '.btn.btn-primary')->click();
         $this->clickCss($page, '.result a.title');
 
@@ -752,7 +752,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.record-tabs .usercomments a');
         $this->waitForPageLoad($page);
         $this->findCss($page, '.comment-form');
-        $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('one');
+        $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'one');
         $this->clickCss($page, 'form.comment-form div.star-rating label', null, 10);
         // Check that "Clear" link is present before submitting:
         $this->findCss($page, 'form.comment-form a');
@@ -767,7 +767,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         );
         if ($allowRemove) {
             // Clear rating when adding another comment
-            $this->findCss($page, 'form.comment-form [name="comment"]')->setValue('two');
+            $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'two');
             $this->clickCss($page, 'form.comment-form a');
             $this->clickCss($page, 'form.comment-form .btn-primary');
             // Check result (wait for the value to update):

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
@@ -29,8 +29,12 @@
 
 namespace VuFindTest\Mink;
 
+use VuFindTest\Feature\LiveDatabaseTrait;
+
 /**
  * Mink SSO test class.
+ *
+ * Class must be final due to use of "new static()" by LiveDatabaseTrait.
  *
  * @category VuFind
  * @package  Tests
@@ -39,8 +43,10 @@ namespace VuFindTest\Mink;
  * @link     https://vufind.org Main Page
  * @retry    4
  */
-class SsoTest extends \VuFindTest\Integration\MinkTestCase
+final class SsoTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use \VuFindTest\Feature\LiveDatabaseTrait;
+
     /**
      * Get config.ini override settings for testing SSO login.
      *
@@ -52,6 +58,11 @@ class SsoTest extends \VuFindTest\Integration\MinkTestCase
             'config' => [
                 'Authentication' => [
                     'method' => 'SimulatedSSO',
+                ],
+            ],
+            'SimulatedSSO' => [
+                'General' => [
+                    'username' => 'ssofakeuser1',
                 ],
             ],
         ];
@@ -131,5 +142,15 @@ class SsoTest extends \VuFindTest\Integration\MinkTestCase
 
         // Check that login link is back
         $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+    }
+
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        static::removeUsers(['ssofakeuser1']);
     }
 }


### PR DESCRIPTION
Improves findCssAndSetValue and uses it more. This should alleviate some full test retries. Also fixes SSO test to not leave a user dangling in the database.