### PR TITLE
Fix showMessage deniedControllerBehavior setting.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -82,7 +82,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      * restriction, null to use configured default (which is usually the same
      * as false)).
      *
-     * @var string|bool
+     * @var string|bool|null
      */
     protected $accessPermission = null;
 
@@ -135,9 +135,10 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
     }
 
     /**
-     * Getter for access permission.
+     * Getter for access permission (string for required permission name, false
+     * for no permission required, null for not determined yet).
      *
-     * @return string|bool
+     * @return string|bool|null
      */
     public function getAccessPermission()
     {

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -72,7 +72,7 @@ use function is_object;
  *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class AbstractBase extends AbstractActionController implements TranslatorAwareInterface
+class AbstractBase extends AbstractActionController implements Feature\AccessPermissionInterface, TranslatorAwareInterface
 {
     use TranslatorAwareTrait;
 
@@ -146,7 +146,7 @@ class AbstractBase extends AbstractActionController implements TranslatorAwareIn
     /**
      * Getter for access permission.
      *
-     * @param string $ap Permission to require for access to the controller (false
+     * @param string|false $ap Permission to require for access to the controller (false
      * for no requirement)
      *
      * @return void

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -35,6 +35,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\View\Model\ViewModel;
+use VuFind\Controller\Feature\AccessPermissionInterface;
 use VuFind\Exception\Auth as AuthException;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\Http\PhpEnvironment\Request as HttpRequest;
@@ -72,7 +73,7 @@ use function is_object;
  *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class AbstractBase extends AbstractActionController implements Feature\AccessPermissionInterface, TranslatorAwareInterface
+class AbstractBase extends AbstractActionController implements AccessPermissionInterface, TranslatorAwareInterface
 {
     use TranslatorAwareTrait;
 

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -136,7 +136,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
 
     /**
      * Getter for access permission (string for required permission name, false
-     * for no permission required, null for not determined yet).
+     * for no permission required, null to use default permission).
      *
      * @return string|bool|null
      */

--- a/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBaseFactory.php
@@ -60,7 +60,7 @@ class AbstractBaseFactory implements FactoryInterface
             ->get('permissionBehavior');
         $permissions = $config->global->controllerAccess ?? [];
 
-        if (!empty($permissions)) {
+        if (!empty($permissions) && $controller instanceof Feature\AccessPermissionInterface) {
             // Iterate through parent classes until we find the most specific
             // class access permission defined (if any):
             $class = $controller::class;

--- a/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
@@ -42,7 +42,7 @@ interface AccessPermissionInterface
 {
     /**
      * Getter for access permission (string for required permission name, false
-     * for no permission required, null for not determined yet).
+     * for no permission required, null to use default permission).
      *
      * @return string|bool|null
      */

--- a/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Access Permission Interface -- provides getters and setters for permission setting.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller_Plugins
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFind\Controller\Feature;
+
+/**
+ * Access Permission Interface -- provides getters and setters for permission setting.
+ *
+ * @category VuFind
+ * @package  Controller_Plugins
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+interface AccessPermissionInterface
+{
+    /**
+     * Getter for access permission.
+     *
+     * @return string|bool
+     */
+    public function getAccessPermission();
+
+    /**
+     * Getter for access permission.
+     *
+     * @param string|false $ap Permission to require for access to the controller (false
+     * for no requirement)
+     *
+     * @return void
+     */
+    public function setAccessPermission($ap);
+}

--- a/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/AccessPermissionInterface.php
@@ -41,9 +41,10 @@ namespace VuFind\Controller\Feature;
 interface AccessPermissionInterface
 {
     /**
-     * Getter for access permission.
+     * Getter for access permission (string for required permission name, false
+     * for no permission required, null for not determined yet).
      *
-     * @return string|bool
+     * @return string|bool|null
      */
     public function getAccessPermission();
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
@@ -66,7 +66,7 @@ final class PermissionsTest extends \VuFindTest\Integration\MinkTestCase
                     ],
                 ],
                 'permissions' => [
-                    'enable-record-api' => [
+                    'access.VuFindInterface' => [
                         'permission' => 'access.VuFindInterface',
                         'require' => 'ANY',
                         'role' => 'loggedin',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Mink test class for permission behaviors.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+/**
+ * Mink test class for permission behaviors.
+ *
+ * Class must be final due to use of "new static()" by LiveDatabaseTrait.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+final class PermissionsTest extends \VuFindTest\Integration\MinkTestCase
+{
+    use \VuFindTest\Feature\LiveDatabaseTrait;
+    use \VuFindTest\Feature\UserCreationTrait;
+
+    /**
+     * Test that a default permission can be applied to all controllers and
+     * configured to display a custom error message.
+     *
+     * @return void
+     */
+    public function testDefaultControllerPermissionWithCustomErrorMessage(): void
+    {
+        $this->changeConfigs(
+            [
+                'permissionBehavior' => [
+                    'global' => [
+                        'controllerAccess' => [
+                            '*' => 'access.VuFindInterface',
+                        ],
+                    ],
+                    'access.VuFindInterface' => [
+                        'deniedControllerBehavior' => 'showMessage:test-error-message',
+                    ],
+                ],
+                'permissions' => [
+                    'enable-record-api' => [
+                        'permission' => 'access.VuFindInterface',
+                        'require' => 'ANY',
+                        'role' => 'loggedin',
+                    ],
+                ],
+            ]
+        );
+
+        // Logged out user gets denied access and shown custom error message:
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results');
+        $page = $session->getPage();
+        $this->waitForPageLoad($page);
+        $this->assertEquals(
+            'test-error-message',
+            $this->findCss($page, '.alert-danger')->getText()
+        );
+        $this->assertEquals(
+            'Error',
+            $this->findCss($page, '.breadcrumb .active')->getText()
+        );
+
+        // Create an account:
+        $this->clickCss($page, '#loginOptions a');
+        $this->clickCss($page, '.modal-body .createAccountLink');
+        $this->fillInAccountForm($page);
+        $this->clickCss($page, '.modal-body .btn.btn-primary');
+        $this->waitForPageLoad($page);
+
+        // Now that we're logged in, we should see search results:
+        $session->visit($this->getVuFindUrl() . '/Search/Results');
+        $this->waitForPageLoad($page);
+        $this->assertEquals(
+            'Search Results',
+            $this->findCss($page, '.breadcrumb .active')->getText()
+        );
+    }
+
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        static::removeUsers(['username1']);
+    }
+}


### PR DESCRIPTION
The showMessage deniedControllerBehavior setting in permissions.ini was incompatible with the controllerAccess setting because the ErrorController used to display the message did not implement getAccessPermission/setAccessPermission methods expected by the AbstractBaseFactory. This PR introduces a marker interface to prevent attempted illegal method calls.

TODO
- [x] Add Mink test to prevent regressions.