### PR TITLE
Use Symfony/Console attributes for forward-compatibility.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Compile/ThemeCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Compile;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,15 +46,12 @@ use VuFindTheme\ThemeCompiler;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'compile/theme',
+    description: 'Theme compiler'
+)]
 class ThemeCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'compile/theme';
-
     /**
      * Theme compiler
      *
@@ -82,7 +80,6 @@ class ThemeCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Theme compiler')
             ->setHelp('Flattens a theme hierarchy for improved performance.')
             ->addArgument(
                 'source',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/DynamicRouteCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/DynamicRouteCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/dynamicroute',
+    description: 'Dynamic route generator'
+)]
 class DynamicRouteCommand extends AbstractRouteCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/dynamicroute';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class DynamicRouteCommand extends AbstractRouteCommand
     protected function configure()
     {
         $this
-            ->setDescription('Dynamic route generator')
             ->setHelp('Adds a dynamic route.')
             ->addArgument(
                 'route',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,15 +44,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/extendclass',
+    description: 'Subclass generator'
+)]
 class ExtendClassCommand extends AbstractContainerAwareCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/extendclass';
-
     /**
      * Configure the command.
      *
@@ -60,7 +58,6 @@ class ExtendClassCommand extends AbstractContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setDescription('Subclass generator')
             ->setHelp('Subclasses a service, with lookup by class name.')
             ->addArgument(
                 'class_name',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendServiceCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendServiceCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/extendservice',
+    description: 'Service generator'
+)]
 class ExtendServiceCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/extendservice';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class ExtendServiceCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Service generator')
             ->setHelp('Override a service with a new child class.')
             ->addArgument(
                 'config_path',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/NonTabRecordActionCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -43,15 +44,12 @@ use VuFindConsole\Generator\GeneratorTools;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/nontabrecordaction',
+    description: 'Non-tab record action route generator'
+)]
 class NonTabRecordActionCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/nontabrecordaction';
-
     /**
      * Main framework configuration
      *
@@ -84,7 +82,6 @@ class NonTabRecordActionCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Non-tab record action route generator')
             ->setHelp('Adds routes for a non-tab record action.')
             ->addArgument(
                 'action',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/PluginCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/PluginCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,15 +44,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/plugin',
+    description: 'Plugin generator'
+)]
 class PluginCommand extends AbstractContainerAwareCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/plugin';
-
     /**
      * Configure the command.
      *
@@ -60,7 +58,6 @@ class PluginCommand extends AbstractContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setDescription('Plugin generator')
             ->setHelp('Creates a new plugin class.')
             ->addArgument(
                 'class_name',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/RecordRouteCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/RecordRouteCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/recordroute',
+    description: 'Record route generator'
+)]
 class RecordRouteCommand extends AbstractRouteCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/recordroute';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class RecordRouteCommand extends AbstractRouteCommand
     protected function configure()
     {
         $this
-            ->setDescription('Record route generator')
             ->setHelp('Adds a record route.')
             ->addArgument(
                 'base',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/StaticRouteCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/StaticRouteCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/staticroute',
+    description: 'Static route generator'
+)]
 class StaticRouteCommand extends AbstractRouteCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/staticroute';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class StaticRouteCommand extends AbstractRouteCommand
     protected function configure()
     {
         $this
-            ->setDescription('Static route generator')
             ->setHelp('Adds a static route.')
             ->addArgument(
                 'route_definition',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeCommand.php
@@ -30,6 +30,7 @@
 namespace VuFindConsole\Command\Generate;
 
 use Laminas\Config\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
 use VuFindTheme\ThemeGenerator;
 
 /**
@@ -41,15 +42,11 @@ use VuFindTheme\ThemeGenerator;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/theme'
+)]
 class ThemeCommand extends AbstractThemeCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/theme';
-
     /**
      * Type of resource being generated (used in help messages)
      *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ThemeMixinCommand.php
@@ -29,7 +29,7 @@
 
 namespace VuFindConsole\Command\Generate;
 
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * Theme mixin generator command.
@@ -40,15 +40,11 @@ use Symfony\Component\Console\Command\Command;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'generate/thememixin'
+)]
 class ThemeMixinCommand extends AbstractThemeCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'generate/thememixin';
-
     /**
      * Type of resource being generated (used in help messages)
      *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/HarvestOaiCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Harvest;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFind\Config\PathResolver;
@@ -43,15 +44,12 @@ use VuFindHarvest\OaiPmh\HarvesterFactory;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'harvest/harvest_oai',
+    description: 'OAI-PMH harvester'
+)]
 class HarvestOaiCommand extends \VuFindHarvest\OaiPmh\HarvesterCommand
 {
-    /**
-     * The name of the command
-     *
-     * @var string
-     */
-    protected static $defaultName = 'harvest/harvest_oai';
-
     /**
      * Config file path resolver
      *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Harvest/MergeMarcCommand.php
@@ -31,6 +31,7 @@
 namespace VuFindConsole\Command\Harvest;
 
 use SimpleXMLElement;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,19 +47,16 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'harvest/merge-marc',
+    description: 'MARC merge tool'
+)]
 class MergeMarcCommand extends Command
 {
     /**
      * XML namespace for MARC21.
      */
     public const MARC21_NAMESPACE = 'http://www.loc.gov/MARC21/slim';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'harvest/merge-marc';
 
     /**
      * Configure the command.
@@ -68,7 +66,6 @@ class MergeMarcCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('MARC merge tool')
             ->setHelp(
                 'Merges harvested MARCXML files into a single <collection>; '
                 . 'writes to stdout.'

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportCsvCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportCsvCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Import;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,15 +48,12 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'import/import-csv',
+    description: 'CSV importer'
+)]
 class ImportCsvCommand extends Command
 {
-    /**
-     * The name of the command
-     *
-     * @var string
-     */
-    protected static $defaultName = 'import/import-csv';
-
     /**
      * CSV importer
      *
@@ -84,7 +82,6 @@ class ImportCsvCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('CSV importer')
             ->setHelp('Indexes CSV files into Solr.')
             ->addArgument(
                 'CSV_file',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/ImportXslCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Import;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,15 +48,12 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'import/import-xsl',
+    description: 'XSLT importer'
+)]
 class ImportXslCommand extends Command
 {
-    /**
-     * The name of the command
-     *
-     * @var string
-     */
-    protected static $defaultName = 'import/import-xsl';
-
     /**
      * XSLT importer
      *
@@ -84,7 +82,6 @@ class ImportXslCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('XSLT importer')
             ->setHelp('Indexes XML into Solr using XSLT.')
             ->addArgument(
                 'XML_file',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommand.php
@@ -30,6 +30,7 @@
 namespace VuFindConsole\Command\Import;
 
 use Laminas\Config\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,15 +47,12 @@ use VuFind\XSLT\Importer;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'import/webcrawl',
+    description: 'Web crawler'
+)]
 class WebCrawlCommand extends Command
 {
-    /**
-     * The name of the command
-     *
-     * @var string
-     */
-    protected static $defaultName = 'import/webcrawl';
-
     /**
      * XSLT importer
      *
@@ -105,7 +103,6 @@ class WebCrawlCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Web crawler')
             ->setHelp('Crawls websites to populate VuFind\'s web index.')
             ->addOption(
                 'test-only',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Install;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -47,18 +48,15 @@ use function intval;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'install/install',
+    description: 'VuFind installer'
+)]
 class InstallCommand extends Command
 {
     public const MULTISITE_NONE = 0;
     public const MULTISITE_DIR_BASED = 1;
     public const MULTISITE_HOST_BASED = 2;
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'install/install';
 
     /**
      * Base directory of VuFind installation.
@@ -134,7 +132,6 @@ class InstallCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('VuFind installer')
             ->setHelp('Set up (or modify) initial VuFind installation.')
             ->addOption(
                 'use-defaults',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/AddUsingTemplateCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/AddUsingTemplateCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Language;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'language/addusingtemplate',
+    description: 'Template-based string builder'
+)]
 class AddUsingTemplateCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'language/addusingtemplate';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class AddUsingTemplateCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Template-based string builder')
             ->setHelp(
                 'Builds new language strings from existing ones using a template'
             )->addArgument(

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/CopyStringCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/CopyStringCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Language;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,15 +44,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'language/copystring',
+    description: 'String copier'
+)]
 class CopyStringCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'language/copystring';
-
     /**
      * Configure the command.
      *
@@ -61,7 +59,6 @@ class CopyStringCommand extends AbstractCommand
     {
         $note = "(may include 'textdomain::' prefix)";
         $this
-            ->setDescription('String copier')
             ->setHelp('Copies one language string to another.')
             ->addArgument(
                 'source',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/DeleteCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/DeleteCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Language;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,15 +43,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'language/delete',
+    description: 'Delete string tool'
+)]
 class DeleteCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'language/delete';
-
     /**
      * Configure the command.
      *
@@ -59,7 +57,6 @@ class DeleteCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Delete string tool')
             ->setHelp(
                 'Removes a language string from all files'
             )->addArgument(

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/ImportLokaliseCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/ImportLokaliseCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Language;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,15 +47,12 @@ use function strlen;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'language/importlokalise',
+    description: 'Lokalise file importer'
+)]
 class ImportLokaliseCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'language/importlokalise';
-
     /**
      * Configure the command.
      *
@@ -63,7 +61,6 @@ class ImportLokaliseCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Lokalise file importer')
             ->setHelp(
                 'Loads and normalizes language strings from Lokalise export files'
             )->addArgument(

--- a/module/VuFindConsole/src/VuFindConsole/Command/Language/NormalizeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Language/NormalizeCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Language;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,15 +44,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'language/normalize',
+    description: 'Language file normalizer'
+)]
 class NormalizeCommand extends AbstractCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'language/normalize';
-
     /**
      * Configure the command.
      *
@@ -60,7 +58,6 @@ class NormalizeCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->setDescription('Language file normalizer')
             ->setHelp(
                 'Normalizes a file or directory of language strings'
             )->addOption(

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -31,6 +31,7 @@ namespace VuFindConsole\Command\ScheduledSearch;
 
 use Laminas\Config\Config;
 use Laminas\View\Renderer\PhpRenderer;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -54,17 +55,14 @@ use function in_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'scheduledsearch/notify',
+    description: 'Scheduled Search Notifier'
+)]
 class NotifyCommand extends Command implements TranslatorAwareInterface
 {
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
     use \VuFind\I18n\Translator\LanguageInitializerTrait;
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'scheduledsearch/notify';
 
     /**
      * Output interface
@@ -204,9 +202,7 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
      */
     protected function configure()
     {
-        $this
-            ->setDescription('Scheduled Search Notifier')
-            ->setHelp('Sends scheduled search email notifications.');
+        $this->setHelp('Sends scheduled search email notifications.');
     }
 
     /**

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractCssBuilderCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractCssBuilderCommand.php
@@ -80,7 +80,6 @@ abstract class AbstractCssBuilderCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription($this->format . ' compiler')
             ->setHelp('Compiles CSS files from ' . $this->format . '.')
             ->addArgument(
                 'themes',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/BrowscapCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/BrowscapCommand.php
@@ -31,6 +31,7 @@ namespace VuFindConsole\Command\Util;
 
 use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
 use Psr\Log\LogLevel;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -49,15 +50,12 @@ use VuFind\Http\GuzzleService;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/browscap',
+    description: 'Browscap Cache Manager'
+)]
 class BrowscapCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/browscap';
-
     /**
      * Cache manager
      *
@@ -95,7 +93,6 @@ class BrowscapCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Browscap Cache Manager')
             ->setHelp('Manages the browscap cache.')
             ->addArgument(
                 'function',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CleanUpRecordCacheCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -43,15 +44,12 @@ use VuFind\Db\Table\Record;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/cleanup_record_cache',
+    description: 'Record cache cleaner'
+)]
 class CleanUpRecordCacheCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/cleanup_record_cache';
-
     /**
      * Record table object
      *
@@ -80,7 +78,6 @@ class CleanUpRecordCacheCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Record cache cleaner')
             ->setHelp('Removes unused cached records from the database.')
             ->setAliases(['util/cleanuprecordcache']);
     }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CommitCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CommitCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,15 +45,12 @@ use function ini_get;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/commit',
+    description: 'Solr commit tool'
+)]
 class CommitCommand extends AbstractSolrCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/commit';
-
     /**
      * The name of the Solr command, for use in help messages.
      *
@@ -68,7 +66,6 @@ class CommitCommand extends AbstractSolrCommand
     protected function configure()
     {
         $this
-            ->setDescription('Solr ' . $this->solrCommand . ' tool')
             ->setHelp('Sends a ' . $this->solrCommand . ' command to a Solr index.')
             ->addArgument(
                 'core',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/CreateHierarchyTreesCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,15 +48,12 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/createHierarchyTrees',
+    description: 'Cache populator for hierarchies'
+)]
 class CreateHierarchyTreesCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/createHierarchyTrees';
-
     /**
      * Record loader
      *
@@ -93,7 +91,6 @@ class CreateHierarchyTreesCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Cache populator for hierarchies')
             ->setHelp('Populates the hierarchy tree cache.')
             ->addArgument(
                 'backend',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/DedupeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/DedupeCommand.php
@@ -32,6 +32,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,15 +48,12 @@ use Symfony\Component\Console\Question\Question;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/dedupe',
+    description: 'Tool for deduplicating lines in a sorted file'
+)]
 class DedupeCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/dedupe';
-
     /**
      * Configure the command.
      *
@@ -64,7 +62,6 @@ class DedupeCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Tool for deduplicating lines in a sorted file')
             ->setHelp('Deduplicates lines in a sorted file.')
             ->addArgument(
                 'input',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/DeletesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/DeletesCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,15 +49,12 @@ use function strlen;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/deletes',
+    description: 'Tool for deleting Solr records'
+)]
 class DeletesCommand extends AbstractSolrCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/deletes';
-
     /**
      * Configure the command.
      *
@@ -65,7 +63,6 @@ class DeletesCommand extends AbstractSolrCommand
     protected function configure()
     {
         $this
-            ->setDescription('Tool for deleting Solr records')
             ->setHelp('Deletes a set of records from the Solr index.')
             ->addArgument(
                 'filename',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAccessTokensCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAccessTokensCommand.php
@@ -31,6 +31,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire access tokens.
  *
@@ -41,6 +43,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_access_tokens'
+)]
 class ExpireAccessTokensCommand extends AbstractExpireCommand
 {
     /**
@@ -56,11 +61,4 @@ class ExpireAccessTokensCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'access tokens';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_access_tokens';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireAuthHashesCommand.php
@@ -29,6 +29,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire authentication hashes.
  *
@@ -38,6 +40,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_auth_hashes'
+)]
 class ExpireAuthHashesCommand extends AbstractExpireCommand
 {
     /**
@@ -53,11 +58,4 @@ class ExpireAuthHashesCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'authentication hashes';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_auth_hashes';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireExternalSessionsCommand.php
@@ -29,6 +29,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire sessions.
  *
@@ -38,6 +40,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_external_sessions'
+)]
 class ExpireExternalSessionsCommand extends AbstractExpireCommand
 {
     /**
@@ -53,11 +58,4 @@ class ExpireExternalSessionsCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'external sessions';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_external_sessions';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireLoginTokensCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireLoginTokensCommand.php
@@ -29,6 +29,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire persistent login tokens.
  *
@@ -38,6 +40,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_login_tokens'
+)]
 class ExpireLoginTokensCommand extends AbstractExpireCommand
 {
     /**
@@ -53,11 +58,4 @@ class ExpireLoginTokensCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'login tokens';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_login_tokens';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSearchesCommand.php
@@ -29,6 +29,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire searches.
  *
@@ -38,6 +40,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_searches'
+)]
 class ExpireSearchesCommand extends AbstractExpireCommand
 {
     /**
@@ -53,11 +58,4 @@ class ExpireSearchesCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'searches';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_searches';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireSessionsCommand.php
@@ -29,6 +29,8 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
+
 /**
  * Console command: expire sessions.
  *
@@ -38,6 +40,9 @@ namespace VuFindConsole\Command\Util;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/expire_sessions'
+)]
 class ExpireSessionsCommand extends AbstractExpireCommand
 {
     /**
@@ -67,11 +72,4 @@ class ExpireSessionsCommand extends AbstractExpireCommand
      * @var string
      */
     protected $rowLabel = 'sessions';
