### PR TITLE
[VUFIND-1628] Clean up record collection factories

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Response/RecordCollectionFactory.php
@@ -29,8 +29,8 @@
 
 namespace VuFindSearch\Backend\BrowZine\Response;
 
-use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
+use VuFindSearch\Response\JsonRecord as Record;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
 
 use function call_user_func;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/Response/RecordCollectionFactory.php
@@ -29,15 +29,6 @@
 
 namespace VuFindSearch\Backend\BrowZine\Response;
 
-use VuFindSearch\Exception\InvalidArgumentException;
-use VuFindSearch\Response\JsonRecord as Record;
-use VuFindSearch\Response\RecordCollectionFactoryInterface;
-
-use function call_user_func;
-use function gettype;
-use function is_array;
-use function is_callable;
-
 /**
  * Simple factory for record collection.
  *
@@ -47,65 +38,27 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class RecordCollectionFactory implements RecordCollectionFactoryInterface
+class RecordCollectionFactory extends \VuFindSearch\Response\AbstractJsonRecordCollectionFactory
 {
     /**
-     * Factory to turn data into a record object.
+     * Get the class name of the record collection to use by default.
      *
-     * @var callable
+     * @return string
      */
-    protected $recordFactory;
-
-    /**
-     * Class of collection.
-     *
-     * @var string
-     */
-    protected $collectionClass;
-
-    /**
-     * Constructor.
-     *
-     * @param callable $recordFactory   Record factory callback (null for default)
-     * @param string   $collectionClass Class of collection
-     *
-     * @return void
-     */
-    public function __construct($recordFactory = null, $collectionClass = null)
+    protected function getDefaultRecordCollectionClass(): string
     {
-        // Set default record factory if none provided:
-        if (null === $recordFactory) {
-            $recordFactory = function ($i) {
-                return new Record($i);
-            };
-        } elseif (!is_callable($recordFactory)) {
-            throw new InvalidArgumentException('Record factory must be callable.');
-        }
-        $this->recordFactory = $recordFactory;
-        $this->collectionClass = $collectionClass ?? RecordCollection::class;
+        return RecordCollection::class;
     }
 
     /**
-     * Return record collection.
+     * Given a backend response, return an array of documents.
      *
-     * @param array $response BrowZine response
+     * @param array $response Backend response
      *
-     * @return RecordCollection
+     * @return array
      */
-    public function factory($response)
+    protected function getDocumentListFromResponse($response): array
     {
-        if (!is_array($response)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Unexpected type of value: Expected array, got %s',
-                    gettype($response)
-                )
-            );
-        }
-        $collection = new $this->collectionClass($response);
-        foreach ($response['data'] as $doc) {
-            $collection->add(call_user_func($this->recordFactory, $doc), false);
-        }
-        return $collection;
+        return $response['data'];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Response/RecordCollectionFactory.php
@@ -29,8 +29,8 @@
 
 namespace VuFindSearch\Backend\LibGuides\Response;
 
-use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
+use VuFindSearch\Response\JsonRecord as Record;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
 
 use function call_user_func;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/Response/RecordCollectionFactory.php
@@ -29,15 +29,6 @@
 
 namespace VuFindSearch\Backend\LibGuides\Response;
 
-use VuFindSearch\Exception\InvalidArgumentException;
-use VuFindSearch\Response\JsonRecord as Record;
-use VuFindSearch\Response\RecordCollectionFactoryInterface;
-
-use function call_user_func;
-use function gettype;
-use function is_array;
-use function is_callable;
-
 /**
  * Simple factory for record collection.
  *
@@ -47,65 +38,27 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class RecordCollectionFactory implements RecordCollectionFactoryInterface
+class RecordCollectionFactory extends \VuFindSearch\Response\AbstractJsonRecordCollectionFactory
 {
     /**
-     * Factory to turn data into a record object.
+     * Get the class name of the record collection to use by default.
      *
-     * @var callable
+     * @return string
      */
