### PR TITLE
[VUFIND-1618] Eliminate setlocale() call from Bootstrapper.

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -144,23 +144,12 @@ class Bootstrapper
     }
 
     /**
-     * Initializes locale and timezone values
+     * Initializes timezone value
      *
      * @return void
      */
-    protected function initLocaleAndTimeZone(): void
+    protected function initTimeZone(): void
     {
-        // Try to set the locale to UTF-8, but fail back to the exact string from
-        // the config file if this doesn't work -- different systems may vary in
-        // their behavior here.
-        setlocale(
-            LC_ALL,
-            [
-                "{$this->config->Site->locale}.UTF8",
-                "{$this->config->Site->locale}.UTF-8",
-                $this->config->Site->locale,
-            ]
-        );
         date_default_timezone_set($this->config->Site->timezone);
     }
 

--- a/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
@@ -74,8 +74,7 @@ class CurrencyFormatter
 
         // Initialize default currency:
         if (null === $defaultCurrency) {
-            $localeInfo = localeconv();
-            $defaultCurrency = trim($localeInfo['int_curr_symbol'] ?? '');
+            $defaultCurrency = trim($this->formatter->getTextAttribute(NumberFormatter::CURRENCY_CODE) ?: '');
         }
         $this->defaultCurrency = empty($defaultCurrency) ? 'USD' : $defaultCurrency;
     }

--- a/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
@@ -62,7 +62,7 @@ class CurrencyFormatter
      * Constructor
      *
      * @param string $defaultCurrency Default currency format (ISO 4217) to use (null
-     * for default from locale)
+     * for default from system locale)
      * @param string $locale          Locale to use for number formatting (null for
      * default system locale)
      */

--- a/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
@@ -63,18 +63,19 @@ class CurrencyFormatter
      *
      * @param string $defaultCurrency Default currency format (ISO 4217) to use (null
      * for default from locale)
+     * @param string $locale          Locale to use for number formatting (null for
+     * default system locale)
      */
-    public function __construct($defaultCurrency = null)
+    public function __construct($defaultCurrency = null, $locale = null)
     {
         // Initialize number formatter:
-        $locale = setlocale(LC_MONETARY, 0);
+        $locale ??= setlocale(LC_MONETARY, 0);
         $this->formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
 
         // Initialize default currency:
         if (null === $defaultCurrency) {
             $localeInfo = localeconv();
-            $defaultCurrency = isset($localeInfo['int_curr_symbol'])
-                ? trim($localeInfo['int_curr_symbol']) : '';
+            $defaultCurrency = trim($localeInfo['int_curr_symbol'] ?? '');
         }
         $this->defaultCurrency = empty($defaultCurrency) ? 'USD' : $defaultCurrency;
     }

--- a/module/VuFind/src/VuFind/Service/CurrencyFormatterFactory.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatterFactory.php
@@ -70,6 +70,9 @@ class CurrencyFormatterFactory implements FactoryInterface
         }
         $config = $container->get(\VuFind\Config\PluginManager::class)
             ->get('config');
-        return new $requestedName($config->Site->defaultCurrency ?? null);
+        return new $requestedName(
+            $config->Site->defaultCurrency ?? null,
+            $config->Site->locale ?? null
+        );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -95,7 +95,7 @@ class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
 
         // test override default locale
         $cc = new \VuFind\Service\CurrencyFormatter(null, 'de_DE');
-        $this->assertEquals("3.000,00\u{a0}\$", $cc->convertToDisplayFormat(3000));
-        $this->assertEquals("3.000,00\u{a0}€", $cc->convertToDisplayFormat(3000, 'EUR'));
+        $this->assertEquals("3.000,00\u{a0}€", $cc->convertToDisplayFormat(3000));
+        $this->assertEquals("3.000,00\u{a0}\$", $cc->convertToDisplayFormat(3000, 'USD'));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -85,12 +85,17 @@ class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
     {
         // test default settings
         $cc = new \VuFind\Service\CurrencyFormatter();
-        $this->assertEquals('$3.00', $cc->convertToDisplayFormat(3));
-        $this->assertEquals('€3.00', $cc->convertToDisplayFormat(3, 'EUR'));
+        $this->assertEquals('$3,000.00', $cc->convertToDisplayFormat(3000));
+        $this->assertEquals('€3,000.00', $cc->convertToDisplayFormat(3000, 'EUR'));
 
         // test override default currency
         $cc = new \VuFind\Service\CurrencyFormatter('EUR');
-        $this->assertEquals('€3.00', $cc->convertToDisplayFormat(3));
-        $this->assertEquals('$3.00', $cc->convertToDisplayFormat(3, 'USD'));
+        $this->assertEquals('€3,000.00', $cc->convertToDisplayFormat(3000));
+        $this->assertEquals('$3,000.00', $cc->convertToDisplayFormat(3000, 'USD'));
+
+        // test override default locale
+        $cc = new \VuFind\Service\CurrencyFormatter(null, 'de_DE');
+        $this->assertEquals('3.000,00 $', $cc->convertToDisplayFormat(3000));
+        $this->assertEquals('3.000,00 €', $cc->convertToDisplayFormat(3000, 'EUR'));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -95,7 +95,7 @@ class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
 
         // test override default locale
         $cc = new \VuFind\Service\CurrencyFormatter(null, 'de_DE');
-        $this->assertEquals('3.000,00 $', $cc->convertToDisplayFormat(3000));
-        $this->assertEquals('3.000,00 €', $cc->convertToDisplayFormat(3000, 'EUR'));
+        $this->assertEquals("3.000,00\u{a0}\$", $cc->convertToDisplayFormat(3000));
+        $this->assertEquals("3.000,00\u{a0}€", $cc->convertToDisplayFormat(3000, 'EUR'));
     }
 }


### PR DESCRIPTION
Use of `setlocale` is being discouraged due to changes introduced in PHP 8. The only explicit user of PHP locale functions in VuFind is the CurrencyFormatter service, which relied on a `setlocale` call in the Bootstrapper to establish appropriate formatting behavior. This PR eliminates the Bootstrapper call and passes locale settings directly to the CurrencyFormatter while maintaining the legacy locale behavior for backward compatibility.

TODO
- [x] Run full test suite
- [x] Update changelog when merging (change to Bootstrapper)
- [x] Resolve [VUFIND-1618](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1618) when merging