### PR TITLE
Make MARC subject heading sort behavior configurable

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2098,9 +2098,10 @@ related[] = "Similar"
 ; records). Default is false.
 ;alwaysDisplayIndexRecordInStaffView = false
 
-; If set to "marc", the subject headings will be displayed in the order they are saved,
-; otherwise they are sorted numerically
-;subjectHeadingsSort = "marc"
+; This setting controls the display order of subject headings from MARC records.
+; If set to "record" it will retain the order of headings from the MARC record; if
+; set to "field" (the default), it will sort numerically by MARC tag.
+marcSubjectHeadingsSort = "record"
 
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2100,7 +2100,7 @@ related[] = "Similar"
 
 ; If set to "marc", the subject headings will be displayed in the order they are saved,
 ; otherwise they are sorted numerically
-subjectHeadingsSort = "marc"
+;subjectHeadingsSort = "marc"
 
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2101,7 +2101,7 @@ related[] = "Similar"
 ; This setting controls the display order of subject headings from MARC records.
 ; If set to "record" (the default) it will retain the order of headings from the
 ; MARC record; if set to "field", it will sort numerically by MARC tag.
-;marcSubjectHeadingsSort = "field"
+;marcSubjectHeadingsSort = "record"
 
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2099,9 +2099,9 @@ related[] = "Similar"
 ;alwaysDisplayIndexRecordInStaffView = false
 
 ; This setting controls the display order of subject headings from MARC records.
-; If set to "record" (the default) it will retain the order of headings from the
-; MARC record; if set to "field", it will sort numerically by MARC tag.
-;marcSubjectHeadingsSort = "record"
+; If set to "record" (the default) it will retain the order of headings from the MARC record.
+; If set to "numerical", it will sort numerically by MARC tag.
+;marcSubjectHeadingsSort = "numerical"
 
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2099,9 +2099,9 @@ related[] = "Similar"
 ;alwaysDisplayIndexRecordInStaffView = false
 
 ; This setting controls the display order of subject headings from MARC records.
-; If set to "record" it will retain the order of headings from the MARC record; if
-; set to "field" (the default), it will sort numerically by MARC tag.
-marcSubjectHeadingsSort = "record"
+; If set to "record" (the default) it will retain the order of headings from the
+; MARC record; if set to "field", it will sort numerically by MARC tag.
+;marcSubjectHeadingsSort = "field"
 
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2098,6 +2098,10 @@ related[] = "Similar"
 ; records). Default is false.
 ;alwaysDisplayIndexRecordInStaffView = false
 
