### PR TITLE
Expand use of UserEntityInterface in AJAX handlers

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserAction.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractIlsAndUserAction.php
@@ -30,7 +30,7 @@
 namespace VuFind\AjaxHandler;
 
 use VuFind\Auth\ILSAuthenticator;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\ILS\Connection;
 use VuFind\Session\Settings as SessionSettings;
@@ -51,16 +51,16 @@ abstract class AbstractIlsAndUserAction extends AbstractBase implements Translat
     /**
      * Constructor
      *
-     * @param SessionSettings  $ss               Session settings
-     * @param Connection       $ils              ILS connection
-     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
-     * @param ?User            $user             Logged in user (or null)
+     * @param SessionSettings      $ss               Session settings
+     * @param Connection           $ils              ILS connection
+     * @param ILSAuthenticator     $ilsAuthenticator ILS authenticator
+     * @param ?UserEntityInterface $user             Logged in user (or null)
      */
     public function __construct(
         SessionSettings $ss,
         protected Connection $ils,
         protected ILSAuthenticator $ilsAuthenticator,
-        protected ?User $user
+        protected ?UserEntityInterface $user
     ) {
         $this->sessionSettings = $ss;
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisAction.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/AbstractRelaisAction.php
@@ -30,7 +30,7 @@
 namespace VuFind\AjaxHandler;
 
 use VuFind\Connection\Relais;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\Session\Settings as SessionSettings;
 
@@ -50,14 +50,14 @@ abstract class AbstractRelaisAction extends AbstractBase implements TranslatorAw
     /**
      * Constructor
      *
-     * @param SessionSettings $ss     Session settings
-     * @param Relais          $relais Relais connector
-     * @param ?User           $user   Logged in user (or null if none)
+     * @param SessionSettings      $ss     Session settings
+     * @param Relais               $relais Relais connector
+     * @param ?UserEntityInterface $user   Logged in user (or null if none)
      */
     public function __construct(
         SessionSettings $ss,
         protected Relais $relais,
-        protected ?User $user
+        protected ?UserEntityInterface $user
     ) {
         $this->sessionSettings = $ss;
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/CommentRecord.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CommentRecord.php
@@ -32,7 +32,7 @@ namespace VuFind\AjaxHandler;
 use Laminas\Mvc\Controller\Plugin\Params;
 use VuFind\Config\AccountCapabilities;
 use VuFind\Controller\Plugin\Captcha;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\CommentsServiceInterface;
 use VuFind\Db\Table\Resource;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
@@ -59,7 +59,7 @@ class CommentRecord extends AbstractBase implements TranslatorAwareInterface
      * @param Resource                 $table               Resource database table
      * @param CommentsServiceInterface $commentsService     Comments database service
      * @param Captcha                  $captcha             Captcha controller plugin
-     * @param ?User                    $user                Logged in user (or null)
+     * @param ?UserEntityInterface     $user                Logged in user (or null)
      * @param bool                     $enabled             Are comments enabled?
      * @param RecordLoader             $recordLoader        Record loader
      * @param AccountCapabilities      $accountCapabilities Account capabilities helper
@@ -68,7 +68,7 @@ class CommentRecord extends AbstractBase implements TranslatorAwareInterface
         protected Resource $table,
         protected CommentsServiceInterface $commentsService,
         protected Captcha $captcha,
-        protected ?User $user,
+        protected ?UserEntityInterface $user,
         protected bool $enabled,
         protected RecordLoader $recordLoader,
         protected AccountCapabilities $accountCapabilities
@@ -146,7 +146,7 @@ class CommentRecord extends AbstractBase implements TranslatorAwareInterface
             || $this->accountCapabilities->isRatingRemovalAllowed())
         ) {
             $driver->addOrUpdateRating(
-                $this->user->id,
+                $this->user->getId(),
                 '' === $rating ? null : intval($rating)
             );
         }

--- a/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordComment.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/DeleteRecordComment.php
@@ -30,7 +30,7 @@
 namespace VuFind\AjaxHandler;
 
 use Laminas\Mvc\Controller\Plugin\Params;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\CommentsServiceInterface;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 
@@ -51,12 +51,12 @@ class DeleteRecordComment extends AbstractBase implements TranslatorAwareInterfa
      * Constructor
      *
      * @param CommentsServiceInterface $commentsService Comments database service
