### PR TITLE
Implement and use UserCardServiceInterface::getAllRowsWithUsernames().

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/UserCardService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserCardService.php
@@ -72,13 +72,26 @@ class UserCardService extends AbstractDbService implements
     }
 
     /**
-     * Get user_card rows with insecure catalog passwords
+     * Get user_card rows with insecure catalog passwords.
      *
      * @return UserCardEntityInterface[]
      */
     public function getInsecureRows(): array
     {
         return iterator_to_array($this->getDbTable('UserCard')->getInsecureRows());
+    }
+
+    /**
+     * Get user_card rows with catalog usernames set.
+     *
+     * @return UserCardEntityInterface[]
+     */
+    public function getAllRowsWithUsernames(): array
+    {
+        $callback = function ($select) {
+            $select->where->isNotNull('cat_username');
+        };
+        return iterator_to_array($this->getDbTable('UserCard')->select($callback));
     }
 
     /**
@@ -143,7 +156,7 @@ class UserCardService extends AbstractDbService implements
     }
 
     /**
-     * Delete library card
+     * Delete library card.
      *
      * @param UserEntityInterface         $user     User owning card to delete
      * @param int|UserCardEntityInterface $userCard UserCard id or object to be deleted
@@ -295,7 +308,7 @@ class UserCardService extends AbstractDbService implements
     }
 
     /**
-     * Activate a library card for the given username
+     * Activate a library card for the given username.
      *
      * @param int|UserEntityInterface $user User owning card
      * @param int                     $id   Library card ID to activate

--- a/module/VuFind/src/VuFind/Db/Service/UserCardServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserCardServiceInterface.php
@@ -46,11 +46,18 @@ use VuFind\Db\Entity\UserEntityInterface;
 interface UserCardServiceInterface extends DbServiceInterface
 {
     /**
-     * Get user_card rows with insecure catalog passwords
+     * Get user_card rows with insecure catalog passwords.
      *
      * @return UserCardEntityInterface[]
      */
     public function getInsecureRows(): array;
+
+    /**
+     * Get user_card rows with catalog usernames set.
+     *
+     * @return UserCardEntityInterface[]
+     */
+    public function getAllRowsWithUsernames(): array;
 
     /**
      * Get all library cards associated with the user.
@@ -75,7 +82,7 @@ interface UserCardServiceInterface extends DbServiceInterface
     public function getOrCreateLibraryCard(int|UserEntityInterface $user, ?int $id = null): UserCardEntityInterface;
 
     /**
-     * Delete library card
+     * Delete library card.
      *
      * @param UserEntityInterface         $user     User owning card to delete
      * @param int|UserCardEntityInterface $userCard UserCard id or object to be deleted
@@ -125,7 +132,7 @@ interface UserCardServiceInterface extends DbServiceInterface
     public function synchronizeUserLibraryCardData(int|UserEntityInterface $user): bool;
 
     /**
-     * Activate a library card for the given username
+     * Activate a library card for the given username.
      *
      * @param int|UserEntityInterface $user User owning card
      * @param int                     $id   Library card ID to activate

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
@@ -42,8 +42,9 @@ use VuFind\Config\Locator as ConfigLocator;
 use VuFind\Config\PathResolver;
 use VuFind\Config\Writer as ConfigWriter;
 use VuFind\Db\Entity\UserCardEntityInterface;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Row\User as UserRow;
-use VuFind\Db\Service\AbstractDbService;
+use VuFind\Db\Service\DbServiceInterface;
 use VuFind\Db\Service\UserCardServiceInterface;
 use VuFind\Db\Table\User as UserTable;
 
@@ -70,7 +71,7 @@ class SwitchDbHashCommand extends Command
      * @param Config                   $config          VuFind configuration
      * @param UserTable                $userTable       User table gateway
      * @param UserCardServiceInterface $userCardService UserCard database service
-     * @param string|null              $name            The name of the command; passing null means
+     * @param ?string                  $name            The name of the command; passing null means
      * it must be set in configure()
      * @param ?PathResolver            $pathResolver    Config file path resolver
      */
@@ -78,7 +79,7 @@ class SwitchDbHashCommand extends Command
         protected Config $config,
         protected UserTable $userTable,
         protected UserCardServiceInterface $userCardService,
