### PR TITLE
Aleph driver: improve ID and date processing.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1535,10 +1535,11 @@ class Aleph extends AbstractBase implements
                         false
                     );
                     $id = $result->xpath('//doc_number/text()');
+                    $idString = (string)$id[0];
                     if (count($this->bib) == 1) {
-                        return $id[0];
+                        return $idString;
                     } else {
-                        return $base . '-' . $id[0];
+                        return $base . '-' . $idString;
                     }
                 }
             } catch (\Exception $ex) {
@@ -1566,6 +1567,9 @@ class Aleph extends AbstractBase implements
         } elseif (preg_match("/^[0-9]+\/[0-9]+\/[0-9]{4}$/", $date) === 1) {
             // 13/7/2012
             return $this->dateConverter->convertToDisplayDate('d/m/Y', $date);
+        } elseif (preg_match("/^[0-9]+\/[0-9]+\/[0-9]{2}$/", $date) === 1) {
+            // 13/7/12
+            return $this->dateConverter->convertToDisplayDate('d/m/y', $date);
         } else {
             throw new \Exception("Invalid date: $date");
         }


### PR DESCRIPTION
This PR addresses two Aleph driver bugs reported by @bankovska (who also deserves credit for the new date processing code):

  - The barcode to ID function attempted to use a SimpleXML object as a string; adding explicit typecasting fixes this.
  - The date formatting function did not support two-digit years, which some Aleph instances may provide; an additional case was added to support this scenario.

I do not have an Aleph instance, so I cannot test this myself, but @bankovska reports that it is working. I'm hoping another Aleph user can confirm for due diligence.