### PR TITLE
Use different debug formatting string on console vs. web.

### DIFF
--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -337,7 +337,9 @@ class LoggerFactory implements FactoryInterface
         $hasDebugWriter = true;
         $writer = new Writer\Stream('php://output');
         $formatter = new \Laminas\Log\Formatter\Simple(
-            '<pre>%timestamp% %priorityName%: %message%</pre>' . PHP_EOL
+            PHP_SAPI === 'cli'
+                ? '%timestamp% %priorityName%: %message%'
+                : '<pre>%timestamp% %priorityName%: %message%</pre>' . PHP_EOL
         );
         $writer->setFormatter($formatter);
         $level = (is_int($debug) ? $debug : '5');


### PR DESCRIPTION
This improves the experience of setting debug = true in config.ini when debugging console commands.