### PR TITLE
Fix holdings paginator check.

### DIFF
--- a/module/VuFind/src/VuFind/RecordTab/HoldingsILS.php
+++ b/module/VuFind/src/VuFind/RecordTab/HoldingsILS.php
@@ -191,7 +191,7 @@ class HoldingsILS extends AbstractBase
     public function getPaginator($totalItemCount, $page, $itemLimit)
     {
         // Return if a paginator is not needed or not supported ($itemLimit = null)
-        if (!$itemLimit || $totalItemCount < $itemLimit) {
+        if (!$itemLimit || $totalItemCount <= $itemLimit) {
             return;
         }
 


### PR DESCRIPTION
Pagination was needlessly displayed when the number of holdings was equal to the page size.