### PR TITLE
Improve ChannelsTest: refactor for clarity/consistency.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -187,7 +187,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
      * @param string $title1              Title of first record
      * @param string $record2             ID of second record
      * @param string $title2              Title of second record
-     * @param ?int   $record2ChannelIndex Index of channel containing second record (null = no special filtering)
+     * @param ?int   $record2ChannelIndex Index of channel containing second record (needed when $record1 === $record2)
      *
      * @return void
      *

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -187,7 +187,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
      * @param string $title1              Title of first record
      * @param string $record2             ID of second record
      * @param string $title2              Title of second record
-     * @param ?int   $record2ChannelIndex Index of channel containing second record
+     * @param ?int   $record2ChannelIndex Index of channel containing second record (null = no special filtering)
      *
      * @return void
      *

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -144,7 +144,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
                 'Octothorpes: Why not?',
                 'dollar$ign/slashcombo',
                 'Of Money and Slashes',
-                '',
+                null,
             ],
             'same record in two channels' => [
                 'id:017791359-1',
@@ -152,7 +152,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
                 'Fake Record 1 with multiple relators/',
                 '017791359-1',
                 'Fake Record 1 with multiple relators/',
-                '[data-channel-id="channel-4afca2ef6c4d86c140a2d01513f9e2be"]',
+                1,
             ],
         ];
     }
@@ -182,12 +182,12 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Test popover behavior by clicking back and forth between two records
      *
-     * @param string $query                Search query
-     * @param string $record1              ID of first record
-     * @param string $title1               Title of first record
-     * @param string $record2              ID of second record
-     * @param string $title2               Title of second record
-     * @param string $record2ExtraSelector Extra selector for accessing $record2 (needed when $record1 === $record2)
+     * @param string $query               Search query
+     * @param string $record1             ID of first record
+     * @param string $title1              Title of first record
+     * @param string $record2             ID of second record
+     * @param string $title2              Title of second record
+     * @param ?int   $record2ChannelIndex Index of channel containing second record
      *
      * @return void
      *
@@ -199,7 +199,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         string $title1,
         string $record2,
         string $title2,
-        string $record2ExtraSelector
+        ?int $record2ChannelIndex
     ): void {
         $page = $this->getChannelsPage($query);
         // Click a record to open the popover:
@@ -207,7 +207,9 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         // The popover should contain an appropriate title and metadata:
         $popoverContents = $this->assertPopoverTitleAndDescription($page, $title1);
         // Click a different record (or the second instance of the same record, if that's what we're testing):
-        $this->clickCss($page, '.channel-record[data-record-id="' . $record2 . '"]' . $record2ExtraSelector);
+        $title2Target = $record2ChannelIndex === null
+            ? $page : $this->findCss($page, '.channel', index: $record2ChannelIndex);
+        $this->clickCss($title2Target, '.channel-record[data-record-id="' . $record2 . '"]');
         $this->assertPopoverTitleAndDescription($page, $title2);
         // Now click back to the original record; the popover should contain the same contents.
         $this->clickCss($page, '.channel-record[data-record-id="' . $record1 . '"]');


### PR DESCRIPTION
The ChannelsTest fails in Jenkins but passes in my local environment. I think this may be related to inconsistent click behavior. This PR refactors the test to ensure more consistent popover handling and to eliminate an unused variable. It still passes in my local environment, and I believe this at least _might_ get it passing again in Jenkins as well.