### PR TITLE
Restrict hostnames for cover proxy.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1023,6 +1023,13 @@ coverimagesCache = true
 ; BrowZine DOI icons:
 coverproxyCache[] = "/assets\.thirdiron\.com/"
 
+; This setting controls which hosts are allowed to provide cover images through
+; the built-in cover proxy. Images from hostnames that do not match the regular
+; expressions below will not be proxied. Be sure to define regular expressions
+; using an end of string ($) marker to prevent abuse.
+coverproxyAllowedHosts[] = "/assets\.thirdiron\.com$/"
+coverproxyAllowedHosts[] = "/.*\.summon\.serialssolutions\.com$/"
+
 ; This setting controls how cover image URLs are loaded. They could be loaded as
 ; part of main request, or asynchronously. Asynchronous loading is disabled by
 ; default; to enable it, just uncomment the line below.

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1028,7 +1028,7 @@ coverproxyCache[] = "/assets\.thirdiron\.com/"
 ; expressions below will not be proxied. Be sure to define regular expressions
 ; using an end of string ($) marker to prevent abuse.
 coverproxyAllowedHosts[] = "/assets\.thirdiron\.com$/"
-coverproxyAllowedHosts[] = "/.*\.summon\.serialssolutions\.com$/"
+coverproxyAllowedHosts[] = "/\.summon\.serialssolutions\.com$/"
 
 ; This setting controls how cover image URLs are loaded. They could be loaded as
 ; part of main request, or asynchronously. Asynchronous loading is disabled by

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -135,6 +135,9 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected function proxyAllowedForUrl(string $url): bool
     {
         $host = parse_url($url, PHP_URL_HOST);
+        if (!$host) {
+            return false;
+        }
         foreach ((array)($this->config['coverproxyAllowedHosts'] ?? []) as $regEx) {
             if (preg_match($regEx, $host)) {
                 return true;

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -135,7 +135,7 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected function proxyAllowedForUrl(string $url): bool
     {
         $host = parse_url($url, PHP_URL_HOST);
-        foreach ((array)($this->config['coverproxyAllowedHosts'] ?? $config) as $regEx) {
+        foreach ((array)($this->config['coverproxyAllowedHosts'] ?? []) as $regEx) {
             if (preg_match($regEx, $host)) {
                 return true;
             }

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -134,7 +134,7 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
      */
     protected function proxyAllowedForUrl(string $url): bool
     {
-        $host = parse_url($url,  PHP_URL_HOST);
+        $host = parse_url($url, PHP_URL_HOST);
         foreach ((array)($this->config['coverproxyAllowedHosts'] ?? $config) as $regEx) {
             if (preg_match($regEx, $host)) {
                 return true;

--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -66,20 +66,30 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     protected $sessionSettings = null;
 
     /**
+     * Configuration settings ([Content] section of config.ini)
+     *
+     * @var array
+     */
+    protected $config;
+
+    /**
      * Constructor
      *
      * @param Loader          $loader Cover loader
      * @param CachingProxy    $proxy  Proxy loader
      * @param SessionSettings $ss     Session settings
+     * @param array           $config Configuration settings
      */
     public function __construct(
         Loader $loader,
         CachingProxy $proxy,
-        SessionSettings $ss
+        SessionSettings $ss,
+        array $config = []
     ) {
         $this->loader = $loader;
         $this->proxy = $proxy;
         $this->sessionSettings = $ss;
+        $this->config = $config;
     }
 
     /**
@@ -116,6 +126,24 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
     }
 
     /**
+     * Is the provided URL included on the configured allow list?
+     *
+     * @param string $url URL to check
+     *
+     * @return bool
+     */
+    protected function proxyAllowedForUrl(string $url): bool
+    {
+        $host = parse_url($url,  PHP_URL_HOST);
+        foreach ((array)($this->config['coverproxyAllowedHosts'] ?? $config) as $regEx) {
+            if (preg_match($regEx, $host)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Send image data for display in the view
      *
      * @return \Laminas\Http\Response
@@ -126,7 +154,7 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
 
         // Special case: proxy a full URL:
         $url = $this->params()->fromQuery('proxy');
-        if (!empty($url)) {
+        if (!empty($url) && $this->proxyAllowedForUrl($url)) {
             try {
                 $image = $this->proxy->fetch($url);
                 $contentType = $image?->getHeaders()?->get('content-type')?->getFieldValue() ?? '';

--- a/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
+++ b/module/VuFind/src/VuFind/Controller/CoverControllerFactory.php
@@ -68,10 +68,13 @@ class CoverControllerFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
+        $configArray = $config?->Content?->toArray() ?? [];
         return new $requestedName(
             $container->get(\VuFind\Cover\Loader::class),
             $container->get(\VuFind\Cover\CachingProxy::class),
-            $container->get(\VuFind\Session\Settings::class)
+            $container->get(\VuFind\Session\Settings::class),
+            $configArray
         );
     }
 }


### PR DESCRIPTION
Note that I included assets.thirdiron.com in the example configuration; I'm pretty sure there are no longer any circumstances where we proxy images from this source, but since the cache example still uses it, it seemed more consistent to include it as an example. We can revisit this separately if we want to change all the defaults related to this hostname.