### PR TITLE
UpdateDateTracker.java: Remove deprecated finalize method

### DIFF
--- a/import/index_java/src/org/vufind/index/UpdateDateTracker.java
+++ b/import/index_java/src/org/vufind/index/UpdateDateTracker.java
@@ -84,7 +84,6 @@ public class UpdateDateTracker
      */
     private boolean readRow() throws SQLException
     {
-        boolean returnValue = true;
         try (
             PreparedStatement selectSql = db.prepareStatement(
                 "SELECT first_indexed, last_indexed, last_record_change, deleted " +
@@ -97,7 +96,7 @@ public class UpdateDateTracker
             try (ResultSet result = selectSql.executeQuery()) {
                 // No results? Return false:
                 if (!result.first()) {
-                    returnValue = false;
+                    return false;
                 } else {
                     // If we got this far, we have results -- load them into the object:
                     firstIndexed = result.getTimestamp(1);
@@ -107,7 +106,7 @@ public class UpdateDateTracker
                 }
             }
         }
-        return returnValue;
+        return true;
     }
 
     /* Private support method: update a row in the change_tracker table.

--- a/import/index_java/src/org/vufind/index/UpdateDateTracker.java
+++ b/import/index_java/src/org/vufind/index/UpdateDateTracker.java
@@ -69,7 +69,7 @@ public class UpdateDateTracker
             PreparedStatement insertSql = db.prepareStatement(
                 "INSERT INTO change_tracker(core, id, first_indexed, last_indexed, last_record_change) " +
                 "VALUES(?, ?, ?, ?, ?);"
-            )
+            );
         ) {
             insertSql.setString(1, core);
             insertSql.setString(2, id);
@@ -84,7 +84,6 @@ public class UpdateDateTracker
      */
     private boolean readRow() throws SQLException
     {
-        ResultSet result;
         try (
             PreparedStatement selectSql = db.prepareStatement(
                 "SELECT first_indexed, last_indexed, last_record_change, deleted " +
@@ -94,23 +93,23 @@ public class UpdateDateTracker
         ) {
             selectSql.setString(1, core);
             selectSql.setString(2, id);
-            result = selectSql.executeQuery();
-        }
+            ResultSet result = selectSql.executeQuery();
 
-        // No results?  Free resources and return false:
-        if (!result.first()) {
+            // No results?  Free resources and return false:
+            if (!result.first()) {
+                result.close();
+                return false;
+            }
+
+            // If we got this far, we have results -- load them into the object:
+            firstIndexed = result.getTimestamp(1);
+            lastIndexed = result.getTimestamp(2);
+            lastRecordChange = result.getTimestamp(3);
+            deleted = result.getTimestamp(4);
+
+            // Free resources and report success:
             result.close();
-            return false;
         }
-
-        // If we got this far, we have results -- load them into the object:
-        firstIndexed = result.getTimestamp(1);
-        lastIndexed = result.getTimestamp(2);
-        lastRecordChange = result.getTimestamp(3);
-        deleted = result.getTimestamp(4);
-
-        // Free resources and report success:
-        result.close();
         return true;
     }
 

--- a/import/index_java/src/org/vufind/index/UpdateDateTracker.java
+++ b/import/index_java/src/org/vufind/index/UpdateDateTracker.java
@@ -142,16 +142,6 @@ public class UpdateDateTracker
             "WHERE core = ? AND id = ?;");
     }
 
-    /* Finalizer
-     */
-    protected void finalize() throws SQLException, Throwable
-    {
-        insertSql.close();
-        selectSql.close();
-        updateSql.close();
-        super.finalize();
-    }
-
     /* Get the first indexed date (IMPORTANT: index() must be called before this method)
      */
     public String getFirstIndexed()


### PR DESCRIPTION
The finalize() method has been deprecated and was never reliably called. This PR switches to use the try-with-resources method to ensure reliable freeing of allocated resources.

TODO
- [ ] Update changelog when merging
- [x] Close [VUFIND-1651](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1651) when merging