### PR TITLE
Update feedback admin template to use FeedbackEntityInterface.

### DIFF
--- a/themes/bootstrap3/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap3/templates/admin/feedback/home.phtml
@@ -72,30 +72,31 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
         </tr>
         <?php foreach ($this->feedback as $feedbackItem): ?>
           <?php
-            $data = json_decode($feedbackItem->form_data, true);
+            $feedbackEntity = $feedbackItem['feedback_entity'];
+            $data = $feedbackEntity->getFormData();
           ?>
           <tr>
             <td>
-              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="checkbox_ui">
-              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>">
-              <?=$this->escapeHtml($feedbackItem->form_name)?>
+              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="checkbox_ui">
+              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>">
+              <?=$this->escapeHtml($feedbackEntity->getFormName())?>
             </td>
-            <td><?=$this->escapeHtml($feedbackItem->site_url)?></td>
+            <td><?=$this->escapeHtml($feedbackEntity->getSiteUrl())?></td>
             <td>
-              <span id="shortMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="collapse in message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>"><?=$this->truncate($feedbackItem->message, 100, '')?></span>
-              <?php if (strlen(($feedbackItem->message)) > 100): ?>
-                <span id="fullMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="collapse fullMessage message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>"><?=$feedbackItem->message?></span>
-                <a id="toggleButton_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" data-toggle="collapse" data-target=".message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" aria-controls="fullMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" aria-expanded="false" >
+              <span id="shortMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="collapse in message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>"><?=$this->truncate($feedbackEntity->getMessage(), 100, '')?></span>
+              <?php if (strlen(($feedbackEntity->getMessage())) > 100): ?>
+                <span id="fullMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="collapse fullMessage message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>"><?=$feedbackEntity->getMessage()?></span>
+                <a id="toggleButton_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" data-toggle="collapse" data-target=".message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" aria-controls="fullMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" aria-expanded="false" >
                   <?=$this->transEsc('more_ellipsis')?>
                 </a>
               <?php endif; ?>
             </td>
             <td>
               <?php if (!empty($data)): ?>
-                <a href="#" class="btn btn-default btn-info" data-toggle="modal" data-target="#feedback-<?=$feedbackItem->id?>">
+                <a href="#" class="btn btn-default btn-info" data-toggle="modal" data-target="#feedback-<?=$feedbackEntity->getId()?>">
                   <?=$this->transEsc('Show')?>
                 </a>
-                <div class="modal" id="feedback-<?=$feedbackItem->id?>" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal" id="feedback-<?=$feedbackEntity->getId()?>" tabindex="-1" role="dialog" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <div class="modal-header">
@@ -109,12 +110,12 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
                           <strong><?=$this->escapeHtml($key)?></strong>: <?=$this->escapeHtml($value)?><br>
                         <?php endforeach; ?>
                         <strong><?=$this->transEsc('Created')?></strong>:
-                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->created))?>
-                        <?=$feedbackItem->user_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->user_name) . ' (' . $feedbackItem->user_id . ')') : ''?>
+                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackEntity->getCreated()->format('Y-m-d H:i:s')))?>
+                        <?=$feedbackItem['user_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['user_name']) . ' (' . $feedbackEntity->getUser()->getId() . ')') : ''?>
                         <br>
                         <strong><?=$this->transEsc('Updated')?></strong>:
-                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->updated))?>
-                        <?=$feedbackItem->manager_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->manager_name) . ' (' . $feedbackItem->updated_by . ')') : ''?>
+                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackEntity->getUpdated()->format('Y-m-d H:i:s')))?>
+                        <?=$feedbackItem['manager_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['manager_name']) . ' (' . $feedbackEntity->getUpdatedBy() . ')') : ''?>
                       </div>
                     </div>
                   </div>
@@ -123,7 +124,7 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
             <td>
               <select class="form-control status_update" name="status_update">
                 <?php foreach ($this->statuses as $status): ?>
-                  <option value="<?=$this->escapeHtmlAttr($status)?>"<?=$status == $feedbackItem->status ? ' selected="selected"' : ''?>>
+                  <option value="<?=$this->escapeHtmlAttr($status)?>"<?=$status == $feedbackEntity->getStatus() ? ' selected="selected"' : ''?>>
                     <?=$this->transEsc('feedback_status_' . $status, [], $status)?>
                   </option>
                 <?php endforeach; ?>

--- a/themes/bootstrap5/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap5/templates/admin/feedback/home.phtml
@@ -72,30 +72,31 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
         </tr>
         <?php foreach ($this->feedback as $feedbackItem): ?>
           <?php
-            $data = json_decode($feedbackItem->form_data, true);
+            $feedbackEntity = $feedbackItem['feedback_entity'];
+            $data = $feedbackEntity->getFormData();
           ?>
           <tr>
             <td>
-              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="checkbox_ui">
-              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackItem->id)?>">
-              <?=$this->escapeHtml($feedbackItem->form_name)?>
+              <input id="checkbox_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="checkbox_ui">
+              <input type="hidden" name="idsAll[]" value="<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>">
+              <?=$this->escapeHtml($feedbackEntity->getFormName())?>
             </td>
