### PR TITLE
Refactor more favorites and list logic into FavoritesService

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -58,7 +58,6 @@ use function is_object;
  *
  * @method Plugin\Captcha captcha() Captcha plugin
  * @method Plugin\DbUpgrade dbUpgrade() DbUpgrade plugin
- * @method Plugin\Favorites favorites() Favorites plugin
  * @method FlashMessenger flashMessenger() FlashMessenger plugin
  * @method Plugin\Followup followup() Followup plugin
  * @method Plugin\Holds holds() Holds plugin

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -420,9 +420,8 @@ class AbstractRecord extends AbstractBase
         $post = $this->getRequest()->getPost()->toArray();
         $tagParser = $this->serviceLocator->get(Tags::class);
         $post['mytags'] = $tagParser->parse($post['mytags'] ?? '');
-        $favorites = $this->serviceLocator
-            ->get(\VuFind\Favorites\FavoritesService::class);
-        $results = $favorites->save($post, $user, $driver);
+        $favorites = $this->serviceLocator->get(\VuFind\Favorites\FavoritesService::class);
+        $results = $favorites->saveRecordToFavorites($post, $user, $driver);
 
         // Display a success status message:
         $listUrl = $this->url()->fromRoute('userList', ['id' => $results['listId']]);

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -35,6 +35,7 @@ use VuFind\Controller\Feature\ListItemSelectionTrait;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Exception\Forbidden as ForbiddenException;
 use VuFind\Exception\Mail as MailException;
+use VuFind\Favorites\FavoritesService;
 
 use function count;
 use function is_array;
