### PR TITLE
Fix title links missing sid

### DIFF
--- a/themes/bootstrap3/templates/search/results-list.phtml
+++ b/themes/bootstrap3/templates/search/results-list.phtml
@@ -20,4 +20,4 @@
     $this->resultsAttrs->add('data-history', $this->saveToHistory ? '1' : '0');
   }
 ?>
-<?=$this->render('search/list-' . $this->params->getView() . '.phtml')?>
+<?=$this->render('search/list-' . $this->params->getView() . '.phtml', ['results' => $this->results])?>


### PR DESCRIPTION
Sometimes in random occasions the sid from title link goes missing and results is null when creating the link. The way I got this to work in my environment was to go to search results and switch the sorting randomly so the sid would go missing from the link in the title.