### PR TITLE
Fix merge recursive for boolean values

### DIFF
--- a/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
+++ b/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
@@ -70,7 +70,7 @@ trait MergeRecursiveTrait
      */
     protected function mergeRecursive($val1, $val2)
     {
-        if ($val2 === null || is_array($val2) && empty($val2)) {
+        if ($val2 === null || $val2 === []) {
             return $val1;
         }
 

--- a/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
+++ b/module/VuFind/src/VuFind/Feature/MergeRecursiveTrait.php
@@ -70,7 +70,7 @@ trait MergeRecursiveTrait
      */
     protected function mergeRecursive($val1, $val2)
     {
-        if (empty($val2)) {
+        if ($val2 === null || is_array($val2) && empty($val2)) {
             return $val1;
         }
 

--- a/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-child.yaml
@@ -15,6 +15,7 @@ Other:
       - Baz
   Replaced:
     Original: Replaces parent
+    Boolean: false
     ChildOnly: From child
   NonMerged:
     Original: Not so original either

--- a/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-parent.yaml
+++ b/module/VuFind/tests/fixtures/configs/yaml/config/vufind/yamlreader-parent.yaml
@@ -11,6 +11,7 @@ Other:
   Replaced:
     ParentOnly: Will exist
     Original: Will not exist
+    Boolean: true
   NonMerged:
     Original: Will not exist
   ParentOnly:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/YamlReaderTest.php
@@ -167,6 +167,7 @@ class YamlReaderTest extends \PHPUnit\Framework\TestCase
                     'Replaced' => [
                         'ParentOnly' => 'Will exist',
                         'Original' => 'Replaces parent',
+                        'Boolean' => false,
                         'ChildOnly' => 'From child',
                     ],
                     'NonMerged' => [


### PR DESCRIPTION
The `mergeRecursive` function does not work for the boolean value `false`: The reason ist that `empty(false) ==true`. This means that `false` values don't override `true`. This should be the same case for all values that are considered to be empty by php's `empty` function, e.g. 0. This PR fixes that.