### PR TITLE
Reflect possible null return from ->current().

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/AuthHash.php
+++ b/module/VuFind/src/VuFind/Db/Table/AuthHash.php
@@ -96,7 +96,7 @@ class AuthHash extends Gateway
      *
      * @param string $sessionId Session ID
      *
-     * @return \VuFind\Db\Row\AuthHash
+     * @return ?\VuFind\Db\Row\AuthHash
      */
     public function getLatestBySessionId($sessionId)
     {

--- a/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Table/ChangeTracker.php
@@ -77,7 +77,7 @@ class ChangeTracker extends Gateway
      * @param string $core The Solr core holding the record.
      * @param string $id   The ID of the record being indexed.
      *
-     * @return \VuFind\Db\Row\ChangeTracker|null
+     * @return ?\VuFind\Db\Row\ChangeTracker
      */
     public function retrieve($core, $id)
     {

--- a/module/VuFind/src/VuFind/Db/Table/ExternalSession.php
+++ b/module/VuFind/src/VuFind/Db/Table/ExternalSession.php
@@ -90,7 +90,7 @@ class ExternalSession extends Gateway
      *
      * @param string $sid External session ID to retrieve
      *
-     * @return \VuFind\Db\Row\ExternalSession
+     * @return ?\VuFind\Db\Row\ExternalSession
      */
     public function getByExternalSessionId($sid)
     {

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -82,7 +82,7 @@ class OaiResumption extends Gateway
      *
      * @param string $token The resumption token to retrieve.
      *
-     * @return \VuFind\Db\Row\OaiResumption|null
+     * @return ?\VuFind\Db\Row\OaiResumption
      */
     public function findToken($token)
     {

--- a/module/VuFind/src/VuFind/Db/Table/Ratings.php
+++ b/module/VuFind/src/VuFind/Db/Table/Ratings.php
@@ -113,7 +113,7 @@ class Ratings extends Gateway
 
         $result = $this->select($callback)->current();
         return [
-            'count' => $result->count,
+            'count' => $result->count ?? 0,
             'rating' => $result->rating ?? 0,
         ];
     }

--- a/module/VuFind/src/VuFind/Db/Table/Search.php
+++ b/module/VuFind/src/VuFind/Db/Table/Search.php
@@ -169,7 +169,7 @@ class Search extends Gateway
      * missing?
      *
      * @throws \Exception
-     * @return \VuFind\Db\Row\Search
+     * @return ?\VuFind\Db\Row\Search
      */
     public function getRowById($id, $exceptionIfMissing = true)
     {

--- a/module/VuFind/src/VuFind/Db/Table/User.php
+++ b/module/VuFind/src/VuFind/Db/Table/User.php
@@ -109,7 +109,7 @@ class User extends Gateway
      *
      * @param string $id ID.
      *
-     * @return UserRow
+     * @return ?UserRow
      */
     public function getById($id)
     {
@@ -135,7 +135,7 @@ class User extends Gateway
      * @param string $username Username to use for retrieval.
      * @param bool   $create   Should we create users that don't already exist?
      *
-     * @return UserRow
+     * @return ?UserRow
      */
     public function getByUsername($username, $create = true)
     {
@@ -152,7 +152,7 @@ class User extends Gateway
      *
      * @param string $email email to use for retrieval.
      *
-     * @return UserRow
+     * @return ?UserRow
      */
     public function getByEmail($email)
     {
@@ -180,7 +180,7 @@ class User extends Gateway
      *
      * @param string $hash User-unique hash string
      *
-     * @return mixed
+     * @return ?UserRow
      */
     public function getByVerifyHash($hash)
     {


### PR DESCRIPTION
While reviewing other database code, I noticed that the fact that Laminas\Db\ResultSet::current() may return null was not reflected in all of our typehints or related logic. This PR cleans that up. I also changed some `type|null` typehints to `?type` format for consistency.