### PR TITLE
OverDrive: Fix incorrect translation string in status-full.phtml.

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/status-full.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/SolrOverdrive/status-full.phtml
@@ -43,9 +43,7 @@ foreach ($ids as $id) {
             : ($avail->copiesAvailable . ' / ' . $avail->copiesOwned);
         $current['full_status'] .= ' ' . $this->transEsc('od_copies_available', ['%%copies%%' => $copies]);
         if ($avail->numberOfHolds > 0) {
-            $current['full_status'] .= '; ' . $avail->numberOfHolds
-              . ' ' . ($avail->numberOfHolds > 1 ? $this->transEsc('od_people') : $this->transEsc('od_person'))
-              . ' ' . $this->transEsc('od_waiting');
+            $current['full_status'] .= '; ' . $this->transEsc('od_waiting', ['holds' => $avail->numberOfHolds], null, true);
         }
     }
     $data[] = $current;

--- a/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/status-full.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/status-full.phtml
@@ -43,9 +43,7 @@ foreach ($ids as $id) {
             : ($avail->copiesAvailable . ' / ' . $avail->copiesOwned);
         $current['full_status'] .= ' ' . $this->transEsc('od_copies_available', ['%%copies%%' => $copies]);
         if ($avail->numberOfHolds > 0) {
-            $current['full_status'] .= '; ' . $avail->numberOfHolds
-              . ' ' . ($avail->numberOfHolds > 1 ? $this->transEsc('od_people') : $this->transEsc('od_person'))
-              . ' ' . $this->transEsc('od_waiting');
+            $current['full_status'] .= '; ' . $this->transEsc('od_waiting', ['holds' => $avail->numberOfHolds], null, true);
         }
     }
     $data[] = $current;


### PR DESCRIPTION
While loading translations, I happened to notice that overdrive/status-full.phtml was using an outdated version of the od_waiting translation. I believe this PR fixes the problem, but I can't easily test it. Could @bpalme or @maccabeelevine please take a look at this?