### PR TITLE
Add markDeleted() to ChangeTrackerService.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/ChangeTrackerService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ChangeTrackerService.php
@@ -120,6 +120,21 @@ class ChangeTrackerService extends AbstractDbService implements
     }
 
     /**
+     * Update the change tracker table to indicate that a record has been deleted.
+     *
+     * The method returns the updated/created row when complete.
+     *
+     * @param string $core The Solr core holding the record.
+     * @param string $id   The ID of the record being indexed.
+     *
+     * @return ChangeTrackerEntityInterface
+     */
+    public function markDeleted(string $core, string $id): ChangeTrackerEntityInterface
+    {
+        return $this->getDbTable('ChangeTracker')->markDeleted($core, $id);
+    }
+
+    /**
      * Update the change_tracker table to reflect that a record has been indexed.
      * We need to know the date of the last change to the record (independent of
      * its addition to the index) in order to tell the difference between a

--- a/module/VuFind/src/VuFind/Db/Service/ChangeTrackerServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/ChangeTrackerServiceInterface.php
@@ -87,6 +87,18 @@ interface ChangeTrackerServiceInterface extends DbServiceInterface
     ): array;
 
     /**
+     * Update the change tracker table to indicate that a record has been deleted.
+     *
+     * The method returns the updated/created row when complete.
+     *
+     * @param string $core The Solr core holding the record.
+     * @param string $id   The ID of the record being indexed.
+     *
+     * @return ChangeTrackerEntityInterface
+     */
+    public function markDeleted(string $core, string $id): ChangeTrackerEntityInterface;
+
+    /**
      * Update the change_tracker table to reflect that a record has been indexed.
      * We need to know the date of the last change to the record (independent of
      * its addition to the index) in order to tell the difference between a

--- a/module/VuFind/src/VuFind/Solr/Writer.php
+++ b/module/VuFind/src/VuFind/Solr/Writer.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\Solr;
 
-use VuFind\Db\Table\ChangeTracker;
+use VuFind\Db\Service\ChangeTrackerServiceInterface;
 use VuFindSearch\Backend\Solr\Command\WriteDocumentCommand;
 use VuFindSearch\Backend\Solr\Document\CommitDocument;
 use VuFindSearch\Backend\Solr\Document\DeleteDocument;
@@ -52,29 +52,15 @@ use function func_get_args;
 class Writer
 {
     /**
-     * Search service
-     *
-     * @var Service
-     */
-    protected $searchService;
-
-    /**
-     * Change tracker database table gateway
-     *
-     * @var ChangeTracker
-     */
-    protected $changeTracker;
-
-    /**
      * Constructor
      *
-     * @param Service       $service Search service
-     * @param ChangeTracker $tracker Change tracker database table gateway
+     * @param Service       $searchService Search service
+     * @param ChangeTracker $changeTracker Change tracker database service
      */
