### PR TITLE
Use UserEntityInterface in profile template (and related code)

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -197,6 +197,22 @@ interface UserEntityInterface extends EntityInterface
     public function getVerifyHash(): string;
 
     /**
+     * Set active authentication method (if any).
+     *
+     * @param ?string $authMethod New value (null for none)
+     *
+     * @return UserEntityInterface
+     */
+    public function setAuthMethod(?string $authMethod): UserEntityInterface;
+
+    /**
+     * Get active authentication method (if any).
+     *
+     * @return ?string
+     */
+    public function getAuthMethod(): ?string;
+
+    /**
      * Get last language.
      *
      * @return string

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -1013,6 +1013,29 @@ class User extends RowGateway implements
     }
 
     /**
+     * Set active authentication method (if any).
+     *
+     * @param ?string $authMethod New value (null for none)
+     *
+     * @return UserEntityInterface
+     */
+    public function setAuthMethod(?string $authMethod): UserEntityInterface
+    {
+        $this->auth_method = $authMethod;
+        return $this;
+    }
+
+    /**
+     * Get active authentication method (if any).
+     *
+     * @return ?string
+     */
+    public function getAuthMethod(): ?string
+    {
+        return $this->auth_method;
+    }
+
+    /**
      * Get last language.
      *
      * @return string

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -776,19 +776,6 @@ class User extends RowGateway implements
     }
 
     /**
-     * Get login token data
-     *
-     * @param string $userId user identifier
-     *
-     * @return array
-     */
-    public function getLoginTokens(string $userId): array
-    {
-        $tokenTable = $this->getDbTable('LoginToken');
-        return $tokenTable->getByUserId($userId);
-    }
-
-    /**
      * Get identifier (returns null for an uninitialized or non-persisted object).
      *
      * @return ?int

--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -31,6 +31,8 @@ namespace VuFind\View\Helper\Root;
 
 use LmcRbacMvc\Identity\IdentityInterface;
 use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Table\DbTableAwareInterface;
+use VuFind\Db\Table\DbTableAwareTrait;
 use VuFind\Exception\ILS as ILSException;
 
 /**
@@ -42,9 +44,10 @@ use VuFind\Exception\ILS as ILSException;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class Auth extends \Laminas\View\Helper\AbstractHelper
+class Auth extends \Laminas\View\Helper\AbstractHelper implements DbTableAwareInterface
 {
     use ClassBasedTemplateRendererTrait;
+    use DbTableAwareTrait;
 
     /**
      * Authentication manager
@@ -194,6 +197,19 @@ class Auth extends \Laminas\View\Helper\AbstractHelper
     public function getLoginDesc($context = [])
     {
         return $this->renderTemplate('logindesc.phtml', $context);
+    }
+
+    /**
+     * Get login token data
+     *
+     * @param string $userId user identifier
+     *
+     * @return array
+     */
+    public function getLoginTokens(string $userId): array
+    {
+        $tokenTable = $this->getDbTable('LoginToken');
+        return $tokenTable->getByUserId($userId);
     }
 
     /**

--- a/themes/bootstrap3/templates/librarycards/selectcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/selectcard.phtml
@@ -4,7 +4,7 @@
     <form class="form-inline" action="<?=$this->url('librarycards-selectcard')?>" method="get" data-clear-account-cache>
       <label for="library_card"><?=$this->transEsc('Library Card')?></label>
       <select id="library_card" name="cardID" class="jumpMenu form-control">
-        <?php if (null === $this->user->cat_username): ?>
+        <?php if (null === $this->user->getCatUsername()): ?>
           <option value="" selected="selected">-</option>
         <?php endif; ?>
         <?php foreach ($cards as $card): ?>
@@ -19,7 +19,7 @@
               $display .= ' (' . $this->transEsc("source_$target", null, $target) . ')';
             }
           ?>
-          <option value="<?=$this->escapeHtmlAttr($card->getId())?>"<?=strcasecmp($card->getCatUsername(), $this->user->cat_username ?? '') == 0 ? ' selected="selected"' : ''?>><?=$display ?></option>
+          <option value="<?=$this->escapeHtmlAttr($card->getId())?>"<?=strcasecmp($card->getCatUsername(), $this->user->getCatUsername() ?? '') == 0 ? ' selected="selected"' : ''?>><?=$display ?></option>
         <?php endforeach; ?>
       </select>
       <noscript><input type="submit" class="btn btn-default" value="<?=$this->transEscAttr('Set')?>"></noscript>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -19,7 +19,11 @@
     <?=
       $this->renderArray(
           $arrTemplate,
-          $this->user,
+          [
+              'firstname' => $this->user->getFirstName(),
+              'lastname' => $this->user->getLastName(),
+              'email' => $this->user->getEmail(),
+          ],
           [
               $this->transEsc('First Name') => 'firstname',
               $this->transEsc('Last Name') => 'lastname',
@@ -82,10 +86,9 @@
     <?php endif; ?>
   </div>
 
-  <?php $user = $this->auth()->getUserObject(); ?>
-  <?php if ($user && $this->auth()->getManager()->supportsPersistentLogin($user->auth_method)): ?>
+  <?php if ($this->user && $this->auth()->getManager()->supportsPersistentLogin($this->user->getAuthMethod())): ?>
     <h3><?=$this->transEsc('Saved Logins')?></h3>
-    <?php $tokens = $user->getLoginTokens($user->id); ?>
+    <?php $tokens = $this->user->getLoginTokens($this->user->getId()); ?>
     <?php if (!$tokens): ?>
       <div class="my-profile-col"><?=$this->transEsc('No saved logins')?></div>
     <?php else: ?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -86,7 +86,7 @@
     <?php endif; ?>
   </div>
 
-  <?php if ($this->user && $this->auth()->getManager()->supportsPersistentLogin($this->user->getAuthMethod())): ?>
+  <?php if ($this->auth()->getManager()->supportsPersistentLogin($this->user->getAuthMethod())): ?>
     <h3><?=$this->transEsc('Saved Logins')?></h3>
     <?php $tokens = $this->user->getLoginTokens($this->user->getId()); ?>
     <?php if (!$tokens): ?>

--- a/themes/bootstrap3/templates/myresearch/profile.phtml
+++ b/themes/bootstrap3/templates/myresearch/profile.phtml
@@ -88,7 +88,7 @@
 
   <?php if ($this->auth()->getManager()->supportsPersistentLogin($this->user->getAuthMethod())): ?>
     <h3><?=$this->transEsc('Saved Logins')?></h3>
-    <?php $tokens = $this->user->getLoginTokens($this->user->getId()); ?>
+    <?php $tokens = $this->auth()->getLoginTokens($this->user->getId()); ?>
     <?php if (!$tokens): ?>
       <div class="my-profile-col"><?=$this->transEsc('No saved logins')?></div>
     <?php else: ?>


### PR DESCRIPTION
This PR uses UserEntityInterface methods in place of direct property access in profile.phtml and some related code. It also eliminates some redundant retrieval of the user object in the profile.phtml template, refactors the getLoginTokens method from the User row object into the Auth view helper (to reduce reliance on non-interface-related calls), and adds new accessor methods to the interface.