### PR TITLE
Dependency updates 2024-03-07

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "lm-commons/lmc-rbac-mvc": "3.3.2",
         "matthiasmullie/minify": "1.3.71",
         "pear/archive_tar": "^1.4",
-        "pear/http_request2": "2.5.1",
+        "pear/http_request2": "2.6.0",
         "phing/phing": "2.17.4",
         "ppito/laminas-whoops": "2.2.0",
         "scssphp/scssphp": "1.12.1",

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "behat/mink": "1.11.0",
         "behat/mink-selenium2-driver": "1.7.0",
         "dmore/chrome-mink-driver": "2.9.2",
-        "firebase/php-jwt": "6.8.1",
+        "firebase/php-jwt": "6.10.0",
         "friendsofphp/php-cs-fixer": "3.51.0",
         "phpmd/phpmd": "2.15.0",
         "phpstan/phpstan": "1.10.59",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "steverhoades/oauth2-openid-connect-server": "2.6.1",
         "swagger-api/swagger-ui": "5.11.8",
         "symfony/console": "5.4.28",
-        "symfony/yaml": "5.4.23",
+        "symfony/yaml": "6.4.3",
         "vstelmakh/url-highlight": "3.0.3",
         "vufind-org/vufindcode": "1.2",
         "vufind-org/vufinddate": "1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "serialssolutions/summon": "1.3.1",
         "slm/locale": "1.1.0",
         "steverhoades/oauth2-openid-connect-server": "2.6.1",
-        "swagger-api/swagger-ui": "5.9.0",
+        "swagger-api/swagger-ui": "5.11.8",
         "symfony/console": "5.4.28",
         "symfony/yaml": "5.4.23",
         "vstelmakh/url-highlight": "3.0.3",

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "swagger-api/swagger-ui": "5.9.0",
         "symfony/console": "5.4.28",
         "symfony/yaml": "5.4.23",
-        "vstelmakh/url-highlight": "3.0.2",
+        "vstelmakh/url-highlight": "3.0.3",
         "vufind-org/vufindcode": "1.2",
         "vufind-org/vufinddate": "1.2.0",
         "vufind-org/vufindharvest": "5.2.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "apereo/phpcas": "1.6.1",
         "browscap/browscap-php": "^7.2",
         "cap60552/php-sip2": "1.0.0",
-        "colinmollenhour/credis": "1.15.0",
+        "colinmollenhour/credis": "1.16.0",
         "composer/package-versions-deprecated": "1.11.99.5",
         "composer/semver": "3.4.0",
         "endroid/qr-code": "4.8.2",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "pear/http_request2": "2.5.1",
         "phing/phing": "2.17.4",
         "ppito/laminas-whoops": "2.2.0",
-        "scssphp/scssphp": "1.11.1",
+        "scssphp/scssphp": "1.12.1",
         "serialssolutions/summon": "1.3.1",
         "slm/locale": "1.1.0",
         "steverhoades/oauth2-openid-connect-server": "2.6.1",

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "laminas/laminas-text": "2.10.0",
         "laminas/laminas-validator": "2.30.1",
         "laminas/laminas-view": "2.27.0",
-        "league/commonmark": "2.4.1",
+        "league/commonmark": "2.4.2",
         "league/oauth2-server": "8.5.4",
         "lm-commons/lmc-rbac-mvc": "3.3.2",
         "matthiasmullie/minify": "1.3.71",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4889448b18fc3ee99d7d74e41348c3e",
+    "content-hash": "a754e8d29115a838998a24e762775a64",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -4974,16 +4974,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.4.1",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "3669d6d5f7a47a93c08ddff335e6d945481a1dd5"
+                "reference": "91c24291965bd6d7c46c46a12ba7492f83b1cadf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/3669d6d5f7a47a93c08ddff335e6d945481a1dd5",
-                "reference": "3669d6d5f7a47a93c08ddff335e6d945481a1dd5",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/91c24291965bd6d7c46c46a12ba7492f83b1cadf",
+                "reference": "91c24291965bd6d7c46c46a12ba7492f83b1cadf",
                 "shasum": ""
             },
             "require": {
@@ -4996,7 +4996,7 @@
             },
             "require-dev": {
                 "cebe/markdown": "^1.0",
-                "commonmark/cmark": "0.30.0",
+                "commonmark/cmark": "0.30.3",
                 "commonmark/commonmark.js": "0.30.0",
                 "composer/package-versions-deprecated": "^1.8",
                 "embed/embed": "^4.4",
@@ -5006,10 +5006,10 @@
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
                 "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0",
+                "symfony/finder": "^5.3 | ^6.0 || ^7.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 || ^7.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0"
             },
