### PR TITLE
Fix bug: handler-specific default sorts broken.

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -637,7 +637,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . $path);
         $page = $session->getPage();
-        $this->submitSearchForm($page, $query, $handler, $path);
+        $this->submitSearchForm($page, $query, $handler);
         return $page;
     }
 

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -630,20 +630,39 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      * @param string $handler Search type (optional)
      * @param string $path    Path to use as search starting point (optional)
      *
-     * @return \Behat\Mink\Element\Element
+     * @return Element
      */
     protected function performSearch($query, $handler = null, $path = '/Search')
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . $path);
         $page = $session->getPage();
+        $this->submitSearchForm($page, $query, $handler, $path);
+        return $page;
+    }
+
+    /**
+     * Submit a search on the provided page.
+     *
+     * @param Element $page    Current page object
+     * @param string  $query   Search term(s)
+     * @param string  $handler Search type (optional)
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function submitSearchForm(
+        Element $page,
+        string $query,
+        ?string $handler = null
+    ): void {
         $this->findCss($page, '#searchForm_lookfor')->setValue($query);
         if ($handler) {
             $this->findCss($page, '#searchForm_type')->setValue($handler);
         }
         $this->clickCss($page, '.btn.btn-primary');
         $this->waitForPageLoad($page);
-        return $page;
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchSortTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchSortTest.php
@@ -103,6 +103,35 @@ class SearchSortTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test sort stickiness
+     *
+     * @return void
+     */
+    public function testSortStickiness(): void
+    {
+        // Call number has a custom default sort; if we do a regular search and leave
+        // the sort at default, then do a call number search, we expect the sort to
+        // change accordingly. We also expect it to change back if we do a non-call-no
+        // search.
+        $page = $this->performSearch('*:*');
+        $this->assertSelectedSort($page, 'relevance');
+        $this->submitSearchForm($page, '*:*', 'CallNumber');
+        $this->assertSelectedSort($page, 'callnumber-sort');
+        $this->submitSearchForm($page, '*:*', 'AllFields');
+        $this->assertSelectedSort($page, 'relevance');
+
+        // However, if we choose a non-default sort, we expect it to stick across
+        // all search types:
+        $this->clickCss($page, $this->sortControlSelector . ' option', null, 2);
+        $this->waitForPageLoad($page);
+        $this->assertSelectedSort($page, 'year asc');
+        $this->submitSearchForm($page, '*:*', 'CallNumber');
+        $this->assertSelectedSort($page, 'year asc');
+        $this->submitSearchForm($page, '*:*', 'AllFields');
+        $this->assertSelectedSort($page, 'year asc');
+    }
+
+    /**
      * Set up a search page with sorting configured
      *
      * @param string $sortParam Requested sort option

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -173,7 +173,7 @@
       if (!empty($lastLimit)) {
         echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '">';
       }
-      if (!empty($lastSort)) {
+      if (!empty($lastSort) && $lastSort !== $params?->getDefaultSort()) {
         echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '">';
       }
     ?>


### PR DESCRIPTION
This fixes [VUFIND-1685](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1685) and adds a test case to prevent regressions.

@dltj reported the problem; I'd be interested in his feedback on this solution.

TODO
- [x] Resolve [VUFIND-1685](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1685) when merging.