### PR TITLE
Refactor AuthManager to use UserService and UserEntityInterface

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -35,12 +35,11 @@ use LmcRbacMvc\Identity\IdentityInterface;
 use VuFind\Cookie\CookieManager;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Row\User as UserRow;
-use VuFind\Db\Table\User as UserTable;
+use VuFind\Db\Service\UserServiceInterface;
 use VuFind\Exception\Auth as AuthException;
 use VuFind\ILS\Connection;
 use VuFind\Validator\CsrfInterface;
 
-use function count;
 use function in_array;
 use function is_callable;
 
@@ -81,53 +80,11 @@ class Manager implements
     protected $legalAuthOptions;
 
     /**
-     * VuFind configuration
-     *
-     * @var Config
-     */
-    protected $config;
-
-    /**
      * Session container
      *
      * @var \Laminas\Session\Container
      */
     protected $session;
-
-    /**
-     * Gateway to user table in database
-     *
-     * @var UserTable
-     */
-    protected $userTable;
-
-    /**
-     * Login token manager
-     *
-     * @var LoginTokenManager
-     */
-    protected $loginTokenManager;
-
-    /**
-     * Session manager
-     *
-     * @var SessionManager
-     */
-    protected $sessionManager;
-
-    /**
-     * Authentication plugin manager
-     *
-     * @var PluginManager
-     */
-    protected $pluginManager;
-
-    /**
-     * Cookie Manager
-     *
-     * @var CookieManager
-     */
-    protected $cookieManager;
 
     /**
      * Cache for current logged in user object
@@ -137,13 +94,6 @@ class Manager implements
     protected $currentUser = null;
 
     /**
-     * CSRF validator
-     *
-     * @var CsrfInterface
-     */
-    protected $csrf;
-
-    /**
      * Cache for hideLogin setting
      *
      * @var ?bool
@@ -151,44 +101,27 @@ class Manager implements
     protected $hideLogin = null;
 
     /**
-     * ILS connection
-     *
-     * @var Connection
-     */
-    protected $ils;
-
-    /**
      * Constructor
      *
-     * @param Config            $config            VuFind configuration
-     * @param UserTable         $userTable         User table gateway
-     * @param SessionManager    $sessionManager    Session manager
-     * @param PluginManager     $pm                Authentication plugin manager
-     * @param CookieManager     $cookieManager     Cookie manager
-     * @param CsrfInterface     $csrf              CSRF validator
-     * @param LoginTokenManager $loginTokenManager Login Token manager
-     * @param Connection        $ils               ILS connection
+     * @param Config               $config            VuFind configuration
+     * @param UserServiceInterface $userService       User database service
+     * @param SessionManager       $sessionManager    Session manager
+     * @param PluginManager        $pluginManager     Authentication plugin manager
+     * @param CookieManager        $cookieManager     Cookie manager
+     * @param CsrfInterface        $csrf              CSRF validator
+     * @param LoginTokenManager    $loginTokenManager Login Token manager
+     * @param Connection           $ils               ILS connection
      */
     public function __construct(
-        Config $config,
-        UserTable $userTable,
-        SessionManager $sessionManager,
-        PluginManager $pm,
-        CookieManager $cookieManager,
-        CsrfInterface $csrf,
-        LoginTokenManager $loginTokenManager,
-        Connection $ils
+        protected Config $config,
+        protected UserServiceInterface $userService,
+        protected SessionManager $sessionManager,
+        protected PluginManager $pluginManager,
+        protected CookieManager $cookieManager,
+        protected CsrfInterface $csrf,
+        protected LoginTokenManager $loginTokenManager,
+        protected Connection $ils
     ) {
-        // Store dependencies:
-        $this->config = $config;
-        $this->userTable = $userTable;
-        $this->loginTokenManager = $loginTokenManager;
-        $this->sessionManager = $sessionManager;
-        $this->pluginManager = $pm;
-        $this->cookieManager = $cookieManager;
-        $this->csrf = $csrf;
-        $this->ils = $ils;
-
         // Set up session:
         $this->session = new \Laminas\Session\Container('Account', $sessionManager);
 
@@ -196,7 +129,7 @@ class Manager implements
         // if no setting passed in):
         $method = $config->Authentication->method ?? 'Database';
         $this->legalAuthOptions = [$method];   // mark it as legal
-        $this->setAuthMethod($method);              // load it
+        $this->setAuthMethod($method);         // load it
     }
 
     /**
@@ -582,7 +515,7 @@ class Manager implements
     /**
      * Checks whether the user is logged in.
      *
-     * @return UserRow|false Object if user is logged in, false otherwise.
+     * @return UserEntityInterface|false Object if user is logged in, false otherwise.
      *
      * @deprecated Use getIdentity() or getUserObject() instead.
      */
