### PR TITLE
Convert DOM events to stored functions

### DIFF
--- a/themes/bootstrap3/js/cart.js
+++ b/themes/bootstrap3/js/cart.js
@@ -312,4 +312,4 @@ function cartFormHandler(event, data) {
   }
 }
 
-document.addEventListener('VuFind.lightbox.closed', VuFind.cart.updateCount, false);
+VuFind.listen('lightbox.closed', VuFind.cart.updateCount);

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -19,6 +19,10 @@ var VuFind = (function VuFind() {
 
   let listeners = {};
   function unlisten(event, fn) {
+    if (typeof listeners[event] === "undefined") {
+      return;
+    }
+
     const index = listeners[event].indexOf(fn);
 
     if (index > -1) {
@@ -34,7 +38,7 @@ var VuFind = (function VuFind() {
     const listenFn = !once ? fn : (...args) => {
       fn(...args);
       // Automatically remove a listener we only want to run once
-      unlisten(arguments.callee);
+      unlisten(event, arguments.callee);
     };
 
     listeners[event].push(listenFn);

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -31,7 +31,7 @@ var VuFind = (function VuFind() {
       listeners[event] = [];
     }
 
-    const listenFn = !once : fn : (...args) => {
+    const listenFn = !once ? fn : (...args) => {
       fn(...args);
       // Automatically remove a listener we only want to run once
       unlisten(arguments.callee);

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -31,8 +31,14 @@ var VuFind = (function VuFind() {
       listeners[event] = [];
     }
 
-    listeners[event].push(fn);
-    return () => unlisten(event, fn);
+    const listenFn = !once : fn : (...args) => {
+      fn(...args);
+      // Automatically remove a listener we only want to run once
+      unlisten(arguments.callee);
+    };
+
+    listeners[event].push(listenFn);
+    return () => unlisten(event, listenFn);
   }
 
   function emit(event, ...args) {

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -55,7 +55,7 @@ var VuFind = (function VuFind() {
     return removeListener;
   }
 
-  // Broadcat an event, passing arguments to all listeners
+  // Broadcast an event, passing arguments to all listeners
   function emit(event, ...args) {
     // No listeners for this event
     if (typeof listeners[event] === "undefined") {

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -30,23 +30,34 @@ var VuFind = (function VuFind() {
     }
   }
 
+  // Add a function to call when an event is emitted
+  //
+  // Options:
+  // - once: remove this listener after it's been called
   function listen(event, fn, { once = false } = {}) {
     if (typeof listeners[event] === "undefined") {
       listeners[event] = [];
     }
 
     listeners[event].push(fn);
+    const removeListener = () => unlisten(event, fn);
 
     if (once) {
-      listeners[event].push(() => {
-        unlisten(event, fn);
-      });
+      // Remove a "once" listener after calling
+      // Add the function to remove the listener
+      // to the array, listeners are called in order
+      listeners[event].push(removeListener);
     }
 
-    return () => unlisten(event, fn);
+    // Return a function to disable the listener
+    // Makes it easier to control activating and deactivating listeners
+    // This is common for similar libraries
+    return removeListener;
   }
 
+  // Broadcat an event, passing arguments to all listeners
   function emit(event, ...args) {
+    // No listeners for this event
     if (typeof listeners[event] === "undefined") {
       return;
     }

--- a/themes/bootstrap3/js/cookie.js
+++ b/themes/bootstrap3/js/cookie.js
@@ -17,18 +17,18 @@ VuFind.register('cookie', function cookie() {
   function setupConsent(_config) {
     consentConfig = _config;
     consentConfig.consentDialog.onFirstConsent = function onFirstConsent() {
-      VuFind.emit('vf-cookie-consent-first-done');
+      VuFind.emit('cookie-consent-first-done');
     };
     consentConfig.consentDialog.onConsent = function onConsent() {
       updateServiceStatus();
-      VuFind.emit('vf-cookie-consent-done');
+      VuFind.emit('cookie-consent-done');
     };
     consentConfig.consentDialog.onChange = function onChange() {
       updateServiceStatus();
-      VuFind.emit('vf-cookie-consent-changed');
+      VuFind.emit('cookie-consent-changed');
     };
     CookieConsent.run(consentConfig.consentDialog);
-    VuFind.emit('vf-cookie-consent-initialized');
+    VuFind.emit('cookie-consent-initialized');
   }
 
   function isCategoryAccepted(category) {

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -323,9 +323,8 @@ VuFind.register('lightbox', function Lightbox() {
     // onclose behavior
     if ('string' === typeof $(form).data('lightboxOnclose')) {
       VuFind.listen('lightbox.closed', function lightboxClosed() {
-        VuFind.unlisten('lightbox.closed', arguments.callee); // only once
         VuFind.evalCallback($(form).data('lightboxOnclose'), null, form);
-      });
+      }, { once: true });
     }
     // Prevent multiple submission of submit button in lightbox
     if (submit.closest(_modal).length > 0) {

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -32,22 +32,6 @@ VuFind.register('lightbox', function Lightbox() {
     _lightboxTitle = false;
     _modal.modal('handleUpdate');
   }
-  function _emit(msg, _details) {
-    var details = _details || {};
-    var event;
-    try {
-      event = new CustomEvent(msg, {
-        detail: details,
-        bubbles: true,
-        cancelable: true
-      });
-    } catch (e) {
-      // Fallback to document.createEvent() if creating a new CustomEvent fails (e.g. IE 11)
-      event = document.createEvent('CustomEvent');
-      event.initCustomEvent(msg, true, true, details);
-    }
-    return document.dispatchEvent(event);
-  }
 
   function _addQueryParameters(url, params) {
     let fragmentSplit = url.split('#');
@@ -220,7 +204,7 @@ VuFind.register('lightbox', function Lightbox() {
             || obj.url.match(/MyResearch\/(?!Bulk|Delete|Recover)/)
           ) && flashMessages.length === 0
         ) {
-          var eventResult = _emit('VuFind.lightbox.login', {
+          var eventResult = VuFind.emit('lightbox.login', {
             originalUrl: _originalUrl,
             formUrl: obj.url
           });
@@ -338,10 +322,10 @@ VuFind.register('lightbox', function Lightbox() {
     }
     // onclose behavior
     if ('string' === typeof $(form).data('lightboxOnclose')) {
-      document.addEventListener('VuFind.lightbox.closed', function lightboxClosed(e) {
-        this.removeEventListener('VuFind.lightbox.closed', arguments.callee);
-        VuFind.evalCallback($(form).data('lightboxOnclose'), e, form);
-      }, false);
+      VuFind.listen('lightbox.closed', function lightboxClosed() {
+        VuFind.unlisten('lightbox.closed', arguments.callee); // only once
+        VuFind.evalCallback($(form).data('lightboxOnclose'), null, form);
+      });
     }
     // Prevent multiple submission of submit button in lightbox
     if (submit.closest(_modal).length > 0) {
@@ -523,12 +507,12 @@ VuFind.register('lightbox', function Lightbox() {
         }
         unbindFocus();
         this.setAttribute('aria-hidden', true);
-        _emit('VuFind.lightbox.closing');
+        VuFind.emit('lightbox.closing');
       }
     });
     _modal.on('hidden.bs.modal', function lightboxHidden() {
       VuFind.lightbox.reset();
-      _emit('VuFind.lightbox.closed');
+      VuFind.emit('lightbox.closed');
     });
     _modal.on("shown.bs.modal", function lightboxShown() {
       bindFocus();

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -209,8 +209,10 @@ VuFind.register('lightbox', function Lightbox() {
 
           VuFind.emit(
             'lightbox.login',
-            obj.url,
-            _originalUrl,
+            {
+              formUrl: obj.url,
+              originalUrl: _originalUrl,
+            },
             cancelRefresh // call this function to cancel refresh
           );
 

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -204,12 +204,18 @@ VuFind.register('lightbox', function Lightbox() {
             || obj.url.match(/MyResearch\/(?!Bulk|Delete|Recover)/)
           ) && flashMessages.length === 0
         ) {
-          var eventResult = VuFind.emit('lightbox.login', {
-            originalUrl: _originalUrl,
-            formUrl: obj.url
-          });
+          let doRefresh = true;
+          const cancelRefresh = () => doRefresh = false;
+
+          VuFind.emit(
+            'lightbox.login',
+            obj.url,
+            _originalUrl,
+            cancelRefresh // call this function to cancel refresh
+          );
+
           if (_originalUrl.match(/UserLogin/) || obj.url.match(/catalogLogin/)) {
-            if (eventResult) {
+            if (doRefresh) {
               VuFind.refreshPage();
             }
             return false;

--- a/themes/bootstrap3/js/search.js
+++ b/themes/bootstrap3/js/search.js
@@ -321,7 +321,7 @@ VuFind.register('search', function search() {
     updateResultControls(pageUrl);
     updateResultLinks(pageUrl);
 
-    VuFind.emit('vf-results-load', {
+    VuFind.emit('results-load', {
       url: pageUrl,
       addToHistory: addToHistory
     });
@@ -364,7 +364,7 @@ VuFind.register('search', function search() {
         VuFind.initResultScripts(jsRecordListSelector);
         initPagination();
 
-        VuFind.emit('vf-results-loaded', {
+        VuFind.emit('results-loaded', {
           url: pageUrl,
           addToHistory: addToHistory,
           data: result

--- a/themes/bootstrap3/js/search.js
+++ b/themes/bootstrap3/js/search.js
@@ -320,7 +320,12 @@ VuFind.register('search', function search() {
     }
     updateResultControls(pageUrl);
     updateResultLinks(pageUrl);
-    VuFind.emit('vf-results-load', {url: pageUrl, addToHistory: addToHistory});
+
+    VuFind.emit('vf-results-load', {
+      url: pageUrl,
+      addToHistory: addToHistory
+    });
+
     fetch(VuFind.path + '/AJAX/JSON?' + queryParams.toString())
       .then((response) => response.json())
       .then((result) => {
@@ -358,7 +363,13 @@ VuFind.register('search', function search() {
         });
         VuFind.initResultScripts(jsRecordListSelector);
         initPagination();
-        VuFind.emit('vf-results-loaded', {url: pageUrl, addToHistory: addToHistory, data: result});
+
+        VuFind.emit('vf-results-loaded', {
+          url: pageUrl,
+          addToHistory: addToHistory,
+          data: result
+        });
+
         recordList.classList.remove('loading');
       })
       .catch((error) => {


### PR DESCRIPTION
Changing `VuFind.listen` and `VuFind.emit` to stored functions instead of DOM Events will enable simpler and more robust messaging. [As discussed recently in a long-standing lightbox issue](https://github.com/vufind-org/vufind/pull/1680#issuecomment-1889942392).

Events are now automatically scoped to VuFind, pass parameters more naturally and natively, and with simpler, smaller syntax. I am concerned that I missed a few places due to the mix of `VuFind.listen` and `addEventListener` (a distinction that is now clearer!) so thorough testing is needed.

- [x] Run full integration tests
- [ ] Update [documentation](https://vufind.org/wiki/development:architecture:lightbox) if necessary
- [x] Update changelog to note BC breaks (no longer using DOM events; custom event hooks will need revision)

This protocol and implementation is inspired by [nanoevents](https://github.com/ai/nanoevents) if we want to use a dependency instead of custom code.