### PR TITLE
Fix illegal token value in js-translations.phtml

### DIFF
--- a/themes/bootstrap3/templates/layout/js-translations.phtml
+++ b/themes/bootstrap3/templates/layout/js-translations.phtml
@@ -27,7 +27,7 @@ $this->jsTranslations()->addStrings(
       'loading_ellipsis' => 'loading_ellipsis',
       'more_ellipsis' => 'more_ellipsis',
       'number_thousands_separator' => [
-        'number_thousands_separator', null, ',',
+        'number_thousands_separator', [], ',',
       ],
       'sms_success' => 'sms_success',
       'toggle_dropdown' => 'toggle_dropdown',


### PR DESCRIPTION
Translation tokens should always be an array, not null; this PR fixes an inappropriate null value.