### PR TITLE
Improve YAML merging by refactoring logic from ThemeInfo

### DIFF
--- a/module/VuFind/src/VuFind/Config/YamlReader.php
+++ b/module/VuFind/src/VuFind/Config/YamlReader.php
@@ -49,6 +49,8 @@ use function is_array;
  */
 class YamlReader
 {
+    use \VuFind\Feature\MergeRecursiveTrait;
+
     /**
      * Cache directory name
      *
@@ -213,7 +215,7 @@ class YamlReader
                     $resultElemRef
                         = &$this->getArrayElemRefByPath($results, $path, true);
                     $resultElemRef
-                        = $this->arrayMergeRecursiveDistinct($parentElem, $resultElemRef);
+                        = $this->mergeRecursive($parentElem, $resultElemRef);
                     unset($parentElem);
                     unset($resultElemRef);
                 }
@@ -255,30 +257,5 @@ class YamlReader
             $result = &$result[$pathPart];
         }
         return $result;
-    }
-
-    /**
-     * Merges arrays recursive without combining single values into an array.
-     *
-     * @param array $arr1 array1
-     * @param array $arr2 array2
-     *
-     * @return array
-     */
-    protected function arrayMergeRecursiveDistinct($arr1, $arr2)
-    {
-        $merged = $arr1;
-        foreach ($arr2 as $key => $value) {
-            if (is_array($merged[$key] ?? null) && is_array($value)) {
-                if (array_is_list($merged[$key]) && array_is_list($value)) {
-                    $merged[$key] = array_merge($merged[$key], $value);
-                } else {
-                    $merged[$key] = $this->arrayMergeRecursiveDistinct($merged[$key], $value);
-                }
-            } else {
-                $merged[$key] = $value;
-            }
-        }
-        return $merged;
     }
 }

--- a/module/VuFind/src/VuFind/Config/YamlReader.php
+++ b/module/VuFind/src/VuFind/Config/YamlReader.php
@@ -201,6 +201,13 @@ class YamlReader
             // Swallow the directive after processing it:
             unset($results['@merge_sections']);
         }
+        // Check for sections to replace recursive instead of overriding:
+        $recursiveReplacedSections = [];
+        if (isset($results['@recursive_replaced_sections'])) {
+            $recursiveReplacedSections = $results['@recursive_replaced_sections'];
+            // Swallow the directive after processing it:
+            unset($results['@recursive_replaced_sections']);
+        }
 
         // Now load in merged or missing sections from parent, if applicable:
         if (null !== $defaultParent) {
@@ -214,6 +221,19 @@ class YamlReader
                         = &$this->getArrayElemRefByPath($results, $path, true);
                     $resultElemRef
                         = array_merge_recursive($parentElem, $resultElemRef);
+                    unset($parentElem);
+                    unset($resultElemRef);
+                }
+            }
+            // Process recursive replaced sections:
+            foreach ($recursiveReplacedSections as $path) {
+                $parentElem
+                    = $this->getArrayElemRefByPath($parentSections, $path);
+                if (is_array($parentElem)) {
+                    $resultElemRef
+                        = &$this->getArrayElemRefByPath($results, $path, true);
+                    $resultElemRef
+                        = array_replace_recursive($parentElem, $resultElemRef);
                     unset($parentElem);
                     unset($resultElemRef);
                 }

--- a/module/VuFind/src/VuFind/Feature/BulkActionTrait.php
+++ b/module/VuFind/src/VuFind/Feature/BulkActionTrait.php
@@ -22,7 +22,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Controller_Plugins
+ * @package  Feature
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
@@ -35,7 +35,7 @@ namespace VuFind\Feature;
  * VuFind Action Feature Trait - Bulk action helper methods
  *
  * @category VuFind
- * @package  Controller_Plugins
+ * @package  Feature
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License

--- a/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
+++ b/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * VuFind Merge Recursive Trait - Provides Custom Array Merge Function
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Feature
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFind\Feature;
+
+use function array_key_exists;
+use function is_array;
+
+/**
+ * VuFind Merge Recursive Trait - Provides Custom Array Merge Function
+ *
+ * @category VuFind
+ * @package  Feature
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Chris Hallberg <challber@villanova.edu>
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+trait MergeRecursiveTrait
+{
+    /**
+     * Determine if a variable is a string-keyed array
+     *
+     * @param mixed $op Variable to test
+     *
+     * @return boolean
+     */
+    protected function isStringKeyedArray($op)
+    {
+        return is_array($op) && !array_is_list($op);
+    }
+
+    /**
+     * Merge array recursive without combining single values to a new array
+     * as php's array_merge_recursive function does.
+     *
+     * @param array|string $val1 First Value
+     * @param array|string $val2 Second Value
+     *
+     * @return array|string merged values
+     */
+    protected function mergeRecursive($val1, $val2)
+    {
+        if (empty($val2)) {
+            return $val1;
+        }
+
+        // Early escape for string, number, etc. values
+        if (!is_array($val2) && !is_array($val1)) {
+            return $val2;
+        }
+
+        if (!$this->isStringKeyedArray($val2)) {
+            return array_merge((array)$val1, (array)$val2);
+        }
+
+        if (!$this->isStringKeyedArray($val1)) {
+            // don't merge if incompatible
+            return $val2;
+        }
+
+        foreach ($val1 as $key => $val) {
+            if (!array_key_exists($key, $val2)) {
+                // capture missing string keys
+                $val2[$key] = $val;
+            } else {
+                // recurse
+                $val2[$key] = $this->mergeRecursive($val, $val2[$key]);
+            }
+        }
+        return $val2;
+    }
+}