-     * @param ?User                    $user            Logged in user (or null)
+     * @param ?UserEntityInterface     $user            Logged in user (or null)
      * @param bool                     $enabled         Are comments enabled?
      */
     public function __construct(
         protected CommentsServiceInterface $commentsService,
-        protected ?User $user,
+        protected ?UserEntityInterface $user,
         protected bool $enabled = true
     ) {
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordTags.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordTags.php
@@ -31,7 +31,7 @@ namespace VuFind\AjaxHandler;
 
 use Laminas\Mvc\Controller\Plugin\Params;
 use Laminas\View\Renderer\RendererInterface;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Table\Tags;
 
 /**
@@ -48,12 +48,15 @@ class GetRecordTags extends AbstractBase
     /**
      * Constructor
      *
-     * @param Tags              $table    Tags table
-     * @param ?User             $user     Logged in user (or null)
-     * @param RendererInterface $renderer View renderer
+     * @param Tags                 $table    Tags table
+     * @param ?UserEntityInterface $user     Logged in user (or null)
+     * @param RendererInterface    $renderer View renderer
      */
-    public function __construct(protected Tags $table, protected ?User $user, protected RendererInterface $renderer)
-    {
+    public function __construct(
+        protected Tags $table,
+        protected ?UserEntityInterface $user,
+        protected RendererInterface $renderer
+    ) {
     }
 
     /**
@@ -65,7 +68,7 @@ class GetRecordTags extends AbstractBase
      */
     public function handleRequest(Params $params)
     {
-        $is_me_id = !$this->user ? null : $this->user->id;
+        $is_me_id = $this->user?->getId();
 
         // Retrieve from database:
         $tags = $this->table->getForResource(

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
@@ -33,7 +33,7 @@ use Laminas\Mvc\Controller\Plugin\Params as ParamsHelper;
 use Laminas\Stdlib\Parameters;
 use Laminas\View\Model\ViewModel;
 use Laminas\View\Renderer\PhpRenderer;
-use VuFind\Db\Row\User as UserRow;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Table\Search;
 use VuFind\Record\Loader as RecordLoader;
 use VuFind\Search\Base\Results;
@@ -109,23 +109,23 @@ class GetSearchResults extends \VuFind\AjaxHandler\AbstractBase implements
     /**
      * Constructor
      *
-     * @param SessionSettings  $sessionSettings  Session settings
-     * @param ResultsManager   $resultsManager   Results Manager
-     * @param PhpRenderer      $renderer         View renderer
-     * @param RecordLoader     $recordLoader     Record loader
-     * @param ?UserRow         $user             Logged-in user
-     * @param string           $sessionId        Session ID
-     * @param SearchNormalizer $searchNormalizer Search normalizer
-     * @param Search           $searchTable      Search table
-     * @param array            $config           Main configuration
-     * @param Memory           $searchMemory     Search memory
+     * @param SessionSettings      $sessionSettings  Session settings
+     * @param ResultsManager       $resultsManager   Results Manager
+     * @param PhpRenderer          $renderer         View renderer
+     * @param RecordLoader         $recordLoader     Record loader
+     * @param ?UserEntityInterface $user             Logged-in user
+     * @param string               $sessionId        Session ID
+     * @param SearchNormalizer     $searchNormalizer Search normalizer
+     * @param Search               $searchTable      Search table
+     * @param array                $config           Main configuration
+     * @param Memory               $searchMemory     Search memory
      */
     public function __construct(
         SessionSettings $sessionSettings,
         protected ResultsManager $resultsManager,
         protected PhpRenderer $renderer,
         protected RecordLoader $recordLoader,
-        protected ?UserRow $user,
+        protected ?UserEntityInterface $user,
         protected string $sessionId,
         protected SearchNormalizer $searchNormalizer,
         protected Search $searchTable,
@@ -365,7 +365,7 @@ class GetSearchResults extends \VuFind\AjaxHandler\AbstractBase implements
             $this->searchNormalizer,
             $results,
             $this->sessionId,
-            $this->user->id ?? null
+            $this->user?->getId()
         );
     }
 }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetUserFines.php
@@ -31,7 +31,7 @@ namespace VuFind\AjaxHandler;
 
 use Laminas\Mvc\Controller\Plugin\Params;
 use VuFind\Auth\ILSAuthenticator;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\ILS\Connection;
 use VuFind\Service\CurrencyFormatter;
 use VuFind\Session\Settings as SessionSettings;
@@ -59,17 +59,17 @@ class GetUserFines extends AbstractIlsAndUserAction
     /**
      * Constructor
      *
-     * @param SessionSettings   $ss                Session settings
-     * @param Connection        $ils               ILS connection
-     * @param ILSAuthenticator  $ilsAuthenticator  ILS authenticator
-     * @param User|bool         $user              Logged in user (or false)
-     * @param CurrencyFormatter $currencyFormatter Currency formatter
+     * @param SessionSettings      $ss                Session settings
+     * @param Connection           $ils               ILS connection
+     * @param ILSAuthenticator     $ilsAuthenticator  ILS authenticator
+     * @param ?UserEntityInterface $user              Logged in user (or false)
+     * @param CurrencyFormatter    $currencyFormatter Currency formatter
      */
     public function __construct(
         SessionSettings $ss,
         Connection $ils,
         ILSAuthenticator $ilsAuthenticator,
-        $user,
+        ?UserEntityInterface $user,
         CurrencyFormatter $currencyFormatter
     ) {
         parent::__construct($ss, $ils, $ilsAuthenticator, $user);

--- a/module/VuFind/src/VuFind/AjaxHandler/RelaisInfo.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/RelaisInfo.php
@@ -53,7 +53,7 @@ class RelaisInfo extends AbstractRelaisAction
     {
         $this->disableSessionWrites();  // avoid session write timing bug
         $oclcNumber = $params->fromQuery('oclcNumber');
-        $lin = $this->user ? $this->user['cat_username'] : null;
+        $lin = $this->user?->getCatUsername();
 
         // Authenticate
         $authResponse = $this->relais->authenticatePatron($lin, true);

--- a/module/VuFind/src/VuFind/AjaxHandler/RelaisOrder.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/RelaisOrder.php
@@ -54,7 +54,7 @@ class RelaisOrder extends AbstractRelaisAction
         $this->disableSessionWrites();  // avoid session write timing bug
         $oclcNumber = $params->fromQuery('oclcNumber');
 
-        $lin = $this->user ? $this->user['cat_username'] : null;
+        $lin = $this->user?->getCatUsername();
 
         // Authenticate
         $authorizationId = $this->relais->authenticatePatron($lin);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisAvailabilityTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisAvailabilityTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * RelaisAvailability test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\AjaxHandler;
+
+use VuFind\AjaxHandler\RelaisAvailability;
+
+/**
+ * RelaisAvailability test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class RelaisAvailabilityTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test authorization failure.
+     *
+     * @return void
+     */
+    public function testAuthorizationFailure(): void
+    {
+        $handler = new RelaisAvailability(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $this->createMock(\VuFind\Connection\Relais::class),
+            null
+        );
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $this->assertEquals(['Failed', 403], $handler->handleRequest($params));
+    }
+
+    /**
+     * Data provider for testSearchResponse()
+     *
+     * @return array[]
+     */
+    public static function searchResponseProvider(): array
+    {
+        return [
+            'error type 1' => ['error: foo', [['result' => 'no']]],
+            'error type 2' => ['ErrorMessage: foo', [['result' => 'no']]],
+            'error type 3' => ['false', [['result' => 'no']]],
+            'success' => ['happy day!', [['result' => 'ok']]],
+        ];
+    }
+
+    /**
+     * Test search response.
+     *
+     * @param string $response Relais search response
+     * @param array  $expected Expected handler response
+     *
+     * @return void
+     *
+     * @dataProvider searchResponseProvider
+     */
+    public function testSearchResponse(string $response, array $expected): void
+    {
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $params->expects($this->once())->method('fromQuery')->with('oclcNumber')
+            ->willReturn('oclcnum');
+        $relais = $this->createMock(\VuFind\Connection\Relais::class);
+        $relais->expects($this->once())->method('authenticatePatron')
+            ->willReturn('authorization-id');
+        $relais->expects($this->once())->method('search')
+            ->with('oclcnum', 'authorization-id')
+            ->willReturn($response);
+        $handler = new RelaisAvailability(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $relais,
+            null
+        );
+        $this->assertEquals($expected, $handler->handleRequest($params));
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisInfoTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisInfoTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * RelaisInfo test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\AjaxHandler;
+
+use VuFind\AjaxHandler\RelaisInfo;
+
+/**
+ * RelaisInfo test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class RelaisInfoTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test authorization failure.
+     *
+     * @return void
+     */
+    public function testAuthorizationFailure(): void
+    {
+        $handler = new RelaisInfo(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $this->createMock(\VuFind\Connection\Relais::class),
+            null
+        );
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $this->assertEquals(['Failed', 403], $handler->handleRequest($params));
+    }
+
+    /**
+     * Data provider for testSearchResponse()
+     *
+     * @return array[]
+     */
+    public static function authenticatedBehaviorProvider(): array
+    {
+        return [
+            'failure' => [null, ['Failed', 403]],
+            'forbidden' => [
+                (object)['AuthorizationId' => 1234, 'AllowLoanAddRequest' => false],
+                ['AllowLoan was false', 500],
+            ],
+            'success' => [
+                (object)['AuthorizationId' => 1234, 'AllowLoanAddRequest' => true],
+                [['result' => 'search-result']],
+            ],
+        ];
+    }
+
+    /**
+     * Test search response.
+     *
+     * @param ?object $response Relais authenticate response
+     * @param array   $expected Expected handler response
+     *
+     * @return void
+     *
+     * @dataProvider authenticatedBehaviorProvider
+     */
+    public function testAuthenticatedBehavior(?object $response, array $expected): void
+    {
+        $user = $this->createMock(\VuFind\Db\Entity\UserEntityInterface::class);
+        $user->expects($this->once())->method('getCatUsername')->willReturn('user');
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $params->expects($this->once())->method('fromQuery')->with('oclcNumber')
+            ->willReturn('oclcnum');
+        $relais = $this->createMock(\VuFind\Connection\Relais::class);
+        $relais->expects($this->once())->method('authenticatePatron')
+            ->with('user', true)
+            ->willReturn($response);
+        $relais->expects($this->any())->method('search')
+            ->with('oclcnum', 1234)
+            ->willReturn('search-result');
+        $handler = new RelaisInfo(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $relais,
+            $user
+        );
+        $this->assertEquals($expected, $handler->handleRequest($params));
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisOrderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/RelaisOrderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * RelaisOrder test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\AjaxHandler;
+
+use VuFind\AjaxHandler\RelaisOrder;
+
+/**
+ * RelaisOrder test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class RelaisOrderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test authorization failure.
+     *
+     * @return void
+     */
+    public function testAuthorizationFailure(): void
+    {
+        $handler = new RelaisOrder(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $this->createMock(\VuFind\Connection\Relais::class),
+            null
+        );
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $this->assertEquals(['Failed', 403], $handler->handleRequest($params));
+    }
+
+    /**
+     * Data provider for testSearchResponse()
+     *
+     * @return array[]
+     */
+    public static function authenticatedBehaviorProvider(): array
+    {
+        return [
+            'failure' => ['error: it is broken', ['error: it is broken', 500]],
+            'success' => ['success', [['result' => 'success']]],
+        ];
+    }
+
+    /**
+     * Test search response.
+     *
+     * @param string $response Relais placeRequest response
+     * @param array  $expected Expected handler response
+     *
+     * @return void
+     *
+     * @dataProvider authenticatedBehaviorProvider
+     */
+    public function testAuthenticatedBehavior(string $response, array $expected): void
+    {
+        $user = $this->createMock(\VuFind\Db\Entity\UserEntityInterface::class);
+        $user->expects($this->once())->method('getCatUsername')->willReturn('user');
+        $params = $this->createMock(\Laminas\Mvc\Controller\Plugin\Params::class);
+        $params->expects($this->once())->method('fromQuery')->with('oclcNumber')
+            ->willReturn('oclcnum');
+        $relais = $this->createMock(\VuFind\Connection\Relais::class);
+        $relais->expects($this->once())->method('authenticatePatron')
+            ->with('user')
+            ->willReturn('authenticated');
+        $relais->expects($this->once())->method('placeRequest')
+            ->with('oclcnum', 'authenticated', 'user')
+            ->willReturn($response);
+        $handler = new RelaisOrder(
+            $this->createMock(\VuFind\Session\Settings::class),
+            $relais,
+            $user
+        );
+        $this->assertEquals($expected, $handler->handleRequest($params));
+    }
+}


### PR DESCRIPTION
This PR replaces most (but not quite all) uses of VuFind\Db\Row\User with VuFind\Db\Entity\UserEntityInterface in the AJAX handlers, to help reduce the footprint of Laminas\Db in the code. The only remaining Row references are for handlers that call non-interface methods, and which will require more aggressive refactoring.

This PR also adds unit tests for the Relais handlers, since these are impossible to test without access to a little-used system. It may make sense to deprecate and remove these handlers at some point, as I'm not aware of any remaining Relais users, but for now at least it ensures that the code still executes.

TODO
- [ ] Update changelog when merging