### PR TITLE
PHPUnit: turn on displayDetailsOnTestsThatTriggerDeprecations.

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -5,6 +5,7 @@
   backupGlobals="false"
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
   displayDetailsOnTestsThatTriggerWarnings="true"
+  displayDetailsOnTestsThatTriggerDeprecations="true"
   cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="AllUnitTests">


### PR DESCRIPTION
During test development, I discovered that PHPUnit was not set up to display deprecation messages when tests triggered deprecation warnings. This PR adjusts the configuration to make it more clear where these problems are coming from.