### PR TITLE
Fix invalid argument in Record Driver test harness.

### DIFF
--- a/module/VuFind/src/VuFindTest/RecordDriver/TestHarness.php
+++ b/module/VuFind/src/VuFindTest/RecordDriver/TestHarness.php
@@ -100,7 +100,7 @@ class TestHarness extends \VuFind\RecordDriver\AbstractBase
         // overridden via rawData (but also allow the "normal" method as a
         // fallback):
         return isset($this->fields['SourceIdentifier'])
-            ? $this->__call('getSourceIdentifier', $this->sourceIdentifier)
+            ? $this->__call('getSourceIdentifier', [])
             : parent::getSourceIdentifier();
     }
 }


### PR DESCRIPTION
This fixes a harmless bug in the record driver test harness -- an invalid argument was being passed to __call (but since it wasn't used, it didn't particularly matter... however, I could see this leading to type errors in future, so it's worth fixing).