@@ -603,22 +536,17 @@ class Manager implements
         if (!$this->currentUser) {
             if (isset($this->session->userId)) {
                 // normal mode
-                $results = $this->userTable
-                    ->select(['id' => $this->session->userId]);
-                $this->currentUser = count($results) < 1
-                    ? null : $results->current();
+                $this->currentUser = $this->userService->getUserById($this->session->userId);
                 // End the session since the logged-in user cannot be found:
                 if (null === $this->currentUser) {
                     $this->logout('');
                 }
             } elseif (isset($this->session->userDetails)) {
                 // privacy mode
-                $results = $this->userTable->createRow();
-                $results->exchangeArray($this->session->userDetails);
-                $this->currentUser = $results;
+                $this->currentUser = $this->userService->getUserFromSessionContainer($this->session);
             } elseif ($user = $this->loginTokenManager->tokenLogin($this->sessionManager->getId())) {
                 if ($this->getAuth() instanceof ChoiceAuth) {
-                    $this->getAuth()->setStrategy($user->auth_method);
+                    $this->getAuth()->setStrategy($user->getAuthMethod());
                 }
                 if ($this->supportsPersistentLogin()) {
                     $this->updateUser($user, null);
@@ -697,9 +625,9 @@ class Manager implements
     {
         $this->currentUser = $user;
         if ($this->inPrivacyMode()) {
-            $this->session->userDetails = $user->toArray();
+            $this->userService->addUserDataToSessionContainer($this->session, $user);
         } else {
-            $this->session->userId = $user->id;
+            $this->session->userId = $user->getId();
         }
         $this->cookieManager->clear('loggedOut');
     }
@@ -711,7 +639,7 @@ class Manager implements
      * new account details.
      *
      * @throws AuthException
-     * @return UserRow New user row.
+     * @return UserEntityInterface New user entity.
      */
     public function create($request)
     {
@@ -728,7 +656,7 @@ class Manager implements
      * password change details.
      *
      * @throws AuthException
-     * @return UserRow New user row.
+     * @return UserEntityInterface Updated user entity.
      */
     public function updatePassword($request)
     {
@@ -755,12 +683,12 @@ class Manager implements
         if ($this->config->Authentication->verify_email ?? false) {
             // If new email address is the current address, just reset any pending
             // email address:
-            $user->pending_email = ($email === $user->email) ? '' : $email;
+            $user->setPendingEmail($email === $user->getEmail() ? '' : $email);
         } else {
             $user->updateEmail($email, true);
-            $user->pending_email = '';
+            $user->setPendingEmail('');
         }
-        $user->save();
+        $this->userService->persistEntity($user);
         $this->updateSession($user);
     }
 
@@ -774,7 +702,7 @@ class Manager implements
      * @throws AuthException
      * @throws \VuFind\Exception\PasswordSecurity
      * @throws \VuFind\Exception\AuthInProgress
-     * @return UserRow Object representing logged-in user.
+     * @return UserEntityInterface Object representing logged-in user.
      */
     public function login($request)
     {
@@ -969,10 +897,10 @@ class Manager implements
     protected function updateUser($user, $authMethod)
     {
         if ($authMethod) {
-            $user->auth_method = strtolower($authMethod);
+            $user->setAuthMethod(strtolower($authMethod));
         }
-        $user->last_login = date('Y-m-d H:i:s');
-        $user->save();
+        $user->setLastLogin(new \DateTime());
+        $this->userService->persistEntity($user);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -80,13 +80,6 @@ class Manager implements
     protected $legalAuthOptions;
 
     /**
-     * Session container
-     *
-     * @var \Laminas\Session\Container
-     */
-    protected $session;
-
-    /**
      * Cache for current logged in user object
      *
      * @var ?UserEntityInterface
@@ -103,18 +96,18 @@ class Manager implements
     /**
      * Constructor
      *
-     * @param Config               $config            VuFind configuration
-     * @param UserServiceInterface $userService       User database service
-     * @param SessionManager       $sessionManager    Session manager
-     * @param PluginManager        $pluginManager     Authentication plugin manager
-     * @param CookieManager        $cookieManager     Cookie manager
-     * @param CsrfInterface        $csrf              CSRF validator
-     * @param LoginTokenManager    $loginTokenManager Login Token manager
-     * @param Connection           $ils               ILS connection
+     * @param Config                                               $config            VuFind configuration
+     * @param UserServiceInterface&UserSessionPersistenceInterface $userService       User database service
+     * @param SessionManager                                       $sessionManager    Session manager
+     * @param PluginManager                                        $pluginManager     Authentication plugin manager
+     * @param CookieManager                                        $cookieManager     Cookie manager
+     * @param CsrfInterface                                        $csrf              CSRF validator
+     * @param LoginTokenManager                                    $loginTokenManager Login Token manager
+     * @param Connection                                           $ils               ILS connection
      */
     public function __construct(
         protected Config $config,
-        protected UserServiceInterface $userService,
+        protected UserServiceInterface&UserSessionPersistenceInterface $userService,
         protected SessionManager $sessionManager,
         protected PluginManager $pluginManager,
         protected CookieManager $cookieManager,
@@ -122,9 +115,6 @@ class Manager implements
         protected LoginTokenManager $loginTokenManager,
         protected Connection $ils
     ) {
-        // Set up session:
-        $this->session = new \Laminas\Session\Container('Account', $sessionManager);
-
         // Initialize active authentication setting (defaulting to Database
         // if no setting passed in):
         $method = $config->Authentication->method ?? 'Database';
@@ -484,8 +474,7 @@ class Manager implements
 
         // Clear out the cached user object and session entry.
         $this->currentUser = null;
-        unset($this->session->userId);
-        unset($this->session->userDetails);
+        $this->userService->clearUserFromSession();
         $this->cookieManager->set('loggedOut', 1);
         $this->loginTokenManager->deleteActiveToken();
 
@@ -534,16 +523,12 @@ class Manager implements
         // If user object is not in cache, but user ID is in session,
         // load the object from the database:
         if (!$this->currentUser) {
-            if (isset($this->session->userId)) {
-                // normal mode
-                $this->currentUser = $this->userService->getUserById($this->session->userId);
-                // End the session since the logged-in user cannot be found:
+            if ($this->userService->hasUserSessionData()) {
+                $this->currentUser = $this->userService->getUserFromSession();
+                // End the session if the logged-in user cannot be found:
                 if (null === $this->currentUser) {
                     $this->logout('');
                 }
-            } elseif (isset($this->session->userDetails)) {
-                // privacy mode
-                $this->currentUser = $this->userService->getUserFromSessionContainer($this->session);
             } elseif ($user = $this->loginTokenManager->tokenLogin($this->sessionManager->getId())) {
                 if ($this->getAuth() instanceof ChoiceAuth) {
                     $this->getAuth()->setStrategy($user->getAuthMethod());
@@ -625,9 +610,9 @@ class Manager implements
     {
         $this->currentUser = $user;
         if ($this->inPrivacyMode()) {
-            $this->userService->addUserDataToSessionContainer($this->session, $user);
+            $this->userService->addUserDataToSession($user);
         } else {
-            $this->session->userId = $user->getId();
+            $this->userService->addUserIdToSession($user->getId());
         }
         $this->cookieManager->clear('loggedOut');
     }

--- a/module/VuFind/src/VuFind/Auth/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ManagerFactory.php
@@ -82,7 +82,8 @@ class ManagerFactory implements FactoryInterface
         // Build the object and make sure account credentials haven't expired:
         $manager = new $requestedName(
             $config,
-            $userService,
+            $userService,   // for UserServiceInterface
+            $userService,   // for UserSessionPersistenceInterface
             $sessionManager,
             $pm,
             $cookies,

--- a/module/VuFind/src/VuFind/Auth/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ManagerFactory.php
@@ -70,7 +70,8 @@ class ManagerFactory implements FactoryInterface
         }
         // Load dependencies:
         $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
-        $userTable = $container->get(\VuFind\Db\Table\PluginManager::class)->get('user');
+        $userService = $container->get(\VuFind\Db\Service\PluginManager::class)
+            ->get(\VuFind\Db\Service\UserServiceInterface::class);
         $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
         $pm = $container->get(\VuFind\Auth\PluginManager::class);
         $cookies = $container->get(\VuFind\Cookie\CookieManager::class);
@@ -81,7 +82,7 @@ class ManagerFactory implements FactoryInterface
         // Build the object and make sure account credentials haven't expired:
         $manager = new $requestedName(
             $config,
-            $userTable,
+            $userService,
             $sessionManager,
             $pm,
             $cookies,

--- a/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
+++ b/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
@@ -44,25 +44,6 @@ use VuFind\Db\Entity\UserEntityInterface;
 interface UserSessionPersistenceInterface
 {
     /**
-     * Retrieve a user object from the database based on ID.
-     *
-     * @param int $id ID.
-     *
-     * @return ?UserEntityInterface
-     */
-    public function getUserById(int $id): ?UserEntityInterface;
-
-    /**
-     * Retrieve a user object from the database based on the given field.
-     *
-     * @param string          $fieldName  Field name
-     * @param int|null|string $fieldValue Field value
-     *
-     * @return ?UserEntityInterface
-     */
-    public function getUserByField(string $fieldName, int|null|string $fieldValue): ?UserEntityInterface;
-
-    /**
      * Update session container to store data representing a user (used by privacy mode).
      *
      * @param UserEntityInterface $user User to store in session.

--- a/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
+++ b/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
@@ -83,11 +83,4 @@ interface UserSessionPersistenceInterface
      * @return bool
      */
     public function hasUserSessionData(): bool;
-
-    /**
-     * Create a new user entity.
-     *
-     * @return UserEntityInterface
-     */
-    public function createEntity(): UserEntityInterface;
 }

--- a/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
+++ b/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
@@ -44,15 +44,6 @@ use VuFind\Db\Entity\UserEntityInterface;
 interface UserSessionPersistenceInterface
 {
     /**
-     * Create an entity for the specified username.
-     *
-     * @param string $username Username
-     *
-     * @return UserEntityInterface
-     */
-    public function createRowForUsername(string $username): UserEntityInterface;
-
-    /**
      * Retrieve a user object from the database based on ID.
      *
      * @param int $id ID.

--- a/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
+++ b/module/VuFind/src/VuFind/Auth/UserSessionPersistenceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Database service interface for users.
+ * Interface for persisting user data in the session.
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2024.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,29 +21,37 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Database
- * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
+ * @package  Auth
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
 
-namespace VuFind\Db\Service;
+namespace VuFind\Auth;
 
 use Exception;
-use Laminas\Session\Container as SessionContainer;
 use VuFind\Db\Entity\UserEntityInterface;
 
 /**
- * Database service interface for users.
+ * Interface for persisting user data in the session.
  *
  * @category VuFind
  * @package  Database
- * @author   Aleksi Peebles <aleksi.peebles@helsinki.fi>
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-interface UserServiceInterface extends DbServiceInterface
+interface UserSessionPersistenceInterface
 {
+    /**
+     * Create an entity for the specified username.
+     *
+     * @param string $username Username
+     *
+     * @return UserEntityInterface
+     */
+    public function createRowForUsername(string $username): UserEntityInterface;
+
     /**
      * Retrieve a user object from the database based on ID.
      *
@@ -62,6 +70,47 @@ interface UserServiceInterface extends DbServiceInterface
      * @return ?UserEntityInterface
      */
     public function getUserByField(string $fieldName, int|null|string $fieldValue): ?UserEntityInterface;
+
+    /**
+     * Update session container to store data representing a user (used by privacy mode).
+     *
+     * @param UserEntityInterface $user User to store in session.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function addUserDataToSession(UserEntityInterface $user): void;
+
+    /**
+     * Update session container to store user ID (used outside of privacy mode).
+     *
+     * @param int $id User ID
+     *
+     * @return void
+     */
+    public function addUserIdToSession(int $id): void;
+
+    /**
+     * Clear the user data from the session.
+     *
+     * @return void
+     */
+    public function clearUserFromSession(): void;
+
+    /**
+     * Build a user entity using data from a session container. Return null if user
+     * data cannot be found.
+     *
+     * @return ?UserEntityInterface
+     */
+    public function getUserFromSession(): ?UserEntityInterface;
+
+    /**
+     * Is there user data currently stored in the session container?
+     *
+     * @return bool
+     */
+    public function hasUserSessionData(): bool;
 
     /**
      * Create a new user entity.

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Entity;
 
+use DateTime;
+
 /**
  * Interface for representing a user account record.
  *
@@ -64,11 +66,29 @@ interface UserEntityInterface extends EntityInterface
     public function getUsername(): string;
 
     /**
+     * Set firstname.
+     *
+     * @param string $firstName New first name
+     *
+     * @return UserEntityInterface
+     */
+    public function setFirstname(string $firstName): UserEntityInterface;
+
+    /**
      * Get firstname.
      *
      * @return string
      */
     public function getFirstname(): string;
+
+    /**
+     * Set lastname.
+     *
+     * @param string $lastName New last name
+     *
+     * @return UserEntityInterface
+     */
+    public function setLastname(string $lastName): UserEntityInterface;
 
     /**
      * Get lastname.
@@ -218,4 +238,36 @@ interface UserEntityInterface extends EntityInterface
      * @return string
      */
     public function getLastLanguage(): string;
+
+    /**
+     * Does the user have a user-provided (true) vs. automatically looked up (false) email address?
+     *
+     * @return bool
+     */
+    public function hasUserProvidedEmail(): bool;
+
+    /**
+     * Set the flag indicating whether the email address is user-provided.
+     *
+     * @param bool $userProvided New value
+     *
+     * @return UserEntityInterface
+     */
+    public function setHasUserProvidedEmail(bool $userProvided): UserEntityInterface;
+
+    /**
+     * Last login setter.
+     *
+     * @param Datetime $dateTime Last login date
+     *
+     * @return UserEntityInterface
+     */
+    public function setLastLogin(DateTime $dateTime): UserEntityInterface;
+
+    /**
+     * Last login getter
+     *
+     * @return Datetime
+     */
+    public function getLastLogin(): Datetime;
 }

--- a/module/VuFind/src/VuFind/Db/Row/PrivateUser.php
+++ b/module/VuFind/src/VuFind/Db/Row/PrivateUser.php
@@ -43,13 +43,6 @@ use function array_key_exists;
 class PrivateUser extends User
 {
     /**
-     * Session container for account information.
-     *
-     * @var \Laminas\Session\Container
-     */
-    protected $session = null;
-
-    /**
      * __get
      *
      * @param string $name Field to retrieve.
@@ -81,10 +74,7 @@ class PrivateUser extends User
     {
         $this->initialize();
         $this->id = -1; // fake ID
-        if (null === $this->session) {
-            throw new \Exception('Expected session container missing.');
-        }
-        $this->session->userDetails = $this->toArray();
+        $this->getDbService(\VuFind\Db\Service\UserService::class)->addUserDataToSession($this);
         return 1;
     }
 
@@ -94,9 +84,10 @@ class PrivateUser extends User
      * @param \Laminas\Session\Container $session Session container
      *
      * @return void
+     *
+     * @deprecated No longer used or needed
      */
     public function setSession(\Laminas\Session\Container $session)
     {
-        $this->session = $session;
     }
 }

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Db\Row;
 
+use DateTime;
 use Laminas\Db\Sql\Expression;
 use Laminas\Db\Sql\Select;
 use VuFind\Auth\ILSAuthenticator;
@@ -809,6 +810,19 @@ class User extends RowGateway implements
     }
 
     /**
+     * Set firstname.
+     *
+     * @param string $firstName New first name
+     *
+     * @return UserEntityInterface
+     */
+    public function setFirstname(string $firstName): UserEntityInterface
+    {
+        $this->firstname = $firstName;
+        return $this;
+    }
+
+    /**
      * Get firstname.
      *
      * @return string
@@ -816,6 +830,19 @@ class User extends RowGateway implements
     public function getFirstname(): string
     {
         return $this->firstname;
+    }
+
+    /**
+     * Set lastname.
+     *
+     * @param string $lastName New last name
+     *
+     * @return UserEntityInterface
+     */
+    public function setLastname(string $lastName): UserEntityInterface
+    {
+        $this->lastname = $lastName;
+        return $this;
     }
 
     /**
@@ -1030,5 +1057,51 @@ class User extends RowGateway implements
     public function getLastLanguage(): string
     {
         return $this->last_language;
+    }
+
+    /**
+     * Does the user have a user-provided (true) vs. automatically looked up (false) email address?
+     *
+     * @return bool
+     */
+    public function hasUserProvidedEmail(): bool
+    {
+        return (bool)($this->user_provided_email ?? false);
+    }
+
+    /**
+     * Set the flag indicating whether the email address is user-provided.
+     *
+     * @param bool $userProvided New value
+     *
+     * @return UserEntityInterface
+     */
+    public function setHasUserProvidedEmail(bool $userProvided): UserEntityInterface
+    {
+        $this->user_provided_email = $userProvided ? 1 : 0;
+        return $this;
+    }
+
+    /**
+     * Last login setter.
+     *
+     * @param Datetime $dateTime Last login date
+     *
+     * @return UserEntityInterface
+     */
+    public function setLastLogin(DateTime $dateTime): UserEntityInterface
+    {
+        $this->last_login = $dateTime->format('Y-m-d H:i:s');
+        return $this;
+    }
+
+    /**
+     * Last login getter
+     *
+     * @return Datetime
+     */
+    public function getLastLogin(): Datetime
+    {
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->last_login, new \DateTimeZone('UTC'));
     }
 }

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -1102,6 +1102,6 @@ class User extends RowGateway implements
      */
     public function getLastLogin(): Datetime
     {
-        return DateTime::createFromFormat('Y-m-d H:i:s', $this->last_login, new \DateTimeZone('UTC'));
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->last_login);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Row/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserFactory.php
@@ -74,20 +74,12 @@ class UserFactory extends RowGatewayFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory!');
         }
-        $config = $container->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
-        $privacy = isset($config->Authentication->privacy)
-            && $config->Authentication->privacy;
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
+        $privacy = $config->Authentication->privacy ?? false;
         $rowClass = $privacy ? $this->privateUserClass : $requestedName;
         $ilsAuthenticator = $container->get(\VuFind\Auth\ILSAuthenticator::class);
         $prototype = parent::__invoke($container, $rowClass, [$ilsAuthenticator]);
         $prototype->setConfig($config);
-        if ($privacy) {
-            $sessionManager = $container
-                ->get(\Laminas\Session\SessionManager::class);
-            $session = new \Laminas\Session\Container('Account', $sessionManager);
-            $prototype->setSession($session);
-        }
         return $prototype;
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Service/PluginManager.php
@@ -69,7 +69,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         ResourceService::class => ResourceServiceFactory::class,
         SessionService::class => SessionServiceFactory::class,
         TagService::class => AbstractDbServiceFactory::class,
-        UserService::class => AbstractDbServiceFactory::class,
+        UserService::class => UserServiceFactory::class,
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -30,7 +30,9 @@
 namespace VuFind\Db\Service;
 
 use Laminas\Log\LoggerAwareInterface;
+use Laminas\Session\Container as SessionContainer;
 use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Row\User as UserRow;
 use VuFind\Db\Table\DbTableAwareInterface;
 use VuFind\Db\Table\DbTableAwareTrait;
 use VuFind\Log\LoggerAwareTrait;
@@ -84,5 +86,47 @@ class UserService extends AbstractDbService implements
                 return $this->getDbTable('User')->getByCatalogId($fieldValue);
         }
         throw new \InvalidArgumentException('Field name must be id, username or cat_id');
+    }
+
+    /**
+     * Update session container to store data representing a user (used by privacy mode).
+     *
+     * @param SessionContainer    $session Session container.
+     * @param UserEntityInterface $user    User to store in session.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function addUserDataToSessionContainer(SessionContainer $session, UserEntityInterface $user): void
+    {
+        if ($user instanceof UserRow) {
+            $session->userDetails = $user->toArray();
+        } else {
+            throw new \Exception($user::class . ' not supported by addUserDataToSessionContainer()');
+        }
+    }
+
+    /**
+     * Build a user entity using data from a session container.
+     *
+     * @param SessionContainer $session Session container.
+     *
+     * @return UserEntityInterface
+     */
+    public function getUserFromSessionContainer(SessionContainer $session): UserEntityInterface
+    {
+        $user = $this->createEntity();
+        $user->exchangeArray($session->userDetails ?? []);
+        return $user;
+    }
+
+    /**
+     * Create a new user entity.
+     *
+     * @return UserEntityInterface
+     */
+    public function createEntity(): UserEntityInterface
+    {
+        return $this->getDbTable('User')->createRow();
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceFactory.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * User table gateway factory.
+ * Database user service factory
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2018.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,29 +21,29 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Db_Table
+ * @package  Database
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
 
-namespace VuFind\Db\Table;
+namespace VuFind\Db\Service;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
-use Psr\Container\ContainerExceptionInterface as ContainerException;
-use Psr\Container\ContainerInterface;
 
 /**
- * User table gateway factory.
+ * Database user service factory
  *
  * @category VuFind
- * @package  Db_Table
+ * @package  Database
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-class UserFactory extends GatewayFactory
+class UserServiceFactory extends AbstractDbServiceFactory
 {
     /**
      * Create an object
@@ -64,7 +64,11 @@ class UserFactory extends GatewayFactory
         $requestedName,
         array $options = null
     ) {
-        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
-        return parent::__invoke($container, $requestedName, [$config]);
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory!');
+        }
+        $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
+        $session = new \Laminas\Session\Container('Account', $sessionManager);
+        return parent::__invoke($container, $requestedName, [$session]);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Service;
 
+use Exception;
+use Laminas\Session\Container as SessionContainer;
 use VuFind\Db\Entity\UserEntityInterface;
 
 /**
@@ -60,4 +62,31 @@ interface UserServiceInterface extends DbServiceInterface
      * @return ?UserEntityInterface
      */
     public function getUserByField(string $fieldName, int|null|string $fieldValue): ?UserEntityInterface;
+
+    /**
+     * Create a new user entity.
+     *
+     * @return UserEntityInterface
+     */
+    public function createEntity(): UserEntityInterface;
+
+    /**
+     * Update session container to store data representing a user (used by privacy mode).
+     *
+     * @param SessionContainer    $session Session container.
+     * @param UserEntityInterface $user    User to store in session.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function addUserDataToSessionContainer(SessionContainer $session, UserEntityInterface $user): void;
+
+    /**
+     * Build a user entity using data from a session container.
+     *
+     * @param SessionContainer $session Session container.
+     *
+     * @return UserEntityInterface
+     */
+    public function getUserFromSessionContainer(SessionContainer $session): UserEntityInterface;
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\Db\Service;
 
-use Exception;
-use Laminas\Session\Container as SessionContainer;
 use VuFind\Db\Entity\UserEntityInterface;
 
 /**

--- a/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
@@ -125,9 +125,11 @@ trait LiveDatabaseTrait
      * Static setup support function to fail if there is already data in the
      * database. We want to ensure a clean state for each test!
      *
+     * @param ?string $failMessage Failure message to display if data exists (null for default).
+     *
      * @return void
      */
-    protected static function failIfDataExists(): void
+    protected static function failIfDataExists(?string $failMessage = null): void
     {
         $test = new static('');   // create instance of current class
         // Fail if the test does not include the LiveDetectionTrait.
@@ -157,7 +159,7 @@ trait LiveDatabaseTrait
             $table = $test->getTable($check['table']);
             if (count($table->select()) > 0) {
                 self::fail(
-                    "Test cannot run with pre-existing {$check['name']} in database!"
+                    $failMessage ?? "Test cannot run with pre-existing {$check['name']} in database!"
                 );
                 return;
             }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PrivateUserTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PrivateUserTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Mink "private user" test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+use Behat\Mink\Element\Element;
+
+/**
+ * Mink "private user" test class.
+ *
+ * Class must be final due to use of "new static()" by LiveDatabaseTrait.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+final class PrivateUserTest extends \VuFindTest\Integration\MinkTestCase
+{
+    use \VuFindTest\Feature\LiveDatabaseTrait;
+    use \VuFindTest\Feature\UserCreationTrait;
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        static::failIfDataExists();
+    }
+
+    /**
+     * Move the current page to a record by performing a search.
+     *
+     * @param string $query Search query to perform.
+     *
+     * @return Element
+     */
+    protected function gotoRecord(string $query = 'Dewey'): Element
+    {
+        $page = $this->performSearch($query);
+        $this->clickCss($page, '.result a.title');
+        return $page;
+    }
+
+    /**
+     * Set up private user configuration.
+     *
+     * @return void
+     */
+    protected function setUpPrivateUser(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Authentication' => [
+                        'privacy' => true,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Test that comments are disabled in private user mode.
+     *
+     * @return void
+     */
+    public function testCommentsDisabled(): void
+    {
+        // Set up configs:
+        $this->setUpPrivateUser();
+        // Go to a record view
+        $page = $this->gotoRecord();
+        // Comment control should not be present
+        $this->unfindCss($page, '.record-tabs .usercomments a');
+    }
+
+    /**
+     * Test that tags are disabled in private user mode.
+     *
+     * @return void
+     */
+    public function testTagsDisabled(): void
+    {
+        // Set up configs:
+        $this->setUpPrivateUser();
+        // Go to a record view
+        $page = $this->gotoRecord();
+        // Click to add tag
+        $this->unfindCss($page, '.tag-record');
+    }
+
+    /**
+     * Test that login does not create database data.
+     *
+     * @return void
+     */
+    public function testLoginDoesNotAddUserToDatabase(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Authentication' => [
+                        'method' => 'SimulatedSSO',
+                        'privacy' => true,
+                    ],
+                ],
+                'SimulatedSSO' => [
+                    'General' => [
+                        'username' => 'ssofakeuser1',
+                    ],
+                ],
+            ]
+        );
+
+        // Login
+        $page = $this->gotoRecord();
+        $this->clickCss($page, '#loginOptions a');
+        // Log out
+        $this->clickCss($page, '.logoutOptions a.logout');
+        // Check that login link is back
+        $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+        // Assert that nothing was added to the user database:
+        static::failIfDataExists('User data should not have been created in private user mode.');
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
@@ -30,11 +30,13 @@
 namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
+use Laminas\Http\PhpEnvironment\Request;
 use Laminas\Session\SessionManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Auth\Manager;
 use VuFind\Auth\PluginManager;
-use VuFind\Db\Row\User as UserRow;
-use VuFind\Db\Table\User as UserTable;
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Service\UserServiceInterface;
 
 use function get_class;
 
@@ -56,7 +58,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testDefaultConfig()
+    public function testDefaultConfig(): void
     {
         $this->assertEquals('Database', $this->getManager()->getAuthMethod());
     }
@@ -66,7 +68,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetSessionInitiator()
+    public function testGetSessionInitiator(): void
     {
         $pm = $this->getMockPluginManager();
         $db = $pm->get('Database');
@@ -81,7 +83,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetSelectableAuthOptions()
+    public function testGetSelectableAuthOptions(): void
     {
         // Simple case -- default Database helper.
         $this->assertEquals(['Database'], $this->getManager()->getSelectableAuthOptions());
@@ -108,7 +110,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetLoginTargets()
+    public function testGetLoginTargets(): void
     {
         $pm = $this->getMockPluginManager();
         $targets = ['a', 'b', 'c'];
@@ -123,7 +125,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetDefaultLoginTarget()
+    public function testGetDefaultLoginTarget(): void
     {
         $pm = $this->getMockPluginManager();
         $target = 'foo';
@@ -138,7 +140,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLogoutWithDestruction()
+    public function testLogoutWithDestruction(): void
     {
         $pm = $this->getMockPluginManager();
         $db = $pm->get('Database');
@@ -155,7 +157,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLogoutWithoutDestruction()
+    public function testLogoutWithoutDestruction(): void
     {
         $pm = $this->getMockPluginManager();
         $db = $pm->get('Database');
@@ -172,7 +174,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginEnabled()
+    public function testLoginEnabled(): void
     {
         $this->assertTrue($this->getManager()->loginEnabled());
     }
@@ -182,7 +184,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginDisabled()
+    public function testLoginDisabled(): void
     {
         $config = ['Authentication' => ['hideLogin' => true]];
         $this->assertFalse($this->getManager($config)->loginEnabled());
@@ -193,7 +195,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSwitchingSuccess()
+    public function testSwitchingSuccess(): void
     {
         $config = ['Authentication' => ['method' => 'ChoiceAuth']];
         $manager = $this->getManager($config);
@@ -209,7 +211,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSwitchingFailure()
+    public function testSwitchingFailure(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Illegal authentication method: MultiILS');
@@ -227,7 +229,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSupportsCreation()
+    public function testSupportsCreation(): void
     {
         $config = ['Authentication' => ['method' => 'ChoiceAuth']];
         $pm = $this->getMockPluginManager();
@@ -245,7 +247,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSupportsRecovery()
+    public function testSupportsRecovery(): void
     {
         // Most common case -- no:
         $this->assertFalse($this->getManager()->supportsRecovery());
@@ -263,7 +265,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSupportsEmailChange()
+    public function testSupportsEmailChange(): void
     {
         // Most common case -- no:
         $this->assertFalse($this->getManager()->supportsEmailChange());
@@ -281,7 +283,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSupportsPasswordChange()
+    public function testSupportsPasswordChange(): void
     {
         // Most common case -- no:
         $this->assertFalse($this->getManager()->supportsPasswordChange());
@@ -301,7 +303,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetAuthClassForTemplateRendering()
+    public function testGetAuthClassForTemplateRendering(): void
     {
         // Simple default case:
         $pm = $this->getMockPluginManager();
@@ -320,7 +322,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUserHasLoggedOut()
+    public function testUserHasLoggedOut(): void
     {
         // this won't be true in the context of a test class due to lack of cookies
         $this->assertFalse($this->getManager()->userHasLoggedOut());
@@ -331,7 +333,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $user = $this->getMockUser();
         $request = $this->getMockRequest();
@@ -349,7 +351,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSuccessfulLogin()
+    public function testSuccessfulLogin(): void
     {
         $user = $this->getMockUser();
         $request = $this->getMockRequest();
@@ -368,7 +370,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testMissingCsrf()
+    public function testMissingCsrf(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('authentication_error_technical');
@@ -384,7 +386,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testIncorrectCsrf()
+    public function testIncorrectCsrf(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('authentication_error_technical');
@@ -401,7 +403,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testPasswordSecurityException()
+    public function testPasswordSecurityException(): void
     {
         $this->expectException(\VuFind\Exception\PasswordSecurity::class);
         $this->expectExceptionMessage('Boom');
@@ -421,7 +423,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testAuthException()
+    public function testAuthException(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('Blam');
@@ -441,7 +443,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUnanticipatedException()
+    public function testUnanticipatedException(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('authentication_error_technical');
@@ -461,7 +463,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUpdatePassword()
+    public function testUpdatePassword(): void
     {
         $user = $this->getMockUser();
         $request = $this->getMockRequest();
@@ -478,7 +480,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCheckForExpiredCredentials()
+    public function testCheckForExpiredCredentials(): void
     {
         // Simple case -- none found:
         $this->assertFalse($this->getManager()->checkForExpiredCredentials());
@@ -500,24 +502,23 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUserLoginFromSession()
+    public function testUserLoginFromSession(): void
     {
-        $table = $this->getMockUserTable();
         $user = $this->getMockUser();
-        $userArray = new \ArrayObject();
-        $userArray->append($user);
-        $table->expects($this->once())->method('select')
-            ->with($this->equalTo(['id' => 'foo']))->will($this->returnValue($userArray->getIterator()));
-        $manager = $this->getManager([], $table);
+        $userId = 1234;
+        $service = $this->createMock(UserServiceInterface::class);
+        $service->expects($this->once())->method('getUserById')
+            ->with($this->equalTo($userId))->willReturn($user);
+        $manager = $this->getManager([], $service);
 
         // Fake the session inside the manager:
         $mockSession = $this->getMockBuilder(\Laminas\Session\Container::class)
             ->onlyMethods(['__get', '__isset', '__set', '__unset'])
             ->disableOriginalConstructor()->getMock();
         $mockSession->expects($this->any())->method('__isset')
-            ->with($this->equalTo('userId'))->will($this->returnValue(true));
+            ->with($this->equalTo('userId'))->willReturn(true);
         $mockSession->expects($this->any())->method('__get')
-            ->with($this->equalTo('userId'))->will($this->returnValue('foo'));
+            ->with($this->equalTo('userId'))->willReturn($userId);
         $this->setProperty($manager, 'session', $mockSession);
 
         $this->assertEquals($user, $manager->getUserObject());
@@ -547,25 +548,20 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a manager object to test with.
      *
-     * @param array          $config         Configuration
-     * @param UserTable      $userTable      User table gateway
-     * @param SessionManager $sessionManager Session manager
-     * @param PluginManager  $pm             Authentication plugin manager
+     * @param array                $config         Configuration
+     * @param UserServiceInterface $userService    User table gateway
+     * @param SessionManager       $sessionManager Session manager
+     * @param PluginManager        $pm             Authentication plugin manager
      *
      * @return Manager
      */
-    protected function getManager($config = [], $userTable = null, $sessionManager = null, $pm = null)
-    {
+    protected function getManager(
+        array $config = [],
+        UserServiceInterface $userService = null,
+        SessionManager $sessionManager = null,
+        PluginManager $pm = null
+    ): Manager {
         $config = new Config($config);
-        if (null === $userTable) {
-            $userTable = $this->getMockUserTable();
-        }
-        if (null === $sessionManager) {
-            $sessionManager = new SessionManager();
-        }
-        if (null === $pm) {
-            $pm = $this->getMockPluginManager();
-        }
         $cookies = new \VuFind\Cookie\CookieManager([]);
         $csrf = new \VuFind\Validator\SessionCsrf(
             [
@@ -573,20 +569,16 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
                 'salt' => 'csrftest',
             ]
         );
-        $loginTokenManager = $this->getMockBuilder(\VuFind\Auth\LoginTokenManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $ils = $this->getMockBuilder(\VuFind\ILS\Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $loginTokenManager = $this->createMock(\VuFind\Auth\LoginTokenManager::class);
+        $ils = $this->createMock(\VuFind\ILS\Connection::class);
         $ils->expects($this->any())
             ->method('loginIsHidden')
             ->willReturn(false);
         return new Manager(
             $config,
-            $userTable,
-            $sessionManager,
-            $pm,
+            $userService ?? $this->createMock(UserServiceInterface::class),
+            $sessionManager ?? new SessionManager(),
+            $pm ?? $this->getMockPluginManager(),
             $cookies,
             $csrf,
             $loginTokenManager,
@@ -595,27 +587,13 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Get a mock user table.
-     *
-     * @return UserTable
-     */
-    protected function getMockUserTable()
-    {
-        return $this->getMockBuilder(\VuFind\Db\Table\User::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    /**
      * Get a mock session manager.
      *
-     * @return SessionManager
+     * @return MockObject&SessionManager
      */
-    protected function getMockSessionManager()
+    protected function getMockSessionManager(): MockObject&SessionManager
     {
-        return $this->getMockBuilder(\Laminas\Session\SessionManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(\Laminas\Session\SessionManager::class);
     }
 
     /**
@@ -623,25 +601,17 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      *
      * @return PluginManager
      */
-    protected function getMockPluginManager()
+    protected function getMockPluginManager(): PluginManager
     {
         $pm = new PluginManager(new \VuFindTest\Container\MockContainer($this));
-        $mockChoice = $this->getMockBuilder(\VuFind\Auth\ChoiceAuth::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockChoice = $this->createMock(\VuFind\Auth\ChoiceAuth::class);
         $mockChoice->expects($this->any())
-            ->method('getSelectableAuthOptions')->will($this->returnValue(['Database', 'Shibboleth']));
-        $mockDb = $this->getMockBuilder(\VuFind\Auth\Database::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+            ->method('getSelectableAuthOptions')->willReturn(['Database', 'Shibboleth']);
+        $mockDb = $this->createMock(\VuFind\Auth\Database::class);
         $mockDb->expects($this->any())->method('needsCsrfCheck')
-            ->will($this->returnValue(true));
-        $mockMulti = $this->getMockBuilder(\VuFind\Auth\MultiILS::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockShib = $this->getMockBuilder(\VuFind\Auth\Shibboleth::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+            ->willReturn(true);
+        $mockMulti = $this->createMock(\VuFind\Auth\MultiILS::class);
+        $mockShib = $this->createMock(\VuFind\Auth\Shibboleth::class);
         $pm->setService(\VuFind\Auth\ChoiceAuth::class, $mockChoice);
         $pm->setService(\VuFind\Auth\Database::class, $mockDb);
         $pm->setService(\VuFind\Auth\MultiILS::class, $mockMulti);
@@ -652,31 +622,25 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a mock user object
      *
-     * @return UserRow
+     * @return MockObject&UserEntityInterface
      */
-    protected function getMockUser()
+    protected function getMockUser(): MockObject&UserEntityInterface
     {
-        return $this->getMockBuilder(\VuFind\Db\Row\User::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UserEntityInterface::class);
     }
 
     /**
      * Get a mock request object
      *
-     * @return \Laminas\Http\PhpEnvironment\Request
+     * @return MockObject&Request
      */
-    protected function getMockRequest()
+    protected function getMockRequest(): MockObject&Request
     {
-        $mock = $this->getMockBuilder(\Laminas\Http\PhpEnvironment\Request::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = $this->createMock(Request::class);
         $post = new \Laminas\Stdlib\Parameters();
-        $mock->expects($this->any())->method('getPost')
-            ->will($this->returnValue($post));
+        $mock->expects($this->any())->method('getPost')->willReturn($post);
         $get = new \Laminas\Stdlib\Parameters();
-        $mock->expects($this->any())->method('getQuery')
-            ->will($this->returnValue($get));
+        $mock->expects($this->any())->method('getQuery')->willReturn($get);
         return $mock;
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ManagerTest.php
@@ -506,7 +506,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     public function testUserLoginFromSession(): void
     {
         $user = $this->getMockUser();
-        $service = $this->getMockUserService();
+        $service = $this->createMock(UserSessionPersistenceInterface::class);
         $service->expects($this->once())->method('hasUserSessionData')->willReturn(true);
         $service->expects($this->once())->method('getUserFromSession')->willReturn($user);
         $manager = $this->getManager([], $service);
@@ -537,18 +537,18 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a manager object to test with.
      *
-     * @param array                                                 $config         Configuration
-     * @param ?UserServiceInterface&UserSessionPersistenceInterface $userService    User service
-     * @param SessionManager                                        $sessionManager Session manager
-     * @param PluginManager                                         $pm             Authentication plugin manager
+     * @param array                            $config         Configuration
+     * @param ?UserSessionPersistenceInterface $userSession    User session persistence service
+     * @param ?SessionManager                  $sessionManager Session manager
+     * @param ?PluginManager                   $pm             Authentication plugin manager
      *
      * @return Manager
      */
     protected function getManager(
         array $config = [],
-        $userService = null,
-        SessionManager $sessionManager = null,
-        PluginManager $pm = null
+        ?UserSessionPersistenceInterface $userSession = null,
+        ?SessionManager $sessionManager = null,
+        ?PluginManager $pm = null
     ): Manager {
         $config = new Config($config);
         $cookies = new \VuFind\Cookie\CookieManager([]);
@@ -565,7 +565,8 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             ->willReturn(false);
         return new Manager(
             $config,
-            $userService ?? $this->getMockUserService(),
+            $this->createMock(UserServiceInterface::class),
+            $userSession ?? $this->createMock(UserSessionPersistenceInterface::class),
             $sessionManager ?? new SessionManager(),
             $pm ?? $this->getMockPluginManager(),
             $cookies,
@@ -573,16 +574,6 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             $loginTokenManager,
             $ils
         );
-    }
-
-    /**
-     * Get a mock user service.
-     *
-     * @return MockObject&UserServiceInterface&UserSessionPersistenceInterface
-     */
-    protected function getMockUserService(): MockObject&UserServiceInterface&UserSessionPersistenceInterface
-    {
-        return $this->createMock(\VuFind\Db\Service\UserService::class);
     }
 
     /**


### PR DESCRIPTION
This PR refactors the AuthManager to use the new UserService instead of depending on the legacy Laminas table gateway. It also creates a new interface to encapsulate session persistence of user data. Right now, the UserService implements both the session and database interfaces, but these could theoretically be split apart in future.

This also adds Mink test coverage for some of the private user functionality and modernizes some of the code in the AuthManager test.