-    public function __construct(Service $service, ChangeTracker $tracker)
-    {
-        $this->searchService = $service;
-        $this->changeTracker = $tracker;
+    public function __construct(
+        protected Service $searchService,
+        protected ChangeTrackerServiceInterface $changeTracker
+    ) {
     }
 
     /**

--- a/module/VuFind/src/VuFind/Solr/Writer.php
+++ b/module/VuFind/src/VuFind/Solr/Writer.php
@@ -54,8 +54,8 @@ class Writer
     /**
      * Constructor
      *
-     * @param Service       $searchService Search service
-     * @param ChangeTracker $changeTracker Change tracker database service
+     * @param Service                       $searchService Search service
+     * @param ChangeTrackerServiceInterface $changeTracker Change tracker database service
      */
     public function __construct(
         protected Service $searchService,

--- a/module/VuFind/src/VuFind/Solr/WriterFactory.php
+++ b/module/VuFind/src/VuFind/Solr/WriterFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Db\Service\ChangeTrackerServiceInterface;
 
 /**
  * Solr writer factory.
@@ -68,11 +69,9 @@ class WriterFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $changeTracker = $container->get(\VuFind\Db\Table\PluginManager::class)
-            ->get('changetracker');
         return new $requestedName(
             $container->get(\VuFindSearch\Service::class),
-            $changeTracker
+            $container->get(\VuFind\Db\Service\PluginManager::class)->get(ChangeTrackerServiceInterface::class)
         );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Solr/WriterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Solr/WriterTest.php
@@ -29,12 +29,14 @@
 
 namespace VuFindTest\Solr;
 
-use VuFind\Db\Table\ChangeTracker;
+use PHPUnit\Framework\MockObject\MockObject;
+use VuFind\Db\Service\ChangeTrackerServiceInterface;
 use VuFind\Solr\Writer;
 use VuFindSearch\Backend\Solr\Command\WriteDocumentCommand;
 use VuFindSearch\Backend\Solr\Document\CommitDocument;
 use VuFindSearch\Backend\Solr\Document\DeleteDocument;
 use VuFindSearch\Backend\Solr\Document\OptimizeDocument;
+use VuFindSearch\Service as SearchService;
 
 /**
  * Solr Utils Test Class
@@ -52,10 +54,9 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCommit()
+    public function testCommit(): void
     {
-        $expectedCommand
-            = new WriteDocumentCommand('Solr', new CommitDocument(), 60 * 60);
+        $expectedCommand = new WriteDocumentCommand('Solr', new CommitDocument(), 60 * 60);
         $this->getWriter($expectedCommand)->commit('Solr');
     }
 
@@ -64,7 +65,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSave()
+    public function testSave(): void
     {
         $commit = new CommitDocument();
         $expectedCommand = new WriteDocumentCommand('Solr', $commit);
@@ -76,7 +77,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSaveWithNonDefaults()
+    public function testSaveWithNonDefaults(): void
     {
         $csv = new \VuFindSearch\Backend\Solr\Document\RawCSVDocument('a,b,c');
         $params = new \VuFindSearch\ParamBag(['foo' => 'bar']);
@@ -87,8 +88,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
             'customUpdateHandler',
             $params
         );
-        $this->getWriter($expectedCommand)
-            ->save('Solr', $csv, 'customUpdateHandler', $params);
+        $this->getWriter($expectedCommand)->save('Solr', $csv, 'customUpdateHandler', $params);
     }
 
     /**
@@ -96,10 +96,9 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testOptimize()
+    public function testOptimize(): void
     {
-        $expectedCommand
-            = new WriteDocumentCommand('Solr', new OptimizeDocument(), 60 * 60 * 24);
+        $expectedCommand = new WriteDocumentCommand('Solr', new OptimizeDocument(), 60 * 60 * 24);
         $this->getWriter($expectedCommand)->optimize('Solr');
     }
 
@@ -108,7 +107,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testDeleteAll()
+    public function testDeleteAll(): void
     {
         $deleteDoc = new DeleteDocument();
         $deleteDoc->addQuery('*:*');
@@ -121,25 +120,22 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testDeleteRecords()
+    public function testDeleteRecords(): void
     {
         $deleteDoc = new DeleteDocument();
         $deleteDoc->addKeys(['foo', 'bar']);
         $expectedCommand = new WriteDocumentCommand('Solr', $deleteDoc);
-        $this->getWriter($expectedCommand, ['core' => 'biblio'])
-            ->deleteRecords('Solr', ['foo', 'bar']);
+        $this->getWriter($expectedCommand, ['core' => 'biblio'])->deleteRecords('Solr', ['foo', 'bar']);
     }
 
     /**
      * Get mock change tracker
      *
-     * @return ChangeTracker
+     * @return MockObject&ChangeTrackerServiceInterface
      */
-    protected function getMockChangeTracker()
+    protected function getMockChangeTracker(): MockObject&ChangeTrackerServiceInterface
     {
-        return $this->getMockBuilder(\VuFind\Db\Table\ChangeTracker::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(ChangeTrackerServiceInterface::class);
     }
 
     /**
@@ -150,20 +146,16 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return MockObject&SearchService
      */
-    protected function getMockSearchService($expectedCommand, $result)
+    protected function getMockSearchService($expectedCommand, $result): MockObject&SearchService
     {
-        $resultCommand = $this->getMockBuilder($expectedCommand::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $resultCommand->expects($this->once())->method('getResult')
-            ->willReturn($result);
+        $resultCommand = $this->createMock($expectedCommand::class);
+        $resultCommand->expects($this->once())->method('getResult')->willReturn($result);
 
-        $searchService = $this->getMockBuilder(\VuFindSearch\Service::class)
-            ->getMock();
+        $searchService = $this->createMock(\VuFindSearch\Service::class);
         $searchService->expects($this->once())
             ->method('invoke')
             ->with($expectedCommand)
-            ->will($this->returnValue($resultCommand));
+            ->willReturn($resultCommand);
         return $searchService;
     }
 
@@ -175,7 +167,7 @@ class WriterTest extends \PHPUnit\Framework\TestCase
      *
      * @return Writer
      */
-    protected function getWriter($expectedCommand, $result = 'TEST')
+    protected function getWriter($expectedCommand, $result = 'TEST'): Writer
     {
         return new Writer(
             $this->getMockSearchService($expectedCommand, $result),


### PR DESCRIPTION
This finishes setting up the ChangeTrackerService in place of the equivalent table.