### PR TITLE
Add phpunitfast-with-shutdown-on-fail Phing task.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -104,6 +104,20 @@
     <phingcall target="shutdown" />
   </target>
 
+  <!-- Run tests, shut down if anything fails (useful when chaining multiple phpunitfast runs in continous integration
+       with different settings; e.g. to repeat tests with differen themes) -->
+  <target name="phpunitfast-with-shutdown-on-fail" description="run phpunitfast task; shutdown if anything fails">
+    <trycatch property="exceptionmsg">
+      <try>
+        <phingcall target="phpunitfast" />
+      </try>
+      <catch>
+        <phingcall target="shutdown" />
+        <fail>${exceptionmsg}</fail>
+      </catch>
+    </trycatch>
+  </target>
+
   <!-- Continuous Integration Tasks -->
   <target name="ci-tasks" description="continuous integration tasks">
 

--- a/build.xml
+++ b/build.xml
@@ -104,8 +104,8 @@
     <phingcall target="shutdown" />
   </target>
 
-  <!-- Run tests, shut down if anything fails (useful when chaining multiple phpunitfast runs in continous integration
-       with different settings; e.g. to repeat tests with differen themes) -->
+  <!-- Run tests, shut down if anything fails (useful when chaining multiple phpunitfast runs in continuous
+       integration with different settings; e.g. to repeat tests with different themes) -->
   <target name="phpunitfast-with-shutdown-on-fail" description="run phpunitfast task; shutdown if anything fails">
     <trycatch property="exceptionmsg">
       <try>


### PR DESCRIPTION
This is needed to set up our Jenkins instance to test the sandal5 theme independently of the default sandal theme. It might be useful to create similar phpunitfaster-with-shutdown-on-fail and phpunit-with-shutdown-on-fail tasks for consistency, but I don't need them right now, so I'm keeping it simple.