### PR TITLE
Adjust PHPUnit .gitignore for forward compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ env.bat
 env.sh
 import/solrmarc.log*
 lessphp_*.list
-module/VuFind/tests/.phpunit.result.cache
+module/VuFind/tests/.phpunit*
 node_modules
 package-lock.json
 public/swagger-ui


### PR DESCRIPTION
PHPUnit 10 uses a different cache location than earlier versions. This adjustment ensures that Git ignores all versions, preventing accidental commits of files when switching between versions.