### PR TITLE
Surround searchbox inputs with a div for styling

### DIFF
--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -1,3 +1,21 @@
+<style>
+    .searchForm-inputs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .searchForm-inputs .searchForm-query {
+        width: auto;
+        flex-grow: 1;
+    }
+
+    @media screen and (min-width: 768px) {
+        .searchForm-inputs .searchForm-query {
+            flex-grow: 0;
+        }
+    }
+  </style>
 <?php
     // Initialize from current search (if available and not explicitly overridden) or defaults:
     if ($results = ($this->results ?? $this->searchMemory()->getCurrentSearch())) {
@@ -81,24 +99,6 @@
   </div>
   <form id="searchForm" class="searchForm navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" autocomplete="off">
     <?= $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $tabConfig['tabs'], 'showCounts' => $tabConfig['showCounts']]); ?>
-    <style>
-      .searchForm-inputs {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 0.5rem;
-      }
-
-      .searchForm-inputs .searchForm-query {
-          width: auto;
-          flex-grow: 1;
-      }
-
-      @media screen and (min-width: 768px) {
-          .searchForm-inputs .searchForm-query {
-              flex-grow: 0;
-          }
-      }
-    </style>
     <div class="searchForm-inputs">
       <?php
         $searchboxAttributes = [

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -81,135 +81,155 @@
   </div>
   <form id="searchForm" class="searchForm navbar-form navbar-left flip" method="get" action="<?=$this->url($basicSearch)?>" name="searchForm" autocomplete="off">
     <?= $this->context($this)->renderInContext('search/searchTabs', ['searchTabs' => $tabConfig['tabs'], 'showCounts' => $tabConfig['showCounts']]); ?>
-    <?php
-      $searchboxAttributes = [
-        'id' => 'searchForm_lookfor',
-        'class' => 'searchForm_lookfor form-control search-query',
-        'type' => 'search',
-        'name' => 'lookfor',
-        'value' => $this->lookfor,
-        'aria-label' => $this->translate('search_terms'),
-      ];
-      if ($placeholder = $this->searchbox()->getPlaceholderText($tabConfig['selected']['id'] ?? $this->searchClassId)) {
-        $searchboxAttributes['placeholder'] = $this->translate($placeholder);
+    <style>
+      .searchForm-inputs {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5rem;
       }
-      if ($this->searchbox()->autocompleteEnabled($this->searchClassId)) {
-        $searchboxAttributes['class'] .= " autocomplete searcher:{$this->searchClassId}"
-          . ($this->searchbox()->autocompleteAutoSubmit($this->searchClassId) ? ' ac-auto-submit' : '');
-        $searchboxAttributes['data-autocomplete-formatting-rules'] = $this->searchbox()->autocompleteFormattingRulesJson($this->searchClassId);
-      }
-      if (!empty($keyboardLayouts)) {
-        $searchboxAttributes['class'] .= ' with-keyboard-selection';
-      }
-    ?>
-    <div class="searchForm-query">
-      <input<?=$this->htmlAttributes($searchboxAttributes)?>>
-      <div id="searchForm_controls">
-        <button id="searchForm-reset" class="searchForm-reset hidden" type="reset" tabindex="-1" aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"><?=$this->icon('ui-reset-search');?></button>
-        <?php if (!empty($keyboardLayouts)): ?>
-          <?php
-          $this->headScript()->appendFile('vendor/js.cookie.js');
-          $this->headScript()->appendFile('vendor/simple-keyboard/index.js');
-          $this->headScript()->appendFile('vendor/simple-keyboard-layouts/index.js');
-          $this->headLink()->appendStylesheet('vendor/simple-keyboard/index.css');
-          ?>
-          <div class="keyboard-selection dropdown">
-            <button class="btn btn-primary dropdown-toggle" type="button" id="keyboard-selection-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <?=$this->icon('keyboard-o') ?>
-              <?=$this->icon('caret-down') ?>
-            </button>
-            <ul class="dropdown-menu" aria-labelledby="keyboard-selection-button">
-              <li>
-                <a class="dropdown-item keyboard-selection-item" href="#" data-value="none"><?= $this->transEsc('None') ?></a>
-              </li>
-              <?php foreach ($keyboardLayouts as $keyboardLayout): ?>
-                <li>
-                  <a class="keyboard-selection-item" href="#" data-value="<?= $this->escapeHtmlAttr($keyboardLayout) ?>"><?= $this->transEsc("KeyboardLayout::$keyboardLayout") ?></a>
-                </li>
-              <?php endforeach; ?>
-            </ul>
-          </div>
-        <?php endif; ?>
-      </div>
-    </div>
-    <?php if ($handlerCount > 1): ?>
-      <select id="searchForm_type" class="searchForm_type form-control" name="type" data-native-menu="false" aria-label="<?=$this->transEscAttr('Search type')?>">
-        <?php $currentGroup = $insideGroup = false; ?>
-        <?php foreach ($handlers as $handler): ?>
-          <?php
-            if ($currentGroup !== ($handler['group'] ?? false)) {
-              $currentGroup = $handler['group'];
-              if ($insideGroup) {
-                echo '</optgroup>';
-              }
-              if ($currentGroup) {
-                echo '<optgroup label="' . $this->escapeHtmlAttr($currentGroup) . '">';
-                $insideGroup = true;
-              } else {
-                $insideGroup = false;
-              }
-            }
-          ?>
-          <option value="<?=$this->escapeHtmlAttr($handler['value'])?>"<?=$handler['selected'] ? ' selected="selected"' : ''?>><?=$handler['indent'] ? '-- ' : ''?><?=$this->transEsc($handler['label'])?></option>
-        <?php endforeach; ?>
-        <?php if ($insideGroup): ?>
-          </optgroup>
-        <?php endif; ?>
-      </select>
-    <?php elseif ($handlerCount == 1): ?>
-      <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($handlers[0]['value'])?>">
-    <?php endif; ?>
-    <button type="submit" class="btn btn-primary"><?=$this->icon('search') ?> <?=$this->transEsc('Find')?></button>
-    <?php if ($advSearch): ?>
-      <?php
-        $advSearchQuery = $results ? ['edit' => $results->getSearchId()] : $hiddenFilters;
-        $advSearchLink = $this->url($advSearch, [], ['query' => $advSearchQuery]);
-      ?>
-      <a href="<?=$advSearchLink?>" class="advanced-search-link btn btn-link" rel="nofollow"><?=$this->transEsc('Advanced')?></a>
-    <?php endif; ?>
-    <?php if ($geoUrl = $this->geocoords()->getSearchUrl($options)) : ?>
-        <a href="<?=$geoUrl ?>" class="btn btn-link"><?=$this->transEsc('Geographic Search')?></a>
-    <?php endif; ?>
 
-    <?php $shards = $options->getShards(); ?>
-    <?php if ($options->showShardCheckboxes() && !empty($shards)): ?>
+      .searchForm-inputs .searchForm-query {
+          width: auto;
+          flex-grow: 1;
+      }
+
+      @media screen and (min-width: 768px) {
+          .searchForm-inputs .searchForm-query {
+              flex-grow: 0;
+          }
+      }
+    </style>
+    <div class="searchForm-inputs">
       <?php
-      $selectedShards = $this->selectedShards ?? $options->getDefaultSelectedShards();
+        $searchboxAttributes = [
+          'id' => 'searchForm_lookfor',
+          'class' => 'searchForm_lookfor form-control search-query',
+          'type' => 'search',
+          'name' => 'lookfor',
+          'value' => $this->lookfor,
+          'aria-label' => $this->translate('search_terms'),
+        ];
+        if ($placeholder = $this->searchbox()->getPlaceholderText($tabConfig['selected']['id'] ?? $this->searchClassId)) {
+          $searchboxAttributes['placeholder'] = $this->translate($placeholder);
+        }
+        if ($this->searchbox()->autocompleteEnabled($this->searchClassId)) {
+          $searchboxAttributes['class'] .= " autocomplete searcher:{$this->searchClassId}"
+            . ($this->searchbox()->autocompleteAutoSubmit($this->searchClassId) ? ' ac-auto-submit' : '');
+          $searchboxAttributes['data-autocomplete-formatting-rules'] = $this->searchbox()->autocompleteFormattingRulesJson($this->searchClassId);
+        }
+        if (!empty($keyboardLayouts)) {
+          $searchboxAttributes['class'] .= ' with-keyboard-selection';
+        }
       ?>
-      <br>
-      <?php foreach ($shards as $shard => $val): ?>
-        <?php $isSelected = empty($selectedShards) || in_array($shard, $selectedShards); ?>
-          <input type="checkbox" <?=$isSelected ? 'checked="checked" ' : ''?>name="shard[]" value='<?=$this->escapeHtmlAttr($shard)?>'> <?=$this->transEsc($shard)?>
-      <?php endforeach; ?>
-    <?php endif; ?>
-    <?php if (($hasDefaultsApplied ?? false) || !empty($filterDetails)): ?>
-      <?php if ($options->getRetainFilterSetting()): ?>
-        <?php foreach ($filterDetails as $current): ?>
-          <input class="applied-filter" id="<?=$this->escapeHtmlAttr($current['id'])?>" type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($current['value'])?>">
+      <div class="searchForm-query">
+        <input<?=$this->htmlAttributes($searchboxAttributes)?>>
+        <div id="searchForm_controls">
+          <button id="searchForm-reset" class="searchForm-reset hidden" type="reset" tabindex="-1" aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"><?=$this->icon('ui-reset-search');?></button>
+          <?php if (!empty($keyboardLayouts)): ?>
+            <?php
+            $this->headScript()->appendFile('vendor/js.cookie.js');
+            $this->headScript()->appendFile('vendor/simple-keyboard/index.js');
+            $this->headScript()->appendFile('vendor/simple-keyboard-layouts/index.js');
+            $this->headLink()->appendStylesheet('vendor/simple-keyboard/index.css');
+            ?>
+            <div class="keyboard-selection dropdown">
+              <button class="btn btn-primary dropdown-toggle" type="button" id="keyboard-selection-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <?=$this->icon('keyboard-o') ?>
+                <?=$this->icon('caret-down') ?>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="keyboard-selection-button">
+                <li>
+                  <a class="dropdown-item keyboard-selection-item" href="#" data-value="none"><?= $this->transEsc('None') ?></a>
+                </li>
+                <?php foreach ($keyboardLayouts as $keyboardLayout): ?>
+                  <li>
+                    <a class="keyboard-selection-item" href="#" data-value="<?= $this->escapeHtmlAttr($keyboardLayout) ?>"><?= $this->transEsc("KeyboardLayout::$keyboardLayout") ?></a>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            </div>
+          <?php endif; ?>
+        </div>
+      </div>
+      <?php if ($handlerCount > 1): ?>
+        <select id="searchForm_type" class="searchForm_type form-control" name="type" data-native-menu="false" aria-label="<?=$this->transEscAttr('Search type')?>">
+          <?php $currentGroup = $insideGroup = false; ?>
+          <?php foreach ($handlers as $handler): ?>
+            <?php
+              if ($currentGroup !== ($handler['group'] ?? false)) {
+                $currentGroup = $handler['group'];
+                if ($insideGroup) {
+                  echo '</optgroup>';
+                }
+                if ($currentGroup) {
+                  echo '<optgroup label="' . $this->escapeHtmlAttr($currentGroup) . '">';
+                  $insideGroup = true;
+                } else {
+                  $insideGroup = false;
+                }
+              }
+            ?>
+            <option value="<?=$this->escapeHtmlAttr($handler['value'])?>"<?=$handler['selected'] ? ' selected="selected"' : ''?>><?=$handler['indent'] ? '-- ' : ''?><?=$this->transEsc($handler['label'])?></option>
+          <?php endforeach; ?>
+          <?php if ($insideGroup): ?>
+            </optgroup>
+          <?php endif; ?>
+        </select>
+      <?php elseif ($handlerCount == 1): ?>
+        <input type="hidden" name="type" value="<?=$this->escapeHtmlAttr($handlers[0]['value'])?>">
+      <?php endif; ?>
+      <button type="submit" class="btn btn-primary"><?=$this->icon('search') ?> <?=$this->transEsc('Find')?></button>
+      <?php if ($advSearch): ?>
+        <?php
+          $advSearchQuery = $results ? ['edit' => $results->getSearchId()] : $hiddenFilters;
+          $advSearchLink = $this->url($advSearch, [], ['query' => $advSearchQuery]);
+        ?>
+        <a href="<?=$advSearchLink?>" class="advanced-search-link btn btn-link" rel="nofollow"><?=$this->transEsc('Advanced')?></a>
+      <?php endif; ?>
+      <?php if ($geoUrl = $this->geocoords()->getSearchUrl($options)) : ?>
+          <a href="<?=$geoUrl ?>" class="btn btn-link"><?=$this->transEsc('Geographic Search')?></a>
+      <?php endif; ?>
+
+      <?php $shards = $options->getShards(); ?>
+      <?php if ($options->showShardCheckboxes() && !empty($shards)): ?>
+        <?php
+        $selectedShards = $this->selectedShards ?? $options->getDefaultSelectedShards();
+        ?>
+        <br>
+        <?php foreach ($shards as $shard => $val): ?>
+          <?php $isSelected = empty($selectedShards) || in_array($shard, $selectedShards); ?>
+            <input type="checkbox" <?=$isSelected ? 'checked="checked" ' : ''?>name="shard[]" value='<?=$this->escapeHtmlAttr($shard)?>'> <?=$this->transEsc($shard)?>
         <?php endforeach; ?>
-        <?php if ($hasDefaultsApplied ?? false): ?>
-          <input class="applied-filter" id="dfApplied" type="hidden" name="dfApplied" value="1">
+      <?php endif; ?>
+      <?php if (($hasDefaultsApplied ?? false) || !empty($filterDetails)): ?>
+        <?php if ($options->getRetainFilterSetting()): ?>
+          <?php foreach ($filterDetails as $current): ?>
+            <input class="applied-filter" id="<?=$this->escapeHtmlAttr($current['id'])?>" type="hidden" name="filter[]" value="<?=$this->escapeHtmlAttr($current['value'])?>">
+          <?php endforeach; ?>
+          <?php if ($hasDefaultsApplied ?? false): ?>
+            <input class="applied-filter" id="dfApplied" type="hidden" name="dfApplied" value="1">
+          <?php endif; ?>
         <?php endif; ?>
       <?php endif; ?>
-    <?php endif; ?>
-    <?php foreach ($hiddenFilters as $key => $filter): ?>
-      <?php foreach ($filter as $value): ?>
-        <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr('"' . $value . '"')?>">
+      <?php foreach ($hiddenFilters as $key => $filter): ?>
+        <?php foreach ($filter as $value): ?>
+          <input type="hidden" name="hiddenFilters[]" value="<?=$this->escapeHtmlAttr($key) . ':' . $this->escapeHtmlAttr('"' . $value . '"')?>">
+        <?php endforeach; ?>
       <?php endforeach; ?>
-    <?php endforeach; ?>
-    <?php
-      /* Show hidden field for active search class when in combined handler mode. */
-      if ($this->searchbox()->combinedHandlersActive()) {
-        echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '">';
-      }
-      /* Load hidden limit preference from Session */
-      if (!empty($lastLimit)) {
-        echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '">';
-      }
-      if (!empty($lastSort) && $lastSort !== $params?->getDefaultSort()) {
-        echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '">';
-      }
-    ?>
+      <?php
+        /* Show hidden field for active search class when in combined handler mode. */
+        if ($this->searchbox()->combinedHandlersActive()) {
+          echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '">';
+        }
+        /* Load hidden limit preference from Session */
+        if (!empty($lastLimit)) {
+          echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '">';
+        }
+        if (!empty($lastSort) && $lastSort !== $params?->getDefaultSort()) {
+          echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '">';
+        }
+      ?>
+    </div>
     <?=$this->context($this)->renderInContext(
         'search/filters.phtml',
         [

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -1,21 +1,3 @@
-<style>
-    .searchForm-inputs {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-    }
-
-    .searchForm-inputs .searchForm-query {
-        width: auto;
-        flex-grow: 1;
-    }
-
-    @media screen and (min-width: 768px) {
-        .searchForm-inputs .searchForm-query {
-            flex-grow: 0;
-        }
-    }
-  </style>
 <?php
     // Initialize from current search (if available and not explicitly overridden) or defaults:
     if ($results = ($this->results ?? $this->searchMemory()->getCurrentSearch())) {

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -231,8 +231,8 @@
       ?>
     </div>
     <?=$this->context($this)->renderInContext(
-        'search/filters.phtml',
-        [
+          'search/filters.phtml',
+          [
           'params' => $params ?? null,
           'urlQuery' => isset($results) ? $results->getUrlQuery() : null,
           'filterList' => $showFilters ? $filterList : [],
@@ -240,6 +240,6 @@
           'searchClassId' => $this->searchClassId,
           'searchType' => $this->searchType,
         ]
-    );?>
+      );?>
   </form>
 <?php endif; ?>


### PR DESCRIPTION
This is essentially a two-line PR that encloses the searchbox inputs with a named div so that they can be styled.  For example the line of inputs could be a flexbox or grid layout.

![image](https://github.com/vufind-org/vufind/assets/31278545/576bcf75-726d-4ba4-85a0-e6e2b32730e3)

Currently those elements share the same parent element `<form id="searchForm"` with the search tabs (among other stuff), so they are difficult to style.