### PR TITLE
Improve return type of getDbService() methods

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -529,9 +529,11 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
     /**
      * Get a database service object.
      *
-     * @param string $name Name of service to retrieve
+     * @param class-string<T> $name Name of service to retrieve
      *
-     * @return \VuFind\Db\Service\DbServiceInterface
+     * @template T
+     *
+     * @return T
      */
     public function getDbService(string $name): \VuFind\Db\Service\DbServiceInterface
     {

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -531,9 +531,9 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      *
      * @param string $name Name of service to retrieve
      *
-     * @return \VuFind\Db\Service\AbstractDbService
+     * @return \VuFind\Db\Service\DbServiceInterface
      */
-    public function getDbService(string $name): \VuFind\Db\Service\AbstractDbService
+    public function getDbService(string $name): \VuFind\Db\Service\DbServiceInterface
     {
         return $this->serviceLocator->get(\VuFind\Db\Service\PluginManager::class)
             ->get($name);

--- a/module/VuFind/src/VuFind/Db/Service/DbServiceAwareTrait.php
+++ b/module/VuFind/src/VuFind/Db/Service/DbServiceAwareTrait.php
@@ -76,9 +76,11 @@ trait DbServiceAwareTrait
     /**
      * Get a database service object.
      *
-     * @param string $name Name of service to retrieve
+     * @param class-string<T> $name Name of service to retrieve
      *
-     * @return DbServiceInterface
+     * @template T
+     *
+     * @return T
      */
     public function getDbService(string $name): DbServiceInterface
     {

--- a/module/VuFind/src/VuFind/Db/Service/DbServiceAwareTrait.php
+++ b/module/VuFind/src/VuFind/Db/Service/DbServiceAwareTrait.php
@@ -78,9 +78,9 @@ trait DbServiceAwareTrait
      *
      * @param string $name Name of service to retrieve
      *
-     * @return AbstractDbService
+     * @return DbServiceInterface
      */
-    public function getDbService(string $name)
+    public function getDbService(string $name): DbServiceInterface
     {
         return $this->getDbServiceManager()->get($name);
     }


### PR DESCRIPTION
This PR is in response to feedback in #3558 -- it uses a more appropriate return type for getDbService (in both of its implementations) and uses PHPDoc generics to improve the accuracy of static analysis.

One annoying thing: I think it would be better to put the `@template` annotation ahead of the `@params` annotations, but PHP_CodeSniffer won't let me, because it insists that `@params` must be first. I'm not sure if it's okay to do it this way, or if we need to disable a phpcs rule to do things in a better order. For what it's worth, the annotations seem to work correctly for me in VSCode regardless of order.