### PR TITLE
Introduce RecordIdUpdater service.

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -473,6 +473,7 @@ $config = [
             'VuFind\Record\Cache' => 'VuFind\Record\CacheFactory',
             'VuFind\Record\FallbackLoader\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Record\Loader' => 'VuFind\Record\LoaderFactory',
+            'VuFind\Record\RecordIdUpdater' => 'VuFind\Record\RecordIdUpdaterFactory',
             'VuFind\Record\ResourcePopulator' => 'VuFind\Record\ResourcePopulatorFactory',
             'VuFind\Record\Router' => 'VuFind\Service\ServiceWithConfigIniFactory',
             'VuFind\RecordDriver\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',

--- a/module/VuFind/src/VuFind/Db/Service/CommentsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsService.php
@@ -152,4 +152,17 @@ class CommentsService extends AbstractDbService implements
     {
         return $this->getDbTable('comments')->select(['id' => $id])->current();
     }
+
+    /**
+     * Change all matching comments to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void
+    {
+        $this->getDbTable('comments')->update(['resource_id' => $new], ['resource_id' => $old]);
+    }
 }

--- a/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/CommentsServiceInterface.php
@@ -110,4 +110,14 @@ interface CommentsServiceInterface extends DbServiceInterface
      * @return ?CommentsEntityInterface
      */
     public function getCommentById(int $id): ?CommentsEntityInterface;
+
+    /**
+     * Change all matching comments to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void;
 }

--- a/module/VuFind/src/VuFind/Db/Service/ResourceService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceService.php
@@ -48,7 +48,7 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:database_gateways Wiki
  */
-class ResourceService extends AbstractDbService implements ResourceServiceInterface
+class ResourceService extends AbstractDbService implements ResourceServiceInterface, Feature\TransactionInterface
 {
     /**
      * Constructor.
@@ -57,6 +57,39 @@ class ResourceService extends AbstractDbService implements ResourceServiceInterf
      */
     public function __construct(protected Resource $resourceTable)
     {
+    }
+
+    /**
+     * Begin a database transaction.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function beginTransaction(): void
+    {
+        $this->resourceTable->getAdapter()->getDriver()->getConnection()->beginTransaction();
+    }
+
+    /**
+     * Commit a database transaction.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function commitTransaction(): void
+    {
+        $this->resourceTable->getAdapter()->getDriver()->getConnection()->commit();
+    }
+
+    /**
+     * Roll back a database transaction.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function rollBackTransaction(): void
+    {
+        $this->resourceTable->getAdapter()->getDriver()->getConnection()->rollback();
     }
 
     /**
@@ -199,5 +232,18 @@ class ResourceService extends AbstractDbService implements ResourceServiceInterf
             $this->resourceTable->update(['source' => $new], $resourceWhere);
         }
         return $count;
+    }
+
+    /**
+     * Delete a resource entity.
+     *
+     * @param ResourceEntityInterface|int $resourceOrId Resource entity or ID value.
+     *
+     * @return void
+     */
+    public function deleteResource(ResourceEntityInterface|int $resourceOrId): void
+    {
+        $id = $resourceOrId instanceof ResourceEntityInterface ? $resourceOrId->getId() : $resourceOrId;
+        $this->resourceTable->delete(['id' => $id]);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Service/ResourceServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceServiceInterface.php
@@ -139,4 +139,13 @@ interface ResourceServiceInterface extends DbServiceInterface
      * @return int
      */
     public function renameSource(string $old, string $new): int;
+
+    /**
+     * Delete a resource entity.
+     *
+     * @param ResourceEntityInterface|int $resourceOrId Resource entity or ID value.
+     *
+     * @return void
+     */
+    public function deleteResource(ResourceEntityInterface|int $resourceOrId): void;
 }

--- a/module/VuFind/src/VuFind/Db/Service/ResourceTagsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceTagsService.php
@@ -324,4 +324,27 @@ class ResourceTagsService extends AbstractDbService implements
         $userId = $userOrId instanceof UserEntityInterface ? $userOrId->getId() : $userOrId;
         $this->getDbTable('ResourceTags')->assignAnonymousTags($userId);
     }
+
+    /**
+     * Change all matching rows to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void
+    {
+        $this->getDbTable('ResourceTags')->update(['resource_id' => $new], ['resource_id' => $old]);
+    }
+
+    /**
+     * Deduplicate rows (sometimes necessary after merging foreign key IDs).
+     *
+     * @return void
+     */
+    public function deduplicate(): void
+    {
+        $this->getDbTable('ResourceTags')->deduplicate();
+    }
 }

