### PR TITLE
CSV importer: Inject dependencies into static callback classes.

### DIFF
--- a/module/VuFind/src/VuFind/CSV/Importer.php
+++ b/module/VuFind/src/VuFind/CSV/Importer.php
@@ -250,6 +250,39 @@ class Importer
     }
 
     /**
+     * Inject dependencies into the callback, if necessary.
+     *
+     * @param string $callable Callback function
+     *
+     * @return void
+     */
+    protected function injectCallbackDependencies(string $callable): void
+    {
+        // Use a static property to keep track of which static classes
+        // have already had dependencies injected.
+        static $alreadyInjected = [];
+
+        // $callable is one of two formats: "function" or "class::method".
+        // We only want to proceed if we have a class name.
+        $parts = explode('::', $callable);
+        if (count($parts) < 2) {
+            return;
+        }
+        $class = $parts[0];
+
+        // If we haven't already injected dependencies, do it now! This makes
+        // it possible to use callbacks from the XSLT importer
+        // (e.g. \VuFind\XSLT\Import\VuFind::harvestWithParser)
+        if (!isset($alreadyInjected[$class])) {
+            if (method_exists($class, 'setServiceLocator')) {
+                $class::setServiceLocator($this->serviceLocator);
+            }
+            $alreadyInjected[$class] = true;
+        }
+
+    }
+
+    /**
      * Apply a single callback to a single value.
      *
      * @param string $callback    Callback string from config
@@ -265,6 +298,7 @@ class Importer
     ): array {
         preg_match('/([^(]+)(\(.*\))?/', $callback, $matches);
         $callable = $matches[1];
+        $this->injectCallbackDependencies($callable);
         $arglist = array_map(
             'trim',
             explode(

--- a/module/VuFind/src/VuFind/CSV/Importer.php
+++ b/module/VuFind/src/VuFind/CSV/Importer.php
@@ -279,7 +279,6 @@ class Importer
             }
             $alreadyInjected[$class] = true;
         }
-
     }
 
     /**

--- a/module/VuFind/tests/fixtures/csv/test-injection.ini
+++ b/module/VuFind/tests/fixtures/csv/test-injection.ini
@@ -1,0 +1,13 @@
+[General]
+header = fields
+encoding = "UTF-8"
+
+[Column:2]
+delimiter = "|"
+
+[Field:title]
+callback[] = "trim"
+callback[] = "\VuFind\XSLT\Import\VuFind::stripBadChars"
+
+[Field:institution]
+value = HardCoded

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/CSV/ImporterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/CSV/ImporterTest.php
@@ -121,6 +121,34 @@ class ImporterTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that importer injects dependencies into static callback classes
+     * when appropriate.
+     *
+     * @return void
+     */
+    public function testCallbackDependencyInjection(): void
+    {
+        // Before running the test, there will be no dependencies injected
+        // into the static callback container, and trying to call getConfig
+        // will throw an exception due to the missing dependency.
+        $errorMsg = '';
+        try {
+            \VuFind\XSLT\Import\VuFind::getConfig();
+        } catch (\Throwable $t) {
+            $errorMsg = $t->getMessage();
+        }
+        $this->assertEquals('Call to a member function get() on null', $errorMsg);
+        $this->runTestModeTest(
+            [
+                'ini' => 'test-injection.ini',
+            ]
+        );
+        // After running the test, dependencies will have been injected, so
+        // we can now call the same method without errors:
+        \VuFind\XSLT\Import\VuFind::getConfig();
+    }
+
+    /**
      * Test skipping the header row in the CSV
      *
      * @return void


### PR DESCRIPTION
Trying to use support methods from the VuFind\XSLT\Import namespace in the CSV importer sometimes failed due to missing dependencies. This PR makes the CSV importer more compatible with the XSLT importer to allow reuse/sharing of helpers.