### PR TITLE
Modernize OAI server code and improve test coverage

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -29,6 +29,9 @@
 
 namespace VuFind\Db\Row;
 
+use DateTime;
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
+
 /**
  * Row Definition for oai_resumption
  *
@@ -42,7 +45,7 @@ namespace VuFind\Db\Row;
  * @property string $params
  * @property string $expires
  */
-class OaiResumption extends RowGateway implements \VuFind\Db\Entity\OaiResumptionEntityInterface
+class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
 {
     /**
      * Constructor
@@ -58,6 +61,8 @@ class OaiResumption extends RowGateway implements \VuFind\Db\Entity\OaiResumptio
      * Extract an array of parameters from the object.
      *
      * @return array Original saved parameters.
+     *
+     * @deprecated Use parse_str() instead
      */
     public function restoreParams()
     {
@@ -87,5 +92,61 @@ class OaiResumption extends RowGateway implements \VuFind\Db\Entity\OaiResumptio
             $processedParams[] = urlencode($key) . '=' . urlencode($value);
         }
         $this->params = implode('&', $processedParams);
+    }
+
+    /**
+     * Id getter
+     *
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Resumption parameters setter
+     *
+     * @param ?string $params Resumption parameters.
+     *
+     * @return OaiResumptionEntityInterface
+     */
+    public function setResumptionParameters(?string $params): OaiResumptionEntityInterface
+    {
+        $this->params = $params;
+        return $this;
+    }
+
+    /**
+     * Get resumption parameters.
+     *
+     * @return ?string
+     */
+    public function getResumptionParameters(): ?string
+    {
+        return $this->params;
+    }
+
+    /**
+     * Expiry date setter.
+     *
+     * @param Datetime $dateTime Expiration date
+     *
+     * @return OaiResumptionEntityInterface
+     */
+    public function setExpiry(DateTime $dateTime): OaiResumptionEntityInterface
+    {
+        $this->expires = $dateTime->format('Y-m-d H:i:s');
+        return $this;
+    }
+
+    /**
+     * Get expiry date.
+     *
+     * @return DateTime
+     */
+    public function getExpiry(): DateTime
+    {
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->expires);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -83,6 +83,8 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
      * @param array $params Parameters to save.
      *
      * @return void
