### PR TITLE
Fix check for OpenURL resolver URL.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/OpenUrl.php
@@ -303,7 +303,7 @@ class OpenUrl extends \Laminas\View\Helper\AbstractHelper
     protected function checkContext()
     {
         // Doesn't matter the target area if no OpenURL resolver is specified:
-        if (!isset($this->config->url)) {
+        if (empty($this->config->url)) {
             return false;
         }
 


### PR DESCRIPTION
Without this check you could set `url = ""` and get silly OpenURL's pointing to the VuFind page.