### PR TITLE
CSP: Generate current Report-To header

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -62,6 +62,25 @@ img-src[] = "'self'"
 ;img-src[] = https://cache3.obalkyknih.cz
 font-src[] = "'self'"
 base-uri[] = "'self'"
-; Set URI that the browser should use to report CSP violation; you should provide
-; this URL when you enable report_only mode to capture the violations.
-;report-to[] = 'https://example.report-uri.com'
+
+; Provide both report-uri and report-to headers to capture CSP violations.  Each is supported
+; by different browsers.  See
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+; 
+; Set URI that some browsers use to report CSP violation.
+;report-uri[] = 'https://example.report-uri.com'
+; Set the named endpoint that other borwsers use to report CSP violations.  The endpoint name
+; should match a group name in ReportTo below.
+;report-to[] = 'CSPReportingEndpoint'
+
+; Define the Report-To response header endpoint groups.  See
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+;[ReportTo]
+;groups[] = 'CSPReportingEndpoint'
+
+; Define each endpoint group named in ReportTo above.
+;[ReportToCSPReportingEndpoint]
+; Maximum seconds to use this reporting endpoint
+;max_age = 10886400
+; URL(s) for this reporting endpoint
+;endpoints_url[] = 'https://example.report-uri.com'

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -80,7 +80,7 @@ base-uri[] = "'self'"
 
 ; Define each endpoint group named in ReportTo above.
 ;[ReportToCSPReportingEndpoint]
-; Maximum seconds to use this reporting endpoint
-;max_age = 10886400
+; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
+;max_age = 86400
 ; URL(s) for this reporting endpoint
 ;endpoints_url[] = 'https://example.report-uri.com'

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -354,5 +354,8 @@ class Bootstrapper
         if ($cspHeader = $cspHeaderGenerator->getHeader()) {
             $headers->addHeader($cspHeader);
         }
+        if ($reportToHeader = $cspHeaderGenerator->getReportToHeader()) {
+            $headers->addHeader($reportToHeader);
+        }
     }
 }

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -351,7 +351,7 @@ class Bootstrapper
         $headers = $this->event->getResponse()->getHeaders();
         $cspHeaderGenerator = $this->container
             ->get(\VuFind\Security\CspHeaderGenerator::class);
-        foreach ($cspHeaders = $cspHeaderGenerator->getHeaders() as $cspHeader) {
+        foreach ($cspHeaderGenerator->getHeaders() as $cspHeader) {
             $headers->addHeader($cspHeader);
         }
     }

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -351,11 +351,8 @@ class Bootstrapper
         $headers = $this->event->getResponse()->getHeaders();
         $cspHeaderGenerator = $this->container
             ->get(\VuFind\Security\CspHeaderGenerator::class);
-        if ($cspHeader = $cspHeaderGenerator->getHeader()) {
+        foreach ($cspHeaders = $cspHeaderGenerator->getHeaders() as $cspHeader) {
             $headers->addHeader($cspHeader);
-        }
-        if ($reportToHeader = $cspHeaderGenerator->getReportToHeader()) {
-            $headers->addHeader($reportToHeader);
         }
     }
 }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -155,7 +155,7 @@ class CspHeaderGenerator
         if (!$groupsText) {
             return false;
         }
-        $reportToHeader->setFieldValue(join(", ", $groupsText));
+        $reportToHeader->setFieldValue(implode(", ", $groupsText));
         return $reportToHeader;
     }
 }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -108,7 +108,7 @@ class CspHeaderGenerator implements
             if ($name == 'report-to') {
                 foreach ($sources as $source) {
                     if (str_contains($source, '://')) {
-                        $this->logWarning("CSP report-to directive should not be a URI.");
+                        $this->logWarning('CSP report-to directive should not be a URI.');
                     }
                 }
             }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -46,8 +46,11 @@ use function in_array;
  *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class CspHeaderGenerator
