### PR TITLE
Deprecate isLoggedIn() method.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserActionFactory.php
@@ -70,7 +70,7 @@ class AbstractIlsAndUserActionFactory implements \Laminas\ServiceManager\Factory
             $container->get(\VuFind\Session\Settings::class),
             $container->get(\VuFind\ILS\Connection::class),
             $container->get(\VuFind\Auth\ILSAuthenticator::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn(),
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
             ...($options ?: [])
         );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisActionFactory.php
@@ -69,7 +69,7 @@ class AbstractRelaisActionFactory implements \Laminas\ServiceManager\Factory\Fac
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $user = $container->get(\VuFind\Auth\Manager::class)->isLoggedIn();
+        $user = $container->get(\VuFind\Auth\Manager::class)->getUserObject();
         return new $requestedName(
             $container->get(\VuFind\Session\Settings::class),
             $container->get(\VuFind\Connection\Relais::class),

--- a/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CommentRecordFactory.php
@@ -76,7 +76,7 @@ class CommentRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInt
             $tablePluginManager->get(\VuFind\Db\Table\Resource::class),
             $controllerPluginManager
                 ->get(\VuFind\Controller\Plugin\Captcha::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn(),
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
             $capabilities->getCommentSetting() !== 'disabled',
             $container->get(\VuFind\Record\Loader::class),
             $container->get(\VuFind\Config\AccountCapabilities::class)

--- a/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordCommentFactory.php
@@ -73,7 +73,7 @@ class DeleteRecordCommentFactory implements \Laminas\ServiceManager\Factory\Fact
         $capabilities = $container->get(\VuFind\Config\AccountCapabilities::class);
         return new $requestedName(
             $tablePluginManager->get(\VuFind\Db\Table\Comments::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn(),
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
             $capabilities->getCommentSetting() !== 'disabled'
         );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTagsFactory.php
@@ -72,7 +72,7 @@ class GetRecordTagsFactory implements \Laminas\ServiceManager\Factory\FactoryInt
         $tablePluginManager = $container->get(\VuFind\Db\Table\PluginManager::class);
         return new $requestedName(
             $tablePluginManager->get(\VuFind\Db\Table\Tags::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn(),
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
             $container->get('ViewRenderer')
         );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
@@ -71,7 +71,7 @@ class GetSaveStatusesFactory implements \Laminas\ServiceManager\Factory\FactoryI
         }
         return new $requestedName(
             $container->get(\VuFind\Session\Settings::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn(),
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
             $container->get('ControllerPluginManager')->get('url')
         );
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSearchResultsFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSearchResultsFactory.php
@@ -74,7 +74,7 @@ class GetSearchResultsFactory implements \Laminas\ServiceManager\Factory\Factory
             $container->get(\VuFind\Search\Results\PluginManager::class),
             $container->get('ViewRenderer'),
             $container->get(\VuFind\Record\Loader::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn() ?: null,
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject() ?: null,
             $container->get(\Laminas\Session\SessionManager::class)->getId(),
             $container->get(\VuFind\Search\SearchNormalizer::class),
             $container->get(\VuFind\Db\Table\PluginManager::class)->get(\VuFind\Db\Table\Search::class),

--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
@@ -72,7 +72,7 @@ class TagRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
         return new $requestedName(
             $container->get(\VuFind\Record\Loader::class),
             $container->get(\VuFind\Tags::class),
-            $container->get(\VuFind\Auth\Manager::class)->isLoggedIn()
+            $container->get(\VuFind\Auth\Manager::class)->getUserObject()
         );
     }
 }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -108,7 +108,7 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->isLoggedIn()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->cat_username)) {
             return [
                 'cat_username' => $user->cat_username,
                 'cat_password' => $user->cat_password,
@@ -130,7 +130,7 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->isLoggedIn()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->cat_username)) {
             // Do we have a previously cached ILS account?
             if (isset($this->ilsAccount[$user->cat_username])) {
                 return $this->ilsAccount[$user->cat_username];
@@ -237,7 +237,7 @@ class ILSAuthenticator
      */
     protected function updateUser($catUsername, $catPassword, $patron)
     {
-        $user = $this->getAuthManager()->isLoggedIn();
+        $user = $this->getAuthManager()->getUserObject();
         if ($user) {
             $user->saveCredentials($catUsername, $catPassword);
             $this->getAuthManager()->updateSession($user);

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -31,6 +31,7 @@ namespace VuFind\Auth;
 
 use Laminas\Config\Config;
 use Laminas\Session\SessionManager;
+use LmcRbacMvc\Identity\IdentityInterface;
 use VuFind\Cookie\CookieManager;
 use VuFind\Db\Row\User as UserRow;
 use VuFind\Db\Table\User as UserTable;
@@ -379,7 +380,7 @@ class Manager implements
             // settings in config.ini. However, if the user is not logged in,
             // they are probably attempting something nasty and should be given
             // an error message.
-            if (!$this->isLoggedIn()) {
+            if (!$this->getIdentity()) {
                 throw $e;
             }
             $this->logout('');
@@ -581,8 +582,20 @@ class Manager implements
      * Checks whether the user is logged in.
      *
      * @return UserRow|false Object if user is logged in, false otherwise.
+     *
+     * @deprecated Use getIdentity() or getUserObject() instead.
      */
     public function isLoggedIn()
+    {
+        return $this->getUserObject();
+    }
+
+    /**
+     * Checks whether the user is logged in.
+     *
+     * @return UserRow|false Object if user is logged in, false otherwise.
+     */
+    public function getUserObject()
     {
         // If user object is not in cache, but user ID is in session,
         // load the object from the database:
@@ -639,13 +652,13 @@ class Manager implements
     }
 
     /**
-     * Get the identity
+     * Get the logged-in user's identity (null if not logged in)
      *
-     * @return \LmcRbacMvc\Identity\IdentityInterface|null
+     * @return ?IdentityInterface
      */
     public function getIdentity()
     {
-        return $this->isLoggedIn() ?: null;
+        return $this->getUserObject() ?: null;
     }
 
     /**
@@ -655,7 +668,7 @@ class Manager implements
      */
     public function checkForExpiredCredentials()
     {
-        if ($this->isLoggedIn() && $this->getAuth()->isExpired()) {
+        if ($this->getIdentity() && $this->getAuth()->isExpired()) {
             $this->logout(null, false);
             return true;
         }

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -218,7 +218,7 @@ class Bootstrapper
         $language = $settings->getUserLocale();
         $authManager = $this->container->get(\VuFind\Auth\Manager::class);
         if (
-            ($user = $authManager->isLoggedIn())
+            ($user = $authManager->getUserObject())
             && $user->last_language != $language
         ) {
             $user->updateLastLanguage($language);

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -331,7 +331,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getUser()
     {
-        return $this->getAuthManager()->isLoggedIn();
+        return $this->getAuthManager()->getUserObject();
     }
 
     /**
@@ -390,7 +390,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
     {
         // First make sure user is logged in to VuFind:
         $account = $this->getAuthManager();
-        if ($account->isLoggedIn() == false) {
+        if (!$account->getIdentity()) {
             return $this->forceLogin();
         }
 

--- a/module/VuFind/src/VuFind/Controller/IndexController.php
+++ b/module/VuFind/src/VuFind/Controller/IndexController.php
@@ -78,7 +78,7 @@ class IndexController extends \Laminas\Mvc\Controller\AbstractActionController
     public function homeAction()
     {
         // Load different configurations depending on whether we're logged in or not:
-        if ($this->authManager->isLoggedIn()) {
+        if ($this->authManager->getIdentity()) {
             $controller = $this->config->Site->defaultLoggedInModule ?? 'MyResearch';
             $actionConfig = 'defaultLoggedInAction';
         } else {

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -200,7 +200,7 @@ class MyResearchController extends AbstractBase
             || $this->params()->fromQuery('auth_method')
         ) {
             try {
-                if (!$this->getAuthManager()->isLoggedIn()) {
+                if (!$this->getAuthManager()->getIdentity()) {
                     $this->getAuthManager()->login($this->getRequest());
                     // Return early to avoid unnecessary processing if we are being
                     // called from login lightbox and don't have a followup action or
@@ -221,7 +221,7 @@ class MyResearchController extends AbstractBase
         }
 
         // Not logged in?  Force user to log in:
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             if (
                 $this->followup()->retrieve('lightboxParent')
                 && $url = $this->getAndClearFollowupUrl(true)
@@ -259,7 +259,7 @@ class MyResearchController extends AbstractBase
     public function accountAction()
     {
         // If the user is already logged in, don't let them create an account:
-        if ($this->getAuthManager()->isLoggedIn()) {
+        if ($this->getAuthManager()->getIdentity()) {
             return $this->redirect()->toRoute('myresearch-home');
         }
         // If authentication mechanism does not support account creation, send
@@ -348,7 +348,7 @@ class MyResearchController extends AbstractBase
     public function userloginAction()
     {
         // Don't log in if already logged in!
-        if ($this->getAuthManager()->isLoggedIn()) {
+        if ($this->getAuthManager()->getIdentity()) {
             return $this->inLightbox()  // different behavior for lightbox context
                 ? $this->getRefreshResponse()
                 : $this->redirect()->toRoute('home');
@@ -371,7 +371,7 @@ class MyResearchController extends AbstractBase
      */
     public function completeLoginAction()
     {
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             return $this->forceLogin('');
         }
         if (!is_array($patron = $this->catalogLogin())) {
@@ -2090,7 +2090,7 @@ class MyResearchController extends AbstractBase
     public function changeEmailAction()
     {
         // Always check that we are logged in and function is enabled first:
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             return $this->forceLogin();
         }
         if (!$this->getAuthManager()->supportsEmailChange()) {
@@ -2148,7 +2148,7 @@ class MyResearchController extends AbstractBase
      */
     public function changePasswordAction()
     {
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             return $this->forceLogin();
         }
         // If not submitted, are we logged in?
@@ -2180,7 +2180,7 @@ class MyResearchController extends AbstractBase
      */
     public function deleteLoginTokenAction()
     {
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             return $this->forceLogin();
         }
         $csrf = $this->serviceLocator->get(CsrfInterface::class);
@@ -2201,7 +2201,7 @@ class MyResearchController extends AbstractBase
      */
     public function deleteUserLoginTokensAction()
     {
-        if (!$this->getAuthManager()->isLoggedIn()) {
+        if (!$this->getAuthManager()->getIdentity()) {
             return $this->forceLogin();
         }
         $csrf = $this->serviceLocator->get(CsrfInterface::class);

--- a/module/VuFind/src/VuFind/Controller/Plugin/Permission.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Permission.php
@@ -146,7 +146,7 @@ class Permission extends AbstractPlugin implements
                     // login" denied permission requirement, there is probably a
                     // configuration error somewhere; throw an exception rather than
                     // triggering an infinite login redirection loop.
-                    if ($this->authManager->isLoggedIn()) {
+                    if ($this->getIdentity()) {
                         throw new ForbiddenException(
                             'Trying to prompt login due to denied ' . $permission
                             . ' permission, but a user is already logged in; '

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -309,7 +309,7 @@ class LoggerFactory implements FactoryInterface
         if ($referenceId = $config->Logging->reference_id ?? false) {
             if ('username' === $referenceId) {
                 $authManager = $container->get(\VuFind\Auth\Manager::class);
-                if ($user = $authManager->isLoggedIn()) {
+                if ($user = $authManager->getUserObject()) {
                     $processor = new \Laminas\Log\Processor\ReferenceId();
                     $processor->setReferenceId($user->username);
                     $logger->addProcessor($processor);

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -382,6 +382,6 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
      */
     protected function getUser(): User|bool
     {
-        return $this->getAuthHelper()->isLoggedIn();
+        return $this->getAuthHelper()->getUserObject();
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\View\Helper\Root;
 
+use LmcRbacMvc\Identity\IdentityInterface;
 use VuFind\Exception\ILS as ILSException;
 
 /**
@@ -104,10 +105,33 @@ class Auth extends \Laminas\View\Helper\AbstractHelper
      *
      * @return \VuFind\Db\Row\User|bool Object if user is logged in, false
      * otherwise.
+     *
+     * @deprecated Use getIdentity() or getUserObject() instead.
      */
     public function isLoggedIn()
     {
-        return $this->getManager()->isLoggedIn();
+        return $this->getUserObject();
+    }
+
+    /**
+     * Checks whether the user is logged in.
+     *
+     * @return \VuFind\Db\Row\User|bool Object if user is logged in, false
+     * otherwise.
+     */
+    public function getUserObject()
+    {
+        return $this->getManager()->getUserObject();
+    }
+
+    /**
+     * Get the logged-in user's identity (null if not logged in)
+     *
+     * @return ?IdentityInterface
+     */
+    public function getIdentity(): ?IdentityInterface
+    {
+        return $this->getManager()->getIdentity();
     }
 
     /**

--- a/module/VuFind/src/VuFindTest/Unit/AjaxHandlerTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AjaxHandlerTestCase.php
@@ -72,9 +72,9 @@ abstract class AjaxHandlerTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Get an auth manager with a value set for isLoggedIn.
+     * Get an auth manager with a value set for getUserObject.
      *
-     * @param \VuFind\Db\Row\User $user Return value for isLoggedIn()
+     * @param \VuFind\Db\Row\User $user Return value for getUserObject()
      *
      * @return \VuFind\Auth\Manager
      */
@@ -82,10 +82,10 @@ abstract class AjaxHandlerTestCase extends \PHPUnit\Framework\TestCase
     {
         $authManager = $this->container->createMock(
             \VuFind\Auth\Manager::class,
-            ['isLoggedIn', 'loginEnabled']
+            ['getUserObject', 'loginEnabled']
         );
-        $authManager->expects($this->any())->method('isLoggedIn')
-            ->will($this->returnValue($user));
+        $authManager->expects($this->any())->method('getUserObject')
+            ->willReturn($user);
         $authManager->expects($this->any())->method('loginEnabled')
             ->willReturn(true);
         return $authManager;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CheckRequestIsValidTest.php
@@ -49,7 +49,7 @@ class CheckRequestIsValidTest extends \VuFindTest\Unit\AjaxHandlerTestCase
     /**
      * Set up a CheckRequestIsValid handler for testing.
      *
-     * @param User|bool $user Return value for isLoggedIn() in auth manager
+     * @param User|bool $user Return value for getUserObject() in auth manager
      *
      * @return CheckRequestIsValid
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/CommentRecordTest.php
@@ -53,7 +53,7 @@ class CommentRecordTest extends \VuFindTest\Unit\AjaxHandlerTestCase
      * Set up a CommentRecord handler for testing.
      *
      * @param bool      $enabled Are comments enabled?
-     * @param User|bool $user    Return value for isLoggedIn() in auth manager
+     * @param User|bool $user    Return value for getUserObject() in auth manager
      *
      * @return CommentRecord
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -55,8 +55,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $user = $this->getMockUser(['saveCredentials']);
         $user->expects($this->once())->method('saveCredentials')
             ->with($this->equalTo('user'), $this->equalTo('pass'));
-        $manager = $this->getMockManager(['isLoggedIn', 'updateSession']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue($user));
+        $manager = $this->getMockManager(['getUserObject', 'updateSession']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $manager->expects($this->once())->method('updateSession')->with($this->equalTo($user));
         $details = ['foo' => 'bar'];
         $connection = $this->getMockConnection(['patronLogin']);
@@ -73,8 +73,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testNewCatalogFailure()
     {
-        $manager = $this->getMockManager(['isLoggedIn']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue(false));
+        $manager = $this->getMockManager(['getUserObject']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn(false);
         $details = false;
         $connection = $this->getMockConnection(['patronLogin']);
         $connection->expects($this->once())->method('patronLogin')
@@ -109,8 +109,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testLoggedOutStoredLoginAttempt()
     {
-        $manager = $this->getMockManager(['isLoggedIn']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue(false));
+        $manager = $this->getMockManager(['getUserObject']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn(false);
         $auth = $this->getAuthenticator($manager);
         $this->assertEquals(false, $auth->storedCatalogLogin());
     }
@@ -128,8 +128,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $user->expects($this->any())->method('__isset')
             ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
         $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
-        $manager = $this->getMockManager(['isLoggedIn']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue($user));
+        $manager = $this->getMockManager(['getUserObject']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $details = ['foo' => 'bar'];
         $connection = $this->getMockConnection(['patronLogin']);
         $connection->expects($this->once())->method('patronLogin')
@@ -156,8 +156,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
         $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
         $user->expects($this->once())->method('clearCredentials');
-        $manager = $this->getMockManager(['isLoggedIn']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue($user));
+        $manager = $this->getMockManager(['getUserObject']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $connection = $this->getMockConnection(['patronLogin']);
         $connection->expects($this->once())->method('patronLogin')
             ->with($this->equalTo('user'), $this->equalTo('pass'))->will($this->returnValue(false));
@@ -181,8 +181,8 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $user->expects($this->any())->method('__isset')
             ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
         $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
-        $manager = $this->getMockManager(['isLoggedIn']);
-        $manager->expects($this->any())->method('isLoggedIn')->will($this->returnValue($user));
+        $manager = $this->getMockManager(['getUserObject']);
+        $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $connection = $this->getMockConnection(['patronLogin']);
         $connection->expects($this->once())
             ->method('patronLogin')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
@@ -339,9 +339,9 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $db = $pm->get('Database');
         $db->expects($this->once())->method('create')->with($request)->will($this->returnValue($user));
         $manager = $this->getManager([], null, null, $pm);
-        $this->assertFalse($manager->isLoggedIn());
+        $this->assertFalse($manager->getUserObject());
         $this->assertEquals($user, $manager->create($request));
-        $this->assertEquals($user, $manager->isLoggedIn());
+        $this->assertEquals($user, $manager->getUserObject());
     }
 
     /**
@@ -358,9 +358,9 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $db->expects($this->once())->method('authenticate')->with($request)->will($this->returnValue($user));
         $manager = $this->getManager([], null, null, $pm);
         $request->getPost()->set('csrf', $manager->getCsrfHash());
-        $this->assertFalse($manager->isLoggedIn());
+        $this->assertFalse($manager->getUserObject());
         $this->assertEquals($user, $manager->login($request));
-        $this->assertEquals($user, $manager->isLoggedIn());
+        $this->assertEquals($user, $manager->getUserObject());
     }
 
     /**
@@ -472,7 +472,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $db->expects($this->once())->method('updatePassword')->with($request)->will($this->returnValue($user));
         $manager = $this->getManager([], null, null, $pm);
         $this->assertEquals($user, $manager->updatePassword($request));
-        $this->assertEquals($user, $manager->isLoggedIn());
+        $this->assertEquals($user, $manager->getUserObject());
     }
 
     /**
@@ -522,7 +522,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('userId'))->will($this->returnValue('foo'));
         $this->setProperty($manager, 'session', $mockSession);
 
-        $this->assertEquals($user, $manager->isLoggedIn());
+        $this->assertEquals($user, $manager->getUserObject());
     }
 
     /**

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-tags.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/data-tags.phtml
@@ -1,5 +1,5 @@
 <?php
-  if ($loggedin = $this->auth()->isLoggedIn()) {
+  if ($loggedin = $this->auth()->getUserObject()) {
     $user_id = $loggedin->id;
     $loggedin = true;
   } else {

--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/core.phtml
@@ -1,5 +1,5 @@
 <?php
-$user = $this->auth()->isLoggedIn();
+$user = $this->auth()->getUserObject();
 $avail = $this->driver->getOverdriveAvailability();
 $previews = $this->driver->getPreviewLinks();
 $od_id = $this->driver->getOverdriveID();

--- a/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils.phtml
@@ -1,7 +1,7 @@
 <?php
     // Set up convenience variables:
     $account = $this->auth()->getManager();
-    $user = $account->isLoggedIn();
+    $user = $account->getUserObject();
     $openUrl = $this->openUrl($this->driver, 'holdings');
     $openUrlActive = $openUrl->isActive();
     $doi = $this->doi($this->driver, 'holdings');
@@ -25,7 +25,7 @@
     $this->headTitle($this->translate('Holdings') . ': ' . $this->driver->getBreadcrumb());
 ?>
 
-<?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+<?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
 <?php if (!empty($holdings['blocks'])):?>
   <div id="account-block-msg" class="alert alert-danger">

--- a/themes/bootstrap3/templates/RecordTab/usercomments.phtml
+++ b/themes/bootstrap3/templates/RecordTab/usercomments.phtml
@@ -10,7 +10,7 @@
   <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">
   <input type="hidden" name="source" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
   <label class="comment-label"><?=$this->transEsc('Your Comment')?></label>
-  <?php $user = $this->auth()->isLoggedIn() ?>
+  <?php $user = $this->auth()->getUserObject() ?>
   <?php if ($user): ?>
     <div class="text-form">
       <textarea name="comment" class="form-control" rows="3" required></textarea>

--- a/themes/bootstrap3/templates/checkouts/history.phtml
+++ b/themes/bootstrap3/templates/checkouts/history.phtml
@@ -16,7 +16,7 @@
   <h2><?=$this->transEsc('Loan History')?></h2>
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (!empty($this->transactions)): ?>
     <nav class="search-header hidden-print">

--- a/themes/bootstrap3/templates/header.phtml
+++ b/themes/bootstrap3/templates/header.phtml
@@ -32,7 +32,7 @@
             </li>
           <?php endif; ?>
           <?php if (is_object($account) && $account->loginEnabled()): // hide login/logout if unavailable ?>
-            <?php if ($account->isLoggedIn()): ?>
+            <?php if ($account->getIdentity()): ?>
               <li class="logoutOptions<?php if ($account->dropdownEnabled()): ?> with-dropdown<?php endif ?>">
                 <a href="<?=$this->url('myresearch-home', [], ['query' => ['redirect' => 0]])?>" class="icon-link">
                   <span id="account-icon" class="icon-link__icon"><?=$this->icon('my-account') ?></span>

--- a/themes/bootstrap3/templates/holds/list.phtml
+++ b/themes/bootstrap3/templates/holds/list.phtml
@@ -17,7 +17,7 @@
 
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm || $this->updateForm): ?>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -78,7 +78,7 @@
           }
         }
         $this->headScript()->prependScript(
-            'var userIsLoggedIn = ' . ($this->auth()->isLoggedIn() ? 'true' : 'false') . ';'
+            'var userIsLoggedIn = ' . ($this->auth()->getIdentity() ? 'true' : 'false') . ';'
         );
       }
 

--- a/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
@@ -2,7 +2,7 @@
   <input type="hidden" name="listID" value="<?=$this->escapeHtmlAttr($list->id)?>">
   <input type="hidden" name="listName" value="<?=$this->escapeHtmlAttr($list->title)?>">
 <?php endif; ?>
-<?php $user = $this->auth()->isLoggedIn(); ?>
+<?php $user = $this->auth()->getUserObject(); ?>
 <nav class="bulkActionButtons">
   <?php
   $socialConfig = $this->config()->get('config')['Social'];

--- a/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
@@ -17,7 +17,7 @@
   <h3><?=$this->transEsc('Library Catalog Profile')?></h3>
   <?=$this->flashmessages()?>
   <p>
-    <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+    <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
   </p>
   <p><?=$this->transEsc('cat_establish_account')?></p>
   <form method="post" action="<?=$this->serverUrl(true)?>" class="form-catalog-login">

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -19,7 +19,7 @@
   <h2><?=$this->transEsc('Your Checked Out Items')?></h2>
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (!empty($this->transactions)): ?>
     <nav class="search-header hidden-print">

--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -10,7 +10,7 @@
 
 <?=$this->flashmessages()?>
 
-<?php if ($this->auth()->isLoggedIn() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
+<?php if ($this->auth()->getIdentity() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
   <div class="<?=$this->layoutClass('mainbody')?>">
   <a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" aria-label="<?=$this->transEsc('sidebar_expand')?>">
       <?=$this->transEsc('Your Account') ?>
@@ -59,7 +59,7 @@
     <input class="btn btn-primary" type="submit" name="submit" value="<?=$this->transEscAttr('Save') ?>">
   </div>
 </form>
-<?php if ($this->auth()->isLoggedIn() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
+<?php if ($this->auth()->getIdentity() && $this->layout()->getTemplate() !== 'layout/lightbox') :?>
   </div>
   <div class="<?=$this->layoutClass('sidebar')?>" id="myresearch-sidebar" role="navigation" aria-label="<?=$this->transEsc('account_menu_label')?>">
     <?=$this->accountMenu()->render(empty($this->list->id) ? 'editlist/NEW' : 'list' . $this->list->id)?>

--- a/themes/bootstrap3/templates/myresearch/fines.phtml
+++ b/themes/bootstrap3/templates/myresearch/fines.phtml
@@ -14,7 +14,7 @@
   <h2><?=$this->transEsc('Your Fines')?></h2>
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (empty($this->fines)): ?>
     <?=$this->transEsc('You do not have any fines')?>

--- a/themes/bootstrap3/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/illrequests.phtml
@@ -18,7 +18,7 @@
 
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm): ?>

--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -1,5 +1,5 @@
 <?php
-  $user = $this->auth()->isLoggedIn();
+  $user = $this->auth()->getUserObject();
 ?>
 <button class="close-offcanvas btn btn-link" data-toggle="offcanvas"><?=$this->transEsc('navigate_back') ?></button>
 <h3 id="acc-menu-acc-header"><?=$this->transEsc('Your Account')?></h3>
@@ -31,7 +31,7 @@
         );
         $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
       ?>
-  
+
       <?php $lists = $user->getLists() ?>
       <?php foreach ($lists as $list): ?>
       <li>

--- a/themes/bootstrap3/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap3/templates/myresearch/mylist.phtml
@@ -22,7 +22,7 @@
 
   // Convenience variable:
   $account = $this->auth()->getManager();
-  $user = $this->auth()->isLoggedIn();
+  $user = $this->auth()->getUserObject();
 ?>
 
 <a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" title="<?=$this->transEsc('sidebar_expand')?>">
@@ -56,7 +56,7 @@
     </div>
     <div class="search-controls">
       <?php if (isset($list)): ?>
-        <?php if ($list->editAllowed($account->isLoggedIn())): ?>
+        <?php if ($list->editAllowed($account->getUserObject())): ?>
           <a href="<?=$this->url('editList', ['id' => $list->id]) ?>" class="btn btn-link icon-link">
             <?=$this->icon('user-list-edit', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('edit_list')?></span>

--- a/themes/bootstrap3/templates/myresearch/newpassword.phtml
+++ b/themes/bootstrap3/templates/myresearch/newpassword.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
         . '<li class="active">' . $this->transEsc('Create New Password') . '</li>';
 ?>
-<?php if ($this->auth()->isLoggedIn()): ?>
+<?php if ($this->auth()->getIdentity()): ?>
   <div class="<?=$this->layoutClass('mainbody')?>">
 <?php endif; ?>
 
@@ -31,7 +31,7 @@
   </form>
 <?php endif; ?>
 
-<?php if ($this->auth()->isLoggedIn()): ?>
+<?php if ($this->auth()->getIdentity()): ?>
   </div>
   <div class="<?=$this->layoutClass('sidebar')?>" id="myresearch-sidebar" role="navigation" aria-label="<?=$this->transEsc('account_menu_label')?>">
     <?=$this->accountMenu()->render('newpassword')?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -84,7 +84,7 @@
     <?php endif; ?>
   </div>
 
-  <?php $user = $this->auth()->isLoggedIn(); ?>
+  <?php $user = $this->auth()->getUserObject(); ?>
   <?php if ($this->auth()->getManager()->supportsPersistentLogin($user->auth_method)): ?>
     <h3><?=$this->transEsc('Saved Logins')?></h3>
     <?php $tokens = $user->getLoginTokens($user->id); ?>

--- a/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
+++ b/themes/bootstrap3/templates/myresearch/schedulesearch.phtml
@@ -6,7 +6,7 @@
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
     . '<li class="active">' . $this->transEsc('Manage Scheduled Alerts') . '</li>';
 
-  $user = $this->auth()->isLoggedIn();
+  $user = $this->auth()->getUserObject();
 ?>
 
 <a class="search-filter-toggle visible-xs" href="#myresearch-sidebar" data-toggle="offcanvas" title="<?=$this->transEsc('sidebar_expand')?>">

--- a/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
@@ -17,7 +17,7 @@
 
   <?=$this->flashmessages()?>
 
-  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->isLoggedIn()]); ?>
+  <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $this->auth()->getUserObject()]); ?>
 
   <?php if (!empty($this->recordList)): ?>
     <?php if ($this->cancelForm): ?>

--- a/themes/bootstrap3/templates/record/comments-list.phtml
+++ b/themes/bootstrap3/templates/record/comments-list.phtml
@@ -8,7 +8,7 @@
         <strong><?=null === $comment->user_id ? $this->transEsc('comment_anonymous_user') : $this->escapeHtml(trim($comment->firstname . ' ' . $comment->lastname))?></strong><br>
         <small>
           <?=$this->escapeHtml($comment->created)?>
-          <?php if (($user = $this->auth()->isLoggedIn()) && $comment->user_id == $user->id): ?>
+          <?php if (($user = $this->auth()->getUserObject()) && $comment->user_id == $user->id): ?>
             <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'DeleteComment', ['delete' => $comment->id]))?>" id="recordComment<?=$this->escapeHtml($comment->id)?>" class="delete"><?=$this->transEsc('Delete')?></a>
           <?php endif; ?>
         </small>

--- a/themes/bootstrap3/templates/record/rating.phtml
+++ b/themes/bootstrap3/templates/record/rating.phtml
@@ -38,7 +38,7 @@
 <?php else: ?>
   <h2><?=$this->transEsc('rating_add_or_update') ?></h2>
 <?php endif; ?>
-<?php if ($this->auth()->isLoggedIn()): ?>
+<?php if ($this->auth()->getIdentity()): ?>
   <form method="post" name="rateRecord" class="form-add-rating">
     <input type="hidden" name="submit" value="1">
     <input type="hidden" name="id" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>">

--- a/themes/bootstrap3/templates/search/history.phtml
+++ b/themes/bootstrap3/templates/search/history.phtml
@@ -13,7 +13,7 @@
     = $parentBreadcrumb . '<li class="active">' . $this->transEsc('Search History') . '</li>';
 
   $saveSupported = $this->accountCapabilities()->getSavedSearchSetting() === 'enabled';
-  $loggedInUser = $this->auth()->isLoggedIn();
+  $loggedInUser = $this->auth()->getUserObject();
 ?>
 
 <?php if ($saveSupported): // do not show menu toggle if not showing menu! ?>


### PR DESCRIPTION
It has long bothered me that we have a method called `isLoggedIn` that returns a non-Boolean value. This PR deprecates the method, replacing it with `getUserObject`. It also adjusts the code so that `getUserObject` is only used when we truly need access to the `\VuFind\Db\Row\User` object, and `getIdentity` is used for simple status checks. This will make it easier to transition to Doctrine, since we can add a `getUserEntity` method and gradually phase out `getUserObject`.

TODO
- [x] Run full test suite
- [x] Update changelog when merging
- [x] Update deprecation cleanup JIRA ticket when merging