### PR TITLE
Improve search table cleanup query.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/SearchService.php
+++ b/module/VuFind/src/VuFind/Db/Service/SearchService.php
@@ -57,8 +57,7 @@ class SearchService extends AbstractDbService implements SearchServiceInterface,
         $searchTable = $this->getDbTable('search');
         $allIds = $this->getDbTable('user')->getSql()->select()->columns(['id']);
         $searchCallback = function ($select) use ($allIds) {
-            $select->where->equalTo('user_id', '0')
-                ->OR->notIn('user_id', $allIds);
+            $select->where->isNotNull('user_id')->AND->notIn('user_id', $allIds);
         };
         $badRows = $searchTable->select($searchCallback);
         $count = count($badRows);


### PR DESCRIPTION
The search table cleanup query introduced in #3757 was flawed -- this PR fixes it to prevent false positive warnings during the upgrade process (null rows were getting re-set to null again unnecessarily).