### PR TITLE
[release-9.1] Fix Solr highlighting in Blender (backported from #3610).

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/PluginManager.php
+++ b/module/VuFind/src/VuFind/RecordDriver/PluginManager.php
@@ -181,9 +181,14 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         );
         $recordType = $this->has($key) ? $key : $keyPrefix . $defaultKeySuffix;
 
+        // Extract highlighting details injected earlier by
+        // \VuFindSearch\Backend\Solr\Response\Json\RecordCollectionFactory
+        $hl = $data['__highlight_details'] ?? [];
+        unset($data['__highlight_details']);
         // Build the object:
         $driver = $this->get($recordType);
         $driver->setRawData($data);
+        $driver->setHighlightDetails($hl);
         return $driver;
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/InjectHighlightingListener.php
@@ -153,26 +153,14 @@ class InjectHighlightingListener
      * @param EventInterface $event Event
      *
      * @return EventInterface
+     *
+     * @deprecated
      */
     public function onSearchPost(EventInterface $event)
     {
-        // Do nothing if highlighting is disabled or context is wrong
-        $command = $event->getParam('command');
-        if (!$this->active || $command->getContext() != 'search') {
-            return $event;
-        }
-
-        // Inject highlighting details into record objects:
-        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
-            $result = $command->getResult();
-            $hlDetails = $result->getHighlighting();
-            foreach ($result->getRecords() as $record) {
-                $id = $record->getUniqueId();
-                if (isset($hlDetails[$id])) {
-                    $record->setHighlightDetails($hlDetails[$id]);
-                }
-            }
-        }
+        // The original functionality of this method has been moved to \VuFind\RecordDriver\PluginManager
+        // and \VuFindSearch\Backend\Solr\Response\Json\RecordCollectionFactory. It will be removed in
+        // release 10.0.
         return $event;
     }
 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollectionFactory.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollectionFactory.php
@@ -101,7 +101,12 @@ class RecordCollectionFactory implements RecordCollectionFactoryInterface
             );
         }
         $collection = new $this->collectionClass($response);
+        $hlDetails = $response['highlighting'] ?? [];
         foreach ($response['response']['docs'] ?? [] as $doc) {
+            // If highlighting details were provided, merge them into the record for future use:
+            if (isset($doc['id']) && ($hl = $hlDetails[$doc['id']] ?? [])) {
+                $doc['__highlight_details'] = $hl;
+            }
             $collection->add(call_user_func($this->recordFactory, $doc), false);
         }
         return $collection;


### PR DESCRIPTION
Injects highlighting data to Solr records when they're created so that it's present when the blended result set is created.

TODO
- [x] Update changelog when merging.