### PR TITLE
Add support for OpenID Connect Discovery.

### DIFF
--- a/config/vufind/OAuth2Server.yaml
+++ b/config/vufind/OAuth2Server.yaml
@@ -28,6 +28,8 @@ Server:
   # Uncomment to disable key permission checks. Only meant for testing, so avoid in
   # any production-like environment if possible.
   #keyPermissionChecks: false
+  # Optional URL for public documentation (returned in the discovery response)
+  documentationUrl: ""
 
 # Known clients configuration
 Clients:

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -108,6 +108,16 @@ $config = [
                     ],
                 ],
             ],
+            'oidc-wellknown-configuration' => [
+                'type' => 'Laminas\Router\Http\Literal',
+                'options' => [
+                    'route'    => '/.well-known/openid-configuration',
+                    'defaults' => [
+                        'controller' => 'OAuth2',
+                        'action'     => 'wellKnownConfiguration',
+                    ],
+                ],
+            ],
             'soap-shibboleth-logout-notification-handler' => [
                 'type' => 'Laminas\Router\Http\Literal',
                 'options' => [

--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -347,7 +347,7 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
             'response_types_supported' => ['code'],
             'grant_types_supported' => ['authorization_code'],
             'subject_types_supported' => ['public'],
-            'id_token_signing_alg_values_supported' => ["RS256"],
+            'id_token_signing_alg_values_supported' => ['RS256'],
         ];
         if ($url = $this->oauth2Config['Server']['documentationUrl'] ?? null) {
             $configuration['service_documentation'] = $url;

--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -337,6 +337,12 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
      */
     public function wellKnownConfigurationAction()
     {
+        // Check that authorization server can be created (means that config is good):
+        try {
+            ($this->oauth2ServerFactory)(null);
+        } catch (\Exception $e) {
+            return $this->createHttpNotFoundModel($this->getResponse());
+        }
         $baseUrl = rtrim($this->getServerUrl('home'), '/');
         $configuration = [
             'issuer' => 'https://' . $_SERVER['HTTP_HOST'], // Same as OpenIDConnectServer\IdTokenResponse

--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -331,6 +331,32 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
     }
 
     /**
+     * Action to retrieve the OIDC configuration
+     *
+     * @return mixed
+     */
+    public function wellKnownConfigurationAction()
+    {
+        $baseUrl = rtrim($this->getServerUrl('home'), '/');
+        $configuration = [
+            'issuer' => 'https://' . $_SERVER['HTTP_HOST'], // Same as OpenIDConnectServer\IdTokenResponse
+            'authorization_endpoint' => "$baseUrl/OAuth2/Authorize",
+            'token_endpoint' => "$baseUrl/OAuth2/Token",
+            'userinfo_endpoint' => "$baseUrl/OAuth2/UserInfo",
+            'jwks_uri' => "$baseUrl/OAuth2/jwks",
+            'response_types_supported' => ['code'],
+            'grant_types_supported' => ['authorization_code'],
+            'subject_types_supported' => ['public'],
+            'id_token_signing_alg_values_supported' => ["RS256"],
+        ];
+        if ($url = $this->oauth2Config['Server']['documentationUrl'] ?? null) {
+            $configuration['service_documentation'] = $url;
+        }
+
+        return $this->getJsonResponse($configuration);
+    }
+
+    /**
      * Convert an instance of OAuthServerException to a Laminas response.
      *
      * @param OAuthServerException $exception Exception

--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -295,6 +295,12 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
      */
     public function jwksAction()
     {
+        // Check that authorization server can be created (means that config is good):
+        try {
+            ($this->oauth2ServerFactory)(null);
+        } catch (\Exception $e) {
+            return $this->createHttpNotFoundModel($this->getResponse());
+        }
         $result = [];
         $keyPath = $this->oauth2Config['Server']['publicKeyPath'] ?? '';
         if (strncmp($keyPath, '/', 1) !== 0) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -31,8 +31,6 @@ declare(strict_types=1);
 
 namespace VuFindTest\Mink;
 
-use const PHP_MAJOR_VERSION;
-
 /**
  * OAuth2/OIDC test class.
  *

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2022.
+ * Copyright (C) The National Library of Finland 2022-2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -107,6 +107,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
                 'encryptionKey' => 'encryption!',
                 'hashSalt' => 'Need more salt!',
                 'keyPermissionChecks' => false,
+                'documentationUrl' => 'https://vufind.org/wiki/configuration:oauth2_oidc',
             ],
             'Clients' => [
                 'test' => [
@@ -431,6 +432,47 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test OpenID Connect Discovery.
+     *
+     * @return void
+     */
+    public function testOIDCDiscovery(): void
+    {
+        // Bogus redirect URI, but it doesn't matter since the page won't handle the
+        // authorization response:
+        $baseUrl = $this->getVuFindUrl();
+        $this->setUpTest('');
+
+        $urlData = parse_url($this->getVuFindUrl());
+        // Issuer is always https:
+        $issuer = 'https://' . $urlData['host'];
+        if ($port = $urlData['port'] ?? null) {
+            $issuer .= ":$port";
+        }
+        $expected = [
+            'issuer' => $issuer,
+            'authorization_endpoint' => "$baseUrl/OAuth2/Authorize",
+            'token_endpoint' => "$baseUrl/OAuth2/Token",
+            'userinfo_endpoint' => "$baseUrl/OAuth2/UserInfo",
+            'jwks_uri' => "$baseUrl/OAuth2/jwks",
+            'response_types_supported' => ['code'],
+            'grant_types_supported' => ['authorization_code'],
+            'subject_types_supported' => ['public'],
+            'id_token_signing_alg_values_supported' => ['RS256'],
+            'service_documentation' => 'https://vufind.org/wiki/configuration:oauth2_oidc',
+        ];
+
+        $http = new \VuFindHttp\HttpService();
+        $response = $http->get($this->getVuFindUrl() . '/.well-known/openid-configuration');
+        $this->assertEquals(
+            'application/json',
+            $response->getHeaders()->get('Content-Type')->getFieldValue()
+        );
+        $json = $response->getBody();
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), $json);
+    }
+
+    /**
      * Create a public/private key pair
      *
      * @return void
@@ -495,11 +537,6 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         }
 
         $this->opensslKeyPairCreated = true;
-
-        // Pre-PHP 8.0: Free the key:
-        if (PHP_MAJOR_VERSION < 8) {
-            openssl_pkey_free($privateKey);
-        }
     }
 
     /**


### PR DESCRIPTION
Adds a well-known URL that returns basic OpenID configuration to a caller.

See https://openid.net/specs/openid-connect-discovery-1_0.html