-    protected $recordFactory;
-
-    /**
-     * Class of collection.
-     *
-     * @var string
-     */
-    protected $collectionClass;
-
-    /**
-     * Constructor.
-     *
-     * @param callable $recordFactory   Record factory callback (null for default)
-     * @param string   $collectionClass Class of collection
-     *
-     * @return void
-     */
-    public function __construct($recordFactory = null, $collectionClass = null)
+    protected function getDefaultRecordCollectionClass(): string
     {
-        // Set default record factory if none provided:
-        if (null === $recordFactory) {
-            $recordFactory = function ($i) {
-                return new Record($i);
-            };
-        } elseif (!is_callable($recordFactory)) {
-            throw new InvalidArgumentException('Record factory must be callable.');
-        }
-        $this->recordFactory = $recordFactory;
-        $this->collectionClass = $collectionClass ?? RecordCollection::class;
+        return RecordCollection::class;
     }
 
     /**
-     * Return record collection.
+     * Given a backend response, return an array of documents.
      *
-     * @param array $response LibGuides response
+     * @param array $response Backend response
      *
-     * @return RecordCollection
+     * @return array
      */
-    public function factory($response)
+    protected function getDocumentListFromResponse($response): array
     {
-        if (!is_array($response)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Unexpected type of value: Expected array, got %s',
-                    gettype($response)
-                )
-            );
-        }
-        $collection = new $this->collectionClass($response);
-        foreach ($response['documents'] as $doc) {
-            $collection->add(call_user_func($this->recordFactory, $doc), false);
-        }
-        return $collection;
+        return $response['documents'];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Response/RecordCollectionFactory.php
@@ -29,15 +29,6 @@
 
 namespace VuFindSearch\Backend\Primo\Response;
 
-use VuFindSearch\Exception\InvalidArgumentException;
-use VuFindSearch\Response\JsonRecord as Record;
-use VuFindSearch\Response\RecordCollectionFactoryInterface;
-
-use function call_user_func;
-use function gettype;
-use function is_array;
-use function is_callable;
-
 /**
  * Simple factory for record collection.
  *
@@ -47,65 +38,27 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class RecordCollectionFactory implements RecordCollectionFactoryInterface
+class RecordCollectionFactory extends \VuFindSearch\Response\AbstractJsonRecordCollectionFactory
 {
     /**
-     * Factory to turn data into a record object.
+     * Get the class name of the record collection to use by default.
      *
-     * @var callable
+     * @return string
      */
-    protected $recordFactory;
-
-    /**
-     * Class of collection.
-     *
-     * @var string
-     */
-    protected $collectionClass;
-
-    /**
-     * Constructor.
-     *
-     * @param callable $recordFactory   Record factory callback (null for default)
-     * @param string   $collectionClass Class of collection
-     *
-     * @return void
-     */
-    public function __construct($recordFactory = null, $collectionClass = null)
+    protected function getDefaultRecordCollectionClass(): string
     {
-        // Set default record factory if none provided:
-        if (null === $recordFactory) {
-            $recordFactory = function ($i) {
-                return new Record($i);
-            };
-        } elseif (!is_callable($recordFactory)) {
-            throw new InvalidArgumentException('Record factory must be callable.');
-        }
-        $this->recordFactory = $recordFactory;
-        $this->collectionClass = $collectionClass ?? RecordCollection::class;
+        return RecordCollection::class;
     }
 
     /**
-     * Return record collection.
+     * Given a backend response, return an array of documents.
      *
-     * @param array $response Primo response
+     * @param array $response Backend response
      *
-     * @return RecordCollection
+     * @return array
      */
-    public function factory($response)
+    protected function getDocumentListFromResponse($response): array
     {
-        if (!is_array($response)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Unexpected type of value: Expected array, got %s',
-                    gettype($response)
-                )
-            );
-        }
-        $collection = new $this->collectionClass($response);
-        foreach ($response['documents'] as $doc) {
-            $collection->add(call_user_func($this->recordFactory, $doc), false);
-        }
-        return $collection;
+        return $response['documents'];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/Response/RecordCollectionFactory.php
@@ -29,8 +29,8 @@
 
 namespace VuFindSearch\Backend\Primo\Response;
 
-use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
+use VuFindSearch\Response\JsonRecord as Record;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
 
 use function call_user_func;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/Record.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/Record.php
