### PR TITLE
Refactor Favorites search results to use database service

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/ResourceService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceService.php
@@ -31,6 +31,8 @@
 namespace VuFind\Db\Service;
 
 use VuFind\Db\Entity\ResourceEntityInterface;
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Entity\UserListEntityInterface;
 use VuFind\Db\Table\Resource;
 
 /**
@@ -120,5 +122,38 @@ class ResourceService extends AbstractDbService implements ResourceServiceInterf
             $select->where->equalTo('source', $source);
         };
         return iterator_to_array($this->resourceTable->select($callback));
+    }
+
+    /**
+     * Get a set of resources from the requested favorite list.
+     *
+     * @param UserEntityInterface|int          $userOrId ID of user owning favorite list
+     * @param UserListEntityInterface|int|null $listOrId ID of list to retrieve (null for all favorites)
+     * @param string[]                         $tags     Tags to use for limiting results
+     * @param ?string                          $sort     Resource table field to use for sorting (null for no
+     * particular sort).
+     * @param int                              $offset   Offset for results
+     * @param ?int                             $limit    Limit for results (null for none)
+     *
+     * @return ResourceEntityInterface[]
+     */
+    public function getFavorites(
+        UserEntityInterface|int $userOrId,
+        UserListEntityInterface|int|null $listOrId = null,
+        array $tags = [],
+        ?string $sort = null,
+        int $offset = 0,
+        ?int $limit = null
+    ): array {
+        return iterator_to_array(
+            $this->resourceTable->getFavorites(
+                $userOrId instanceof UserEntityInterface ? $userOrId->getId() : $userOrId,
+                $listOrId instanceof UserListEntityInterface ? $listOrId->getId() : $listOrId,
+                $tags,
+                $sort,
+                $offset,
+                $limit
+            )
+        );
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/ResourceServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceServiceInterface.php
@@ -31,6 +31,8 @@
 namespace VuFind\Db\Service;
 
 use VuFind\Db\Entity\ResourceEntityInterface;
+use VuFind\Db\Entity\UserEntityInterface;
+use VuFind\Db\Entity\UserListEntityInterface;
 
 /**
  * Database service interface for resource.
@@ -90,4 +92,26 @@ interface ResourceServiceInterface extends DbServiceInterface
      * @return ResourceEntityInterface[]
      */
     public function getResourcesByRecordIds(array $ids, string $source = DEFAULT_SEARCH_BACKEND): array;
+
+    /**
+     * Get a set of resources from the requested favorite list.
+     *
+     * @param UserEntityInterface|int          $userOrId ID of user owning favorite list
+     * @param UserListEntityInterface|int|null $listOrId ID of list to retrieve (null for all favorites)
+     * @param string[]                         $tags     Tags to use for limiting results
+     * @param ?string                          $sort     Resource table field to use for sorting (null for no
+     * particular sort).
+     * @param int                              $offset   Offset for results
+     * @param ?int                             $limit    Limit for results (null for none)
+     *
+     * @return ResourceEntityInterface[]
+     */
+    public function getFavorites(
+        UserEntityInterface|int $userOrId,
+        UserListEntityInterface|int|null $listOrId = null,
+        array $tags = [],
+        ?string $sort = null,
+        int $offset = 0,
+        ?int $limit = null
+    ): array;
 }

--- a/module/VuFind/src/VuFind/Search/Favorites/Results.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/Results.php
@@ -189,38 +189,32 @@ class Results extends BaseResults implements AuthorizationServiceAwareInterface
         $userId = $list ? $list->getUser()->getId() : $this->user->getId();
         $listId = $list?->getId();
         // Get results as an array so that we can rewind it:
-        $rawResults = $this->resourceTable->getFavorites(
-            $userId,
-            $listId,
-            $this->getTagFilters(),
-            $this->getParams()->getSort()
-        )->toArray();
+        $rawResults = iterator_to_array(
+            $this->resourceTable->getFavorites(
+                $userId,
+                $listId,
+                $this->getTagFilters(),
+                $this->getParams()->getSort()
+            )
+        );
         $this->resultTotal = count($rawResults);
         $this->allIds = array_map(function ($result) {
-            return $result['source'] . '|' . $result['record_id'];
+            return $result->getSource() . '|' . $result->getRecordId();
         }, $rawResults);
 
         // Apply offset and limit if necessary!
         $limit = $this->getParams()->getLimit();
         if ($this->resultTotal > $limit) {
-            // Get results as an array so that we can rewind it:
-            $rawResults = $this->resourceTable->getFavorites(
-                $userId,
-                $listId,
-                $this->getTagFilters(),
-                $this->getParams()->getSort(),
-                $this->getStartRecord() - 1,
-                $limit
-            )->toArray();
+            $rawResults = array_slice($rawResults, $this->getStartRecord() - 1, $limit);
         }
 
         // Retrieve record drivers for the selected items.
         $recordsToRequest = [];
         foreach ($rawResults as $row) {
             $recordsToRequest[] = [
-                'id' => $row['record_id'], 'source' => $row['source'],
+                'id' => $row->getRecordId(), 'source' => $row->getSource(),
                 'extra_fields' => [
-                    'title' => $row['title'],
+                    'title' => $row->getTitle(),
                 ],
             ];
         }

--- a/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Favorites/ResultsFactory.php
@@ -33,6 +33,7 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Service\UserListServiceInterface;
 
 /**
@@ -68,9 +69,10 @@ class ResultsFactory extends \VuFind\Search\Results\ResultsFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory!');
         }
-        $resourceTable = $container->get(\VuFind\Db\Table\PluginManager::class)->get('Resource');
-        $listService = $container->get(\VuFind\Db\Service\PluginManager::class)->get(UserListServiceInterface::class);
-        $obj = parent::__invoke($container, $requestedName, [$resourceTable, $listService]);
+        $serviceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
+        $resourceService = $serviceManager->get(ResourceServiceInterface::class);
+        $listService = $serviceManager->get(UserListServiceInterface::class);
+        $obj = parent::__invoke($container, $requestedName, [$resourceService, $listService]);
         $init = new \LmcRbacMvc\Initializer\AuthorizationServiceInitializer();
         $init($container, $obj);
         return $obj;


### PR DESCRIPTION
This refactors the favorite list retrieval to use ResourceEntityInterface and ResourceServiceInterface. It also improves efficiency by using in-database subquerying and eliminating double-retrieval of data. It's still inefficient that the entire list is being retrieved all the time, but this is a necessary evil to support persistent selections (and is not a new problem introduced here).