### PR TITLE
Move password encryption handling to ILSAuthenticator

### DIFF
--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -55,6 +55,15 @@ class CAS extends AbstractBase
     protected $phpCASSetup = false;
 
     /**
+     * Constructor
+     *
+     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
+     */
+    public function __construct(protected ILSAuthenticator $ilsAuthenticator)
+    {
+    }
+
+    /**
      * Validate configuration parameters. This is a support method for getConfig(),
      * so the configuration MUST be accessed using $this->config; do not call
      * $this->getConfig() from within this method!
@@ -167,7 +176,7 @@ class CAS extends AbstractBase
         if (!empty($user->cat_username)) {
             $user->saveCredentials(
                 $user->cat_username,
-                empty($catPassword) ? $user->getCatPassword() : $catPassword
+                empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }
 

--- a/module/VuFind/src/VuFind/Auth/CASFactory.php
+++ b/module/VuFind/src/VuFind/Auth/CASFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Factory for Shibboleth authentication module.
+ * Factory for CAS authentication module.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2019.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -33,11 +33,9 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
-use VuFind\Auth\Shibboleth\MultiIdPConfigurationLoader;
-use VuFind\Auth\Shibboleth\SingleIdPConfigurationLoader;
 
 /**
- * Factory for Shibboleth authentication module.
+ * Factory for CAS authentication module.
  *
  * @category VuFind
  * @package  Authentication
@@ -45,10 +43,8 @@ use VuFind\Auth\Shibboleth\SingleIdPConfigurationLoader;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class CASFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
-    public const SHIBBOLETH_CONFIG_FILE_NAME = 'Shibboleth';
-
     /**
      * Create an object
      *
@@ -71,32 +67,6 @@ class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $loader = $this->getConfigurationLoader($container);
-        $request = $container->get('Request');
-        return new $requestedName(
-            $container->get(\Laminas\Session\SessionManager::class),
-            $loader,
-            $request,
-            $container->get(\VuFind\Auth\ILSAuthenticator::class)
-        );
-    }
-
-    /**
-     * Return configuration loader for shibboleth
-     *
-     * @param ContainerInterface $container Service manager
-     *
-     * @return configuration loader
-     */
-    public function getConfigurationLoader(ContainerInterface $container)
-    {
-        $configManager = $container->get(\VuFind\Config\PluginManager::class);
-        $config = $configManager->get('config');
-        $override = $config->Shibboleth->allow_configuration_override ?? false;
-        if ($override) {
-            $shibConfig = $configManager->get(self::SHIBBOLETH_CONFIG_FILE_NAME);
-            return new MultiIdPConfigurationLoader($config, $shibConfig);
-        }
-        return new SingleIdPConfigurationLoader($config);
+        return new $requestedName($container->get(\VuFind\Auth\ILSAuthenticator::class));
     }
 }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -29,6 +29,9 @@
 
 namespace VuFind\Auth;
 
+use Laminas\Crypt\BlockCipher;
+use Laminas\Crypt\Symmetric\Openssl;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\ILS\Connection as ILSConnection;
 
