### PR TITLE
Use StorageInterface instead of AbstractAdapter for cache hints.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -29,9 +29,7 @@
 
 namespace VuFind\Recommend;
 
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
-use Laminas\Config\Config;
-use VuFind\Connection\LibGuides;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 
 use function count;
 use function intval;

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\Recommend;
 
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 use Laminas\Config\Config;
 use VuFind\Connection\LibGuides;
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ProxyUrl.php
@@ -30,7 +30,7 @@
 namespace VuFind\View\Helper\Root;
 
 use Exception;
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 
 use function intval;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
@@ -31,7 +31,7 @@
 
 namespace VuFindTest\Config;
 
-use Laminas\Cache\Storage\Adapter\AbstractAdapter;
+use Laminas\Cache\Storage\StorageInterface;
 use VuFind\Config\YamlReader;
 use VuFindTest\Feature\FixtureTrait;
 use VuFindTest\Feature\PathResolverTrait;
@@ -59,8 +59,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
     public function testCacheWrite()
     {
         $yamlData = ['foo' => 'bar'];
-        $cache = $this->getMockBuilder(AbstractAdapter::class)
-            ->getMock();
+        $cache = $this->createMock(StorageInterface::class);
         $cache->expects($this->once())->method('getItem')
             ->will($this->returnValue(null));
         $cache->expects($this->once())->method('setItem')
@@ -92,8 +91,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
     public function testCacheRead()
     {
         $yamlData = ['foo' => 'bar'];
-        $cache = $this->getMockBuilder(AbstractAdapter::class)
-            ->getMock();
+        $cache = $this->createMock(StorageInterface::class);
         $cache->expects($this->once())->method('getItem')
             ->will($this->returnValue($yamlData));
         $cache->expects($this->never())->method('setItem');
@@ -122,8 +120,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
     public function testCacheForcedReload()
     {
         $yamlData = ['foo' => 'bar'];
-        $cache = $this->getMockBuilder(AbstractAdapter::class)
-            ->getMock();
+        $cache = $this->createMock(StorageInterface::class);
         $cache->expects($this->exactly(2))->method('getItem')
             ->will($this->returnValue($yamlData));
         $cache->expects($this->never())->method('setItem');

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/DatabasesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/DatabasesTest.php
@@ -29,7 +29,7 @@
 
 namespace VuFindTest\Recommend;
 
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 use VuFind\Recommend\Databases;
 
 /**
@@ -162,7 +162,7 @@ class DatabasesTest extends \PHPUnit\Framework\TestCase
             return $libGuides;
         };
 
-        $cache = $this->getMockBuilder(CacheAdapter::class)->getMock();
+        $cache = $this->createMock(CacheAdapter::class);
         $module = $this->getMockBuilder(Databases::class)
             ->setConstructorArgs([$configManager, $libGuidesGetter, $cache])
             ->onlyMethods(['getCachedData', 'putCachedData'])

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -30,7 +30,7 @@
 
 namespace VuFindTest\Recommend;
 
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 use Laminas\Config\Config;
 use VuFind\Config\PluginManager as ConfigPluginManager;
 use VuFind\Connection\LibGuides;
@@ -200,7 +200,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
     {
         // Mock caching logic in LibGuidesProfile.
         // Caching is from a trait, which is not the point of this test suite.
-        $this->cacheAdapter = $this->getMockBuilder(CacheAdapter::class)->getMock();
+        $this->cacheAdapter = $this->createMock(CacheAdapter::class);
 
         // For the target class LibGuidesProfile, only mock the caching methods
         $libGuidesProfile = $this->getMockBuilder(LibGuidesProfile::class)

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -31,7 +31,7 @@
 namespace VuFindSearch\Backend\EDS;
 
 use Exception;
-use Laminas\Cache\Storage\Adapter\AbstractAdapter as CacheAdapter;
+use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 use Laminas\Config\Config;
 use Laminas\Session\Container as SessionContainer;
 use VuFindSearch\Backend\AbstractBackend;

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Blender/BackendTest.php
@@ -1245,9 +1245,7 @@ class BackendTest extends TestCase
             ->method('call')
             ->will($this->returnCallback($callback));
 
-        $cache = $this->getMockForAbstractClass(
-            \Laminas\Cache\Storage\Adapter\AbstractAdapter::class
-        );
+        $cache = $this->createMock(\Laminas\Cache\Storage\StorageInterface::class);
         $container = $this->getMockBuilder(\Laminas\Session\Container::class)
             ->disableOriginalConstructor()->getMock();
         $params = [

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/EDS/BackendTest.php
@@ -303,7 +303,7 @@ class BackendTest extends \PHPUnit\Framework\TestCase
      *
      * @param \VuFindSearch\Backend\EDS\Connector                     $connector Connector
      * @param \VuFindSearch\Response\RecordCollectionFactoryInterface $factory   Record collection factory
-     * @param \Laminas\Cache\Storage\Adapter\AbstractAdapter          $cache     Object cache adapter
+     * @param \Laminas\Cache\Storage\StorageInterface                 $cache     Object cache adapter
      * @param \Laminas\Session\Container                              $container Session container
      * @param array                                                   $settings  Additional settings
      * @param array                                                   $mock      Methods to mock (or null for a
@@ -323,7 +323,7 @@ class BackendTest extends \PHPUnit\Framework\TestCase
             $factory = $this->createMock(\VuFindSearch\Response\RecordCollectionFactoryInterface::class);
         }
         if (null === $cache) {
-            $cache = $this->getMockForAbstractClass(\Laminas\Cache\Storage\Adapter\AbstractAdapter::class);
+            $cache = $this->createMock(\Laminas\Cache\Storage\StorageInterface::class);
         }
         if (null === $container) {
             $container = $this->getMockBuilder(\Laminas\Session\Container::class)


### PR DESCRIPTION
It is better practice to typehint with interfaces instead of specific implementations. This PR switches AbstractAdapter hints to StorageInterface hints when using Laminas\Cache, as well as adjusting unit tests to mock the interface instead of the abstract class (which fixes a number of warnings when upgrading to PHPUnit 10).

TODO
- [x] Note changed signatures in changelog when merging