### PR TITLE
Use regex route for content pages

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -34,16 +34,14 @@ $config = [
                 ],
             ],
             'content-page' => [
-                'type'    => 'Laminas\Router\Http\Segment',
+                'type'    => 'Laminas\Router\Http\Regex',
                 'options' => [
-                    'route'    => '/Content/:page',
-                    'constraints' => [
-                        'page'     => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
+                    'regex'    => '/[C|c]ontent/(?<page>[a-zA-Z][a-zA-Z0-9_-]*)',
                     'defaults' => [
                         'controller' => 'Content',
                         'action'     => 'Content',
                     ],
+                    'spec' => '/Content/%page%',
                 ],
             ],
             'shortlink' => [

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Mink test class for Markdown rendering support.
+ * Mink test class for the static content controller.
  *
  * PHP version 8
  *
@@ -32,7 +32,7 @@ declare(strict_types=1);
 namespace VuFindTest\Mink;
 
 /**
- * Mink test class for Markdown rendering support.
+ * Mink test class for the static content controller.
  *
  * @category VuFind
  * @package  Tests
@@ -40,7 +40,7 @@ namespace VuFindTest\Mink;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class MarkdownTest extends \VuFindTest\Integration\MinkTestCase
+class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
 {
     /**
      * Data provider for testMarkdownContentRendering() to confirm that the initial part

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
@@ -49,7 +49,7 @@ class MarkdownTest extends \VuFindTest\Integration\MinkTestCase
     public static function basePathProvider(): array
     {
         return [
-            'uppercase path' => ['/Content'],
+            'capitalized path' => ['/Content'],
             'lowercase path' => ['/content'],
         ];
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
@@ -26,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
+
 declare(strict_types=1);
 
 namespace VuFindTest\Mink;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
@@ -41,11 +41,29 @@ namespace VuFindTest\Mink;
 class MarkdownTest extends \VuFindTest\Integration\MinkTestCase
 {
     /**
+     * Data provider for testMarkdownContentRendering() to confirm that the initial part
+     * of the content URL is case-insensitive.
+     *
+     * @return array
+     */
+    public static function basePathProvider(): array
+    {
+        return [
+            'uppercase path' => ['/Content'],
+            'lowercase path' => ['/content'],
+        ];
+    }
+
+    /**
      * Test that Markdown static content rendering is working.
+     *
+     * @param string $basePath Base path of content route
+     *
+     * @dataProvider basePathProvider
      *
      * @return void
      */
-    public function testMarkdownContentRendering()
+    public function testMarkdownContentRendering($basePath)
     {
         // Switch to the example theme, because that's where a Markdown example lives:
         $this->changeConfigs(
@@ -59,7 +77,7 @@ class MarkdownTest extends \VuFindTest\Integration\MinkTestCase
         );
         // Open the page:
         $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Content/example');
+        $session->visit($this->getVuFindUrl() . $basePath . '/example');
         $page = $session->getPage();
         // Confirm that the Markdown was converted into appropriate h1/a tags:
         $this->assertEquals(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/MarkdownTest.php
@@ -26,6 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
+declare(strict_types=1);
 
 namespace VuFindTest\Mink;
 
@@ -63,7 +64,7 @@ class MarkdownTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testMarkdownContentRendering($basePath)
+    public function testMarkdownContentRendering(string $basePath): void
     {
         // Switch to the example theme, because that's where a Markdown example lives:
         $this->changeConfigs(


### PR DESCRIPTION
This changes the content page route type to regex. It seems that literal segments are always case-sensitive, but using regex we can allow both `/Content` and `/content`.