### PR TITLE
Sierra: Avoid error if a requested record is not found.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -3092,7 +3092,7 @@ class SierraRest extends AbstractBase implements
             'GET',
             $patron
         );
-        foreach ($records['entries'] as $record) {
+        foreach ($records['entries'] ?? [] as $record) {
             $id = $this->extractId($record['id']);
             $this->putCachedRecordData("$type|$id", $requiredFields, $record, $ttl);
             $result[$id] = $record;


### PR DESCRIPTION
This should not happen under normal circumstances, but better to be safe.