+     *
+     * @deprecated
      */
     public function saveParams($params)
     {

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -84,7 +84,7 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
      *
      * @return void
      *
-     * @deprecated
+     * @deprecated Use \VuFind\Db\Service\OaiResumptionService::saveToken()
      */
     public function saveParams($params)
     {

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -68,9 +68,9 @@ class OaiResumptionService extends AbstractDbService implements
      *
      * @param string $token The resumption token to retrieve.
      *
-     * @return ?OaiResumption
+     * @return ?OaiResumptionEntityInterface
      */
-    public function findToken($token): ?OaiResumptionEntityInterface
+    public function findToken(string $token): ?OaiResumptionEntityInterface
     {
         return $this->getDbTable('oairesumption')->findToken($token);
     }
@@ -82,8 +82,10 @@ class OaiResumptionService extends AbstractDbService implements
      * @param int   $expire Expiration time for token (Unix timestamp).
      *
      * @return int          ID of new token
+     *
+     * @throws \Exception
      */
-    public function saveToken($params, $expire): int
+    public function saveToken(array $params, int $expire): int
     {
         $row = $this->createEntity()
             ->setResumptionParameters($this->encodeParams($params))
@@ -92,7 +94,7 @@ class OaiResumptionService extends AbstractDbService implements
             $this->persistEntity($row);
         } catch (\Exception $e) {
             $this->logError('Could not save token: ' . $e->getMessage());
-            return false;
+            throw $e;
         }
         return $row->getId();
     }
@@ -114,7 +116,7 @@ class OaiResumptionService extends AbstractDbService implements
      *
      * @return string
      */
-    protected function encodeParams($params): string
+    protected function encodeParams(array $params): string
     {
         ksort($params);
         $processedParams = http_build_query($params, '', '&', PHP_QUERY_RFC3986);

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Database service for OaiResumption.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+
+namespace VuFind\Db\Service;
+
+use Laminas\Log\LoggerAwareInterface;
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
+use VuFind\Db\Table\DbTableAwareInterface;
+use VuFind\Db\Table\DbTableAwareTrait;
+use VuFind\Log\LoggerAwareTrait;
+
+/**
+ * Database service for OaiResumption.
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+class OaiResumptionService extends AbstractDbService implements
+    DbTableAwareInterface,
+    LoggerAwareInterface,
+    OaiResumptionServiceInterface
+{
+    use DbTableAwareTrait;
+    use LoggerAwareTrait;
+
+    /**
+     * Remove all expired tokens from the database.
+     *
+     * @return void
+     */
+    public function removeExpired(): void
+    {
+        return $this->getDbTable('oairesumption')->removeExpired();
+    }
+
+    /**
+     * Retrieve a row from the database based on primary key; return null if it
+     * is not found.
+     *
+     * @param string $token The resumption token to retrieve.
+     *
+     * @return ?OaiResumption
+     */
+    public function findToken($token): ?OaiResumptionEntityInterface
+    {
+        return $this->getDbTable('oairesumption')->findToken($token);
+    }
+
+    /**
+     * Create a new resumption token
+     *
+     * @param array $params Parameters associated with the token.
+     * @param int   $expire Expiration time for token (Unix timestamp).
+     *
+     * @return int          ID of new token
+     */
+    public function saveToken($params, $expire): int
+    {
+        $row = $this->createEntity()
+            ->setResumptionParameters($this->encodeParams($params))
+            ->setExpiry(\DateTime::createFromFormat('U', $expire));
+        try {
+            $this->persistEntity($row);
+        } catch (\Exception $e) {
+            $this->logError('Could not save token: ' . $e->getMessage());
+            return false;
+        }
+        return $row->getId();
+    }
+
+    /**
+     * Create a OaiResumption entity object.
+     *
+     * @return OaiResumptionEntityInterface
+     */
+    public function createEntity(): OaiResumptionEntityInterface
+    {
+        return $this->getDbTable('oairesumption')->createRow();
+    }
+
+    /**
+     * Encode an array of parameters into the object.
+     *
+     * @param array $params Parameters to save.
+     *
+     * @return string
+     */
+    protected function encodeParams($params): string
+    {
+        ksort($params);
+        $processedParams = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        return $processedParams;
+    }
+}

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -59,7 +59,7 @@ class OaiResumptionService extends AbstractDbService implements
      */
     public function removeExpired(): void
     {
-        return $this->getDbTable('oairesumption')->removeExpired();
+        $this->getDbTable('oairesumption')->removeExpired();
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Entity model interface for oai_resumption table
+ * Database service interface for OaiResumption.
  *
  * PHP version 8
  *
@@ -23,61 +23,58 @@
  * @category VuFind
  * @package  Database
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
 
-namespace VuFind\Db\Entity;
+namespace VuFind\Db\Service;
 
-use DateTime;
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
 
 /**
- * Entity model interface for oai_resumption table
+ * Database service interface for OaiResumption.
  *
  * @category VuFind
  * @package  Database
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-interface OaiResumptionEntityInterface extends EntityInterface
+interface OaiResumptionServiceInterface
 {
     /**
-     * Id getter
+     * Remove all expired tokens from the database.
      *
-     * @return int
+     * @return void
      */
-    public function getId(): int;
+    public function removeExpired(): void;
 
     /**
-     * Resumption parameters setter
+     * Retrieve a row from the database based on primary key; return null if it
+     * is not found.
      *
-     * @param ?string $params Resumption parameters.
+     * @param string $token The resumption token to retrieve.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findToken($token): ?OaiResumptionEntityInterface;
+
+    /**
+     * Create a new resumption token
+     *
+     * @param array $params Parameters associated with the token.
+     * @param int   $expire Expiration time for token (Unix timestamp).
+     *
+     * @return int          ID of new token
+     */
+    public function saveToken($params, $expire): int;
+
+    /**
+     * Create a OaiResumption entity object.
      *
      * @return OaiResumptionEntityInterface
      */
-    public function setResumptionParameters(?string $params): OaiResumptionEntityInterface;
-
-    /**
-     * Get resumption parameters.
-     *
-     * @return ?string
-     */
-    public function getResumptionParameters(): ?string;
-
-    /**
-     * Expiry date setter.
-     *
-     * @param Datetime $dateTime Expiration date
-     *
-     * @return OaiResumptionEntityInterface
-     */
-    public function setExpiry(DateTime $dateTime): OaiResumptionEntityInterface;
-
-    /**
-     * Get expiry date.
-     *
-     * @return DateTime
-     */
-    public function getExpiry(): DateTime;
+    public function createEntity(): OaiResumptionEntityInterface;
 }

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -59,7 +59,7 @@ interface OaiResumptionServiceInterface
      *
      * @return ?OaiResumptionEntityInterface
      */
-    public function findToken($token): ?OaiResumptionEntityInterface;
+    public function findToken(string $token): ?OaiResumptionEntityInterface;
 
     /**
      * Create a new resumption token
@@ -69,7 +69,7 @@ interface OaiResumptionServiceInterface
      *
      * @return int          ID of new token
      */
-    public function saveToken($params, $expire): int;
+    public function saveToken(array $params, int $expire): int;
 
     /**
      * Create a OaiResumption entity object.

--- a/module/VuFind/src/VuFind/Db/Service/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Service/PluginManager.php
@@ -48,6 +48,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $aliases = [
         AccessTokenServiceInterface::class => AccessTokenService::class,
         CommentsServiceInterface::class => CommentsService::class,
+        OaiResumptionServiceInterface::class => OaiResumptionService::class,
         ResourceServiceInterface::class => ResourceService::class,
         SessionServiceInterface::class => SessionService::class,
         TagServiceInterface::class => TagService::class,
@@ -62,6 +63,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $factories = [
         AccessTokenService::class => AccessTokenServiceFactory::class,
         CommentsService::class => AbstractDbServiceFactory::class,
+        OaiResumptionService::class => AbstractDbServiceFactory::class,
         ResourceService::class => ResourceServiceFactory::class,
         SessionService::class => SessionServiceFactory::class,
         TagService::class => AbstractDbServiceFactory::class,

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Table;
 
 use Laminas\Db\Adapter\Adapter;
 use VuFind\Db\Row\RowGateway;
+use VuFind\Db\Service\DbServiceAwareInterface;
 
 /**
  * Table Definition for oai_resumption
@@ -41,8 +42,10 @@ use VuFind\Db\Row\RowGateway;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
-class OaiResumption extends Gateway
+class OaiResumption extends Gateway implements DbServiceAwareInterface
 {
+    use \VuFind\Db\Service\DbServiceAwareTrait;
+
     /**
      * Constructor
      *
@@ -96,13 +99,12 @@ class OaiResumption extends Gateway
      * @param int   $expire Expiration time for token (Unix timestamp).
      *
      * @return int          ID of new token
+     *
+     * @deprecated Use \VuFind\Db\Service\OaiResumptionService::saveToken()
      */
     public function saveToken($params, $expire)
     {
-        $row = $this->createRow();
-        $row->saveParams($params);
-        $row->expires = date('Y-m-d H:i:s', $expire);
-        $row->save();
-        return $row->id;
+        return $this->getDbService(\VuFind\Db\Service\OaiResumptionServiceInterface::class)
+            ->saveToken($params, $expire);
     }
 }

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -147,27 +147,6 @@ class Server
     protected $adminEmail;
 
     /**
-     * Results plugin manager
-     *
-     * @var \VuFind\Search\Results\PluginManager
-     */
-    protected $resultsManager;
-
-    /**
-     * Record loader
-     *
-     * @var \VuFind\Record\Loader
-     */
-    protected $recordLoader;
-
-    /**
-     * Table manager
-     *
-     * @var \VuFind\Db\Table\PluginManager
-     */
-    protected $tableManager;
-
-    /**
      * Record link helper (optional)
      *
      * @var \VuFind\View\Helper\Root\RecordLinker
@@ -231,19 +210,15 @@ class Server
     /**
      * Constructor
      *
-     * @param \VuFind\Search\Results\PluginManager $results Search manager for
-     * retrieving records
-     * @param \VuFind\Record\Loader                $loader  Record loader
-     * @param \VuFind\Db\Table\PluginManager       $tables  Table manager
+     * @param \VuFind\Search\Results\PluginManager $resultsManager Search manager for retrieving records
+     * @param \VuFind\Record\Loader                $recordLoader   Record loader
+     * @param \VuFind\Db\Table\PluginManager       $tableManager   Table manager
      */
     public function __construct(
-        \VuFind\Search\Results\PluginManager $results,
-        \VuFind\Record\Loader $loader,
-        \VuFind\Db\Table\PluginManager $tables
+        protected \VuFind\Search\Results\PluginManager $resultsManager,
+        protected \VuFind\Record\Loader $recordLoader,
+        protected \VuFind\Db\Table\PluginManager $tableManager
     ) {
-        $this->resultsManager = $results;
-        $this->recordLoader = $loader;
-        $this->tableManager = $tables;
     }
 
     /**

--- a/module/VuFind/src/VuFind/OAI/Server/Auth.php
+++ b/module/VuFind/src/VuFind/OAI/Server/Auth.php
@@ -47,17 +47,16 @@ class Auth extends Base
     /**
      * Constructor
      *
-     * @param \VuFind\Search\Results\PluginManager $results Search manager for
-     * retrieving records
-     * @param \VuFind\Record\Loader                $loader  Record loader
-     * @param \VuFind\Db\Table\PluginManager       $tables  Table manager
+     * @param \VuFind\Search\Results\PluginManager $resultsManager Search manager for retrieving records
+     * @param \VuFind\Record\Loader                $recordLoader   Record loader
+     * @param \VuFind\Db\Table\PluginManager       $tableManager   Table manager
      */
     public function __construct(
-        \VuFind\Search\Results\PluginManager $results,
-        \VuFind\Record\Loader $loader,
-        \VuFind\Db\Table\PluginManager $tables
+        protected \VuFind\Search\Results\PluginManager $resultsManager,
+        protected \VuFind\Record\Loader $recordLoader,
+        protected \VuFind\Db\Table\PluginManager $tableManager
     ) {
-        parent::__construct($results, $loader, $tables);
+        parent::__construct($resultsManager, $recordLoader, $tableManager);
         $this->core = 'authority';
         $this->searchClassId = 'SolrAuth';
     }

