### PR TITLE
VUFIND-1682 - Flash message update for purgeTransactionHistory

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CheckoutsController.php
+++ b/module/VuFind/src/VuFind/Controller/CheckoutsController.php
@@ -233,7 +233,7 @@ class CheckoutsController extends AbstractBase
             }
             $this->flashMessenger()->addMessage(
                 $result['status'],
-                $result['success'] ? 'info' : 'error'
+                $result['success'] ? 'success' : 'error'
             );
         }
         return $redirectResponse;


### PR DESCRIPTION
Updated CheckoutsController.php so that the confirmation menu banners for "Selected loans have been purged from your loan history" and "Your loan history has been purged" now display as green (success) rather than blue (info). 

This is based on suggestions I made in VUFIND-1682.