@@ -532,8 +533,8 @@ class CartController extends AbstractBase
 
         // Process submission if necessary:
         if (!($submitDisabled ?? false) && $this->formWasSubmitted()) {
-            $results = $this->favorites()
-                ->saveBulk($this->getRequest()->getPost()->toArray(), $user);
+            $results = $this->serviceLocator->get(FavoritesService::class)
+                ->saveRecordsToFavorites($this->getRequest()->getPost()->toArray(), $user);
             $listUrl = $this->url()->fromRoute(
                 'userList',
                 ['id' => $results['listId']]

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1248,12 +1248,13 @@ class MyResearchController extends AbstractBase
         $newList = ($id == 'NEW');
         // If this is a new list, use the FavoritesService to pre-populate some values in
         // a fresh object; if it's an existing list, we can just fetch from the database.
+        $favoritesService = $this->serviceLocator->get(FavoritesService::class);
         $list = $newList
-            ? $this->serviceLocator->get(FavoritesService::class)->createListForUser($user)
+            ? $favoritesService->createListForUser($user)
             : $this->getDbService(UserListServiceInterface::class)->getUserListById($id);
 
         // Make sure the user isn't fishing for other people's lists:
-        if (!$newList && !$list->editAllowed($user)) {
+        if (!$newList && !$favoritesService->userCanEditList($user, $list)) {
             throw new ListPermissionException('Access denied.');
         }
 

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -877,7 +877,8 @@ class MyResearchController extends AbstractBase
                 return $redirect;
             }
         } elseif ($this->formWasSubmitted()) {
-            $this->favorites()->delete($ids, $listID, $user);
+            $this->serviceLocator->get(FavoritesService::class)
+                ->deleteFavorites($ids, $listID === null ? null : (int)$listID, $user);
             $this->flashMessenger()->addMessage('fav_delete_success', 'success');
             return $this->redirect()->toUrl($newUrl);
         }

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1330,7 +1330,7 @@ class MyResearchController extends AbstractBase
         if ($confirm) {
             try {
                 $list = $this->getDbService(UserListServiceInterface::class)->getUserListById($listID);
-                $list->delete($this->getUser());
+                $this->serviceLocator->get(FavoritesService::class)->destroyList($list, $this->getUser() ?: null);
 
                 // Success Message
                 $this->flashMessenger()->addMessage('fav_list_delete', 'success');

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1169,7 +1169,7 @@ class MyResearchController extends AbstractBase
      * Process the "edit list" submission.
      *
      * @param UserEntityInterface     $user Logged in user
-     * @param \VuFind\Db\Row\UserList $list List being created/edited
+     * @param UserListEntityInterface $list List being created/edited
      *
      * @return object|bool                  Response object if redirect is
      * needed, false if form needs to be redisplayed.
@@ -1178,8 +1178,8 @@ class MyResearchController extends AbstractBase
     {
         // Process form within a try..catch so we can handle errors appropriately:
         try {
-            $finalId
-                = $list->updateFromRequest($user, $this->getRequest()->getPost());
+            $favoritesService = $this->serviceLocator->get(FavoritesService::class);
+            $finalId = $favoritesService->updateListFromRequest($list, $user, $this->getRequest()->getPost());
 
             // If the user is in the process of saving a record, send them back
             // to the save screen; otherwise, send them back to the list they

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -919,16 +919,16 @@ class MyResearchController extends AbstractBase
         }
 
         // Perform delete and send appropriate flash message:
+        $favoritesService = $this->serviceLocator->get(FavoritesService::class);
         if (null !== $listID) {
             // ...Specific List
             $list = $this->getDbService(UserListServiceInterface::class)->getUserListById($listID);
-            $list->removeResourcesById($user, [$id], $source);
+            $favoritesService->removeListResourcesById($list, $user, [$id], $source);
             $this->flashMessenger()->addMessage('Item removed from list', 'success');
         } else {
             // ...All Saved Items
-            $user->removeResourcesById([$id], $source);
-            $this->flashMessenger()
-                ->addMessage('Item removed from favorites', 'success');
+            $favoritesService->removeUserResourcesById($user, [$id], $source);
+            $this->flashMessenger()->addMessage('Item removed from favorites', 'success');
         }
 
         // All done -- return true to indicate success.

--- a/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
@@ -168,13 +168,13 @@ class Favorites extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
         // on whether we are working with a list or user favorites.
         if (empty($listID)) {
             foreach ($sorted as $source => $ids) {
-                $user->removeResourcesById($ids, $source);
+                $this->favoritesService->removeUserResourcesById($user, $ids, $source);
             }
         } else {
             $service = $this->getController()->getDbService(UserListServiceInterface::class);
             $list = $service->getUserListById($listID);
             foreach ($sorted as $source => $ids) {
-                $list->removeResourcesById($user, $ids, $source);
+                $this->favoritesService->removeListResourcesById($list, $user, $ids, $source);
             }
         }
     }

--- a/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Favorites.php
@@ -29,14 +29,7 @@
 
 namespace VuFind\Controller\Plugin;
 
-use VuFind\Db\Row\User;
-use VuFind\Db\Service\UserListServiceInterface;
-use VuFind\Exception\LoginRequired as LoginRequiredException;
 use VuFind\Favorites\FavoritesService;
-use VuFind\Record\Cache;
-use VuFind\Record\Loader;
-use VuFind\Record\ResourcePopulator;
-use VuFind\Tags;
 
 /**
  * Action helper to perform favorites-related actions
@@ -46,136 +39,54 @@ use VuFind\Tags;
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
+ *
+ * @deprecated Use \VuFind\Favorites\FavoritesService
  */
 class Favorites extends \Laminas\Mvc\Controller\Plugin\AbstractPlugin
 {
     /**
      * Constructor
      *
-     * @param Loader            $loader            Record loader
-     * @param Cache             $cache             Record cache
-     * @param Tags              $tags              Tag parser
-     * @param FavoritesService  $favoritesService  Favorites service
-     * @param ResourcePopulator $resourcePopulator Resource populator
+     * @param FavoritesService $favoritesService Favorites service
      */
     public function __construct(
-        protected Loader $loader,
-        protected Cache $cache,
-        protected Tags $tags,
         protected FavoritesService $favoritesService,
-        protected ResourcePopulator $resourcePopulator
     ) {
-    }
-
-    /**
-     * Support method for saveBulk() -- save a batch of records to the cache.
-     *
-     * @param array $cacheRecordIds Array of IDs in source|id format
-     *
-     * @return void
-     */
-    protected function cacheBatch(array $cacheRecordIds)
-    {
-        if ($cacheRecordIds) {
-            // Disable the cache so that we fetch latest versions, not cached ones:
-            $this->loader->setCacheContext(Cache::CONTEXT_DISABLED);
-            $records = $this->loader->loadBatch($cacheRecordIds);
-            // Re-enable the cache so that we actually save the records:
-            $this->loader->setCacheContext(Cache::CONTEXT_FAVORITE);
-            foreach ($records as $record) {
-                $this->cache->createOrUpdate(
-                    $record->getUniqueID(),
-                    $record->getSourceIdentifier(),
-                    $record->getRawData()
-                );
-            }
-        }
     }
 
     /**
      * Save a group of records to the user's favorites.
      *
-     * @param array $params Array with some or all of these keys:
+     * @param array               $params Array with some or all of these keys:
      *  <ul>
      *    <li>ids - Array of IDs in source|id format</li>
      *    <li>mytags - Unparsed tag string to associate with record (optional)</li>
      *    <li>list - ID of list to save record into (omit to create new list)</li>
      *  </ul>
-     * @param User  $user   The user saving the record
+     * @param UserEntityInterface $user   The user saving the record
      *
      * @return array list information
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::saveRecordsToFavorites()
      */
     public function saveBulk($params, $user)
     {
-        // Validate incoming parameters:
-        if (!$user) {
-            throw new LoginRequiredException('You must be logged in first');
-        }
-
-        // Load helper objects needed for the saving process:
-        $list = $this->favoritesService->getAndRememberListObject(
-            $this->favoritesService->getListIdFromParams($params),
-            $user
-        );
-        $this->cache->setContext(Cache::CONTEXT_FAVORITE);
-
-        $cacheRecordIds = [];   // list of record IDs to save to cache
-        foreach ($params['ids'] as $current) {
-            // Break apart components of ID:
-            [$source, $id] = explode('|', $current, 2);
-
-            // Get or create a resource object as needed:
-            $resource = $this->resourcePopulator->getOrCreateResourceForRecordId($id, $source);
-
-            // Add the information to the user's account:
-            $tags = isset($params['mytags'])
-                ? $this->tags->parse($params['mytags']) : [];
-            $user->saveResource($resource, $list, $tags, '', false);
-
-            // Collect record IDs for caching
-            if ($this->cache->isCachable($resource->source)) {
-                $cacheRecordIds[] = $current;
-            }
-        }
-
-        $this->cacheBatch($cacheRecordIds);
-        return ['listId' => $list->id];
+        return $this->favoritesService->saveRecordsToFavorites($params, $user);
     }
 
     /**
      * Delete a group of favorites.
      *
-     * @param array $ids    Array of IDs in source|id format.
-     * @param mixed $listID ID of list to delete from (null for all
-     * lists)
-     * @param User  $user   Logged in user
+     * @param array               $ids    Array of IDs in source|id format.
+     * @param mixed               $listID ID of list to delete from (null for all lists)
+     * @param UserEntityInterface $user   Logged in user
      *
      * @return void
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::deleteFavorites()
      */
     public function delete($ids, $listID, $user)
     {
-        // Sort $ids into useful array:
-        $sorted = [];
-        foreach ($ids as $current) {
-            [$source, $id] = explode('|', $current, 2);
-            if (!isset($sorted[$source])) {
-                $sorted[$source] = [];
-            }
-            $sorted[$source][] = $id;
-        }
-
-        // Delete favorites one source at a time, using a different object depending
-        // on whether we are working with a list or user favorites.
-        if (empty($listID)) {
-            foreach ($sorted as $source => $ids) {
-                $this->favoritesService->removeUserResourcesById($user, $ids, $source);
-            }
-        } else {
-            $service = $this->getController()->getDbService(UserListServiceInterface::class);
-            $list = $service->getUserListById($listID);
-            foreach ($sorted as $source => $ids) {
-                $this->favoritesService->removeListResourcesById($list, $user, $ids, $source);
-            }
-        }
+        $this->favoritesService->deleteFavorites($ids, $listID, $user);
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/FavoritesFactory.php
@@ -34,7 +34,6 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
-use VuFind\Record\ResourcePopulator;
 
 /**
  * Factory for Favorites controller plugin.
@@ -70,11 +69,7 @@ class FavoritesFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         return new $requestedName(
-            $container->get(\VuFind\Record\Loader::class),
-            $container->get(\VuFind\Record\Cache::class),
-            $container->get(\VuFind\Tags::class),
             $container->get(\VuFind\Favorites\FavoritesService::class),
-            $container->get(ResourcePopulator::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -39,6 +39,7 @@ use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserCardServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Db\Service\UserServiceInterface;
+use VuFind\Favorites\FavoritesService;
 
 use function count;
 
@@ -96,11 +97,13 @@ class User extends RowGateway implements
      * @param \Laminas\Db\Adapter\Adapter $adapter          Database adapter
      * @param ILSAuthenticator            $ilsAuthenticator ILS authenticator
      * @param AccountCapabilities         $capabilities     Account capabilities configuration (null for defaults)
+     * @param FavoritesService            $favoritesService Favorites service
      */
     public function __construct(
         $adapter,
         protected ILSAuthenticator $ilsAuthenticator,
-        protected AccountCapabilities $capabilities
+        protected AccountCapabilities $capabilities,
+        protected FavoritesService $favoritesService,
     ) {
         parent::__construct('id', 'user', $adapter);
     }
@@ -606,7 +609,7 @@ class User extends RowGateway implements
         // Remove all lists owned by the user:
         $listService = $this->getDbService(UserListServiceInterface::class);
         foreach ($listService->getUserListsByUser($this) as $current) {
-            $current->delete($this, true);
+            $this->favoritesService->destroyList($current, $this, true);
         }
         $resourceTags = $this->getDbTable('ResourceTags');
         $resourceTags->destroyResourceLinks(null, $this->id);

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -450,6 +450,8 @@ class User extends RowGateway implements
      * @param string $source Type of resource identified by IDs
      *
      * @return void
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::removeUserResourcesById()
      */
     public function removeResourcesById($ids, $source = DEFAULT_SEARCH_BACKEND)
     {

--- a/module/VuFind/src/VuFind/Db/Row/UserFactory.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserFactory.php
@@ -33,6 +33,7 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Favorites\FavoritesService;
 
 /**
  * User row gateway factory.
@@ -79,7 +80,8 @@ class UserFactory extends RowGatewayFactory
         $capabilities = $container->get(\VuFind\Config\AccountCapabilities::class);
         $rowClass = $privacy ? $this->privateUserClass : $requestedName;
         $ilsAuthenticator = $container->get(\VuFind\Auth\ILSAuthenticator::class);
-        $prototype = parent::__invoke($container, $rowClass, [$ilsAuthenticator, $capabilities]);
+        $favoritesService = $container->get(FavoritesService::class);
+        $prototype = parent::__invoke($container, $rowClass, [$ilsAuthenticator, $capabilities, $favoritesService]);
         $prototype->setConfig($config);
         return $prototype;
     }

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -246,11 +246,13 @@ class UserList extends RowGateway implements
     /**
      * Given an array of item ids, remove them from all lists.
      *
-     * @param \VuFind\Db\Row\User|bool $user   Logged-in user (false if none)
+     * @param UserEntityInterface|bool $user   Logged-in user (false if none)
      * @param array                    $ids    IDs to remove from the list
      * @param string                   $source Type of resource identified by IDs
      *
      * @return void
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::removeListResourcesById()
      */
     public function removeResourcesById(
         $user,

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -96,9 +96,11 @@ class UserList extends RowGateway implements
     /**
      * Is the current user allowed to edit this list?
      *
-     * @param ?\VuFind\Db\Row\User $user Logged-in user (null if none)
+     * @param ?UserEntityInterface $user Logged-in user (null if none)
      *
      * @return bool
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::userCanEditList()
      */
     public function editAllowed($user)
     {

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -178,6 +178,8 @@ class UserList extends RowGateway implements
      * dialog boxes.
      *
      * @return void
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::rememberLastUsedList()
      */
     public function rememberLastUsed()
     {

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -149,6 +149,8 @@ class UserList extends RowGateway implements
      * @return int ID of newly created row
      * @throws ListPermissionException
      * @throws MissingFieldException
+     *
+     * @deprecated Use \VuFind\Favorites\FavoritesService::updateListFromRequest()
      */
     public function updateFromRequest($user, $request)
     {

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -236,32 +236,6 @@ class UserList extends RowGateway implements
     }
 
     /**
-     * Destroy the list.
-     *
-     * @param \VuFind\Db\Row\User|bool $user  Logged-in user (false if none)
-     * @param bool                     $force Should we force the delete without checking permissions?
-     *
-     * @return int The number of rows deleted.
-     */
-    public function delete($user = false, $force = false)
-    {
-        if (!$force && !$this->editAllowed($user ?: null)) {
-            throw new ListPermissionException('list_access_denied');
-        }
-
-        // Remove user_resource and resource_tags rows:
-        $userResource = $this->getDbTable('UserResource');
-        $userResource->destroyLinks(null, $this->user_id, $this->id);
-
-        // Remove resource_tags rows for list tags:
-        $linker = $this->getDbTable('resourcetags');
-        $linker->destroyListLinks($this->id, $user->id);
-
-        // Remove the list itself:
-        return parent::delete();
-    }
-
-    /**
      * Get identifier (returns null for an uninitialized or non-persisted object).
      *
      * @return ?int

--- a/module/VuFind/src/VuFind/Db/Service/UserListService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserListService.php
@@ -67,6 +67,19 @@ class UserListService extends AbstractDbService implements DbTableAwareInterface
     }
 
     /**
+     * Delete a user list entity.
+     *
+     * @param UserListEntityInterface|int $listOrId List entity object or ID to delete
+     *
+     * @return void
+     */
+    public function deleteUserList(UserListEntityInterface|int $listOrId): void
+    {
+        $listId = $listOrId instanceof UserListEntityInterface ? $listOrId->getId() : $listOrId;
+        $this->getDbTable('UserList')->delete(['id' => $listId]);
+    }
+
+    /**
      * Retrieve a list object.
      *
      * @param int $id Numeric ID for existing list.

--- a/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserListServiceInterface.php
@@ -54,6 +54,15 @@ interface UserListServiceInterface extends DbServiceInterface
     public function createEntity(): UserListEntityInterface;
 
     /**
+     * Delete a user list entity.
+     *
+     * @param UserListEntityInterface|int $listOrId List entity object or ID to delete
+     *
+     * @return void
+     */
+    public function deleteUserList(UserListEntityInterface|int $listOrId): void;
+
+    /**
      * Retrieve a list object.
      *
      * @param int $id Numeric ID for existing list.

--- a/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
+++ b/module/VuFind/src/VuFind/Db/Table/UserListFactory.php
@@ -67,8 +67,6 @@ class UserListFactory extends GatewayFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory!');
         }
-        $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
-        $session = new \Laminas\Session\Container('List', $sessionManager);
-        return parent::__invoke($container, $requestedName, [$session]);
+        return parent::__invoke($container, $requestedName, [null]);
     }
 }

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -164,7 +164,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
     /**
      * Given an array of item ids, remove them from the specified list.
      *
-     * @param UserListEntityInterface $list
+     * @param UserListEntityInterface $list   List being updated
      * @param ?UserEntityInterface    $user   Logged-in user (null if none)
      * @param string[]                $ids    IDs to remove from the list
      * @param string                  $source Type of resource identified by IDs

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -47,6 +47,7 @@ use VuFind\Record\ResourcePopulator;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\Tags;
 
+use function func_get_args;
 use function intval;
 
 /**
@@ -289,6 +290,18 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
     }
 
     /**
+     * Legacy name for saveRecordToFavorites()
+     *
+     * @return array
+     *
+     * @deprecated Use saveRecordToFavorites()
+     */
+    public function save()
+    {
+        return $this->saveRecordToFavorites(...func_get_args());
+    }
+
+    /**
      * Save this record to the user's favorites.
      *
      * @param array               $params Array with some or all of these keys:
@@ -297,16 +310,16 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
      *    <li>notes - Notes to associate with record (optional)</li>
      *    <li>list - ID of list to save record into (omit to create new list)</li>
      *  </ul>
-     * @param \VuFind\Db\Row\User $user   The user saving the record
+     * @param UserEntityInterface $user   The user saving the record
      * @param RecordDriver        $driver Record driver for record being saved
      *
      * @return array list information
      */
-    public function save(
+    public function saveRecordToFavorites(
         array $params,
-        \VuFind\Db\Row\User $user,
+        UserEntityInterface $user,
         RecordDriver $driver
-    ) {
+    ): array {
         // Validate incoming parameters:
         if (!$user) {
             throw new LoginRequiredException('You must be logged in first');
@@ -328,7 +341,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
             $params['mytags'] ?? [],
             $params['notes'] ?? ''
         );
-        return ['listId' => $list->id];
+        return ['listId' => $list->getId()];
     }
 
     /**

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -128,7 +128,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
         $linker = $this->getDbTable('resourcetags');
         $linker->destroyListLinks($list->getId(), $user?->getId());
 
-        $list->delete();
+        $this->userListService->deleteUserList($list);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -109,7 +109,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
      * Destroy a list.
      *
      * @param UserListEntityInterface $list  List to destroy
-     * @param ?UserEntityInterface    $user  Logged-in user (false if none)
+     * @param ?UserEntityInterface    $user  Logged-in user (null if none)
      * @param bool                    $force Should we force the delete without checking permissions?
      *
      * @return void
@@ -195,7 +195,7 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
     /**
      * Retrieve the ID of the last list that was accessed, if any.
      *
-     * @return ?int User_list ID (if set) or null (if not available).
+     * @return ?int Identifier value of a UserListEntityInterface object (if set) or null (if not available).
      */
     public function getLastUsedList(): ?int
     {
@@ -455,11 +455,6 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
      */
     public function saveRecordsToFavorites(array $params, UserEntityInterface $user): array
     {
-        // Validate incoming parameters:
-        if (!$user) {
-            throw new LoginRequiredException('You must be logged in first');
-        }
-
         // Load helper objects needed for the saving process:
         $list = $this->getAndRememberListObject($this->getListIdFromParams($params), $user);
         $this->recordCache?->setContext(RecordCache::CONTEXT_FAVORITE);

--- a/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
@@ -33,6 +33,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
+use VuFind\Record\Loader;
 use VuFind\Record\ResourcePopulator;
 use VuFind\Tags;
 
@@ -70,6 +71,7 @@ class FavoritesServiceFactory implements FactoryInterface
             $serviceManager->get(UserListServiceInterface::class),
             $container->get(ResourcePopulator::class),
             $container->get(Tags::class),
+            $container->get(Loader::class),
             $container->get(\VuFind\Record\Cache::class),
             $session
         );

--- a/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
@@ -34,6 +34,7 @@ use Psr\Container\ContainerInterface;
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Record\ResourcePopulator;
+use VuFind\Tags;
 
 /**
  * Favorites service
@@ -66,6 +67,7 @@ class FavoritesServiceFactory implements FactoryInterface
             $serviceManager->get(ResourceServiceInterface::class),
             $serviceManager->get(UserListServiceInterface::class),
             $container->get(ResourcePopulator::class),
+            $container->get(Tags::class),
             $container->get(\VuFind\Record\Cache::class)
         );
     }

--- a/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
@@ -63,12 +63,15 @@ class FavoritesServiceFactory implements FactoryInterface
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
         $serviceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
+        $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
+        $session = new \Laminas\Session\Container('List', $sessionManager);
         return new FavoritesService(
             $serviceManager->get(ResourceServiceInterface::class),
             $serviceManager->get(UserListServiceInterface::class),
             $container->get(ResourcePopulator::class),
             $container->get(Tags::class),
-            $container->get(\VuFind\Record\Cache::class)
+            $container->get(\VuFind\Record\Cache::class),
+            $session
         );
     }
 }

--- a/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesServiceFactory.php
@@ -31,6 +31,7 @@ namespace VuFind\Favorites;
 
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
+use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Record\ResourcePopulator;
 
@@ -62,6 +63,7 @@ class FavoritesServiceFactory implements FactoryInterface
     {
         $serviceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
         return new FavoritesService(
+            $serviceManager->get(ResourceServiceInterface::class),
             $serviceManager->get(UserListServiceInterface::class),
             $container->get(ResourcePopulator::class),
             $container->get(\VuFind\Record\Cache::class)

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
@@ -31,6 +31,7 @@ namespace VuFind\View\Helper\Root;
 
 use Laminas\View\Helper\AbstractHelper;
 use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Entity\UserListEntityInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Favorites\FavoritesService;
 
@@ -89,5 +90,18 @@ class UserList extends AbstractHelper
     public function lastUsed()
     {
         return $this->favoritesService->getLastUsedList();
+    }
+
+    /**
+     * Is the provided user allowed to edit the provided list?
+     *
+     * @param ?UserEntityInterface    $user Logged-in user (null if none)
+     * @param UserListEntityInterface $list List to check
+     *
+     * @return bool
+     */
+    public function userCanEditList(?UserEntityInterface $user, UserListEntityInterface $list): bool
+    {
+        return $this->favoritesService->userCanEditList($user, $list);
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserList.php
@@ -29,10 +29,10 @@
 
 namespace VuFind\View\Helper\Root;
 
-use Laminas\Session\Container;
 use Laminas\View\Helper\AbstractHelper;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\UserListServiceInterface;
+use VuFind\Favorites\FavoritesService;
 
 /**
  * List view helper
@@ -48,13 +48,12 @@ class UserList extends AbstractHelper
     /**
      * Constructor
      *
-     * @param Container                $session         Session container (must use same namespace as
-     * container provided to \VuFind\Db\Table\UserList)
-     * @param UserListServiceInterface $userListService List database service
-     * @param string                   $mode            List mode (enabled or disabled)
+     * @param FavoritesService         $favoritesService Favorites service
+     * @param UserListServiceInterface $userListService  List database service
+     * @param string                   $mode             List mode (enabled or disabled)
      */
     public function __construct(
-        protected Container $session,
+        protected FavoritesService $favoritesService,
         protected UserListServiceInterface $userListService,
         protected string $mode = 'enabled'
     ) {
@@ -89,6 +88,6 @@ class UserList extends AbstractHelper
      */
     public function lastUsed()
     {
-        return $this->session->lastUsed ?? null;
+        return $this->favoritesService->getLastUsedList();
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserListFactory.php
@@ -35,6 +35,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use VuFind\Db\Service\UserListServiceInterface;
+use VuFind\Favorites\FavoritesService;
 
 /**
  * UserList helper factory.
@@ -69,11 +70,9 @@ class UserListFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $sessionManager = $container->get(\Laminas\Session\SessionManager::class);
-        $session = new \Laminas\Session\Container('List', $sessionManager);
         $capabilities = $container->get(\VuFind\Config\AccountCapabilities::class);
         return new $requestedName(
-            $session,
+            $container->get(FavoritesService::class),
             $container->get(\VuFind\Db\Service\PluginManager::class)->get(UserListServiceInterface::class),
             $capabilities->getListSetting()
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Favorites/FavoritesServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Favorites/FavoritesServiceTest.php
@@ -32,9 +32,11 @@ namespace VuFindTest\Favorites;
 use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Entity\UserListEntityInterface;
+use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Favorites\FavoritesService;
 use VuFind\Record\ResourcePopulator;
+use VuFind\Tags;
 
 /**
  * FavoritesService Test Class
@@ -57,8 +59,10 @@ class FavoritesServiceTest extends \PHPUnit\Framework\TestCase
     protected function getFavoritesService(?UserListServiceInterface $listService = null): FavoritesService
     {
         return new FavoritesService(
+            $this->createMock(ResourceServiceInterface::class),
             $listService ?? $this->createMock(UserListServiceInterface::class),
-            $this->createMock(ResourcePopulator::class)
+            $this->createMock(ResourcePopulator::class),
+            $this->createMock(Tags::class)
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Favorites/FavoritesServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Favorites/FavoritesServiceTest.php
@@ -35,6 +35,7 @@ use VuFind\Db\Entity\UserListEntityInterface;
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 use VuFind\Favorites\FavoritesService;
+use VuFind\Record\Loader;
 use VuFind\Record\ResourcePopulator;
 use VuFind\Tags;
 
@@ -62,7 +63,8 @@ class FavoritesServiceTest extends \PHPUnit\Framework\TestCase
             $this->createMock(ResourceServiceInterface::class),
             $listService ?? $this->createMock(UserListServiceInterface::class),
             $this->createMock(ResourcePopulator::class),
-            $this->createMock(Tags::class)
+            $this->createMock(Tags::class),
+            $this->createMock(Loader::class)
         );
     }
 

--- a/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
+++ b/themes/bootstrap3/templates/myresearch/bulk-action-buttons.phtml
@@ -20,7 +20,7 @@
           ]
       )
     ?>
-    <?php if ((null !== $this->list && $this->list->editAllowed($user)) || null === $this->list && $user): ?>
+    <?php if ((null !== $this->list && $this->userlist()->userCanEditList($user, $list)) || null === $this->list && $user): ?>
       <?=
         $this->bulkAction()->button(
             'delete',

--- a/themes/bootstrap3/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap3/templates/myresearch/mylist.phtml
@@ -54,7 +54,7 @@
     </div>
     <div class="search-controls">
       <?php if (isset($list)): ?>
-        <?php if ($list->editAllowed($account->getUserObject())): ?>
+        <?php if ($this->userlist()->userCanEditList($account->getUserObject(), $list)): ?>
           <a href="<?=$this->url('editList', ['id' => $list->getId()]) ?>" class="btn btn-link icon-link">
             <?=$this->icon('user-list-edit', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('edit_list')?></span>

--- a/themes/bootstrap5/templates/myresearch/bulk-action-buttons.phtml
+++ b/themes/bootstrap5/templates/myresearch/bulk-action-buttons.phtml
@@ -20,7 +20,7 @@
           ]
       )
     ?>
-    <?php if ((null !== $this->list && $this->list->editAllowed($user)) || null === $this->list && $user): ?>
+    <?php if ((null !== $this->list && $this->userlist()->userCanEditList($user, $list)) || null === $this->list && $user): ?>
       <?=
         $this->bulkAction()->button(
             'delete',

--- a/themes/bootstrap5/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap5/templates/myresearch/mylist.phtml
@@ -54,7 +54,7 @@
     </div>
     <div class="search-controls">
       <?php if (isset($list)): ?>
-        <?php if ($list->editAllowed($account->getUserObject())): ?>
+        <?php if ($this->userlist()->userCanEditList($account->getUserObject(), $list)): ?>
           <a href="<?=$this->url('editList', ['id' => $list->getId()]) ?>" class="btn btn-link icon-link">
             <?=$this->icon('user-list-edit', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('edit_list')?></span>


### PR DESCRIPTION
Favorites and list logic is scattered around, not always in a logical way; this PR consolidates more logic in the FavoritesService.

TODO
- [x] Update changelog when merging (constructor signature changes, removal of UserList::save and updateFromRequest methods, deprecation of Favorites controller plugin)