### PR TITLE
Fix PHP warning if availability element is missing from item status.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1181,7 +1181,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     public function getStatusParser()
     {
         return function ($item) {
-            if (!($item['availability'] instanceof AvailabilityStatus)) {
+            if (!(($item['availability'] ?? null) instanceof AvailabilityStatus)) {
                 $availability = $item['availability'] ?? false;
                 if ($item['use_unknown_message'] ?? false) {
                     $availability = Logic\AvailabilityStatusInterface::STATUS_UNKNOWN;


### PR DESCRIPTION
This was encountered in Mink test HoldingsTest::testItemStatusFailure when PHP is set up to output warnings.