--- a/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
@@ -2,6 +2,8 @@
 "@merge_sections":
   - [Other, Merged]
   - [Other, ParentOnly]
+"@recursive_replaced_sections":
+  - [Other, Replaced]
 
 Overridden:
   Original: Not so original
@@ -12,6 +14,9 @@ Other:
     Child:
       - Foo
       - Baz
+  Replaced:
+    Original: Replaces parent
+    ChildOnly: From child
   NonMerged:
     Original: Not so original either
 ChildOnly:

--- a/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
@@ -2,7 +2,6 @@
 "@merge_sections":
   - [Other, Merged]
   - [Other, ParentOnly]
-"@recursive_replaced_sections":
   - [Other, Replaced]
 
 Overridden:

--- a/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-parent.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-parent.yaml
@@ -8,6 +8,9 @@ Other:
     Baz:
       - Bar
       - Bar
+  Replaced:
+    ParentOnly: Will exist
+    Original: Will not exist
   NonMerged:
     Original: Will not exist
   ParentOnly:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
@@ -164,6 +164,11 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
                         'Baz' => ['Bar', 'Bar', 'ChildBaz'],
                         'Child' => ['Foo', 'Baz'],
                     ],
+                    'Replaced' => [
+                        'ParentOnly' => 'Will exist',
+                        'Original' => 'Replaces parent',
+                        'ChildOnly' => 'From child',
+                    ],
                     'NonMerged' => [
                         'Original' => 'Not so original either',
                     ],

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
@@ -31,9 +31,7 @@ namespace VuFindTheme;
 
 use Laminas\Cache\Storage\StorageInterface;
 
-use function array_key_exists;
 use function is_array;
