### PR TITLE
Work around illegal characters in translation keys.

### DIFF
--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -187,7 +187,7 @@ trait TranslatorAwareTrait
     /**
      * Get translation for a string
      *
-     * @param string $str             String to translate
+     * @param string $rawStr          String to translate
      * @param array  $tokens          Tokens to inject into the translated string
      * @param string $default         Default value to use if no translation is found
      *                                (null for no default).

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -280,6 +280,6 @@ trait TranslatorAwareTrait
         // platform, so they should not be allowed in our code. We'll replace them
         // with underscores so that translations can still be provided if the input
         // cannot be changed (e.g. if it comes from a third-party system).
-        return preg_replace('/[()!?]/', '_', $key);
+        return str_replace(['(', ')', '!', '?'], '_', $key);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
@@ -170,6 +170,37 @@ class TranslateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test translation of a key with illegal characters.
+     *
+     * @return void
+     */
+    public function testTranslationWithIllegalKeyCharacters(): void
+    {
+        $translate = new Translate();
+        $translate->setTranslator(
+            $this->getMockTranslator(['default' => ['____' => 'success']])
+        );
+
+        $this->assertEquals('success', $translate('()?!'));
+    }
+
+    /**
+     * Test default fallback after translation of a key with illegal characters when
+     * no matching translations are found.
+     *
+     * @return void
+     */
+    public function testTranslationDefaultsWithIllegalKeyCharacters(): void
+    {
+        $translate = new Translate();
+        $translate->setTranslator(
+            $this->getMockTranslator(['default' => []])
+        );
+
+        $this->assertEquals('()?!', $translate('()?!'));
+    }
+
+    /**
      * Test translation of a TranslatableString object with a loaded translator
      *
      * @return void


### PR DESCRIPTION
This is an implementation of idea 1 discussed on #2642. I'll work on idea 2 after this is reviewed and merged.

The goal is to ensure that we prevent use of Lokalise-incompatible characters in translation keys while still making it possible to translate such keys if they come from a source (like a third-party API) that we have no control over.

I think this is fairly straightforward; the only question is whether there are performance concerns with running regex on so many values.