### PR TITLE
Upgrade PHPUnit to 10.5.20; fix deprecation warnings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,9 +109,9 @@
         "friendsofphp/php-cs-fixer": "3.51.0",
         "phpmd/phpmd": "2.15.0",
         "phpstan/phpstan": "1.10.59",
-        "phpunit/php-code-coverage": "10.1.11",
+        "phpunit/php-code-coverage": "10.1.14",
         "phpunit/phpcov": "^9.0",
-        "phpunit/phpunit": "10.5.11",
+        "phpunit/phpunit": "10.5.20",
         "pietercolpaert/hardf": "0.4.0",
         "squizlabs/php_codesniffer": "3.9.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf708734d0ccd237a6ce31bea87dfbd7",
+    "content-hash": "8c23dfaaf1e9ac5721a7953e89a75f39",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -10891,16 +10891,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.11",
+            "version": "10.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
                 "shasum": ""
             },
             "require": {
@@ -10957,7 +10957,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
             },
             "funding": [
                 {
@@ -10965,7 +10965,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T15:38:30+00:00"
+            "time": "2024-03-12T15:33:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -11274,16 +11274,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.11",
+            "version": "10.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4"
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4",
-                "reference": "0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
                 "shasum": ""
             },
             "require": {
@@ -11355,7 +11355,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
             },
             "funding": [
                 {
@@ -11371,7 +11371,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-25T14:05:00+00:00"
+            "time": "2024-04-24T06:32:35+00:00"
         },
         {
             "name": "phrity/net-uri",

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrMarcTest.php
@@ -194,8 +194,8 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
         ];
         return [
             'field config' => [
-                'config' => 'numerical',
-                'results' => [
+                'numerical',
+                [
                     [
                         'Street photography',
                         'Mexico',
@@ -212,12 +212,12 @@ class SolrMarcTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'record config' => [
-                'config' => 'record',
-                'results' => $recordOrderResults,
+                'record',
+                $recordOrderResults,
             ],
             'default config' => [
-                'config' => null,
-                'results' => $recordOrderResults,
+                null,
+                $recordOrderResults,
             ],
         ];
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -610,7 +610,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Single value' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -626,7 +626,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Two values' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => [
@@ -651,7 +651,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Value with SearchTypeIn condition' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -674,7 +674,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Value with SearchTypeNotIn condition' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -697,7 +697,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Value with NoDisMaxParams = [bf] condition' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -718,7 +718,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Value with SortIn condition' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -741,7 +741,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'Value with SortNotIn condition' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -829,7 +829,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'Search type in [test]' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -840,12 +840,12 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         ],
                     ],
                 ],
-                'expected' => [
+                'expectedFields' => [
                     'bq' => ['a:foo'],
                 ],
             ],
             'All search types in [test, test2]' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -856,12 +856,12 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         ],
                     ],
                 ],
-                'expected' => [
+                'expectedFields' => [
                     'bq' => ['a:foo'],
                 ],
             ],
             'All search types in [test, no]' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -872,12 +872,12 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         ],
                     ],
                 ],
-                'expected' => [
+                'expectedFields' => [
                     'bq' => null,
                 ],
             ],
             'All search types in [test, test2, no]' => [
-                'GlobalExtraParams' => [
+                'globalExtraParams' => [
                     [
                         'param' => 'bq',
                         'value' => 'a:foo',
@@ -888,7 +888,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                         ],
                     ],
                 ],
-                'expected' => [
+                'expectedFields' => [
                     'bq' => ['a:foo'],
                 ],
             ],


### PR DESCRIPTION
I've been encountering some PHPUnit issues recently, so I thought it would be worth upgrading to the latest patch release. The release introduces some new deprecation warnings, so this PR both upgrades the tool and fixes the deprecations (which were caused by text fixtures including named arguments that didn't match the corresponding method argument names).