### PR TITLE
DB services: Fix argument names for consistency.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/CommentsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsService.php
@@ -68,24 +68,24 @@ class CommentsService extends AbstractDbService implements
     /**
      * Add a comment to the current resource. Returns comment ID on success, null on failure.
      *
-     * @param string                      $comment  The comment to save.
-     * @param int|UserEntityInterface     $user     User object or identifier
-     * @param int|ResourceEntityInterface $resource Resource object or identifier
+     * @param string                      $comment      The comment to save.
+     * @param UserEntityInterface|int     $userOrId     User object or identifier
+     * @param ResourceEntityInterface|int $resourceOrId Resource object or identifier
      *
      * @return ?int
      */
     public function addComment(
         string $comment,
-        int|UserEntityInterface $user,
-        int|ResourceEntityInterface $resource
+        UserEntityInterface|int $userOrId,
+        ResourceEntityInterface|int $resourceOrId
     ): ?int {
-        $userVal = is_int($user)
-            ? $this->getDbService(UserServiceInterface::class)->getUserById($user)
-            : $user;
-        $resourceVal = is_int($resource)
-            ? $this->getDbService(ResourceServiceInterface::class)->getResourceById($resource)
-            : $resource;
-        return $resourceVal->addComment($comment, $userVal);
+        $user = is_int($userOrId)
+            ? $this->getDbService(UserServiceInterface::class)->getUserById($userOrId)
+            : $userOrId;
+        $resource = is_int($resourceOrId)
+            ? $this->getDbService(ResourceServiceInterface::class)->getResourceById($resourceOrId)
+            : $resourceOrId;
+        return $resource->addComment($comment, $user);
     }
 
     /**
@@ -105,31 +105,29 @@ class CommentsService extends AbstractDbService implements
     /**
      * Delete a comment if the owner is logged in.  Returns true on success.
      *
-     * @param int                     $id   ID of row to delete
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param int                     $id       ID of row to delete
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return bool
      */
-    public function deleteIfOwnedByUser(int $id, int|UserEntityInterface $user): bool
+    public function deleteIfOwnedByUser(int $id, UserEntityInterface|int $userOrId): bool
     {
-        if (is_int($user)) {
-            $user = $this->getDbService(UserServiceInterface::class)->getUserById($user);
-        }
+        $user = is_int($userOrId)
+            ? $this->getDbService(UserServiceInterface::class)->getUserById($userOrId) : $userOrId;
         return $this->getDbTable('comments')->deleteIfOwnedByUser($id, $user);
     }
 
     /**
      * Deletes all comments by a user.
      *
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return void
      */