@@ -5076,7 +5076,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-30T16:55:00+00:00"
+            "time": "2024-02-02T11:59:32+00:00"
         },
         {
             "name": "league/config",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1dce9ef1acc04450d53ab8e86841036",
+    "content-hash": "ae5f160ef4ce1affc2808f4a162d54cf",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -9031,31 +9031,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.23",
+            "version": "v6.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4cd2e3ea301aadd76a4172756296fe552fb45b0b"
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4cd2e3ea301aadd76a4172756296fe552fb45b0b",
-                "reference": "4cd2e3ea301aadd76a4172756296fe552fb45b0b",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d75715985f0f94f978e3a8fa42533e10db921b90",
+                "reference": "d75715985f0f94f978e3a8fa42533e10db921b90",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -9086,7 +9083,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.23"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.3"
             },
             "funding": [
                 {
@@ -9102,7 +9099,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-23T19:33:36+00:00"
+            "time": "2024-01-23T14:51:35+00:00"
         },
         {
             "name": "vstelmakh/url-highlight",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97684335958f71ecb9588f9610fb5810",
+    "content-hash": "b42091f93e67d727e3a3aa3d0d44e397",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -9106,16 +9106,16 @@
         },
         {
             "name": "vstelmakh/url-highlight",
-            "version": "v3.0.2",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vstelmakh/url-highlight.git",
-                "reference": "458f1af6acdf63d33e7fb43aeeecb4bfe64bda2b"
+                "reference": "986c32c7f5b254c800472197fb31dd378c528a47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vstelmakh/url-highlight/zipball/458f1af6acdf63d33e7fb43aeeecb4bfe64bda2b",
-                "reference": "458f1af6acdf63d33e7fb43aeeecb4bfe64bda2b",
+                "url": "https://api.github.com/repos/vstelmakh/url-highlight/zipball/986c32c7f5b254c800472197fb31dd378c528a47",
+                "reference": "986c32c7f5b254c800472197fb31dd378c528a47",
                 "shasum": ""
             },
             "require": {
@@ -9159,9 +9159,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vstelmakh/url-highlight/issues",
-                "source": "https://github.com/vstelmakh/url-highlight/tree/v3.0.2"
+                "source": "https://github.com/vstelmakh/url-highlight/tree/v3.0.3"
             },
-            "time": "2023-01-15T16:58:38+00:00"
+            "time": "2023-11-04T19:15:03+00:00"
         },
         {
             "name": "vufind-org/vufind-marc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b42091f93e67d727e3a3aa3d0d44e397",
+    "content-hash": "c70e1e59a5f2f71b2cd7bfb35ef1343e",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -7666,16 +7666,16 @@
         },
         {
             "name": "scssphp/scssphp",
-            "version": "v1.11.1",
+            "version": "v1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "ace2503684bab0dcc817d7614c8a54b865122414"
+                "reference": "394ed1e960138710a60d035c1a85d43d0bf0faeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/ace2503684bab0dcc817d7614c8a54b865122414",
-                "reference": "ace2503684bab0dcc817d7614c8a54b865122414",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/394ed1e960138710a60d035c1a85d43d0bf0faeb",
+                "reference": "394ed1e960138710a60d035c1a85d43d0bf0faeb",
                 "shasum": ""
             },
             "require": {
@@ -7740,9 +7740,9 @@
             ],
             "support": {
                 "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/v1.11.1"
+                "source": "https://github.com/scssphp/scssphp/tree/v1.12.1"
             },
