### PR TITLE
Add support for subdirectories in content pages.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -566,6 +566,27 @@
     <append destFile="${localdir}/languages/Facets/en.ini" text="0/level1z/ = Top Level, Sorted First${line.separator}" />
     <append destFile="${localdir}/languages/Facets/en.ini" text="1/level1z/level2y/ = Second Level, Sorted Last${line.separator}" />
     <append destFile="${localdir}/languages/Facets/en.ini" text="1/level1z/level2z/ = Second Level, Sorted First${line.separator}" />
+
+    <!-- Add templates to a minktest theme for tests -->
+    <property name="themedir" value="${srcdir}/themes/minktest" />
+    <property name="templatedir" value="${themedir}/templates/content" />
+    <if>
+      <not>
+        <available file="${templatedir}/test" type="dir" />
+      </not>
+      <then>
+        <mkdir dir="${templatedir}/test" />
+      </then>
+    </if>
+    <echo file="${themedir}/theme.config.php">&lt;?php
+return [
+    'extends' =&gt; 'sandal',
+];
+</echo>
+    <echo file="${templatedir}/test.phtml">&lt;h1&gt;MAIN LEVEL TEST&lt;/h1&gt;</echo>
+    <echo file="${templatedir}/test_fi.phtml">&lt;h1&gt;FINNISH TEST&lt;/h1&gt;</echo>
+    <echo file="${templatedir}/test/test.phtml">&lt;h1&gt;SUB LEVEL PHTML&lt;/h1&gt;</echo>
+    <echo file="${templatedir}/test/testmd.md"># SUB LEVEL MD</echo>
   </target>
 
   <target name="setup_database" description="setup demo database">
@@ -791,6 +812,7 @@ ${git_status}
         <include name="**/*" />
       </fileset>
     </delete>
+    <delete dir="${srcdir}/themes/minktest" />
     <delete file="${srcdir}/env.bat" />
     <delete file="${srcdir}/env.sh" />
     <delete file="${localdir}/import/import.properties" />

--- a/build.xml
+++ b/build.xml
@@ -569,13 +569,13 @@
 
     <!-- Add templates to a minktest theme for tests -->
     <property name="themedir" value="${srcdir}/themes/minktest" />
-    <property name="templatedir" value="${themedir}/templates/content" />
+    <property name="contentdir" value="${themedir}/templates/content" />
     <if>
       <not>
-        <available file="${templatedir}/test" type="dir" />
+        <available file="${contentdir}/test/sub" type="dir" />
       </not>
       <then>
-        <mkdir dir="${templatedir}/test" />
+        <mkdir dir="${contentdir}/test/sub" />
       </then>
     </if>
     <echo file="${themedir}/theme.config.php">&lt;?php
@@ -583,10 +583,11 @@ return [
     'extends' =&gt; 'sandal',
 ];
 </echo>
-    <echo file="${templatedir}/test.phtml">&lt;h1&gt;MAIN LEVEL TEST&lt;/h1&gt;</echo>
-    <echo file="${templatedir}/test_fi.phtml">&lt;h1&gt;FINNISH TEST&lt;/h1&gt;</echo>
-    <echo file="${templatedir}/test/test.phtml">&lt;h1&gt;SUB LEVEL PHTML&lt;/h1&gt;</echo>
-    <echo file="${templatedir}/test/testmd.md"># SUB LEVEL MD</echo>
+    <echo file="${contentdir}/test.phtml">&lt;h1&gt;MAIN LEVEL TEST&lt;/h1&gt;</echo>
+    <echo file="${contentdir}/test_fi.phtml">&lt;h1&gt;FINNISH TEST&lt;/h1&gt;</echo>
+    <echo file="${contentdir}/test/test.phtml">&lt;h1&gt;SUB LEVEL PHTML&lt;/h1&gt;</echo>
+    <echo file="${contentdir}/test/testmd.md"># SUB LEVEL MD</echo>
+    <echo file="${contentdir}/test/sub/test.phtml">&lt;h1&gt;SUB SUB LEVEL PHTML&lt;/h1&gt;</echo>
   </target>
 
   <target name="setup_database" description="setup demo database">

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "vufind-org/vufindhttp": "3.2.0",
         "vufind-org/vufind-marc": "1.1.0",
         "webfontkit/open-sans": "^1.0",
+        "webmozart/glob": "^4.6",
         "wikimedia/composer-merge-plugin": "2.1.0",
         "yajra/laravel-pdo-via-oci8": "3.4.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb296211f68f9fe210c79fdbe1de4dae",
