### PR TITLE
KohaRest: Handle an Item::Recalled availability status

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -208,7 +208,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     protected $itemStatusMappings = [
         'Item::Held' => 'On Hold',
         'Item::Waiting' => 'On Holdshelf',
-        'Item::Recalled' => 'On Holdshelf',
+        'Item::Recalled' => 'Recalled',
     ];
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -208,6 +208,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
     protected $itemStatusMappings = [
         'Item::Held' => 'On Hold',
         'Item::Waiting' => 'On Holdshelf',
+        'Item::Recalled' => 'On Holdshelf',
     ];
 
     /**


### PR DESCRIPTION
This basic fix allows VuFind to handle an Item::Recalled availability status from the KohaSuomi plugin https://github.com/NatLibFi/koha-plugin-rest-di/pull/29