### PR TITLE
Allow DynamicRoleProviderFactory to be used for subclasses

### DIFF
--- a/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
+++ b/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
@@ -53,7 +53,7 @@ class DynamicRoleProviderFactory implements FactoryInterface
      * @param string             $name    Requested service name (unused)
      * @param array              $options Extra options (unused)
      *
-     * @return DynamicRoleProvider
+     * @return object
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -61,7 +61,7 @@ class DynamicRoleProviderFactory implements FactoryInterface
     {
         $config = $sm->get('config');
         $rbacConfig = $config['lmc_rbac'];
-        return new DynamicRoleProvider(
+        return new $name(
             $this->getPermissionProviderPluginManager($sm, $rbacConfig),
             $this->getPermissionConfiguration($sm, $rbacConfig)
         );


### PR DESCRIPTION
This change allows `DynamicRoleProviderFactory` to be used for `DynamicRoleProvider` subclasses.

I am using a subclass to always add all dynamically defined permissions to a superadmin role. This might be a useful thing to have in upstream VuFind, but that would be a case for another PR.