### PR TITLE
Fix type handling/annotation related to encrypted passwords.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -116,12 +116,12 @@ class ILSAuthenticator
     /**
      * Decrypt text.
      *
-     * @param string $text The text to decrypt
+     * @param ?string $text The text to decrypt (null values will be returned as null)
      *
-     * @return string|bool The decrypted string (or false if invalid)
+     * @return ?string|bool The decrypted string (null if empty or false if invalid)
      * @throws \VuFind\Exception\PasswordSecurity
      */
-    public function decrypt(string $text)
+    public function decrypt(?string $text)
     {
         return $this->encryptOrDecrypt($text, false);
     }
@@ -129,12 +129,12 @@ class ILSAuthenticator
     /**
      * Encrypt text.
      *
-     * @param string $text The text to encrypt
+     * @param ?string $text The text to encrypt (null values will be returned as null)
      *
-     * @return string|bool The encrypted string (or false if invalid)
+     * @return ?string|bool The encrypted string (null if empty or false if invalid)
      * @throws \VuFind\Exception\PasswordSecurity
      */
-    public function encrypt(string $text)
+    public function encrypt(?string $text)
     {
         return $this->encryptOrDecrypt($text, true);
     }
@@ -143,18 +143,18 @@ class ILSAuthenticator
      * This is a central function for encrypting and decrypting so that
      * logic is all in one location
      *
-     * @param string $text    The text to be encrypted or decrypted
-     * @param bool   $encrypt True if we wish to encrypt text, False if we wish to
+     * @param ?string $text    The text to be encrypted or decrypted
+     * @param bool    $encrypt True if we wish to encrypt text, False if we wish to
      * decrypt text.
      *
-     * @return string|bool    The encrypted/decrypted string
+     * @return ?string|bool    The encrypted/decrypted string (null = empty input; false = error)
      * @throws \VuFind\Exception\PasswordSecurity
      */
