### PR TITLE
Fix phing build issues.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -992,6 +992,7 @@ ${git_status}
         <delete failonerror="true">
           <fileset dir="${templatesdir}">
             <exclude name="header.phtml" />
+            <exclude name="RecordTab/similaritemscarousel.phtml" />
           </fileset>
         </delete>
       </then>
@@ -1066,7 +1067,7 @@ ${git_status}
     <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/templates" />
     <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/templates" />
     <foreach target="check-dir-single-file" param="filename">
-      <fileset dir="${check_dir_base}" defaultexcludes="false">
+      <fileset dir="${check_dir_base}">
         <exclude name="header.phtml" />
         <exclude name="RecordTab/similaritemscarousel.phtml" />
         <different targetdir="${check_dir_compare}" ignoreFileTimes="true" />
@@ -1076,7 +1077,7 @@ ${git_status}
     <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/scss" />
     <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/scss" />
     <foreach target="check-dir-single-file" param="filename">
-      <fileset dir="${check_dir_base}" defaultexcludes="false">
+      <fileset dir="${check_dir_base}">
         <exclude name="/" />
         <exclude name="bootstrap.scss" />
         <exclude name="components/similar-carousel.scss" />
@@ -1088,7 +1089,7 @@ ${git_status}
     <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/js" />
     <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/js" />
     <foreach target="check-dir-single-file" param="filename">
-      <fileset dir="${check_dir_base}" defaultexcludes="false">
+      <fileset dir="${check_dir_base}">
         <exclude name="/" />
         <exclude name="account_ajax.js" />
         <exclude name="cart.js" />


### PR DESCRIPTION
- Fixes RecordTab/similaritemscarousel.phtml getting deleted in update-bootstrap3
- Enables default excludes so that check-bootstrap5 ignores dotfiles.