### PR TITLE
VuFindTheme: Do not search for URLs/absolute paths inside themes.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -48,6 +48,7 @@ use VuFindTheme\ThemeInfo;
 class HeadLink extends \Laminas\View\Helper\HeadLink implements \Laminas\Log\LoggerAwareInterface
 {
     use ConcatTrait;
+    use RelativePathTrait;
     use \VuFind\Log\LoggerAwareTrait;
 
     /**
@@ -112,17 +113,18 @@ class HeadLink extends \Laminas\View\Helper\HeadLink implements \Laminas\Log\Log
      */
     public function itemToString(stdClass $item)
     {
-        // Normalize href to account for themes, then call the parent class:
-        $relPath = 'css/' . $item->href;
-        $details = $this->themeInfo
-            ->findContainingTheme($relPath, ThemeInfo::RETURN_ALL_DETAILS);
-
-        if (!empty($details)) {
-            $urlHelper = $this->getView()->plugin('url');
-            $url = $urlHelper('home') . "themes/{$details['theme']}/" . $relPath;
-            $url .= strstr($url, '?') ? '&_=' : '?_=';
-            $url .= filemtime($details['path']);
-            $item->href = $url;
+        // Normalize href to account for themes (if appropriate), then call the parent class:
+        if ($this->isRelativePath($item->href)) {
+            $relPath = 'css/' . $item->href;
+            $details = $this->themeInfo
+                ->findContainingTheme($relPath, ThemeInfo::RETURN_ALL_DETAILS);
+            if (!empty($details)) {
+                $urlHelper = $this->getView()->plugin('url');
+                $url = $urlHelper('home') . "themes/{$details['theme']}/" . $relPath;
+                $url .= strstr($url, '?') ? '&_=' : '?_=';
+                $url .= filemtime($details['path']);
+                $item->href = $url;
+            }
         }
         $this->addNonce($item);
         return parent::itemToString($item);

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
@@ -51,6 +51,7 @@ class HeadScript extends \Laminas\View\Helper\HeadScript implements \Laminas\Log
     use ConcatTrait {
         getMinifiedData as getBaseMinifiedData;
     }
+    use RelativePathTrait;
     use \VuFind\Log\LoggerAwareTrait;
 
     /**
@@ -105,8 +106,8 @@ class HeadScript extends \Laminas\View\Helper\HeadScript implements \Laminas\Log
      */
     public function itemToString($item, $indent, $escapeStart, $escapeEnd)
     {
-        // Normalize href to account for themes:
-        if (!empty($item->attributes['src'])) {
+        // Normalize href to account for themes (if appropriate):
+        if (!empty($item->attributes['src']) && $this->isRelativePath($item->attributes['src'])) {
             $relPath = 'js/' . $item->attributes['src'];
             $details = $this->themeInfo
                 ->findContainingTheme($relPath, ThemeInfo::RETURN_ALL_DETAILS);

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
@@ -40,6 +40,8 @@ namespace VuFindTheme\View\Helper;
  */
 class ImageLink extends \Laminas\View\Helper\AbstractHelper
 {
+    use RelativePathTrait;
+
     /**
      * Theme information service
      *
@@ -66,7 +68,11 @@ class ImageLink extends \Laminas\View\Helper\AbstractHelper
      */
     public function __invoke($image)
     {
-        // Normalize href to account for themes:
+        // If this is an absolute path, return it as-is:
+        if (!$this->isRelativePath($image)) {
+            return $image;
+        }
+        // Otherwise, normalize href to account for themes:
         $relPath = 'images/' . $image;
         $details = $this->themeInfo->findContainingTheme(
             $relPath,

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/RelativePathTrait.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/RelativePathTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Trait to detect relative paths in asset sources.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFindTheme\View\Helper;
+
+/**
+ * Trait to detect relative paths in asset sources.
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait RelativePathTrait
+{
+    /**
+     * Is the provided src value a relative path? Returns true if this should be searched
+     * within the local theme, or false if it is an absolute path or full URL.
+     *
+     * @param string $src Value to check
+     *
+     * @return bool
+     */
+    protected function isRelativePath(string $src): bool
+    {
+        return !str_starts_with($src, '/') && !str_contains($src, '://');
+    }
+}


### PR DESCRIPTION
The VuFindTheme view helpers look for resources inside themes -- but sometimes this is not the correct behavior, if the provided path is absolute or a complete URL. This PR bypasses the theme search in scenarios where it is inappropriate.