### PR TITLE
Use UserEntityInterface in ExternalAuthController.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
+++ b/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
@@ -77,7 +77,7 @@ class ExternalAuthController extends AbstractBase implements LoggerAwareInterfac
                 $logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
                 $logger->info(
                     "EZproxy login to '" . $config->EZproxy->host
-                    . "' for '" . ($user ? $user->username : 'anonymous')
+                    . "' for '" . ($user ? $user->getUsername() : 'anonymous')
                     . "' from IP address "
                     . $this->request->getServer()->get('REMOTE_ADDR')
                 );
@@ -86,8 +86,8 @@ class ExternalAuthController extends AbstractBase implements LoggerAwareInterfac
                 'url',
                 $this->params()->fromQuery('url')
             );
-            $username = !empty($config->EZproxy->anonymous_ticket) || !$user
-                ? 'anonymous' : $user->username;
+            $username = (!empty($config->EZproxy->anonymous_ticket) || !$user)
+                ? 'anonymous' : $user->getUsername();
             return $this->redirect()->toUrl(
                 $this->createEzproxyTicketUrl($username, $url)
             );


### PR DESCRIPTION
More work to begin using UserEntityInterface instead of direct property access. I've been working on doing this more comprehensively, but in the interest of keeping commits readable, I'm trying to break off small pieces to separately review and merge.