### PR TITLE
OverDrive: Load availability via overdrive ID

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/result-list.phtml
@@ -12,7 +12,7 @@
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif; ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getOverdriveID())?>" class="hiddenId">
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
 <input type="hidden" value="overdrive" class="handler-name">
 <div class="media">

--- a/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/result-list.phtml
@@ -12,7 +12,7 @@
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif; ?>
-<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" class="hiddenId">
+<input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getOverdriveID())?>" class="hiddenId">
 <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" class="hiddenSource">
 <input type="hidden" value="overdrive" class="handler-name">
 <div class="media">


### PR DESCRIPTION
I love all the fixes and styling improvements from @bpalme in the recent PR #3025.  This proposes reverting [one line](https://github.com/vufind-org/vufind/pull/3025/files#diff-2394803c41994fdb1acb2cb618c04b095b58f97a5fc71efd65d46aab30ad03f1) of it.  

The ID set in this hidden field is passed to OverdriveConnector->getAvailabilityBulk() which clearly expects it to be an Overdrive ID.  But the record driver's `getUniqueId` is not necessarily the Overdrive ID, or at least it's not if we use the [configuration](https://vufind.org/wiki/configuration:overdrive) option to use MARC records and simply add the ID in there somewhere.  

Calling `getOverdriveId` instead works great.  Although I haven't tested how it works if you *do* import the records directly from OD.