### PR TITLE
VUFIND-1667: Fix tabbing within a modal dialog

### DIFF
--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -528,7 +528,7 @@ VuFind.register('lightbox', function Lightbox() {
       // retainFocus() above handles it better.
       // This is moot once that library (and bootstrap3) are retired.
       var focEls = _modal.find(":tabbable");
-      var lastEl = $(focEls[focEls.length-1]);
+      var lastEl = $(focEls[focEls.length - 1]);
       $(lastEl).off('keydown.bs.modal');
     });
 

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -523,6 +523,13 @@ VuFind.register('lightbox', function Lightbox() {
     });
     _modal.on("shown.bs.modal", function lightboxShown() {
       bindFocus();
+
+      // Disable bootstrap-accessibility.js "enforceFocus" events.
+      // retainFocus() above handles it better.
+      // This is moot once that library (and bootstrap3) are retired.
+      var focEls = _modal.find(":tabbable");
+      var lastEl = $(focEls[focEls.length-1]);
+      $(lastEl).off('keydown.bs.modal');
     });
 
     VuFind.modal = function modalShortcut(cmd) {

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -528,8 +528,9 @@ VuFind.register('lightbox', function Lightbox() {
       // retainFocus() above handles it better.
       // This is moot once that library (and bootstrap3) are retired.
       var focEls = _modal.find(":tabbable");
+      var firstEl = $(focEls[0]);
       var lastEl = $(focEls[focEls.length - 1]);
-      $(lastEl).off('keydown.bs.modal');
+      $(firstEl).add(lastEl).off('keydown.bs.modal');
     });
 
     VuFind.modal = function modalShortcut(cmd) {


### PR DESCRIPTION
For https://openlibraryfoundation.atlassian.net/browse/VUFIND-1667

Disable the "Modal Extension" event listener in bootstrap-accessibility(.min).js.  Lightbox.js does the same idea better in `retainFocus`.