### PR TITLE
Add/implement CommentsServiceInterface::createEntity()

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/CommentsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsService.php
@@ -56,6 +56,16 @@ class CommentsService extends AbstractDbService implements
     use DbTableAwareTrait;
 
     /**
+     * Create a comments entity object.
+     *
+     * @return CommentsEntityInterface
+     */
+    public function createEntity(): CommentsEntityInterface
+    {
+        return $this->getDbTable('comments')->createRow();
+    }
+
+    /**
      * Add a comment to the current resource. Returns comment ID on success, null on failure.
      *
      * @param string                      $comment  The comment to save.

--- a/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
@@ -45,6 +45,13 @@ use VuFind\Db\Entity\UserEntityInterface;
 interface CommentsServiceInterface extends DbServiceInterface
 {
     /**
+     * Create a comments entity object.
+     *
+     * @return CommentsEntityInterface
+     */
+    public function createEntity(): CommentsEntityInterface;
+
+    /**
      * Add a comment to the current resource. Returns comment ID on success, null on failure.
      *
      * @param string                      $comment  The comment to save.


### PR DESCRIPTION
This PR adds a createEntity method for the CommentsServiceInterface for forward-compatibility with #2233. This method is not yet used in the dev branch, but it seemed worth adding for consistency with other services and to reduce diffs with the Doctrine PR.