-    public function deleteByUser(int|UserEntityInterface $user): void
+    public function deleteByUser(UserEntityInterface|int $userOrId): void
     {
-        if (is_int($user)) {
-            $user = $this->getDbService(UserServiceInterface::class)->getUserById($user);
-        }
+        $user = is_int($userOrId)
+            ? $this->getDbService(UserServiceInterface::class)->getUserById($userOrId) : $userOrId;
         $this->getDbTable('comments')->deleteByUser($user);
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
@@ -54,16 +54,16 @@ interface CommentsServiceInterface extends DbServiceInterface
     /**
      * Add a comment to the current resource. Returns comment ID on success, null on failure.
      *
-     * @param string                      $comment  The comment to save.
-     * @param int|UserEntityInterface     $user     User object or identifier
-     * @param int|ResourceEntityInterface $resource Resource object or identifier
+     * @param string                      $comment      The comment to save.
+     * @param UserEntityInterface|int     $userOrId     User object or identifier
+     * @param ResourceEntityInterface|int $resourceOrId Resource object or identifier
      *
      * @return ?int
      */
     public function addComment(
         string $comment,
-        int|UserEntityInterface $user,
-        int|ResourceEntityInterface $resource
+        UserEntityInterface|int $userOrId,
+        ResourceEntityInterface|int $resourceOrId
     ): ?int;
 
     /**
@@ -79,21 +79,21 @@ interface CommentsServiceInterface extends DbServiceInterface
     /**
      * Delete a comment if the owner is logged in.  Returns true on success.
      *
-     * @param int                     $id   ID of row to delete
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param int                     $id       ID of row to delete
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return bool
      */
-    public function deleteIfOwnedByUser(int $id, int|UserEntityInterface $user): bool;
+    public function deleteIfOwnedByUser(int $id, UserEntityInterface|int $userOrId): bool;
 
     /**
      * Deletes all comments by a user.
      *
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return void
      */
-    public function deleteByUser(int|UserEntityInterface $user): void;
+    public function deleteByUser(UserEntityInterface|int $userOrId): void;
 
     /**
      * Get statistics on use of comments.

--- a/module/VuFind/src/VuFind/Db/Service/LoginTokenService.php
+++ b/module/VuFind/src/VuFind/Db/Service/LoginTokenService.php
@@ -124,27 +124,27 @@ class LoginTokenService extends AbstractDbService implements LoginTokenServiceIn
     /**
      * Delete all tokens for a user.
      *
-     * @param UserEntityInterface|int $user User entity object or identifier
+     * @param UserEntityInterface|int $userOrId User entity object or identifier
      *
      * @return void
      */
-    public function deleteByUser(UserEntityInterface|int $user): void
+    public function deleteByUser(UserEntityInterface|int $userOrId): void
     {
-        $userId = is_int($user) ? $user : $user->getId();
+        $userId = is_int($userOrId) ? $userOrId : $userOrId->getId();
         $this->getDbTable('LoginToken')->deleteByUserId($userId);
     }
 
     /**
      * Get tokens for a given user.
      *
-     * @param UserEntityInterface|int $user    User entity object or identifier
-     * @param bool                    $grouped Whether to return results grouped by series
+     * @param UserEntityInterface|int $userOrId User entity object or identifier
+     * @param bool                    $grouped  Whether to return results grouped by series
      *
      * @return LoginTokenEntityInterface[]
      */
-    public function getByUser(UserEntityInterface|int $user, bool $grouped = true): array
+    public function getByUser(UserEntityInterface|int $userOrId, bool $grouped = true): array
     {
-        $userId = is_int($user) ? $user : $user->getId();
+        $userId = is_int($userOrId) ? $userOrId : $userOrId->getId();
         return $this->getDbTable('LoginToken')->getByUserId($userId, $grouped);
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/LoginTokenServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/LoginTokenServiceInterface.php
@@ -97,21 +97,21 @@ interface LoginTokenServiceInterface extends DbServiceInterface
     /**
      * Delete all tokens for a user.
      *
-     * @param UserEntityInterface|int $user User entity object or identifier
+     * @param UserEntityInterface|int $userOrId User entity object or identifier
      *
      * @return void
      */
-    public function deleteByUser(UserEntityInterface|int $user): void;
+    public function deleteByUser(UserEntityInterface|int $userOrId): void;
 
     /**
      * Get tokens for a given user.
      *
-     * @param UserEntityInterface|int $user    User entity object or identifier
-     * @param bool                    $grouped Whether to return results grouped by series
+     * @param UserEntityInterface|int $userOrId User entity object or identifier
+     * @param bool                    $grouped  Whether to return results grouped by series
      *
      * @return LoginTokenEntityInterface[]
      */
-    public function getByUser(UserEntityInterface|int $user, bool $grouped = true): array;
+    public function getByUser(UserEntityInterface|int $userOrId, bool $grouped = true): array;
 
     /**
      * Get token by series.

--- a/module/VuFind/src/VuFind/Db/Service/RatingsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/RatingsService.php
@@ -86,14 +86,14 @@ class RatingsService extends AbstractDbService implements
     /**
      * Deletes all ratings by a user.
      *
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return void
      */
-    public function deleteByUser(int|UserEntityInterface $user): void
+    public function deleteByUser(UserEntityInterface|int $userOrId): void
     {
         $this->getDbTable('ratings')->deleteByUser(
-            is_int($user) ? $this->getDbTable('user')->getById($user) : $user
+            is_int($userOrId) ? $this->getDbTable('user')->getById($userOrId) : $userOrId
         );
     }
 
@@ -110,21 +110,20 @@ class RatingsService extends AbstractDbService implements
     /**
      * Add or update user's rating for a resource.
      *
-     * @param int|ResourceEntityInterface $resource Resource to add or update rating.
-     * @param int|UserEntityInterface     $user     User
-     * @param ?int                        $rating   Rating (null to delete)
+     * @param ResourceEntityInterface|int $resourceOrId Resource to add or update rating.
+     * @param UserEntityInterface|int     $userOrId     User
+     * @param ?int                        $rating       Rating (null to delete)
      *
      * @throws \Exception
      * @return int ID of rating added, deleted or updated
      */
     public function addOrUpdateRating(
-        int|ResourceEntityInterface $resource,
-        int|UserEntityInterface $user,
+        ResourceEntityInterface|int $resourceOrId,
+        UserEntityInterface|int $userOrId,
         ?int $rating
     ): int {
-        if (is_int($resource)) {
-            $resource = $this->getDbTable('resource')->select(['id' => $resource])->current();
-        }
-        return $resource->addOrUpdateRating(is_int($user) ? $user : $user->getId(), $rating);
+        $resource = is_int($resourceOrId)
+            ? $this->getDbTable('resource')->select(['id' => $resourceOrId])->current() : $resourceOrId;
+        return $resource->addOrUpdateRating(is_int($userOrId) ? $userOrId : $userOrId->getId(), $rating);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/RatingsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/RatingsServiceInterface.php
@@ -73,11 +73,11 @@ interface RatingsServiceInterface extends DbServiceInterface
     /**
      * Deletes all ratings by a user.
      *
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return void
      */
-    public function deleteByUser(int|UserEntityInterface $user): void;
+    public function deleteByUser(UserEntityInterface|int $userOrId): void;
 
     /**
      * Get statistics on use of Ratings.
@@ -89,16 +89,16 @@ interface RatingsServiceInterface extends DbServiceInterface
     /**
      * Add or update user's rating for a resource.
      *
-     * @param int|ResourceEntityInterface $resource Resource to add or update rating.
-     * @param int|UserEntityInterface     $user     User
-     * @param ?int                        $rating   Rating (null to delete)
+     * @param ResourceEntityInterface|int $resourceOrId Resource to add or update rating.
+     * @param UserEntityInterface|int     $userOrId     User
+     * @param ?int                        $rating       Rating (null to delete)
      *
      * @throws \Exception
      * @return int ID of rating added, deleted or updated
      */
     public function addOrUpdateRating(
-        int|ResourceEntityInterface $resource,
-        int|UserEntityInterface $user,
+        ResourceEntityInterface|int $resourceOrId,
+        UserEntityInterface|int $userOrId,
         ?int $rating
     ): int;
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserCardServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserCardServiceInterface.php
@@ -62,35 +62,39 @@ interface UserCardServiceInterface extends DbServiceInterface
     /**
      * Get all library cards associated with the user.
      *
-     * @param int|UserEntityInterface $user        User object or identifier
+     * @param UserEntityInterface|int $userOrId    User object or identifier
      * @param ?int                    $id          Optional card ID filter
      * @param ?string                 $catUsername Optional catalog username filter
      *
      * @return UserCardEntityInterface[]
      */
-    public function getLibraryCards(int|UserEntityInterface $user, ?int $id = null, ?string $catUsername = null): array;
+    public function getLibraryCards(
+        UserEntityInterface|int $userOrId,
+        ?int $id = null,
+        ?string $catUsername = null
+    ): array;
 
     /**
      * Get or create library card data.
      *
-     * @param int|UserEntityInterface $user User object or identifier
-     * @param ?int                    $id   Card ID to fetch (or null to create a new card)
+     * @param UserEntityInterface|int $userOrId User object or identifier
+     * @param ?int                    $id       Card ID to fetch (or null to create a new card)
      *
      * @return UserCardEntityInterface Card data if found; throws exception otherwise
      * @throws \VuFind\Exception\LibraryCard
      */
-    public function getOrCreateLibraryCard(int|UserEntityInterface $user, ?int $id = null): UserCardEntityInterface;
+    public function getOrCreateLibraryCard(UserEntityInterface|int $userOrId, ?int $id = null): UserCardEntityInterface;
 
     /**
      * Delete library card.
      *
      * @param UserEntityInterface         $user     User owning card to delete
-     * @param int|UserCardEntityInterface $userCard UserCard id or object to be deleted
+     * @param UserCardEntityInterface|int $userCard UserCard id or object to be deleted
      *
      * @return bool
      * @throws \Exception
      */
-    public function deleteLibraryCard(UserEntityInterface $user, int|UserCardEntityInterface $userCard): bool;
+    public function deleteLibraryCard(UserEntityInterface $user, UserCardEntityInterface|int $userCard): bool;
 
     /**
      * Persist the provided library card data, either by updating a specified card
@@ -100,8 +104,8 @@ interface UserCardServiceInterface extends DbServiceInterface
      *
      * Returns the row that was added or updated.
      *
-     * @param int|UserEntityInterface          $user     User object or identifier
-     * @param int|UserCardEntityInterface|null $card     Card ID (null = create new)
+     * @param UserEntityInterface|int          $userOrId User object or identifier
+     * @param UserCardEntityInterface|int|null $cardOrId Card ID (null = create new)
      * @param string                           $cardName Card name
      * @param string                           $username Username
      * @param string                           $password Password
@@ -111,8 +115,8 @@ interface UserCardServiceInterface extends DbServiceInterface
      * @throws \VuFind\Exception\LibraryCard
      */
     public function persistLibraryCardData(
-        int|UserEntityInterface $user,
-        int|UserCardEntityInterface|null $card,
+        UserEntityInterface|int $userOrId,
+        UserCardEntityInterface|int|null $cardOrId,
         string $cardName,
         string $username,
         string $password,
@@ -124,23 +128,23 @@ interface UserCardServiceInterface extends DbServiceInterface
      * (if enabled) and are up to date. Designed to be called after updating the
      * user row; will create or modify library card rows as needed.
      *
-     * @param int|UserEntityInterface $user User object or identifier
+     * @param UserEntityInterface|int $userOrId User object or identifier
      *
      * @return bool
      * @throws \VuFind\Exception\PasswordSecurity
      */
-    public function synchronizeUserLibraryCardData(int|UserEntityInterface $user): bool;
+    public function synchronizeUserLibraryCardData(UserEntityInterface|int $userOrId): bool;
 
     /**
      * Activate a library card for the given username.
      *
-     * @param int|UserEntityInterface $user User owning card
-     * @param int                     $id   Library card ID to activate
+     * @param UserEntityInterface|int $userOrId User owning card
+     * @param int                     $id       Library card ID to activate
      *
      * @return void
      * @throws \VuFind\Exception\LibraryCard
      */
-    public function activateLibraryCard(int|UserEntityInterface $user, int $id): void;
+    public function activateLibraryCard(UserEntityInterface|int $userOrId, int $id): void;
 
     /**
      * Create a UserCard entity object.

--- a/module/VuFind/src/VuFind/Db/Service/UserResourceService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserResourceService.php
@@ -57,9 +57,9 @@ class UserResourceService extends AbstractDbService implements
      *
      * @param string                           $recordId ID of record being checked.
      * @param string                           $source   Source of record to look up
-     * @param int|UserListEntityInterface|null $list     Optional list ID or entity
+     * @param UserListEntityInterface|int|null $listOrId Optional list entity or ID
      * (to limit results to a particular list).
-     * @param int|UserEntityInterface|null     $user     Optional user ID or entity
+     * @param UserEntityInterface|int|null     $userOrId Optional user entity or ID
      * (to limit results to a particular user).
      *
      * @return UserResourceEntityInterface[]
@@ -67,11 +67,11 @@ class UserResourceService extends AbstractDbService implements
     public function getFavoritesForRecord(
         string $recordId,
         string $source = DEFAULT_SEARCH_BACKEND,
-        int|UserListEntityInterface|null $list = null,
-        int|UserEntityInterface|null $user = null
+        UserListEntityInterface|int|null $listOrId = null,
+        UserEntityInterface|int|null $userOrId = null
     ): array {
-        $listId = is_int($list) ? $list : $list?->getId();
-        $userId = is_int($user) ? $user : $user?->getId();
+        $listId = is_int($listOrId) ? $listOrId : $listOrId?->getId();
+        $userId = is_int($userOrId) ? $userOrId : $userOrId?->getId();
         return iterator_to_array(
             $this->getDbTable('UserResource')->getSavedData($recordId, $source, $listId, $userId)
         );

--- a/module/VuFind/src/VuFind/Db/Service/UserResourceServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserResourceServiceInterface.php
@@ -49,9 +49,9 @@ interface UserResourceServiceInterface extends DbServiceInterface
      *
      * @param string                           $recordId ID of record being checked.
      * @param string                           $source   Source of record to look up
-     * @param int|UserListEntityInterface|null $list     Optional list ID or entity
+     * @param UserListEntityInterface|int|null $listOrId Optional list entity or ID
      * (to limit results to a particular list).
-     * @param int|UserEntityInterface|null     $user     Optional user ID or entity
+     * @param UserEntityInterface|int|null     $userOrId Optional user entity or ID
      * (to limit results to a particular user).
      *
      * @return UserResourceEntityInterface[]
@@ -59,8 +59,8 @@ interface UserResourceServiceInterface extends DbServiceInterface
     public function getFavoritesForRecord(
         string $recordId,
         string $source = DEFAULT_SEARCH_BACKEND,
-        int|UserListEntityInterface|null $list = null,
-        int|UserEntityInterface|null $user = null
+        UserListEntityInterface|int|null $listOrId = null,
+        UserEntityInterface|int|null $userOrId = null
     ): array;
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -82,11 +82,11 @@ class UserService extends AbstractDbService implements
      * Field name must be id, username or cat_id.
      *
      * @param string          $fieldName  Field name
-     * @param int|null|string $fieldValue Field value
+     * @param int|string|null $fieldValue Field value
      *
      * @return ?UserEntityInterface
      */
-    public function getUserByField(string $fieldName, int|null|string $fieldValue): ?UserEntityInterface
+    public function getUserByField(string $fieldName, int|string|null $fieldValue): ?UserEntityInterface
     {
         switch ($fieldName) {
             case 'id':

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
@@ -55,11 +55,11 @@ interface UserServiceInterface extends DbServiceInterface
      * Retrieve a user object from the database based on the given field.
      *
      * @param string          $fieldName  Field name
-     * @param int|null|string $fieldValue Field value
+     * @param int|string|null $fieldValue Field value
      *
      * @return ?UserEntityInterface
      */
-    public function getUserByField(string $fieldName, int|null|string $fieldValue): ?UserEntityInterface;
+    public function getUserByField(string $fieldName, int|string|null $fieldValue): ?UserEntityInterface;
 
     /**
      * Update the user's email address, if appropriate. Note that this does NOT


### PR DESCRIPTION
This PR uses a more consistent pattern for "entity or ID" function arguments. It also fixes a related bug in UserCardService::synchronizeUserLibraryCardData() where a variable was being treated as an object before it had been resolved as one.