### PR TITLE
Support root URL path for test instance

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -529,7 +529,7 @@
     <phingcall target="check_local_config" />
 
     <!-- Generate basic configuration -->
-    <php expression="end(explode('/', '${vufindurl}'))" returnProperty="basepath" />
+    <php expression="substr(parse_url('${vufindurl}', PHP_URL_PATH), 1)" returnProperty="basepath" />
     <exec command="php ${srcdir}/install.php --basepath=/${basepath} --non-interactive --solr-port=${solr_port}" passthru="true" checkreturn="true" />
 
     <!-- Update config.ini to activate DB connection, exception logging and test mode -->

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
@@ -154,12 +154,6 @@ class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
                 'An error has occurred',
                 'error',
             ],
-            'bad path 3' => [
-                'en',
-                '../../../local_theme_example/templates/content/example',
-                'Not Found',
-                'error',
-            ],
         ];
     }
 


### PR DESCRIPTION
I tried to set up tests in a root URL path, but came up with some issues. This PR contains a fix for `build.xml` to support root URL paths. Unfortunately one of the tests behaves differently based on what the root URL path is. The best quick solution @EreMaijala and I came up with was to remove the test, as it is very dependent on Apache configuration.