@@ -58,20 +61,6 @@ class ILSAuthenticator
     protected $authManager = null;
 
     /**
-     * ILS connector
-     *
-     * @var ILSConnection
-     */
-    protected $catalog;
-
-    /**
-     * Email authenticator
-     *
-     * @var EmailAuthenticator
-     */
-    protected $emailAuthenticator;
-
-    /**
      * Cache for ILS account information (keyed by username)
      *
      * @var array
@@ -79,20 +68,165 @@ class ILSAuthenticator
     protected $ilsAccount = [];
 
     /**
+     * Is encryption enabled?
+     *
+     * @var bool
+     */
+    protected $encryptionEnabled = null;
+
+    /**
+     * Encryption key used for catalog passwords (null if encryption disabled):
+     *
+     * @var string
+     */
+    protected $encryptionKey = null;
+
+    /**
+     * VuFind configuration
+     *
+     * @var \Laminas\Config\Config
+     */
+    protected $config = null;
+
+    /**
      * Constructor
      *
-     * @param callable           $authCB    Auth manager callback
-     * @param ILSConnection      $catalog   ILS connection
-     * @param EmailAuthenticator $emailAuth Email authenticator
+     * @param callable            $authCB    Auth manager callback
+     * @param ILSConnection       $catalog   ILS connection
+     * @param ?EmailAuthenticator $emailAuth Email authenticator
      */
     public function __construct(
         callable $authCB,
-        ILSConnection $catalog,
-        EmailAuthenticator $emailAuth = null
+        protected ILSConnection $catalog,
+        protected ?EmailAuthenticator $emailAuthenticator = null
     ) {
         $this->authManagerCallback = $authCB;
-        $this->catalog = $catalog;
-        $this->emailAuthenticator = $emailAuth;
+    }
+
+    /**
+     * Configuration setter
+     *
+     * @param \Laminas\Config\Config $config VuFind configuration
+     *
+     * @return void
+     */
+    public function setConfig(\Laminas\Config\Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Is ILS password encryption enabled?
+     *
+     * @return bool
+     */
+    public function passwordEncryptionEnabled()
+    {
+        if (null === $this->encryptionEnabled) {
+            $this->encryptionEnabled
+                = $this->config->Authentication->encrypt_ils_password ?? false;
+        }
+        return $this->encryptionEnabled;
+    }
+
+    /**
+     * Decrypt text.
+     *
+     * @param string $text The text to decrypt
+     *
+     * @return string|bool The decrypted string (or false if invalid)
+     * @throws \VuFind\Exception\PasswordSecurity
+     */
+    public function decrypt(string $text)
+    {
+        return $this->encryptOrDecrypt($text, false);
+    }
+
+    /**
+     * Encrypt text.
+     *
+     * @param string $text The text to encrypt
+     *
+     * @return string|bool The encrypted string (or false if invalid)
+     * @throws \VuFind\Exception\PasswordSecurity
+     */
+    public function encrypt(string $text)
+    {
+        return $this->encryptOrDecrypt($text, true);
+    }
+
+    /**
+     * This is a central function for encrypting and decrypting so that
+     * logic is all in one location
+     *
+     * @param string $text    The text to be encrypted or decrypted
+     * @param bool   $encrypt True if we wish to encrypt text, False if we wish to
+     * decrypt text.
+     *
+     * @return string|bool    The encrypted/decrypted string
+     * @throws \VuFind\Exception\PasswordSecurity
+     */
+    protected function encryptOrDecrypt($text, $encrypt = true)
+    {
+        // Ignore empty text:
+        if (empty($text)) {
+            return $text;
+        }
+
+        $configAuth = $this->config->Authentication ?? new \Laminas\Config\Config([]);
+
+        // Load encryption key from configuration if not already present:
+        if ($this->encryptionKey === null) {
+            if (empty($configAuth->ils_encryption_key)) {
+                throw new \VuFind\Exception\PasswordSecurity(
+                    'ILS password encryption on, but no key set.'
+                );
+            }
+
+            $this->encryptionKey = $configAuth->ils_encryption_key;
+        }
+
+        // Perform encryption:
+        $algo = $configAuth->ils_encryption_algo ?? 'blowfish';
+
+        // Check if OpenSSL error is caused by blowfish support
+        try {
+            $cipher = new BlockCipher(new Openssl(['algorithm' => $algo]));
+            if ($algo == 'blowfish') {
+                trigger_error(
+                    'Deprecated encryption algorithm (blowfish) detected',
+                    E_USER_DEPRECATED
+                );
+            }
+        } catch (\InvalidArgumentException $e) {
+            if ($algo == 'blowfish') {
+                throw new \VuFind\Exception\PasswordSecurity(
+                    'The blowfish encryption algorithm ' .
+                    'is not supported by your version of OpenSSL. ' .
+                    'Please visit /Upgrade/CriticalFixBlowfish for further details.'
+                );
+            } else {
+                throw $e;
+            }
+        }
+        $cipher->setKey($this->encryptionKey);
+        return $encrypt ? $cipher->encrypt($text) : $cipher->decrypt($text);
+    }
+
+    /**
+     * Given a user object, retrieve the decrypted password.
+     *
+     * @param UserEntityInterface $user User
+     *
+     * @return string
+     */
+    public function getCatPasswordForUser(UserEntityInterface $user)
+    {
+        if ($this->passwordEncryptionEnabled()) {
+            $encrypted = $user->getCatPassEnc();
+            return !empty($encrypted) ? $this->decrypt($encrypted) : null;
+        }
+        return $user->getRawCatPassword();
     }
 
     /**
@@ -137,7 +271,7 @@ class ILSAuthenticator
             }
             $patron = $this->catalog->patronLogin(
                 $user->cat_username,
-                $user->getCatPassword()
+                $this->getCatPasswordForUser($user)
             );
             if (empty($patron)) {
                 // Problem logging in -- clear user credentials so they can be

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -226,9 +226,9 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->getCatUsername())) {
+        if (($user = $this->getAuthManager()->getUserObject()) && ($username = $user->getCatUsername())) {
             return [
-                'cat_username' => $user->getCatUsername(),
+                'cat_username' => $username,
                 'cat_password' => $this->getCatPasswordForUser($user),
             ];
         }
@@ -248,7 +248,7 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->getUserObject()) && $username = $user->getCatUsername()) {
+        if (($user = $this->getAuthManager()->getUserObject()) && ($username = $user->getCatUsername())) {
             // Do we have a previously cached ILS account?
             if (isset($this->ilsAccount[$username])) {
                 return $this->ilsAccount[$username];

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -242,10 +242,10 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->getCatUsername())) {
             return [
-                'cat_username' => $user->cat_username,
-                'cat_password' => $user->cat_password,
+                'cat_username' => $user->getCatUsername(),
+                'cat_password' => $this->getCatPasswordForUser($user),
             ];
         }
         return false;
@@ -264,13 +264,13 @@ class ILSAuthenticator
     {
         // Fail if no username is found, but allow a missing password (not every ILS
         // requires a password to connect).
-        if (($user = $this->getAuthManager()->getUserObject()) && !empty($user->cat_username)) {
+        if (($user = $this->getAuthManager()->getUserObject()) && $username = $user->getCatUsername()) {
             // Do we have a previously cached ILS account?
-            if (isset($this->ilsAccount[$user->cat_username])) {
-                return $this->ilsAccount[$user->cat_username];
+            if (isset($this->ilsAccount[$username])) {
+                return $this->ilsAccount[$username];
             }
             $patron = $this->catalog->patronLogin(
-                $user->cat_username,
+                $username,
                 $this->getCatPasswordForUser($user)
             );
             if (empty($patron)) {
@@ -280,7 +280,7 @@ class ILSAuthenticator
                 $user->clearCredentials();
             } else {
                 // cache for future use
-                $this->ilsAccount[$user->cat_username] = $patron;
+                $this->ilsAccount[$username] = $patron;
                 return $patron;
             }
         }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -91,9 +91,9 @@ class ILSAuthenticator
     /**
      * Constructor
      *
-     * @param callable            $authCB    Auth manager callback
-     * @param ILSConnection       $catalog   ILS connection
-     * @param ?EmailAuthenticator $emailAuth Email authenticator
+     * @param callable            $authCB             Auth manager callback
+     * @param ILSConnection       $catalog            ILS connection
+     * @param ?EmailAuthenticator $emailAuthenticator Email authenticator
      */
     public function __construct(
         callable $authCB,

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Auth;
 
+use Laminas\Config\Config;
 use Laminas\Crypt\BlockCipher;
 use Laminas\Crypt\Symmetric\Openssl;
 use VuFind\Db\Entity\UserEntityInterface;
@@ -82,37 +83,20 @@ class ILSAuthenticator
     protected $encryptionKey = null;
 
     /**
-     * VuFind configuration
-     *
-     * @var \Laminas\Config\Config
-     */
-    protected $config = null;
-
-    /**
      * Constructor
      *
      * @param callable            $authCB             Auth manager callback
      * @param ILSConnection       $catalog            ILS connection
      * @param ?EmailAuthenticator $emailAuthenticator Email authenticator
+     * @param ?Config             $config             Configuration from config.ini
      */
     public function __construct(
         callable $authCB,
         protected ILSConnection $catalog,
-        protected ?EmailAuthenticator $emailAuthenticator = null
+        protected ?EmailAuthenticator $emailAuthenticator = null,
+        protected ?Config $config = null
     ) {
         $this->authManagerCallback = $authCB;
-    }
-
-    /**
-     * Configuration setter
-     *
-     * @param \Laminas\Config\Config $config VuFind configuration
-     *
-     * @return void
-     */
-    public function setConfig(\Laminas\Config\Config $config)
-    {
-        $this->config = $config;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
@@ -69,12 +69,15 @@ class ILSAuthenticatorFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         // Use a callback to retrieve authentication manager to break a circular reference:
-        return new $requestedName(
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
+        $service = new $requestedName(
             function () use ($container) {
                 return $container->get(\VuFind\Auth\Manager::class);
             },
             $container->get(\VuFind\ILS\Connection::class),
             $container->get(\VuFind\Auth\EmailAuthenticator::class)
         );
+        $service->setConfig($config);
+        return $service;
     }
 }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticatorFactory.php
@@ -68,16 +68,15 @@ class ILSAuthenticatorFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        // Use a callback to retrieve authentication manager to break a circular reference:
-        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
         $service = new $requestedName(
+            // Use a callback to retrieve authentication manager to break a circular reference:
             function () use ($container) {
                 return $container->get(\VuFind\Auth\Manager::class);
             },
             $container->get(\VuFind\ILS\Connection::class),
-            $container->get(\VuFind\Auth\EmailAuthenticator::class)
+            $container->get(\VuFind\Auth\EmailAuthenticator::class),
+            $container->get(\VuFind\Config\PluginManager::class)->get('config')
         );
-        $service->setConfig($config);
         return $service;
     }
 }

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -47,6 +47,15 @@ use function in_array;
 class LDAP extends AbstractBase
 {
     /**
+     * Constructor
+     *
+     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
+     */
+    public function __construct(protected ILSAuthenticator $ilsAuthenticator)
+    {
+    }
+
+    /**
      * Validate configuration parameters. This is a support method for getConfig(),
      * so the configuration MUST be accessed using $this->config; do not call
      * $this->getConfig() from within this method!
@@ -319,7 +328,7 @@ class LDAP extends AbstractBase
         if (!empty($user->cat_username)) {
             $user->saveCredentials(
                 $user->cat_username,
-                empty($catPassword) ? $user->getCatPassword() : $catPassword
+                empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }
 

--- a/module/VuFind/src/VuFind/Auth/LDAPFactory.php
+++ b/module/VuFind/src/VuFind/Auth/LDAPFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Factory for Shibboleth authentication module.
+ * Factory for LDAP authentication module.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2019.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -33,11 +33,9 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
-use VuFind\Auth\Shibboleth\MultiIdPConfigurationLoader;
-use VuFind\Auth\Shibboleth\SingleIdPConfigurationLoader;
 
 /**
- * Factory for Shibboleth authentication module.
+ * Factory for LDAP authentication module.
  *
  * @category VuFind
  * @package  Authentication
@@ -45,10 +43,8 @@ use VuFind\Auth\Shibboleth\SingleIdPConfigurationLoader;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class LDAPFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
-    public const SHIBBOLETH_CONFIG_FILE_NAME = 'Shibboleth';
-
     /**
      * Create an object
      *
@@ -71,32 +67,6 @@ class ShibbolethFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $loader = $this->getConfigurationLoader($container);
-        $request = $container->get('Request');
-        return new $requestedName(
-            $container->get(\Laminas\Session\SessionManager::class),
-            $loader,
-            $request,
-            $container->get(\VuFind\Auth\ILSAuthenticator::class)
-        );
-    }
-
-    /**
-     * Return configuration loader for shibboleth
-     *
-     * @param ContainerInterface $container Service manager
-     *
-     * @return configuration loader
-     */
-    public function getConfigurationLoader(ContainerInterface $container)
-    {
-        $configManager = $container->get(\VuFind\Config\PluginManager::class);
-        $config = $configManager->get('config');
-        $override = $config->Shibboleth->allow_configuration_override ?? false;
-        if ($override) {
-            $shibConfig = $configManager->get(self::SHIBBOLETH_CONFIG_FILE_NAME);
-            return new MultiIdPConfigurationLoader($config, $shibConfig);
-        }
-        return new SingleIdPConfigurationLoader($config);
+        return new $requestedName($container->get(\VuFind\Auth\ILSAuthenticator::class));
     }
 }

