### PR TITLE
Only proxy images through cover proxy.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -129,7 +129,7 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
         if (!empty($url)) {
             try {
                 $image = $this->proxy->fetch($url);
-                $contentType = $image->getHeaders()->get('content-type')->getFieldValue();
+                $contentType = $image?->getHeaders()?->get('content-type')?->getFieldValue() ?? '';
                 if (str_starts_with($contentType, 'image/')) {
                     return $this->displayImage(
                         $contentType,

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -130,7 +130,7 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
             try {
                 $image = $this->proxy->fetch($url);
                 $contentType = $image?->getHeaders()?->get('content-type')?->getFieldValue() ?? '';
-                if (str_starts_with($contentType, 'image/')) {
+                if (str_starts_with(strtolower($contentType), 'image/')) {
                     return $this->displayImage(
                         $contentType,
                         $image->getContent()

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -129,10 +129,13 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
         if (!empty($url)) {
             try {
                 $image = $this->proxy->fetch($url);
-                return $this->displayImage(
-                    $image->getHeaders()->get('content-type')->getFieldValue(),
-                    $image->getContent()
-                );
+                $contentType = $image->getHeaders()->get('content-type')->getFieldValue();
+                if (str_starts_with($contentType, 'image/')) {
+                    return $this->displayImage(
+                        $contentType,
+                        $image->getContent()
+                    );
+                }
             } catch (\Exception $e) {
                 // If an exception occurs, drop through to the standard case
                 // to display an image unavailable graphic.


### PR DESCRIPTION
The cover image proxy did not validate the content type of the proxied content, which could result in invalid image links. This PR corrects the problem.