### PR TITLE
AbstractAPI: use status instead of code to capture HTTP status.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractAPI.php
@@ -197,7 +197,7 @@ abstract class AbstractAPI extends AbstractBase implements
                     'expectedParams' => $params,
                     'body' => $jsonBody ? $jsonBody : $body,
                     'bodyType' => $jsonBody ? 'json' : 'string',
-                    'code' => $code,
+                    'status' => $code,
                 ];
                 file_put_contents($jsonLog, json_encode($json));
             }

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-checkedout.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-checkedout.json
@@ -83,7 +83,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -135,7 +135,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -182,7 +182,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -219,7 +219,7 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -250,6 +250,6 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     }
 ]

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-empty-statements.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-empty-statements.json
@@ -83,7 +83,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -144,7 +144,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -191,7 +191,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -222,6 +222,6 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     }
 ]

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-multi-volume.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-multi-volume.json
@@ -83,7 +83,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -135,7 +135,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -210,7 +210,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -241,6 +241,6 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     }
 ]

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-sorted.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-sorted.json
@@ -83,7 +83,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -135,7 +135,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -182,7 +182,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -213,6 +213,6 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     }
 ]

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding.json
@@ -83,7 +83,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -129,7 +129,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -176,7 +176,7 @@
             }
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "GET",
@@ -207,6 +207,6 @@
             "totalRecords": 1
         },
         "bodyType": "json",
-        "code": 200
+        "status": 200
     }
 ]

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-legacy.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-legacy.json
@@ -9,7 +9,7 @@
         "expectedParams": [],
         "body": [ {"id":"mod-circulation-23.5.7"} ],
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "POST",

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-no-expiration-date.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-no-expiration-date.json
@@ -8,7 +8,7 @@
         "expectedParams": [],
         "body": [ {"id":"mod-circulation-24.0.0"} ],
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "POST",

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold.json
@@ -9,7 +9,7 @@
         "expectedParams": [],
         "body": [ {"id":"mod-circulation-24.0.0"} ],
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "expectedMethod": "POST",

--- a/module/VuFind/tests/fixtures/folio/responses/unsuccessful-place-hold.json
+++ b/module/VuFind/tests/fixtures/folio/responses/unsuccessful-place-hold.json
@@ -8,7 +8,7 @@
         "expectedParams": [],
         "body": [ {"id":"mod-circulation-24.0.0"} ],
         "bodyType": "json",
-        "code": 200
+        "status": 200
     },
     {
         "status": 500,


### PR DESCRIPTION
There was some inconsistency in tests and test fixtures with regard to HTTP status code handling. The FolioTest looks for a `status` value in test fixtures, but the JSON capture functionality in AbstractAPI was capturing this value to `code` instead. This PR normalizes to use `status` everywhere and fixes invalid values in existing fixtures. This was not previously causing test failures because all of these incorrect fixtures were using the same value as the default fallback.