### PR TITLE
Fix search result links losing sid when e.g. sort is changed multiple times.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
@@ -241,6 +241,7 @@ class GetSearchResults extends \VuFind\AjaxHandler\AbstractBase implements
                 'showBulkOptions' => $showBulkOptions,
                 'showCartControls' => $showCartControls,
                 'showCheckboxes' => $showCheckboxes,
+                'saveToHistory' => (bool)$requestParams->fromQuery('history', false),
             ]
         );
     }

--- a/module/VuFind/src/VuFindTest/Feature/SearchSortTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/SearchSortTrait.php
@@ -80,6 +80,11 @@ trait SearchSortTrait
         $this->assertCount($count, $titles);
         $this->assertEquals($first, $titles[0]->getText());
         $this->assertEquals($last, $titles[$count - 1]->getText());
+        // Check that record links contain sid parameter:
+        $url = $titles[0]->getAttribute('href');
+        parse_str(parse_url($url, PHP_URL_QUERY), $urlParams);
+        $this->assertArrayHasKey('sid', $urlParams);
+        $this->assertNotEmpty($urlParams['sid']);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchSortTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchSortTest.php
@@ -99,6 +99,11 @@ class SearchSortTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertResultTitles($page, 20, 'Test Publication 20177', 'Test Publication 201738');
         // Check that url no longer contains the page parameter:
         $this->assertStringNotContainsString('&page', $this->getCurrentQueryString());
+
+        // Change sort back to relevance (first option) and verify:
+        $this->clickCss($page, $this->sortControlSelector . ' option');
+        $this->waitForPageLoad($page);
+        $this->assertResultTitles($page, 20, 'Test Publication 20001', 'Test Publication 20020');
     }
 
     /**


### PR DESCRIPTION
saveToHistory wasn't being properly relayed when rendering the search results.

Continued from #3582.