### PR TITLE
Primo: Trim quotes from the record ID before fetching it in citation search.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/PrimoController.php
+++ b/module/VuFind/src/VuFind/Controller/PrimoController.php
@@ -98,7 +98,7 @@ class PrimoController extends AbstractSearch
      */
     protected function performCitationSearch()
     {
-        if (!$id = $this->params()->fromQuery('lookfor')) {
+        if (!($id = trim($this->params()->fromQuery('lookfor', ''), '"'))) {
             return $this->forwardTo('Primo', 'Home');
         }
         $driver = $this->getRecordLoader()->load($id, $this->searchClassId);


### PR DESCRIPTION
This doesn't affect functionality but could, at least in theory, cause trouble in future. It still makes sense to keep quotes in the lookfor field because that's how it's presented in Primo query.