-            "time": "2023-09-24T13:38:17+00:00"
+            "time": "2024-01-13T12:36:40+00:00"
         },
         {
             "name": "serialssolutions/summon",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c70e1e59a5f2f71b2cd7bfb35ef1343e",
+    "content-hash": "e4889448b18fc3ee99d7d74e41348c3e",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -6769,16 +6769,16 @@
         },
         {
             "name": "pear/http_request2",
-            "version": "v2.5.1",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/HTTP_Request2.git",
-                "reference": "db4ce7844f838d3adca0513a77420c0fec22ed2d"
+                "reference": "f010a16ccddd1ee7d2ee085e8006ee712c00f706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/db4ce7844f838d3adca0513a77420c0fec22ed2d",
-                "reference": "db4ce7844f838d3adca0513a77420c0fec22ed2d",
+                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/f010a16ccddd1ee7d2ee085e8006ee712c00f706",
+                "reference": "f010a16ccddd1ee7d2ee085e8006ee712c00f706",
                 "shasum": ""
             },
             "require": {
@@ -6824,7 +6824,7 @@
                 "issues": "https://github.com/pear/HTTP_Request2/issues",
                 "source": "https://github.com/pear/HTTP_Request2"
             },
-            "time": "2022-01-06T18:20:25+00:00"
+            "time": "2023-11-01T19:51:41+00:00"
         },
         {
             "name": "pear/net_url2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecc3c5115cbd47dffbaa984ab90ce8f6",
+    "content-hash": "d1dce9ef1acc04450d53ab8e86841036",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -7942,16 +7942,16 @@
         },
         {
             "name": "swagger-api/swagger-ui",
-            "version": "v5.9.0",
+            "version": "v5.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swagger-api/swagger-ui.git",
-                "reference": "cbfc3e949d3d9e2b71d566fb722cb3970036f593"
+                "reference": "da3d4a9946a218e1f51e879357bafcf09983aadc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/cbfc3e949d3d9e2b71d566fb722cb3970036f593",
-                "reference": "cbfc3e949d3d9e2b71d566fb722cb3970036f593",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/da3d4a9946a218e1f51e879357bafcf09983aadc",
+                "reference": "da3d4a9946a218e1f51e879357bafcf09983aadc",
                 "shasum": ""
             },
             "type": "library",
@@ -7997,9 +7997,9 @@
             ],
             "support": {
                 "issues": "https://github.com/swagger-api/swagger-ui/issues",
-                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.9.0"
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.11.8"
             },
-            "time": "2023-09-29T12:27:07+00:00"
+            "time": "2024-02-23T11:46:00+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a754e8d29115a838998a24e762775a64",
+    "content-hash": "ecc3c5115cbd47dffbaa984ab90ce8f6",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -10132,16 +10132,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.8.1",
+            "version": "v6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
                 "shasum": ""
             },
             "require": {
@@ -10189,9 +10189,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
             },
-            "time": "2023-07-14T18:33:00+00:00"
+            "time": "2023-12-01T16:26:39+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae5f160ef4ce1affc2808f4a162d54cf",
+    "content-hash": "3f49e2d640e8fdd7716f71aa056cd0f3",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -360,16 +360,16 @@
         },
         {
             "name": "colinmollenhour/credis",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "28810439de1d9597b7ba11794ed9479fb6f3de7c"
+                "reference": "5641140e14a9679f5a6f66c97268727f9558b881"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/28810439de1d9597b7ba11794ed9479fb6f3de7c",
-                "reference": "28810439de1d9597b7ba11794ed9479fb6f3de7c",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/5641140e14a9679f5a6f66c97268727f9558b881",
+                "reference": "5641140e14a9679f5a6f66c97268727f9558b881",
                 "shasum": ""
             },
             "require": {
@@ -401,9 +401,9 @@
             "homepage": "https://github.com/colinmollenhour/credis",
             "support": {
                 "issues": "https://github.com/colinmollenhour/credis/issues",
-                "source": "https://github.com/colinmollenhour/credis/tree/v1.15.0"
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.16.0"
             },
-            "time": "2023-04-18T15:34:23+00:00"
+            "time": "2023-10-26T17:02:51+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",


### PR DESCRIPTION
I updated all of the non-laminas, non-dev tool dependencies I could. (There were a few that failed to update or failed tests; we will deal with those later.)

The following dependencies are updated in this PR:
- colinmollenhour/credis
- firebase/php-jwt
- league/commonmark
- pear/http_request2
- scssphp/scssphp
- swagger-api/swagger-ui
- symfony/yaml
- vstelmakh/url-highlight