### PR TITLE
Generate NEL (Network Error Logging) header

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -88,7 +88,7 @@ base-uri[] = "'self'"
 ; Send the NEL (Network Error Logging) HTTP response header.
 ; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL
 ;[NetworkErrorLogging]
-; Set the named endpoint that borwsers use to report network errors.  The endpoint name
+; Set the named endpoint that browsers use to report network errors.  The endpoint name
 ; should match a group name in ReportTo above.
 ;report_to = CSPReportingEndpoint
 ; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -93,7 +93,7 @@ base-uri[] = "'self'"
 ;report_to = CSPReportingEndpoint
 ; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
 ;max_age = 86400
-; The following properties  are optional in the NEL specification, so VuFind will include
+; The following properties are optional in the NEL specification, so VuFind will include
 ; them in the NEL response header only if they are specified here.  See definitions at
 ; https://w3c.github.io/network-error-logging/#nel-response-header
 ;include_subdomains = false

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -84,3 +84,17 @@ base-uri[] = "'self'"
 ;max_age = 86400
 ; URL(s) for this reporting endpoint
 ;endpoints_url[] = 'https://example.report-uri.com'
+
+; Send the NEL (Network Error Logging) HTTP response header.
+; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL
+;[NetworkErrorLogging]
+; Set the named endpoint that borwsers use to report network errors.  The endpoint name
+; should match a group name in ReportTo above.
+;report_to = CSPReportingEndpoint
+; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
+;max_age = 86400
+; The following properties  are optional in the NEL specification, so VuFind will include
+; them in the NEL response header only if they are specified here.  See definitions at
+; https://w3c.github.io/network-error-logging/#nel-response-header
+;include_subdomains = false
+;failure_fraction = 1.0

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -220,8 +220,12 @@ class CspHeaderGenerator implements
             return null;
         }
         $nelData['max_age'] = $nelConfig['max_age'] ?? 86400; // one day
-        $nelData['include_subdomains'] = $nelConfig['include_subdomains'] ?? false;
-        $nelData['failure_fraction'] = (float)$nelConfig['failure_fraction'] ?? 1.0;
+        if ($includeSubdomains = (bool)$nelConfig['include_subdomains'] ?? null) {
+            $nelData['include_subdomains'] = $includeSubdomains;
+        }
+        if ($failureFraction = (float)$nelConfig['failure_fraction'] ?? null) {
+            $nelData['failure_fraction'] = $failureFraction;
+        }
 
         $nelText = json_encode($nelData, JSON_UNESCAPED_SLASHES);
         $nelHeader->setFieldValue($nelText);

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -220,11 +220,11 @@ class CspHeaderGenerator implements
             return null;
         }
         $nelData['max_age'] = $nelConfig['max_age'] ?? 86400; // one day
-        if ($includeSubdomains = (bool)$nelConfig['include_subdomains'] ?? null) {
-            $nelData['include_subdomains'] = $includeSubdomains;
+        if (isset($nelConfig['include_subdomains'])) {
+            $nelData['include_subdomains'] = (bool)$nelConfig['include_subdomains'];
         }
-        if ($failureFraction = (float)$nelConfig['failure_fraction'] ?? null) {
-            $nelData['failure_fraction'] = $failureFraction;
+        if (isset($nelConfig['failure_fraction'])) {
+            $nelData['failure_fraction'] = (float)$nelConfig['failure_fraction'];
         }
 
         $nelText = json_encode($nelData, JSON_UNESCAPED_SLASHES);

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -98,6 +98,9 @@ class CspHeaderGenerator implements
         if ($reportToHeader = $this->getReportToHeader()) {
             $headers[] = $reportToHeader;
         }
+        if ($nelHeader = $this->getNetworkErrorLoggingHeader()) {
+            $headers[] = $nelHeader;
+        }
         return $headers;
     }
 
@@ -197,5 +200,31 @@ class CspHeaderGenerator implements
         }
         $reportToHeader->setFieldValue(implode(', ', $groupsText));
         return $reportToHeader;
+    }
+
+    /**
+     * Create NEL (Network Error Logging) header based on given configuration
+     *
+     * @return ?GenericHeader
+     */
+    public function getNetworkErrorLoggingHeader()
+    {
+        $nelHeader = new \Laminas\Http\Header\GenericHeader();
+        $nelHeader->setFieldName('NEL');
+        $nelData = [];
+
+        $nelConfig = $this->config->NetworkErrorLogging;
+        if ($reportTo = $nelConfig['report_to'] ?? null) {
+            $nelData['report_to'] = $reportTo;
+        } else {
+            return null;
+        }
+        $nelData['max_age'] = $nelConfig['max_age'] ?? 86400; // one day
+        $nelData['include_subdomains'] = $nelConfig['include_subdomains'] ?? false;
+        $nelData['failure_fraction'] = (float)$nelConfig['failure_fraction'] ?? 1.0;
+
+        $nelText = json_encode($nelData, JSON_UNESCAPED_SLASHES);
+        $nelHeader->setFieldValue($nelText);
+        return $nelHeader;
     }
 }

