### PR TITLE
Fix inconsistent capitalization of DateTime class.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/CommentsEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/CommentsEntityInterface.php
@@ -68,7 +68,7 @@ interface CommentsEntityInterface extends EntityInterface
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return Comments
      */
@@ -77,9 +77,9 @@ interface CommentsEntityInterface extends EntityInterface
     /**
      * Created getter
      *
-     * @return Datetime
+     * @return DateTime
      */
-    public function getCreated(): Datetime;
+    public function getCreated(): DateTime;
 
     /**
      * User setter.

--- a/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
@@ -68,7 +68,7 @@ interface OaiResumptionEntityInterface extends EntityInterface
     /**
      * Expiry date setter.
      *
-     * @param Datetime $dateTime Expiration date
+     * @param DateTime $dateTime Expiration date
      *
      * @return OaiResumptionEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Entity/SessionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/SessionEntityInterface.php
@@ -61,7 +61,7 @@ interface SessionEntityInterface extends EntityInterface
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return SessionEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -258,7 +258,7 @@ interface UserEntityInterface extends EntityInterface
     /**
      * Last login setter.
      *
-     * @param Datetime $dateTime Last login date
+     * @param DateTime $dateTime Last login date
      *
      * @return UserEntityInterface
      */
@@ -267,7 +267,7 @@ interface UserEntityInterface extends EntityInterface
     /**
      * Last login getter
      *
-     * @return Datetime
+     * @return DateTime
      */
-    public function getLastLogin(): Datetime;
+    public function getLastLogin(): DateTime;
 }

--- a/module/VuFind/src/VuFind/Db/Row/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Row/Comments.php
@@ -101,7 +101,7 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return Comments
      */
@@ -114,9 +114,9 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
     /**
      * Created getter
      *
-     * @return Datetime
+     * @return DateTime
      */
-    public function getCreated(): Datetime
+    public function getCreated(): DateTime
     {
         return DateTime::createFromFormat('Y-m-d H:i:s', $this->created, new \DateTimeZone('UTC'));
     }

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -132,7 +132,7 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
     /**
      * Expiry date setter.
      *
-     * @param Datetime $dateTime Expiration date
+     * @param DateTime $dateTime Expiration date
      *
      * @return OaiResumptionEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Row/Session.php
+++ b/module/VuFind/src/VuFind/Db/Row/Session.php
@@ -85,7 +85,7 @@ class Session extends RowGateway implements SessionEntityInterface
     /**
      * Created setter.
      *
-     * @param Datetime $dateTime Created date
+     * @param DateTime $dateTime Created date
      *
      * @return SessionEntityInterface
      */

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -1085,7 +1085,7 @@ class User extends RowGateway implements
     /**
      * Last login setter.
      *
-     * @param Datetime $dateTime Last login date
+     * @param DateTime $dateTime Last login date
      *
      * @return UserEntityInterface
      */
@@ -1098,9 +1098,9 @@ class User extends RowGateway implements
     /**
      * Last login getter
      *
-     * @return Datetime
+     * @return DateTime
      */
-    public function getLastLogin(): Datetime
+    public function getLastLogin(): DateTime
     {
         return DateTime::createFromFormat('Y-m-d H:i:s', $this->last_login);
     }


### PR DESCRIPTION
This trivial PR corrects some inconsistent capitalization of the DateTime class. Class names are case-insensitive, so this makes no functional difference, but it's stylistically preferable to be consistent.