### PR TITLE
[VUFIND-1689] Reduce EDS full text link inconsistencies.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Permission.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Permission.php
@@ -76,6 +76,18 @@ class Permission extends AbstractHelper
     }
 
     /**
+     * Determine if the current user is authorized for a permission.
+     *
+     * @param string $context Name of the permission rule
+     *
+     * @return bool
+     */
+    public function isAuthorized($context)
+    {
+        return $this->permissionManager->isAuthorized($context )=== true;
+    }
+
+    /**
      * Determine if a local block inside the template should be displayed
      *
      * @param string $context Name of the permission rule

--- a/module/VuFind/src/VuFind/View/Helper/Root/Permission.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Permission.php
@@ -84,7 +84,7 @@ class Permission extends AbstractHelper
      */
     public function isAuthorized($context)
     {
-        return $this->permissionManager->isAuthorized($context )=== true;
+        return $this->permissionManager->isAuthorized($context) === true;
     }
 
     /**

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -100,13 +100,13 @@
         </tr>
       <?php elseif ($this->driver->hasHTMLFullTextAvailable() && $restrictedView): ?>
         <tr id="html">
-          <td>
-            <?=$this->transEsc('Full text is not displayed to guests')?>
-          </td>
-          <td>
-            <a class="login" href="<?=$this->url('myresearch-userlogin')?>" rel="nofollow">
-              <strong><?=$this->transEsc('Login for full access')?></strong>
-            </a>
+          <td colspan="2">
+            <div class="alert alert-info">
+              <?=$this->transEsc('Full text is not displayed to guests')?>
+              <a class="login" href="<?=$this->url('myresearch-userlogin')?>" rel="nofollow">
+                <strong><?=$this->transEsc('Login for full access')?></strong>
+              </a>
+            </div>
           </td>
         </tr>
       <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -26,28 +26,28 @@
       <?php if ($this->permission()->isAuthorized('access.EDSExtendedResults')): ?>
         <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
           <span>
-            <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver))?>#html" class="icon--eds html fulltext" target="_blank">
+            <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver))?>#html" class="icon--eds html fulltext">
               <?=$this->transEsc('HTML Full Text')?>
             </a>
           </span>
         <?php endif; ?>
         <?php if ($ftLink = $this->driver->getLinkedFullTextLink()): ?>
           <span>
-            <a href="<?=$ftLink?>" class="fulltext" target="_blank">
+            <a href="<?=$ftLink?>" class="fulltext">
               <?=$this->transEsc('Linked Full Text')?>
             </a>
           </span>
         <?php endif; ?>
         <?php if ($pdfLink = $this->driver->getPdfLink()): ?>
           <span>
-            <a href="<?=$pdfLink?>" class="icon--eds pdf fulltext" target="_blank">
+            <a href="<?=$pdfLink?>" class="icon--eds pdf fulltext">
               <?=$this->transEsc('PDF Full Text')?>
             </a>
           </span>
         <?php endif; ?>
         <?php if ($epubLink = $this->driver->getEpubLink()): ?>
           <span>
-            <a href="<?=$epubLink?>" class="icon--eds epub fulltext" target="_blank">
+            <a href="<?=$epubLink?>" class="icon--eds epub fulltext">
               <?=$this->transEsc('ePub Full Text')?>
             </a>
           </span>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -23,36 +23,37 @@
           </a>
         </span>
       <?php endif; ?>
-      <?php $ftLink = $this->driver->getLinkedFullTextLink();
-          if ($ftLink): ?>
-        <span>
-          <a href="<?=$ftLink?>" class="fulltext">
-            <?=$this->transEsc('Linked Full Text')?>
-          </a>
-        </span>
-      <?php endif; ?>
-      <?php $pdfLink = $this->driver->getPdfLink();
-          if ($pdfLink): ?>
-        <span>
-          <a href="<?=$pdfLink?>" class="icon--eds pdf fulltext">
-            <?=$this->transEsc('PDF Full Text')?>
-          </a>
-        </span>
-      <?php endif; ?>
-      <?php $epubLink = $this->driver->getEpubLink();
-          if ($epubLink): ?>
-        <span>
-          <a href="<?=$epubLink?>" class="icon--eds epub fulltext">
-            <?=$this->transEsc('ePub Full Text')?>
-          </a>
-        </span>
-      <?php endif; ?>
-      <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
-        <span>
-          <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver))?>#html" class="icon--eds html fulltext">
-            <?=$this->transEsc('HTML Full Text')?>
-          </a>
-        </span>
+      <?php if ($this->permission()->isAuthorized('access.EDSExtendedResults')): ?>
+        <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
+          <span>
+            <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver))?>#html" class="icon--eds html fulltext" target="_blank">
+              <?=$this->transEsc('HTML Full Text')?>
+            </a>
+          </span>
+        <?php endif; ?>
+        <?php if ($ftLink = $this->driver->getLinkedFullTextLink()): ?>
+          <span>
+            <a href="<?=$ftLink?>" class="fulltext" target="_blank">
+              <?=$this->transEsc('Linked Full Text')?>
+            </a>
+          </span>
+        <?php endif; ?>
+        <?php if ($pdfLink = $this->driver->getPdfLink()): ?>
+          <span>
+            <a href="<?=$pdfLink?>" class="icon--eds pdf fulltext" target="_blank">
+              <?=$this->transEsc('PDF Full Text')?>
+            </a>
+          </span>
+        <?php endif; ?>
+        <?php if ($epubLink = $this->driver->getEpubLink()): ?>
+          <span>
+            <a href="<?=$epubLink?>" class="icon--eds epub fulltext" target="_blank">
+              <?=$this->transEsc('ePub Full Text')?>
+            </a>
+          </span>
+        <?php endif; ?>
+      <?php else: ?>
+        <?=$this->render('RecordDriver/EDS/result-list/full-text-links.phtml', ['driver' => $this->driver, 'recordLinker' => $this->recordLinker()])?>
       <?php endif; ?>
     </div>
   </div>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -81,7 +81,7 @@
 
       <?=$this->record($this->driver)->renderTemplate(
                 'result-list/full-text-links.phtml',
-                ['recordLinker' => $recordLinker]
+                ['recordLinker' => $recordLinker, 'newWindow' => true]
             );
       ?>
 

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list/full-text-links.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list/full-text-links.phtml
@@ -1,6 +1,7 @@
+<?php $target = ($newWindow ?? false) ? ' target="_blank"' : ''; ?>
 <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
   <span>
-    <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver)) ?>#html" class="icon--eds html fulltext _record_link" target="_blank">
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver)) ?>#html" class="icon--eds html fulltext _record_link"<?=$target?>>
       <?=$this->transEsc('HTML Full Text')?>
     </a>
   </span>
@@ -8,7 +9,7 @@
 
 <?php if ($this->driver->hasLinkedFullTextAvailable()): ?>
   <span>
-    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'LinkedText')) ?>" class="fulltext" target="_blank">
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'LinkedText')) ?>" class="fulltext"<?=$target?>>
       <?=$this->transEsc('Linked Full Text')?>
     </a>
   </span>
@@ -16,7 +17,7 @@
 
 <?php if ($this->driver->hasPdfAvailable()): ?>
   <span>
-    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'PDF')) ?>" class="icon--eds pdf fulltext" target="_blank">
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'PDF')) ?>" class="icon--eds pdf fulltext"<?=$target?>>
       <?=$this->transEsc('PDF Full Text')?>
     </a>
   </span>
@@ -24,7 +25,7 @@
 
 <?php if ($this->driver->hasEpubAvailable()): ?>
   <span>
-    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'Epub')) ?>" class="icon--eds epub fulltext" target="_blank">
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'Epub')) ?>" class="icon--eds epub fulltext"<?=$target?>>
       <?=$this->transEsc('ePub Full Text')?>
     </a>
   </span>

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list/full-text-links.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list/full-text-links.phtml
@@ -1,24 +1,31 @@
 <?php if ($this->driver->hasHTMLFullTextAvailable()): ?>
-  <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver)) ?>#html" class="icon--eds html fulltext _record_link" target="_blank">
-    <?=$this->transEsc('HTML Full Text')?>
-  </a>
-  &nbsp; &nbsp;
+  <span>
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver)) ?>#html" class="icon--eds html fulltext _record_link" target="_blank">
+      <?=$this->transEsc('HTML Full Text')?>
+    </a>
+  </span>
 <?php endif; ?>
 
 <?php if ($this->driver->hasLinkedFullTextAvailable()): ?>
-  <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'LinkedText')) ?>" class="fulltext" target="_blank">
-    <?=$this->transEsc('Linked Full Text')?>
-  </a>
+  <span>
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'LinkedText')) ?>" class="fulltext" target="_blank">
+      <?=$this->transEsc('Linked Full Text')?>
+    </a>
+  </span>
 <?php endif; ?>
 
 <?php if ($this->driver->hasPdfAvailable()): ?>
-  <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'PDF')) ?>" class="icon--eds pdf fulltext" target="_blank">
-    <?=$this->transEsc('PDF Full Text')?>
-  </a>
+  <span>
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'PDF')) ?>" class="icon--eds pdf fulltext" target="_blank">
+      <?=$this->transEsc('PDF Full Text')?>
+    </a>
+  </span>
 <?php endif; ?>
 
 <?php if ($this->driver->hasEpubAvailable()): ?>
-  <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'Epub')) ?>" class="icon--eds epub fulltext" target="_blank">
-    <?=$this->transEsc('ePub Full Text')?>
-  </a>
+  <span>
+    <a href="<?=$this->escapeHtmlAttr($recordLinker->getTabUrl($this->driver, 'Epub')) ?>" class="icon--eds epub fulltext" target="_blank">
+      <?=$this->transEsc('ePub Full Text')?>
+    </a>
+  </span>
 <?php endif; ?>


### PR DESCRIPTION
This PR attempts to reduce inconsistencies between EDS full text links in search results vs. the record view reported in [VUFIND-1689](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1689).

This issue is caused by the fact that an anonymous user gets fewer details in the EDS API response than an authorized one. The system broadly looks for full text links in the search results and creates links that will trigger logins as needed. But sometimes when richer data is available, it turns out that some of these links don't really exist. This can result in a logged-in user seeing fewer links than a logged-out user.

Previously, the record page relied entirely on the authorized-user method, which meant logged out users would see no full text links at all. The primary change of this PR is to leverage the result list logic on the core record page when a user is logged out.

It is still not perfect because of inherent inconsistencies in the EDS API itself, but this at least reduces the problem of NO LINKS on the record page when there are one or more links in the search results.

It also does a few other related things:

- It adds a new method to the permissions view helper to directly check permissions.
- It adds `target="blank"` everywhere for consistent link behavior
- It refactors to use "assignment inside if" to compact some code
- It changes the order of link lists to make them the same in both places
- It adds some spans for consistent markup
- It removes some seemingly unnecessary `&nbsp;` entities.
- It makes the login message for HTML text access more visible.

TODO
- [ ] Resolve [VUFIND-1689](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1689) when merging