### PR TITLE
Use PHP8 attribute to toggle HTML validation in tests.

### DIFF
--- a/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
+++ b/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTest\Attribute;
 
+use Attribute;
+
 /**
  * Attribute to track HTML validation behavior in tests.
  *
@@ -38,22 +40,7 @@ namespace VuFindTest\Attribute;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
+#[Attribute]
 class HtmlValidation
 {
-    /**
-     * Should HTML validation be applied to this test?
-     *
-     * @var bool
-     */
-    public $useValidation;
-
-    /**
-     * Constructor
-     *
-     * @param bool $useValidation Should HTML validation be applied to this test?
-     */
-    public function __construct($useValidation = true)
-    {
-        $this->useValidation = $useValidation;
-    }
 }

--- a/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
+++ b/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
@@ -43,4 +43,20 @@ use Attribute;
 #[Attribute]
 class HtmlValidation
 {
+    /**
+     * Should HTML validation be applied to this test?
+     *
+     * @var bool
+     */
+    public $useValidation;
+
+    /**
+     * Constructor
+     *
+     * @param bool $useValidation Should HTML validation be applied to this test?
+     */
+    public function __construct($useValidation = true)
+    {
+        $this->useValidation = $useValidation;
+    }
 }

--- a/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
+++ b/module/VuFind/src/VuFindTest/Attribute/HtmlValidation.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Attribute to track HTML validation behavior in tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Attribute;
+
+/**
+ * Attribute to track HTML validation behavior in tests.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class HtmlValidation
+{
+    /**
+     * Should HTML validation be applied to this test?
+     *
+     * @var bool
+     */
+    public $useValidation;
+
+    /**
+     * Constructor
+     *
+     * @param bool $useValidation Should HTML validation be applied to this test?
+     */
+    public function __construct($useValidation = true)
+    {
+        $this->useValidation = $useValidation;
+    }
+}

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -33,6 +33,7 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\Element;
 use DMore\ChromeDriver\ChromeDriver;
 use PHPUnit\Util\Test;
+use ReflectionException;
 use Symfony\Component\Yaml\Yaml;
 use VuFind\Config\PathResolver;
 use VuFind\Config\Writer as ConfigWriter;
@@ -858,6 +859,28 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Extract the first parameter of the first attribute matching the specified
+     * criteria.
+     *
+     * @param string $method    Method name to check for attributes
+     * @param string $attribute Attribute class name to look up
+     * @param mixed  $default   Default value to use if no match found
+     *
+     * @return mixed
+     * @throws ReflectionException
+     */
+    protected function getFirstMethodAttributeValue(
+        string $method,
+        string $attribute,
+        mixed $default = null
+    ): mixed {
+        $reflection = new \ReflectionObject($this);
+        $matches = $reflection->getMethod($method)->getAttributes($attribute);
+        $args = ($matches[0] ?? null)?->getArguments() ?? [];
+        return $args[0] ?? $default;
+    }
+
+    /**
      * Validate current page HTML if validation is enabled and a session exists
      *
      * @param ?Element $page Page to check (optional; uses the page from session by
@@ -869,19 +892,15 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function validateHtml(?Element $page = null): void
     {
-        if (
-            (!$this->session && !$page)
-            || !($nuAddress = getenv('VUFIND_HTML_VALIDATOR'))
-        ) {
-            return;
-        }
-        $annotations = Test::parseTestMethodAnnotations(
-            static::class,
-            $this->getName(false)
+        $validatorEnabled = $this->getFirstMethodAttributeValue(
+            $this->getName(false),
+            \VuFindTest\Attribute\HtmlValidation::class,
+            true
         );
         if (
-            ($annotations['method']['skip_html_validation'][0] ?? false)
-            || ($annotations['class']['skip_html_validation'][0] ?? false)
+            !$validatorEnabled
+            || (!$this->session && !$page)
+            || !($nuAddress = getenv('VUFIND_HTML_VALIDATOR'))
         ) {
             return;
         }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
@@ -91,11 +91,11 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Test that we can save a favorite from tab mode.
      *
-     * @skip_html_validation true
-     * @todo                 Enable HTML validation when the issues are fixed in the upstream code
+     * @todo Enable HTML validation when the issues are fixed in the upstream code
      *
      * @return void
      */
+    #[\VuFindTest\Attribute\HtmlValidation(false)]
     public function testFavoritesInTabMode()
     {
         // Change the theme:
@@ -127,11 +127,11 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @depends testFavoritesInTabMode
      *
-     * @skip_html_validation true
-     * @todo                 Enable HTML validation when the issues are fixed in the upstream code
+     * @todo Enable HTML validation when the issues are fixed in the upstream code
      *
      * @return void
      */
+    #[\VuFindTest\Attribute\HtmlValidation(false)]
     public function testFavoritesInAccordionMode()
     {
         // Change the theme:


### PR DESCRIPTION
This modernizes the way we control HTML validation in Mink tests to eliminate dependency on a soon-to-be-removed PHPUnit annotation feature.