### PR TITLE
Use ->getHomeLibrary() instead of ->home_library

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -258,7 +258,7 @@ trait HoldsTrait
 
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
-            ? $this->getUser()->home_library : '';
+            ? $this->getUser()->getHomeLibrary() : '';
         // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkHolds['helpText'];
 

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -166,7 +166,7 @@ trait ILLRequestsTrait
 
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
-            ? $this->getUser()->home_library : '';
+            ? $this->getUser()->getHomeLibrary() : '';
         // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -736,7 +736,7 @@ class MyResearchController extends AbstractBase
             $this->addAccountBlocksToFlashMessenger($catalog, $patron);
             $profile = $catalog->getMyProfile($patron);
             $profile['home_library'] = $allowHomeLibrary
-                ? $user->home_library
+                ? $user->getHomeLibrary()
                 : ($profile['home_library'] ?? '');
             $view->profile = $profile;
             $pickup = $defaultPickupLocation = null;

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -171,7 +171,7 @@ trait StorageRetrievalRequestsTrait
 
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
-            ? $this->getUser()->home_library : '';
+            ? $this->getUser()->getHomeLibrary() : '';
         // helpText is only for backward compatibility:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -329,7 +329,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Check the default library and possible values:
         $userTable = $this->getTable(User::class);
-        $this->assertSame('', $userTable->getByUsername('username2')->home_library);
+        $this->assertSame('', $userTable->getByUsername('username2')->getHomeLibrary());
         $this->assertEquals(
             '',
             $this->findCssAndGetValue($page, '#home_library')
@@ -356,7 +356,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('B', $this->findCssAndGetValue($page, '#home_library'));
         $this->assertEquals(
             'B',
-            $userTable->getByUsername('username2')->home_library
+            $userTable->getByUsername('username2')->getHomeLibrary()
         );
 
         // Change to "Always ask me":
@@ -367,7 +367,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
             ' ** ',
             $this->findCssAndGetValue($page, '#home_library')
         );
-        $this->assertNull($userTable->getByUsername('username2')->home_library);
+        $this->assertNull($userTable->getByUsername('username2')->getHomeLibrary());
 
         // Back to default:
         $this->findCssAndSetValue($page, '#home_library', '');
@@ -377,7 +377,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
             '',
             $this->findCssAndGetValue($page, '#home_library')
         );
-        $this->assertSame('', $userTable->getByUsername('username2')->home_library);
+        $this->assertSame('', $userTable->getByUsername('username2')->getHomeLibrary());
     }
 
     /**


### PR DESCRIPTION
This is just a little more work to use UserEntityInterface more consistently. Note that in all of these controllers/traits, we don't need to worry about a non-object return value from `getUser` because of earlier checks to ensure the user is logged in.