### PR TITLE
FOLIO: make holdingsRecordId and itemID optional in getMyHoldings

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1413,10 +1413,10 @@ class Folio extends AbstractAPI implements
                 'expire' => $expireDate ?? '',
                 'id' => $this->getBibId(
                     $hold->instanceId,
-                    $hold->holdingsRecordId,
-                    $hold->itemId
+                    $hold->holdingsRecordId ?? null,
+                    $hold->itemId ?? null
                 ),
-                'item_id' => $hold->itemId,
+                'item_id' => $hold->itemId ?? null,
                 'reqnum' => $hold->id,
                 // Title moved from item to instance in Lotus release:
                 'title' => $hold->instance->title ?? $hold->item->title ?? '',


### PR DESCRIPTION
Hi @demiankatz, this solution works for me as discussed: https://folio-project.slack.com/archives/CQQMFR3EZ/p1709033853491989?thread_ts=1708966105.889979&cid=CQQMFR3EZ

Thank you!