### PR TITLE
Prevent accidental commit of Mink test theme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /downloads
 /Gruntfile.local.js
 /solr/vendor
+/themes/minktest
 /vendor
 ChangeLog
 TAGS


### PR DESCRIPTION
I just accidentally committed the new minktest theme (introduced in #3452) into a branch I was working on, and I anticipated that would be the first time of many. This PR adds it to .gitignore to prevent accidents. :-)