### PR TITLE
Allow the order of author groups to be configurable

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -58,6 +58,16 @@ class RecordDataFormatterFactory implements FactoryInterface
     protected $schemaOrgHelper = null;
 
     /**
+     * The order in which groups of authors are displayed.
+     * 
+     * The dictionary keys here correspond to the dictionary keys in the $labels
+     * array in getAuthorFunction()
+     *
+     * @var string[]
+     */
+    protected $authorOrder = ['primary' => 1, 'corporate' => 2, 'secondary' => 3];
+
+    /**
      * Create an object
      *
      * @param ContainerInterface $container     Service manager
@@ -120,8 +130,6 @@ class RecordDataFormatterFactory implements FactoryInterface
                 'corporate' => 'creator',
                 'secondary' => 'contributor',
             ];
-            // Lookup array of sort orders.
-            $order = ['primary' => 1, 'corporate' => 2, 'secondary' => 3];
 
             // Sort the data:
             $final = [];
@@ -130,7 +138,7 @@ class RecordDataFormatterFactory implements FactoryInterface
                     'label' => $labels[$type][count($values) == 1 ? 0 : 1],
                     'values' => [$type => $values],
                     'options' => [
-                        'pos' => $options['pos'] + $order[$type],
+                        'pos' => $options['pos'] + $this->order[$type],
                         'renderType' => 'RecordDriverTemplate',
                         'template' => 'data-authors.phtml',
                         'context' => [
@@ -204,8 +212,10 @@ class RecordDataFormatterFactory implements FactoryInterface
             'Edition',
             'getEdition',
             null,
-            ['itemPrefix' => '<span property="bookEdition">',
-             'itemSuffix' => '</span>']
+            [
+                'itemPrefix' => '<span property="bookEdition">',
+                'itemSuffix' => '</span>'
+            ]
         );
         $spec->setTemplateLine('Series', 'getSeries', 'data-series.phtml');
         $spec->setTemplateLine(
@@ -318,8 +328,10 @@ class RecordDataFormatterFactory implements FactoryInterface
             'Edition',
             'getEdition',
             null,
-            ['itemPrefix' => '<span property="bookEdition">',
-             'itemSuffix' => '</span>']
+            [
+                'itemPrefix' => '<span property="bookEdition">',
+                'itemSuffix' => '</span>'
+            ]
         );
         $spec->setTemplateLine('Series', 'getSeries', 'data-series.phtml');
         $spec->setTemplateLine(
@@ -383,8 +395,10 @@ class RecordDataFormatterFactory implements FactoryInterface
             'DOI',
             'getCleanDOI',
             null,
-            ['itemPrefix' => '<span property="identifier">',
-             'itemSuffix' => '</span>']
+            [
+                'itemPrefix' => '<span property="identifier">',
+                'itemSuffix' => '</span>'
+            ]
         );
         $spec->setLine('Related Items', 'getRelationshipNotes');
         $spec->setLine('Access', 'getAccessRestrictions');

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -138,7 +138,7 @@ class RecordDataFormatterFactory implements FactoryInterface
                     'label' => $labels[$type][count($values) == 1 ? 0 : 1],
                     'values' => [$type => $values],
                     'options' => [
-                        'pos' => $options['pos'] + $this->order[$type],
+                        'pos' => $options['pos'] + $this->authorOrder[$type],
                         'renderType' => 'RecordDriverTemplate',
                         'template' => 'data-authors.phtml',
                         'context' => [

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -59,11 +59,11 @@ class RecordDataFormatterFactory implements FactoryInterface
 
     /**
      * The order in which groups of authors are displayed.
-     * 
+     *
      * The dictionary keys here correspond to the dictionary keys in the $labels
      * array in getAuthorFunction()
      *
-     * @var string[]
+     * @var array<string, int>
      */
     protected $authorOrder = ['primary' => 1, 'corporate' => 2, 'secondary' => 3];
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -214,7 +214,7 @@ class RecordDataFormatterFactory implements FactoryInterface
             null,
             [
                 'itemPrefix' => '<span property="bookEdition">',
-                'itemSuffix' => '</span>'
+                'itemSuffix' => '</span>',
             ]
         );
         $spec->setTemplateLine('Series', 'getSeries', 'data-series.phtml');
@@ -330,7 +330,7 @@ class RecordDataFormatterFactory implements FactoryInterface
             null,
             [
                 'itemPrefix' => '<span property="bookEdition">',
-                'itemSuffix' => '</span>'
+                'itemSuffix' => '</span>',
             ]
         );
         $spec->setTemplateLine('Series', 'getSeries', 'data-series.phtml');
@@ -397,7 +397,7 @@ class RecordDataFormatterFactory implements FactoryInterface
             null,
             [
                 'itemPrefix' => '<span property="identifier">',
-                'itemSuffix' => '</span>'
+                'itemSuffix' => '</span>',
             ]
         );
         $spec->setLine('Related Items', 'getRelationshipNotes');


### PR DESCRIPTION
This pulls out the $order array from getAuthorFunction() into a protected class variable that can be overridden in the class hierarchy.

We had a library that asked for the order to be 1) primary, 2) secondary, 3) corporate. Making this array a class variable means that the whole getAuthorFunction() doesn't need to be overridden in a sub-class.