### PR TITLE
Make unique tag sort unambiguous.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Table/ResourceTags.php
@@ -561,7 +561,7 @@ class ResourceTags extends Gateway implements DbServiceAwareInterface
                 $select->where->equalTo('resource_tags.tag_id', $tagId);
             }
             $select->group(['tag_id', 'tag']);
-            $select->order([new Expression('lower(tag)')]);
+            $select->order([new Expression('lower(tag)'), 'tag']);
         };
         return $this->select($callback);
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -491,9 +491,11 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // We expect specific form name and site URL values:
         $this->assertEquals('All username2', $this->findCss($page, '#user_id')->getText());
+        // We need to do a case-insensitive comparison here because different database engines
+        // may make different decisions about uppercase-first vs. lowercase-first:
         $this->assertEquals(
-            'All five new tag one ONE three 4 THREE 4',
-            $this->findCss($page, '#tag_id')->getText()
+            strtolower('All five new tag ONE one THREE 4 three 4'),
+            strtolower($this->findCss($page, '#tag_id')->getText())
         );
 
         // Apply a filter to see just the "five" tag (we need to extract the ID value
@@ -542,9 +544,11 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '#type')->setValue('tag');
         $this->clickCss($page, 'input[value="Submit"]');
         $this->waitForPageLoad($page);
+        // We need to do a case-insensitive comparison here because different database engines
+        // may make different decisions about uppercase-first vs. lowercase-first:
         $this->assertEquals(
-            'new tag one ONE three 4 THREE 4',
-            $this->findCss($page, '#tag_id')->getText()
+            strtolower('new tag ONE one THREE 4 three 4'),
+            strtolower($this->findCss($page, '#tag_id')->getText())
         );
         $this->clickCss($page, 'input[value="Delete Tags"]');
         $this->waitForPageLoad($page);


### PR DESCRIPTION
This PR addresses the test failure reported by @ThoWagen in #3779. Unique tag retrieval was ambiguous due to lowercase sorting; this adds case-sensitive sorting as a tie-breaker. However, even with this unambiguous approach, different database engines make different decisions about sorting by case, so the test has also been made case-insensitive to ensure that it passes for both MySQL and PostgreSQL environments.