### PR TITLE
Add ContentBlock wrapper for Recommendation modules

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -876,6 +876,11 @@ view=full
 ; prepends a warning message to the HTML element identified by the jQuery selector
 ; provided in [target] (which defaults to .searchHomeContent.
 ;
+; Recommend:[backend]:[module_name]:[module_params] - Display a recommendation
+; module, using the parameter object for the specified backend (default = Solr);
+; this will not work for all recommendation modules, but may be especially
+; useful for, e.g., Deferred recommendations that do not rely on search results.
+;
 ; TemplateBased:[template] - Display the content of template defined after colon.
 ; The template could be in phtml or md (markdown) format and has to be saved in
 ; ContentBlock/TemplateBased/ directory of your theme. You can use language code

--- a/module/VuFind/src/VuFind/ContentBlock/PluginManager.php
+++ b/module/VuFind/src/VuFind/ContentBlock/PluginManager.php
@@ -51,6 +51,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'channels' => Channels::class,
         'facetlist' => FacetList::class,
         'ilsstatusmonitor' => IlsStatusMonitor::class,
+        'recommend' => Recommend::class,
         'templatebased' => TemplateBased::class,
     ];
 
@@ -63,6 +64,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         Channels::class => ChannelsFactory::class,
         FacetList::class => FacetListFactory::class,
         IlsStatusMonitor::class => InvokableFactory::class,
+        Recommend::class => RecommendFactory::class,
         TemplateBased::class => TemplateBasedFactory::class,
     ];
 

--- a/module/VuFind/src/VuFind/ContentBlock/Recommend.php
+++ b/module/VuFind/src/VuFind/ContentBlock/Recommend.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Recommend ContentBlock.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  VuFind\ContentBlock
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\ContentBlock;
+
+use Laminas\Stdlib\Parameters;
+use VuFind\Recommend\PluginManager as RecommendPluginManager;
+use VuFind\Recommend\RecommendInterface;
+use VuFind\Search\Params\PluginManager as ParamsPluginManager;
+
+/**
+ * Recommend ContentBlock.
+ *
+ * @category VuFind
+ * @package  VuFind\ContentBlock
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Recommend implements ContentBlockInterface
+{
+    /**
+     * Recommendation module.
+     *
+     * @var RecommendInterface
+     */
+    protected $recommend;
+
+    /**
+     * Constructor.
+     *
+     * @param ParamsPluginManager    $paramsManager    Search params plugin manager
+     * @param RecommendPluginManager $recommendManager Recommendation plugin manager
+     * @param Parameters             $request          Query parameters from request
+     */
+    public function __construct(
+        protected ParamsPluginManager $paramsManager,
+        protected RecommendPluginManager $recommendManager,
+        protected Parameters $request
+    ) {
+    }
+
+    /**
+     * Store the configuration of the content block.
+     *
+     * @param string $settings Settings from searches.ini.
+     *
+     * @return void
+     */
+    public function setConfig($settings)
+    {
+        $parts = explode(':', $settings, 3);
+        $backend = array_shift($parts);
+        $module = array_shift($parts);
+        $this->recommend = $this->recommendManager->get($module);
+        $this->recommend->setConfig($parts[0] ?? '');
+        $params = $this->paramsManager->get($backend ?: DEFAULT_SEARCH_BACKEND);
+        $this->recommend->init($params, $this->request);
+    }
+
+    /**
+     * Return context variables used for rendering the block's template.
+     *
+     * @return array
+     */
+    public function getContext()
+    {
+        return ['recommend' => $this->recommend];
+    }
+}

--- a/module/VuFind/src/VuFind/ContentBlock/RecommendFactory.php
+++ b/module/VuFind/src/VuFind/ContentBlock/RecommendFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Factory for Recommend ContentBlock.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  VuFind\ContentBlock
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  https://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\ContentBlock;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Factory for Recommend ContentBlock.
+ *
+ * @category VuFind
+ * @package  ContentBlock
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class RecommendFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ) {
+        if ($options !== null) {
+            throw new \Exception('Unexpected options sent to factory!');
+        }
+        return new $requestedName(
+            $container->get(\VuFind\Search\Params\PluginManager::class),
+            $container->get(\VuFind\Recommend\PluginManager::class),
+            $container->get('Request')->getQuery()
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/RecommendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/RecommendTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Recommend ContentBlock Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\ContentBlock;
+
+/**
+ * Recommend ContentBlock Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RecommendTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test the normal workflow of the block.
+     *
+     * @return void
+     */
+    public function testNormalBehavior(): void
+    {
+        $params = $this->createMock(\VuFind\Search\Base\Params::class);
+        $request = new \Laminas\Stdlib\Parameters();
+        $recommend = $this->createMock(\VuFind\Recommend\RecommendInterface::class);
+        $recommend->expects($this->once())->method('setConfig')->with('baz:xyzzy');
+        $recommend->expects($this->once())->method('init')->with($params, $request);
+        $paramsManager = $this->createMock(\VuFind\Search\Params\PluginManager::class);
+        $paramsManager->expects($this->once())->method('get')->with('foo')->willReturn($params);
+        $recommendManager = $this->createMock(\VuFind\Recommend\PluginManager::class);
+        $recommendManager->expects($this->once())->method('get')->with('bar')->willReturn($recommend);
+        $config = 'foo:bar:baz:xyzzy';
+        $block = new \VuFind\ContentBlock\Recommend($paramsManager, $recommendManager, $request);
+        $block->setConfig($config);
+        $this->assertEquals(
+            ['recommend' => $recommend],
+            $block->getContext()
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/TemplateBasedTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ContentBlock/TemplateBasedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * TemplateBased ContentBlack Test Class
+ * TemplateBased ContentBlock Test Class
  *
  * PHP version 8
  *
@@ -30,7 +30,7 @@
 namespace VuFindTest\ContentBlock;
 
 /**
- * TemplateBased ContentBlack Test Class
+ * TemplateBased ContentBlock Test Class
  *
  * @category VuFind
  * @package  Tests

--- a/themes/bootstrap3/templates/ContentBlock/Recommend.phtml
+++ b/themes/bootstrap3/templates/ContentBlock/Recommend.phtml
@@ -1,0 +1,1 @@
+<?=$this->recommend($recommend);


### PR DESCRIPTION
There are situations where it would be useful to display a Recommendation module in a position where a ContentBlock is used; this class creates a wrapper to enable this behavior. It will not work for every Recommendation module, but it will be useful for several.