### PR TITLE
Fix: Always retrieve database services by interface.

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -226,7 +226,7 @@ class Bootstrapper
                 && $user->getLastLanguage() != $language
             ) {
                 $user->setLastLanguage($language);
-                $this->getDbService(\VuFind\Db\Service\UserService::class)->persistEntity($user);
+                $this->getDbService(\VuFind\Db\Service\UserServiceInterface::class)->persistEntity($user);
             }
         };
         $this->events->attach('dispatch.error', $callback);

--- a/module/VuFind/src/VuFind/Db/Row/PrivateUser.php
+++ b/module/VuFind/src/VuFind/Db/Row/PrivateUser.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Row;
 
+use VuFind\Auth\UserSessionPersistenceInterface;
+
 use function array_key_exists;
 
 /**
@@ -64,7 +66,7 @@ class PrivateUser extends User
     {
         $this->initialize();
         $this->id = -1; // fake ID
-        $this->getDbService(\VuFind\Db\Service\UserService::class)->addUserDataToSession($this);
+        $this->getDbService(UserSessionPersistenceInterface::class)->addUserDataToSession($this);
         return 1;
     }
 

--- a/module/VuFind/src/VuFind/Db/Row/UserCard.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserCard.php
@@ -258,6 +258,6 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      */
     public function getUser(): UserEntityInterface
     {
-        return $this->getDbService(\VuFind\Db\Service\UserService::class)->getUserById($this->user_id);
+        return $this->getDbService(\VuFind\Db\Service\UserServiceInterface::class)->getUserById($this->user_id);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/PluginManager.php
+++ b/module/VuFind/src/VuFind/Db/Service/PluginManager.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Db\Service;
 
+use VuFind\Auth\UserSessionPersistenceInterface;
+
 /**
  * Database service plugin manager
  *
@@ -62,6 +64,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         UserListServiceInterface::class => UserListService::class,
         UserResourceServiceInterface::class => UserResourceService::class,
         UserServiceInterface::class => UserService::class,
+        UserSessionPersistenceInterface::class => UserService::class,
     ];
 
     /**


### PR DESCRIPTION
There were a few places where we were accidentally retrieving services using `UserService::class` instead of the appropriate interface. I set up an alias for `UserSessionPersistenceInterface` so we can retrieve the service by that interface when needed. It's not a perfect solution, but I think it's clearer (and better for static analysis and future refactoring) than what we were doing before.