--- a/module/VuFind/src/VuFind/Auth/PluginManager.php
+++ b/module/VuFind/src/VuFind/Auth/PluginManager.php
@@ -73,13 +73,13 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      */
     protected $factories = [
         AlmaDatabase::class => ILSFactory::class,
-        CAS::class => InvokableFactory::class,
+        CAS::class => CASFactory::class,
         ChoiceAuth::class => ChoiceAuthFactory::class,
         Database::class => InvokableFactory::class,
         Email::class => EmailFactory::class,
         Facebook::class => FacebookFactory::class,
         ILS::class => ILSFactory::class,
-        LDAP::class => InvokableFactory::class,
+        LDAP::class => LDAPFactory::class,
         MultiAuth::class => MultiAuthFactory::class,
         MultiILS::class => ILSFactory::class,
         Shibboleth::class => ShibbolethFactory::class,

--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -36,6 +36,7 @@
 namespace VuFind\Auth;
 
 use Laminas\Http\PhpEnvironment\Request;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\Shibboleth\ConfigurationLoaderInterface;
 use VuFind\Exception\Auth as AuthException;
 
@@ -74,27 +75,6 @@ class Shibboleth extends AbstractBase
     ];
 
     /**
-     * Session manager
-     *
-     * @var \Laminas\Session\ManagerInterface
-     */
-    protected $sessionManager;
-
-    /**
-     * Configuration loading implementation
-     *
-     * @var ConfigurationLoaderInterface
-     */
-    protected $configurationLoader;
-
-    /**
-     * Http Request object
-     *
-     * @var Request
-     */
-    protected $request;
-
-    /**
      * Read attributes from headers instead of environment variables
      *
      * @var boolean
@@ -121,15 +101,14 @@ class Shibboleth extends AbstractBase
      * @param \Laminas\Session\ManagerInterface $sessionManager      Session manager
      * @param ConfigurationLoaderInterface      $configurationLoader Configuration loader
      * @param Request                           $request             Http request object
+     * @param ILSAuthenticator                  $ilsAuthenticator    ILS authenticator
      */
     public function __construct(
-        \Laminas\Session\ManagerInterface $sessionManager,
-        ConfigurationLoaderInterface $configurationLoader,
-        Request $request
+        protected \Laminas\Session\ManagerInterface $sessionManager,
+        protected ConfigurationLoaderInterface $configurationLoader,
+        protected Request $request,
+        protected ILSAuthenticator $ilsAuthenticator;
     ) {
-        $this->sessionManager = $sessionManager;
-        $this->configurationLoader = $configurationLoader;
-        $this->request = $request;
     }
 
     /**
@@ -250,7 +229,7 @@ class Shibboleth extends AbstractBase
         if (!empty($user->cat_username)) {
             $user->saveCredentials(
                 $user->cat_username,
-                empty($catPassword) ? $user->getCatPassword() : $catPassword
+                empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }
 

--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -36,7 +36,6 @@
 namespace VuFind\Auth;
 
 use Laminas\Http\PhpEnvironment\Request;
-use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\Shibboleth\ConfigurationLoaderInterface;
 use VuFind\Exception\Auth as AuthException;
 
@@ -107,7 +106,7 @@ class Shibboleth extends AbstractBase
         protected \Laminas\Session\ManagerInterface $sessionManager,
         protected ConfigurationLoaderInterface $configurationLoader,
         protected Request $request,
-        protected ILSAuthenticator $ilsAuthenticator;
+        protected ILSAuthenticator $ilsAuthenticator
     ) {
     }
 

--- a/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
+++ b/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
@@ -30,6 +30,7 @@
 namespace VuFind\Auth;
 
 use Laminas\Http\PhpEnvironment\Request;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Exception\Auth as AuthException;
 
 use function is_array;
@@ -73,10 +74,11 @@ class SimulatedSSO extends AbstractBase
     /**
      * Constructor
      *
-     * @param callable $url    Session initiator URL callback
-     * @param array    $config Configuration settings
+     * @param callable         $url              Session initiator URL callback
+     * @param array            $config           Configuration settings
+     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
      */
