### PR TITLE
Add browscap cache to ignore list in admin API.

### DIFF
--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -96,9 +96,11 @@ class Manager
      *
      * Following settings are supported:
      *
-     *   cliOverride   Set to false to not allow cache directory override in CLI mode (optional, enabled by default)
+     *   cliOverride   Set to false to not allow cache directory override in CLI mode (optional, true by default)
      *   directory     Cache directory (required)
      *   options       Array of cache options (optional, e.g. disabled, ttl)
+     *   persistent    Set to true to disable clearing of the cache by default with the admin API clearCache command
+     *                 (optional, false by default)
      *
      * @var array
      */
@@ -110,12 +112,14 @@ class Manager
                 'ttl' => 0, // no expiration - cache is updated with console util/browscap
                 'keyPattern' => '/^[a-z0-9_\+\-\.]*$/Di',
             ],
+            'persistent' => true,
         ],
         'config' => [
             'directory' => 'configs',
         ],
         'cover' => [
             'directory' => 'covers',
+            'persistent' => true,
         ],
         'language' => [
             'directory' => 'languages',
@@ -244,6 +248,22 @@ class Manager
                 ...array_keys($this->cacheSettings),
             ]
         );
+    }
+
+    /**
+     * Get the names of all non-persistent caches (ones that can be cleared).
+     *
+     * @return array
+     */
+    public function getNonPersistentCacheList(): array
+    {
+        $result = [];
+        foreach ($this->getCacheList() as $cache) {
+            if (!($this->cacheSpecs[$cache]['persistent'] ?? false)) {
+                $result[] = $cache;
+            }
+        }
+        return $result;
     }
 
     /**

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
@@ -98,8 +98,9 @@ class MaintenanceController extends AbstractAdmin
     public function homeAction()
     {
         $view = $this->createViewModel();
-        $view->caches = $this->serviceLocator->get(\VuFind\Cache\Manager::class)
-            ->getCacheList();
+        $cacheManager = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+        $view->caches = $cacheManager->getCacheList();
+        $view->nonPersistentCaches = $cacheManager->getNonPersistentCacheList();
         $view->scripts = $this->getScripts();
         $view->setTemplate('admin/maintenance/home');
         return $view;

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -78,7 +78,7 @@ class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiI
      *
      * @var array
      */
-    protected $defaultIgnoredCaches = ['cover'];
+    protected $defaultIgnoredCaches = ['browscap', 'cover'];
 
     /**
      * Clear the cache

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -32,8 +32,6 @@ namespace VuFindApi\Controller;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFind\Cache\Manager as CacheManager;
 
-use function in_array;
-
 /**
  * Admin Api Controller
  *

--- a/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/AdminApiController.php
@@ -74,13 +74,6 @@ class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiI
     protected $cacheAccessPermission = 'access.api.admin.cache';
 
     /**
-     * Caches that are not cleared by the clearCache command by default
-     *
-     * @var array
-     */
-    protected $defaultIgnoredCaches = ['browscap', 'cover'];
-
-    /**
      * Clear the cache
      *
      * @return \Laminas\Http\Response
@@ -175,10 +168,7 @@ class AdminApiController extends \VuFind\Controller\AbstractBase implements ApiI
     protected function getDefaultCachesToClear(): array
     {
         $result = [];
-        foreach ($this->cacheManager->getCacheList() as $id) {
-            if (in_array($id, $this->defaultIgnoredCaches)) {
-                continue;
-            }
+        foreach ($this->cacheManager->getNonPersistentCacheList() as $id) {
             $cache = $this->cacheManager->getCache($id);
             if ($cache instanceof \Laminas\Cache\Storage\FlushableInterface) {
                 $result[] = $id;

--- a/themes/bootstrap3/templates/admin/maintenance/home.phtml
+++ b/themes/bootstrap3/templates/admin/maintenance/home.phtml
@@ -23,7 +23,7 @@
     Clear cache(s):
     <?php foreach ($caches as $cache): ?>
       <label>
-        <input type="checkbox"<?='browscap' !== $cache ? ' checked="checked"' : ''?> name="cache[]" value="<?=$this->escapeHtmlAttr($cache)?>">
+        <input type="checkbox"<?=in_array($cache, $nonPersistentCaches) ? ' checked="checked"' : ''?> name="cache[]" value="<?=$this->escapeHtmlAttr($cache)?>">
         <?=$this->escapeHtml($cache) ?>
       </label>
     <?php endforeach; ?>


### PR DESCRIPTION
Since browscap cache should be a long-living one just like cover cache, it should not be cleared by cache clear command by default.