### PR TITLE
Default required-string User getters to blank strings if unset.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -1072,7 +1072,7 @@ class User extends RowGateway implements
      */
     public function getLastLanguage(): string
     {
-        return $this->last_language;
+        return $this->last_language ?? '';
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -901,7 +901,7 @@ class User extends RowGateway implements
      */
     public function getPendingEmail(): string
     {
-        return $this->pending_email;
+        return $this->pending_email ?? '';
     }
 
     /**
@@ -1026,7 +1026,7 @@ class User extends RowGateway implements
      */
     public function getVerifyHash(): string
     {
-        return $this->verify_hash;
+        return $this->verify_hash ?? '';
     }
 
     /**


### PR DESCRIPTION
While these values are always set in the database, we need these defaults for PrivateUser support.

(This fixes a bug and test failure introduced by #3639).