### PR TITLE
Remove unnecessary timezone from Comments class.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Row/Comments.php
@@ -118,7 +118,7 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
      */
     public function getCreated(): DateTime
     {
-        return DateTime::createFromFormat('Y-m-d H:i:s', $this->created, new \DateTimeZone('UTC'));
+        return DateTime::createFromFormat('Y-m-d H:i:s', $this->created);
     }
 
     /**


### PR DESCRIPTION
Some time zone logic got aggressively copied and pasted throughout #2233, but I don't think it's actually necessary; at least, removing it has no visible effect that I can see. Cleaning it up to prevent future confusion.