### PR TITLE
Fix layout when sidebar on left and is empty.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
@@ -41,29 +41,15 @@ namespace VuFind\View\Helper;
 abstract class AbstractLayoutClass extends \Laminas\View\Helper\AbstractHelper
 {
     /**
-     * Does the sidebar go on the left?
-     *
-     * @var bool
-     */
-    protected $sidebarOnLeft;
-
-    /**
-     * Is the sidebar offcanvas?
-     *
-     * @var bool
-     */
-    protected $offcanvas;
-
-    /**
      * Constructor
      *
      * @param bool $left      Does the sidebar go on the left?
      * @param bool $offcanvas Is offcanvas menu active?
      */
-    public function __construct($left = false, $offcanvas = false)
-    {
-        $this->sidebarOnLeft = $left;
-        $this->offcanvas = $offcanvas;
+    public function __construct(
+        protected bool $left = false,
+        protected bool $offcanvas = false
+    ) {
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
@@ -43,11 +43,11 @@ abstract class AbstractLayoutClass extends \Laminas\View\Helper\AbstractHelper
     /**
      * Constructor
      *
-     * @param bool $left      Does the sidebar go on the left?
-     * @param bool $offcanvas Is offcanvas menu active?
+     * @param bool $sidebarOnLeft Does the sidebar go on the left?
+     * @param bool $offcanvas     Is offcanvas menu active?
      */
     public function __construct(
-        protected bool $left = false,
+        protected bool $sidebarOnLeft = false,
         protected bool $offcanvas = false
     ) {
     }

--- a/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/AbstractLayoutClass.php
@@ -45,10 +45,12 @@ abstract class AbstractLayoutClass extends \Laminas\View\Helper\AbstractHelper
      *
      * @param bool $sidebarOnLeft Does the sidebar go on the left?
      * @param bool $offcanvas     Is offcanvas menu active?
+     * @param bool $rtl           Are we in right-to-left mode?
      */
     public function __construct(
         protected bool $sidebarOnLeft = false,
-        protected bool $offcanvas = false
+        protected bool $offcanvas = false,
+        protected bool $rtl = false
     ) {
     }
 

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
@@ -56,9 +56,12 @@ class LayoutClass extends \VuFind\View\Helper\AbstractLayoutClass
     {
         switch ($class) {
             case 'mainbody':
-                return $this->sidebarOnLeft && $hasSidebar
-                    ? 'mainbody right'
-                    : 'mainbody left';
+                if (!$hasSidebar) {
+                    $direction = $this->rtl ? 'right' : 'left';
+                } else {
+                    $direction = $this->sidebarOnLeft ? 'right' : 'left';
+                }
+                return "mainbody $direction";
             case 'sidebar':
                 return $this->sidebarOnLeft
                     ? 'sidebar left hidden-print'
@@ -67,7 +70,7 @@ class LayoutClass extends \VuFind\View\Helper\AbstractLayoutClass
                 if (!$this->offcanvas) {
                     return '';
                 }
-                return $this->sidebarOnLeft && $hasSidebar
+                return $this->sidebarOnLeft
                     ? 'offcanvas offcanvas-left'
                     : 'offcanvas offcanvas-right';
         }

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
@@ -57,11 +57,11 @@ class LayoutClass extends \VuFind\View\Helper\AbstractLayoutClass
         switch ($class) {
             case 'mainbody':
                 if (!$hasSidebar) {
-                    $direction = $this->rtl ? 'right' : 'left';
+                    $side = $this->rtl ? 'right' : 'left';
                 } else {
-                    $direction = $this->sidebarOnLeft ? 'right' : 'left';
+                    $side = $this->sidebarOnLeft ? 'right' : 'left';
                 }
-                return "mainbody $direction";
+                return "mainbody $side";
             case 'sidebar':
                 return $this->sidebarOnLeft
                     ? 'sidebar left hidden-print'

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClass.php
@@ -47,15 +47,16 @@ class LayoutClass extends \VuFind\View\Helper\AbstractLayoutClass
      * name, return appropriate CSS classes to lay out the page according to
      * the current configuration file settings.
      *
-     * @param string $class Type of class to return ('mainbody' or 'sidebar')
+     * @param string $class      Type of class to return ('mainbody' or 'sidebar')
+     * @param bool   $hasSidebar Whether sidebar is available
      *
      * @return string       CSS classes to apply
      */
-    public function __invoke($class)
+    public function __invoke($class, $hasSidebar = true)
     {
         switch ($class) {
             case 'mainbody':
-                return $this->sidebarOnLeft
+                return $this->sidebarOnLeft && $hasSidebar
                     ? 'mainbody right'
                     : 'mainbody left';
             case 'sidebar':
@@ -66,7 +67,7 @@ class LayoutClass extends \VuFind\View\Helper\AbstractLayoutClass
                 if (!$this->offcanvas) {
                     return '';
                 }
-                return $this->sidebarOnLeft
+                return $this->sidebarOnLeft && $hasSidebar
                     ? 'offcanvas offcanvas-left'
                     : 'offcanvas offcanvas-right';
         }

--- a/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Bootstrap3/LayoutClassFactory.php
@@ -80,6 +80,6 @@ class LayoutClassFactory implements FactoryInterface
         if ($layout->rtl && $mirror) {
             $sidebarOnLeft = !$sidebarOnLeft;
         }
-        return new $requestedName($sidebarOnLeft, $offcanvas);
+        return new $requestedName($sidebarOnLeft, $offcanvas, $layout->rtl);
     }
 }

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -47,11 +47,12 @@
           'jsResults' => $options->loadResultsWithJsEnabled(),
       ]
   );
+  $recommendations = $this->results->getRecommendations('side');
 ?>
 
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>
 
-<div class="<?=$this->layoutClass('mainbody')?>">
+<div class="<?=$this->layoutClass('mainbody', (bool)$recommendations)?>">
   <?php if (($recordTotal = $this->results->getResultTotal()) > 0): // only display these at very top if we have results ?>
     <?php foreach ($this->results->getRecommendations('top') as $index => $current): ?>
       <?=$this->recommend($current, 'top', $index)?>
@@ -119,7 +120,7 @@
 <?php /* End Main Listing */ ?>
 
 <?php /* Refine Search Options */ ?>
-<?php if ($recommendations = $this->results->getRecommendations('side')): ?>
+<?php if ($recommendations): ?>
   <div class="<?=$this->layoutClass('sidebar')?>" id="search-sidebar">
     <?php foreach ($recommendations as $index => $current): ?>
       <?=$this->recommend($current, 'side', $index)?>

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -68,9 +68,11 @@
         <?php else: ?>
           <?=$this->context()->renderInContext('search/controls/showing.phtml', ['lookfor' => $lookfor, 'recordTotal' => $recordTotal]) ?>
         <?php endif; ?>
-        <a class="search-filter-toggle visible-xs" href="#search-sidebar" data-toggle="offcanvas" title="<?=$this->transEscAttr('sidebar_expand') ?>">
-          <?=$this->transEsc('Refine Results') ?>
-        </a>
+        <?php if ($recommendations): ?>
+          <a class="search-filter-toggle visible-xs" href="#search-sidebar" data-toggle="offcanvas" title="<?=$this->transEscAttr('sidebar_expand') ?>">
+            <?=$this->transEsc('Refine Results') ?>
+          </a>
+        <?php endif; ?>
       <?php else: ?>
         <h2><?=$this->transEsc('nohit_heading')?></h2>
       <?php endif; ?>


### PR DESCRIPTION
I just noticed that when the sidebar is on left but doesn't have content (like with #3393), results are still displayed on right, which doesn't look nice. This fixes the results list layout in this case.