--- a/module/VuFind/src/VuFind/OAI/Server/Auth.php
+++ b/module/VuFind/src/VuFind/OAI/Server/Auth.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\OAI\Server;
 
+use VuFind\Db\Service\OaiResumptionServiceInterface;
 use VuFind\OAI\Server as Base;
 
 /**
@@ -47,16 +48,18 @@ class Auth extends Base
     /**
      * Constructor
      *
-     * @param \VuFind\Search\Results\PluginManager $resultsManager Search manager for retrieving records
-     * @param \VuFind\Record\Loader                $recordLoader   Record loader
-     * @param \VuFind\Db\Table\PluginManager       $tableManager   Table manager
+     * @param \VuFind\Search\Results\PluginManager $resultsManager    Search manager for retrieving records
+     * @param \VuFind\Record\Loader                $recordLoader      Record loader
+     * @param \VuFind\Db\Table\PluginManager       $tableManager      Table manager
+     * @param OaiResumptionServiceInterface        $resumptionService Database service for resumption tokens
      */
     public function __construct(
         protected \VuFind\Search\Results\PluginManager $resultsManager,
         protected \VuFind\Record\Loader $recordLoader,
-        protected \VuFind\Db\Table\PluginManager $tableManager
+        protected \VuFind\Db\Table\PluginManager $tableManager,
+        protected OaiResumptionServiceInterface $resumptionService
     ) {
-        parent::__construct($resultsManager, $recordLoader, $tableManager);
+        parent::__construct($resultsManager, $recordLoader, $tableManager, $resumptionService);
         $this->core = 'authority';
         $this->searchClassId = 'SolrAuth';
     }