-    public function __construct($url, array $config = [])
+    public function __construct($url, array $config = [], protected ILSAuthenticator $ilsAuthenticator)
     {
         $this->getSessionInitiatorCallback = $url;
         $this->simulatedSSOConfig = $config;
@@ -120,7 +122,7 @@ class SimulatedSSO extends AbstractBase
         if (!empty($user->cat_username)) {
             $user->saveCredentials(
                 $user->cat_username,
-                empty($catPassword) ? $user->getCatPassword() : $catPassword
+                empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }
 

--- a/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
+++ b/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
@@ -30,7 +30,6 @@
 namespace VuFind\Auth;
 
 use Laminas\Http\PhpEnvironment\Request;
-use VuFind\Auth\ILSAuthenticator;
 use VuFind\Exception\Auth as AuthException;
 
 use function is_array;
@@ -78,7 +77,7 @@ class SimulatedSSO extends AbstractBase
      * @param array            $config           Configuration settings
      * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
      */
-    public function __construct($url, array $config = [], protected ILSAuthenticator $ilsAuthenticator)
+    public function __construct($url, array $config, protected ILSAuthenticator $ilsAuthenticator)
     {
         $this->getSessionInitiatorCallback = $url;
         $this->simulatedSSOConfig = $config;

--- a/module/VuFind/src/VuFind/Auth/SimulatedSSOFactory.php
+++ b/module/VuFind/src/VuFind/Auth/SimulatedSSOFactory.php
@@ -78,8 +78,7 @@ class SimulatedSSOFactory implements \Laminas\ServiceManager\Factory\FactoryInte
                 $url('simulatedsso-login', [], ['query' => ['return' => $target]])
             );
         };
-        $config = $container->get(\VuFind\Config\PluginManager::class)
-            ->get('SimulatedSSO')->toArray();
-        return new $requestedName($getUrl, $config);
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('SimulatedSSO')->toArray();
+        return new $requestedName($getUrl, $config, $container->get(\VuFind\Auth\ILSAuthenticator::class));
     }
 }

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -32,7 +32,6 @@ namespace VuFind\Controller;
 use Laminas\Crypt\Password\Bcrypt;
 use Laminas\Mvc\MvcEvent;
 use VuFind\Config\Writer as ConfigWriter;
-use VuFind\Db\Service\UserService;
 use VuFindSearch\Command\RetrieveCommand;
 
 use function count;

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -811,7 +811,6 @@ class InstallController extends AbstractBase
 
         // Now we want to loop through the database and update passwords (if
         // necessary).
