### PR TITLE
Final logger mocking fix.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/LiveSolrTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/LiveSolrTrait.php
@@ -69,6 +69,7 @@ trait LiveSolrTrait
             $container,
             $config['vufind']['config_reader']
         );
+        $container->set(\VuFind\Log\Logger::class, $this->createMock(\Laminas\Log\LoggerInterface::class));
         $container->set(\VuFind\Config\PluginManager::class, $configManager);
         $this->addPathResolverToContainer($container);
         $httpFactory = new \VuFind\Service\HttpServiceFactory();


### PR DESCRIPTION
This PR finishes the work started in #3374, fixing logger mocking to prevent destructor errors in PHPUnit 10. This is the last fix needed to complete the PHPUnit 10 upgrade.