+    "content-hash": "b940541baf9043cfa50bdc29912514cd",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -9584,6 +9584,55 @@
             "time": "2022-06-03T18:03:27+00:00"
         },
         {
+            "name": "webmozart/glob",
+            "version": "4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.6.0"
+            },
+            "time": "2022-05-24T19:45:58+00:00"
+        },
+        {
             "name": "wikimedia/composer-merge-plugin",
             "version": "v2.1.0",
             "source": {
@@ -13227,5 +13276,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -36,7 +36,8 @@ $config = [
             'content-page' => [
                 'type'    => 'Laminas\Router\Http\Regex',
                 'options' => [
-                    'regex'    => '/[C|c]ontent/(?<page>[a-zA-Z][a-zA-Z0-9_-]*)',
+                    // Note: %2F is needed for encoded slashes to match the route regex:
+                    'regex'    => '/[C|c]ontent/(?<page>[a-zA-Z]([a-zA-Z0-9/_-]|%2[fF])*)',
                     'defaults' => [
                         'controller' => 'Content',
                         'action'     => 'Content',

--- a/module/VuFind/src/VuFind/Controller/ContentController.php
+++ b/module/VuFind/src/VuFind/Controller/ContentController.php
@@ -71,14 +71,15 @@ class ContentController extends AbstractBase
         if (str_contains($page, '..')) {
             return $this->notFoundAction();
         }
-        if (false !== ($p = strpos($page, '/'))) {
+        // Find last slash and add preceding part to path if found:
+        if (false !== ($p = strrpos($page, '/'))) {
             $subPath = substr($page, 0, $p + 1);
             $pathPrefix .= $subPath;
-            $page = substr($page, $p + 1);
-            // Ensure the the page does not start with a slash as an extra precaution:
-            if (str_starts_with($page, '/')) {
+            // Ensure the the path prefix does not contain extra slashes:
+            if (str_ends_with($pathPrefix, '//')) {
                 return $this->notFoundAction();
             }
+            $page = substr($page, $p + 1);
         }
         $pageLocator = $this->serviceLocator->get(\VuFind\Content\PageLocator::class);
         $data = $pageLocator->determineTemplateAndRenderer($pathPrefix, $page);

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPages.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPages.php
@@ -32,8 +32,10 @@ namespace VuFind\Sitemap\Plugin;
 use Laminas\Config\Config;
 use Laminas\Router\RouteStackInterface;
 use VuFindTheme\ThemeInfo;
+use Webmozart\Glob\Glob;
 
 use function in_array;
+use function strlen;
 
 /**
  * Content pages generator plugin
@@ -77,15 +79,25 @@ class ContentPages extends AbstractGeneratorPlugin
     /**
      * Patterns of files to be included
      *
+     * @see https://github.com/webmozarts/glob
+     *
      * @var array
      */
     protected $includedFiles = [
-        'templates/content/*.phtml',
-        'templates/content/*.md',
+        [
+            'path' => 'templates/content/',
+            'pattern' => '**/*.phtml',
+        ],
+        [
+            'path' => 'templates/content/',
+            'pattern' => '**/*.md',
+        ],
     ];
 
     /**
-     * Files to be ignored when searching for content pages
+     * Patterns of files to be ignored when searching for content pages
+     *
+     * @see https://github.com/webmozarts/glob
      *
      * @var array
      */
@@ -143,38 +155,61 @@ class ContentPages extends AbstractGeneratorPlugin
      */
     public function getUrls(): \Generator
     {
-        $files = $this->themeInfo->findInThemes($this->includedFiles);
         $nonLanguageFiles = [];
         $languages = isset($this->config->Languages)
             ? array_keys($this->config->Languages->toArray())
             : [];
-        // Check each file for language suffix and combine the files into a
-        // non-language specific array
-        foreach ($files as $fileInfo) {
-            if (
-                in_array($fileInfo['relativeFile'], $this->excludedFiles)
-            ) {
-                continue;
-            }
-            $baseName = pathinfo($fileInfo['relativeFile'], PATHINFO_FILENAME);
-            // Check the filename for a known language suffix
-            $p = strrpos($baseName, '_');
-            if ($p > 0) {
-                $fileLanguage = substr($baseName, $p + 1);
-                if (in_array($fileLanguage, $languages)) {
-                    $baseName = substr($baseName, 0, $p);
+        foreach ($this->includedFiles as $fileSpec) {
+            $files = $this->themeInfo->findInThemes([$fileSpec['path'] . $fileSpec['pattern']]);
+            // Check each file for language suffix and combine the files into a
+            // non-language specific array
+            $pathLen = strlen($fileSpec['path']);
+            foreach ($files as $fileInfo) {
+                if ($this->isExcluded($fileInfo['relativeFile'])) {
+                    continue;
                 }
+                // Get file name relative to the original path
+                $pathInfo = pathinfo($fileInfo['relativeFile']);
+                if ($pagePath = substr($pathInfo['dirname'], $pathLen)) {
+                    $pagePath .= '/';
+                }
+                $pageName = $pagePath . $pathInfo['filename'];
+                // Check the filename for a known language suffix
+                $p = strrpos($pageName, '_');
+                if ($p > 0) {
+                    $fileLanguage = substr($pageName, $p + 1);
+                    if (in_array($fileLanguage, $languages)) {
+                        $pageName = substr($pageName, 0, $p);
+                    }
+                }
+                $nonLanguageFiles[$pageName] = true;
             }
-            $nonLanguageFiles[$baseName] = true;
         }
 
         foreach (array_keys($nonLanguageFiles) as $fileName) {
             $url = $this->baseUrl . $this->router->assemble(
                 ['page' => $fileName],
-                ['name' => 'content-page']
+                ['name' => 'content-page'],
             );
             $this->verboseMsg("Adding content page $url");
             yield $url;
         }
+    }
+
+    /**
+     * Check if the given file should be excluded from sitemap
+     *
+     * @param string $filename Filename
+     *
+     * @return bool
+     */
+    protected function isExcluded(string $filename): bool
+    {
+        foreach ($this->excludedFiles as $pattern) {
+            if (Glob::match($filename, $pattern)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPages.php
+++ b/module/VuFind/src/VuFind/Sitemap/Plugin/ContentPages.php
@@ -189,7 +189,7 @@ class ContentPages extends AbstractGeneratorPlugin
         foreach (array_keys($nonLanguageFiles) as $fileName) {
             $url = $this->baseUrl . $this->router->assemble(
                 ['page' => $fileName],
-                ['name' => 'content-page'],
+                ['name' => 'content-page']
             );
             $this->verboseMsg("Adding content page $url");
             yield $url;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
@@ -91,4 +91,87 @@ class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCssAndGetText($page, '#content a')
         );
     }
+
+    /**
+     * Data provider for testDirectoryHandling().
+     *
+     * @return array
+     */
+    public static function requestPathProvider(): array
+    {
+        return [
+            'main path en' => [
+                'en',
+                'test',
+                'MAIN LEVEL TEST',
+            ],
+            'main path de' => [
+                'de',
+                'test',
+                'MAIN LEVEL TEST',
+            ],
+            'main path fi' => [
+                'fi',
+                'test',
+                'FINNISH TEST',
+            ],
+            'sub path phtml' => [
+                'en',
+                'test/test',
+                'SUB LEVEL PHTML',
+            ],
+            'sub path md' => [
+                'en',
+                'test/testmd',
+                'SUB LEVEL MD',
+            ],
+            'bad path' => [
+                'en',
+                'test//testmd',
+                'An error has occurred',
+            ],
+            'bad path 2' => [
+                'en',
+                'test/.testmd',
+                'An error has occurred',
+            ],
+            'bad path 3' => [
+                'en',
+                '../../../local_theme_example/templates/content/example',
+                'Not Found',
+            ],
+        ];
+    }
+
+    /**
+     * Test directory handling.
+     *
+     * @param string $language Language
+     * @param string $path     Path to request
+     * @param string $expected Expected heading
+     *
+     * @dataProvider requestPathProvider
+     *
+     * @return void
+     */
+    public function testDirectoryHandling(string $language, string $path, string $expected): void
+    {
+        // Switch to the minktest theme:
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Site' => [
+                        'theme' => 'minktest',
+                        'language' => $language,
+                    ],
+                ],
+            ]
+        );
+        // Open the page:
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . "/Content/$path");
+        $page = $session->getPage();
+        // Confirm that the correct page was retrieved:
+        $this->assertEquals($expected, $this->findCssAndGetText($page, 'h1'));
+    }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
@@ -125,7 +125,17 @@ class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
                 'test/testmd',
                 'SUB LEVEL MD',
             ],
-            'bad path' => [
+            'sub sub path phtml' => [
+                'en',
+                'test/sub/test',
+                'SUB SUB LEVEL PHTML',
+            ],
+            'bad sub path phtml' => [
+                'en',
+                'test/sub/bad/test',
+                'An error has occurred',
+            ],
+            'bad path 1' => [
                 'en',
                 'test//testmd',
                 'An error has occurred',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/ContentPagesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Sitemap/Plugin/ContentPagesTest.php
@@ -63,30 +63,49 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
      * @var array
      */
     protected $themeInfoData = [
-        [
-          'theme' => 'bootstrap3',
-          'file' => '/themepath/templates/content/asklibrary_en.phtml',
-          'relativeFile' => 'templates/content/asklibrary_en.phtml',
+        'templates/content/**/*.phtml' => [
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/asklibrary_en.phtml',
+                'relativeFile' => 'templates/content/asklibrary_en.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/asklibrary.phtml',
+                'relativeFile' => 'templates/content/asklibrary.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/content.phtml',
+                'relativeFile' => 'templates/content/content.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/faq.phtml',
+                'relativeFile' => 'templates/content/faq.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/help/search.phtml',
+                'relativeFile' => 'templates/content/help/search.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/help/search_en.phtml',
+                'relativeFile' => 'templates/content/help/search_en.phtml',
+            ],
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/markdown.phtml',
+                'relativeFile' => 'templates/content/markdown.phtml',
+            ],
         ],
-        [
-          'theme' => 'bootstrap3',
-          'file' => '/themepath/templates/content/asklibrary.phtml',
-          'relativeFile' => 'templates/content/asklibrary.phtml',
-        ],
-        [
-          'theme' => 'bootstrap3',
-          'file' => '/themepath/templates/content/content.phtml',
-          'relativeFile' => 'templates/content/content.phtml',
-        ],
-        [
-          'theme' => 'bootstrap3',
-          'file' => '/themepath/templates/content/faq.phtml',
-          'relativeFile' => 'templates/content/faq.phtml',
-        ],
-        [
-          'theme' => 'bootstrap3',
-          'file' => '/themepath/templates/content/markdown.phtml',
-          'relativeFile' => 'templates/content/markdown.phtml',
+        'templates/content/**/*.md' => [
+            [
+                'theme' => 'bootstrap3',
+                'file' => '/themepath/templates/content/example.md',
+                'relativeFile' => 'templates/content/example.md',
+            ],
         ],
     ];
 
@@ -146,7 +165,7 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
             return $options['name'] . '/' . $params['page'];
         };
         $router->expects($this->any())->method('assemble')
-            ->will($this->returnCallback($callback));
+            ->willReturnCallback($callback);
         return $router;
     }
 
@@ -157,14 +176,13 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockThemeInfo(): ThemeInfo
     {
-        $expectedTemplates = [
-            'templates/content/*.phtml',
-            'templates/content/*.md',
-        ];
         $themeInfo = $this->container->get(ThemeInfo::class);
-        $themeInfo->expects($this->once())->method('findInThemes')
-            ->with($this->equalTo($expectedTemplates))
-            ->will($this->returnValue($this->themeInfoData));
+        $themeInfo->expects($this->exactly(2))->method('findInThemes')
+            ->willReturnCallback(
+                function ($paths) {
+                    return $this->themeInfoData[reset($paths)] ?? null;
+                }
+            );
         return $themeInfo;
     }
 
@@ -183,6 +201,9 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
                 'content-page/asklibrary_en',
                 'content-page/asklibrary',
                 'content-page/faq',
+                'content-page/help/search',
+                'content-page/help/search_en',
+                'content-page/example',
             ],
             iterator_to_array($plugin->getUrls())
         );
@@ -202,6 +223,8 @@ class ContentPagesTest extends \PHPUnit\Framework\TestCase
             [
                 'content-page/asklibrary',
                 'content-page/faq',
+                'content-page/help/search',
+                'content-page/example',
             ],
             iterator_to_array($plugin->getUrls())
         );

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfo.php
@@ -30,6 +30,7 @@
 namespace VuFindTheme;
 
 use Laminas\Cache\Storage\StorageInterface;
+use Webmozart\Glob\Glob;
 
 use function is_array;
 use function strlen;
@@ -354,7 +355,7 @@ class ThemeInfo
             $themePath = "$basePath/$theme/";
             foreach ($allPaths as $currentPath) {
                 $path = $themePath . $currentPath;
-                foreach (glob($path) as $file) {
+                foreach (Glob::glob($path) as $file) {
                     if (filetype($file) === 'dir') {
                         continue;
                     }


### PR DESCRIPTION
When there are more than a few content pages, it's very useful to be able to arrange them into subdirectories. To keep routing simple, this implementation supports paths with encoded slashes (as well as unencoded) so that the page part of the route can be specified with a single parameter (that Laminas router forces to be encoded with `rawurlencode`).

TODO
- [x] Update changelog when merging (change to getViewFor* method signatures in ContentController)