-        $userService = $this->getDbService(UserService::class);
         $userRows = $this->getTable('user')->getInsecureRows();
         if (count($userRows) > 0) {
             $bcrypt = new Bcrypt();
@@ -830,9 +829,10 @@ class InstallController extends AbstractBase
             $this->flashMessenger()->addMessage($msg, 'info');
         }
         $cardRows = $this->getTable('usercard')->getInsecureRows();
+        $ilsAuthenticator = $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
         if (count($cardRows) > 0) {
             foreach ($cardRows as $row) {
-                $row->cat_pass_enc = $userService->encrypt($row->cat_password);
+                $row->cat_pass_enc = $ilsAuthenticator->encrypt($row->cat_password);
                 $row->cat_password = null;
                 $row->save();
             }

--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -204,7 +204,7 @@ class LibraryCardsController extends AbstractBase
             $catalog = $this->getILS();
             $patron = $catalog->patronLogin(
                 $user->cat_username,
-                $user->getCatPassword()
+                $this->getILSAuthenticator()->getCatPasswordForUser($user)
             );
             if (!$patron) {
                 $this->flashMessenger()

--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -194,7 +194,8 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
                     $user,
                     $this->getILS(),
                     $this->oauth2Config,
-                    $this->accessTokenService
+                    $this->accessTokenService,
+                    $this->getILSAuthenticator()
                 )
             );
             $authRequest->setAuthorizationApproved($this->formWasSubmitted('allow'));

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Row;
 
 use Laminas\Db\Sql\Expression;
 use Laminas\Db\Sql\Select;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Db\Entity\UserEntityInterface;
 
 use function count;
@@ -70,11 +71,9 @@ use function count;
 class User extends RowGateway implements
     UserEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
