### PR TITLE
Add missing dependency annotation to BulkTest.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -339,6 +339,8 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
      * Test that the print control works.
      *
      * @return void
+     *
+     * @depends testBulkEmail
      */
     public function testBulkActionLimits(): void
     {


### PR DESCRIPTION
This fixes a minor omission to one of our Mink tests.