### PR TITLE
Fix issues with search database table and entity interface

### DIFF
--- a/module/VuFind/sql/migrations/pgsql/10.0/002-modify-search-user-column.sql
+++ b/module/VuFind/sql/migrations/pgsql/10.0/002-modify-search-user-column.sql
@@ -1,0 +1,11 @@
+--
+-- Modifications to user_id column in table `comments`
+--
+
+ALTER TABLE "search"
+   ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE "search"
+   ALTER COLUMN user_id SET DEFAULT NULL;
+
+UPDATE "search" SET user_id=NULL WHERE user_id='0' OR user_id NOT IN (SELECT DISTINCT id FROM "user");

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -133,7 +133,7 @@ CREATE TABLE `resource_tags` (
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `search` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL DEFAULT '0',
+  `user_id` int(11) DEFAULT NULL,
   `session_id` varchar(128) DEFAULT NULL,
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `title` varchar(20) DEFAULT NULL,

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -90,7 +90,7 @@ DROP TABLE IF EXISTS "search";
 
 CREATE TABLE search (
 id BIGSERIAL,
-user_id int NOT NULL DEFAULT '0',
+user_id int DEFAULT NULL,
 session_id varchar(128),
 created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
 title varchar(20) DEFAULT NULL,

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -141,7 +141,7 @@ class AbstractSearch extends AbstractBase
 
         // If we got this far, the user is allowed to view the search, so we can
         // deminify it to a new object.
-        $minSO = $search->getSearchObject();
+        $minSO = $search->getSearchObjectOrThrowException();
         $savedSearch = $minSO->deminify($this->getResultsManager());
 
         // Now redirect to the URL associated with the saved search; this
@@ -562,7 +562,7 @@ class AbstractSearch extends AbstractBase
         }
 
         // Restore the full search object:
-        $minSO = $search->getSearchObject();
+        $minSO = $search->getSearchObjectOrThrowException();
         $savedSearch = $minSO->deminify($this->getResultsManager());
 
         // Fail if this is not the right type of search:

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -592,7 +592,7 @@ class MyResearchController extends AbstractBase
         // Now fetch all the results:
         $resultsManager = $this->serviceLocator
             ->get(\VuFind\Search\Results\PluginManager::class);
-        $results = $search->getSearchObject()->deminify($resultsManager);
+        $results = $search->getSearchObjectOrThrowException()->deminify($resultsManager);
 
         // Build the form.
         return $this->createViewModel(
@@ -622,7 +622,7 @@ class MyResearchController extends AbstractBase
         $normalizer = $this->serviceLocator
             ->get(\VuFind\Search\SearchNormalizer::class);
         $normalized = $normalizer
-            ->normalizeMinifiedSearch($rowToCheck->getSearchObject());
+            ->normalizeMinifiedSearch($rowToCheck->getSearchObjectOrThrowException());
         $matches = $searchTable->getSearchRowsMatchingNormalizedSearch(
             $normalized,
             $sessId,

--- a/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/ResultScroller.php
@@ -666,7 +666,7 @@ class ResultScroller extends AbstractPlugin
             null
         );
         if (!empty($row)) {
-            $minSO = $row->getSearchObject();
+            $minSO = $row->getSearchObjectOrThrowException();
             $search = $minSO->deminify($this->resultsManager);
             // The saved search does not remember its original limit or sort;
             // we should reapply them from the session data:

--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -49,6 +49,7 @@ use VuFind\Cookie\CookieManager;
 use VuFind\Crypt\Base62;
 use VuFind\Db\AdapterFactory;
 use VuFind\Db\Service\ResourceServiceInterface;
+use VuFind\Db\Service\SearchServiceInterface;
 use VuFind\Exception\RecordMissing as RecordMissingException;
 use VuFind\Record\ResourcePopulator;
 use VuFind\Search\Results\PluginManager as ResultsManager;
@@ -328,6 +329,20 @@ class UpgradeController extends AbstractBase
     }
 
     /**
+     * Support method for fixdatabaseAction() -- clean up invalid user ID
+     * values in the search table.
+     *
+     * @return void
+     */
+    protected function fixInvalidUserIdsInSearchTable(): void
+    {
+        $count = $this->getDbService(SearchServiceInterface::class)->cleanUpInvalidUserIds();
+        if ($count) {
+            $this->session->warnings->append("Converted $count invalid user_id values in search table");
+        }
+    }
+
+    /**
      * Support method for fixdatabaseAction() -- add checksums to search table rows.
      *
      * @return void
@@ -340,7 +355,7 @@ class UpgradeController extends AbstractBase
         $searchRows = $search->select($searchWhere);
         if (count($searchRows) > 0) {
             foreach ($searchRows as $searchRow) {
-                $searchObj = $searchRow->getSearchObject()->deminify($manager);
+                $searchObj = $searchRow->getSearchObjectOrThrowException()->deminify($manager);
                 $url = $searchObj->getUrlQuery()->getParams();
                 $checksum = crc32($url) & 0xFFFFFFF;
                 $searchRow->checksum = $checksum;
@@ -586,6 +601,9 @@ class UpgradeController extends AbstractBase
 
             // Clean up the "VuFind" source, if necessary.
             $this->fixVuFindSourceInDatabase();
+
+            // Fix invalid user IDs in search table, if necessary.
+            $this->fixInvalidUserIdsInSearchTable();
         } catch (Exception $e) {
             $this->flashMessenger()->addMessage(
                 'Database upgrade failed: ' . $e->getMessage(),

--- a/module/VuFind/src/VuFind/Db/Entity/SearchEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/SearchEntityInterface.php
@@ -52,18 +52,18 @@ interface SearchEntityInterface extends EntityInterface
     /**
      * Get user.
      *
-     * @return UserEntityInterface
+     * @return ?UserEntityInterface
      */
-    public function getUser(): UserEntityInterface;
+    public function getUser(): ?UserEntityInterface;
 
     /**
      * Set user.
      *
-     * @param int $user User
+     * @param ?UserEntityInterface $user User
      *
      * @return SearchEntityInterface
      */
-    public function setUser(UserEntityInterface $user): SearchEntityInterface;
+    public function setUser(?UserEntityInterface $user): SearchEntityInterface;
 
     /**
      * Get session identifier.
@@ -75,11 +75,11 @@ interface SearchEntityInterface extends EntityInterface
     /**
      * Set session identifier.
      *
-     * @param ?string $session_id Session id
+     * @param ?string $sessionId Session id
      *
      * @return SearchEntityInterface
      */
-    public function setSessionId(?string $session_id): SearchEntityInterface;
+    public function setSessionId(?string $sessionId): SearchEntityInterface;
 
     /**
      * Get created date.
@@ -132,18 +132,18 @@ interface SearchEntityInterface extends EntityInterface
     /**
      * Get the search object from the row.
      *
-     * @return \VuFind\Search\Minified
+     * @return ?\VuFind\Search\Minified
      */
-    public function getSearchObject(): \VuFind\Search\Minified;
+    public function getSearchObject(): ?\VuFind\Search\Minified;
 
     /**
      * Set search object.
      *
-     * @param \VuFind\Search\Minified $searchObject Search object
+     * @param ?\VuFind\Search\Minified $searchObject Search object
      *
      * @return SearchEntityInterface
      */
-    public function setSearchObject(\VuFind\Search\Minified $searchObject): SearchEntityInterface;
+    public function setSearchObject(?\VuFind\Search\Minified $searchObject): SearchEntityInterface;
 
     /**
      * Get checksum.

--- a/module/VuFind/src/VuFind/Db/Row/Search.php
+++ b/module/VuFind/src/VuFind/Db/Row/Search.php
@@ -97,14 +97,24 @@ class Search extends RowGateway implements
     /**
      * Get the search object from the row.
      *
-     * @return \VuFind\Search\Minified
+     * @return ?\VuFind\Search\Minified
      */
-    public function getSearchObject(): \VuFind\Search\Minified
+    public function getSearchObject(): ?\VuFind\Search\Minified
     {
         // We need to make sure the search object is a string before unserializing:
         $this->normalizeSearchObject();
-        $result = unserialize($this->search_object);
-        if (!($result instanceof \VuFind\Search\Minified)) {
+        return $this->search_object ? unserialize($this->search_object) : null;
+    }
+
+    /**
+     * Get the search object from the row, and throw an exception if it is missing.
+     *
+     * @return \VuFind\Search\Minified
+     * @throws \Exception
+     */
+    public function getSearchObjectOrThrowException(): \VuFind\Search\Minified
+    {
+        if (!($result = $this->getSearchObject())) {
             throw new \Exception('Problem decoding saved search');
         }
         return $result;
@@ -185,23 +195,25 @@ class Search extends RowGateway implements
     /**
      * Get user.
      *
-     * @return UserEntityInterface
+     * @return ?UserEntityInterface
      */
-    public function getUser(): UserEntityInterface
+    public function getUser(): ?UserEntityInterface
     {
-        return $this->getDbServiceManager()->get(UserServiceInterface::class)->getUserById($this->user_id);
+        return $this->user_id
+            ? $this->getDbServiceManager()->get(UserServiceInterface::class)->getUserById($this->user_id)
+            : null;
     }
 
     /**
      * Set user.
      *
-     * @param UserEntityInterface $user User
+     * @param ?UserEntityInterface $user User
      *
      * @return SearchEntityInterface
      */
-    public function setUser(UserEntityInterface $user): SearchEntityInterface
+    public function setUser(?UserEntityInterface $user): SearchEntityInterface
     {
-        $this->user_id = $user->getId();
+        $this->user_id = $user?->getId();
         return $this;
     }
 
@@ -218,13 +230,13 @@ class Search extends RowGateway implements
     /**
      * Set session identifier.
      *
-     * @param ?string $session_id Session id
+     * @param ?string $sessionId Session id
      *
      * @return SearchEntityInterface
      */
-    public function setSessionId(?string $session_id): SearchEntityInterface
+    public function setSessionId(?string $sessionId): SearchEntityInterface
     {
-        $this->session_id = $session_id;
+        $this->session_id = $sessionId;
         return $this;
     }
 
@@ -300,13 +312,13 @@ class Search extends RowGateway implements
     /**
      * Set search object.
      *
-     * @param \VuFind\Search\Minified $searchObject Search object
+     * @param ?\VuFind\Search\Minified $searchObject Search object
      *
      * @return SearchEntityInterface
      */
-    public function setSearchObject(\VuFind\Search\Minified $searchObject): SearchEntityInterface
+    public function setSearchObject(?\VuFind\Search\Minified $searchObject): SearchEntityInterface
     {
-        $this->search_object = serialize($searchObject);
+        $this->search_object = $searchObject ? serialize($searchObject) : null;
         return $this;
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/SearchServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/SearchServiceInterface.php
@@ -40,4 +40,10 @@ namespace VuFind\Db\Service;
  */
 interface SearchServiceInterface extends DbServiceInterface
 {
+    /**
+     * Set invalid user_id values in the table to null; return count of affected rows.
+     *
+     * @return int
+     */
+    public function cleanUpInvalidUserIds(): int;
 }

--- a/module/VuFind/src/VuFind/Db/Table/Search.php
+++ b/module/VuFind/src/VuFind/Db/Table/Search.php
@@ -251,7 +251,7 @@ class Search extends Gateway
         };
         $results = [];
         foreach ($this->select($callback) as $match) {
-            $minified = $match->getSearchObject();
+            $minified = $match->getSearchObjectOrThrowException();
             if ($normalized->isEquivalentToMinifiedSearch($minified)) {
                 $results[] = $match;
                 if (count($results) >= $limit) {
@@ -293,7 +293,7 @@ class Search extends Gateway
                 $existingRow->created = date('Y-m-d H:i:s');
                 // Keep the ID of the old search:
                 $minified = $normalized->getMinified();
-                $minified->id = $existingRow->getSearchObject()->id;
+                $minified->id = $existingRow->getSearchObjectOrThrowException()->id;
                 $existingRow->search_object = serialize($minified);
                 $existingRow->session_id = $sessionId;
                 $existingRow->save();

--- a/module/VuFind/src/VuFind/Search/History.php
+++ b/module/VuFind/src/VuFind/Search/History.php
@@ -119,7 +119,7 @@ class History
         // Loop through and sort the history
         $saved = $schedule = $unsaved = [];
         foreach ($searchHistory as $current) {
-            $search = $current->getSearchObject()->deminify($this->resultsManager);
+            $search = $current->getSearchObjectOrThrowException()->deminify($this->resultsManager);
             // $current->saved may be 1 (MySQL) or true (PostgreSQL), so we should
             // avoid a strict === comparison here:
             if ($current->saved == 1) {

--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -304,7 +304,7 @@ class Memory
             $search
                 = $this->searchTable->getOwnedRowById($id, $this->sessionId, null);
             if ($search) {
-                $minSO = $search->getSearchObject();
+                $minSO = $search->getSearchObjectOrThrowException();
                 $this->searchCache[$id] = $minSO->deminify($this->resultsManager);
             } else {
                 $this->searchCache[$id] = null;

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -362,7 +362,7 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
      */
     protected function getObjectForSearch($s)
     {
-        $minSO = $s->getSearchObject();
+        $minSO = $s->getSearchObjectOrThrowException();
         $searchObject = $minSO->deminify($this->resultsManager);
         if (!$searchObject->getOptions()->supportsScheduledSearch()) {
             $this->err(


### PR DESCRIPTION
This PR addresses a few problems related to the search table and its newly-introduced entity interface:

  - The search table's user_id field defaulted to '0' which prevents it from being used as a foreign key. This PR makes the field nullable and includes migration tools to fix incorrect legacy ID values. The foreign key will be added in release 11.0 -- doing both changes at once would make the migration process more challenging.
  - A new getSearchObjectOrThrowException() method has been added to separate the pre-existing validation logic from the raw getter required by the SearchEntityInterface. This will be further refactored when the SearchService is fleshed out in the near future, but this seemed like a reasonable stopgap measure.
  - A few minor errors/inconsistencies in SearchEntityInterface that I overlooked in my review are corrected here.

TODO
- [x] Update database changelog when merging