-    \LmcRbacMvc\Identity\IdentityInterface,
-    \VuFind\Db\Service\DbServiceAwareInterface
+    \LmcRbacMvc\Identity\IdentityInterface
 {
     use \VuFind\Db\Table\DbTableAwareTrait;
-    use \VuFind\Db\Service\DbServiceAwareTrait;
 
     /**
      * VuFind configuration
@@ -86,9 +85,10 @@ class User extends RowGateway implements
     /**
      * Constructor
      *
-     * @param \Laminas\Db\Adapter\Adapter $adapter Database adapter
+     * @param \Laminas\Db\Adapter\Adapter $adapter          Database adapter
+     * @param ILSAuthenticator            $ilsAuthenticator ILS authenticator
      */
-    public function __construct($adapter)
+    public function __construct($adapter, protected ILSAuthenticator $ilsAuthenticator)
     {
         parent::__construct('id', 'user', $adapter);
     }
@@ -144,7 +144,7 @@ class User extends RowGateway implements
         $this->cat_username = $username;
         if ($this->passwordEncryptionEnabled()) {
             $this->cat_password = null;
-            $this->cat_pass_enc = $this->getUserService()->encrypt($password);
+            $this->cat_pass_enc = $this->ilsAuthenticator->encrypt($password);
         } else {
             $this->cat_password = $password;
             $this->cat_pass_enc = null;
@@ -195,14 +195,12 @@ class User extends RowGateway implements
      *
      * @return string The Catalog password in plain text
      * @throws \VuFind\Exception\PasswordSecurity
+     *
+     * @deprecated Use ILSAuthenticator::getCatPasswordForUser()
      */
     public function getCatPassword()
     {
-        if ($this->passwordEncryptionEnabled()) {
-            return isset($this->cat_pass_enc)
-                ? $this->getUserService()->decrypt($this->cat_pass_enc) : null;
-        }
-        return $this->cat_password ?? null;
+        return $this->ilsAuthenticator->getCatPasswordForUser($this);
     }
 
     /**
@@ -212,7 +210,7 @@ class User extends RowGateway implements
      */
     protected function passwordEncryptionEnabled()
     {
-        return $this->getUserService()->passwordEncryptionEnabled();
+        return $this->ilsAuthenticator->passwordEncryptionEnabled();
     }
 
     /**
@@ -226,12 +224,12 @@ class User extends RowGateway implements
      * @return string|bool    The encrypted/decrypted string
      * @throws \VuFind\Exception\PasswordSecurity
      *
-     * @deprecated Use $this->getUserService()->encrypt() or $this->getUserService()->decrypt()
+     * @deprecated Use ILSAuthenticator::encrypt() or ILSAuthenticator::decrypt()
      */
     protected function encryptOrDecrypt($text, $encrypt = true)
     {
         $method = $encrypt ? 'encrypt' : 'decrypt';
-        return $this->getUserService()->$method($text);
+        return $this->ilsAuthenticator->$method($text);
     }
 
     /**
@@ -509,7 +507,7 @@ class User extends RowGateway implements
                 throw new \VuFind\Exception\LibraryCard('Library Card Not Found');
             }
             if ($this->passwordEncryptionEnabled()) {
-                $row->cat_password = $this->getUserService()->decrypt($row->cat_pass_enc);
+                $row->cat_password = $this->ilsAuthenticator->decrypt($row->cat_pass_enc);
             }
         }
 
@@ -628,7 +626,7 @@ class User extends RowGateway implements
         }
         if ($this->passwordEncryptionEnabled()) {
             $row->cat_password = null;
-            $row->cat_pass_enc = $this->getUserService()->encrypt($password);
+            $row->cat_pass_enc = $this->ilsAuthenticator->encrypt($password);
         } else {
             $row->cat_password = $password;
             $row->cat_pass_enc = null;
@@ -678,16 +676,6 @@ class User extends RowGateway implements
         $row->cat_pass_enc = $this->cat_pass_enc;
 
         $row->save();
-    }
-
-    /**
-     * Get a User service object.
-     *
-     * @return \VuFind\Db\Service\UserService
-     */
-    public function getUserService()
-    {
-        return $this->getDbService(\VuFind\Db\Service\UserService::class);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Row/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserFactory.php
@@ -79,7 +79,8 @@ class UserFactory extends RowGatewayFactory
         $privacy = isset($config->Authentication->privacy)
             && $config->Authentication->privacy;
         $rowClass = $privacy ? $this->privateUserClass : $requestedName;
-        $prototype = parent::__invoke($container, $rowClass, $options);
+        $ilsAuthenticator = $container->get(\VuFind\Auth\ILSAuthenticator::class);
+        $prototype = parent::__invoke($container, $rowClass, [$ilsAuthenticator]);
         $prototype->setConfig($config);
         if ($privacy) {
             $sessionManager = $container

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\Db\Service;
 
-use Laminas\Crypt\BlockCipher;
-use Laminas\Crypt\Symmetric\Openssl;
 use Laminas\Log\LoggerAwareInterface;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Table\User;
@@ -52,143 +50,12 @@ class UserService extends AbstractDbService implements
     use LoggerAwareTrait;
 
     /**
-     * Is encryption enabled?
-     *
-     * @var bool
-     */
-    protected $encryptionEnabled = null;
-
-    /**
-     * Encryption key used for catalog passwords (null if encryption disabled):
-     *
-     * @var string
-     */
-    protected $encryptionKey = null;
-
-    /**
-     * VuFind configuration
-     *
-     * @var \Laminas\Config\Config
-     */
-    protected $config = null;
-
-    /**
      * Constructor.
      *
      * @param User $userTable User table
      */
     public function __construct(protected User $userTable)
     {
-    }
-
-    /**
-     * Configuration setter
-     *
-     * @param \Laminas\Config\Config $config VuFind configuration
-     *
-     * @return void
-     */
-    public function setConfig(\Laminas\Config\Config $config)
-    {
-        $this->config = $config;
-    }
-
-    /**
-     * Is ILS password encryption enabled?
-     *
-     * @return bool
-     */
-    public function passwordEncryptionEnabled()
-    {
-        if (null === $this->encryptionEnabled) {
-            $this->encryptionEnabled
-                = $this->config->Authentication->encrypt_ils_password ?? false;
-        }
-        return $this->encryptionEnabled;
-    }
-
-    /**
-     * Decrypt text.
-     *
-     * @param string $text The text to decrypt
-     *
-     * @return string|bool The decrypted string (or false if invalid)
-     * @throws \VuFind\Exception\PasswordSecurity
-     */
-    public function decrypt(string $text)
-    {
-        return $this->encryptOrDecrypt($text, false);
-    }
-
-    /**
-     * Encrypt text.
-     *
-     * @param string $text The text to encrypt
-     *
-     * @return string|bool The encrypted string (or false if invalid)
-     * @throws \VuFind\Exception\PasswordSecurity
-     */
-    public function encrypt(string $text)
-    {
-        return $this->encryptOrDecrypt($text, true);
-    }
-
-    /**
-     * This is a central function for encrypting and decrypting so that
-     * logic is all in one location
-     *
-     * @param string $text    The text to be encrypted or decrypted
-     * @param bool   $encrypt True if we wish to encrypt text, False if we wish to
-     * decrypt text.
-     *
-     * @return string|bool    The encrypted/decrypted string
-     * @throws \VuFind\Exception\PasswordSecurity
-     */
-    protected function encryptOrDecrypt($text, $encrypt = true)
-    {
-        // Ignore empty text:
-        if (empty($text)) {
-            return $text;
-        }
-
-        $configAuth = $this->config->Authentication ?? new \Laminas\Config\Config([]);
-
-        // Load encryption key from configuration if not already present:
-        if ($this->encryptionKey === null) {
-            if (empty($configAuth->ils_encryption_key)) {
-                throw new \VuFind\Exception\PasswordSecurity(
-                    'ILS password encryption on, but no key set.'
-                );
-            }
-
-            $this->encryptionKey = $configAuth->ils_encryption_key;
-        }
-
-        // Perform encryption:
-        $algo = $configAuth->ils_encryption_algo ?? 'blowfish';
-
-        // Check if OpenSSL error is caused by blowfish support
-        try {
-            $cipher = new BlockCipher(new Openssl(['algorithm' => $algo]));
-            if ($algo == 'blowfish') {
-                trigger_error(
-                    'Deprecated encryption algorithm (blowfish) detected',
-                    E_USER_DEPRECATED
-                );
-            }
-        } catch (\InvalidArgumentException $e) {
-            if ($algo == 'blowfish') {
-                throw new \VuFind\Exception\PasswordSecurity(
-                    'The blowfish encryption algorithm ' .
-                    'is not supported by your version of OpenSSL. ' .
-                    'Please visit /Upgrade/CriticalFixBlowfish for further details.'
-                );
-            } else {
-                throw $e;
-            }
-        }
-        $cipher->setKey($this->encryptionKey);
-        return $encrypt ? $cipher->encrypt($text) : $cipher->decrypt($text);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceFactory.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceFactory.php
@@ -69,10 +69,7 @@ class UserServiceFactory extends AbstractDbServiceFactory
         }
         $userTable = $container->get(\VuFind\Db\Table\PluginManager::class)
             ->get('user');
-        $config = $container->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
         $userService = parent::__invoke($container, $requestedName, [$userTable]);
-        $userService->setConfig($config);
         return $userService;
     }
 }

--- a/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
@@ -32,6 +32,7 @@ namespace VuFind\OAuth2\Entity;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\UserEntityInterface as OAuth2UserEntityInterface;
 use OpenIDConnectServer\Entities\ClaimSetInterface;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Db\Entity\UserEntityInterface as DbUserEntityInterface;
 use VuFind\Db\Service\AccessTokenServiceInterface;
 use VuFind\ILS\Connection;
@@ -61,7 +62,8 @@ class UserEntity implements OAuth2UserEntityInterface, ClaimSetInterface
         protected DbUserEntityInterface $user,
         protected ?Connection $ils,
         protected array $oauth2Config,
-        protected AccessTokenServiceInterface $accessTokenService
+        protected AccessTokenServiceInterface $accessTokenService,
+        protected ILSAuthenticator $ilsAuthenticator
     ) {
         $this->setIdentifier($user->getId());
     }
@@ -80,7 +82,7 @@ class UserEntity implements OAuth2UserEntityInterface, ClaimSetInterface
             try {
                 $patron = $this->ils->patronLogin(
                     $this->user->getCatUsername(),
-                    $this->user->getCatPassword()
+                    $this->ilsAuthenticator->getCatPasswordForUser($this->user)
                 );
                 $profile = $this->ils->getMyProfile($patron);
                 $blocksSupported = $this->ils

--- a/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/UserEntity.php
@@ -57,6 +57,7 @@ class UserEntity implements OAuth2UserEntityInterface, ClaimSetInterface
      * @param ?Connection                 $ils                ILS connection
      * @param array                       $oauth2Config       OAuth2 configuration
      * @param AccessTokenServiceInterface $accessTokenService Access token service
+     * @param ILSAuthenticator            $ilsAuthenticator   ILS authenticator
      */
     public function __construct(
         protected DbUserEntityInterface $user,

--- a/module/VuFind/src/VuFind/OAuth2/Repository/IdentityRepository.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/IdentityRepository.php
@@ -30,6 +30,7 @@
 namespace VuFind\OAuth2\Repository;
 
 use OpenIDConnectServer\Repositories\IdentityProviderInterface;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Db\Service\AccessTokenServiceInterface;
 use VuFind\Db\Service\UserServiceInterface;
 use VuFind\ILS\Connection;
@@ -53,12 +54,14 @@ class IdentityRepository implements IdentityProviderInterface
      * @param AccessTokenServiceInterface $accessTokenService Access token service
      * @param ?Connection                 $ils                ILS connection
      * @param array                       $oauth2Config       OAuth2 configuration
+     * @param ILSAuthenticator            $ilsAuthenticator   ILS authenticator
      */
     public function __construct(
         protected UserServiceInterface $userService,
         protected AccessTokenServiceInterface $accessTokenService,
         protected ?Connection $ils,
-        protected array $oauth2Config
+        protected array $oauth2Config,
+        protected ILSAuthenticator $ilsAuthenticator
     ) {
     }
 
@@ -76,7 +79,8 @@ class IdentityRepository implements IdentityProviderInterface
                 $user,
                 $this->ils,
                 $this->oauth2Config,
-                $this->accessTokenService
+                $this->accessTokenService,
+                $this->ilsAuthenticator
             );
         }
         return null;

--- a/module/VuFind/src/VuFind/OAuth2/Repository/IdentityRepositoryFactory.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/IdentityRepositoryFactory.php
@@ -74,7 +74,8 @@ class IdentityRepositoryFactory implements FactoryInterface
             $dbPluginManager->get(\VuFind\Db\Service\UserServiceInterface::class),
             $dbPluginManager->get(\VuFind\Db\Service\AccessTokenServiceInterface::class),
             $container->get(\VuFind\ILS\Connection::class),
-            $yamlReader->get('OAuth2Server.yaml')
+            $yamlReader->get('OAuth2Server.yaml'),
+            $container->get(\VuFind\Auth\ILSAuthenticator::class)
         );
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
@@ -324,7 +324,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
         $patron = ['cat_username' => 'testuser'];
         $user = $this->getAuth($driver, $patron)->updatePassword($request);
         $this->assertEquals('testuser', $user->username);