--- a/module/VuFind/src/VuFind/Db/Service/ResourceTagsServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceTagsServiceInterface.php
@@ -235,4 +235,21 @@ interface ResourceTagsServiceInterface extends DbServiceInterface
      * @return void
      */
     public function assignAnonymousTags(UserEntityInterface|int $userOrId): void;
+
+    /**
+     * Change all matching rows to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void;
+
+    /**
+     * Deduplicate rows (sometimes necessary after merging foreign key IDs).
+     *
+     * @return void
+     */
+    public function deduplicate(): void;
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserResourceService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserResourceService.php
@@ -148,4 +148,27 @@ class UserResourceService extends AbstractDbService implements
     {
         return $this->getDbTable('UserResource')->createRow();
     }
+
+    /**
+     * Change all matching rows to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void
+    {
+        $this->getDbTable('UserResource')->update(['resource_id' => $new], ['resource_id' => $old]);
+    }
+
+    /**
+     * Deduplicate rows (sometimes necessary after merging foreign key IDs).
+     *
+     * @return void
+     */
+    public function deduplicate(): void
+    {
+        $this->getDbTable('UserResource')->deduplicate();
+    }
 }

--- a/module/VuFind/src/VuFind/Db/Service/UserResourceServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserResourceServiceInterface.php
@@ -94,4 +94,21 @@ interface UserResourceServiceInterface extends DbServiceInterface
      * @return UserResourceEntityInterface
      */
     public function createEntity(): UserResourceEntityInterface;
+
+    /**
+     * Change all matching rows to use the new resource ID instead of the old one (called when an ID changes).
+     *
+     * @param int $old Original resource ID
+     * @param int $new New resource ID
+     *
+     * @return void
+     */
+    public function changeResourceId(int $old, int $new): void;
+
+    /**
+     * Deduplicate rows (sometimes necessary after merging foreign key IDs).
+     *
+     * @return void
+     */
+    public function deduplicate(): void;
 }

--- a/module/VuFind/src/VuFind/Db/Table/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Table/Resource.php
@@ -226,6 +226,8 @@ class Resource extends Gateway implements DbServiceAwareInterface
      * @param string $source Record source
      *
      * @return void
+     *
+     * @deprecated Use \VuFind\Record\RecordIdUpdater::updateRecordId()
      */
     public function updateRecordId($oldId, $newId, $source = DEFAULT_SEARCH_BACKEND)
     {

--- a/module/VuFind/src/VuFind/Record/FallbackLoader/AbstractFallbackLoader.php
+++ b/module/VuFind/src/VuFind/Record/FallbackLoader/AbstractFallbackLoader.php
@@ -30,7 +30,7 @@
 namespace VuFind\Record\FallbackLoader;
 
 use VuFind\Db\Service\ResourceServiceInterface;
-use VuFind\Db\Table\Resource;
+use VuFind\Record\RecordIdUpdater;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\RecordDriver\Feature\PreviousUniqueIdInterface;
 use VuFindSearch\Service;
@@ -56,13 +56,13 @@ abstract class AbstractFallbackLoader implements FallbackLoaderInterface
     /**
      * Constructor
      *
-     * @param Resource                 $table           Resource database table object
      * @param ResourceServiceInterface $resourceService Resource database service
+     * @param RecordIdUpdater          $recordIdUpdater Record ID updater service
      * @param Service                  $searchService   Search service
      */
     public function __construct(
-        protected Resource $table,
         protected ResourceServiceInterface $resourceService,
+        protected RecordIdUpdater $recordIdUpdater,
         protected Service $searchService
     ) {
     }
@@ -111,7 +111,6 @@ abstract class AbstractFallbackLoader implements FallbackLoaderInterface
         $record->setPreviousUniqueId($previousId);
 
         // Update the database to replace the obsolete identifier...
-        $this->table
-            ->updateRecordId($previousId, $record->getUniqueId(), $this->source);
+        $this->recordIdUpdater->updateRecordId($previousId, $record->getUniqueId(), $this->source);
     }
 }