--- a/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
+++ b/module/VuFind/src/VuFind/Security/CspHeaderGenerator.php
@@ -36,7 +36,9 @@ use Laminas\Http\Header\GenericHeader;
 use function in_array;
 
 /**
- * VuFind class for generating Content Security Policy http headers
+ * VuFind class for generating Content Security Policy http headers.
+ * Also generates related headers like NEL (network error logging)
+ * and reporting headers like Report-To.
  *
  * @category VuFind
  * @package  Security

--- a/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
+++ b/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
@@ -84,3 +84,17 @@ groups[] = 'CSPReportingEndpoint'
 max_age = 12345
 ; URL(s) for this reporting endpoint
 endpoints_url[] = 'https://abc.report-uri.com'
+
+; Send the NEL (Network Error Logging) HTTP response header.
+; See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL
+[NetworkErrorLogging]
+; Set the named endpoint that browsers use to report network errors.  The endpoint name
+; should match a group name in ReportTo above.
+report_to = CSPReportingEndpoint
+; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
+max_age = 55555
+; The following properties  are optional in the NEL specification, so VuFind will include
+; them in the NEL response header only if they are specified here.  See definitions at
+; https://w3c.github.io/network-error-logging/#nel-response-header
+;include_subdomains = false
+;failure_fraction = 1.0

--- a/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
+++ b/module/VuFind/tests/fixtures/configs/contentsecuritypolicy/contentsecuritypolicy.ini
@@ -93,7 +93,7 @@ endpoints_url[] = 'https://abc.report-uri.com'
 report_to = CSPReportingEndpoint
 ; Maximum seconds to use this reporting endpoint.  Default (86400) is one day.
 max_age = 55555
-; The following properties  are optional in the NEL specification, so VuFind will include
+; The following properties are optional in the NEL specification, so VuFind will include
 ; them in the NEL response header only if they are specified here.  See definitions at
 ; https://w3c.github.io/network-error-logging/#nel-response-header
 ;include_subdomains = false

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -155,6 +155,29 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test a Network Error Logging header configuration with falsy values
+     *
+     * @return void
+     */
+    public function testNetworkErrorLoggingHeaderFalsyValues(): void
+    {
+        $configData = parse_ini_file(
+            $this->getFixtureDir() . 'configs/contentsecuritypolicy/contentsecuritypolicy.ini',
+            true
+        );
+        $configData['NetworkErrorLogging']['max_age'] = 0;
+        $configData['NetworkErrorLogging']['include_subdomains'] = false;
+        $configData['NetworkErrorLogging']['failure_fraction'] = 0;
+        $generator = $this->buildGenerator($configData);
+
+        $header = $generator->getNetworkErrorLoggingHeader();
+        $expectedHeaderValue =
+            '{"report_to":"CSPReportingEndpoint","max_age":0,"include_subdomains":false,"failure_fraction":0}';
+        $this->assertEquals($expectedHeaderValue, $header->getFieldValue());
+        $this->assertEquals('NEL', $header->getFieldName());
+    }
+
+    /**
      * Build the CspHeaderGenerator object
      *
      * @param array $configData The contentsecuritypolicy.ini config data as an array

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Security/CspHeaderGeneratorTest.php
@@ -113,6 +113,48 @@ class CspHeaderGeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test a basic Network Error Logging header configuration
+     *
+     * @return void
+     */
+    public function testNetworkErrorLoggingHeaderSimple(): void
+    {
+        $configData = parse_ini_file(
+            $this->getFixtureDir() . 'configs/contentsecuritypolicy/contentsecuritypolicy.ini',
+            true
+        );
+        $generator = $this->buildGenerator($configData);
+
+        $header = $generator->getNetworkErrorLoggingHeader();
+        $expectedHeaderValue =
+            '{"report_to":"CSPReportingEndpoint","max_age":"55555"}';
+        $this->assertEquals($expectedHeaderValue, $header->getFieldValue());
+        $this->assertEquals('NEL', $header->getFieldName());
+    }
+
+    /**
+     * Test a Network Error Logging header configuration with custom params
+     *
+     * @return void
+     */
+    public function testNetworkErrorLoggingHeaderComplex(): void
+    {
+        $configData = parse_ini_file(
+            $this->getFixtureDir() . 'configs/contentsecuritypolicy/contentsecuritypolicy.ini',
+            true
+        );
+        $configData['NetworkErrorLogging']['include_subdomains'] = true;
+        $configData['NetworkErrorLogging']['failure_fraction'] = 0.5;
+        $generator = $this->buildGenerator($configData);
+
+        $header = $generator->getNetworkErrorLoggingHeader();
+        $expectedHeaderValue =
+            '{"report_to":"CSPReportingEndpoint","max_age":"55555","include_subdomains":true,"failure_fraction":0.5}';
+        $this->assertEquals($expectedHeaderValue, $header->getFieldValue());
+        $this->assertEquals('NEL', $header->getFieldName());
+    }
+
+    /**
      * Build the CspHeaderGenerator object
      *
      * @param array $configData The contentsecuritypolicy.ini config data as an array


### PR DESCRIPTION
Generate the `NEL` HTTP response header for network error logging.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL

TODO

- [x] Unit testing
- [x] Sample config