### PR TITLE
Update yajra/laravel-pdo-via-oci8 to 3.4.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "vufind-org/vufind-marc": "1.1.0",
         "webfontkit/open-sans": "^1.0",
         "wikimedia/composer-merge-plugin": "2.1.0",
-        "yajra/laravel-pdo-via-oci8": "3.4.0"
+        "yajra/laravel-pdo-via-oci8": "3.4.2"
     },
     "require-dev": {
         "behat/mink": "1.11.0",
@@ -130,6 +130,7 @@
         "post-install-cmd": "@phing-install-dependencies",
         "post-update-cmd": "@phing-install-dependencies",
         "qa": "phing qa-console -Ddefaultconfigs=true",
+        "show-outdated": "composer show -oD --ignore-platform-req=ext-oci8",
         "update-npm-dependencies": [
             "npm update",
             "cd themes/bootstrap3 && npm run updateDeps"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2de02a69f5e3932109b482fe82cf131",
+    "content-hash": "d01827ccd8eab5723e90413f850a8cf3",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -9641,16 +9641,16 @@
         },
         {
             "name": "yajra/laravel-pdo-via-oci8",
-            "version": "v3.4.0",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yajra/pdo-via-oci8.git",
-                "reference": "9dd81df74e81c1461a4c4bd548a6dbc94908997f"
+                "reference": "2fc30b24d888297843aaf3457be133c795566dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yajra/pdo-via-oci8/zipball/9dd81df74e81c1461a4c4bd548a6dbc94908997f",
-                "reference": "9dd81df74e81c1461a4c4bd548a6dbc94908997f",
+                "url": "https://api.github.com/repos/yajra/pdo-via-oci8/zipball/2fc30b24d888297843aaf3457be133c795566dc6",
+                "reference": "2fc30b24d888297843aaf3457be133c795566dc6",
                 "shasum": ""
             },
             "require": {
@@ -9685,7 +9685,7 @@
             "description": "PDO userspace driver proxying calls to PHP OCI8 driver",
             "support": {
                 "issues": "https://github.com/yajra/pdo-via-oci8/issues",
-                "source": "https://github.com/yajra/pdo-via-oci8/tree/v3.4.0"
+                "source": "https://github.com/yajra/pdo-via-oci8/tree/v3.4.2"
             },
             "funding": [
                 {
@@ -9701,7 +9701,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-06-15T11:24:06+00:00"
+            "time": "2024-01-04T23:54:01+00:00"
         },
         {
             "name": "zfr/rbac",
@@ -13227,5 +13227,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This makes minor updates to the yajra/laravel-pdo-via-oci8 dependency and also adds a convenient `composer run show-outdated` script to support the dependency upgrade process. This command filters out the ext-oci constraint which was causing confusing behavior related to yajra/laravel-pdo-via-oci8.