### PR TITLE
Databases & ConsortialVuFind: Fix bug in advanced search

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
+++ b/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
@@ -198,7 +198,10 @@ class ConsortialVuFind implements RecommendInterface, \Laminas\Log\LoggerAwareIn
      */
     public function process($results)
     {
-        $this->queryString = $results->getParams()->getQuery()->getString();
+        $query = $results->getParams()->getQuery();
+        if (method_exists($query, 'getString')) {
+            $this->queryString = $query->getString();
+        }
     }
 
     /**
@@ -208,7 +211,7 @@ class ConsortialVuFind implements RecommendInterface, \Laminas\Log\LoggerAwareIn
      */
     public function getResults()
     {
-        if (!$this->hasMinimumConfig) {
+        if (!$this->hasMinimumConfig || !$this->queryString) {
             return [];
         }
 

--- a/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
+++ b/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
@@ -33,6 +33,7 @@ use Laminas\Config\Config;
 use VuFind\Connection\ExternalVuFind as Connection;
 
 use function intval;
+use function is_callable;
 
 /**
  * ConsortialVuFind Recommendations Module

--- a/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
+++ b/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
@@ -112,9 +112,9 @@ class ConsortialVuFind implements RecommendInterface, \Laminas\Log\LoggerAwareIn
     /**
      * Query string from the original search results
      *
-     * @var string
+     * @var ?string
      */
-    protected $queryString;
+    protected $queryString = null;
 
     /**
      * Constructor

--- a/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
+++ b/module/VuFind/src/VuFind/Recommend/ConsortialVuFind.php
@@ -199,7 +199,7 @@ class ConsortialVuFind implements RecommendInterface, \Laminas\Log\LoggerAwareIn
     public function process($results)
     {
         $query = $results->getParams()->getQuery();
-        if (method_exists($query, 'getString')) {
+        if (is_callable([$query, 'getString'])) {
             $this->queryString = $query->getString();
         }
     }

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -272,7 +272,10 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
 
         // Add databases from search query
         if ($this->useQuery) {
-            $query = strtolower($this->results->getParams()->getQuery()->getString());
+            $queryObject = $this->results->getParams()->getQuery();
+            $query = method_exists($queryObject, 'getString')
+                ? strtolower($queryObject->getString())
+                : null;
             if (strlen($query) >= $this->useQueryMinLength) {
                 foreach ($nameToDatabase as $name => $databaseInfo) {
                     if (str_contains(strtolower($name), $query)) {

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -33,6 +33,7 @@ use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 
 use function count;
 use function intval;
+use function is_callable;
 use function strlen;
 
 /**

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -273,7 +273,7 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
         // Add databases from search query
         if ($this->useQuery) {
             $queryObject = $this->results->getParams()->getQuery();
-            $query = method_exists($queryObject, 'getString')
+            $query = is_callable([$queryObject, 'getString'])
                 ? strtolower($queryObject->getString())
                 : '';
             if (strlen($query) >= $this->useQueryMinLength) {

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -275,7 +275,7 @@ class Databases implements RecommendInterface, \Laminas\Log\LoggerAwareInterface
             $queryObject = $this->results->getParams()->getQuery();
             $query = method_exists($queryObject, 'getString')
                 ? strtolower($queryObject->getString())
-                : null;
+                : '';
             if (strlen($query) >= $this->useQueryMinLength) {
                 foreach ($nameToDatabase as $name => $databaseInfo) {
                     if (str_contains(strtolower($name), $query)) {


### PR DESCRIPTION
This fixes the assumption that `getQuery` returned a Query which has a `getString` method.  In the case of advanced search, it returns a QueryGroup which does not.  That bad assumption was used in both Databases and ConsortialVuFind recommendation modules.

In theory either module could try to parse the QueryGroup and still use its contained queries.  But if someone is doing an advanced query, I don't think they are actually looking for a database by name.  And consortial VuFind instances might handle advanced queries differently.