-        $name = null,
+        ?string $name = null,
         protected ?PathResolver $pathResolver = null
     ) {
         parent::__construct($name);
@@ -148,16 +149,20 @@ class SwitchDbHashCommand extends Command
     /**
      * Re-encrypt an entity.
      *
-     * @param AbstractDbService       $service   Database service
-     * @param UserCardEntityInterface $entity    Row to update
-     * @param ?BlockCipher            $oldcipher Old cipher (null for none)
-     * @param BlockCipher             $newcipher New cipher
+     * @param AbstractDbService                           $service   Database service
+     * @param UserEntityInterface|UserCardEntityInterface $entity    Row to update
+     * @param ?BlockCipher                                $oldcipher Old cipher (null for none)
+     * @param BlockCipher                                 $newcipher New cipher
      *
      * @return void
      * @throws InvalidArgumentException
      */
-    protected function fixEntity($service, $entity, ?BlockCipher $oldcipher, BlockCipher $newcipher): void
-    {
+    protected function fixEntity(
+        DbServiceInterface $service,
+        UserEntityInterface|UserCardEntityInterface $entity,
+        ?BlockCipher $oldcipher,
+        BlockCipher $newcipher
+    ): void {
         $oldEncrypted = $entity->getCatPassEnc();
         $pass = ($oldcipher && $oldEncrypted !== null)
             ? $oldcipher->decrypt($oldEncrypted)

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommand.php
@@ -41,10 +41,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use VuFind\Config\Locator as ConfigLocator;
 use VuFind\Config\PathResolver;
 use VuFind\Config\Writer as ConfigWriter;
+use VuFind\Db\Entity\UserCardEntityInterface;
 use VuFind\Db\Row\User as UserRow;
-use VuFind\Db\Row\UserCard as UserCardRow;
+use VuFind\Db\Service\AbstractDbService;
+use VuFind\Db\Service\UserCardServiceInterface;
 use VuFind\Db\Table\User as UserTable;
-use VuFind\Db\Table\UserCard as UserCardTable;
 
 use function count;
 
@@ -64,54 +65,22 @@ use function count;
 class SwitchDbHashCommand extends Command
 {
     /**
-     * VuFind configuration.
-     *
-     * @var Config
-     */
-    protected $config;
-
-    /**
-     * User table gateway
-     *
-     * @var UserTable
-     */
-    protected $userTable;
-
-    /**
-     * UserCard table gateway
-     *
-     * @var UserCardTable
-     */
-    protected $userCardTable;
-
-    /**
-     * Config file path resolver
-     *
-     * @var PathResolver
-     */
-    protected $pathResolver;
-
-    /**
      * Constructor
      *
-     * @param Config        $config        VuFind configuration
-     * @param UserTable     $userTable     User table gateway
-     * @param UserCardTable $userCardTable UserCard table gateway
-     * @param string|null   $name          The name of the command; passing null means
+     * @param Config                   $config          VuFind configuration
+     * @param UserTable                $userTable       User table gateway
+     * @param UserCardServiceInterface $userCardService UserCard database service
+     * @param string|null              $name            The name of the command; passing null means
      * it must be set in configure()
-     * @param PathResolver  $pathResolver  Config file path resolver
+     * @param ?PathResolver            $pathResolver    Config file path resolver
      */
     public function __construct(
-        Config $config,
-        UserTable $userTable,
-        UserCardTable $userCardTable,
+        protected Config $config,
+        protected UserTable $userTable,
+        protected UserCardServiceInterface $userCardService,
         $name = null,
-        PathResolver $pathResolver = null
+        protected ?PathResolver $pathResolver = null
     ) {
-        $this->config = $config;
-        $this->userTable = $userTable;
-        $this->userCardTable = $userCardTable;
-        $this->pathResolver = $pathResolver;
         parent::__construct($name);
     }
 
@@ -159,9 +128,9 @@ class SwitchDbHashCommand extends Command
     /**
      * Re-encrypt a row.
      *
-     * @param UserRow|UserCardRow $row       Row to update
-     * @param ?BlockCipher        $oldcipher Old cipher (null for none)
-     * @param BlockCipher         $newcipher New cipher
+     * @param UserRow      $row       Row to update
+     * @param ?BlockCipher $oldcipher Old cipher (null for none)
+     * @param BlockCipher  $newcipher New cipher
      *
      * @return void
      * @throws InvalidArgumentException
@@ -174,6 +143,28 @@ class SwitchDbHashCommand extends Command
         $row->setRawCatPassword(null);
         $row->setCatPassEnc($pass === null ? null : $newcipher->encrypt($pass));
         $row->save();
+    }
+
+    /**
+     * Re-encrypt an entity.
+     *
+     * @param AbstractDbService       $service   Database service
+     * @param UserCardEntityInterface $entity    Row to update
+     * @param ?BlockCipher            $oldcipher Old cipher (null for none)
+     * @param BlockCipher             $newcipher New cipher
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    protected function fixEntity($service, $entity, ?BlockCipher $oldcipher, BlockCipher $newcipher): void
+    {
+        $oldEncrypted = $entity->getCatPassEnc();
+        $pass = ($oldcipher && $oldEncrypted !== null)
+            ? $oldcipher->decrypt($oldEncrypted)
+            : $entity->getRawCatPassword();
+        $entity->setRawCatPassword(null);
+        $entity->setCatPassEnc($pass === null ? null : $newcipher->encrypt($pass));
+        $service->persistEntity($entity);
     }
 
     /**
@@ -257,7 +248,7 @@ class SwitchDbHashCommand extends Command
             $select->where->isNotNull('cat_username');
         };
         $users = $this->userTable->select($callback);
-        $cards = $this->userCardTable->select($callback);
+        $cards = $this->userCardService->getAllRowsWithUsernames();
         $output->writeln("\tConverting hashes for " . count($users) . ' user(s).');
         foreach ($users as $row) {
             try {
@@ -268,11 +259,11 @@ class SwitchDbHashCommand extends Command
         }
         if (count($cards) > 0) {
             $output->writeln("\tConverting hashes for " . count($cards) . ' card(s).');
-            foreach ($cards as $row) {
+            foreach ($cards as $entity) {
                 try {
-                    $this->fixRow($row, $oldcipher, $newcipher);
+                    $this->fixEntity($this->userCardService, $entity, $oldcipher, $newcipher);
                 } catch (\Exception $e) {
-                    $output->writeln("Problem with card {$row['id']}: " . (string)$e);
+                    $output->writeln("Problem with card {$entity->getId()}: " . (string)$e);
                 }
             }
         }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/SwitchDbHashCommandFactory.php
@@ -68,10 +68,11 @@ class SwitchDbHashCommandFactory implements FactoryInterface
         $config = $container->get(\VuFind\Config\PluginManager::class)
             ->get('config');
         $tableManager = $container->get(\VuFind\Db\Table\PluginManager::class);
+        $serviceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
         return new $requestedName(
             $config,
             $tableManager->get(\VuFind\Db\Table\User::class),
-            $tableManager->get(\VuFind\Db\Table\UserCard::class),
+            $serviceManager->get(\VuFind\Db\Service\UserCardServiceInterface::class),
             null,
             $container->get(\VuFind\Config\PathResolver::class),
             ...($options ?? [])

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/SwitchDbHashCommandTest.php
@@ -292,7 +292,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @return MockObject&UserCardEntityInterface
      */
-    protected function getUserCardEntity(): MockObject&UserCardEntityInterface
+    protected function getMockUserCardEntity(): MockObject&UserCardEntityInterface
     {
         $card = $this->createMock(UserCardEntityInterface::class);
         $rawPass = 'mypassword';
@@ -400,7 +400,7 @@ class SwitchDbHashCommandTest extends \PHPUnit\Framework\TestCase
             ]
         );
         $writer->expects($this->once())->method('save')->willReturn(true);
-        $card = $this->getUserCardEntity();
+        $card = $this->getMockUserCardEntity();
         $userTable = $this->getMockUserTable();
         $userTable->expects($this->once())->method('select')->willReturn([]);
         $cardService = $this->getMockCardService();


### PR DESCRIPTION
This backports the one remaining UserCardService method from #2233 to dev, further eliminating changed files from that PR. It also normalizes punctuation in some comments, significantly modernizes the associated test and introduces constructor property promotion to simplify code.

This can be further simplified, and more redundancy removed, when we expand the UserService and eliminate reliance on the UserTable; that will be done as a separate follow-up action.