### PR TITLE
Add "!default" flag to SASS variables for easier configuration

### DIFF
--- a/themes/bootstrap3/less/components/autocomplete.less
+++ b/themes/bootstrap3/less/components/autocomplete.less
@@ -1,11 +1,21 @@
 /* https://github.com/vufind-org/autocomplete.js (v2.1.3) */
 
+/* #LESS> */
 @autocomplete-item-bg     : #fff;
 @autocomplete-active-bg   : @brand-primary;
 @autocomplete-hover-bg    : lighten(@brand-primary, 40%);
 @autocomplete-disabled-bg : lightgray;
 @autocomplete-border      : lightgray;
 @autocomplete-secondary   : darkgray; // item description
+/* <#LESS */
+/* #SCSS>
+$autocomplete-item-bg     : #fff !default;
+$autocomplete-active-bg   : $brand-primary !default;
+$autocomplete-hover-bg    : lighten($brand-primary, 40%) !default;
+$autocomplete-disabled-bg : lightgray !default;
+$autocomplete-border      : lightgray !default;
+$autocomplete-secondary   : darkgray !default; // item description
+<#SCSS */
 
 .autocomplete-results {
   position: absolute;

--- a/themes/bootstrap3/less/components/cookie-consent/core/components/consent-modal.less
+++ b/themes/bootstrap3/less/components/cookie-consent/core/components/consent-modal.less
@@ -1,8 +1,15 @@
 @import "../global";
 
+/* #LESS> */
 @cc-sections-padding-y: 1rem;
 @cc-sections-padding-x: 1.3rem;
 @cc-footer-links-gap: 1.3rem;
+/* <#LESS */
+/* #SCSS>
+$cc-sections-padding-y: 1rem !default;
+$cc-sections-padding-x: 1.3rem !default;
+$cc-footer-links-gap: 1.3rem !default;
+<#SCSS */
 
 #cc-main{
 

--- a/themes/bootstrap3/less/components/cookie-consent/core/components/preferences-modal.less
+++ b/themes/bootstrap3/less/components/cookie-consent/core/components/preferences-modal.less
@@ -1,5 +1,6 @@
 @import "../global";
 
+/* #LESS> */
 @cc-padding-y: 1em;
 @cc-padding-x: 1.4em;
 
@@ -10,6 +11,19 @@
 @cc-service-toggle-knob-height: 19px;
 @cc-service-toggle-knob-width: 42px;
 @cc-service-toggle-knob-icon-width: 1.7px;
+/* <#LESS */
+/* #SCSS>
+$cc-padding-y: 1em !default;
+$cc-padding-x: 1.4em !default;
+
+$cc-toggle-knob-height: 23px !default;
+$cc-toggle-knob-width: 50px !default;
+$cc-toggle-knob-icon-width: 2px !default;
+
+$cc-service-toggle-knob-height: 19px !default;
+$cc-service-toggle-knob-width: 42px !default;
+$cc-service-toggle-knob-icon-width: 1.7px !default;
+<#SCSS */
 
 :root{
     --cc-pm-toggle-border-radius: 4em;

--- a/themes/bootstrap3/less/components/cookie-consent/core/global.less
+++ b/themes/bootstrap3/less/components/cookie-consent/core/global.less
@@ -1,3 +1,4 @@
+/* #LESS> */
 @cc-translate-y: 1.6em;
 @cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3);
 @cc-font-weight-bold: 500;
@@ -5,3 +6,13 @@
 @cc-btn-height: 42px;
 @cc-btn-vertical-padding: .5em;
 @cc-btn-gap: .375rem;
+/* <#LESS */
+/* #SCSS>
+$cc-translate-y: 1.6em !default;
+$cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3) !default;
+$cc-font-weight-bold: 500 !default;
+
+$cc-btn-height: 42px !default;
+$cc-btn-vertical-padding: .5em !default;
+$cc-btn-gap: .375rem !default;
+<#SCSS */

--- a/themes/bootstrap3/less/components/offcanvas.less
+++ b/themes/bootstrap3/less/components/offcanvas.less
@@ -1,4 +1,9 @@
+/* #LESS> */
 @offcanvas-offset: 80vw;  // Width of open menu
+/* <#LESS */
+/* #SCSS>
+$offcanvas-offset: 80vw !default;  // Width of open menu
+<#SCSS */
 
 .vufind-offcanvas-overlay { display: none; }
 

--- a/themes/bootstrap3/less/components/search.less
+++ b/themes/bootstrap3/less/components/search.less
@@ -1,7 +1,14 @@
 // Thumbnail sizes for media items: search results, list entries, record views
+/* #LESS> */
 @thumbnail-width-small:   60px;
 @thumbnail-width-medium: 100px;
 @thumbnail-width-large:  160px;
+/* <#LESS */
+/* #SCSS>
+$thumbnail-width-small:   60px !default;
+$thumbnail-width-medium: 100px !default;
+$thumbnail-width-large:  160px !default;
+<#SCSS */
 
 // record result list ol, ul that contains li.result
 .record-list {

--- a/themes/bootstrap3/scss/components/autocomplete.scss
+++ b/themes/bootstrap3/scss/components/autocomplete.scss
@@ -1,10 +1,10 @@
 /* https://github.com/vufind-org/autocomplete.js (v2.1.3) */
 
-$autocomplete-item-bg     : #fff;
-$autocomplete-active-bg   : $brand-primary;
-$autocomplete-hover-bg    : lighten($brand-primary, 40%);
-$autocomplete-disabled-bg : lightgray;
-$autocomplete-border      : lightgray;
+$autocomplete-item-bg     : #fff !default;
+$autocomplete-active-bg   : $brand-primary !default;
+$autocomplete-hover-bg    : lighten($brand-primary, 40%) !default;
+$autocomplete-disabled-bg : lightgray !default;
+$autocomplete-border      : lightgray !default;
 $autocomplete-secondary   : darkgray; // item description
 
 .autocomplete-results {

--- a/themes/bootstrap3/scss/components/autocomplete.scss
+++ b/themes/bootstrap3/scss/components/autocomplete.scss
@@ -1,12 +1,12 @@
 /* https://github.com/vufind-org/autocomplete.js (v2.1.3) */
 
 /* #LESS>
-@autocomplete-item-bg     : #fff;
-@autocomplete-active-bg   : @brand-primary;
-@autocomplete-hover-bg    : lighten(@brand-primary, 40%);
-@autocomplete-disabled-bg : lightgray;
-@autocomplete-border      : lightgray;
-@autocomplete-secondary   : darkgray; // item description
+$autocomplete-item-bg     : #fff;
+$autocomplete-active-bg   : $brand-primary;
+$autocomplete-hover-bg    : lighten($brand-primary, 40%);
+$autocomplete-disabled-bg : lightgray;
+$autocomplete-border      : lightgray;
+$autocomplete-secondary   : darkgray; // item description
 <#LESS */
 /* #SCSS> */
 $autocomplete-item-bg     : #fff !default;

--- a/themes/bootstrap3/scss/components/autocomplete.scss
+++ b/themes/bootstrap3/scss/components/autocomplete.scss
@@ -5,7 +5,7 @@ $autocomplete-active-bg   : $brand-primary !default;
 $autocomplete-hover-bg    : lighten($brand-primary, 40%) !default;
 $autocomplete-disabled-bg : lightgray !default;
 $autocomplete-border      : lightgray !default;
-$autocomplete-secondary   : darkgray; // item description
+$autocomplete-secondary   : darkgray !default; // item description
 
 .autocomplete-results {
   position: absolute;

--- a/themes/bootstrap3/scss/components/autocomplete.scss
+++ b/themes/bootstrap3/scss/components/autocomplete.scss
@@ -1,11 +1,21 @@
 /* https://github.com/vufind-org/autocomplete.js (v2.1.3) */
 
+/* #LESS>
+@autocomplete-item-bg     : #fff;
+@autocomplete-active-bg   : @brand-primary;
+@autocomplete-hover-bg    : lighten(@brand-primary, 40%);
+@autocomplete-disabled-bg : lightgray;
+@autocomplete-border      : lightgray;
+@autocomplete-secondary   : darkgray; // item description
+<#LESS */
+/* #SCSS> */
 $autocomplete-item-bg     : #fff !default;
 $autocomplete-active-bg   : $brand-primary !default;
 $autocomplete-hover-bg    : lighten($brand-primary, 40%) !default;
 $autocomplete-disabled-bg : lightgray !default;
 $autocomplete-border      : lightgray !default;
 $autocomplete-secondary   : darkgray !default; // item description
+/* <#SCSS */
 
 .autocomplete-results {
   position: absolute;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
@@ -1,8 +1,8 @@
 @import "../global";
 
-$cc-sections-padding-y: 1rem;
-$cc-sections-padding-x: 1.3rem;
-$cc-footer-links-gap: 1.3rem;
+$cc-sections-padding-y: 1rem !default;
+$cc-sections-padding-x: 1.3rem !default;
+$cc-footer-links-gap: 1.3rem !default;
 
 #cc-main{
 

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
@@ -1,8 +1,15 @@
 @import "../global";
 
+/* #LESS>
+@cc-sections-padding-y: 1rem;
+@cc-sections-padding-x: 1.3rem;
+@cc-footer-links-gap: 1.3rem;
+<#LESS */
+/* #SCSS> */
 $cc-sections-padding-y: 1rem !default;
 $cc-sections-padding-x: 1.3rem !default;
 $cc-footer-links-gap: 1.3rem !default;
+/* <#SCSS */
 
 #cc-main{
 

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
@@ -1,9 +1,9 @@
 @import "../global";
 
 /* #LESS>
-@cc-sections-padding-y: 1rem;
-@cc-sections-padding-x: 1.3rem;
-@cc-footer-links-gap: 1.3rem;
+$cc-sections-padding-y: 1rem;
+$cc-sections-padding-x: 1.3rem;
+$cc-footer-links-gap: 1.3rem;
 <#LESS */
 /* #SCSS> */
 $cc-sections-padding-y: 1rem !default;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
@@ -1,16 +1,16 @@
 @import "../global";
 
 /* #LESS>
-@cc-padding-y: 1em;
-@cc-padding-x: 1.4em;
+$cc-padding-y: 1em;
+$cc-padding-x: 1.4em;
 
-@cc-toggle-knob-height: 23px;
-@cc-toggle-knob-width: 50px;
-@cc-toggle-knob-icon-width: 2px;
+$cc-toggle-knob-height: 23px;
+$cc-toggle-knob-width: 50px;
+$cc-toggle-knob-icon-width: 2px;
 
-@cc-service-toggle-knob-height: 19px;
-@cc-service-toggle-knob-width: 42px;
-@cc-service-toggle-knob-icon-width: 1.7px;
+$cc-service-toggle-knob-height: 19px;
+$cc-service-toggle-knob-width: 42px;
+$cc-service-toggle-knob-icon-width: 1.7px;
 <#LESS */
 /* #SCSS> */
 $cc-padding-y: 1em !default;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
@@ -1,5 +1,18 @@
 @import "../global";
 
+/* #LESS>
+@cc-padding-y: 1em;
+@cc-padding-x: 1.4em;
+
+@cc-toggle-knob-height: 23px;
+@cc-toggle-knob-width: 50px;
+@cc-toggle-knob-icon-width: 2px;
+
+@cc-service-toggle-knob-height: 19px;
+@cc-service-toggle-knob-width: 42px;
+@cc-service-toggle-knob-icon-width: 1.7px;
+<#LESS */
+/* #SCSS> */
 $cc-padding-y: 1em !default;
 $cc-padding-x: 1.4em !default;
 
@@ -10,6 +23,7 @@ $cc-toggle-knob-icon-width: 2px !default;
 $cc-service-toggle-knob-height: 19px !default;
 $cc-service-toggle-knob-width: 42px !default;
 $cc-service-toggle-knob-icon-width: 1.7px !default;
+/* <#SCSS */
 
 :root{
     --cc-pm-toggle-border-radius: 4em;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
@@ -1,15 +1,15 @@
 @import "../global";
 
-$cc-padding-y: 1em;
-$cc-padding-x: 1.4em;
+$cc-padding-y: 1em !default;
+$cc-padding-x: 1.4em !default;
 
-$cc-toggle-knob-height: 23px;
-$cc-toggle-knob-width: 50px;
-$cc-toggle-knob-icon-width: 2px;
+$cc-toggle-knob-height: 23px !default;
+$cc-toggle-knob-width: 50px !default;
+$cc-toggle-knob-icon-width: 2px !default;
 
-$cc-service-toggle-knob-height: 19px;
-$cc-service-toggle-knob-width: 42px;
-$cc-service-toggle-knob-icon-width: 1.7px;
+$cc-service-toggle-knob-height: 19px !default;
+$cc-service-toggle-knob-width: 42px !default;
+$cc-service-toggle-knob-icon-width: 1.7px !default;
 
 :root{
     --cc-pm-toggle-border-radius: 4em;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
@@ -1,3 +1,13 @@
+/* #LESS>
+@cc-translate-y: 1.6em;
+@cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3);
+@cc-font-weight-bold: 500;
+
+@cc-btn-height: 42px;
+@cc-btn-vertical-padding: .5em;
+@cc-btn-gap: .375rem;
+<#LESS */
+/* #SCSS> */
 $cc-translate-y: 1.6em !default;
 $cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3) !default;
 $cc-font-weight-bold: 500 !default;
@@ -5,3 +15,4 @@ $cc-font-weight-bold: 500 !default;
 $cc-btn-height: 42px !default;
 $cc-btn-vertical-padding: .5em !default;
 $cc-btn-gap: .375rem !default;
+/* <#SCSS */

--- a/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
@@ -1,11 +1,11 @@
 /* #LESS>
-@cc-translate-y: 1.6em;
-@cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3);
-@cc-font-weight-bold: 500;
+$cc-translate-y: 1.6em;
+$cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3);
+$cc-font-weight-bold: 500;
 
-@cc-btn-height: 42px;
-@cc-btn-vertical-padding: .5em;
-@cc-btn-gap: .375rem;
+$cc-btn-height: 42px;
+$cc-btn-vertical-padding: .5em;
+$cc-btn-gap: .375rem;
 <#LESS */
 /* #SCSS> */
 $cc-translate-y: 1.6em !default;

--- a/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/global.scss
@@ -1,7 +1,7 @@
-$cc-translate-y: 1.6em;
-$cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3);
-$cc-font-weight-bold: 500;
+$cc-translate-y: 1.6em !default;
+$cc-modal-box-shadow: 0 0.625em 1.875em rgba(0, 0, 2, .3) !default;
+$cc-font-weight-bold: 500 !default;
 
-$cc-btn-height: 42px;
-$cc-btn-vertical-padding: .5em;
-$cc-btn-gap: .375rem;
+$cc-btn-height: 42px !default;
+$cc-btn-vertical-padding: .5em !default;
+$cc-btn-gap: .375rem !default;

--- a/themes/bootstrap3/scss/components/offcanvas.scss
+++ b/themes/bootstrap3/scss/components/offcanvas.scss
@@ -1,4 +1,4 @@
-$offcanvas-offset: 80vw;  // Width of open menu
+$offcanvas-offset: 80vw !default;  // Width of open menu
 
 .vufind-offcanvas-overlay { display: none; }
 

--- a/themes/bootstrap3/scss/components/offcanvas.scss
+++ b/themes/bootstrap3/scss/components/offcanvas.scss
@@ -1,5 +1,5 @@
 /* #LESS>
-@offcanvas-offset: 80vw;  // Width of open menu
+$offcanvas-offset: 80vw;  // Width of open menu
 <#LESS */
 /* #SCSS> */
 $offcanvas-offset: 80vw !default;  // Width of open menu

--- a/themes/bootstrap3/scss/components/offcanvas.scss
+++ b/themes/bootstrap3/scss/components/offcanvas.scss
@@ -1,4 +1,9 @@
+/* #LESS>
+@offcanvas-offset: 80vw;  // Width of open menu
+<#LESS */
+/* #SCSS> */
 $offcanvas-offset: 80vw !default;  // Width of open menu
+/* <#SCSS */
 
 .vufind-offcanvas-overlay { display: none; }
 

--- a/themes/bootstrap3/scss/components/search.scss
+++ b/themes/bootstrap3/scss/components/search.scss
@@ -1,7 +1,14 @@
 // Thumbnail sizes for media items: search results, list entries, record views
+/* #LESS>
+@thumbnail-width-small:   60px;
+@thumbnail-width-medium: 100px;
+@thumbnail-width-large:  160px;
+<#LESS */
+/* #SCSS> */
 $thumbnail-width-small:   60px !default;
 $thumbnail-width-medium: 100px !default;
 $thumbnail-width-large:  160px !default;
+/* <#SCSS */
 
 // record result list ol, ul that contains li.result
 .record-list {

--- a/themes/bootstrap3/scss/components/search.scss
+++ b/themes/bootstrap3/scss/components/search.scss
@@ -1,8 +1,8 @@
 // Thumbnail sizes for media items: search results, list entries, record views
 /* #LESS>
-@thumbnail-width-small:   60px;
-@thumbnail-width-medium: 100px;
-@thumbnail-width-large:  160px;
+$thumbnail-width-small:   60px;
+$thumbnail-width-medium: 100px;
+$thumbnail-width-large:  160px;
 <#LESS */
 /* #SCSS> */
 $thumbnail-width-small:   60px !default;

--- a/themes/bootstrap3/scss/components/search.scss
+++ b/themes/bootstrap3/scss/components/search.scss
@@ -1,7 +1,7 @@
 // Thumbnail sizes for media items: search results, list entries, record views
-$thumbnail-width-small:   60px;
-$thumbnail-width-medium: 100px;
-$thumbnail-width-large:  160px;
+$thumbnail-width-small:   60px !default;
+$thumbnail-width-medium: 100px !default;
+$thumbnail-width-large:  160px !default;
 
 // record result list ol, ul that contains li.result
 .record-list {


### PR DESCRIPTION
Some SASS-variables like the ones used in autocomplete.scss are not flagged as !default and cannot be easily overridden. To override them one has to copy the whole file into the cusom theme and change the variables.