### PR TITLE
Fix ILS exception handling when editing holds.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/Feature/CatchIlsExceptionsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/CatchIlsExceptionsTrait.php
@@ -81,7 +81,9 @@ trait CatchIlsExceptionsTrait
             if ('development' == APPLICATION_ENV) {
                 $this->flashMessenger()->addErrorMessage($exception->getMessage());
             }
-            return $this->ilsExceptionResponse ?? $this->createViewModel();
+            $actionResponse = $this->ilsExceptionResponse ?? $this->createViewModel();
+            $event->setResult($actionResponse);
+            return $actionResponse;
         }
     }
 }

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -198,6 +198,13 @@ class HoldsController extends AbstractBase
      */
     public function editAction()
     {
+        $this->ilsExceptionResponse = $this->createViewModel(
+            [
+                'selectedIDS' => [],
+                'fields' => [],
+            ]
+        );
+
         // Stop now if the user does not have valid catalog credentials available:
         if (!is_array($patron = $this->catalogLogin())) {
             return $patron;

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -77,9 +77,11 @@
     <?php endif; ?>
   <?php endif; ?>
 
-  <div class="form-group">
-    <input class="btn btn-primary" type="submit" name="updateHolds" value="<?=$this->transEscAttr('Save')?>">
-  </div>
+  <?php if ($this->fields): ?>
+    <div class="form-group">
+      <input class="btn btn-primary" type="submit" name="updateHolds" value="<?=$this->transEscAttr('Save')?>">
+    </div>
+  <?php endif; ?>
 </form>
 
 <?php


### PR DESCRIPTION
If editing of holds fails, the hold form requires a couple of variables to function properly. Result handling in CatchIlsExceptionTrait wasn't working properly, so this fixes it too.