### PR TITLE
Add an option to specify sort order conditions for extra params in searchspecs.

### DIFF
--- a/config/vufind/searchspecs.yaml
+++ b/config/vufind/searchspecs.yaml
@@ -98,6 +98,8 @@
 # - SearchTypeIn      At least one of the search types must be in the given list
 # - AllSearchTypesIn  All of the search types must be in the given list
 # - SearchTypeNotIn   None of the search types must be in the given list
+# - SortIn            Sort order (exactly as it's sent to Solr) must be in the given list
+# - SortNotIn         Sort order (exactly as it's sent to Solr) must not be in the given list
 #
 # Example: Boost more recent material if any of the search fields is of type
 # "AllFields" or "Title" unless there's a search type specific boost:
@@ -112,6 +114,8 @@
 #       - NoDismaxParams:
 #         - bf
 #         - bq
+#       - SortIn:
+#         - score desc,id asc
 #
 #
 # Example: Boost material in English if any of the search fields is of type

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/QueryBuilder.php
@@ -49,12 +49,14 @@ class QueryBuilder
     /**
      * Return BrowZine search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Send back results
         $q = $this->abstractQueryToArray($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/BrowZine/QueryBuilder.php
@@ -49,16 +49,16 @@ class QueryBuilder
     /**
      * Return BrowZine search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Send back results
         $q = $this->abstractQueryToArray($query);
-        $params = new ParamBag(['query' => empty($q) ? '*' : $q]);
-        return $params;
+        return new ParamBag(['query' => empty($q) ? '*' : $q]);
     }
 
     /// Internal API

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/QueryBuilder.php
@@ -63,18 +63,18 @@ class QueryBuilder
     /**
      * Construct EdsApi search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Build base query
         $queries = $this->abstractQueryToArray($query);
 
         // Send back results
-        $params = new ParamBag(['query' => $queries]);
-        return $params;
+        return new ParamBag(['query' => $queries]);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/QueryBuilder.php
@@ -63,12 +63,14 @@ class QueryBuilder
     /**
      * Construct EdsApi search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Build base query
         $queries = $this->abstractQueryToArray($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EIT/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EIT/QueryBuilder.php
@@ -66,12 +66,14 @@ class QueryBuilder
     /**
      * Return EIT search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EIT/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EIT/QueryBuilder.php
@@ -66,19 +66,20 @@ class QueryBuilder
     /**
      * Return EIT search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);
 
         // Send back results
-        $params = new ParamBag();
-        $params->set('query', $queryStr);
-        return $params;
+        $newParams = new ParamBag();
+        $newParams->set('query', $queryStr);
+        return $newParams;
     }
 
     /// Internal API

--- a/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/QueryBuilder.php
@@ -62,12 +62,14 @@ class QueryBuilder
     /**
      * Return LibGuides search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Send back results
         $newParams = new ParamBag();

--- a/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/LibGuides/QueryBuilder.php
@@ -62,28 +62,30 @@ class QueryBuilder
     /**
      * Return LibGuides search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Send back results
-        $params = new ParamBag();
+        $newParams = new ParamBag();
 
         // Convert the query to an array, then flatten that to a string
         // (right now, we're ignoring a lot of data -- we may want to
         // revisit this and see if more detail can be utilized).
         $array = $this->abstractQueryToArray($query);
         if (isset($array[0]['lookfor'])) {
-            $params->set('search', $array[0]['lookfor']);
+            $newParams->set('search', $array[0]['lookfor']);
         }
 
-        if (!$params->hasParam('widget_type')) {
-            $params->set('widget_type', $this->defaultWidgetType);
+        // TODO: is this check correct?
+        if (!$newParams->hasParam('widget_type')) {
+            $newParams->set('widget_type', $this->defaultWidgetType);
         }
 
-        return $params;
+        return $newParams;
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Pazpar2/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Pazpar2/QueryBuilder.php
@@ -61,19 +61,20 @@ class QueryBuilder
     /**
      * Return Pazpar2 search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);
 
         // Send back results
-        $params = new ParamBag();
-        $params->set('query', $queryStr);
-        return $params;
+        $newParams = new ParamBag();
+        $newParams->set('query', $queryStr);
+        return $newParams;
     }
 
     /// Internal API

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Pazpar2/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Pazpar2/QueryBuilder.php
@@ -61,12 +61,14 @@ class QueryBuilder
     /**
      * Return Pazpar2 search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/QueryBuilder.php
@@ -54,16 +54,17 @@ class QueryBuilder
     /**
      * Return Primo search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Send back results
-        $params = new ParamBag();
-        $params->set('query', $this->abstractQueryToArray($query));
-        return $params;
+        $newParams = new ParamBag();
+        $newParams->set('query', $this->abstractQueryToArray($query));
+        return $newParams;
     }
 
     /// Internal API

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/QueryBuilder.php
@@ -54,12 +54,14 @@ class QueryBuilder
     /**
      * Return Primo search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Send back results
         $newParams = new ParamBag();

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -165,7 +165,7 @@ class Backend extends AbstractBackend implements
 
         $params->set('rows', $limit);
         $params->set('start', $offset);
-        $params->mergeWith($this->getQueryBuilder()->build($query));
+        $params->mergeWith($this->getQueryBuilder()->build($query, $params));
         return $this->connector->search($params);
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -126,18 +126,19 @@ class QueryBuilder implements QueryBuilderInterface
     /**
      * Return SOLR search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
-        $params = new ParamBag();
+        $newParams = new ParamBag();
 
         // Add spelling query if applicable -- note that we must set this up before
         // we process the main query in order to avoid unwanted extra syntax:
         if ($this->createSpellingQuery) {
-            $params->set(
+            $newParams->set(
                 'spellcheck.q',
                 $this->getLuceneHelper()->extractSearchTerms($query->getAllTerms())
             );
@@ -169,17 +170,17 @@ class QueryBuilder implements QueryBuilderInterface
                     // If a boost was added, we don't want to highlight based on
                     // the boost query, so we should use the non-boosted version:
                     if ($highlight && $oldString != $string) {
-                        $params->set('hl.q', $oldString);
+                        $newParams->set('hl.q', $oldString);
                     }
                 }
             } elseif ($handler->hasDismax()) {
-                $params->set('qf', implode(' ', $handler->getDismaxFields()));
-                $params->set('qt', $handler->getDismaxHandler());
+                $newParams->set('qf', implode(' ', $handler->getDismaxFields()));
+                $newParams->set('qt', $handler->getDismaxHandler());
                 foreach ($handler->getDismaxParams() as $param) {
-                    $params->add(reset($param), next($param));
+                    $newParams->add(reset($param), next($param));
                 }
                 if ($handler->hasFilterQuery()) {
-                    $params->add('fq', $handler->getFilterQuery());
+                    $newParams->add('fq', $handler->getFilterQuery());
                 }
             } else {
                 $string = $handler->createSimpleQueryString($string);
@@ -188,9 +189,9 @@ class QueryBuilder implements QueryBuilderInterface
         // Set an appropriate highlight field list when applicable:
         if ($highlight) {
             $filter = $handler ? $handler->getAllFields() : [];
-            $params->add('hl.fl', $this->getFieldsToHighlight($filter));
+            $newParams->add('hl.fl', $this->getFieldsToHighlight($filter));
         }
-        $params->set('q', $string);
+        $newParams->set('q', $string);
 
         // Handle any extra parameters:
         foreach ($this->globalExtraParams as $extraParam) {
@@ -198,28 +199,30 @@ class QueryBuilder implements QueryBuilderInterface
                 continue;
             }
             if (
-                !$this->checkParamConditions($query, $extraParam['conditions'] ?? [])
+                !$this->checkParamConditions($query, $params, $extraParam['conditions'] ?? [])
             ) {
                 continue;
             }
             foreach ((array)$extraParam['value'] as $value) {
-                $params->add($extraParam['param'], $value);
+                $newParams->add($extraParam['param'], $value);
             }
         }
 
-        return $params;
+        return $newParams;
     }
 
     /**
      * Check if the conditions match for an extra parameter
      *
      * @param AbstractQuery $query      Search query
+     * @param ?ParamBag     $params     Search backend parameters
      * @param array         $conditions Required conditions
      *
      * @return bool
      */
     protected function checkParamConditions(
         AbstractQuery $query,
+        ?ParamBag $params,
         array $conditions
     ): bool {
         if (empty($conditions)) {
@@ -253,6 +256,18 @@ class QueryBuilder implements QueryBuilderInterface
                         if ($this->hasDismaxParamsField($searchTypes, $value)) {
                             return false;
                         }
+                    }
+                    break;
+                case 'SortIn':
+                    $sort = $params?->get('sort');
+                    if (empty(array_intersect((array)$values, (array)$sort))) {
+                        return false;
+                    }
+                    break;
+                case 'SortNotIn':
+                    $sort = $params?->get('sort');
+                    if (!empty(array_intersect((array)$values, (array)$sort))) {
+                        return false;
                     }
                     break;
                 default:

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilderInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilderInterface.php
@@ -48,14 +48,14 @@ use VuFindSearch\Query\AbstractQuery;
 interface QueryBuilderInterface
 {
     /**
-     * Build SOLR query based on VuFind query object.
+     * Build query based on VuFind query object.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query, ParamBag $params = null);
+    public function build(AbstractQuery $query, ?ParamBag $params = null);
 
     /**
      * Control whether or not the QueryBuilder should create a spellcheck.q

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilderInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilderInterface.php
@@ -50,11 +50,12 @@ interface QueryBuilderInterface
     /**
      * Build SOLR query based on VuFind query object.
      *
-     * @param AbstractQuery $query Query object
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query);
+    public function build(AbstractQuery $query, ParamBag $params = null);
 
     /**
      * Control whether or not the QueryBuilder should create a spellcheck.q

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/QueryBuilder.php
@@ -64,12 +64,14 @@ class QueryBuilder
     /**
      * Return Summon search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Summon/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Summon/QueryBuilder.php
@@ -64,19 +64,20 @@ class QueryBuilder
     /**
      * Return Summon search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);
 
         // Send back results
-        $params = new ParamBag();
-        $params->set('query', $queryStr);
-        return $params;
+        $newParams = new ParamBag();
+        $newParams->set('query', $queryStr);
+        return $newParams;
     }
 
     /// Internal API

--- a/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/QueryBuilder.php
@@ -73,12 +73,14 @@ class QueryBuilder
     /**
      * Return WorldCat search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query  Query object
-     * @param ParamBag      $params Search backend parameters
+     * @param AbstractQuery $query  User query
+     * @param ?ParamBag     $params Search backend parameters
      *
      * @return ParamBag
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function build(AbstractQuery $query, ParamBag $params = null)
+    public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/WorldCat/QueryBuilder.php
@@ -73,11 +73,12 @@ class QueryBuilder
     /**
      * Return WorldCat search parameters based on a user query and params.
      *
-     * @param AbstractQuery $query User query
+     * @param AbstractQuery $query  Query object
+     * @param ParamBag      $params Search backend parameters
      *
      * @return ParamBag
      */
-    public function build(AbstractQuery $query)
+    public function build(AbstractQuery $query, ParamBag $params = null)
     {
         // Build base query
         $queryStr = $this->abstractQueryToString($query);
@@ -88,9 +89,9 @@ class QueryBuilder
         }
 
         // Send back results
-        $params = new ParamBag();
-        $params->set('query', $queryStr);
-        return $params;
+        $newParams = new ParamBag();
+        $newParams->set('query', $queryStr);
+        return $newParams;
     }
 
     /// Internal API

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Backend\Solr;
 
 use VuFindSearch\Backend\Solr\QueryBuilder;
+use VuFindSearch\ParamBag;
 use VuFindSearch\Query\Query;
 use VuFindSearch\Query\QueryGroup;
 
@@ -716,6 +717,52 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                     'bq' => ['a:foo'],
                 ],
             ],
