### PR TITLE
Fix invalid key handling in secure session delegator.

### DIFF
--- a/module/VuFind/src/VuFind/Session/SecureDelegator.php
+++ b/module/VuFind/src/VuFind/Session/SecureDelegator.php
@@ -154,7 +154,7 @@ class SecureDelegator implements HandlerInterface
     public function read($session_id): string|false
     {
         $data = $this->handler->read($session_id);
-        return $data ? $this->cipher->decrypt($data) : $data;
+        return $data ? ($this->cipher->decrypt($data) ?: '') : $data;
     }
 
     /**


### PR DESCRIPTION
If key didn't match the session, it would have caused the session startup to fail, and the only remedy would have been to clear the cookies.

Since `decrypt` returns false if decryption fails, and `SessionHandlerInterface::read` returning false means that session startup failed, we need to turn the false into an empty string instead.