### PR TITLE
Move tag CRUD operations out of record drivers.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecord.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecord.php
@@ -93,7 +93,8 @@ class TagRecord extends AbstractBase implements TranslatorAwareInterface
                 ? 'addTagsToRecord'
                 : 'deleteTagsFromRecord';
             $this->tagService->$serviceMethod(
-                $driver,
+                $driver->getUniqueID(),
+                $driver->getSourceIdentifier(),
                 $this->user,
                 $this->tagParser->parse($tag)
             );

--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
@@ -71,6 +71,7 @@ class TagRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
         }
         return new $requestedName(
             $container->get(\VuFind\Record\Loader::class),
+            $container->get(\VuFind\Db\Service\PluginManager::class)->get(\VuFind\Db\Service\TagService::class),
             $container->get(\VuFind\Tags::class),
             $container->get(\VuFind\Auth\Manager::class)->getUserObject()
         );

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -237,7 +237,12 @@ class AbstractRecord extends AbstractBase
         // Save tags, if any:
         if ($tags = $this->params()->fromPost('tag')) {
             $tagParser = $this->serviceLocator->get(\VuFind\Tags::class);
-            $this->getDbService(TagService::class)->addTagsToRecord($driver, $user, $tagParser->parse($tags));
+            $this->getDbService(TagService::class)->addTagsToRecord(
+                $driver->getUniqueID(),
+                $driver->getSourceIdentifier(),
+                $user,
+                $tagParser->parse($tags)
+            );
             $this->flashMessenger()
                 ->addMessage(['msg' => 'add_tag_success'], 'success');
             return $this->redirectToRecord();
@@ -271,7 +276,12 @@ class AbstractRecord extends AbstractBase
 
         // Save tags, if any:
         if ($tag = $this->params()->fromPost('tag')) {
-            $this->getDbService(TagService::class)->deleteTagsFromRecord($driver, $user, [$tag]);
+            $this->getDbService(TagService::class)->deleteTagsFromRecord(
+                $driver->getUniqueID(),
+                $driver->getSourceIdentifier(),
+                $user,
+                [$tag]
+            );
             $this->flashMessenger()->addMessage(
                 [
                     'msg' => 'tags_deleted',

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Controller;
 
+use VuFind\Db\Service\TagService;
 use VuFind\Exception\BadRequest as BadRequestException;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
@@ -236,7 +237,7 @@ class AbstractRecord extends AbstractBase
         // Save tags, if any:
         if ($tags = $this->params()->fromPost('tag')) {
             $tagParser = $this->serviceLocator->get(\VuFind\Tags::class);
-            $driver->addTags($user, $tagParser->parse($tags));
+            $this->getDbService(TagService::class)->addTagsToRecord($driver, $user, $tagParser->parse($tags));
             $this->flashMessenger()
                 ->addMessage(['msg' => 'add_tag_success'], 'success');
             return $this->redirectToRecord();
@@ -270,7 +271,7 @@ class AbstractRecord extends AbstractBase
 
         // Save tags, if any:
         if ($tag = $this->params()->fromPost('tag')) {
-            $driver->deleteTags($user, [$tag]);
+            $this->getDbService(TagService::class)->deleteTagsFromRecord($driver, $user, [$tag]);
             $this->flashMessenger()->addMessage(
                 [
                     'msg' => 'tags_deleted',

--- a/module/VuFind/src/VuFind/Db/Service/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Service/PluginManager.php
@@ -46,6 +46,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $aliases = [
+        'tag' => TagService::class,
         'user' => UserService::class,
     ];
 
@@ -55,6 +56,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $factories = [
+        TagService::class => AbstractDbServiceFactory::class,
         UserService::class => UserServiceFactory::class,
     ];
 

--- a/module/VuFind/src/VuFind/Db/Service/TagService.php
+++ b/module/VuFind/src/VuFind/Db/Service/TagService.php
@@ -30,7 +30,6 @@
 namespace VuFind\Db\Service;
 
 use VuFind\Db\Entity\UserEntityInterface;
-use VuFind\RecordDriver\AbstractBase as RecordDriver;
 
 /**
  * Database service for tags.
@@ -48,19 +47,17 @@ class TagService extends AbstractDbService implements \VuFind\Db\Table\DbTableAw
     /**
      * Add tags to the record.
      *
-     * @param RecordDriver        $driver The record being modified
+     * @param string              $id     Unique record ID
+     * @param string              $source Record source
      * @param UserEntityInterface $user   The user adding the tag(s)
      * @param string[]            $tags   The user-provided tag(s)
      *
      * @return void
      */
-    public function addTagsToRecord(RecordDriver $driver, UserEntityInterface $user, array $tags): void
+    public function addTagsToRecord(string $id, string $source, UserEntityInterface $user, array $tags): void
     {
         $resources = $this->getDbTable('Resource');
-        $resource = $resources->findResource(
-            $driver->getUniqueId(),
-            $driver->getSourceIdentifier()
-        );
+        $resource = $resources->findResource($id, $source);
         foreach ($tags as $tag) {
             $resource->addTag($tag, $user);
         }
@@ -69,19 +66,17 @@ class TagService extends AbstractDbService implements \VuFind\Db\Table\DbTableAw
     /**
      * Remove tags from the record.
      *
-     * @param RecordDriver        $driver The record being modified
+     * @param string              $id     Unique record ID
+     * @param string              $source Record source
      * @param UserEntityInterface $user   The user deleting the tag(s)
      * @param string[]            $tags   The user-provided tag(s)
      *
      * @return void
      */
-    public function deleteTagsFromRecord(RecordDriver $driver, UserEntityInterface $user, array $tags): void
+    public function deleteTagsFromRecord(string $id, string $source, UserEntityInterface $user, array $tags): void
     {
         $resources = $this->getDbTable('Resource');
-        $resource = $resources->findResource(
-            $driver->getUniqueId(),
-            $driver->getSourceIdentifier()
-        );
+        $resource = $resources->findResource($id, $source);
         foreach ($tags as $tag) {
             $resource->deleteTag($tag, $user);
         }

--- a/module/VuFind/src/VuFind/Db/Service/TagService.php
+++ b/module/VuFind/src/VuFind/Db/Service/TagService.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Database service for tags.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+
+namespace VuFind\Db\Service;
+
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\RecordDriver\AbstractBase as RecordDriver;
+
+/**
+ * Database service for tags.
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+class TagService extends AbstractDbService implements \VuFind\Db\Table\DbTableAwareInterface
+{
+    use \VuFind\Db\Table\DbTableAwareTrait;
+
+    /**
+     * Add tags to the record.
+     *
+     * @param RecordDriver        $driver The record being modified
+     * @param UserEntityInterface $user   The user adding the tag(s)
+     * @param string[]            $tags   The user-provided tag(s)
+     *
+     * @return void
+     */
+    public function addTagsToRecord(RecordDriver $driver, UserEntityInterface $user, array $tags): void
+    {
+        $resources = $this->getDbTable('Resource');
+        $resource = $resources->findResource(
+            $driver->getUniqueId(),
+            $driver->getSourceIdentifier()
+        );
+        foreach ($tags as $tag) {
+            $resource->addTag($tag, $user);
+        }
+    }
+
+    /**
+     * Remove tags from the record.
+     *
+     * @param RecordDriver        $driver The record being modified
+     * @param UserEntityInterface $user   The user deleting the tag(s)
+     * @param string[]            $tags   The user-provided tag(s)
+     *
+     * @return void
+     */
+    public function deleteTagsFromRecord(RecordDriver $driver, UserEntityInterface $user, array $tags): void
+    {
+        $resources = $this->getDbTable('Resource');
+        $resource = $resources->findResource(
+            $driver->getUniqueId(),
+            $driver->getSourceIdentifier()
+        );
+        foreach ($tags as $tag) {
+            $resource->deleteTag($tag, $user);
+        }
+    }
+}

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\RecordDriver;
 
+use VuFind\Db\Service\TagService;
 use VuFind\XSLT\Import\VuFind as ArticleStripper;
 
 use function is_callable;
@@ -45,10 +46,12 @@ use function is_callable;
  * @link     https://vufind.org Main Page
  */
 abstract class AbstractBase implements
+    \VuFind\Db\Service\DbServiceAwareInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     \VuFind\I18n\Translator\TranslatorAwareInterface,
     \VuFindSearch\Response\RecordInterface
 {
+    use \VuFind\Db\Service\DbServiceAwareTrait;
     use \VuFind\Db\Table\DbTableAwareTrait;
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
     use \VuFindSearch\Response\RecordTrait;
@@ -207,17 +210,12 @@ abstract class AbstractBase implements
      * @param array               $tags The user-provided tags
      *
      * @return void
+     *
+     * @deprecated Use TagService::addTagsToRecord()
      */
     public function addTags($user, $tags)
     {
-        $resources = $this->getDbTable('Resource');
-        $resource = $resources->findResource(
-            $this->getUniqueId(),
-            $this->getSourceIdentifier()
-        );
-        foreach ($tags as $tag) {
-            $resource->addTag($tag, $user);
-        }
+        $this->getDbService(TagService::class)->addTagsToRecord($this, $user, $tags);
     }
 
     /**
@@ -227,17 +225,12 @@ abstract class AbstractBase implements
      * @param array               $tags The user-provided tags
      *
      * @return void
+     *
+     * @deprecated Use TagService::deleteTagsFromRecord()
      */
     public function deleteTags($user, $tags)
     {
-        $resources = $this->getDbTable('Resource');
-        $resource = $resources->findResource(
-            $this->getUniqueId(),
-            $this->getSourceIdentifier()
-        );
-        foreach ($tags as $tag) {
-            $resource->deleteTag($tag, $user);
-        }
+        $this->getDbService(TagService::class)->deleteTagsFromRecord($this, $user, $tags);
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -215,7 +215,8 @@ abstract class AbstractBase implements
      */
     public function addTags($user, $tags)
     {
-        $this->getDbService(TagService::class)->addTagsToRecord($this, $user, $tags);
+        $this->getDbService(TagService::class)
+            ->addTagsToRecord($this->getUniqueID(), $this->getSourceIdentifier(), $user, $tags);
     }
 
     /**
@@ -230,7 +231,8 @@ abstract class AbstractBase implements
      */
     public function deleteTags($user, $tags)
     {
-        $this->getDbService(TagService::class)->deleteTagsFromRecord($this, $user, $tags);
+        $this->getDbService(TagService::class)
+            ->deleteTagsFromRecord($this->getUniqueID(), $this->getSourceIdentifier(), $user, $tags);
     }
 
     /**


### PR DESCRIPTION
I didn't find too much time to make progress on database refactoring today, but I at least managed this small thing -- it has long bothered me that we have database CRUD operations entangled with the record drivers. This disentangles the tag part, moving that code to the appropriate service. If you're happy with this direction, I'll follow up with more work to further separate database logic from record drivers.

TODO
- [x] Note deprecations in changelog
- [x] Note deprecations in appropriate JIRA cleanup ticket