### PR TITLE
[VUFIND-1632] Improve install.php existing file handling

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
@@ -744,11 +744,8 @@ class InstallCommand extends Command
     protected function buildImportConfig(OutputInterface $output, $filename)
     {
         $target = $this->overrideDir . '/import/' . $filename;
-        if (file_exists($target)) {
-            $output->writeln(
-                "Warning: $target already exists; skipping file creation."
-            );
-            return true;
+        if (($msg = $this->backUpFile($output, $target, 'import configuration')) !== true) {
+            return $msg;
         }
         $import = @file_get_contents($this->baseDir . '/import/' . $filename);
         $import = str_replace(

--- a/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Install/InstallCommand.php
@@ -108,6 +108,13 @@ class InstallCommand extends Command
     protected $solrPort = '8983';
 
     /**
+     * Should we make backups of existing files?
+     *
+     * @var bool
+     */
+    protected $makeBackups = true;
+
+    /**
      * Constructor
      *
      * @param string|null $name The name of the command; passing null means it must
@@ -179,6 +186,11 @@ class InstallCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Use settings if provided via arguments, otherwise use defaults'
+            )->addOption(
+                'skip-backups',
+                null,
+                InputOption::VALUE_NONE,
+                'Overwrite existing files without creating backups'
             );
     }
 
@@ -595,7 +607,7 @@ class InstallCommand extends Command
      */
     protected function backUpFile(OutputInterface $output, string $filename, string $desc)
     {
-        if (file_exists($filename)) {
+        if ($this->makeBackups && file_exists($filename)) {
             $bak = $filename . '.bak.' . time();
             if (!copy($filename, $bak)) {
                 return "Problem backing up $filename to $bak";
@@ -1015,6 +1027,10 @@ class InstallCommand extends Command
         // Normalize the module setting to remove whitespace:
         $this->module = preg_replace('/\s/', '', $this->module);
 
+        // Should we make backups of existing files?
+        if ($input->getOption('skip-backups')) {
+            $this->makeBackups = false;
+        }
         return 0;
     }
 

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
@@ -59,7 +59,7 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
         $command = $this->getMockCommand(
             ['backUpFile', 'buildDirs', 'getApacheLocation', 'getInput', 'writeFileToDisk']
         );
-        $command->expects($this->exactly(3))->method('backUpFile')->will($this->returnValue(true));
+        $command->expects($this->exactly(5))->method('backUpFile')->willReturn(true);
         $this->expectConsecutiveCalls(
             $command,
             'getInput',
@@ -162,7 +162,7 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
             $localFixtures . '/harvest',
             $localFixtures . '/import',
         ];
-        $command->expects($this->exactly(3))->method('backUpFile')->will($this->returnValue(true));
+        $command->expects($this->exactly(5))->method('backUpFile')->willReturn(true);
         $command->expects($this->once())->method('buildDirs')
             ->with($this->equalTo($expectedDirs))
             ->will($this->returnValue(true));

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Install/InstallCommandTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Command\Import;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -48,18 +49,44 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
     use \VuFindTest\Feature\WithConsecutiveTrait;
 
     /**
+     * Data provider for testing with or without the skip-backups flag.
+     *
+     * @return array[]
+     */
+    public static function skipBackupsProvider(): array
+    {
+        return [
+            'skip backups' => [true],
+            'with backups' => [false],
+        ];
+    }
+
+    /**
      * Test the interactive installation process.
      *
+     * @param bool $skipBackups Should we test with backups disabled?
+     *
      * @return void
+     *
+     * @dataProvider skipBackupsProvider
      */
-    public function testInteractiveInstallation()
+    public function testInteractiveInstallation(bool $skipBackups): void
     {
         $expectedBaseDir = realpath(__DIR__ . '/../../../../../../../../');
         $localFixtures = $expectedBaseDir . '/module/VuFindConsole/tests/fixtures';
-        $command = $this->getMockCommand(
-            ['backUpFile', 'buildDirs', 'getApacheLocation', 'getInput', 'writeFileToDisk']
-        );
-        $command->expects($this->exactly(5))->method('backUpFile')->willReturn(true);
+        $methodsToMock = ['buildDirs', 'getApacheLocation', 'getInput', 'writeFileToDisk'];
+        // If we test without the --skip-backups flag, we need to mock the backUpFile method,
+        // because we don't want the test to cause files to get written to disk. If we test
+        // with the flag, we can skip this mocking because the actual method will bypass
+        // file writing. We will know the flag worked, because if something goes wrong, the
+        // backup process will add messages to the output which will cause an assertion to fail.
+        if (!$skipBackups) {
+            $methodsToMock[] = 'backUpFile';
+        }
+        $command = $this->getMockCommand($methodsToMock);
+        if (!$skipBackups) {
+            $command->expects($this->exactly(5))->method('backUpFile')->willReturn(true);
+        }
         $this->expectConsecutiveCalls(
             $command,
             'getInput',
@@ -117,7 +144,7 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
         $command->expects($this->once())->method('getApacheLocation')
             ->with($this->isInstanceOf(OutputInterface::class));
         $commandTester = new CommandTester($command);
-        $commandTester->execute([]);
+        $commandTester->execute($skipBackups ? ['--skip-backups' => true] : []);
         $expectedOutput = <<<TEXT
             VuFind has been found in $expectedBaseDir.
 
@@ -148,7 +175,7 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNonInteractiveInstallation()
+    public function testNonInteractiveInstallation(): void
     {
         $expectedBaseDir = realpath(__DIR__ . '/../../../../../../../../');
         $localFixtures = $expectedBaseDir . '/module/VuFindConsole/tests/fixtures';
@@ -213,7 +240,7 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testInvalidSolrPort()
+    public function testInvalidSolrPort(): void
     {
         $expectedBaseDir = realpath(__DIR__ . '/../../../../../../../../');
         $command = $this->getMockCommand(
@@ -239,11 +266,11 @@ class InstallCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $methods Methods to mock
      *
-     * @return InstallCommand
+     * @return InstallCommand&MockObject
      */
     protected function getMockCommand(
         array $methods = ['buildDirs', 'getInput', 'writeFileToDisk']
-    ) {
+    ): InstallCommand&MockObject {
         return $this->getMockBuilder(InstallCommand::class)
             ->onlyMethods($methods)
             ->getMock();


### PR DESCRIPTION
This PR makes the install script's handling of existing files more consistent, and adds a switch to bypass creation of backups for scenarios where they are not needed (e.g. when local files are under version control).

Also includes some general improvements to the associated test class (including coverage for the new functionality).

TODO
- [x] Close [VUFIND-1632](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1632) when merging