--- a/module/VuFind/src/VuFind/Record/FallbackLoader/Solr.php
+++ b/module/VuFind/src/VuFind/Record/FallbackLoader/Solr.php
@@ -31,6 +31,7 @@ namespace VuFind\Record\FallbackLoader;
 
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Db\Table\Resource;
+use VuFind\Record\RecordIdUpdater;
 use VuFindSearch\Command\SearchCommand;
 use VuFindSearch\Service;
 
@@ -55,20 +56,19 @@ class Solr extends AbstractFallbackLoader
     /**
      * Constructor
      *
-     * @param Resource                 $table           Resource database table object
      * @param ResourceServiceInterface $resourceService Resource database service
+     * @param RecordIdUpdater          $recordIdUpdater Record ID updater service
      * @param Service                  $searchService   Search service
      * @param ?string                  $legacyIdField   Solr field containing legacy IDs (null to
      * disable lookups)
      */
     public function __construct(
-        Resource $table,
         ResourceServiceInterface $resourceService,
+        RecordIdUpdater $recordIdUpdater,
         Service $searchService,
         protected ?string $legacyIdField = 'previous_id_str_mv'
     ) {
-        parent::__construct($table, $resourceService, $searchService);
-        $this->legacyIdField = $legacyIdField;
+        parent::__construct($resourceService, $recordIdUpdater, $searchService);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Record/RecordIdUpdater.php
+++ b/module/VuFind/src/VuFind/Record/RecordIdUpdater.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Class for updating the database when a record ID changes.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Record
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+
+namespace VuFind\Record;
+
+use VuFind\Db\Service\CommentsServiceInterface;
+use VuFind\Db\Service\Feature\TransactionInterface;
+use VuFind\Db\Service\ResourceServiceInterface;
+use VuFind\Db\Service\ResourceTagsServiceInterface;
+use VuFind\Db\Service\UserResourceServiceInterface;
+
+/**
+ * Class for updating the database when a record ID changes.
+ *
+ * @category VuFind
+ * @package  Record
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class RecordIdUpdater
+{
+    /**
+     * Constructor
+     *
+     * @param ResourceServiceInterface&TransactionInterface $resourceService     Resource database service
+     * @param CommentsServiceInterface                      $commentsService     Comments database service
+     * @param UserResourceServiceInterface                  $userResourceService User/Resource database service
+     * @param ResourceTagsServiceInterface                  $resourceTagsService Resource/Tags database service
+     */
+    public function __construct(
+        protected ResourceServiceInterface&TransactionInterface $resourceService,
+        protected CommentsServiceInterface $commentsService,
+        protected UserResourceServiceInterface $userResourceService,
+        protected ResourceTagsServiceInterface $resourceTagsService
+    ) {
+    }
+
+    /**
+     * Update the database to reflect a changed record identifier.
+     *
+     * @param string $oldId  Original record ID
+     * @param string $newId  Revised record ID
+     * @param string $source Record source
+     *
+     * @return void
+     */
+    public function updateRecordId(string $oldId, string $newId, string $source = DEFAULT_SEARCH_BACKEND): void
+    {
+        if (
+            $oldId !== $newId
+            && $resource = $this->resourceService->getResourceByRecordId($oldId, $source)
+        ) {
+            $needsDeduplication = false;
+
+            // Do this as a transaction to prevent odd behavior:
+            $this->resourceService->beginTransaction();
+            // Does the new ID already exist?
+            if ($newResource = $this->resourceService->getResourceByRecordId($newId, $source)) {
+                // Special case: merge new ID and old ID:
+                foreach ([$this->commentsService, $this->userResourceService, $this->resourceTagsService] as $service) {
+                    $service->changeResourceId($resource->getId(), $newResource->getId());
+                }
+                $this->resourceService->deleteResource($resource);
+                $needsDeduplication = true;
+            } else {
+                // Default case: just update the record ID:
+                $resource->setRecordId($newId);
+                $this->resourceService->persistEntity($resource);
+            }
+            // Done -- commit the transaction:
+            $this->resourceService->commitTransaction();
+
+            // Deduplicate rows where necessary (this can be safely done outside of the transaction):
+            if ($needsDeduplication) {
+                $this->resourceTagsService->deduplicate();
+                $this->userResourceService->deduplicate();
+            }
+        }
+    }
+}

