### PR TITLE
Add and use VuFind\Db\Service\TagServiceInterface.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/TagRecordFactory.php
@@ -69,9 +69,10 @@ class TagRecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
+        $dbServiceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
         return new $requestedName(
             $container->get(\VuFind\Record\Loader::class),
-            $container->get(\VuFind\Db\Service\PluginManager::class)->get(\VuFind\Db\Service\TagService::class),
+            $dbServiceManager->get(\VuFind\Db\Service\TagServiceInterface::class),
             $container->get(\VuFind\Tags::class),
             $container->get(\VuFind\Auth\Manager::class)->getUserObject()
         );

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\Controller;
 
-use VuFind\Db\Service\TagService;
+use VuFind\Db\Service\TagServiceInterface;
 use VuFind\Exception\BadRequest as BadRequestException;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
@@ -237,7 +237,7 @@ class AbstractRecord extends AbstractBase
         // Save tags, if any:
         if ($tags = $this->params()->fromPost('tag')) {
             $tagParser = $this->serviceLocator->get(\VuFind\Tags::class);
-            $this->getDbService(TagService::class)->addTagsToRecord(
+            $this->getDbService(TagServiceInterface::class)->addTagsToRecord(
                 $driver->getUniqueID(),
                 $driver->getSourceIdentifier(),
                 $user,
@@ -276,7 +276,7 @@ class AbstractRecord extends AbstractBase
 
         // Save tags, if any:
         if ($tag = $this->params()->fromPost('tag')) {
-            $this->getDbService(TagService::class)->deleteTagsFromRecord(
+            $this->getDbService(TagServiceInterface::class)->deleteTagsFromRecord(
                 $driver->getUniqueID(),
                 $driver->getSourceIdentifier(),
                 $user,

--- a/module/VuFind/src/VuFind/Db/Service/TagService.php
+++ b/module/VuFind/src/VuFind/Db/Service/TagService.php
@@ -40,7 +40,7 @@ use VuFind\Db\Entity\UserEntityInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-class TagService extends AbstractDbService implements \VuFind\Db\Table\DbTableAwareInterface
+class TagService extends AbstractDbService implements TagServiceInterface, \VuFind\Db\Table\DbTableAwareInterface
 {
     use \VuFind\Db\Table\DbTableAwareTrait;
 

--- a/module/VuFind/src/VuFind/Db/Service/TagServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/TagServiceInterface.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Service;
 
+use VuFind\Db\Entity\UserEntityInterface;
+
 /**
  * Database service interface for tags.
  *

--- a/module/VuFind/src/VuFind/Db/Service/TagServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/TagServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Database service plugin manager
+ * Database service interface for tags.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2023.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -30,7 +30,7 @@
 namespace VuFind\Db\Service;
 
 /**
- * Database service plugin manager
+ * Database service interface for tags.
  *
  * @category VuFind
  * @package  Database
@@ -38,38 +38,29 @@ namespace VuFind\Db\Service;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
+interface TagServiceInterface extends DbServiceInterface
 {
     /**
-     * Default plugin aliases.
+     * Add tags to the record.
      *
-     * @var array
+     * @param string              $id     Unique record ID
+     * @param string              $source Record source
+     * @param UserEntityInterface $user   The user adding the tag(s)
+     * @param string[]            $tags   The user-provided tag(s)
+     *
+     * @return void
      */
-    protected $aliases = [
-        AccessTokenServiceInterface::class => AccessTokenService::class,
-        TagServiceInterface::class => TagService::class,
-        UserServiceInterface::class => UserService::class,
-    ];
+    public function addTagsToRecord(string $id, string $source, UserEntityInterface $user, array $tags): void;
 
     /**
-     * Default plugin factories.
+     * Remove tags from the record.
      *
-     * @var array
-     */
-    protected $factories = [
-        AccessTokenService::class => AccessTokenServiceFactory::class,
-        TagService::class => AbstractDbServiceFactory::class,
-        UserService::class => UserServiceFactory::class,
-    ];
-
-    /**
-     * Return the name of the base class or interface that plug-ins must conform
-     * to.
+     * @param string              $id     Unique record ID
+     * @param string              $source Record source
+     * @param UserEntityInterface $user   The user deleting the tag(s)
+     * @param string[]            $tags   The user-provided tag(s)
      *
-     * @return string
+     * @return void
      */
-    protected function getExpectedInterface()
-    {
-        return DbServiceInterface::class;
-    }
+    public function deleteTagsFromRecord(string $id, string $source, UserEntityInterface $user, array $tags): void;
 }


### PR DESCRIPTION
This PR updates the TagService to follow the same interface pattern as the other two database services for consistency. It also eliminates useless string aliases for the database services in the plugin manager.

TODO
- [x] Run full test suite