### PR TITLE
Disable module config cache in CLI mode.

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -70,8 +70,8 @@ if (!is_dir($cacheDir)) {
     mkdir($cacheDir);
 }
 
-// Enable caching unless in dev mode or running tests:
-$useCache = APPLICATION_ENV != 'development' && APPLICATION_ENV != 'testing';
+// Enable caching unless in CLI mode, dev mode or running tests:
+$useCache = PHP_SAPI !== 'cli' && APPLICATION_ENV != 'development' && APPLICATION_ENV != 'testing';
 
 // Build configuration:
 return [


### PR DESCRIPTION
Disable Laminas module config cache also in CLI mode.