@@ -54,7 +54,6 @@ class Record extends JsonRecord
      */
     public function __construct(array $fields)
     {
-        parent::__construct($fields);
-        $this->setSourceIdentifiers('Solr');
+        parent::__construct($fields, 'Solr');
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
@@ -29,8 +29,8 @@
 
 namespace VuFindSearch\Backend\Summon\Response;
 
-use VuFindSearch\Backend\Solr\Response\Json\Record;
 use VuFindSearch\Exception\InvalidArgumentException;
+use VuFindSearch\Response\JsonRecord as Record;
 use VuFindSearch\Response\RecordCollectionFactoryInterface;
 
 use function call_user_func;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/Response/RecordCollectionFactory.php
@@ -29,15 +29,6 @@
 
 namespace VuFindSearch\Backend\Summon\Response;
 
-use VuFindSearch\Exception\InvalidArgumentException;
-use VuFindSearch\Response\JsonRecord as Record;
-use VuFindSearch\Response\RecordCollectionFactoryInterface;
-
-use function call_user_func;
-use function gettype;
-use function is_array;
-use function is_callable;
-
 /**
  * Simple factory for record collection.
  *
@@ -47,65 +38,27 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class RecordCollectionFactory implements RecordCollectionFactoryInterface
+class RecordCollectionFactory extends \VuFindSearch\Response\AbstractJsonRecordCollectionFactory
 {
     /**
-     * Factory to turn data into a record object.
+     * Get the class name of the record collection to use by default.
      *
-     * @var callable
+     * @return string
      */
-    protected $recordFactory;
-
-    /**
-     * Class of collection.
-     *
-     * @var string
-     */
-    protected $collectionClass;
-
-    /**
-     * Constructor.
-     *
-     * @param callable $recordFactory   Record factory callback (null for default)
-     * @param string   $collectionClass Class of collection
-     *
-     * @return void
-     */
-    public function __construct($recordFactory = null, $collectionClass = null)
+    protected function getDefaultRecordCollectionClass(): string
     {
-        // Set default record factory if none provided:
-        if (null === $recordFactory) {
-            $recordFactory = function ($i) {
-                return new Record($i);
-            };
-        } elseif (!is_callable($recordFactory)) {
-            throw new InvalidArgumentException('Record factory must be callable.');
-        }
-        $this->recordFactory = $recordFactory;
-        $this->collectionClass = $collectionClass ?? RecordCollection::class;
+        return RecordCollection::class;
     }
 
     /**
-     * Return record collection.
+     * Given a backend response, return an array of documents.
      *
-     * @param array $response Summon response
+     * @param array $response Backend response
      *
-     * @return RecordCollection
+     * @return array
      */
-    public function factory($response)
+    protected function getDocumentListFromResponse($response): array
     {
-        if (!is_array($response)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Unexpected type of value: Expected array, got %s',
-                    gettype($response)
-                )
-            );
-        }
-        $collection = new $this->collectionClass($response);
-        foreach ($response['documents'] as $doc) {
-            $collection->add(call_user_func($this->recordFactory, $doc), false);
-        }
-        return $collection;
+        return $response['documents'];
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Response/AbstractJsonRecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Response/AbstractJsonRecordCollectionFactory.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Simple abstract factory for record collection.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2010-2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   David Maus <maus@hab.de>
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFindSearch\Response;
+
+use VuFindSearch\Exception\InvalidArgumentException;
+
+use function call_user_func;
+use function gettype;
+use function is_array;
+use function is_callable;
+
+/**
+ * Simple factory for record collection.
+ *
+ * @category VuFind
+ * @package  Search
+ * @author   David Maus <maus@hab.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+abstract class AbstractJsonRecordCollectionFactory implements RecordCollectionFactoryInterface
+{
+    /**
+     * Factory to turn data into a record object.
+     *
+     * @var callable
+     */
+    protected $recordFactory;
+
+    /**
+     * Class of collection.
+     *
+     * @var string
+     */
+    protected $collectionClass;
+
+    /**
+     * Constructor.
+     *
+     * @param callable $recordFactory   Record factory callback (null for default)
+     * @param string   $collectionClass Class of collection
+     *
+     * @return void
+     */
+    public function __construct($recordFactory = null, $collectionClass = null)
+    {
+        // Set default record factory if none provided:
+        if (null === $recordFactory) {
+            $recordFactory = function ($i) {
+                return new JsonRecord($i);
+            };
+        } elseif (!is_callable($recordFactory)) {
+            throw new InvalidArgumentException('Record factory must be callable.');
+        }
+        $this->recordFactory = $recordFactory;
+        $this->collectionClass = $collectionClass ?? $this->getDefaultRecordCollectionClass();
+    }
+
+    /**
+     * Return record collection.
+     *
+     * @param array $response Backend response
+     *
+     * @return RecordCollection
+     */
+    public function factory($response)
+    {
+        if (!is_array($response)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Unexpected type of value: Expected array, got %s',
+                    gettype($response)
+                )
+            );
+        }
+        $collection = new $this->collectionClass($response);
+        foreach ($this->getDocumentListFromResponse($response) as $doc) {
+            $collection->add(call_user_func($this->recordFactory, $doc), false);
+        }
+        return $collection;
+    }
+
+    /**
+     * Get the class name of the record collection to use by default.
+     *
+     * @return string
+     */
+    abstract protected function getDefaultRecordCollectionClass(): string;
+
+    /**
+     * Given a backend response, return an array of documents.
+     *
+     * @param array $response Backend response
+     *
+     * @return array
+     */
+    abstract protected function getDocumentListFromResponse($response): array;
+}

