### PR TITLE
[9.1] Fix conditional filter listener to check the backend id.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -332,7 +332,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
             isset($search->ConditionalHiddenFilters)
             && $search->ConditionalHiddenFilters->count() > 0
         ) {
-            $this->getInjectConditionalFilterListener($search)->attach($events);
+            $this->getInjectConditionalFilterListener($backend, $search)->attach($events);
         }
 
         // Spellcheck
@@ -693,13 +693,15 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
     /**
      * Get a Conditional Filter Listener
      *
-     * @param Config $search Search configuration
+     * @param BackendInterface $backend Search backend
+     * @param Config           $search  Search configuration
      *
      * @return InjectConditionalFilterListener
      */
-    protected function getInjectConditionalFilterListener(Config $search)
+    protected function getInjectConditionalFilterListener(BackendInterface $backend, Config $search)
     {
         $listener = new InjectConditionalFilterListener(
+            $backend,
             $search->ConditionalHiddenFilters->toArray()
         );
         $listener->setAuthorizationService(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -101,8 +101,8 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp(): void
     {
-        $handlermap    = new HandlerMap(['select' => ['fallback' => true]]);
-        $connector     = new Connector(
+        $handlermap = new HandlerMap(['select' => ['fallback' => true]]);
+        $connector = new Connector(
             'http://localhost/',
             $handlermap,
             function () {
@@ -138,13 +138,13 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterWithoutAuthorizationService()
     {
-        $params   = new ParamBag([]);
+        $params = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
 
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals([], $fq);
     }
 
@@ -157,17 +157,17 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterWithoutAuthorizationServiceWithParams()
     {
-        $params   = new ParamBag(
+        $params = new ParamBag(
             [
                 'fq' => ['fulltext:VuFind', 'field2:novalue'],
             ]
         );
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
 
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue'],
@@ -182,17 +182,17 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterEmptyConfig()
     {
-        $params   = new ParamBag([]);
+        $params = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$emptySearchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $listener->setAuthorizationService($mockAuth);
 
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals([], $fq);
     }
 
@@ -204,7 +204,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterEmptyConfigWithFQ()
     {
-        $params   = new ParamBag(
+        $params = new ParamBag(
             [
                 'fq' => ['fulltext:VuFind', 'field2:novalue'],
             ]
@@ -215,10 +215,10 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $listener->setAuthorizationService($mockAuth);
 
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue'],
@@ -234,7 +234,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilter()
     {
-        $params   = new ParamBag([]);
+        $params = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)
             ->disableOriginalConstructor()
@@ -254,7 +254,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
         );
 
         // Check that a filter is not added for wrong backend:
-        $params   = new ParamBag([]);
+        $params = new ParamBag([]);
         $event = $this->getMockPreEvent($params, 'Other');
         $listener->onSearchPre($event);
         $this->assertEmpty($params->get('fq'));
@@ -268,7 +268,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testNegativeConditionalFilter()
     {
-        $params   = new ParamBag([]);
+        $params = new ParamBag([]);
 
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)
@@ -278,10 +278,10 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('conditionalFilter.sample'))
             ->will($this->returnValue(false));
         $listener->setAuthorizationService($mockAuth);
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals([0 => '(NOT institution:"MyInst")'], $fq);
     }
 
@@ -293,7 +293,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testNegativeConditionalFilterWithFQ()
     {
-        $params   = new ParamBag(
+        $params = new ParamBag(
             [
                 'fq' => ['fulltext:VuFind', 'field2:novalue'],
             ]
@@ -307,10 +307,10 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('conditionalFilter.sample'))
             ->will($this->returnValue(false));
         $listener->setAuthorizationService($mockAuth);
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue',
@@ -328,7 +328,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterWithFQ()
     {
-        $params   = new ParamBag(
+        $params = new ParamBag(
             [
                 'fq' => ['fulltext:VuFind', 'field2:novalue'],
             ]
@@ -342,10 +342,10 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('conditionalFilter.sample'))
             ->will($this->returnValue(true));
         $listener->setAuthorizationService($mockAuth);
-        $event    = $this->getMockPreEvent($params);
+        $event = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
-        $fq   = $params->get('fq');
+        $fq = $params->get('fq');
         $this->assertEquals(
             [0 => 'fulltext:VuFind',
             1 => 'field2:novalue',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ConditionalFilterListenerTest.php
@@ -67,7 +67,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      *
      * @var array
      */
-    protected static $emptySearchConfig = [ ];
+    protected static $emptySearchConfig = [];
 
     /**
      * Backend.
@@ -138,14 +138,14 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterWithoutAuthorizationService()
     {
-        $params   = new ParamBag([ ]);
+        $params   = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
 
         $event    = $this->getMockPreEvent($params);
         $listener->onSearchPre($event);
 
         $fq   = $params->get('fq');
-        $this->assertEquals([ ], $fq);
+        $this->assertEquals([], $fq);
     }
 
     /**
@@ -182,7 +182,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilterEmptyConfig()
     {
-        $params   = new ParamBag([ ]);
+        $params   = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$emptySearchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)
             ->disableOriginalConstructor()
@@ -193,7 +193,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
         $listener->onSearchPre($event);
 
         $fq   = $params->get('fq');
-        $this->assertEquals([ ], $fq);
+        $this->assertEquals([], $fq);
     }
 
     /**
@@ -234,7 +234,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testConditionalFilter()
     {
-        $params   = new ParamBag([ ]);
+        $params   = new ParamBag([]);
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)
             ->disableOriginalConstructor()
@@ -254,7 +254,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
         );
 
         // Check that a filter is not added for wrong backend:
-        $params   = new ParamBag([ ]);
+        $params   = new ParamBag([]);
         $event = $this->getMockPreEvent($params, 'Other');
         $listener->onSearchPre($event);
         $this->assertEmpty($params->get('fq'));
@@ -268,7 +268,7 @@ class ConditionalFilterListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testNegativeConditionalFilter()
     {
-        $params   = new ParamBag([ ]);
+        $params   = new ParamBag([]);
 
         $listener = new InjectConditionalFilterListener($this->backend, self::$searchConfig);
         $mockAuth = $this->getMockBuilder(\LmcRbacMvc\Service\AuthorizationService::class)


### PR DESCRIPTION
While this problem would cause no trouble when only a single backend is used within a request, with Blender the conditional filter listener would have added the filters to all backends.

TODO
- [x] Update changelog when merging (constructor signature change).