### PR TITLE
OverDrive: Update content security policy for images

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -60,7 +60,7 @@ img-src[] = "'self'"
 ;img-src[] = https://cache.obalkyknih.cz
 ;img-src[] = https://cache2.obalkyknih.cz
 ;img-src[] = https://cache3.obalkyknih.cz
-; For Overdrive records, uncomment the line below.
+; For OverDrive records, uncomment the line below.
 ;img-src[] = https://*.od-cdn.com
 font-src[] = "'self'"
 base-uri[] = "'self'"

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -60,6 +60,8 @@ img-src[] = "'self'"
 ;img-src[] = https://cache.obalkyknih.cz
 ;img-src[] = https://cache2.obalkyknih.cz
 ;img-src[] = https://cache3.obalkyknih.cz
+; For Overdrive records, uncomment the line below.
+;img-src[] = https://*.od-cdn.com
 font-src[] = "'self'"
 base-uri[] = "'self'"
 


### PR DESCRIPTION
OverDrive cover images seem to be loaded from https://img1.od-cdn.com/.  Given the number in the subdomain it's safer to assume it may vary.