--- a/module/VuFind/src/VuFind/Record/RecordIdUpdaterFactory.php
+++ b/module/VuFind/src/VuFind/Record/RecordIdUpdaterFactory.php
@@ -48,7 +48,7 @@ use VuFind\Db\Service\UserResourceServiceInterface;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class ResourcePopulatorFactory implements FactoryInterface
+class RecordIdUpdaterFactory implements FactoryInterface
 {
     /**
      * Create an object

--- a/module/VuFind/src/VuFind/Record/RecordIdUpdaterFactory.php
+++ b/module/VuFind/src/VuFind/Record/RecordIdUpdaterFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Abstract record fallback loader factory
+ * Record ID updater factory.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2018.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -24,29 +24,31 @@
  * @package  Record
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org Main Site
+ * @link     https://vufind.org/wiki/development Wiki
  */
 
-namespace VuFind\Record\FallbackLoader;
+namespace VuFind\Record;
 
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Db\Service\CommentsServiceInterface;
 use VuFind\Db\Service\ResourceServiceInterface;
-use VuFind\Record\RecordIdUpdater;
+use VuFind\Db\Service\ResourceTagsServiceInterface;
+use VuFind\Db\Service\UserResourceServiceInterface;
 
 /**
- * Abstract record fallback loader factory
+ * Record ID updater factory.
  *
  * @category VuFind
  * @package  Record
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org Main Site
+ * @link     https://vufind.org/wiki/development Wiki
  */
-class AbstractFallbackLoaderFactory implements FactoryInterface
+class ResourcePopulatorFactory implements FactoryInterface
 {
     /**
      * Create an object
@@ -67,11 +69,15 @@ class AbstractFallbackLoaderFactory implements FactoryInterface
         $requestedName,
         array $options = null
     ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options passed to factory.');
+        }
+        $serviceManager = $container->get(\VuFind\Db\Service\PluginManager::class);
         return new $requestedName(
-            $container->get(\VuFind\Db\Service\PluginManager::class)->get(ResourceServiceInterface::class),
-            $container->get(RecordIdUpdater::class),
-            $container->get(\VuFindSearch\Service::class),
-            ...$options ?? []
+            $serviceManager->get(ResourceServiceInterface::class),
+            $serviceManager->get(CommentsServiceInterface::class),
+            $serviceManager->get(UserResourceServiceInterface::class),
+            $serviceManager->get(ResourceTagsServiceInterface::class)
         );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/FallbackLoader/SolrTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/FallbackLoader/SolrTest.php
@@ -32,6 +32,7 @@ namespace VuFindTest\Record\FallbackLoader;
 
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Record\FallbackLoader\Solr;
+use VuFind\Record\RecordIdUpdater;
 
 /**
  * Solr fallback loader test.
@@ -51,8 +52,7 @@ class SolrTest extends \PHPUnit\Framework\TestCase
      */
     public function testEnabledLoader(): void
     {
-        $record = $this->getMockBuilder(\VuFind\RecordDriver\SolrDefault::class)
-            ->disableOriginalConstructor()->getMock();
+        $record = $this->createMock(\VuFind\RecordDriver\SolrDefault::class);
         $record->expects($this->once())->method('setPreviousUniqueId')
             ->with($this->equalTo('oldId'));
         $record->expects($this->once())->method('getUniqueId')->willReturn('newId');
@@ -60,31 +60,26 @@ class SolrTest extends \PHPUnit\Framework\TestCase
             ['recordCount' => 1]
         );
         $collection->add($record);
-        $commandObj = $this->getMockBuilder(\VuFindSearch\Command\AbstractBase::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $commandObj->expects($this->once())->method('getResult')
-            ->will($this->returnValue($collection));
+        $commandObj = $this->createMock(\VuFindSearch\Command\AbstractBase::class);
+        $commandObj->expects($this->once())->method('getResult')->willReturn($collection);
         $checkCommand = function ($command) {
             return $command::class === \VuFindSearch\Command\SearchCommand::class
                 && $command->getTargetIdentifier() === 'Solr'
                 && $command->getArguments()[0]->getString() ===
                 'previous_id_str_mv:"oldId"';
         };
-        $search = $this->getMockBuilder(\VuFindSearch\Service::class)
-            ->disableOriginalConstructor()->getMock();
+        $search = $this->createMock(\VuFindSearch\Service::class);
         $search->expects($this->once())->method('invoke')
             ->with($this->callback($checkCommand))
-            ->will($this->returnValue($commandObj));
-        $resource = $this->getMockBuilder(\VuFind\Db\Table\Resource::class)
-            ->disableOriginalConstructor()->getMock();
-        $resource->expects($this->once())->method('updateRecordId')
+            ->willReturn($commandObj);
+        $updater = $this->createMock(RecordIdUpdater::class);
+        $updater->expects($this->once())->method('updateRecordId')
             ->with(
                 $this->equalTo('oldId'),
                 $this->equalTo('newId'),
                 $this->equalTo('Solr')
             );
-        $loader = new Solr($resource, $this->createMock(ResourceServiceInterface::class), $search);
+        $loader = new Solr($this->createMock(ResourceServiceInterface::class), $updater, $search);
         $this->assertEquals([$record], $loader->load(['oldId']));
     }
 
@@ -95,11 +90,9 @@ class SolrTest extends \PHPUnit\Framework\TestCase
      */
     public function testDisabledLoader(): void
     {
-        $search = $this->getMockBuilder(\VuFindSearch\Service::class)
-            ->disableOriginalConstructor()->getMock();
-        $resource = $this->getMockBuilder(\VuFind\Db\Table\Resource::class)
-            ->disableOriginalConstructor()->getMock();
-        $loader = new Solr($resource, $this->createMock(ResourceServiceInterface::class), $search, null);
+        $search = $this->createMock(\VuFindSearch\Service::class);
+        $updater = $this->createMock(RecordIdUpdater::class);
+        $loader = new Solr($this->createMock(ResourceServiceInterface::class), $updater, $search, null);
         $this->assertCount(0, $loader->load(['oldId']));
     }
 }


### PR DESCRIPTION
This refactors some remaining resource-related functionality to the new database service interfaces. I thought about building this directly into the AbstractFallbackLoader, but it seemed possible the functionality might be needed in other contexts, so a new service seemed like a better choice.

See [this wiki page](https://vufind.org/wiki/development:testing:manual_testing#merging_record_data_when_ids_change) for a testing protocol. We should probably automate this at some point, but it's complicated, and I'm short on time. For today, manual testing is probably easier.