### PR TITLE
Fix Blender default_filters examples.

### DIFF
--- a/config/vufind/Blender.ini
+++ b/config/vufind/Blender.ini
@@ -62,7 +62,9 @@ retain_filters_by_default = true
 always_display_reset_filters = false
 ;default_filters[] = "format:Book"
 ;default_filters[] = "institution:MyInstitution"
-;default_filters[] = "(format:Book AND institution:MyInstitution)"
+; OR filter:
+;default_filters[] = "~format:Book"
+;default_filters[] = "~format:Journal"
 
 ; Whether the "versions" (FRBR) link and record tab are enabled. Default is true.
 ;display_versions = true


### PR DESCRIPTION
Blender can't handle advanced default filters, so I added an example for an OR filter instead.