### PR TITLE
Fix potential null being passed to array_merge.

### DIFF
--- a/themes/bootstrap3/templates/Helpers/pagination-item.phtml
+++ b/themes/bootstrap3/templates/Helpers/pagination-item.phtml
@@ -7,7 +7,7 @@
     'aria-label' => $this->label,
     'href' => null !== $this->results
       ? $this->results->getUrlQuery()->setPage($this->page)->getParams(false)
-      : $this->currentPath() . '?' . http_build_query(array_merge($this->params, ['page' => $this->page])),
+      : $this->currentPath() . '?' . http_build_query(array_merge($this->params ?? [], ['page' => $this->page])),
   ]);
   if ($this->page === $this->current) {
     $liAttrs->add('class', 'active');


### PR DESCRIPTION
This used to be an implicit array promotion (now deprecated in PHP), but array_merge doesn't like a null.