-            <td><?=$this->escapeHtml($feedbackItem->site_url)?></td>
+            <td><?=$this->escapeHtml($feedbackEntity->getSiteUrl())?></td>
             <td>
-              <span id="shortMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="collapse in message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>"><?=$this->truncate($feedbackItem->message, 100, '')?></span>
-              <?php if (strlen(($feedbackItem->message)) > 100): ?>
-                <span id="fullMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" class="collapse fullMessage message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>"><?=$feedbackItem->message?></span>
-                <a id="toggleButton_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" data-bs-toggle="collapse" data-bs-target=".message_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" aria-controls="fullMessage_<?=$this->escapeHtmlAttr($feedbackItem->id)?>" aria-expanded="false" >
+              <span id="shortMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="collapse in message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>"><?=$this->truncate($feedbackEntity->getMessage(), 100, '')?></span>
+              <?php if (strlen(($feedbackEntity->getMessage())) > 100): ?>
+                <span id="fullMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" class="collapse fullMessage message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>"><?=$feedbackEntity->getMessage()?></span>
+                <a id="toggleButton_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" data-bs-toggle="collapse" data-bs-target=".message_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" aria-controls="fullMessage_<?=$this->escapeHtmlAttr($feedbackEntity->getId())?>" aria-expanded="false" >
                   <?=$this->transEsc('more_ellipsis')?>
                 </a>
               <?php endif; ?>
             </td>
             <td>
               <?php if (!empty($data)): ?>
-                <a href="#" class="btn btn-default btn-info" data-bs-toggle="modal" data-bs-target="#feedback-<?=$feedbackItem->id?>">
+                <a href="#" class="btn btn-default btn-info" data-bs-toggle="modal" data-bs-target="#feedback-<?=$feedbackEntity->getId()?>">
                   <?=$this->transEsc('Show')?>
                 </a>
-                <div class="modal" id="feedback-<?=$feedbackItem->id?>" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal" id="feedback-<?=$feedbackEntity->getId()?>" tabindex="-1" role="dialog" aria-hidden="true">
                   <div class="modal-dialog">
                     <div class="modal-content">
                       <div class="modal-header">
@@ -109,12 +110,12 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
                           <strong><?=$this->escapeHtml($key)?></strong>: <?=$this->escapeHtml($value)?><br>
                         <?php endforeach; ?>
                         <strong><?=$this->transEsc('Created')?></strong>:
-                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->created))?>
-                        <?=$feedbackItem->user_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->user_name) . ' (' . $feedbackItem->user_id . ')') : ''?>
+                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackEntity->getCreated()->format('Y-m-d H:i:s')))?>
+                        <?=$feedbackItem['user_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['user_name']) . ' (' . $feedbackEntity->getUser()->getId() . ')') : ''?>
                         <br>
                         <strong><?=$this->transEsc('Updated')?></strong>:
-                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackItem->updated))?>
-                        <?=$feedbackItem->manager_name ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem->manager_name) . ' (' . $feedbackItem->updated_by . ')') : ''?>
+                        <?=$this->escapeHtml($this->dateTime()->convertToDisplayDateAndTime('Y-m-d H:i:s', $feedbackEntity->getUpdated()->format('Y-m-d H:i:s')))?>
+                        <?=$feedbackItem['manager_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['manager_name']) . ' (' . $feedbackEntity->getUpdatedBy() . ')') : ''?>
                       </div>
                     </div>
                   </div>
@@ -123,7 +124,7 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
             <td>
               <select class="form-control status_update" name="status_update">
                 <?php foreach ($this->statuses as $status): ?>
-                  <option value="<?=$this->escapeHtmlAttr($status)?>"<?=$status == $feedbackItem->status ? ' selected="selected"' : ''?>>
+                  <option value="<?=$this->escapeHtmlAttr($status)?>"<?=$status == $feedbackEntity->getStatus() ? ' selected="selected"' : ''?>>
                     <?=$this->transEsc('feedback_status_' . $status, [], $status)?>
                   </option>
                 <?php endforeach; ?>


### PR DESCRIPTION
This PR puts some finishing touches on the feedback admin module, updating the template to use the FeedbackEntityInterface where appropriate. This was a little trickier than anticipated because of the way Laminas\Db returns results. Some data remapping was necessary to convert what Laminas\Db provides into the future format we'll get from Doctrine (which offers proper entity support and better separation of fields). The solution here feels like a bit of a hack, but it works, it's temporary, and it only impacts a rarely-used admin feature. Seems worth patching in to further minimize template diffs vs. #2233.