### PR TITLE
Add "composer fix" to run php-cs-fixer and phpcbf.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -130,6 +130,12 @@
     <phingcall target="phpstan-console"/>
   </target>
 
+  <!-- Fix PHP Tasks -->
+  <target name="fix-php" description="quality assurance php tasks">
+    <phingcall target="php-cs-fixer"/>
+    <phingcall target="phpcbf"/>
+  </target>
+
   <!-- Report rule violations with PHPMD (mess detector) -->
   <target name="phpmd">
     <exec command="${srcdir}/vendor/bin/phpmd ${srcdir}/module xml ${srcdir}/tests/phpmd.xml --exclude ${srcdir}/module/VuFind/tests,${srcdir}/module/VuFindSearch/tests --reportfile ${builddir}/reports/phpmd.xml" />
@@ -142,7 +148,29 @@
 
   <!-- PHP CodeSniffer -->
   <target name="phpcbf">
-    <exec command="${srcdir}/vendor/bin/phpcbf --standard=${srcdir}/tests/phpcs.xml" escape="false" passthru="true" checkreturn="true" />
+    <!-- Run phpcs first to find any problems (faster than phpcbf): -->
+    <exec command="${srcdir}/vendor/bin/phpcs --cache=${srcdir}/tests/phpcs.cache.json --standard=${srcdir}/tests/phpcs.xml" escape="false" returnProperty="phpcs_retval" outputProperty="phpcs_output" />
+    <if>
+      <not><equals arg1="${phpcs_retval}" arg2="0" /></not>
+      <then>
+        <echo msg="Trying to fix the following issues: " />
+        <echo msg="${phpcs_output}" />
+        <!-- Extract file names from phpcs output: -->
+        <property name="phpcbf_filelist" value="${phpcs_output}">
+            <filterchain>
+              <linecontainsregexp>
+                <regexp pattern="^FILE: (.*)" />
+              </linecontainsregexp>
+              <striplinebreaks />
+              <replaceregexp>
+                <regexp pattern="FILE: " replace=" " />
+              </replaceregexp>
+            </filterchain>
+        </property>
+        <!-- Finally, run phpcbf: -->
+        <exec command="${srcdir}/vendor/bin/phpcbf --standard=${srcdir}/tests/phpcs.xml ${phpcbf_filelist}" escape="false" passthru="true" checkreturn="true" />
+      </then>
+    </if>
   </target>
   <target name="phpcs">
     <exec command="${srcdir}/vendor/bin/phpcs --cache=${srcdir}/tests/phpcs.cache.json --standard=${srcdir}/tests/phpcs.xml --report=checkstyle &gt; ${builddir}/reports/checkstyle.xml" escape="false" />

--- a/build.xml
+++ b/build.xml
@@ -157,15 +157,15 @@
         <echo msg="${phpcs_output}" />
         <!-- Extract file names from phpcs output: -->
         <property name="phpcbf_filelist" value="${phpcs_output}">
-            <filterchain>
-              <linecontainsregexp>
-                <regexp pattern="^FILE: (.*)" />
-              </linecontainsregexp>
-              <striplinebreaks />
-              <replaceregexp>
-                <regexp pattern="FILE: " replace=" " />
-              </replaceregexp>
-            </filterchain>
+          <filterchain>
+            <linecontainsregexp>
+              <regexp pattern="^FILE: (.*)" />
+            </linecontainsregexp>
+            <striplinebreaks />
+            <replaceregexp>
+              <regexp pattern="FILE: " replace=" " />
+            </replaceregexp>
+          </filterchain>
         </property>
         <!-- Finally, run phpcbf: -->
         <exec command="${srcdir}/vendor/bin/phpcbf --standard=${srcdir}/tests/phpcs.xml ${phpcbf_filelist}" escape="false" passthru="true" checkreturn="true" />

--- a/build.xml
+++ b/build.xml
@@ -168,7 +168,7 @@
           </filterchain>
         </property>
         <!-- Finally, run phpcbf: -->
-        <exec command="${srcdir}/vendor/bin/phpcbf --standard=${srcdir}/tests/phpcs.xml ${phpcbf_filelist}" escape="false" passthru="true" checkreturn="true" />
+        <exec command="${srcdir}/vendor/bin/phpcbf --standard=${srcdir}/tests/phpcs.xml ${phpcbf_filelist}" escape="false" passthru="true" />
       </then>
     </if>
   </target>

--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
         }
     },
     "scripts": {
+        "fix": "phing fix-php",
         "phing-install-dependencies": ["phing patch-dependencies", "phing installsolr installswaggerui"],
         "post-install-cmd": "@phing-install-dependencies",
         "post-update-cmd": "@phing-install-dependencies",


### PR DESCRIPTION
Includes a change to phpcbf to run it with the output of phpcs, because phpcs is much faster with the cache.