### PR TITLE
Fix .gitignore for TAGS files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 /themes/minktest
 /vendor
 ChangeLog
-TAGS
+/TAGS
 composer.phar
 env.bat
 env.sh


### PR DESCRIPTION
Restricts TAGS to root to avoid problems with matching 'tags' in case-insensitive file systems.