### PR TITLE
Clarify use of getWorkKeys in documentation

### DIFF
--- a/import/marc.properties
+++ b/import/marc.properties
@@ -125,4 +125,5 @@ pattern_map.oclc_num.pattern_2 = ocn[0]*([0-9]+).*=>$1
 pattern_map.oclc_num.pattern_3 = on[0]*([0-9]+).*=>$1
 
 # Work identification keys
+# See marc_local.properties for an explanation of the getWorkKeys parameters.
 work_keys_str_mv = custom, getWorkKeys(130anp:730anp, 240anpmr:245abn:246abn:247abn, 240anpmr:245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; :: Latin; :: [^[:letter:] [:number:]] Remove; :: NFKC;")

--- a/import/marc.properties
+++ b/import/marc.properties
@@ -125,4 +125,4 @@ pattern_map.oclc_num.pattern_2 = ocn[0]*([0-9]+).*=>$1
 pattern_map.oclc_num.pattern_3 = on[0]*([0-9]+).*=>$1
 
 # Work identification keys
-work_keys_str_mv = custom, getWorkKeys(130anp:730anp, 240anpmr:245abn:246abn:247abn, 240anpmr:245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; :: Latin; :: [^[:letter:] [:number:]] Remove; :: NFKC;")
+work_keys_str_mv = custom, getWorkKeys(130anp:240anpmr:730anp, 245abn:246abn:247abn, 245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; :: Latin; :: [^[:letter:] [:number:]] Remove; :: NFKC;")

--- a/import/marc.properties
+++ b/import/marc.properties
@@ -125,4 +125,4 @@ pattern_map.oclc_num.pattern_2 = ocn[0]*([0-9]+).*=>$1
 pattern_map.oclc_num.pattern_3 = on[0]*([0-9]+).*=>$1
 
 # Work identification keys
-work_keys_str_mv = custom, getWorkKeys(130anp:240anpmr:730anp, 245abn:246abn:247abn, 245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; :: Latin; :: [^[:letter:] [:number:]] Remove; :: NFKC;")
+work_keys_str_mv = custom, getWorkKeys(130anp:730anp, 240anpmr:245abn:246abn:247abn, 240anpmr:245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; :: Latin; :: [^[:letter:] [:number:]] Remove; :: NFKC;")

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -88,6 +88,7 @@
 #   characters to include (regex)
 #   characters to exclude (regex)
 #   transliterations
+
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -85,6 +85,10 @@
 #   characters to exclude (regex)
 #   transliterations
 #
+# A work key will be generated for:
+#   each uniform title field
+#   each combination of a title field (both with and without non-filing characters) and author field
+ 
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -92,7 +92,7 @@
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.
-#work_keys_str_mv = custom, getWorkKeys(130anp:240anpmr:730anp, 245abn:246abn:247abn, 245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; a\U00000308>AE; o\U00000308>OE; a\U0000030A>AA; :: Latin; :: [:Nonspacing Mark:] Remove; :: [:Punctuation:] Remove; :: [:Whitespace:] Remove; :: NFKC; AE>ä; OE>ö; AA>å")
+#work_keys_str_mv = custom, getWorkKeys(130anp:730anp, 240anpmr:245abn:246abn:247abn, 240anpmr:245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; a\U00000308>AE; o\U00000308>OE; a\U0000030A>AA; :: Latin; :: [:Nonspacing Mark:] Remove; :: [:Punctuation:] Remove; :: [:Whitespace:] Remove; :: NFKC; AE>ä; OE>ö; AA>å")
 
 # UUIDs (Universally unique identifiers) are commonly used in, for example, digital
 # library or repository systems and can be a useful match point with third party

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -88,7 +88,6 @@
 #   characters to include (regex)
 #   characters to exclude (regex)
 #   transliterations
- 
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -79,7 +79,7 @@
 # Parameters:
 #   uniform title fields (field spec)
 #       Note: This field specification is to use for generating uniform title keys;
-#       its uniform title fields will be used solo.
+#       its fields will be used solo.
 #   title fields (field spec)
 #   title fields with non-filing characters removed (field spec)
 #       Note: The two "title fields" specifications above are for regular title fields

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -88,7 +88,7 @@
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.
-#work_keys_str_mv = custom, getWorkKeys(130anp:730anp, 240anpmr:245abn:246abn:247abn, 240anpmr:245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; a\U00000308>AE; o\U00000308>OE; a\U0000030A>AA; :: Latin; :: [:Nonspacing Mark:] Remove; :: [:Punctuation:] Remove; :: [:Whitespace:] Remove; :: NFKC; AE>ä; OE>ö; AA>å")
+#work_keys_str_mv = custom, getWorkKeys(130anp:240anpmr:730anp, 245abn:246abn:247abn, 245abn, 100ab:110ab:111ac:700ab:710ab:711ac, "", "", ":: NFD; :: lower; a\U00000308>AE; o\U00000308>OE; a\U0000030A>AA; :: Latin; :: [:Nonspacing Mark:] Remove; :: [:Punctuation:] Remove; :: [:Whitespace:] Remove; :: NFKC; AE>ä; OE>ö; AA>å")
 
 # UUIDs (Universally unique identifiers) are commonly used in, for example, digital
 # library or repository systems and can be a useful match point with third party

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -79,7 +79,7 @@
 # Parameters:
 #   uniform title fields (field spec)
 #       Note: This field specification is for generating uniform title keys;
-#       its fields will be used solo.
+#       its fields will be used solo, not combined to make author/title keys.
 #   title fields (field spec)
 #   title fields with non-filing characters removed (field spec)
 #       Note: The two "title fields" specifications above are for regular title fields

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -78,7 +78,7 @@
 #
 # Parameters:
 #   uniform title fields (field spec)
-#       Note: This field specification is to use for generating uniform title keys;
+#       Note: This field specification is for generating uniform title keys;
 #       its fields will be used solo.
 #   title fields (field spec)
 #   title fields with non-filing characters removed (field spec)

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -88,7 +88,7 @@
 #   characters to include (regex)
 #   characters to exclude (regex)
 #   transliterations
-
+#
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators
 # for more information on the transliteration rules.

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -78,16 +78,16 @@
 #
 # Parameters:
 #   uniform title fields (field spec)
+#       Note: This field specification is to use for generating uniform title keys;
+#       its uniform title fields will be used solo.
 #   title fields (field spec)
 #   title fields with non-filing characters removed (field spec)
+#       Note: The two "title fields" specifications above are for regular title fields
+#       like 240 that should be used to generate combined author/title keys.
 #   author fields (field spec)
 #   characters to include (regex)
 #   characters to exclude (regex)
 #   transliterations
-#
-# A work key will be generated for:
-#   each uniform title field
-#   each combination of a title field (both with and without non-filing characters) and author field
  
 # See
 # https://unicode-org.github.io/icu/userguide/transforms/general/#icu-transliterators

--- a/import/marc_local.properties
+++ b/import/marc_local.properties
@@ -83,7 +83,7 @@
 #   title fields (field spec)
 #   title fields with non-filing characters removed (field spec)
 #       Note: The two "title fields" specifications above are for regular title fields
-#       like 240 that should be used to generate combined author/title keys.
+#       like 240 and will be used to generate combined author/title keys.
 #   author fields (field spec)
 #   characters to include (regex)
 #   characters to exclude (regex)


### PR DESCRIPTION
MARC 240 has been listed as a non-uniform title field since #1581 introduced record versions, and I can't find any discussion about it specifically in that PR, but [LOC](https://www.loc.gov/marc/bibliographic/bd240.html) (and others) say 240 is a uniform title field.