-    protected function encryptOrDecrypt($text, $encrypt = true)
+    protected function encryptOrDecrypt(?string $text, bool $encrypt = true)
     {
         // Ignore empty text:
-        if (empty($text)) {
-            return $text;
+        if ($text === null || $text === '') {
+            return null;
         }
 
         $configAuth = $this->config->Authentication ?? new \Laminas\Config\Config([]);

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -203,12 +203,17 @@ class ILSAuthenticator
      * @param UserEntityInterface $user User
      *
      * @return ?string
+     * @throws \Exception
      */
     public function getCatPasswordForUser(UserEntityInterface $user)
     {
         if ($this->passwordEncryptionEnabled()) {
             $encrypted = $user->getCatPassEnc();
-            return !empty($encrypted) ? $this->decrypt($encrypted) : null;
+            $decrypted = !empty($encrypted) ? $this->decrypt($encrypted) : null;
+            if ($decrypted === false) {
+                throw new \Exception('Unexpected error decrypting password');
+            }
+            return $decrypted;
         }
         return $user->getRawCatPassword();
     }

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -203,7 +203,6 @@ class ILSAuthenticator
      * @param UserEntityInterface $user User
      *
      * @return ?string
-     * @throws \Exception
      */
     public function getCatPasswordForUser(UserEntityInterface $user)
     {

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -198,11 +198,11 @@ class ILSAuthenticator
     }
 
     /**
-     * Given a user object, retrieve the decrypted password.
+     * Given a user object, retrieve the decrypted password (or null if unset/invalid).
      *
      * @param UserEntityInterface $user User
      *
-     * @return string
+     * @return ?string
      */
     public function getCatPasswordForUser(UserEntityInterface $user)
     {

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -211,7 +211,8 @@ class ILSAuthenticator
             $encrypted = $user->getCatPassEnc();
             $decrypted = !empty($encrypted) ? $this->decrypt($encrypted) : null;
             if ($decrypted === false) {
-                throw new \Exception('Unexpected error decrypting password');
+                // Unexpected error decrypting password; let's treat it as unset for now:
+                return null;
             }
             return $decrypted;
         }

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -508,7 +508,7 @@ class User extends RowGateway implements
             if ($row === false) {
                 throw new \VuFind\Exception\LibraryCard('Library Card Not Found');
             }
-            if ($this->passwordEncryptionEnabled()) {
+            if ($this->passwordEncryptionEnabled() && $row->cat_pass_enc) {
                 $row->cat_password = $this->ilsAuthenticator->decrypt($row->cat_pass_enc);
             }
         }

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -146,7 +146,7 @@ class User extends RowGateway implements
         $this->cat_username = $username;
         if ($this->passwordEncryptionEnabled()) {
             $this->cat_password = null;
-            $this->cat_pass_enc = $password === null ? null : $this->ilsAuthenticator->encrypt($password);
+            $this->cat_pass_enc = $this->ilsAuthenticator->encrypt($password);
         } else {
             $this->cat_password = $password;
             $this->cat_pass_enc = null;
@@ -509,8 +509,7 @@ class User extends RowGateway implements
                 throw new \VuFind\Exception\LibraryCard('Library Card Not Found');
             }
             if ($this->passwordEncryptionEnabled()) {
-                $row->cat_password = $row->cat_pass_enc
-                    ? $this->ilsAuthenticator->decrypt($row->cat_pass_enc) : null;
+                $row->cat_password = $this->ilsAuthenticator->decrypt($row->cat_pass_enc);
             }
         }
 

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -136,8 +136,8 @@ class User extends RowGateway implements
     /**
      * Set ILS login credentials without saving them.
      *
-     * @param string $username Username to save
-     * @param string $password Password to save
+     * @param string  $username Username to save
+     * @param ?string $password Password to save (null for none)
      *
      * @return void
      */
@@ -146,7 +146,7 @@ class User extends RowGateway implements
         $this->cat_username = $username;
         if ($this->passwordEncryptionEnabled()) {
             $this->cat_password = null;
-            $this->cat_pass_enc = $this->ilsAuthenticator->encrypt($password);
+            $this->cat_pass_enc = $password === null ? null : $this->ilsAuthenticator->encrypt($password);
         } else {
             $this->cat_password = $password;
             $this->cat_pass_enc = null;

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -508,8 +508,9 @@ class User extends RowGateway implements
             if ($row === false) {
                 throw new \VuFind\Exception\LibraryCard('Library Card Not Found');
             }
-            if ($this->passwordEncryptionEnabled() && $row->cat_pass_enc) {
-                $row->cat_password = $this->ilsAuthenticator->decrypt($row->cat_pass_enc);
+            if ($this->passwordEncryptionEnabled()) {
+                $row->cat_password = $row->cat_pass_enc
+                    ? $this->ilsAuthenticator->decrypt($row->cat_pass_enc) : null;
             }
         }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTest\Auth;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use VuFind\Auth\EmailAuthenticator;
 use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\Manager;
 use VuFind\Db\Row\User;
@@ -50,7 +52,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNewCatalogLoginSuccess()
+    public function testNewCatalogLoginSuccess(): void
     {
         $user = $this->getMockUser(['saveCredentials']);
         $user->expects($this->once())->method('saveCredentials')
@@ -71,7 +73,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNewCatalogFailure()
+    public function testNewCatalogFailure(): void
     {
         $manager = $this->getMockManager(['getUserObject']);
         $manager->expects($this->any())->method('getUserObject')->willReturn(null);
@@ -88,7 +90,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testNewCatalogFailureByException()
+    public function testNewCatalogFailureByException(): void
     {
         $this->expectException(\VuFind\Exception\ILS::class);
         $this->expectExceptionMessage('kaboom');
@@ -107,7 +109,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoggedOutStoredLoginAttempt()
+    public function testLoggedOutStoredLoginAttempt(): void
     {
         $manager = $this->getMockManager(['getUserObject']);
         $manager->expects($this->any())->method('getUserObject')->willReturn(null);
@@ -120,7 +122,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSuccessfulStoredLoginAttempt()
+    public function testSuccessfulStoredLoginAttempt(): void
     {
         $user = $this->getMockUser(['getCatUsername', 'getRawCatPassword']);
         $user->expects($this->any())->method('getCatUsername')->willReturn('user');
@@ -144,7 +146,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUnsuccessfulStoredLoginAttempt()
+    public function testUnsuccessfulStoredLoginAttempt(): void
     {
         $user = $this->getMockUser(['clearCredentials', 'getCatUsername', 'getRawCatPassword']);
         $user->expects($this->any())->method('getCatUsername')->willReturn('user');
@@ -164,7 +166,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testExceptionDuringStoredLoginAttempt()
+    public function testExceptionDuringStoredLoginAttempt(): void
     {
         $this->expectException(\VuFind\Exception\ILS::class);
         $this->expectExceptionMessage('kaboom');
@@ -184,15 +186,62 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test encryption and decryption of a string.
+     *
+     * @return void
+     */
+    public function testStringEncryptionAndDecryption(): void
+    {
+        $string = 'gobbledygook';
+        $auth = $this->getAuthenticator(config: $this->getAuthConfig());
+        $encrypted = $auth->encrypt($string);
+        $this->assertNotEquals($string, $encrypted);
+        $this->assertEquals($string, $auth->decrypt($encrypted));
+    }
+
+    /**
+     * Test encryption and decryption of null.
+     *
+     * @return void
+     */
+    public function testNullEncryptionAndDecryption(): void
+    {
+        $auth = $this->getAuthenticator(config: $this->getAuthConfig());
+        $this->assertNull($auth->encrypt(null));
+        $this->assertNull($auth->decrypt(null));
+    }
+
+    /**
+     * Get authentication-specific configuration.
+     *
+     * @return array
+     */
+    protected function getAuthConfig(): array
+    {
+        return [
+            'Authentication' => [
+                'ils_encryption_key' => 'foo',
+                'ils_encryption_algo' => 'aes',
+            ],
+        ];
+    }
+
+    /**
      * Get an authenticator
      *
-     * @param Manager       $manager    Auth manager (null for default mock)
-     * @param ILSConnection $connection ILS connection (null for default mock)
+     * @param Manager            $manager    Auth manager (null for default mock)
+     * @param ILSConnection      $connection ILS connection (null for default mock)
+     * @param EmailAuthenticator $emailAuth  Email authenticator (null for default mock)
+     * @param array              $config     Configuration (null for empty)
      *
      * @return ILSAuthenticator
      */
-    protected function getAuthenticator(Manager $manager = null, ILSConnection $connection = null)
-    {
+    protected function getAuthenticator(
+        Manager $manager = null,
+        ILSConnection $connection = null,
+        EmailAuthenticator $emailAuth = null,
+        array $config = []
+    ): ILSAuthenticator {
         if (null === $manager) {
             $manager = $this->getMockManager();
         }
@@ -203,7 +252,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
             function () use ($manager) {
                 return $manager;
             },
-            $connection
+            $connection,
+            $emailAuth ?? $this->createMock(EmailAuthenticator::class),
+            new \Laminas\Config\Config($config)
         );
     }
 
@@ -212,9 +263,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $methods Methods to mock
      *
-     * @return User
+     * @return MockObject&User
      */
-    protected function getMockUser($methods = [])
+    protected function getMockUser(array $methods = []): MockObject&User
     {
         return $this->getMockBuilder(\VuFind\Db\Row\User::class)
             ->disableOriginalConstructor()
@@ -227,9 +278,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $methods Methods to mock
      *
-     * @return Manager
+     * @return MockObject&Manager
      */
-    protected function getMockManager($methods = [])
+    protected function getMockManager(array $methods = []): MockObject&Manager
     {
         return $this->getMockBuilder(\VuFind\Auth\Manager::class)
             ->disableOriginalConstructor()
@@ -242,9 +293,9 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $methods Methods to mock
      *
-     * @return ILSConnection
+     * @return MockObject&ILSConnection
      */
-    protected function getMockConnection($methods = [])
+    protected function getMockConnection(array $methods = []): MockObject&ILSConnection
     {
         // We need to use addMethods here instead of onlyMethods, because
         // we're generally mocking behavior that gets handled by __call


### PR DESCRIPTION
@welblaud reported an error caused by an attempt to encrypt a null value; on investigation I discovered that this was possible because some of our type annotations were incorrect and there was a potentially problematic edge case. This PR should address those problems -- @welblaud has confirmed below that it resolves his issues. I've also added some relevant unit tests and confirmed that the full test suite still passes.