### PR TITLE
Upgrade to endroid/qr-code v5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "colinmollenhour/credis": "1.16.0",
         "composer/package-versions-deprecated": "1.11.99.5",
         "composer/semver": "3.4.0",
-        "endroid/qr-code": "4.8.2",
+        "endroid/qr-code": "5.0.7",
         "guzzlehttp/guzzle": "7.8.1",
         "laminas/laminas-cache": "3.12.1",
         "laminas/laminas-cache-storage-adapter-blackhole": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e9d04dcf34663b94eb10355373dc98a",
+    "content-hash": "39beb62aa805ed9067fd7ae29897bcb0",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -1156,27 +1156,27 @@
         },
         {
             "name": "endroid/qr-code",
-            "version": "4.8.2",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/endroid/qr-code.git",
-                "reference": "2436c2333a3931c95e2b96eb82f16f53143d6bba"
+                "reference": "0cc00f0626b73bc71a1ea17af01387d0ac75e046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/endroid/qr-code/zipball/2436c2333a3931c95e2b96eb82f16f53143d6bba",
-                "reference": "2436c2333a3931c95e2b96eb82f16f53143d6bba",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/0cc00f0626b73bc71a1ea17af01387d0ac75e046",
+                "reference": "0cc00f0626b73bc71a1ea17af01387d0ac75e046",
                 "shasum": ""
             },
             "require": {
                 "bacon/bacon-qr-code": "^2.0.5",
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "conflict": {
                 "khanamiryan/qrcode-detector-decoder": "^1.0.6"
             },
             "require-dev": {
-                "endroid/quality": "dev-master",
+                "endroid/quality": "dev-main",
                 "ext-gd": "*",
                 "khanamiryan/qrcode-detector-decoder": "^1.0.4||^2.0.2",
                 "setasign/fpdf": "^1.8.2"
@@ -1190,7 +1190,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-main": "5.x-dev"
                 }
             },
             "autoload": {
@@ -1219,7 +1219,7 @@
             ],
             "support": {
                 "issues": "https://github.com/endroid/qr-code/issues",
-                "source": "https://github.com/endroid/qr-code/tree/4.8.2"
+                "source": "https://github.com/endroid/qr-code/tree/5.0.7"
             },
             "funding": [
                 {
@@ -1227,7 +1227,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-30T18:46:02+00:00"
+            "time": "2024-03-08T11:24:40+00:00"
         },
         {
             "name": "filp/whoops",

--- a/module/VuFind/src/VuFind/QRCode/Loader.php
+++ b/module/VuFind/src/VuFind/QRCode/Loader.php
@@ -31,11 +31,7 @@
 
 namespace VuFind\QRCode;
 
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelHigh;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelInterface;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
-use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelQuartile;
+use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\QrCode;
 use Endroid\QrCode\Writer\PngWriter;
 
@@ -138,24 +134,24 @@ class Loader extends \VuFind\ImageLoader
      *
      * @param string $level Error correction level parameter
      *
-     * @return ErrorCorrectionLevelInterface
+     * @return ErrorCorrectionLevel
      */
-    protected function mapErrorLevel($level): ErrorCorrectionLevelInterface
+    protected function mapErrorLevel($level): ErrorCorrectionLevel
     {
         switch (strtoupper(substr($level, 0, 1))) {
             case '3':
             case 'H':
-                return new ErrorCorrectionLevelHigh();
+                return ErrorCorrectionLevel::High;
             case '2':
             case 'Q':
-                return new ErrorCorrectionLevelQuartile();
+                return ErrorCorrectionLevel::Quartile;
             case '1':
             case 'M':
-                return new ErrorCorrectionLevelMedium();
+                return ErrorCorrectionLevel::Medium;
             case '0':
             case 'L':
             default:
-                return new ErrorCorrectionLevelLow();
+                return ErrorCorrectionLevel::Low;
         }
     }
 
@@ -182,9 +178,7 @@ class Loader extends \VuFind\ImageLoader
             $code->setErrorCorrectionLevel($level);
             $code->setSize($size);
             $code->setEncoding(new \Endroid\QrCode\Encoding\Encoding('UTF-8'));
-            $code->setRoundBlockSizeMode(
-                new \Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeNone()
-            );
+            $code->setRoundBlockSizeMode(\Endroid\QrCode\RoundBlockSizeMode::None);
 
             // Save the values.
             $writer = new PngWriter();

--- a/module/VuFind/src/VuFind/QRCode/Loader.php
+++ b/module/VuFind/src/VuFind/QRCode/Loader.php
@@ -111,9 +111,9 @@ class Loader extends \VuFind\ImageLoader
             // smartest way to do this, but it seems good enough for VuFind's
             // limited needs.
             $sizeIncrement = ceil(ceil(sqrt(strlen($text))) / 10);
-            if ($level instanceof ErrorCorrectionLevelHigh) {
+            if ($level == ErrorCorrectionLevel::High) {
                 $sizeIncrement *= 38;
-            } elseif ($level instanceof ErrorCorrectionLevelQuartile) {
+            } elseif ($level == ErrorCorrectionLevel::Quartile) {
                 $sizeIncrement *= 34;
             } else {
                 $sizeIncrement *= 30;


### PR DESCRIPTION
A new major version of endroid/qr-code has been released, and it has replaced some classes with enums, requiring minor adjustments to our code.