### PR TITLE
Increase error tolerance: Wikipedia outage shouldn't break author page.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
@@ -203,7 +203,7 @@ class AuthorInfo implements RecommendInterface, TranslatorAwareInterface
         try {
             return stristr($this->sources, 'wikipedia') ? $this->wikipedia->get($this->getAuthor()) : null;
         } catch (Exception $e) {
-            error_log("Unexpected error while loading author info: " . $e->getMessage());
+            error_log("Unexpected error while loading author info: {$e->getMessage()}");
             return null;
         }
     }

--- a/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Recommend;
 
+use Exception;
 use Laminas\I18n\Translator\TranslatorInterface;
 use VuFind\Connection\Wikipedia;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
@@ -199,8 +200,12 @@ class AuthorInfo implements RecommendInterface, TranslatorAwareInterface
     public function getAuthorInfo()
     {
         // Don't load Wikipedia content if Wikipedia is disabled:
-        return stristr($this->sources, 'wikipedia')
-            ? $this->wikipedia->get($this->getAuthor()) : null;
+        try {
+            return stristr($this->sources, 'wikipedia') ? $this->wikipedia->get($this->getAuthor()) : null;
+        } catch (Exception $e) {
+            error_log("Unexpected error while loading author info: " . $e->getMessage());
+            return null;
+        }
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuthorControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuthorControllerTest.php
@@ -41,6 +41,25 @@ namespace VuFindTest\Mink;
 class AuthorControllerTest extends \VuFindTest\Integration\MinkTestCase
 {
     /**
+     * Standard setup method that runs before each test.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup config
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Content' => ['authors' => false], // turn off Wikipedia for testing
+                ],
+            ]
+        );
+    }
+
+    /**
      * Test searching for an author in the author module
      *
      * @return void


### PR DESCRIPTION
I noticed that when my test environment lost network connectivity, author-related integration tests would fail because of Wikipedia being inaccesssible. We really don't want a Wikipedia outage to be a single point of failure for VuFind's author module, so this PR makes the AuthorInfo module more error-tolerant, so it logs a problem instead of throwing an exception if it fails to retrieve Wikipedia data.

Also, independently of this fix, I've disabled wikipedia in the author controller tests, since it's better not to waste time calling third-party APIs during integration testing, especially since we're not currently looking at the results (we could make an exception to turn it on if we want to explicitly test it in the future, of course).