+; If set to "marc", the subject headings will be displayed in the order they are saved,
+; otherwise they are sorted numerically
+subjectHeadingsSort = "marc"
+
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]
 ; This setting controls how many headings are displayed on each page of results:

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,7 +120,11 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        if ($this->mainConfig->get('Record')->get('subjectHeadingsSort') === 'marc') {
+        if (
+            isset($this->mainConfig)
+            && $this->mainConfig->get('Record') !== null
+            && $this->mainConfig->get('Record')->get('subjectHeadingsSort') === 'marc'
+        ) {
             $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
         } else {
             $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);
@@ -138,7 +142,12 @@ trait MarcAdvancedTrait
      * returned as an array of chunks, increasing from least specific to most
      * specific. Sorted in the same way it is saved for the record.
      *
-     * @param bool $extended
+     * @param bool $extended Whether to return a keyed array with the following
+     *  keys:
+     *  - heading: the actual subject heading chunks
+     *  - type: heading type
+     *  - source: source vocabulary
+     *
      * @return array
      */
     protected function getAllSubjectHeadingsMarcOrder(bool $extended = false): array
@@ -161,7 +170,12 @@ trait MarcAdvancedTrait
      * returned as an array of chunks, increasing from least specific to most
      * specific. Sorted numerically on marc fields.
      *
-     * @param bool $extended
+     * @param bool $extended Whether to return a keyed array with the following
+     *  keys:
+     *  - heading: the actual subject heading chunks
+     *  - type: heading type
+     *  - source: source vocabulary
+     *
      * @return array
      */
     protected function getAllSubjectHeadingsNumericalOrder(bool $extended = false): array
@@ -187,14 +201,22 @@ trait MarcAdvancedTrait
      * Get subject headings of a given record field.
      * The heading is returned as a chunk, increasing from least specific to most specific.
      *
-     * @param array  $returnValues
-     * @param array  $field
-     * @param bool   $extended
-     * @param string $fieldType
+     * @param array  $returnValues Array of return values to append to
+     * @param array  $field        field to handle
+     * @param bool   $extended     Whether to return a keyed array with the following keys:
+     *                             - heading: the actual subject heading chunks
+     *                             - type: heading type
+     *                             - source: source vocabulary
+     * @param string $fieldType    Type of the field
+     *
      * @return void
      */
-    protected function processSubjectHeadings(array &$returnValues, array $field, bool $extended, string $fieldType): void
-    {
+    protected function processSubjectHeadings(
+        array &$returnValues,
+        array $field,
+        bool $extended,
+        string $fieldType
+    ): void {
         // Start an array for holding the chunks of the current heading:
         $current = [];
 

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,11 +120,11 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        if (($this->mainConfig->Record->marcSubjectHeadingsSort ?? '') === 'field') {
+        if (($this->mainConfig->Record->marcSubjectHeadingsSort ?? '') === 'numerical') {
             $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);
         } else {
-            // Default | value === 'marc'
-            $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
+            // Default | value === 'record'
+            $returnValues = $this->getAllSubjectHeadingsRecordOrder($extended);
         }
 
         // Remove duplicates and then send back everything we collected:
@@ -147,7 +147,7 @@ trait MarcAdvancedTrait
      *
      * @return array
      */
-    protected function getAllSubjectHeadingsMarcOrder(bool $extended = false): array
+    protected function getAllSubjectHeadingsRecordOrder(bool $extended = false): array
     {
         $returnValues = [];
         $allFields = $this->getMarcReader()->getAllFields();

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -201,14 +201,13 @@ trait MarcAdvancedTrait
      * Get subject headings of a given record field.
      * The heading is returned as a chunk, increasing from least specific to most specific.
      *
-     * @param array  $field        field to handle
-     * @param bool   $extended     Whether to return a keyed array with the following keys:
-     *                             - heading: the actual subject heading chunks
-     *                             - type: heading type
-     *                             - source: source vocabulary
-     * @param string $fieldType    Type of the field
+     * @param array  $field     field to handle
+     * @param bool   $extended  Whether to return a keyed array with the following keys:
+     *                          - heading: the actual subject heading chunks - type:
+     *                          heading type - source: source vocabulary
+     * @param string $fieldType Type of the field
      *
-     * @return array|null
+     * @return ?array
      */
     protected function processSubjectHeadings(
         array $field,
@@ -217,7 +216,6 @@ trait MarcAdvancedTrait
     ): ?array {
         // Start an array for holding the chunks of the current heading:
         $current = [];
-        $returnValues = null;
 
         // Get all the chunks and collect them together:
         foreach ($field['subfields'] as $subfield) {
@@ -233,17 +231,17 @@ trait MarcAdvancedTrait
                 $sourceIndicator = $field['i2'];
                 $source = $this->subjectSources[$sourceIndicator]
                     ?? $this->getSubfield($field, '2');
-                $returnValues = [
+                return [
                     'heading' => $current,
                     'type' => $fieldType,
                     'source' => $source,
                     'id' => $this->getSubfield($field, '0'),
                 ];
             } else {
-                $returnValues = $current;
+                return $current;
             }
         }
-        return $returnValues;
+        return null;
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,7 +120,7 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        if ($this->mainConfig->Record->subjectHeadingsSort ?? '' === 'marc') {
+        if ($this->mainConfig->Record->marcSubjectHeadingsSort ?? '' === 'record') {
             $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
         } else {
             $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,10 +120,11 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        if ($this->mainConfig->Record->marcSubjectHeadingsSort ?? 'record' === 'record') {
-            $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
-        } else {
+        if (($this->mainConfig->Record->marcSubjectHeadingsSort ?? '') === 'field') {
             $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);
+        } else {
+            // Default | value === 'marc'
+            $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
         }
 
         // Remove duplicates and then send back everything we collected:

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,7 +120,7 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        if ($this->mainConfig->Record->marcSubjectHeadingsSort ?? '' === 'record') {
+        if ($this->mainConfig->Record->marcSubjectHeadingsSort ?? 'record' === 'record') {
             $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
         } else {
             $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -120,54 +120,108 @@ trait MarcAdvancedTrait
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        // This is all the collected data:
-        $retval = [];
-
-        // Try each MARC field one at a time:
-        foreach ($this->subjectFields as $field => $fieldType) {
-            // Do we have any results for the current field?  If not, try the next.
-            $results = $this->getMarcReader()->getFields($field);
-            if (!$results) {
-                continue;
-            }
-
-            // If we got here, we found results -- let's loop through them.
-            foreach ($results as $result) {
-                // Start an array for holding the chunks of the current heading:
-                $current = [];
-
-                // Get all the chunks and collect them together:
-                foreach ($result['subfields'] as $subfield) {
-                    // Numeric subfields are for control purposes and should not
-                    // be displayed:
-                    if (!is_numeric($subfield['code'])) {
-                        $current[] = $subfield['data'];
-                    }
-                }
-                // If we found at least one chunk, add a heading to our result:
-                if (!empty($current)) {
-                    if ($extended) {
-                        $sourceIndicator = $result['i2'];
-                        $source = $this->subjectSources[$sourceIndicator]
-                            ?? $this->getSubfield($result, '2');
-                        $retval[] = [
-                            'heading' => $current,
-                            'type' => $fieldType,
-                            'source' => $source,
-                            'id' => $this->getSubfield($result, '0'),
-                        ];
-                    } else {
-                        $retval[] = $current;
-                    }
-                }
-            }
+        if ($this->mainConfig->get('Record')->get('subjectHeadingsSort') === 'marc') {
+            $returnValues = $this->getAllSubjectHeadingsMarcOrder($extended);
+        } else {
+            $returnValues = $this->getAllSubjectHeadingsNumericalOrder($extended);
         }
 
         // Remove duplicates and then send back everything we collected:
         return array_map(
             'unserialize',
-            array_unique(array_map('serialize', $retval))
+            array_unique(array_map('serialize', $returnValues))
         );
+    }
+
+    /**
+     * Get all subject headings associated with this record. Each heading is
+     * returned as an array of chunks, increasing from least specific to most
+     * specific. Sorted in the same way it is saved for the record.
+     *
+     * @param bool $extended
+     * @return array
+     */
+    protected function getAllSubjectHeadingsMarcOrder(bool $extended = false): array
+    {
+        $returnValues = [];
+        $allFields = $this->getMarcReader()->getAllFields();
+        $subjectFieldsKeys = array_keys($this->subjectFields);
+        // Go through all the fields and handle them if they are part of what we want
+        foreach ($allFields as $field) {
+            if (isset($field['tag']) && in_array($field['tag'], $subjectFieldsKeys)) {
+                $fieldType = $this->subjectFields[$field['tag']];
+                $this->processSubjectHeadings($returnValues, $field, $extended, $fieldType);
+            }
+        }
+        return $returnValues;
+    }
+
+    /**
+     * Get all subject headings associated with this record. Each heading is
+     * returned as an array of chunks, increasing from least specific to most
+     * specific. Sorted numerically on marc fields.
+     *
+     * @param bool $extended
+     * @return array
+     */
+    protected function getAllSubjectHeadingsNumericalOrder(bool $extended = false): array
+    {
+        $returnValues = [];
+        // Try each MARC field one at a time:
+        foreach ($this->subjectFields as $field => $fieldType) {
+            // Do we have any results for the current field?  If not, try the next.
+            $fields = $this->getMarcReader()->getFields($field);
+            if (!$fields) {
+                continue;
+            }
+
+            // If we got here, we found results -- let's loop through them.
+            foreach ($fields as $f) {
+                $this->processSubjectHeadings($returnValues, $f, $extended, $fieldType);
+            }
+        }
+        return $returnValues;
+    }
+
+    /**
+     * Get subject headings of a given record field.
+     * The heading is returned as a chunk, increasing from least specific to most specific.
+     *
+     * @param array  $returnValues
+     * @param array  $field
+     * @param bool   $extended
+     * @param string $fieldType
+     * @return void
+     */
+    protected function processSubjectHeadings(array &$returnValues, array $field, bool $extended, string $fieldType): void
+    {
+        // Start an array for holding the chunks of the current heading:
+        $current = [];
+
+        // Get all the chunks and collect them together:
+        foreach ($field['subfields'] as $subfield) {
+            // Numeric subfields are for control purposes and should not
+            // be displayed:
+            if (!is_numeric($subfield['code'])) {
+                $current[] = $subfield['data'];
+            }
+        }
+        // If we found at least one chunk, add a heading to our result:
+        if (!empty($current)) {
+            if ($extended) {
+                $sourceIndicator = $field['i2'];
+                $source = $this->subjectSources[$sourceIndicator]
+                    ?? $this->getSubfield($field, '2');
+                $returnValues[] = [
+                    'heading' => $current,
+                    'type' => $fieldType,
+                    'source' => $source,
+                    'id' => $this->getSubfield($field, '0'),
+                ];
+            } else {
+                $returnValues[] = $current;
+            }
+        }
     }
 
     /**

--- a/module/VuFind/tests/fixtures/marc/subjectheadingsorder.xml
+++ b/module/VuFind/tests/fixtures/marc/subjectheadingsorder.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<collection>
+    <record>
+        <leader>01919cam a2200421 i 4500</leader>
+        <controlfield tag="001">in00006796642</controlfield>
+        <controlfield tag="008">230324t20182018ilua 000 0 eng d</controlfield>
+        <controlfield tag="005">20230412235149.0</controlfield>
+        <datafield ind1=" " ind2="0" tag="651">
+            <subfield code="a">Guerrero (Mexico : State)</subfield>
+            <subfield code="x">Social life and customs</subfield>
+            <subfield code="v">Pictorial works.</subfield>
+        </datafield>
+        <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Street photography</subfield>
+            <subfield code="z">Mexico</subfield>
+            <subfield code="z">Guerrero (State)</subfield>
+        </datafield>
+        <datafield ind1=" " ind2="7" tag="655">
+            <subfield code="a">Photobooks.</subfield>
+            <subfield code="2">lcgft</subfield>
+            <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026144</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -176,7 +176,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
-                'config' => null,
+                'config' => 'field',
                 'results' => [
                     [
                         'Street photography',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -128,8 +128,8 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
         foreach ($configOptions as $option) {
             $configArray = [
                 'Record' => [
-                    'subjectHeadingsSort' => $option
-                ]
+                    'subjectHeadingsSort' => $option,
+                ],
             ];
             $config = new \Laminas\Config\Config($configArray);
             $record = new \VuFind\RecordDriver\SolrMarc($config);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -174,8 +174,26 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
      */
     public static function marcSubjectHeadingsSortOptionsProvider()
     {
-        return [
+        // Record order is the default; save it to a variable so we
+        // can test both explicit and default configuration behaviors
+        // using the same values.
+        $recordOrderResults = [
             [
+                'Guerrero (Mexico : State)',
+                'Social life and customs',
+                'Pictorial works.',
+            ],
+            [
+                'Street photography',
+                'Mexico',
+                'Guerrero (State)',
+            ],
+            [
+                'Photobooks.',
+            ],
+        ];
+        return [
+            'field config' => [
                 'config' => 'field',
                 'results' => [
                     [
@@ -193,23 +211,13 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
                     ],
                 ],
             ],
-            [
+            'record config' => [
                 'config' => 'record',
-                'results' => [
-                    [
-                        'Guerrero (Mexico : State)',
-                        'Social life and customs',
-                        'Pictorial works.',
-                    ],
-                    [
-                        'Street photography',
-                        'Mexico',
-                        'Guerrero (State)',
-                    ],
-                    [
-                        'Photobooks.',
-                    ],
-                ],
+                'results' => $recordOrderResults,
+            ],
+            'default config' => [
+                'config' => null,
+                'results' => $recordOrderResults,
             ],
         ];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -144,19 +144,20 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
     /**
      * Test regular and extended subject heading support for different possible config options.
      *
-     * @param ?string $subjectHeadingsSortConfig the config value for $this->mainConfig->Record->subjectHeadingsSort
-     * @param array   $expectedResults           array of the expected values returned from
-     *                                           $record->getAllSubjectHeadings()
+     * @param ?string $marcSubjectHeadingsSortConfig the config value for
+     *                                               $this->mainConfig->Record->marcSubjectHeadingsSort
+     * @param array   $expectedResults               array of the expected values returned from
+     *                                               $record->getAllSubjectHeadings()
      *
      * @return void
      *
-     * @dataProvider subjectHeadingsSortOptionsProvider
+     * @dataProvider marcSubjectHeadingsSortOptionsProvider
      */
-    public function testSubjectHeadingsOrder(?string $subjectHeadingsSortConfig, array $expectedResults)
+    public function testSubjectHeadingsOrder(?string $marcSubjectHeadingsSortConfig, array $expectedResults)
     {
         $configArray = [
             'Record' => [
-                'subjectHeadingsSort' => $subjectHeadingsSortConfig,
+                'marcSubjectHeadingsSort' => $marcSubjectHeadingsSortConfig,
             ],
         ];
         $marc = $this->getFixture('marc/subjectheadingsorder.xml');
@@ -171,7 +172,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
      *
      * @return array[]
      */
-    public static function subjectHeadingsSortOptionsProvider()
+    public static function marcSubjectHeadingsSortOptionsProvider()
     {
         return [
             [
@@ -193,7 +194,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             [
-                'config' => 'marc',
+                'config' => 'record',
                 'results' => [
                     [
                         'Guerrero (Mexico : State)',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -194,7 +194,7 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
         ];
         return [
             'field config' => [
-                'config' => 'field',
+                'config' => 'numerical',
                 'results' => [
                     [
                         'Street photography',

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -114,31 +114,43 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test regular and extended subject heading support.
+     * Test regular and extended subject heading support for different possible config options.
      *
      * @return void
      */
     public function testSubjectHeadings()
     {
-        $config = new \Laminas\Config\Config([]);
-        $record = new \VuFind\RecordDriver\SolrMarc($config);
-        $fixture = $this->getJsonFixture('misc/testbug1.json');
-        $record->setRawData($fixture['response']['docs'][0]);
-        $this->assertEquals(
-            [['Matematica', 'Periodici.']],
-            $record->getAllSubjectHeadings()
-        );
-        $this->assertEquals(
-            [
+        $configOptions = [
+            null,
+            'marc',
+        ];
+
+        foreach ($configOptions as $option) {
+            $configArray = [
+                'Record' => [
+                    'subjectHeadingsSort' => $option
+                ]
+            ];
+            $config = new \Laminas\Config\Config($configArray);
+            $record = new \VuFind\RecordDriver\SolrMarc($config);
+            $fixture = $this->getJsonFixture('misc/testbug1.json');
+            $record->setRawData($fixture['response']['docs'][0]);
+            $this->assertEquals(
+                [['Matematica', 'Periodici.']],
+                $record->getAllSubjectHeadings()
+            );
+            $this->assertEquals(
                 [
-                    'heading' => ['Matematica', 'Periodici.'],
-                    'type' => '',
-                    'source' => '',
-                    'id' => '',
+                    [
+                        'heading' => ['Matematica', 'Periodici.'],
+                        'type' => '',
+                        'source' => '',
+                        'id' => '',
+                    ],
                 ],
-            ],
-            $record->getAllSubjectHeadings(true)
-        );
+                $record->getAllSubjectHeadings(true)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Subjects appear in item display in the same order they appear in the MARC record, e.g. if a 651 is entered before a 650, the display matches that.
Example : https://catalog.lib.msu.edu/Record/folio.in00006796642#details

TODO
- [x] Update changelog when merging