### PR TITLE
Rename UserAccountInterface to UserEntityInterface.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -33,7 +33,7 @@ use Laminas\Config\Config;
 use Laminas\Session\SessionManager;
 use LmcRbacMvc\Identity\IdentityInterface;
 use VuFind\Cookie\CookieManager;
-use VuFind\Db\Interface\UserAccountInterface;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Row\User as UserRow;
 use VuFind\Db\Table\User as UserTable;
 use VuFind\Exception\Auth as AuthException;
@@ -132,7 +132,7 @@ class Manager implements
     /**
      * Cache for current logged in user object
      *
-     * @var ?UserAccountInterface
+     * @var ?UserEntityInterface
      */
     protected $currentUser = null;
 
@@ -594,9 +594,9 @@ class Manager implements
     /**
      * Checks whether the user is logged in.
      *
-     * @return ?UserAccountInterface Object if user is logged in, null otherwise.
+     * @return ?UserEntityInterface Object if user is logged in, null otherwise.
      */
-    public function getUserObject(): ?UserAccountInterface
+    public function getUserObject(): ?UserEntityInterface
     {
         // If user object is not in cache, but user ID is in session,
         // load the object from the database:

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -38,6 +38,6 @@ namespace VuFind\Db\Interface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-interface UserAccountInterface
+interface UserEntityInterface
 {
 }

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -27,7 +27,7 @@
  * @link     https://vufind.org Main Site
  */
 
-namespace VuFind\Db\Interface;
+namespace VuFind\Db\Entity;
 
 /**
  * Interface for representing a user account record.

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -69,7 +69,7 @@ use function count;
  * @property string  $last_language
  */
 class User extends RowGateway implements
-    \VuFind\Db\Interface\UserAccountInterface,
+    \VuFind\Db\Entity\UserEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     \LmcRbacMvc\Identity\IdentityInterface
 {

--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -30,7 +30,7 @@
 namespace VuFind\View\Helper\Root;
 
 use LmcRbacMvc\Identity\IdentityInterface;
-use VuFind\Db\Interface\UserAccountInterface;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Exception\ILS as ILSException;
 
 /**
@@ -117,9 +117,9 @@ class Auth extends \Laminas\View\Helper\AbstractHelper
     /**
      * Checks whether the user is logged in.
      *
-     * @return ?UserAccountInterface Object if user is logged in, null otherwise.
+     * @return ?UserEntityInterface Object if user is logged in, null otherwise.
      */
-    public function getUserObject(): ?UserAccountInterface
+    public function getUserObject(): ?UserEntityInterface
     {
         return $this->getManager()->getUserObject();
     }


### PR DESCRIPTION
Following discussion on #3499, this renames the newly-introduced user marker interface to use a better naming convention.

TODO
- [x] Run full test suite
- [x] Update changelog when merging (reflect revised interface name)