### PR TITLE
Use SSL to download Solr.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -343,7 +343,7 @@
           <not><available file="${srcdir}/downloads/solr-${solr_version}.tgz" /></not>
            <then>
             <mkdir dir="${srcdir}/downloads" />
-            <httpget url="http://archive.apache.org/dist/solr/solr/${solr_version}/solr-${solr_version}.tgz" dir="${srcdir}/downloads" />
+            <httpget url="https://archive.apache.org/dist/solr/solr/${solr_version}/solr-${solr_version}.tgz" dir="${srcdir}/downloads" />
           </then>
         </if>
         <!-- unpack the archive into solr/vendor -->


### PR DESCRIPTION
@crhallberg noticed that the installsolr task was encountering a 301 redirect -- might as well just go straight to the secure source.