### PR TITLE
Sort and deduplicate facet values on EDS advanced search

### DIFF
--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -40,9 +40,18 @@
                 $sorted[$i] = $value['Value'];
               }
               $this->sorter()->natsort($sorted);
+              $lastDisplay = $lastValue = '';
               ?>
               <?php foreach ($sorted as $i => $display): ?>
-                <?php $facetValue = $facet['LimiterValues'][$i]; ?>
+                <?php
+                  $facetValue = $facet['LimiterValues'][$i];
+                  // Filter out duplicate values:
+                  if ($lastDisplay === $display && $lastValue === $facetValue) {
+                    continue;
+                  }
+                  $lastDisplay = $display;
+                  $lastValue = $facetValue;
+                ?>
                 <option value="<?='LIMIT|' . $this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
               <?php endforeach; ?>
             </select>

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -31,8 +31,18 @@
           case 'multiselectvalue': ?>
             <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>"><?=$this->transEsc($facet['Label'])?></label><br>
             <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-control">
-              <?php foreach ($facet['LimiterValues'] as $id => $facetValue): ?>
-                <?php $value = $facetValue['Value']; ?>
+              <?php
+              // Sort the current facet list alphabetically; we'll use this data
+              // along with the foreach below to display facet options in the
+              // correct order.
+              $sorted = [];
+              foreach ($facet['LimiterValues'] as $i => $value) {
+                $sorted[$i] = $value['Value'];
+              }
+              $this->sorter()->natsort($sorted);
+              ?>
+              <?php foreach ($sorted as $i => $display): ?>
+                <?php $facetValue = $facet['LimiterValues'][$i]; ?>
                 <option value="<?='LIMIT|' . $this->escapeHtmlAttr($field . ':' . $facetValue['Value'])?>"<?=(isset($facetValue['selected']) && $facetValue['selected']) ? ' selected="selected"' : ''?>><?=$this->escapeHtml($facetValue['Value'])?></option>
               <?php endforeach; ?>
             </select>


### PR DESCRIPTION
This adds logic to sort the facet values in the EDS advanced search in a method consistent with how it is done in the other advanced search templates (such as solr and summon).