-
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/expire_sessions';
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/IndexReservesCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,15 +50,12 @@ use function ini_get;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/index_reserves',
+    description: 'Course reserves index builder'
+)]
 class IndexReservesCommand extends AbstractSolrAndIlsCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/index_reserves';
-
     /**
      * Default delimiter for reading files
      *
@@ -87,7 +85,6 @@ class IndexReservesCommand extends AbstractSolrAndIlsCommand
     protected function configure()
     {
         $this
-            ->setDescription('Course reserves index builder')
             ->setHelp(
                 'This tool populates your course reserves Solr index. If run with'
                 . ' no options, it will attempt to load data from your ILS.'

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/LintMarcCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/LintMarcCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -47,15 +48,12 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/lint_marc',
+    description: 'MARC validator'
+)]
 class LintMarcCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/lint_marc';
-
     /**
      * Configure the command.
      *
@@ -64,7 +62,6 @@ class LintMarcCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('MARC validator')
             ->setHelp('This command lets you validate MARC file contents.')
             ->addArgument('filename', InputArgument::REQUIRED, 'MARC filename');
     }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/OptimizeCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/OptimizeCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -41,15 +42,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/optimize',
+    description: 'Solr optimize tool'
+)]
 class OptimizeCommand extends CommitCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/optimize';
-
     /**
      * The name of the Solr command, for use in help messages.
      *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/PurgeCachedRecordCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/PurgeCachedRecordCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,15 +47,12 @@ use VuFind\Db\Table\Resource;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/purge_cached_record',
+    description: 'Purge a cached record and optionally a resource'
+)]
 class PurgeCachedRecordCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/purge_cached_record';
-
     /**
      * Record table object
      *
@@ -92,7 +90,6 @@ class PurgeCachedRecordCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Purge a cached record and optionally a resource')
             ->setHelp('Removes a record and optionally a resource from the database.')
             ->addOption(
                 'purge-resource',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ScssBuilderCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 use VuFindTheme\ScssCompiler;
 
@@ -41,15 +42,12 @@ use VuFindTheme\ScssCompiler;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/scssBuilder',
+    description: 'SCSS compiler'
+)]
 class ScssBuilderCommand extends AbstractCssBuilderCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/scssBuilder';
-
     /**
      * Name of precompiler format
      *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SitemapCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -44,15 +45,12 @@ use VuFind\Sitemap\Generator;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/sitemap',
+    description: 'XML sitemap generator'
+)]
 class SitemapCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/sitemap';
-
     /**
      * Sitemap generator
      *
@@ -81,7 +79,6 @@ class SitemapCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('XML sitemap generator')
             ->setHelp('Generates XML sitemap files.')
             ->addOption(
                 'baseurl',

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SuppressedCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SuppressedCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Util;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,15 +45,12 @@ use function is_array;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/suppressed',
+    description: 'Remove ILS-suppressed records from Solr'
+)]
 class SuppressedCommand extends AbstractSolrAndIlsCommand
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/suppressed';
-
     /**
      * Configure the command.
      *
@@ -61,7 +59,6 @@ class SuppressedCommand extends AbstractSolrAndIlsCommand
     protected function configure()
     {
         $this
-            ->setDescription('Remove ILS-suppressed records from Solr')
             ->setHelp(
                 'This tool removes ILS-suppressed records from Solr.'
             )->addOption(

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
@@ -33,6 +33,7 @@ use Laminas\Config\Config;
 use Laminas\Crypt\BlockCipher;
 use Laminas\Crypt\Exception\InvalidArgumentException;
 use Laminas\Crypt\Symmetric\Openssl;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,15 +57,12 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
+#[AsCommand(
+    name: 'util/switch_db_hash',
+    description: 'Encryption algorithm switcher'
+)]
 class SwitchDbHashCommand extends Command
 {
-    /**
-     * The name of the command (the part after "public/index.php")
-     *
-     * @var string
-     */
-    protected static $defaultName = 'util/switch_db_hash';
-
     /**
      * VuFind configuration.
      *
@@ -125,7 +123,6 @@ class SwitchDbHashCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Encryption algorithm switcher')
             ->setHelp(
                 'Switches the encryption algorithm in the database '
                 . 'and config. Expects new algorithm and (optional) new key as'


### PR DESCRIPTION
Symfony/Console 7 will drop the public defaultName property; this switches us to using attributes for forward-compatibility.