### PR TITLE
Improve HttpRequestTrait for tests.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
@@ -43,16 +43,13 @@ trait HttpRequestTrait
     use RemoteCoverageTrait;
 
     /**
-     * Perform an HTTP get operation with coverage awareness.
+     * Get extra HTTP headers to support testing.
      *
-     * @param string $url URL to retrieve
-     *
-     * @return \Laminas\Http\Response
+     * @return array
      */
-    protected function httpGet(string $url): \Laminas\Http\Response
+    protected function getExtraVuFindHttpRequestHeaders(): array
     {
-        $http = new \VuFindHttp\HttpService();
-        $headers = ($coverageDir = $this->getRemoteCoverageDirectory())
+        return ($coverageDir = $this->getRemoteCoverageDirectory())
             ? [
                 'X-VuFind-Remote-Coverage' => json_encode(
                     [
@@ -62,6 +59,58 @@ trait HttpRequestTrait
                     ]
                 ),
             ] : [];
-        return $http->get($url, headers: $headers);
+    }
+
+    /**
+     * Perform an HTTP GET operation with coverage awareness.
+     *
+     * @param string $url     Request URL
+     * @param array  $params  Request parameters
+     * @param float  $timeout Request timeout in seconds
+     * @param array  $headers Request headers
+     *
+     * @return \Laminas\Http\Response
+     */
+    protected function httpGet(
+        $url,
+        array $params = [],
+        $timeout = null,
+        array $headers = []
+    ): \Laminas\Http\Response {
+        $http = new \VuFindHttp\HttpService();
+        return $http->get(
+            $url,
+            $params,
+            $timeout,
+            array_merge($headers, $this->getExtraVuFindHttpRequestHeaders())
+        );
+    }
+
+    /**
+     * Perform an HTTP POST operation with coverage awareness.
+     *
+     * @param string $url     Request URL
+     * @param mixed  $body    Request body document
+     * @param string $type    Request body content type
+     * @param float  $timeout Request timeout in seconds
+     * @param array  $headers Request http-headers
+     *
+     * @return \Laminas\Http\Response
+     */
+    protected function httpPost(
+        $url,
+        $body = null,
+        $type = 'application/octet-stream',
+        $timeout = null,
+        array $headers = []
+    ): \Laminas\Http\Response {
+        $http = new \VuFindHttp\HttpService();
+        return $http->post(
+            $url,
+            $body,
+            $type,
+            $timeout,
+            array_merge($headers, $this->getExtraVuFindHttpRequestHeaders())
+        );
     }
 }

--- a/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/HttpRequestTrait.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTest\Feature;
 
+use VuFindHttp\HttpService;
+
 /**
  * HTTP request helper methods for integration tests.
  *
@@ -41,6 +43,13 @@ namespace VuFindTest\Feature;
 trait HttpRequestTrait
 {
     use RemoteCoverageTrait;
+
+    /**
+     * HTTP service
+     *
+     * @var ?HttpService
+     */
+    protected $httpService = null;
 
     /**
      * Get extra HTTP headers to support testing.
@@ -62,6 +71,19 @@ trait HttpRequestTrait
     }
 
     /**
+     * Get HTTP service.
+     *
+     * @return HttpService
+     */
+    protected function getHttpService(): HttpService
+    {
+        if (!$this->httpService) {
+            $this->httpService = new HttpService();
+        }
+        return $this->httpService;
+    }
+
+    /**
      * Perform an HTTP GET operation with coverage awareness.
      *
      * @param string $url     Request URL
@@ -77,8 +99,7 @@ trait HttpRequestTrait
         $timeout = null,
         array $headers = []
     ): \Laminas\Http\Response {
-        $http = new \VuFindHttp\HttpService();
-        return $http->get(
+        return $this->getHttpService()->get(
             $url,
             $params,
             $timeout,
@@ -104,8 +125,7 @@ trait HttpRequestTrait
         $timeout = null,
         array $headers = []
     ): \Laminas\Http\Response {
-        $http = new \VuFindHttp\HttpService();
-        return $http->post(
+        return $this->getHttpService()->post(
             $url,
             $body,
             $type,

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -45,6 +45,7 @@ namespace VuFindTest\Mink;
 final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
 {
     use \VuFindTest\Feature\DemoDriverTestTrait;
+    use \VuFindTest\Feature\HttpRequestTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\UserCreationTrait;
 
@@ -215,8 +216,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'client_id' => 'test',
             'client_secret' => 'mysecret',
         ];
-        $http = new \VuFindHttp\HttpService();
-        $response = $http->post(
+        $response = $this->httpPost(
             $this->getVuFindUrl() . '/OAuth2/token',
             http_build_query($tokenParams),
             'application/x-www-form-urlencoded'
@@ -228,7 +228,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         $this->assertArrayHasKey('token_type', $tokenResult);
 
         // Fetch public key to verify idToken:
-        $response = $http->get($this->getVuFindUrl() . '/OAuth2/jwks');
+        $response = $this->httpGet($this->getVuFindUrl() . '/OAuth2/jwks');
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -260,7 +260,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         );
 
         // Test the userinfo endpoint:
-        $response = $http->get(
+        $response = $this->httpGet(
             $this->getVuFindUrl() . '/OAuth2/userinfo',
             [],
             '',
@@ -288,7 +288,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
 
         // Test token request with bad credentials:
         $tokenParams['client_secret'] = 'badsecret';
-        $response = $http->post(
+        $response = $this->httpPost(
             $this->getVuFindUrl() . '/OAuth2/token',
             http_build_query($tokenParams),
             'application/x-www-form-urlencoded'
@@ -460,8 +460,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'service_documentation' => 'https://vufind.org/wiki/configuration:oauth2_oidc',
         ];
 
-        $http = new \VuFindHttp\HttpService();
-        $response = $http->get($this->getVuFindUrl() . '/.well-known/openid-configuration');
+        $response = $this->httpGet($this->getVuFindUrl() . '/.well-known/openid-configuration');
         $this->assertEquals(
             'application/json',
             $response->getHeaders()->get('Content-Type')->getFieldValue()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ShibbolethLogoutNotificationTest.php
@@ -45,6 +45,7 @@ use VuFind\Db\Table\ExternalSession;
 final class ShibbolethLogoutNotificationTest extends \VuFindTest\Integration\MinkTestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\HttpRequestTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\LiveDetectionTrait;
 
@@ -82,8 +83,7 @@ final class ShibbolethLogoutNotificationTest extends \VuFindTest\Integration\Min
         $table->addSessionMapping($sessionId, 'EXTERNAL_SESSION_ID');
 
         // Call the notification endpoint:
-        $http = new \VuFindHttp\HttpService();
-        $result = $http->post(
+        $result = $this->httpPost(
             $this->getVuFindUrl() . '/soap/shiblogout',
             $this->getFixture('shibboleth/logout_notification.xml'),
             'application/xml'


### PR DESCRIPTION
This PR improves and expands the use of the HttpRequestTrait for tests introduced in #3597. This should improve Jenkins code coverage reporting for integration tests that make HTTP requests outside of the normal Mink framework.