### PR TITLE
Simplify <br> tags in Javascript code.

### DIFF
--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -92,7 +92,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
     } else {
       // Default case -- load call number and location into appropriate containers:
       el.querySelectorAll('.callnumber').forEach((callnumber) => {
-        callnumber.innerHTML = formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br/>';
+        callnumber.innerHTML = formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br>';
       });
       el.querySelectorAll('.location').forEach((location) => {
         location.innerHTML = result.reserve === 'true'

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -90,7 +90,7 @@ VuFind.register('lightbox', function Lightbox() {
     if (alerts.length > 0) {
       var msgs = alerts.toArray().map(function getSuccessHtml(el) {
         return el.innerHTML;
-      }).join('<br/>');
+      }).join('<br>');
       var href = alerts.find('.download').attr('href');
       if (typeof href !== 'undefined') {
         location.href = href;
@@ -187,7 +187,7 @@ VuFind.register('lightbox', function Lightbox() {
             if (errorMsgs.length && testDiv.find('.record').length) {
               var msgs = errorMsgs.toArray().map(function getAlertHtml(el) {
                 return el.innerHTML;
-              }).join('<br/>');
+              }).join('<br>');
               showAlert(msgs, 'danger');
               return false;
             }
@@ -233,7 +233,7 @@ VuFind.register('lightbox', function Lightbox() {
         render(content);
       })
       .fail(function lbAjaxFail(deferred, errorType, msg) {
-        showAlert(VuFind.translate('error_occurred') + '<br/>' + msg, 'danger');
+        showAlert(VuFind.translate('error_occurred') + '<br>' + msg, 'danger');
       });
     return _xhr;
   }

--- a/themes/bootstrap5/js/check_item_statuses.js
+++ b/themes/bootstrap5/js/check_item_statuses.js
@@ -92,7 +92,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
     } else {
       // Default case -- load call number and location into appropriate containers:
       el.querySelectorAll('.callnumber').forEach((callnumber) => {
-        callnumber.innerHTML = formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br/>';
+        callnumber.innerHTML = formatCallnumbers(result.callnumber, result.callnumber_handler) + '<br>';
       });
       el.querySelectorAll('.location').forEach((location) => {
         location.innerHTML = result.reserve === 'true'

--- a/themes/bootstrap5/js/lightbox.js
+++ b/themes/bootstrap5/js/lightbox.js
@@ -92,7 +92,7 @@ VuFind.register('lightbox', function Lightbox() {
     if (alerts.length > 0) {
       var msgs = alerts.toArray().map(function getSuccessHtml(el) {
         return el.innerHTML;
-      }).join('<br/>');
+      }).join('<br>');
       var href = alerts.find('.download').attr('href');
       if (typeof href !== 'undefined') {
         location.href = href;
@@ -189,7 +189,7 @@ VuFind.register('lightbox', function Lightbox() {
             if (errorMsgs.length && testDiv.find('.record').length) {
               var msgs = errorMsgs.toArray().map(function getAlertHtml(el) {
                 return el.innerHTML;
-              }).join('<br/>');
+              }).join('<br>');
               showAlert(msgs, 'danger');
               return false;
             }
@@ -235,7 +235,7 @@ VuFind.register('lightbox', function Lightbox() {
         render(content);
       })
       .fail(function lbAjaxFail(deferred, errorType, msg) {
-        showAlert(VuFind.translate('error_occurred') + '<br/>' + msg, 'danger');
+        showAlert(VuFind.translate('error_occurred') + '<br>' + msg, 'danger');
       });
     return _xhr;
   }


### PR DESCRIPTION
I happened to notice that earlier work to simplify self-closing break tags from `<br/>` to `<br>` did not catch a few instances in Javascript files. This PR addresses them.