--- a/module/VuFind/src/VuFind/OAI/ServerFactory.php
+++ b/module/VuFind/src/VuFind/OAI/ServerFactory.php
@@ -68,10 +68,14 @@ class ServerFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
+        $servicePluginManager = $container->get(
+            \VuFind\Db\Service\PluginManager::class
+        );
         return new $requestedName(
             $container->get(\VuFind\Search\Results\PluginManager::class),
             $container->get(\VuFind\Record\Loader::class),
-            $container->get(\VuFind\Db\Table\PluginManager::class)
+            $container->get(\VuFind\Db\Table\PluginManager::class),
+            $servicePluginManager->get(\VuFind\Db\Service\OaiResumptionServiceInterface::class)
         );
     }
 }

--- a/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * HTTP request helper methods for integration tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Feature;
+
+/**
+ * HTTP request helper methods for integration tests.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait HttpRequestTrait
+{
+    use RemoteCoverageTrait;
+
+    /**
+     * Perform an HTTP get operation with coverage awareness.
+     *
+     * @param string $url URL to retrieve
+     *
+     * @return \Laminas\Http\Response
+     */
+    protected function httpGet(string $url): \Laminas\Http\Response
+    {
+        $http = new \VuFindHttp\HttpService();
+        $headers = ($coverageDir = $this->getRemoteCoverageDirectory())
+            ? [
+                'X-VuFind-Remote-Coverage' => json_encode(
+                    [
+                        'action' => 'record',
+                        'testName' => $this->getTestName(),
+                        'outputDir' => $coverageDir,
+                    ]
+                )
+            ] : [];
+        return $http->get($url, headers: $headers);
+    }
+}