+            'Value with SortIn condition' => [
+                'GlobalExtraParams' => [
+                    [
+                        'param' => 'bq',
+                        'value' => 'a:foo',
+                        'conditions' => [
+                            [
+                                'SortIn' => [
+                                    'score desc',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'expected1' => [
+                    'bf' => ['a:filter'],
+                    'bq' => ['a:foo'],
+                ],
+                'expected2' => [
+                    'bf' => null,
+                    'bq' => null,
+                ],
+            ],
+            'Value with SortNotIn condition' => [
+                'GlobalExtraParams' => [
+                    [
+                        'param' => 'bq',
+                        'value' => 'a:foo',
+                        'conditions' => [
+                            [
+                                'SortNotIn' => [
+                                    'score desc',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'expected1' => [
+                    'bf' => ['a:filter'],
+                    'bq' => null,
+                ],
+                'expected2' => [
+                    'bf' => null,
+                    'bq' => ['a:foo'],
+                ],
+            ],
         ];
     }
 
@@ -736,7 +783,9 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
         $expected2
     ) {
         $q1 = new Query('q', 'test');
+        $params1 = new ParamBag(['sort' => 'score desc']);
         $q2 = new Query('q', 'test2');
+        $params2 = new ParamBag(['sort' => 'title asc']);
 
         $specs = [
             'test' => [
@@ -751,7 +800,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
         }
 
         $qb = new QueryBuilder($specs);
-        $response = $qb->build($q1);
+        $response = $qb->build($q1, $params1);
         foreach ($expected1 as $field => $expected) {
             $values = $response->get($field);
             $this->assertEquals(
@@ -760,7 +809,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 'query 1'
             );
         }
-        $response = $qb->build($q2);
+        $response = $qb->build($q2, $params2);
         foreach ($expected2 as $field => $expected) {
             $values = $response->get($field);
             $this->assertEquals(


### PR DESCRIPTION
With the option to check requested sort order it's possible to e.g. add a [ReRank query](https://solr.apache.org/guide/solr/latest/query-guide/query-re-ranking.html) when results are requested in the relevance order without affecting other sort orders.