### PR TITLE
Use a callback in ILSAuthenticator to get Auth Manager.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -44,11 +44,18 @@ use VuFind\ILS\Connection as ILSConnection;
 class ILSAuthenticator
 {
     /**
-     * Auth manager
+     * Callback for retrieving the authentication manager
+     *
+     * @var callable
+     */
+    protected $authManagerCallback;
+
+    /**
+     * Authentication manager
      *
      * @var Manager
      */
-    protected $auth;
+    protected $authManager = null;
 
     /**
      * ILS connector
@@ -74,16 +81,16 @@ class ILSAuthenticator
     /**
      * Constructor
      *
-     * @param Manager            $auth      Auth manager
+     * @param callable           $authCB    Auth manager callback
      * @param ILSConnection      $catalog   ILS connection
      * @param EmailAuthenticator $emailAuth Email authenticator
      */
     public function __construct(
-        Manager $auth,
+        callable $authCB,
         ILSConnection $catalog,
         EmailAuthenticator $emailAuth = null
     ) {
-        $this->auth = $auth;
+        $this->authManagerCallback = $authCB;
         $this->catalog = $catalog;
         $this->emailAuthenticator = $emailAuth;
     }
@@ -101,7 +108,7 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->auth->isLoggedIn()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->isLoggedIn()) && !empty($user->cat_username)) {
             return [
                 'cat_username' => $user->cat_username,
                 'cat_password' => $user->cat_password,
@@ -123,7 +130,7 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->auth->isLoggedIn()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->isLoggedIn()) && !empty($user->cat_username)) {
             // Do we have a previously cached ILS account?
             if (isset($this->ilsAccount[$user->cat_username])) {
                 return $this->ilsAccount[$user->cat_username];
@@ -230,12 +237,25 @@ class ILSAuthenticator
      */
     protected function updateUser($catUsername, $catPassword, $patron)
     {
-        $user = $this->auth->isLoggedIn();
+        $user = $this->getAuthManager()->isLoggedIn();
         if ($user) {
             $user->saveCredentials($catUsername, $catPassword);
-            $this->auth->updateSession($user);
+            $this->getAuthManager()->updateSession($user);
             // cache for future use
             $this->ilsAccount[$catUsername] = $patron;
         }
+    }
+
+    /**
+     * Get authentication manager
+     *
+     * @return Manager
+     */
+    protected function getAuthManager(): Manager
+    {
+        if (null === $this->authManager) {
+            $this->authManager = ($this->authManagerCallback)();
+        }
+        return $this->authManager;
     }
 }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
@@ -68,8 +68,11 @@ class ILSAuthenticatorFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
+        // Use a callback to retrieve authentication manager to break a circular reference:
         return new $requestedName(
-            $container->get(\VuFind\Auth\Manager::class),
+            function () use ($container) {
+                return $container->get(\VuFind\Auth\Manager::class);
+            },
             $container->get(\VuFind\ILS\Connection::class),
             $container->get(\VuFind\Auth\EmailAuthenticator::class)
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -381,12 +381,47 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test ILS authentication.
+     *
+     * @return void
+     */
+    public function testILSAuthentication(): void
+    {
+        // Setup config
+        $this->changeConfigs(
+            [
+                'Demo' => [
+                    'Users' => ['username3' => 'catpass'],
+                ],
+                'config' => [
+                    'Catalog' => ['driver' => 'Demo'],
+                    'Authentication' => ['method' => 'ILS'],
+                ],
+            ]
+        );
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl('/MyResearch/Profile'));
+        $page = $session->getPage();
+
+        // Log in
+        $this->findCssAndSetValue($page, '#login_ILS_username', 'username3');
+        $this->findCssAndSetValue($page, '#login_ILS_password', 'catpass');
+        $this->clickCss($page, 'input.btn.btn-primary');
+
+        // Check that profile page is displayed
+        $this->findCss($page, '#home_library');
+
+        // Log out
+        $this->clickCss($page, '.logoutOptions a.logout');
+    }
+
+    /**
      * Standard teardown method.
      *
      * @return void
      */
     public static function tearDownAfterClass(): void
     {
-        static::removeUsers(['username1', 'username2']);
+        static::removeUsers(['username1', 'username2', 'username3']);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -208,7 +208,12 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         if (null === $connection) {
             $connection = $this->getMockConnection();
         }
-        return new ILSAuthenticator(function () use ($manager) { return $manager; }, $connection);
+        return new ILSAuthenticator(
+            function () use ($manager) {
+                return $manager;
+            },
+            $connection
+        );
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -208,7 +208,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         if (null === $connection) {
             $connection = $this->getMockConnection();
         }
-        return new ILSAuthenticator($manager, $connection);
+        return new ILSAuthenticator(function () use ($manager) { return $manager; }, $connection);
     }
 
     /**


### PR DESCRIPTION
Fixes a circular reference when authentication method is set to ILS.

After #3343 there was still a circular factory call via Auth Manager's setAuthMethod method.