### PR TITLE
Initialize head theme resources in combined AJAX responses.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -131,13 +131,15 @@ class CombinedController extends AbstractSearch
                     && ($general->Site->showBulkOptions ?? false),
                 'domId' => 'combined_' . str_replace(':', '____', $sectionId),
             ];
-            // Load custom CSS, if necessary:
-            $html = ($this->getViewRenderer()->plugin('headLink'))();
+            // Initialize theme resources:
+            ($this->getViewRenderer()->plugin('headThemeResources'))();
             // Render content:
-            $html .= $this->getViewRenderer()->render(
+            $html = $this->getViewRenderer()->render(
                 'combined/results-list.phtml',
                 $viewParams
             );
+            // Prepend CSS in case of custom files added by templates:
+            $html = ($this->getViewRenderer()->plugin('headLink'))() . $html;
         }
         return $this->getAjaxResponse('text/html', $html);
     }


### PR DESCRIPTION
The code to generate combined search AJAX responses was intended to output CSS links in case of dynamic style addition during template rendering. However, this logic did not quite work correctly, and would sometimes cause default styles to override custom styles. This PR properly initializes resources and changes order of operations to ensure that template rendering is completed before style links are added to the response.