### PR TITLE
Expand Feedback entity interface; add Feedback service

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Entity;
 
+use DateTime;
+
 /**
  * Entity model interface for feedback table
  *
@@ -40,4 +42,154 @@ namespace VuFind\Db\Entity;
  */
 interface FeedbackEntityInterface extends EntityInterface
 {
+    /**
+     * Id getter
+     *
+     * @return int
+     */
+    public function getId(): int;
+
+    /**
+     * Message setter
+     *
+     * @param string $message Message
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setMessage(string $message): FeedbackEntityInterface;
+
+    /**
+     * Message getter
+     *
+     * @return string
+     */
+    public function getMessage(): string;
+
+    /**
+     * Form data setter.
+     *
+     * @param array $data Form data
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setFormData(array $data): FeedbackEntityInterface;
+
+    /**
+     * Form data getter
+     *
+     * @return array
+     */
+    public function getFormData(): array;
+
+    /**
+     * Form name setter.
+     *
+     * @param string $name Form name
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setFormName(string $name): FeedbackEntityInterface;
+
+    /**
+     * Form name getter
+     *
+     * @return string
+     */
+    public function getFormName(): string;
+
+    /**
+     * Created setter.
+     *
+     * @param Datetime $dateTime Created date
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setCreated(DateTime $dateTime): FeedbackEntityInterface;
+
+    /**
+     * Created getter
+     *
+     * @return Datetime
+     */
+    public function getCreated(): DateTime;
+
+    /**
+     * Updated setter.
+     *
+     * @param Datetime $dateTime Last update date
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUpdated(DateTime $dateTime): FeedbackEntityInterface;
+
+    /**
+     * Updated getter
+     *
+     * @return DateTime
+     */
+    public function getUpdated(): DateTime;
+
+    /**
+     * Status setter.
+     *
+     * @param string $status Status
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setStatus(string $status): FeedbackEntityInterface;
+
+    /**
+     * Status getter
+     *
+     * @return string
+     */
+    public function getStatus(): string;
+
+    /**
+     * Site URL setter.
+     *
+     * @param string $url Site URL
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setSiteUrl(string $url): FeedbackEntityInterface;
+
+    /**
+     * Site URL getter
+     *
+     * @return string
+     */
+    public function getSiteUrl(): string;
+
+    /**
+     * User setter.
+     *
+     * @param ?UserEntityInterface $user User that created request
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUser(?UserEntityInterface $user): FeedbackEntityInterface;
+
+    /**
+     * User getter
+     *
+     * @return ?UserEntityInterface
+     */
+    public function getUser(): ?UserEntityInterface;
+
+    /**
+     * Updatedby setter.
+     *
+     * @param ?UserEntityInterface $user User that updated request
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUpdatedBy(?UserEntityInterface $user): FeedbackEntityInterface;
+
+    /**
+     * Updatedby getter
+     *
+     * @return ?UserEntityInterface
+     */
+    public function getUpdatedBy(): ?UserEntityInterface;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
@@ -100,7 +100,7 @@ interface FeedbackEntityInterface extends EntityInterface
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return FeedbackEntityInterface
      */
@@ -109,14 +109,14 @@ interface FeedbackEntityInterface extends EntityInterface
     /**
      * Created getter
      *
-     * @return Datetime
+     * @return DateTime
      */
     public function getCreated(): DateTime;
 
     /**
      * Updated setter.
      *
-     * @param Datetime $dateTime Last update date
+     * @param DateTime $dateTime Last update date
      *
      * @return FeedbackEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Row/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Row/Feedback.php
@@ -154,7 +154,7 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return FeedbackEntityInterface
      */
@@ -167,7 +167,7 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
     /**
      * Created getter
      *
-     * @return Datetime
+     * @return DateTime
      */
     public function getCreated(): DateTime
     {
@@ -177,7 +177,7 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
     /**
      * Updated setter.
      *
-     * @param Datetime $dateTime Last update date
+     * @param DateTime $dateTime Last update date
      *
      * @return FeedbackEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Row/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Row/Feedback.php
@@ -252,7 +252,7 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      */
     public function setUser(?UserEntityInterface $user): FeedbackEntityInterface
     {
-        $this->user_id = $user ? $user->getId() : null;
+        $this->user_id = $user?->getId();
         return $this;
     }
 

--- a/module/VuFind/src/VuFind/Db/Row/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Row/Feedback.php
@@ -31,6 +31,13 @@ declare(strict_types=1);
 
 namespace VuFind\Db\Row;
 
+use DateTime;
+use VuFind\Db\Entity\FeedbackEntityInterface;
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Service\DbServiceAwareInterface;
+use VuFind\Db\Service\DbServiceAwareTrait;
+use VuFind\Db\Service\UserServiceInterface;
+
 /**
  * Class Feedback
  *
@@ -39,9 +46,22 @@ namespace VuFind\Db\Row;
  * @author   Josef Moravec <moravec@mzk.cz>
  * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
+ *
+ * @property int    $id
+ * @property int    $user_id
+ * @property string $message
+ * @property string $form_data
+ * @property string $form_name
+ * @property string $created
+ * @property string $updated
+ * @property int    $updated_by
+ * @property string $status
+ * @property string $site_url
  */
-class Feedback extends RowGateway implements \VuFind\Db\Entity\FeedbackEntityInterface
+class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceAwareInterface
 {
+    use DbServiceAwareTrait;
+
     /**
      * Constructor
      *
@@ -50,5 +70,226 @@ class Feedback extends RowGateway implements \VuFind\Db\Entity\FeedbackEntityInt
     public function __construct($adapter)
     {
         parent::__construct('id', 'feedback', $adapter);
+    }
+
+    /**
+     * Id getter
+     *
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Message setter
+     *
+     * @param string $message Message
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setMessage(string $message): FeedbackEntityInterface
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * Message getter
+     *
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * Form data setter.
+     *
+     * @param array $data Form data
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setFormData(array $data): FeedbackEntityInterface
+    {
+        $this->form_data = json_encode($data);
+        return $this;
+    }
+
+    /**
+     * Form data getter
+     *
+     * @return array
+     */
+    public function getFormData(): array
+    {
+        return json_decode($this->form_data, true);
+    }
+
+    /**
+     * Form name setter.
+     *
+     * @param string $name Form name
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setFormName(string $name): FeedbackEntityInterface
+    {
+        $this->form_name = $name;
+        return $this;
+    }
+
+    /**
+     * Form name getter
+     *
+     * @return string
+     */
+    public function getFormName(): string
+    {
+        return $this->form_name;
+    }
+
+    /**
+     * Created setter.
+     *
+     * @param Datetime $dateTime Created date
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setCreated(DateTime $dateTime): FeedbackEntityInterface
+    {
+        $this->created = $dateTime->format('Y-m-d H:i:s');
+        return $this;
+    }
+
+    /**
+     * Created getter
+     *
+     * @return Datetime
+     */
+    public function getCreated(): DateTime
+    {
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->created);
+    }
+
+    /**
+     * Updated setter.
+     *
+     * @param Datetime $dateTime Last update date
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUpdated(DateTime $dateTime): FeedbackEntityInterface
+    {
+        $this->updated = $dateTime->format('Y-m-d H:i:s');
+        return $this;
+    }
+
+    /**
+     * Updated getter
+     *
+     * @return DateTime
+     */
+    public function getUpdated(): DateTime
+    {
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->updated);
+    }
+
+    /**
+     * Status setter.
+     *
+     * @param string $status Status
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setStatus(string $status): FeedbackEntityInterface
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    /**
+     * Status getter
+     *
+     * @return string
+     */
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Site URL setter.
+     *
+     * @param string $url Site URL
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setSiteUrl(string $url): FeedbackEntityInterface
+    {
+        $this->site_url = $url;
+        return $this;
+    }
+
+    /**
+     * Site URL getter
+     *
+     * @return string
+     */
+    public function getSiteUrl(): string
+    {
+        return $this->site_url;
+    }
+
+    /**
+     * User setter.
+     *
+     * @param ?UserEntityInterface $user User that created request
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUser(?UserEntityInterface $user): FeedbackEntityInterface
+    {
+        $this->user_id = $user ? $user->getId() : null;
+        return $this;
+    }
+
+    /**
+     * User getter
+     *
+     * @return ?UserEntityInterface
+     */
+    public function getUser(): ?UserEntityInterface
+    {
+        return $this->user_id
+            ? $this->getDbServiceManager()->get(UserServiceInterface::class)->getUserById($this->user_id)
+            : null;
+    }
+
+    /**
+     * Updatedby setter.
+     *
+     * @param ?UserEntityInterface $user User that updated request
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function setUpdatedBy(?UserEntityInterface $user): FeedbackEntityInterface
+    {
+        $this->updated_by = $user ? $user->getId() : null;
+        return $this;
+    }
+
+    /**
+     * Updatedby getter
+     *
+     * @return ?UserEntityInterface
+     */
+    public function getUpdatedBy(): ?UserEntityInterface
+    {
+        return $this->updated_by
+            ? $this->getDbServiceManager()->get(UserServiceInterface::class)->getUserById($this->updated_by)
+            : null;
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/FeedbackService.php
+++ b/module/VuFind/src/VuFind/Db/Service/FeedbackService.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Database service for feedback.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+
+namespace VuFind\Db\Service;
+
+use VuFind\Db\Entity\FeedbackEntityInterface;
+use VuFind\Db\Table\DbTableAwareInterface;
+use VuFind\Db\Table\DbTableAwareTrait;
+
+/**
+ * Database service for feedback.
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+class FeedbackService extends AbstractDbService implements DbTableAwareInterface, FeedbackServiceInterface
+{
+    use DbTableAwareTrait;
+
+    /**
+     * Create a feedback entity object.
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function createEntity(): FeedbackEntityInterface
+    {
+        return $this->getDbTable('feedback')->createRow();
+    }
+}

--- a/module/VuFind/src/VuFind/Db/Service/FeedbackServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/FeedbackServiceInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Database service interface for feedback.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+
+namespace VuFind\Db\Service;
+
+use VuFind\Db\Entity\FeedbackEntityInterface;
+
+/**
+ * Database service interface for feedback.
+ *
+ * @category VuFind
+ * @package  Database
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
+ */
+interface FeedbackServiceInterface extends DbServiceInterface
+{
+    /**
+     * Create a feedback entity object.
+     *
+     * @return FeedbackEntityInterface
+     */
+    public function createEntity(): FeedbackEntityInterface;
+}

--- a/module/VuFind/src/VuFind/Db/Service/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Service/PluginManager.php
@@ -48,6 +48,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $aliases = [
         AccessTokenServiceInterface::class => AccessTokenService::class,
         CommentsServiceInterface::class => CommentsService::class,
+        FeedbackServiceInterface::class => FeedbackService::class,
         OaiResumptionServiceInterface::class => OaiResumptionService::class,
         RatingsServiceInterface::class => RatingsService::class,
         ResourceServiceInterface::class => ResourceService::class,
@@ -64,6 +65,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
     protected $factories = [
         AccessTokenService::class => AccessTokenServiceFactory::class,
         CommentsService::class => AbstractDbServiceFactory::class,
+        FeedbackService::class => AbstractDbServiceFactory::class,
         OaiResumptionService::class => AbstractDbServiceFactory::class,
         RatingsService::class => AbstractDbServiceFactory::class,
         ResourceService::class => ResourceServiceFactory::class,

--- a/module/VuFind/src/VuFind/Db/Table/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Table/PluginManager.php
@@ -50,6 +50,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'changetracker' => ChangeTracker::class,
         'comments' => Comments::class,
         'externalsession' => ExternalSession::class,
+        'feedback' => Feedback::class,
         'logintoken' => LoginToken::class,
         'oairesumption' => OaiResumption::class,
         'ratings' => Ratings::class,

--- a/module/VuFind/src/VuFind/Form/Handler/Database.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Database.php
@@ -6,6 +6,7 @@
  * PHP version 8
  *
  * Copyright (C) Moravian Library 2022.
+ * Copyright (C) Villanova University 2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -33,6 +34,7 @@ namespace VuFind\Form\Handler;
 
 use Laminas\Log\LoggerAwareInterface;
 use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Service\FeedbackServiceInterface;
 use VuFind\Log\LoggerAwareTrait;
 
 /**
@@ -49,31 +51,15 @@ class Database implements HandlerInterface, LoggerAwareInterface
     use LoggerAwareTrait;
 
     /**
-     * Feedback table
-     *
-     * @var \VuFind\Db\Table\Feedback
-     */
-    protected $table;
-
-    /**
-     * Site base url
-     *
-     * @var string
-     */
-    protected $baseUrl;
-
-    /**
      * Constructor
      *
-     * @param \VuFind\Db\Table\Feedback $feedbackTable Feedback db table
-     * @param string                    $baseUrl       Site base url
+     * @param FeedbackServiceInterface $feedbackService Feedback database service
+     * @param string                   $baseUrl         Site base url
      */
     public function __construct(
-        \VuFind\Db\Table\Feedback $feedbackTable,
-        string $baseUrl
+        protected FeedbackServiceInterface $feedbackService,
+        protected string $baseUrl
     ) {
-        $this->table = $feedbackTable;
-        $this->baseUrl = $baseUrl;
     }
 
     /**
@@ -92,24 +78,25 @@ class Database implements HandlerInterface, LoggerAwareInterface
     ): bool {
         $fields = $form->mapRequestParamsToFieldValues($params->fromPost());
         $fields = array_column($fields, 'value', 'name');
-
         $formData = $fields;
         unset($formData['message']);
-        $data = [
-            'user_id' => $user?->getId(),
-            'message' => $fields['message'] ?? '',
-            'form_data' => json_encode($formData),
-            'form_name' => $form->getFormId(),
-            'site_url' => $this->baseUrl,
-            'created' => date('Y-m-d H:i:s'),
-            'updated' => date('Y-m-d H:i:s'),
-        ];
+        $now = new \DateTime();
+        $data = $this->feedbackService->createEntity()
+            ->setUser($user)
+            ->setMessage($fields['message'] ?? '')
+            ->setFormData($formData)
+            ->setFormName($form->getFormId())
+            ->setSiteUrl($this->baseUrl)
+            ->setCreated($now)
+            ->setUpdated($now);
         try {
-            $success = (bool)$this->table->insert($data);
+            $this->feedbackService->persistEntity($data);
         } catch (\Exception $e) {
             $this->logError('Could not save feedback data: ' . $e->getMessage());
             return false;
         }
-        return $success;
+        // If we got this far, we succeeded; otherwise, persistEntity would have
+        // thrown an exception above.
+        return true;
     }
 }

--- a/module/VuFind/src/VuFind/Form/Handler/DatabaseFactory.php
+++ b/module/VuFind/src/VuFind/Form/Handler/DatabaseFactory.php
@@ -6,6 +6,7 @@
  * PHP version 8
  *
  * Copyright (C) Moravian Library 2022.
+ * Copyright (C) Villanova University 2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -71,12 +72,12 @@ class DatabaseFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
 
-        $dbTableManager = $container->get(\VuFind\Db\Table\PluginManager::class);
+        $dbServiceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
         $router = $container->get('HttpRouter');
         $serverUrl = $container->get('ViewRenderer')->plugin('serverurl');
         $baseUrl = $serverUrl($router->assemble([], ['name' => 'home']));
         return new $requestedName(
-            $dbTableManager->get(\VuFind\Db\Table\Feedback::class),
+            $dbServiceManager->get(\VuFind\Db\Service\FeedbackServiceInterface::class),
             $baseUrl
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/Handler/DatabaseTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/Handler/DatabaseTest.php
@@ -34,7 +34,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Db\Entity\FeedbackEntityInterface;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\FeedbackServiceInterface;
-use VuFind\Db\Service\UserService;
 use VuFind\Form\Form;
 use VuFind\Form\Handler\Database;
 


### PR DESCRIPTION
This PR fleshes out the FeedbackEntityInterface and introduces the FeedbackService. It also corrects a small oversight in the legacy table configuration. It uses the new code in feedback form database saving logic. More work will need to be done in the admin module; that work will be completed separately after this is merged.