-        $this->assertEquals('newpass', $user->getCatPassword());
+        $this->assertEquals('newpass', $user->getRawCatPassword());
     }
 
     /**
@@ -350,7 +350,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
         $auth->setConfig(new \Laminas\Config\Config($config));
         $user = $auth->updatePassword($request);
         $this->assertEquals('1234', $user->username);
-        $this->assertEquals('newpass', $user->getCatPassword());
+        $this->assertEquals('newpass', $user->getRawCatPassword());
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
@@ -125,7 +125,8 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
         $obj = new Shibboleth(
             $this->createMock(\Laminas\Session\ManagerInterface::class),
             $loader,
-            $this->createMock(\Laminas\Http\PhpEnvironment\Request::class)
+            $this->createMock(\Laminas\Http\PhpEnvironment\Request::class),
+            $this->createMock(\VuFind\Auth\ILSAuthenticator::class)
         );
         $obj->setDbTableManager($this->getLiveTableManager());
         $obj->setConfig($config);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * CAS authentication test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Auth;
+
+use Laminas\Config\Config;
+use VuFind\Auth\CAS;
+
+/**
+ * CAS authentication test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class CASTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\ReflectionTrait;
+
+    /**
+     * Get an authentication object.
+     *
+     * @param ?Config $config Configuration to use (null for default)
+     *
+     * @return CAS
+     */
+    public function getAuthObject(?Config $config = null): CAS
+    {
+        $obj = new CAS($this->createMock(\VuFind\Auth\ILSAuthenticator::class));
+        $obj->setConfig($config ?? $this->getAuthConfig());
+        return $obj;
+    }
+
+    /**
+     * Get a working configuration for the CAS object
+     *
+     * @return Config
+     */
+    public function getAuthConfig(): Config
+    {
+        $casConfig = new Config(
+            [
+                'server' => 'localhost',
+                'port' => 1234,
+                'context' => 'foo',
+                'CACert' => 'bar',
+                'login' => 'login',
+                'logout' => 'logout',
+            ],
+            true
+        );
+        return new Config(['CAS' => $casConfig], true);
+    }
+
+    /**
+     * Data provider for testWithMissingConfiguration.
+     *
+     * @return void
+     */
+    public static function configKeyProvider(): array
+    {
+        return [
+            'missing server' => ['server'],
+            'missing port' => ['port'],
+            'missing context' => ['context'],
+            'missing CACert' => ['CACert'],
+            'missing login' => ['login'],
+            'missing logout' => ['logout'],
+        ];
+    }
+
+    /**
+     * Verify that missing configuration keys cause failure.
+     *
+     * @param string $key Key to omit
+     *
+     * @return void
+     *
+     * @dataProvider configKeyProvider
+     */
+    public function testConfigValidation(string $key): void
+    {
+        $this->expectException(\VuFind\Exception\Auth::class);
+
+        $config = $this->getAuthConfig();
+        unset($config->CAS->$key);
+        $this->getAuthObject($config)->getConfig();
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -122,18 +122,15 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testSuccessfulStoredLoginAttempt()
     {
-        $user = $this->getMockUser(['__get', '__isset', 'getCatPassword']);
-        $user->expects($this->any())->method('__get')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue('user'));
-        $user->expects($this->any())->method('__isset')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
-        $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
+        $user = $this->getMockUser(['getCatUsername', 'getRawCatPassword']);
+        $user->expects($this->any())->method('getCatUsername')->willReturn('user');
+        $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $manager = $this->getMockManager(['getUserObject']);
         $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $details = ['foo' => 'bar'];
         $connection = $this->getMockConnection(['patronLogin']);
         $connection->expects($this->once())->method('patronLogin')
-            ->with($this->equalTo('user'), $this->equalTo('pass'))->will($this->returnValue($details));
+            ->with($this->equalTo('user'), $this->equalTo('pass'))->willReturn($details);
         $auth = $this->getAuthenticator($manager, $connection);
         $this->assertEquals($details, $auth->storedCatalogLogin());
 
@@ -149,12 +146,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnsuccessfulStoredLoginAttempt()
     {
-        $user = $this->getMockUser(['__get', '__isset', 'clearCredentials', 'getCatPassword']);
-        $user->expects($this->any())->method('__get')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue('user'));
-        $user->expects($this->any())->method('__isset')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
-        $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
+        $user = $this->getMockUser(['clearCredentials', 'getCatUsername', 'getRawCatPassword']);
+        $user->expects($this->any())->method('getCatUsername')->willReturn('user');
+        $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $user->expects($this->once())->method('clearCredentials');
         $manager = $this->getMockManager(['getUserObject']);
         $manager->expects($this->any())->method('getUserObject')->willReturn($user);
@@ -175,12 +169,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\VuFind\Exception\ILS::class);
         $this->expectExceptionMessage('kaboom');
 