-use function is_string;
 use function strlen;
 
 /**
@@ -47,6 +45,8 @@ use function strlen;
  */
 class ThemeInfo
 {
+    use \VuFind\Feature\MergeRecursiveTrait;
+
     /**
      * Base directory for theme files
      *
@@ -218,74 +218,6 @@ class ThemeInfo
     }
 
     /**
-     * Determine if a variable is a string-keyed array
-     *
-     * @param mixed $op Variable to test
-     *
-     * @return boolean
-     */
-    protected function isStringKeyedArray($op)
-    {
-        if (!is_array($op)) {
-            return false;
-        }
-
-        reset($op);
-        return is_string(key($op));
-    }
-
-    /**
-     * Add parent theme information to a collection of merged theme info.
-     * Using the string-keyed array format of theme config info,
-     * recursively walk the array, capturing unique or missing values.
-     *
-     * @param array|string $children Merged theme info, overrides parent theme
-     * @param array|string $parent   Theme info to be merged
-     *
-     * @return array|string merged theme info, favoring child themes (merged)
-     */
-    protected function mergeWithoutOverride($children, $parent)
-    {
-        if (empty($children)) {
-            return $parent;
-        }
-
-        // Early escape for string, number, etc. values
-        if (!is_array($children) && !is_array($parent)) {
-            return $children;
-        }
-
-        if ($this->isStringKeyedArray($children)) {
-            if (!$this->isStringKeyedArray($parent)) {
-                // don't override if incompatible
-                return $children;
-            }
-
-            foreach ($parent as $key => $val) {
-                if (!array_key_exists($key, $children)) {
-                    // capture missing string keys
-                    $children[$key] = $val;
-                } elseif ($this->isStringKeyedArray($val)) {
-                    // recurse
-                    $children[$key]
-                        = $this->mergeWithoutOverride($children[$key], $val);
-                } elseif (is_array($val)) {
-                    // capture unique or missing array items
-                    $children[$key] = array_merge($val, (array)$children[$key]);
-                } elseif (is_array($children[$key])) {
-                    // string -> array
-                    $children[$key] = array_merge((array)$val, $children[$key]);
-                }
-            }
-
-            return $children;
-        }
-
-        // capture unique or missing array items
-        return array_merge((array)$parent, (array)$children);
-    }
-
-    /**
      * Get a configuration element, merged to reflect theme inheritance.
      *
      * @param string $key Configuration key to retrieve (or empty string to
@@ -326,7 +258,7 @@ class ThemeInfo
                         ? $allThemeInfo[$theme]
                         : $allThemeInfo[$theme][$key];
 
-                    $merged = $this->mergeWithoutOverride($merged, $current);
+                    $merged = $this->mergeRecursive($current, $merged);
                 }
             }
 

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/ThemeInfoTest.php
@@ -326,7 +326,7 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
     {
         $ti = $this->getThemeInfo();
 
-        $merged = $this->callMethod($ti, 'mergeWithoutOverride', $test);
+        $merged = $this->callMethod($ti, 'mergeRecursive', $test);
 
         $this->assertEquals($expected, $merged);
     }
@@ -342,8 +342,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // string
             [
                 [
-                    'original',
                     'override',
+                    'original',
                 ],
                 'original',
             ],
@@ -351,8 +351,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // array
             [
                 [
-                    ['original'],
                     ['override'],
+                    ['original'],
                 ],
                 ['override', 'original'],
             ],
@@ -360,8 +360,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // string-keyed arrays
             [
                 [
-                    ['array' => [1], 'string' => 'original', 'sub' => ['a' => 1]],
                     ['array' => [2], 'string' => 'override', 'sub' => ['a' => 2]],
+                    ['array' => [1], 'string' => 'original', 'sub' => ['a' => 1]],
                 ],
                 ['array' => [2, 1], 'string' => 'original', 'sub' => ['a' => 1]],
             ],
@@ -369,8 +369,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // string-keyed arrays: missing
             [
                 [
-                    ['shared' => [1], 'parent' => 'only'],
                     ['shared' => [1], 'child' => 'only'],
+                    ['shared' => [1], 'parent' => 'only'],
                 ],
                 ['shared' => [1, 1], 'parent' => 'only', 'child' => 'only'],
             ],
@@ -378,8 +378,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // string-keyed string -> array
             [
                 [
-                    ['mixed' => ['array']],
                     ['mixed' => 'string'],
+                    ['mixed' => ['array']],
                 ],
                 ['mixed' => ['string', 'array']],
             ],
@@ -387,8 +387,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // string-keyed array -> string
             [
                 [
-                    ['mixed' => 'string'],
                     ['mixed' => ['array']],
+                    ['mixed' => 'string'],
                 ],
                 ['mixed' => ['array', 'string']],
             ],
@@ -396,8 +396,8 @@ class ThemeInfoTest extends \PHPUnit\Framework\TestCase
             // arrays and strings
             [
                 [
-                    ['mixed' => ['array']],
                     'not an array',
+                    ['mixed' => ['array']],
                 ],
                 [
                     'mixed' => ['array'],


### PR DESCRIPTION
The option `@merge_sections` in the yaml reader does not work as expected if the arrays on the deepest level are associative arrays. Using `array_merge_recursive` results in combining the values into a new array. 

E.g. merging

```
Section:
   Key: value1
```
and

```
Section:
   Key: value2
```
results in
```
Section:
   Key:
      - value1
      - value2
```
To fix this problem this PR introduces the new option `@recursive_replaced_sections` that uses `array_replace_recursive` instead of `array_merge_recursive`.

We could also change the `array_merge_recursive` function with an own function that merges in case of indexed arrays and replaces on the deepest level for associative arrays. But that might break old configs if the behavior described above is actually wanted.