### PR TITLE
MinkTestCase: move screenshot handling to onNotSuccessfulTest().

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -1023,19 +1023,19 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Standard teardown method.
+     * Hook for unsuccessful test runs.
+     *
+     * @param \Throwable $t Exception caused by test failure.
      *
      * @return void
+     * @throws \Throwable
      */
-    public function tearDown(): void
+    protected function onNotSuccessfulTest(\Throwable $t): void
     {
         // Take screenshot of failed test, if we have a screenshot directory set
         // and we have run out of retries ($this->retriesLeft is set by the
         // AutoRetryTrait):
-        if (
-            $this->hasFailed()
-            && ($imageDir = getenv('VUFIND_SCREENSHOT_DIR'))
-        ) {
+        if ($imageDir = getenv('VUFIND_SCREENSHOT_DIR')) {
             $filename = $this->getName() . '-' . $this->retriesLeft . '-'
                 . hrtime(true);
 
@@ -1059,7 +1059,16 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
                 file_put_contents($imageDir . '/' . $filename . '.png', $imageData);
             }
         }
+        parent::onNotSuccessfulTest($t);
+    }
 
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
         $htmlValidationException = null;
         if (!$this->hasFailed()) {
             try {


### PR DESCRIPTION
It is better practice in PHPUnit to use the onNotSuccessfulTest hook instead of relying on $this->hasFailed(). This PR moves screenshot processing into the onNotSuccessfulTest hook for greater clarity.

We still use the hasFailed method in relation to HTML validation, and I think more work is going to be needed there... but let's get this obvious improvement merged first, and then we can address that issue separately.