### PR TITLE
Sierra: Fix hard-coded API version strings.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1264,7 +1264,7 @@ class SierraRest extends AbstractBase implements
 
         foreach ($details as $holdId) {
             $result = $this->makeRequest(
-                ['v5', 'patrons', 'holds', $holdId],
+                [$this->apiBase, 'patrons', 'holds', $holdId],
                 '',
                 'DELETE',
                 $patron
@@ -2347,7 +2347,7 @@ class SierraRest extends AbstractBase implements
         $holdingsData = [];
         if ($checkHoldings && $this->apiVersion >= 5.1) {
             $holdingsResult = $this->makeRequest(
-                ['v5', 'holdings'],
+                [$this->apiBase, 'holdings'],
                 [
                     'bibIds' => $this->extractBibId($id),
                     'deleted' => 'false',
@@ -3381,6 +3381,7 @@ class SierraRest extends AbstractBase implements
                 'caseSensitivity' => false,
             ];
             try {
+                // Note: hard-coded to use v5 API:
                 $result = $this->makeRequest(
                     ['v5', 'patrons', 'validate'],
                     json_encode($request),
@@ -3573,7 +3574,7 @@ class SierraRest extends AbstractBase implements
         $titleInfo = [];
         if ($db) {
             try {
-                $query = 'SELECT 
+                $query = 'SELECT
                         bib_record_property.best_title as title,
                         bib_record_property.best_author as author,
                         --hold.status, -- this shows sierra hold status not inn-reach status
@@ -3621,15 +3622,15 @@ class SierraRest extends AbstractBase implements
         $titleInfo = [];
         if ($db) {
             try {
-                $query = 'SELECT 
+                $query = 'SELECT
   bib_record_property.best_title as title,
   bib_record_property.best_author as author,
   bib_record_property.best_title_norm as sort_title
-FROM 
+FROM
   sierra_view.checkout,
   sierra_view.bib_record_item_record_link,
   sierra_view.bib_record_property
-WHERE 
+WHERE
   checkout.id = $1
   AND checkout.item_record_id = bib_record_item_record_link.item_record_id
   AND bib_record_item_record_link.bib_record_id = bib_record_property.bib_record_id';


### PR DESCRIPTION
Since older Sierra REST API versions get deprecated, it's important to use the version specified in driver configuration. Most calls used the configured version, but there were still a couple of hard-coded ones.