### PR TITLE
EPF: Add embargo description to record page

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
@@ -53,7 +53,10 @@
                   if (!empty($holding)): ?>
                     <li>
                       <a href="<?=$this->escapeHtmlAttr($holding['URL'])?>"><?=$this->escapeHtml($holding['Name'])?></a>
-                      <?=$this->escapeHtml($holding['CoverageStatement'])?>
+                      <span class="coverage-statement"><?=$this->escapeHtml($holding['CoverageStatement'])?></span>
+                      <?php if (!empty($holding['EmbargoDescription'])): ?>
+                        <span class="embargo-description">(<?=$this->escapeHtml($holding['EmbargoDescription'])?>)</span>
+                      <?php endif; ?>
                     </li>
                   <?php endif;
                 endforeach; ?>


### PR DESCRIPTION
#3238 added the embargo description to the EBSCO Publication Finder result list.  This adds it to the record page as well.

![image](https://github.com/vufind-org/vufind/assets/31278545/aea08d05-c2ae-4dbb-a9d3-a1571cc916c6)
