### PR TITLE
Fix ILSAuthenticator to handle granular user data in email authentication.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -218,7 +218,9 @@ class ILSAuthenticator
         }
 
         try {
-            $patron = $this->emailAuthenticator->authenticate($hash);
+            $loginData = $this->emailAuthenticator->authenticate($hash);
+            // Check if we have more granular data available:
+            $patron = $loginData['userData'] ?? $loginData;
         } catch (\VuFind\Exception\Auth $e) {
             return false;
         }


### PR DESCRIPTION
When I fixed "Remember me" for email authentication, I failed to update ILSAuthenticator to also handle the new array format. This fixes the problem. Reproduceable e.g. by logging in with Demo driver set to email authentication, removing library card, going to holdings screen and trying to do email-based catalog login there.