-        $user = $this->getMockUser(['__get', '__isset', 'clearCredentials', 'getCatPassword']);
-        $user->expects($this->any())->method('__get')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue('user'));
-        $user->expects($this->any())->method('__isset')
-            ->with($this->equalTo('cat_username'))->will($this->returnValue(true));
-        $user->expects($this->any())->method('getCatPassword')->will($this->returnValue('pass'));
+        $user = $this->getMockUser(['clearCredentials', 'getCatUsername', 'getRawCatPassword']);
+        $user->expects($this->any())->method('getCatUsername')->willReturn('user');
+        $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $manager = $this->getMockManager(['getUserObject']);
         $manager->expects($this->any())->method('getUserObject')->willReturn($user);
         $connection = $this->getMockConnection(['patronLogin']);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
@@ -55,11 +55,8 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
      */
     public function getAuthObject(?Config $config = null): LDAP
     {
-        if (null === $config) {
-            $config = $this->getAuthConfig();
-        }
-        $obj = new LDAP();
-        $obj->setConfig($config);
+        $obj = new LDAP($this->createMock(\VuFind\Auth\ILSAuthenticator::class));
+        $obj->setConfig($config ?? $this->getAuthConfig());
         return $obj;
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAuth2/Repository/IdentityRepositoryTest.php
@@ -29,9 +29,9 @@
 
 namespace VuFindTest\OAuth2\Repository;
 
+use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Framework\InvalidArgumentException;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Auth\ILSAuthenticator;
 use VuFind\Db\Entity\UserEntityInterface;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/ScheduledSearch/NotifyCommandTest.php
@@ -506,7 +506,7 @@ class NotifyCommandTest extends \PHPUnit\Framework\TestCase
             'last_language' => 'en',
         ];
         $adapter = $this->container->createMock(\Laminas\Db\Adapter\Adapter::class);
-        $user = new \VuFind\Db\Row\User($adapter);
+        $user = new \VuFind\Db\Row\User($adapter, $this->createMock(\VuFind\Auth\ILSAuthenticator::class));
         $user->populate($data, true);
         return $user;
     }

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
@@ -278,7 +278,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
         ];
         $adapter = $this->createMock(\Laminas\Db\Adapter\Adapter::class);
         $user = $this->getMockBuilder(\VuFind\Db\Row\User::class)
-            ->setConstructorArgs([$adapter])
+            ->setConstructorArgs([$adapter, $this->createMock(\VuFind\Auth\ILSAuthenticator::class)])
             ->onlyMethods(['save'])
             ->getMock();
         $user->populate($data, true);


### PR DESCRIPTION
After discussion with @aleksip, it became clear that `\VuFind\Db\Service\UserService` was not the right place to centralize our encryption logic. It is also problematic to include business logic like the current `\VuFind\Db\Row\User::getCatPassword()` method in an entity model. Since all of this logic is associated with ILS authentication, the most logical central place for it (short of creating a new service) is in the `\VuFind\Auth\ILSAuthenticator` class. This PR refactors code to move all relevant logic into the ILSAuthenticator.

TODO
- [x] Run full test suite
- [x] Update changelog when merging (changed constructor signatures, deprecated getCatPassword method, relocated encryption logic)