### PR TITLE
Fix login token grouping.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/LoginToken.php
+++ b/module/VuFind/src/VuFind/Db/Table/LoginToken.php
@@ -193,7 +193,7 @@ class LoginToken extends Gateway
                         'expires',
                     ]
                 );
-                $select->group(['id', 'series', 'user_id', 'browser', 'platform', 'expires']);
+                $select->group(['series', 'user_id', 'browser', 'platform', 'expires']);
             }
         };
         return iterator_to_array($this->select($callback));


### PR DESCRIPTION
`id` should not have been part of the group, since it's the value of the actual `id` column and not the static value.