--- a/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
@@ -60,7 +60,7 @@ trait HttpRequestTrait
                         'testName' => $this->getTestName(),
                         'outputDir' => $coverageDir,
                     ]
-                )
+                ),
             ] : [];
         return $http->get($url, headers: $headers);
     }

--- a/module/VuFind/src/VuFindTest/Feature/RemoteCoverageTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/RemoteCoverageTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Remote coverage helper methods for integration tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Feature;
+
+/**
+ * Remote coverage helper methods for integration tests.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait RemoteCoverageTrait
+{
+    /**
+     * Get the remote coverage directory (or return null if remote coverage disabled)
+     *
+     * @return ?string
+     */
+    public function getRemoteCoverageDirectory(): ?string
+    {
+        return getenv('VUFIND_REMOTE_COVERAGE_DIR') ?: null;
+    }
+}

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -56,6 +56,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
 {
     use \VuFindTest\Feature\LiveDetectionTrait;
     use \VuFindTest\Feature\PathResolverTrait;
+    use \VuFindTest\Feature\RemoteCoverageTrait;
 
     public const DEFAULT_TIMEOUT = 5000;
 
@@ -283,7 +284,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     {
         if (empty($this->session)) {
             $this->session = new Session($this->getMinkDriver());
-            if ($coverageDir = getenv('VUFIND_REMOTE_COVERAGE_DIR')) {
+            if ($coverageDir = $this->getRemoteCoverageDirectory()) {
                 $this->session->setRemoteCoverageConfig(
                     $this->getTestName(),
                     $coverageDir
@@ -292,29 +293,6 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             $this->session->start();
         }
         return $this->session;
-    }
-
-    /**
-     * Perform an HTTP get operation with coverage awareness.
-     *
-     * @param string $url URL to retrieve
-     *
-     * @return \Laminas\Http\Response
-     */
-    protected function httpGet(string $url): \Laminas\Http\Response
-    {
-        $http = new \VuFindHttp\HttpService();
-        $headers = ($coverageDir = getenv('VUFIND_REMOTE_COVERAGE_DIR'))
-            ? [
-                'X-VuFind-Remote-Coverage' => json_encode(
-                    [
-                        'action' => 'record',
-                        'testName' => $this->getTestName(),
-                        'outputDir' => $coverageDir,
-                    ]
-                )
-            ] : [];
-        return $http->get($url, headers: $headers);
     }
 
     /**

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -295,6 +295,27 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Perform an HTTP get operation with coverage awareness.
+     *
+     * @return \Laminas\Http\Response
+     */
+    protected function httpGet($url): \Laminas\Http\Response
+    {
+        $http = new \VuFindHttp\HttpService();
+        $headers = ($coverageDir = getenv('VUFIND_REMOTE_COVERAGE_DIR'))
+            ? [
+                'X-VuFind-Remote-Coverage' => json_encode(
+                    [
+                        'action' => 'record',
+                        'testName' => $this->getTestName(),
+                        'outputDir' => $coverageDir,
+                    ]
+                )
+            ] : [];
+        return $http->get($url, headers: $headers);
+    }
+
+    /**
      * Shut down the Mink session.
      *
      * @return void

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -297,9 +297,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Perform an HTTP get operation with coverage awareness.
      *
+     * @param string $url URL to retrieve
+     *
      * @return \Laminas\Http\Response
      */
-    protected function httpGet($url): \Laminas\Http\Response
+    protected function httpGet(string $url): \Laminas\Http\Response
     {
         $http = new \VuFindHttp\HttpService();
         $headers = ($coverageDir = getenv('VUFIND_REMOTE_COVERAGE_DIR'))

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * OAI-PMH test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+declare(strict_types=1);
+
+namespace VuFindTest\Mink;
+
+/**
+ * OAI-PMH test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class OaiTest extends \VuFindTest\Integration\MinkTestCase
+{
+    /**
+     * Data provider describing OAI servers.
+     *
+     * @return array[]
+     */
+    public static function serverProvider(): array
+    {
+        return [
+            'auth' => ['/OAI/Server/Auth'],
+            'biblio' => ['/OAI/Server'],
+        ];
+    }
+
+    /**
+     * Test that OAI-PMH is disabled by default.
+     *
+     * @param string $path URL path to OAI-PMH server.
+     *
+     * @return void
+     *
+     * @dataProvider serverProvider
+     */
+    public function testDisabledByDefault(string $path): void
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/OAI/Server');
+        $page = $session->getPage();
+        $this->assertEquals(
+            'OAI Server Not Configured.',
+            $page->getText()
+        );
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
@@ -103,4 +103,24 @@ class OaiTest extends \VuFindTest\Integration\MinkTestCase
         $xml = simplexml_load_string($rawXml);
         $this->assertEquals('Missing Verb Argument', $xml->error);
     }
+
+    /**
+     * Test that an identify response is provided and includes an appropriate repository name.
+     *
+     * @param string $path URL path to OAI-PMH server.
+     *
+     * @return void
+     *
+     * @dataProvider serverProvider
+     */
+    public function testIdentifyResponseRepositoryName(string $path): void
+    {
+        $this->changeConfigs(['config' => $this->defaultOaiConfig]);
+        $rawXml = file_get_contents($this->getVuFindUrl() . $path . '?verb=Identify');
+        $xml = simplexml_load_string($rawXml);
+        // Authority endpoint overrides default name:
+        $expectedName = $path === '/OAI/AuthServer'
+            ? 'Authority Data Store' : $this->defaultOaiConfig['OAI']['repository_name'];
+        $this->assertEquals($expectedName, $xml->Identify->repositoryName);
+    }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
@@ -44,6 +44,8 @@ use function count;
  */
 class OaiTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use \VuFindTest\Feature\HttpRequestTrait;
+
     /**
      * Default OAI config settings
      *

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/Server/AuthTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/Server/AuthTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * OAI-PMH server unit test.
+ * OAI-PMH auth unit test.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2010.
+ * Copyright (C) Villanova University 2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,7 @@
  *
  * @category Search
  * @package  Service
- * @author   David Maus <maus@hab.de>
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development
  */
@@ -30,18 +30,18 @@
 namespace VuFindTest\OAI;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use VuFind\OAI\Server;
+use VuFind\OAI\Server\Auth;
 
 /**
- * OAI-PMH server unit test.
+ * OAI-PMH auth unit test.
  *
  * @category Search
  * @package  Service
- * @author   David Maus <maus@hab.de>
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development
  */
-class ServerTest extends \PHPUnit\Framework\TestCase
+class AuthTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test an empty input.
@@ -50,20 +50,20 @@ class ServerTest extends \PHPUnit\Framework\TestCase
      */
     public function testEmptyInput(): void
     {
-        $server = $this->getServer();
+        $auth = $this->getAuth();
         $this->assertTrue(
-            str_contains($server->getResponse(), '<error code="badVerb">Missing Verb Argument</error>')
+            str_contains($auth->getResponse(), '<error code="badVerb">Missing Verb Argument</error>')
         );
     }
 
     /**
-     * Get a server object.
+     * Get a auth object.
      *
      * @param array $config Server configuration
      *
-     * @return Server
+     * @return Auth
      */
-    protected function getServer($config = []): Server
+    protected function getAuth(array $config = []): Auth
     {
         // Force an email into the configuration if missing; this is required by the
         // server.
@@ -71,13 +71,13 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             $config['Site']['email'] = 'fake@example.com';
         }
 
-        $server = new Server(
+        $auth = new Auth(
             $this->getMockResultsManager(),
             $this->getMockRecordLoader(),
             $this->getMockTableManager()
         );
-        $server->setRecordFormatter($this->getMockRecordFormatter());
-        return $server;
+        $auth->setRecordFormatter($this->getMockRecordFormatter());
+        return $auth;
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/Server/AuthTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/Server/AuthTest.php
@@ -74,7 +74,8 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $auth = new Auth(
             $this->getMockResultsManager(),
             $this->getMockRecordLoader(),
-            $this->getMockTableManager()
+            $this->getMockTableManager(),
+            $this->getMockResumptionService()
         );
         $auth->setRecordFormatter($this->getMockRecordFormatter());
         return $auth;
@@ -118,5 +119,15 @@ class AuthTest extends \PHPUnit\Framework\TestCase
     protected function getMockRecordFormatter(): MockObject&\VuFindApi\Formatter\RecordFormatter
     {
         return $this->createMock(\VuFindApi\Formatter\RecordFormatter::class);
+    }
+
+    /**
+     * Get a mock resumption Service
+     *
+     * @return MockObject&\VuFind\Db\Service\OaiResumptionService
+     */
+    protected function getMockResumptionService(): MockObject&\VuFind\Db\Service\OaiResumptionService
+    {
+        return $this->createMock(\VuFind\Db\Service\OaiResumptionService::class);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/ServerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/OAI/ServerTest.php
@@ -74,7 +74,8 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         $server = new Server(
             $this->getMockResultsManager(),
             $this->getMockRecordLoader(),
-            $this->getMockTableManager()
+            $this->getMockTableManager(),
+            $this->getMockResumptionService()
         );
         $server->setRecordFormatter($this->getMockRecordFormatter());
         return $server;
@@ -118,5 +119,15 @@ class ServerTest extends \PHPUnit\Framework\TestCase
     protected function getMockRecordFormatter(): MockObject&\VuFindApi\Formatter\RecordFormatter
     {
         return $this->createMock(\VuFindApi\Formatter\RecordFormatter::class);
+    }
+
+    /**
+     * Get a mock resumption Service
+     *
+     * @return MockObject&\VuFind\Db\Service\OaiResumptionService
+     */
+    protected function getMockResumptionService(): MockObject&\VuFind\Db\Service\OaiResumptionService
+    {
+        return $this->createMock(\VuFind\Db\Service\OaiResumptionService::class);
     }
 }

--- a/tests/data/author_relators.mrc.properties
+++ b/tests/data/author_relators.mrc.properties
@@ -1,0 +1,5 @@
+# Turn on change tracking for this record set so we can use it for testing OAI, etc.
+# This data set was chosen arbitrarily based on its size; the change tracking is not
+# specifically related to other relator testing functionality.
+first_indexed = custom, getFirstIndexed(001)
+last_indexed = custom, getLastIndexed(001)


### PR DESCRIPTION
This PR backports most of the OAI resumption token database refactoring from #2233 while also modernizing the style some of the OAI classes and existing tests, and also adding more test coverage. Test coverage is still far from comprehensive, but it now covers basic functionality and will at least detect major breakages of the OAI server.