### PR TITLE
Feedback: expand test; improve error handling.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -125,16 +125,21 @@ class Email implements HandlerInterface, LoggerAwareInterface
 
         $result = true;
         foreach ($recipients as $recipient) {
-            $success = $this->sendEmail(
-                $recipient['name'],
-                $recipient['email'],
-                $senderName,
-                $senderEmail,
-                $replyToName,
-                $replyToEmail,
-                $emailSubject,
-                $emailMessage
-            );
+            if ($recipient['email']) {
+                $success = $this->sendEmail(
+                    $recipient['name'],
+                    $recipient['email'],
+                    $senderName,
+                    $senderEmail,
+                    $replyToName,
+                    $replyToEmail,
+                    $emailSubject,
+                    $emailMessage
+                );
+            } else {
+                $this->logError('Form recipient email missing; check recipient_email in config.ini.');
+                $success = false;
+            }
 
             $result = $result && $success;
         }


### PR DESCRIPTION
This PR includes some improvements I made while testing #3709:

  - If a feedback recipient email is incorrectly configured, an error is logged (instead of throwing a fatal validation exception).
  - The Mink FeedbackTest now tests that feedback can be persisted to the database, and exercises some (though definitely not all) of the functionality of the feedback admin page. More can be done here, but this is better than the nothing we had before!