### PR TITLE
Improve method names/terminology -- use record instead of resource.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/CommentsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsService.php
@@ -89,14 +89,14 @@ class CommentsService extends AbstractDbService implements
     }
 
     /**
-     * Get comments associated with the specified resource.
+     * Get comments associated with the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
      *
      * @return CommentsEntityInterface[]
      */
-    public function getForResource(string $id, string $source = DEFAULT_SEARCH_BACKEND): array
+    public function getRecordComments(string $id, string $source = DEFAULT_SEARCH_BACKEND): array
     {
         $comments = $this->getDbTable('comments')->getForResource($id, $source);
         return is_array($comments) ? $comments : iterator_to_array($comments);

--- a/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
@@ -67,14 +67,14 @@ interface CommentsServiceInterface extends DbServiceInterface
     ): ?int;
 
     /**
-     * Get comments associated with the specified resource.
+     * Get comments associated with the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
      *
      * @return CommentsEntityInterface[]
      */
-    public function getForResource(string $id, string $source = DEFAULT_SEARCH_BACKEND): array;
+    public function getRecordComments(string $id, string $source = DEFAULT_SEARCH_BACKEND): array;
 
     /**
      * Delete a comment if the owner is logged in.  Returns true on success.

--- a/module/VuFind/src/VuFind/Db/Service/RatingsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/RatingsService.php
@@ -52,7 +52,7 @@ class RatingsService extends AbstractDbService implements
     use DbTableAwareTrait;
 
     /**
-     * Get average rating and rating count associated with the specified resource.
+     * Get average rating and rating count associated with the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
@@ -60,13 +60,13 @@ class RatingsService extends AbstractDbService implements
      *
      * @return array Array with keys count and rating (between 0 and 100)
      */
-    public function getForResource(string $id, string $source, ?int $userId): array
+    public function getRecordRatings(string $id, string $source, ?int $userId): array
     {
         return $this->getDbTable('ratings')->getForResource($id, $source, $userId);
     }
 
     /**
-     * Get rating breakdown for the specified resource.
+     * Get rating breakdown for the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
@@ -75,7 +75,7 @@ class RatingsService extends AbstractDbService implements
      * @return array Array with keys count and rating (between 0 and 100) as well as
      * an groups array with ratings from lowest to highest
      */
-    public function getCountsForResource(
+    public function getCountsForRecord(
         string $id,
         string $source,
         array $groups

--- a/module/VuFind/src/VuFind/Db/Service/RatingsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/RatingsServiceInterface.php
@@ -44,7 +44,7 @@ use VuFind\Db\Entity\UserEntityInterface;
 interface RatingsServiceInterface extends DbServiceInterface
 {
     /**
-     * Get average rating and rating count associated with the specified resource.
+     * Get average rating and rating count associated with the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
@@ -52,10 +52,10 @@ interface RatingsServiceInterface extends DbServiceInterface
      *
      * @return array Array with keys count and rating (between 0 and 100)
      */
-    public function getForResource(string $id, string $source, ?int $userId): array;
+    public function getRecordRatings(string $id, string $source, ?int $userId): array;
 
     /**
-     * Get rating breakdown for the specified resource.
+     * Get rating breakdown for the specified record.
      *
      * @param string $id     Record ID to look up
      * @param string $source Source of record to look up
@@ -64,7 +64,7 @@ interface RatingsServiceInterface extends DbServiceInterface
      * @return array Array with keys count and rating (between 0 and 100) as well as
      * an groups array with ratings from lowest to highest
      */
-    public function getCountsForResource(
+    public function getCountsForRecord(
         string $id,
         string $source,
         array $groups

--- a/module/VuFind/src/VuFind/Ratings/RatingsService.php
+++ b/module/VuFind/src/VuFind/Ratings/RatingsService.php
@@ -83,7 +83,7 @@ class RatingsService
         $source = $driver->getSourceIdentifier();
         $cacheKey = $recordId . '-' . $source . '-' . ($userId ?? '');
         if (!isset($this->ratingCache[$cacheKey])) {
-            $this->ratingCache[$cacheKey] = $this->dbService->getForResource($recordId, $source, $userId);
+            $this->ratingCache[$cacheKey] = $this->dbService->getRecordRatings($recordId, $source, $userId);
         }
         return $this->ratingCache[$cacheKey];
     }
@@ -104,7 +104,7 @@ class RatingsService
      */
     public function getRatingBreakdown(RecordDriver $driver, array $groups)
     {
-        return $this->dbService->getCountsForResource(
+        return $this->dbService->getCountsForRecord(
             $driver->getUniqueId(),
             $driver->getSourceIdentifier(),
             $groups

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -154,11 +154,11 @@ abstract class AbstractBase implements
      *
      * @return array
      *
-     * @deprecated Use CommentsServiceInterface::getForResource()
+     * @deprecated Use CommentsServiceInterface::getRecordComments()
      */
     public function getComments()
     {
-        return $this->getDbService(CommentsServiceInterface::class)->getForResource(
+        return $this->getDbService(CommentsServiceInterface::class)->getRecordComments(
             $this->getUniqueId(),
             $this->getSourceIdentifier()
         );
@@ -272,7 +272,7 @@ abstract class AbstractBase implements
             $ratingsService = $this->getDbService(
                 \VuFind\Db\Service\RatingsServiceInterface::class
             );
-            $this->ratingCache[$cacheKey] = $ratingsService->getForResource(
+            $this->ratingCache[$cacheKey] = $ratingsService->getRecordRatings(
                 $this->getUniqueId(),
                 $this->getSourceIdentifier(),
                 $userId
@@ -299,7 +299,7 @@ abstract class AbstractBase implements
     public function getRatingBreakdown(array $groups)
     {
         return $this->getDbService(\VuFind\Db\Service\RatingsServiceInterface::class)
-            ->getCountsForResource(
+            ->getCountsForRecord(
                 $this->getUniqueId(),
                 $this->getSourceIdentifier(),
                 $groups

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -186,7 +186,7 @@ class Record extends \Laminas\View\Helper\AbstractHelper implements DbServiceAwa
      */
     public function getComments(): array
     {
-        return $this->getDbService(CommentsServiceInterface::class)->getForResource(
+        return $this->getDbService(CommentsServiceInterface::class)->getRecordComments(
             $this->driver->getUniqueId(),
             $this->driver->getSourceIdentifier()
         );


### PR DESCRIPTION
Methods that use record ID+source should not have "resource" in the name, because this leads to confusion with the resource table. This PR clarifies this terminology and replaces getForResource() with more specific method names to make the code easier to analyze and navigate.

This complements parallel renaming of tag methods in #3771 to make everything consistent.