--- a/module/VuFindSearch/src/VuFindSearch/Response/JsonRecord.php
+++ b/module/VuFindSearch/src/VuFindSearch/Response/JsonRecord.php
@@ -50,12 +50,16 @@ class JsonRecord implements RecordInterface
     /**
      * Constructor.
      *
-     * @param array $fields Document fields
+     * @param array   $fields   Document fields
+     * @param ?string $sourceId Record source identifier (optional)
      *
      * @return void
      */
-    public function __construct(protected array $fields)
+    public function __construct(protected array $fields, ?string $sourceId = null)
     {
+        if ($sourceId) {
+            $this->setSourceIdentifiers($sourceId);
+        }
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Response/JsonRecord.php
+++ b/module/VuFindSearch/src/VuFindSearch/Response/JsonRecord.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Simple, schema-less SOLR record.
+ * Simple, schema-less JSON record.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2010.
+ * Copyright (C) Villanova University 2010-2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -23,38 +23,50 @@
  * @category VuFind
  * @package  Search
  * @author   David Maus <maus@hab.de>
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
 
-namespace VuFindSearch\Backend\Solr\Response\Json;
-
-use VuFindSearch\Response\JsonRecord;
+namespace VuFindSearch\Response;
 
 /**
- * Simple, schema-less SOLR record.
+ * Simple, schema-less JSON record.
  *
  * This record primarily serves as an example or blueprint for a schema-less
- * record. All SOLR fields are exposed via object properties.
+ * record. All fields are exposed via object properties.
  *
  * @category VuFind
  * @package  Search
  * @author   David Maus <maus@hab.de>
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org
  */
-class Record extends JsonRecord
+class JsonRecord implements RecordInterface
 {
+    use RecordTrait;
+
     /**
      * Constructor.
      *
-     * @param array $fields SOLR document fields
+     * @param array $fields Document fields
      *
      * @return void
      */
-    public function __construct(array $fields)
+    public function __construct(protected array $fields)
     {
-        parent::__construct($fields);
-        $this->setSourceIdentifiers('Solr');
+    }
+
+    /**
+     * __get()
+     *
+     * @param string $name Field name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->fields[$name] ?? null;
     }
 }


### PR DESCRIPTION
This PR fixes a bug where non-Solr records would be injected with Solr backend IDs. It also reduces redundancy in several very similar factory classes.

TODO
- [x] Run full test suite
- [x] Manually test BrowZine
- [x] Manually test LibGuides
- [x] Manually test Primo
- [x] Manually test Summon
- [x] Resolve [VUFIND-1628](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1628) when merging