### PR TITLE
Refactor and replace User row's getLists() method.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Controller;
 
+use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Db\Service\UserResourceServiceInterface;
 use VuFind\Exception\BadRequest as BadRequestException;
 use VuFind\Exception\Forbidden as ForbiddenException;
@@ -507,7 +508,7 @@ class AbstractRecord extends AbstractBase
 
         // Loop through all user lists and sort out containing/non-containing lists
         $containingLists = $nonContainingLists = [];
-        foreach ($user->getLists() as $list) {
+        foreach ($this->getDbService(UserListServiceInterface::class)->getUserListsByUser($user) as $list) {
             // Assign list to appropriate array based on whether or not we found
             // it earlier in the list of lists containing the selected record.
             if (in_array($list->getId(), $listIds)) {

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -32,6 +32,7 @@ namespace VuFind\Controller;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Session\Container;
 use VuFind\Controller\Feature\ListItemSelectionTrait;
+use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
 
@@ -551,7 +552,7 @@ class CartController extends AbstractBase
         return $this->createViewModel(
             [
                 'records' => $this->getRecordLoader()->loadBatch($ids),
-                'lists' => $user->getLists(),
+                'lists' => $this->getDbService(UserListServiceInterface::class)->getUserListsByUser($user),
             ]
         );
     }

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1041,11 +1041,11 @@ class MyResearchController extends AbstractBase
         }
 
         // Send non-containing lists to the view for user selection:
-        $userLists = $user->getLists();
+        $userLists = $this->getDbService(UserListServiceInterface::class)->getUserListsByUser($user);
         $lists = [];
         foreach ($userLists as $userList) {
-            if (!in_array($userList->id, $containingLists)) {
-                $lists[$userList->id] = $userList->title;
+            if (!in_array($userList->getId(), $containingLists)) {
+                $lists[$userList->getId()] = $userList->getTitle();
             }
         }
 

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -347,6 +347,8 @@ class User extends RowGateway implements
      * Get all of the lists associated with this user.
      *
      * @return \Laminas\Db\ResultSet\AbstractResultSet
+     *
+     * @deprecated Use UserListServiceInterface::getUserListsAndCountsByUser()
      */
     public function getLists()
     {
@@ -600,13 +602,9 @@ class User extends RowGateway implements
     public function delete($removeComments = true, $removeRatings = true)
     {
         // Remove all lists owned by the user:
-        $lists = $this->getLists();
         $listService = $this->getDbService(UserListServiceInterface::class);
-        foreach ($lists as $current) {
-            // The rows returned by getLists() are read-only, so we need to retrieve
-            // a new object for each row in order to perform a delete operation:
-            $list = $listService->getUserListById($current->getId());
-            $list->delete($this, true);
+        foreach ($listService->getUserListsByUser($this) as $current) {
+            $current->delete($this, true);
         }
         $resourceTags = $this->getDbTable('ResourceTags');
         $resourceTags->destroyResourceLinks(null, $this->id);

--- a/module/VuFind/src/VuFind/Db/Service/UserListService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserListService.php
@@ -32,6 +32,7 @@ namespace VuFind\Db\Service;
 
 use Exception;
 use Laminas\Db\Sql\Expression;
+use Laminas\Db\Sql\ExpressionInterface;
 use Laminas\Db\Sql\Select;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Entity\UserListEntityInterface;
@@ -86,22 +87,22 @@ class UserListService extends AbstractDbService implements DbTableAwareInterface
      * Get lists belonging to the user and their count. Returns an array of arrays with
      * list_entity and count keys.
      *
-     * @param int|UserEntityInterface $userOrId User entity object or ID
+     * @param UserEntityInterface|int $userOrId User entity object or ID
      *
      * @return array
      * @throws Exception
      */
-    public function getUserListsAndCountsByUser(int|UserEntityInterface $userOrId): array
+    public function getUserListsAndCountsByUser(UserEntityInterface|int $userOrId): array
     {
         $userId = $userOrId instanceof UserEntityInterface ? $userOrId->getId() : $userOrId;
-        $callback = function ($select) use ($userId) {
+        $callback = function (Select $select) use ($userId) {
             $select->columns(
                 [
                     Select::SQL_STAR,
                     'cnt' => new Expression(
                         'COUNT(DISTINCT(?))',
                         ['ur.resource_id'],
-                        [Expression::TYPE_IDENTIFIER]
+                        [ExpressionInterface::TYPE_IDENTIFIER]
                     ),
                 ]
             );
@@ -131,11 +132,11 @@ class UserListService extends AbstractDbService implements DbTableAwareInterface
     /**
      * Get list objects belonging to the specified user.
      *
-     * @param int|UserEntityInterface $userOrId User entity object or ID
+     * @param UserEntityInterface|int $userOrId User entity object or ID
      *
      * @return UserListEntityInterface[]
      */
-    public function getUserListsByUser(int|UserEntityInterface $userOrId): array
+    public function getUserListsByUser(UserEntityInterface|int $userOrId): array
     {
         $userId = $userOrId instanceof UserEntityInterface ? $userOrId->getId() : $userOrId;
         $callback = function ($select) use ($userId) {
@@ -150,7 +151,7 @@ class UserListService extends AbstractDbService implements DbTableAwareInterface
      *
      * @param string                       $recordId ID of record being checked.
      * @param string                       $source   Source of record to look up
-     * @param int|UserEntityInterface|null $user     Optional user ID or entity object (to limit results
+     * @param UserEntityInterface|int|null $userOrId Optional user ID or entity object (to limit results
      * to a particular user).
      *
      * @return UserListEntityInterface[]
@@ -158,13 +159,13 @@ class UserListService extends AbstractDbService implements DbTableAwareInterface
     public function getListsContainingRecord(
         string $recordId,
         string $source = DEFAULT_SEARCH_BACKEND,
-        int|UserEntityInterface|null $user = null
+        UserEntityInterface|int|null $userOrId = null
     ): array {
         return iterator_to_array(
             $this->getDbTable('UserList')->getListsContainingResource(
                 $recordId,
                 $source,
-                is_int($user) ? $user : $user->getId()
+                is_int($userOrId) ? $userOrId : $userOrId->getId()
             )
         );
     }

--- a/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
@@ -64,6 +64,26 @@ interface UserListServiceInterface extends DbServiceInterface
     public function getUserListById(int $id): UserListEntityInterface;
 
     /**
+     * Get lists belonging to the user and their count. Returns an array of arrays with
+     * list_entity and count keys.
+     *
+     * @param int|UserEntityInterface $userOrId User entity object or ID
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function getUserListsAndCountsByUser(int|UserEntityInterface $userOrId): array;
+
+    /**
+     * Get list objects belonging to the specified user.
+     *
+     * @param int|UserEntityInterface $userOrId User entity object or ID
+     *
+     * @return UserListEntityInterface[]
+     */
+    public function getUserListsByUser(int|UserEntityInterface $userOrId): array;
+
+    /**
      * Get lists containing a specific record.
      *
      * @param string                       $recordId ID of record being checked.

--- a/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
@@ -67,28 +67,28 @@ interface UserListServiceInterface extends DbServiceInterface
      * Get lists belonging to the user and their count. Returns an array of arrays with
      * list_entity and count keys.
      *
-     * @param int|UserEntityInterface $userOrId User entity object or ID
+     * @param UserEntityInterface|int $userOrId User entity object or ID
      *
      * @return array
      * @throws Exception
      */
-    public function getUserListsAndCountsByUser(int|UserEntityInterface $userOrId): array;
+    public function getUserListsAndCountsByUser(UserEntityInterface|int $userOrId): array;
 
     /**
      * Get list objects belonging to the specified user.
      *
-     * @param int|UserEntityInterface $userOrId User entity object or ID
+     * @param UserEntityInterface|int $userOrId User entity object or ID
      *
      * @return UserListEntityInterface[]
      */
-    public function getUserListsByUser(int|UserEntityInterface $userOrId): array;
+    public function getUserListsByUser(UserEntityInterface|int $userOrId): array;
 
     /**
      * Get lists containing a specific record.
      *
      * @param string                       $recordId ID of record being checked.
      * @param string                       $source   Source of record to look up
-     * @param int|UserEntityInterface|null $user     Optional user ID or entity object (to limit results
+     * @param UserEntityInterface|int|null $userOrId Optional user ID or entity object (to limit results
      * to a particular user).
      *
      * @return UserListEntityInterface[]
@@ -96,6 +96,6 @@ interface UserListServiceInterface extends DbServiceInterface
     public function getListsContainingRecord(
         string $recordId,
         string $source = DEFAULT_SEARCH_BACKEND,
-        int|UserEntityInterface|null $user = null
+        UserEntityInterface|int|null $userOrId = null
     ): array;
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
@@ -31,6 +31,8 @@ namespace VuFind\View\Helper\Root;
 
 use Laminas\Session\Container;
 use Laminas\View\Helper\AbstractHelper;
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Service\UserListServiceInterface;
 
 /**
  * List view helper
@@ -44,30 +46,30 @@ use Laminas\View\Helper\AbstractHelper;
 class UserList extends AbstractHelper
 {
     /**
-     * List mode (enabled or disabled)
-     *
-     * @var string
-     */
-    protected $mode;
-
-    /**
-     * Session container for last list information.
-     *
-     * @var Container
-     */
-    protected $session;
-
-    /**
      * Constructor
      *
-     * @param Container $session Session container (must use same namespace as
+     * @param Container                $session         Session container (must use same namespace as
      * container provided to \VuFind\Db\Table\UserList)
-     * @param string    $mode    List mode (enabled or disabled)
+     * @param UserListServiceInterface $userListService List database service
+     * @param string                   $mode            List mode (enabled or disabled)
      */
-    public function __construct(Container $session, $mode = 'enabled')
+    public function __construct(
+        protected Container $session,
+        protected UserListServiceInterface $userListService,
+        protected string $mode = 'enabled'
+    ) {
+    }
+
+    /**
+     * Get lists with counts for the provided user.
+     *
+     * @param UserEntityInterface $user User owning lists
+     *
+     * @return array
+     */
+    public function getUserListsAndCountsByUser(UserEntityInterface $user): array
     {
-        $this->mode = $mode;
-        $this->session = $session;
+        return $this->userListService->getUserListsAndCountsByUser($user);
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Db\Service\UserListServiceInterface;
 
 /**
  * UserList helper factory.
@@ -71,6 +72,10 @@ class UserListFactory implements FactoryInterface
         $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
         $session = new \Laminas\Session\Container('List', $sessionManager);
         $capabilities = $container->get(\VuFind\Config\AccountCapabilities::class);
-        return new $requestedName($session, $capabilities->getListSetting());
+        return new $requestedName(
+            $session,
+            $container->get(\VuFind\Db\Service\PluginManager::class)->get(UserListServiceInterface::class),
+            $capabilities->getListSetting()
+        );
     }
 }

--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -26,16 +26,16 @@
         $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
       ?>
 
-      <?php $lists = $user->getLists() ?>
-      <?php foreach ($lists as $list): ?>
-      <li>
-        <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
-          <?=$this->icon('user-list', 'icon-link__icon') ?>
-          <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
-          <?=$list->isPublic() ? $publicInd : ''?>
-          <span class="badge"><?=$list->cnt ?></span>
-        </a>
-      </li>
+      <?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
+        <?php $list = $current['list_entity']; ?>
+        <li>
+          <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
+            <?=$this->icon('user-list', 'icon-link__icon') ?>
+            <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
+            <?=$list->isPublic() ? $publicInd : ''?>
+            <span class="badge"><?=$current['count'] ?></span>
+          </a>
+        </li>
       <?php endforeach; ?>
       <li>
         <a href="<?=$this->url('editList', ['id' => 'NEW'])?>" class="icon-link <?=$this->active == 'editlist/NEW' ? ' active' : ''?>">

--- a/themes/bootstrap5/templates/myresearch/menu.phtml
+++ b/themes/bootstrap5/templates/myresearch/menu.phtml
@@ -26,16 +26,16 @@
         $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
       ?>
 
-      <?php $lists = $user->getLists() ?>
-      <?php foreach ($lists as $list): ?>
-      <li>
-        <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
-          <?=$this->icon('user-list', 'icon-link__icon') ?>
-          <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
-          <?=$list->isPublic() ? $publicInd : ''?>
-          <span class="badge"><?=$list->cnt ?></span>
-        </a>
-      </li>
+      <?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
+        <?php $list = $current['list_entity']; ?>
+        <li>
+          <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
+            <?=$this->icon('user-list', 'icon-link__icon') ?>
+            <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
+            <?=$list->isPublic() ? $publicInd : ''?>
+            <span class="badge"><?=$current['count'] ?></span>
+          </a>
+        </li>
       <?php endforeach; ?>
       <li>
         <a href="<?=$this->url('editList', ['id' => 'NEW'])?>" class="icon-link <?=$this->active == 'editlist/NEW' ? ' active' : ''?>">


### PR DESCRIPTION
This replaces the VuFind\Db\Row\UserList::getLists() method with two separate database service methods -- a simple one to get just the list of lists, and a more complex one to get lists and counts. Only fetching the counts when actually needed should significantly improve efficiency and reduce unnecessary data processing complexity.