### PR TITLE
Move catalog credential saving to ILSAuthenticator.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
@@ -132,7 +132,7 @@ class AlmaDatabase extends Database
 
             // Save the credentials to cat_username and cat_password to bypass
             // the ILS login screen from VuFind
-            $user->saveCredentials($params['username'], $params['password']);
+            $this->authenticator->saveUserCatalogCredentials($user, $params['username'], $params['password']);
         } else {
             throw new AuthException($this->translate('ils_account_create_error'));
         }

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -178,9 +178,10 @@ class CAS extends AbstractBase
         // see https://github.com/vufind-org/vufind/pull/612). Note that in the
         // (unlikely) scenario that a password can actually change from non-blank
         // to blank, additional work may need to be done here.
-        if (!empty($user->cat_username)) {
-            $user->saveCredentials(
-                $user->cat_username,
+        if (!empty($catUsername = $user->getCatUsername())) {
+            $this->ilsAuthenticator->setUserCatalogCredentials(
+                $user,
+                $catUsername,
                 empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }

--- a/module/VuFind/src/VuFind/Auth/Email.php
+++ b/module/VuFind/src/VuFind/Auth/Email.php
@@ -44,20 +44,15 @@ use VuFind\Exception\Auth as AuthException;
 class Email extends AbstractBase
 {
     /**
-     * Email Authenticator
-     *
-     * @var EmailAuthenticator
-     */
-    protected $emailAuthenticator;
-
-    /**
      * Constructor
      *
-     * @param EmailAuthenticator $emailAuth Email authenticator
+     * @param EmailAuthenticator $emailAuthenticator Email authenticator
+     * @param ILSAuthenticator   $ilsAuthenticator   ILS authenticator
      */
-    public function __construct(EmailAuthenticator $emailAuth)
-    {
-        $this->emailAuthenticator = $emailAuth;
+    public function __construct(
+        protected EmailAuthenticator $emailAuthenticator,
+        protected ILSAuthenticator $ilsAuthenticator
+    ) {
     }
 
     /**
@@ -167,7 +162,8 @@ class Email extends AbstractBase
         }
 
         // Update the user in the database, then return it to the caller:
-        $user->saveCredentials(
+        $this->ilsAuthenticator->saveUserCatalogCredentials(
+            $user,
             $info['cat_username'] ?? ' ',
             $info['cat_password'] ?? ' '
         );

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -33,6 +33,10 @@ use Laminas\Config\Config;
 use Laminas\Crypt\BlockCipher;
 use Laminas\Crypt\Symmetric\Openssl;
 use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Service\DbServiceAwareInterface;
+use VuFind\Db\Service\DbServiceAwareTrait;
+use VuFind\Db\Service\UserCardServiceInterface;
+use VuFind\Db\Service\UserServiceInterface;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\ILS\Connection as ILSConnection;
 
@@ -45,8 +49,10 @@ use VuFind\ILS\Connection as ILSConnection;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class ILSAuthenticator
+class ILSAuthenticator implements DbServiceAwareInterface
 {
+    use DbServiceAwareTrait;
+
     /**
      * Callback for retrieving the authentication manager
      *
@@ -219,6 +225,47 @@ class ILSAuthenticator
     }
 
     /**
+     * Set ILS login credentials for a user without saving them.
+     *
+     * @param UserEntityInterface $user     User to update
+     * @param string              $username Username to save
+     * @param string              $password Password to save (null for none)
+     *
+     * @return void
+     */
+    public function setUserCatalogCredentials(UserEntityInterface $user, string $username, string $password): void
+    {
+        $user->setCatUsername($username);
+        if ($this->passwordEncryptionEnabled()) {
+            $user->setRawCatPassword(null);
+            $user->setCatPassEnc($this->encrypt($password));
+        } else {
+            $user->setRawCatPassword($password);
+            $user->setCatPassEnc(null);
+        }
+    }
+
+    /**
+     * Save ILS login credentials.
+     *
+     * @param UserEntityInterface $user     User to update
+     * @param string              $username Username to save
+     * @param string              $password Password to save
+     *
+     * @return void
+     * @throws \VuFind\Exception\PasswordSecurity
+     */
+    public function saveUserCatalogCredentials(UserEntityInterface $user, string $username, string $password): void
+    {
+        $this->setUserCatalogCredentials($user, $username, $password);
+        $this->getDbService(UserServiceInterface::class)->persistEntity($user);
+
+        // Update library card entry after saving the user so that we always have a
+        // user id:
+        $this->getDbService(UserCardServiceInterface::class)->synchronizeUserLibraryCardData($user);
+    }
+
+    /**
      * Get stored catalog credentials for the current user.
      *
      * Returns associative array of cat_username and cat_password if they are
@@ -364,7 +411,7 @@ class ILSAuthenticator
     {
         $user = $this->getAuthManager()->getUserObject();
         if ($user) {
-            $user->saveCredentials($catUsername, $catPassword);
+            $this->saveUserCatalogCredentials($user, $catUsername, $catPassword);
             $this->getAuthManager()->updateSession($user);
             // cache for future use
             $this->ilsAccount[$catUsername] = $patron;

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -229,11 +229,11 @@ class ILSAuthenticator implements DbServiceAwareInterface
      *
      * @param UserEntityInterface $user     User to update
      * @param string              $username Username to save
-     * @param string              $password Password to save (null for none)
+     * @param ?string             $password Password to save (null for none)
      *
      * @return void
      */
-    public function setUserCatalogCredentials(UserEntityInterface $user, string $username, string $password): void
+    public function setUserCatalogCredentials(UserEntityInterface $user, string $username, ?string $password): void
     {
         $user->setCatUsername($username);
         if ($this->passwordEncryptionEnabled()) {
@@ -250,12 +250,12 @@ class ILSAuthenticator implements DbServiceAwareInterface
      *
      * @param UserEntityInterface $user     User to update
      * @param string              $username Username to save
-     * @param string              $password Password to save
+     * @param ?string             $password Password to save
      *
      * @return void
      * @throws \VuFind\Exception\PasswordSecurity
      */
-    public function saveUserCatalogCredentials(UserEntityInterface $user, string $username, string $password): void
+    public function saveUserCatalogCredentials(UserEntityInterface $user, string $username, ?string $password): void
     {
         $this->setUserCatalogCredentials($user, $username, $password);
         $this->getDbService(UserServiceInterface::class)->persistEntity($user);

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -284,7 +284,7 @@ class LDAP extends AbstractBase
         $user = $this->getUserTable()->getByUsername($username);
 
         // Variable to hold catalog password (handled separately from other
-        // attributes since we need to use saveCredentials method to store it):
+        // attributes since we need to use setUserCatalogCredentials method to store it):
         $catPassword = null;
 
         // Loop through LDAP response and map fields to database object based
@@ -325,9 +325,10 @@ class LDAP extends AbstractBase
         // see https://github.com/vufind-org/vufind/pull/612). Note that in the
         // (unlikely) scenario that a password can actually change from non-blank
         // to blank, additional work may need to be done here.
-        if (!empty($user->cat_username)) {
-            $user->saveCredentials(
-                $user->cat_username,
+        if (!empty($catUsername = $user->getCatUsername())) {
+            $this->ilsAuthenticator->setUserCatalogCredentials(
+                $user,
+                $catUsername,
                 empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }

--- a/module/VuFind/src/VuFind/Auth/PluginManager.php
+++ b/module/VuFind/src/VuFind/Auth/PluginManager.php
@@ -84,7 +84,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         MultiILS::class => ILSFactory::class,
         Shibboleth::class => ShibbolethFactory::class,
         SimulatedSSO::class => SimulatedSSOFactory::class,
-        SIP2::class => InvokableFactory::class,
+        SIP2::class => SIP2Factory::class,
     ];
 
     /**

--- a/module/VuFind/src/VuFind/Auth/SIP2.php
+++ b/module/VuFind/src/VuFind/Auth/SIP2.php
@@ -45,6 +45,15 @@ use VuFind\Exception\Auth as AuthException;
 class SIP2 extends AbstractBase
 {
     /**
+     * Constructor
+     *
+     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
+     */
+    public function __construct(protected ILSAuthenticator $ilsAuthenticator)
+    {
+    }
+
+    /**
      * Attempt to authenticate the current user. Throws exception if login fails.
      *
      * @param \Laminas\Http\PhpEnvironment\Request $request Request object containing
@@ -141,7 +150,7 @@ class SIP2 extends AbstractBase
         $user->lastname = trim(substr($ae, 0, strripos($ae, ',')));
         // I'm inserting the sip username and password since the ILS is the source.
         // Should revisit this.
-        $user->saveCredentials($username, $password);
+        $this->ilsAuthenticator->saveUserCatalogCredentials($user, $username, $password);
         return $user;
     }
 }

--- a/module/VuFind/src/VuFind/Auth/SIP2Factory.php
+++ b/module/VuFind/src/VuFind/Auth/SIP2Factory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Factory for Email authentication module.
+ * Factory for SIP2 authentication module.
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2019.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,7 @@
  *
  * @category VuFind
  * @package  Authentication
- * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -35,15 +35,15 @@ use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 
 /**
- * Factory for Email authentication module.
+ * Factory for SIP2 authentication module.
  *
  * @category VuFind
  * @package  Authentication
- * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class EmailFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class SIP2Factory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object
@@ -68,7 +68,6 @@ class EmailFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         return new $requestedName(
-            $container->get(EmailAuthenticator::class),
             $container->get(ILSAuthenticator::class)
         );
     }

--- a/module/VuFind/src/VuFind/Auth/Shibboleth.php
+++ b/module/VuFind/src/VuFind/Auth/Shibboleth.php
@@ -197,7 +197,7 @@ class Shibboleth extends AbstractBase
         $user = $this->getUserTable()->getByUsername($username);
 
         // Variable to hold catalog password (handled separately from other
-        // attributes since we need to use saveCredentials method to store it):
+        // attributes since we need to use setUserCatalogCredentials method to store it):
         $catPassword = null;
 
         // Has the user configured attributes to use for populating the user table?
@@ -227,9 +227,10 @@ class Shibboleth extends AbstractBase
         // see https://github.com/vufind-org/vufind/pull/612). Note that in the
         // (unlikely) scenario that a password can actually change from non-blank
         // to blank, additional work may need to be done here.
-        if (!empty($user->cat_username)) {
-            $user->saveCredentials(
-                $user->cat_username,
+        if (!empty($catUsername = $user->getCatUsername())) {
+            $this->ilsAuthenticator->setUserCatalogCredentials(
+                $user,
+                $catUsername,
                 empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }

--- a/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
+++ b/module/VuFind/src/VuFind/Auth/SimulatedSSO.php
@@ -119,9 +119,10 @@ class SimulatedSSO extends AbstractBase
                 $catPassword = $value;
             }
         }
-        if (!empty($user->cat_username)) {
-            $user->saveCredentials(
-                $user->cat_username,
+        if (!empty($catUsername = $user->getCatUsername())) {
+            $this->ilsAuthenticator->setUserCatalogCredentials(
+                $user,
+                $catUsername,
                 empty($catPassword) ? $this->ilsAuthenticator->getCatPasswordForUser($user) : $catPassword
             );
         }

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -811,6 +811,7 @@ class InstallController extends AbstractBase
 
         // Now we want to loop through the database and update passwords (if
         // necessary).
+        $ilsAuthenticator = $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
         $userRows = $this->getTable('user')->getInsecureRows();
         if (count($userRows) > 0) {
             $bcrypt = new Bcrypt();
@@ -819,8 +820,8 @@ class InstallController extends AbstractBase
                     $row->pass_hash = $bcrypt->create($row->password);
                     $row->password = '';
                 }
-                if ($row->cat_password) {
-                    $row->saveCredentials($row->cat_username, $row->cat_password);
+                if ($rawPassword = $row->getRawCatPassword()) {
+                    $ilsAuthenticator->saveUserCatalogCredentials($row, $row->getCatUsername(), $rawPassword);
                 } else {
                     $row->save();
                 }
@@ -830,7 +831,6 @@ class InstallController extends AbstractBase
         }
         $cardService = $this->getDbService(UserCardServiceInterface::class);
         $cardRows = $cardService->getInsecureRows();
-        $ilsAuthenticator = $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
         if (count($cardRows) > 0) {
             foreach ($cardRows as $row) {
                 $row->setCatPassEnc($ilsAuthenticator->encrypt($row->getRawCatPassword()));

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -897,7 +897,7 @@ class User extends RowGateway implements
      */
     public function getCatUsername(): ?string
     {
-        return $this->cat_username;
+        return $this->cat_username ?? '';
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -154,17 +154,12 @@ class User extends RowGateway implements
      * @param ?string $password Password to save (null for none)
      *
      * @return void
+     *
+     * @deprecated Use ILSAuthenticator::setUserCatalogCredentials()
      */
     public function setCredentials($username, $password)
     {
-        $this->cat_username = $username;
-        if ($this->passwordEncryptionEnabled()) {
-            $this->cat_password = null;
-            $this->cat_pass_enc = $this->ilsAuthenticator->encrypt($password);
-        } else {
-            $this->cat_password = $password;
-            $this->cat_pass_enc = null;
-        }
+        $this->ilsAuthenticator->setUserCatalogCredentials($this, $username, $password);
     }
 
     /**
@@ -173,19 +168,14 @@ class User extends RowGateway implements
      * @param string $username Username to save
      * @param string $password Password to save
      *
-     * @return mixed           The output of the save method.
+     * @return void
      * @throws \VuFind\Exception\PasswordSecurity
+     *
+     * @deprecated Use ILSAuthenticator::saveUserCatalogCredentials()
      */
     public function saveCredentials($username, $password)
     {
-        $this->setCredentials($username, $password);
-        $result = $this->save();
-
-        // Update library card entry after saving the user so that we always have a
-        // user id:
-        $this->getUserCardService()->synchronizeUserLibraryCardData($this);
-
-        return $result;
+        $this->ilsAuthenticator->saveUserCatalogCredentials($this, $username, $password);
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
@@ -116,6 +116,7 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
         );
         $auth->setDbServiceManager($this->getLiveDbServiceManager());
         $auth->setDbTableManager($this->getLiveTableManager());
+        $auth->setDbServiceManager($this->getLiveDbServiceManager());
         $auth->getCatalog()->setDriver($driver);
         return $auth;
     }
@@ -373,8 +374,8 @@ final class ILSTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['storedCatalogLogin'])
             ->getMock();
-        $mock->expects($this->any())->method('storedCatalogLogin')
-            ->will($this->returnValue($patron));
+        $mock->expects($this->any())->method('storedCatalogLogin')->willReturn($patron);
+        $mock->setDbServiceManager($this->getLiveDbServiceManager());
         return $mock;
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
@@ -32,6 +32,7 @@ namespace VuFindTest\Auth;
 use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\MultiILS;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\UserServiceInterface;
 use VuFind\ILS\Driver\MultiBackend;
 use VuFindTest\Container\MockDbServicePluginManager;
@@ -163,9 +164,13 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
         $driver->expects($this->once())->method('patronLogin')
             ->with($this->equalTo('ils1.testuser'), $this->equalTo('testpass'))
             ->willReturn($response);
-        $user = $this->getMultiILS($driver)->authenticate($this->getLoginRequest());
-        $this->assertEquals('ils1.testuser', $user->username);
-        $this->assertEquals('user@test.com', $user->email);
+        $mockUser = $this->getMockUser();
+        $mockUser->expects($this->once())->method('setCatUsername')->with('testuser');
+        $mockUser->expects($this->once())->method('setEmail')->with('user@test.com');
+        $this->assertEquals(
+            $mockUser,
+            $this->getMultiILS($driver, mockUser: $mockUser)->authenticate($this->getLoginRequest())
+        );
     }
 
     /**
@@ -217,9 +222,9 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $patron Logged in patron to simulate (null for none).
      *
-     * @return ILSAuthenticator
+     * @return MockObject&ILSAuthenticator
      */
-    protected function getMockILSAuthenticator($patron = null): ILSAuthenticator
+    protected function getMockILSAuthenticator($patron = null): MockObject&ILSAuthenticator
     {
         $mock = $this->getMockBuilder(ILSAuthenticator::class)
             ->disableOriginalConstructor()
@@ -227,6 +232,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $mock->expects($this->any())->method('storedCatalogLogin')
             ->willReturn($patron);
+        $mock->setDbServiceManager(new MockDbServicePluginManager($this));
         return $mock;
     }
 
@@ -276,33 +282,41 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Get a mock UserEntityInterface.
+     *
+     * @return MockObject&UserEntityInterface
+     */
+    protected function getMockUser(): MockObject&UserEntityInterface
+    {
+        return $this->createMock(\VuFind\Db\Row\User::class);
+    }
+
+    /**
      * Get the object to test.
      *
-     * @param ?MultiBackend $driver Mock MultiBackend driver to test with.
-     * @param ?array        $patron Logged in patron for mock
+     * @param ?MultiBackend        $driver   Mock MultiBackend driver to test with.
+     * @param ?array               $patron   Logged in patron for mock
      * authenticator (null for none)
+     * @param ?UserEntityInterface $mockUser Mock user object (null for default)
      *
      * @return MultiILS
      */
     protected function getMultiILS(
-        MultiBackend $driver = null,
-        array $patron = null
+        ?MultiBackend $driver = null,
+        ?array $patron = null,
+        ?UserEntityInterface $mockUser = null
     ): MultiILS {
         if (empty($driver)) {
             $driver = $this->getMockMultiBackend();
         }
         $mockAuthenticator = $this->getMockILSAuthenticator($patron);
-        $mockUser = $this->getMockBuilder(\VuFind\Db\Row\User::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['saveCredentials'])
-            ->getMock();
-        $mockUser->username = 'ils1.testuser';
+        $mockUser ??= $this->getMockUser();
         $mockUserService = $this->createMock(UserServiceInterface::class);
         $mockUserService->expects($this->any())
             ->method('updateUserEmail')
             ->willReturnCallback(
                 function ($mockUser, $email) {
-                    $mockUser->email = $email;
+                    $mockUser->setEmail($email);
                 }
             );
         $mockUserTable = $this->getMockBuilder(\VuFind\Db\Table\User::class)

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
@@ -288,7 +288,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
      */
     protected function getMockUser(): MockObject&UserEntityInterface
     {
-        return $this->createMock(\VuFind\Db\Row\User::class);
+        return $this->createMock(UserEntityInterface::class);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
@@ -31,6 +31,7 @@ namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
 use Laminas\Http\Request;
+use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\SIP2;
 
 /**
@@ -56,7 +57,7 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
         if (null === $config) {
             $config = $this->getAuthConfig();
         }
-        $obj = new SIP2();
+        $obj = new SIP2($this->createMock(ILSAuthenticator::class));
         $obj->setConfig($config);
         return $obj;
     }


### PR DESCRIPTION
This is more work in support of #3625, focused on one specific piece of the refactoring (setting/saving ILS credentials belongs in the ILSAuthenticator class, not the User row object).