+class CspHeaderGenerator implements
+    \Laminas\Log\LoggerAwareInterface
 {
+    use \VuFind\Log\LoggerAwareTrait;
+
     /**
      * Configuration for generator from contensecuritypolicy.ini
      *
@@ -100,6 +103,14 @@ class CspHeaderGenerator
                 && $this->config->CSP->use_nonce
             ) {
                 $sources[] = "'nonce-$this->nonce'";
+            }
+            // Warn about report-to being used in place of report-uri
+            if ($name == 'report-to') {
+                foreach ($sources as $source) {
+                    if (str_contains($source, '://')) {
+                        $this->logWarning("CSP report-to directive should not be a URI.");
+                    }
+                }
             }
             $cspHeader->setDirective($name, $sources);
         }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -155,7 +155,7 @@ class CspHeaderGenerator
         if (!$groupsText) {
             return false;
         }
-        $reportToHeader->setFieldValue(implode(", ", $groupsText));
+        $reportToHeader->setFieldValue(implode(', ', $groupsText));
         return $reportToHeader;
     }
 }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -136,7 +136,7 @@ class CspHeaderGenerator implements
     /**
      * Create Report-To header based on given configuration
      *
-     * @return >GenericHeader
+     * @return ?GenericHeader
      */
     public function getReportToHeader()
     {

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -180,7 +180,7 @@ class CspHeaderGenerator implements
             if ($groupConfig) {
                 $group = [
                     'group' => $groupName,
-                    'max-age' => $groupConfig->max_age ?? 86400, // one day
+                    'max_age' => $groupConfig->max_age ?? 86400, // one day
                     'endpoints' => [],
                 ];
                 foreach ($groupConfig->endpoints_url ?? [] as $url) {

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -136,7 +136,7 @@ class CspHeaderGenerator implements
     /**
      * Create Report-To header based on given configuration
      *
-     * @return GenericHeader
+     * @return >GenericHeader
      */
     public function getReportToHeader()
     {
@@ -164,7 +164,7 @@ class CspHeaderGenerator implements
         }
 
         if (!$groupsText) {
-            return false;
+            return null;
         }
         $reportToHeader->setFieldValue(implode(', ', $groupsText));
         return $reportToHeader;

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -85,11 +85,40 @@ class CspHeaderGenerator implements
     }
 
     /**
+     * Create all relevant CSP-related headers based on given configuration
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        $headers = [];
+        if ($cspHeader = $this->getCspHeader()) {
+            $headers[] = $cspHeader;
+        }
+        if ($reportToHeader = $this->getReportToHeader()) {
+            $headers[] = $reportToHeader;
+        }
+        return $headers;
+    }
+
+    /**
+     * Create CSP header base on given configuration
+     *
+     * @return ContentSecurityPolicy
+     *
+     * @deprecated Use getCspHeader instead
+     */
+    public function getHeader()
+    {
+        return $this->getCspHeader();
+    }
+
+    /**
      * Create CSP header base on given configuration
      *
      * @return ContentSecurityPolicy
      */
-    public function getHeader()
+    public function getCspHeader()
     {
         $cspHeader = $this->createHeaderObject();
         $directives = $this->config->Directives ?? [];

--- a/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
+++ b/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
@@ -1,0 +1,86 @@
+; Settings for Content Security Policy header; you can learn more here:
+; https://vufind.org/wiki/administration:security:content_security_policy
+[CSP]
+; This setting can be used to control the operating mode for each APPLICATION_ENV
+; value (written as an array key below). Please note that the Whoops error handler
+; (enabled in development mode) does not show correctly when enabled[development] is
+; set to true.
+;
+; Following options are supported:
+; false         - Disabled
+; "report_only" - Enabled in report-only mode (default). See report-to setting below.
+; true          - Enabled in enforcing mode
+enabled[production] = "report_only"
+enabled[development] = "report_only"
+
+; The nonce (number used once) - unique number for each request. It is strongly
+; recommended to keep this setting on. The generated nonce directive is automatically
+; added to script-src directives if any are set in [Directives] below.
+use_nonce = true
+
+; Directives; you can find a list of available directives on this page:
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+; For evaluation of CSP you can use this tool provided by Google:
+; https://csp-evaluator.withgoogle.com/
+; See also the VuFind wiki for additional recommendations and tools:
+; https://vufind.org/wiki/administration:security:content_security_policy
+[Directives]
+; default of 'self' with 'none' on child, object, prefetch allows SVG requests.
+default-src[] = "'self'"
+child-src[] = "'none'"
+object-src[] = "'none'"
+; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
+;   Safari 15.3 and earlier does not support this feature. Since these browser
+;   versions constitute a significant portion of users, especially mobile users,
+;   'strict-dynamic' is disabled by default.
+;   https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
+;script-src[] = "'strict-dynamic'"
+; backwards compatible to CSP 2
+script-src[] = "http:"
+script-src[] = "https:"
+;script-src-elem[] = "'self'"
+connect-src[] = "'self'"
+; If you are using Google Analytics, uncomment the line below
+;connect-src[] = "https://*.google-analytics.com"
+; worker-src required for jsTree with browsers that don't support 'strict-dynamic' (e.g. Safari):
+worker-src[] = "blob:"
+style-src[] = "'self'"
+style-src[] = "'unsafe-inline'"
+img-src[] = "'self'"
+; If you are using LibGuidesProfile recommendation module, uncomment the line below
+;img-src[] = libapps.s3.amazonaws.com
+; If you are using MapSelection recommendation module, uncomment a line below
+; for the basemap you are using:
+;img-src[] = "https://maps.wikimedia.org"
+;img-src[] = "http://tile.stamen.com"
+;img-src[] = "http://basemaps.cartocdn.com"
+; If you are using ObalkyKnih as cover service you will need to uncomment the two
+; lines below. Note these are default URLs; their change is unlikely but possible,
+; so you should ensure they are still valid.
+;img-src[] = https://cache.obalkyknih.cz
+;img-src[] = https://cache2.obalkyknih.cz
+;img-src[] = https://cache3.obalkyknih.cz
+font-src[] = "'self'"
+base-uri[] = "'self'"
+
+; Provide both report-uri and report-to headers to capture CSP violations.  Each is supported
+; by different browsers.  See
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+; 
+; Set URI that some browsers use to report CSP violation.
+report-uri[] = 'https://abc.report-uri.com'
+; Set the named endpoint that other borwsers use to report CSP violations.  The endpoint name
+; should match a group name in ReportTo below.
+report-to[] = 'CSPReportingEndpoint'
+
+; Define the Report-To response header endpoint groups.  See
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+[ReportTo]
+groups[] = 'CSPReportingEndpoint'
+
+; Define each endpoint group named in ReportTo above.
+[ReportToCSPReportingEndpoint]
+; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
+max_age = 12345
+; URL(s) for this reporting endpoint
+endpoints_url[] = 'https://abc.report-uri.com'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -76,7 +76,7 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $header = $generator->getReportToHeader();
         $expectedHeader =
-            '{"group":"CSPReportingEndpoint","max-age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}';
+            '{"group":"CSPReportingEndpoint","max_age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}';
         $this->assertEquals($expectedHeader, $header->getFieldValue());
     }
 
@@ -104,8 +104,8 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
         $header = $generator->getReportToHeader();
         // phpcs:disable Generic.Files.LineLength
         $expectedHeader =
-            '{"group":"CSPReportingEndpoint","max-age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}, ' .
-            '{"group":"Endpoint2","max-age":"67890","endpoints":[{"url":"https://url1.endpoint2.com"},{"url":"https://url2.endpoint2.com"}]}';
+            '{"group":"CSPReportingEndpoint","max_age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}, ' .
+            '{"group":"Endpoint2","max_age":"67890","endpoints":[{"url":"https://url1.endpoint2.com"},{"url":"https://url2.endpoint2.com"}]}';
         // phpcs:enable
         $this->assertEquals($expectedHeader, $header->getFieldValue());
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -75,9 +75,10 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
         $generator = $this->buildGenerator($configData);
 
         $header = $generator->getReportToHeader();
-        $expectedHeader =
+        $expectedHeaderValue =
             '{"group":"CSPReportingEndpoint","max_age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}';
-        $this->assertEquals($expectedHeader, $header->getFieldValue());
+        $this->assertEquals($expectedHeaderValue, $header->getFieldValue());
+        $this->assertEquals('Report-To', $header->getFieldName());
     }
 
     /**
@@ -103,11 +104,12 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
 
         $header = $generator->getReportToHeader();
         // phpcs:disable Generic.Files.LineLength
-        $expectedHeader =
+        $expectedHeaderValue =
             '{"group":"CSPReportingEndpoint","max_age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}, ' .
             '{"group":"Endpoint2","max_age":"67890","endpoints":[{"url":"https://url1.endpoint2.com"},{"url":"https://url2.endpoint2.com"}]}';
         // phpcs:enable
-        $this->assertEquals($expectedHeader, $header->getFieldValue());
+        $this->assertEquals($expectedHeaderValue, $header->getFieldValue());
+        $this->assertEquals('Report-To', $header->getFieldName());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * CspHeaderGenerator test
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Security;
+
+use VuFind\Security\CspHeaderGenerator;
+
+/**
+ * CspHeaderGenerator test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\FixtureTrait;
+
+    /**
+     * Nonce generator mock
+     *
+     * @type \PHPUnit\Framework\MockObject
+     */
+    protected $nonceGenerator;
+
+    /**
+     * Set up the tests
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->nonceGenerator = $this->createMock(\VuFind\Security\NonceGenerator::class);
+    }
+
+    /**
+     * Test a basic ReportTo header configuration
+     *
+     * @return void
+     */
+    public function testReportToHeaderSimple(): void
+    {
+        $configData = parse_ini_file(
+            $this->getFixtureDir() . 'configs/contentsecuritypolicy/contentsecuritypolicy.ini',
+            true
+        );
+        $generator = $this->buildGenerator($configData);
+
+        $header = $generator->getReportToHeader();
+        $expectedHeader =
+            '{"group":"CSPReportingEndpoint","max-age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}';
+        $this->assertEquals($expectedHeader, $header->getFieldValue());
+    }
+
+    /**
+     * Test a ReportTo header configuration with two endpoints and three urls
+     *
+     * @return void
+     */
+    public function testReportToHeaderComplex(): void
+    {
+        $configData = parse_ini_file(
+            $this->getFixtureDir() . 'configs/contentsecuritypolicy/contentsecuritypolicy.ini',
+            true
+        );
+        $configData['ReportTo']['groups'][] = 'Endpoint2';
+        $configData['ReportToEndpoint2'] = [
+            'max_age' => '67890',
+            'endpoints_url' => [
+                'https://url1.endpoint2.com',
+                'https://url2.endpoint2.com',
+            ],
+        ];
+        $generator = $this->buildGenerator($configData);
+
+        $header = $generator->getReportToHeader();
+        // phpcs:disable Generic.Files.LineLength
+        $expectedHeader =
+            '{"group":"CSPReportingEndpoint","max-age":"12345","endpoints":[{"url":"https://abc.report-uri.com"}]}, ' .
+            '{"group":"Endpoint2","max-age":"67890","endpoints":[{"url":"https://url1.endpoint2.com"},{"url":"https://url2.endpoint2.com"}]}';
+        // phpcs:enable
+        $this->assertEquals($expectedHeader, $header->getFieldValue());
+    }
+
+    /**
+     * Build the CspHeaderGenerator object
+     *
+     * @param array $configData The contentsecuritypolicy.ini config data as an array
+     *
+     * @return CspHeaderGenerator
+     */
+    protected function buildGenerator($configData)
+    {
+        $config = new \Laminas\Config\Config($configData);
+        $generator = new CspHeaderGenerator($config, $this->nonceGenerator);
+        return $generator;
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -47,7 +47,7 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * Nonce generator mock
      *
-     * @type \PHPUnit\Framework\MockObject
+     * @var \PHPUnit\Framework\MockObject&\VuFind\Security\NonceGenerator
      */
     protected $nonceGenerator;
 


### PR DESCRIPTION
The state of CSP (content security policy) reporting headers has changed since CSP support was [originally added](https://github.com/vufind-org/vufind/pull/1494).  In the CSP and CSP-Report-Only headers, 

- the [report-uri directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) is now deprecated and allegedly not supported in browsers that support the new report-to directive, but is still necessary for those browsers that don't.
- the [report-to directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) has a very different format than report-uri -- it's not just a copy of the URL.  It requires another supporting HTTP header "Report-To".

TODO
- [x] Write some unit tests.
- [x] Add note to changelog about report-to directive having a different use; needing to add report-uri etc.
- [x] Add note about deprecation of CspHeaderGenerator::getHeader() to appropriate JIRA deprecation ticket