### PR TITLE
Remove undefined variable reference caused by merge error.

### DIFF
--- a/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
+++ b/themes/bootstrap3/templates/RecordTab/holdingsils/standard.phtml
@@ -24,7 +24,7 @@
       <span class="<?=$this->escapeHtmlAttr($statusClass)?>">
         <?=$this->transEsc($statusDescription)?>
         <?php if ($schemaAvailabilityUri): ?>
-          <?=$this->transEsc($status)?><?=$this->schemaOrg()->getLink($schemaAvailabilityUri, 'availability')?>
+          <?=$this->schemaOrg()->getLink($schemaAvailabilityUri, 'availability')?>
         <?php endif; ?>
       </span>
       <?php if ($availabilityStatus->isAvailable()): ?>


### PR DESCRIPTION
When resolving merge conflicts in #3585, it looks like I somehow introduced a reference to an undefined variable. This did not create any visible problems, but it would trigger a PHP notice on every record page load. This PR gets rid of it. Sorry for not noticing it in the first place!