### PR TITLE
Add testing of deleted records to OaiTest.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -509,6 +509,7 @@
 
     <phingcall target="import_biblios" />
     <phingcall target="import_authorities" />
+    <phingcall target="delete_fake_records" />
     <phingcall target="build_alphabrowse" />
   </target>
 
@@ -709,6 +710,11 @@ return [
     </foreach>
   </target>
 
+  <!-- Delete some fake record IDs so we have deleted records to test with -->
+  <target name="delete_fake_records" description="delete fake records">
+    <exec command="VUFIND_HOME=${srcdir} VUFIND_LOCAL_DIR=${localdir} php ${srcdir}/public/index.php util/deletes ${srcdir}/tests/data/fake-deleted-ids.txt flat" checkreturn="true" passthru="true" />
+  </target>
+
   <!-- Build alphabrowse index -->
   <target name="build_alphabrowse" description="build the alphabrowse index">
     <exec command="VUFIND_HOME=${srcdir} VUFIND_LOCAL_DIR=${localdir} ${srcdir}/index-alphabetic-browse.sh" passthru="true" />
@@ -871,6 +877,7 @@ ${git_status}
 
     <phingcall target="configure_install" />
     <phingcall target="setup_database" />
+    <phingcall target="delete_fake_records" />
   </target>
 
   <!-- Prepare VuFind for distribution -->

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
@@ -55,7 +55,7 @@ class OaiTest extends \VuFindTest\Integration\MinkTestCase
         'OAI' => [
             'identifier' => 'vufind.org',
             'repository_name' => 'test repo',
-            'page_size' => 10,
+            'page_size' => 15,
         ],
     ];
 
@@ -138,14 +138,15 @@ class OaiTest extends \VuFindTest\Integration\MinkTestCase
     {
         $this->changeConfigs(['config' => $this->defaultOaiConfig]);
 
-        // Get the first page of results. We expect 20 total results because we only turned on change
-        // tracking in the demo setup for one 20-record file; if more change tracking is added in
-        // future, this test will need to be adjusted.
+        // Get the first page of results. We expect 22 total results because we only turned on change
+        // tracking in the demo setup for one 20-record file, plus we've created 2 fake deleted records
+        // as part of our standard setup procedure; if more change tracking is added in future, this
+        // test will need to be adjusted.
         $rawXml = $this
             ->httpGet($this->getVuFindUrl() . '/OAI/Server?verb=ListRecords&metadataPrefix=oai_dc')
             ->getBody();
         $xml = simplexml_load_string($rawXml);
-        $resultSetSize = 20;
+        $resultSetSize = 22;
         $pageSize = $this->defaultOaiConfig['OAI']['page_size'];
         $resumptionAttributes = $xml->ListRecords->resumptionToken->attributes();
         $this->assertCount($pageSize, $xml->ListRecords->record);
@@ -155,11 +156,17 @@ class OaiTest extends \VuFindTest\Integration\MinkTestCase
         $firstPageFirstId = (string)$xml->ListRecords->record[0]->header->identifier;
         $this->assertStringStartsWith('oai:vufind.org:', $firstPageFirstId);
 
+        // Assert that only the first two records are marked deleted:
+        $this->assertEquals('deleted', (string)$xml->ListRecords->record[0]->header->attributes());
+        $this->assertEquals('deleted', (string)$xml->ListRecords->record[1]->header->attributes());
+        $this->assertEquals('', (string)$xml->ListRecords->record[2]->header->attributes());
+
         // Now get the second page of results, using the resumption token from the first. Make sure
         // the results are different than before by comparing first record IDs.
         $rawXml2 = $this->httpGet(
             $this->getVuFindUrl() . '/OAI/Server?verb=ListRecords&resumptionToken=' . urlencode($resumptionToken)
         )->getBody();
+        //echo "\n$rawXml2\n";
         $xml2 = simplexml_load_string($rawXml2);
         $resumptionAttributes2 = $xml2->ListRecords->resumptionToken->attributes();
         $this->assertEquals($resultSetSize - $pageSize, count($xml2->ListRecords->record));

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OaiTest.php
@@ -166,7 +166,6 @@ class OaiTest extends \VuFindTest\Integration\MinkTestCase
         $rawXml2 = $this->httpGet(
             $this->getVuFindUrl() . '/OAI/Server?verb=ListRecords&resumptionToken=' . urlencode($resumptionToken)
         )->getBody();
-        //echo "\n$rawXml2\n";
         $xml2 = simplexml_load_string($rawXml2);
         $resumptionAttributes2 = $xml2->ListRecords->resumptionToken->attributes();
         $this->assertEquals($resultSetSize - $pageSize, count($xml2->ListRecords->record));

--- a/tests/data/fake-deleted-ids.txt
+++ b/tests/data/fake-deleted-ids.txt
@@ -1,0 +1,3 @@
+fake-deleted-record-1
+fake-deleted-record-2
+


### PR DESCRIPTION
Our simple OaiTest didn't account for deleted records. This PR creates a mechanism for generating a couple of fake deleted records in the system (and ensures that they don't get destroyed by a reset_setup command), and then leverages them in the OAI server integration test.

As with many tests, we could potentially go deeper here and cover more edge cases, but this is at least a start!