### PR TITLE
Fix bug: popover broke when clicking same record in different channels.

### DIFF
--- a/themes/bootstrap3/js/channels.js
+++ b/themes/bootstrap3/js/channels.js
@@ -37,7 +37,9 @@ VuFind.register('channels', function Channels() {
   var currentPopover = false;
   function isCurrentPopoverRecord(record) {
     return record && currentPopover
-      && record.data('record-id') === currentPopover.data('record-id');
+      && record.data('record-id') === currentPopover.data('record-id')
+      && record.data('record-source') === currentPopover.data('record-source')
+      && record.data('channel-id') === currentPopover.data('channel-id');
   }
   function switchPopover(record) {
     // Hide the old popover:

--- a/themes/bootstrap3/templates/channels/channelList.phtml
+++ b/themes/bootstrap3/templates/channels/channelList.phtml
@@ -60,7 +60,7 @@
       <!-- Wrapper for slides -->
       <?php foreach ($channel['contents'] as $index => $item): ?>
         <?php $url = empty($item['routeDetails']) ? $this->recordLinker()->getUrl("{$item['source']}|{$item['id']}") : $this->url($item['routeDetails']['route'], $item['routeDetails']['params']); ?>
-        <a href="<?=$this->escapeHtmlAttr($url)?>" class="channel-record slide hidden" data-record-id="<?=$this->escapeHtmlAttr($item['id']) ?>" data-record-source="<?=$item['source'] ?>" title="<?=$this->escapeHtml($item['title'])?>">
+        <a href="<?=$this->escapeHtmlAttr($url)?>" class="channel-record slide hidden" data-channel-id="<?=$this->escapeHtmlAttr($channelID)?>" data-record-id="<?=$this->escapeHtmlAttr($item['id']) ?>" data-record-source="<?=$item['source'] ?>" title="<?=$this->escapeHtml($item['title'])?>">
           <div class="thumb">
             <img <?=$index < 6 ? 'src' : 'src="#" data-lazy' ?>="<?=$this->escapeHtmlAttr($item['thumbnail'] ? $item['thumbnail'] : $this->url('cover-unavailable'))?>" alt="">
           </div>


### PR DESCRIPTION
This PR adds some additional data to channel items to help the popover code differentiate between instances when the same item appears in multiple channels. This fixes a bug discussed in #2934.