### PR TITLE
Improve logger initialization process.

### DIFF
--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -30,6 +30,8 @@
 namespace VuFind\Log;
 
 use Laminas\Log\Logger as BaseLogger;
+use Laminas\Log\Writer\WriterInterface;
+use Laminas\Stdlib\SplPriorityQueue;
 use Traversable;
 use VuFind\Net\UserIpReader;
 
@@ -222,6 +224,24 @@ class Logger extends BaseLogger
         ];
 
         $this->log($this->getSeverityFromException($error), $errorDetails);
+    }
+
+    /**
+     * Remove a writer.
+     *
+     * @param WriterInterface $writer Writer to remove
+     *
+     * @return void
+     */
+    public function removeWriter(WriterInterface $writer): void
+    {
+        $newQueue = new SplPriorityQueue();
+        foreach ($this->getWriters() as $i => $current) {
+            if ($current !== $writer) {
+                $newQueue->insert($current, $i);
+            }
+        }
+        $this->setWriters($newQueue);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -37,6 +37,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 
+use function count;
 use function is_array;
 use function is_int;
 
@@ -260,29 +261,28 @@ class LoggerFactory implements FactoryInterface
         $config = $container->get(\VuFind\Config\PluginManager::class)
             ->get('config');
 
-        $hasWriter = false;
+        // Add a no-op writer so fatal errors are not triggered if log messages are
+        // sent during the initialization process.
+        $noOpWriter = new \Laminas\Log\Writer\Noop();
+        $logger->addWriter($noOpWriter);
 
         // DEBUGGER
         if (!$config->System->debug == false || $this->hasDynamicDebug($container)) {
-            $hasWriter = true;
             $this->addDebugWriter($logger, $config->System->debug);
         }
 
         // Activate database logging, if applicable:
         if (isset($config->Logging->database)) {
-            $hasWriter = true;
             $this->addDbWriters($logger, $container, $config->Logging->database);
         }
 
         // Activate file logging, if applicable:
         if (isset($config->Logging->file)) {
-            $hasWriter = true;
             $this->addFileWriters($logger, $config->Logging->file);
         }
 
         // Activate email logging, if applicable:
         if (isset($config->Logging->email)) {
-            $hasWriter = true;
             $this->addEmailWriters($logger, $container, $config);
         }
 
@@ -291,19 +291,18 @@ class LoggerFactory implements FactoryInterface
             isset($config->Logging->office365)
             && isset($config->Logging->office365_url)
         ) {
-            $hasWriter = true;
             $this->addOffice365Writers($logger, $container, $config);
         }
 
         // Activate slack logging, if applicable:
         if (isset($config->Logging->slack) && isset($config->Logging->slackurl)) {
-            $hasWriter = true;
             $this->addSlackWriters($logger, $container, $config);
         }
 
-        // Null (no-op) writer to avoid errors
-        if (!$hasWriter) {
-            $logger->addWriter(new \Laminas\Log\Writer\Noop());
+        // We're done now -- clean out the no-op writer if any other writers
+        // are found.
+        if (count($logger->getWriters()) > 1) {
+            $logger->removeWriter($noOpWriter);
         }
 
         // Add ReferenceId processor, if applicable:


### PR DESCRIPTION
A problem was discovered where checking a permission during the logger initialization process could lead to an uninitialized logger receiving messages. This PR adjusts logger initialization so that a no-op writer is temporarily added to the logger to process messages that get sent during initialization. The no-op writer is removed at the end of initialization as long as other writers are initialized.