### PR TITLE
Clean up outdated row references in VuFind module.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatuses.php
@@ -31,8 +31,8 @@ namespace VuFind\AjaxHandler;
 
 use Laminas\Mvc\Controller\Plugin\Params;
 use Laminas\Mvc\Controller\Plugin\Url;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Entity\UserResourceEntityInterface;
-use VuFind\Db\Row\User;
 use VuFind\Db\Service\UserResourceServiceInterface;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\Session\Settings as SessionSettings;
@@ -58,13 +58,13 @@ class GetSaveStatuses extends AbstractBase implements TranslatorAwareInterface
      * Constructor
      *
      * @param SessionSettings              $ss                  Session settings
-     * @param ?User                        $user                Logged in user (or null)
+     * @param ?UserEntityInterface         $user                Logged in user (or null)
      * @param Url                          $urlHelper           URL helper
      * @param UserResourceServiceInterface $userResourceService User resource database service
      */
     public function __construct(
         SessionSettings $ss,
-        protected ?User $user,
+        protected ?UserEntityInterface $user,
         protected Url $urlHelper,
         protected UserResourceServiceInterface $userResourceService
     ) {

--- a/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
+++ b/module/VuFind/src/VuFind/Auth/LoginTokenManager.php
@@ -139,14 +139,14 @@ class LoginTokenManager implements LoggerAwareInterface, TranslatorAwareInterfac
             try {
                 if (
                     ($token = $this->loginTokenService->matchToken($cookie))
-                    && ($user = $this->userService->getUserById($token->user_id))
+                    && ($user = $token->getUser())
                 ) {
                     // Queue token update to be done after everything else is
                     // successfully processed:
                     $this->tokenToUpdate = compact('user', 'token', 'sessionId');
                     $this->debug(
-                        "Token login successful for user {$token->user_id}"
-                        . ", token {$token->token} series {$token->series}"
+                        "Token login successful for user {$user->getId()}"
+                        . ", token {$token->getToken()} series {$token->getSeries()}"
                     );
                 } else {
                     $this->cookieManager->clear($this->getCookieName());
@@ -217,9 +217,9 @@ class LoginTokenManager implements LoggerAwareInterface, TranslatorAwareInterfac
             $this->createOrRotateToken(
                 $this->tokenToUpdate['user'],
                 $this->tokenToUpdate['sessionId'],
-                $token->series,
-                $token->expires,
-                $token->id
+                $token->getSeries(),
+                $token->getExpires(),
+                $token->getId()
             );
             $this->tokenToUpdate = null;
         }
@@ -241,7 +241,7 @@ class LoginTokenManager implements LoggerAwareInterface, TranslatorAwareInterfac
         }
         $handler = $this->sessionManager->getSaveHandler();
         foreach ($this->loginTokenService->getBySeries($series) as $token) {
-            $handler->destroy($token->last_session_id);
+            $handler->destroy($token->getLastSessionId());
         }
         $this->loginTokenService->deleteBySeries($series);
     }
@@ -259,7 +259,7 @@ class LoginTokenManager implements LoggerAwareInterface, TranslatorAwareInterfac
         $userTokens = $this->loginTokenService->getByUser($userId, false);
         $handler = $this->sessionManager->getSaveHandler();
         foreach ($userTokens as $t) {
-            $handler->destroy($t->last_session_id);
+            $handler->destroy($t->getLastSessionId());
         }
         $this->loginTokenService->deleteByUser($userId);
     }

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -349,7 +349,7 @@ class AlmaController extends AbstractBase
      * Send the "set password email" to a new user that was created in Alma and sent
      * to VuFind via webhook.
      *
-     * @param \VuFind\Db\Row\User    $user   A user row object from the VuFind
+     * @param UserEntityInterface    $user   A user row object from the VuFind
      * user table.
      * @param \Laminas\Config\Config $config A config object of config.ini
      *

--- a/module/VuFind/src/VuFind/Favorites/FavoritesService.php
+++ b/module/VuFind/src/VuFind/Favorites/FavoritesService.php
@@ -217,19 +217,19 @@ class FavoritesService implements \VuFind\I18n\Translator\TranslatorAwareInterfa
      * Persist a resource to the record cache (if applicable).
      *
      * @param RecordDriver            $driver   Record driver to persist
-     * @param \VuFind\Db\Row\Resource $resource Resource row
+     * @param ResourceEntityInterface $resource Resource row
      *
      * @return void
      */
     protected function persistToCache(
         RecordDriver $driver,
-        \VuFind\Db\Row\Resource $resource
+        ResourceEntityInterface $resource
     ) {
         if ($this->recordCache) {
             $this->recordCache->setContext(RecordCache::CONTEXT_FAVORITE);
             $this->recordCache->createOrUpdate(
-                $resource->record_id,
-                $resource->source,
+                $resource->getRecordId(),
+                $resource->getSource(),
                 $driver->getRawData()
             );
         }

--- a/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/RecordDriver/AbstractBase.php
@@ -211,7 +211,7 @@ abstract class AbstractBase implements
     /**
      * Add tags to the record.
      *
-     * @param \VuFind\Db\Row\User $user The user posting the tag
+     * @param UserEntityInterface $user The user posting the tag
      * @param array               $tags The user-provided tags
      *
      * @return void
@@ -233,7 +233,7 @@ abstract class AbstractBase implements
     /**
      * Remove tags from the record.
      *
-     * @param \VuFind\Db\Row\User $user The user posting the tag
+     * @param UserEntityInterface $user The user posting the tag
      * @param array               $tags The user-provided tags
      *
      * @return void

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\View\Helper\Root;
 
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\ILS\Connection as IlsConnection;
 
 /**
@@ -380,9 +380,9 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     /**
      * Get authenticated user
      *
-     * @return ?User Object if user is logged in, null otherwise.
+     * @return ?UserEntityInterface Object if user is logged in, null otherwise.
      */
-    protected function getUser(): ?User
+    protected function getUser(): ?UserEntityInterface
     {
         return $this->getAuthHelper()->getUserObject();
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -108,7 +108,7 @@ class Auth extends \Laminas\View\Helper\AbstractHelper implements DbServiceAware
     /**
      * Checks whether the user is logged in.
      *
-     * @return \VuFind\Db\Row\User|bool Object if user is logged in, false
+     * @return UserEntityInterface|bool Object if user is logged in, false
      * otherwise.
      *
      * @deprecated Use getIdentity() or getUserObject() instead.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/DatabaseUnitTest.php
@@ -34,7 +34,6 @@ use Laminas\Stdlib\Parameters;
 use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Auth\Database;
 use VuFind\Db\Entity\UserEntityInterface;
-use VuFind\Db\Row\User;
 use VuFind\Db\Service\UserServiceInterface;
 use VuFind\Http\PhpEnvironment\Request;
 
@@ -548,16 +547,6 @@ class DatabaseUnitTest extends \PHPUnit\Framework\TestCase
             'password2' => 'pass',
             'email' => 'me@mysite.com',
         ];
-    }
-
-    /**
-     * Get a mock row object
-     *
-     * @return MockObject&User
-     */
-    protected function getMockRow(): MockObject&User
-    {
-        return $this->createMock(User::class);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -273,8 +273,6 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a mock user object
      *
-     * @param array $methods Methods to mock
-     *
      * @return MockObject&UserEntityInterface
      */
     protected function getMockUser(): MockObject&UserEntityInterface

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/ILSAuthenticatorTest.php
@@ -33,7 +33,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Auth\EmailAuthenticator;
 use VuFind\Auth\ILSAuthenticator;
 use VuFind\Auth\Manager;
-use VuFind\Db\Row\User;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\UserCardService;
 use VuFind\Db\Service\UserCardServiceInterface;
 use VuFind\Db\Service\UserServiceInterface;
@@ -134,7 +134,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testSuccessfulStoredLoginAttempt(): void
     {
-        $user = $this->getMockUser(['getCatUsername', 'getRawCatPassword']);
+        $user = $this->getMockUser();
         $user->expects($this->any())->method('getCatUsername')->willReturn('user');
         $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $manager = $this->getMockManager(['getUserObject']);
@@ -158,9 +158,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnsuccessfulStoredLoginAttempt(): void
     {
-        $user = $this->getMockUser(
-            ['setCatUsername', 'setRawCatPassword', 'setCatPassEnc', 'getCatUsername', 'getRawCatPassword']
-        );
+        $user = $this->getMockUser();
         $user->expects($this->any())->method('getCatUsername')->willReturn('user');
         $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $user->expects($this->once())->method('setCatUsername')->with(null)->willReturn($user);
@@ -185,7 +183,7 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\VuFind\Exception\ILS::class);
         $this->expectExceptionMessage('kaboom');
 
-        $user = $this->getMockUser(['getCatUsername', 'getRawCatPassword']);
+        $user = $this->getMockUser();
         $user->expects($this->any())->method('getCatUsername')->willReturn('user');
         $user->expects($this->any())->method('getRawCatPassword')->willReturn('pass');
         $manager = $this->getMockManager(['getUserObject']);
@@ -277,14 +275,11 @@ class ILSAuthenticatorTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $methods Methods to mock
      *
-     * @return MockObject&User
+     * @return MockObject&UserEntityInterface
      */
-    protected function getMockUser(array $methods = []): MockObject&User
+    protected function getMockUser(): MockObject&UserEntityInterface
     {
-        return $this->getMockBuilder(\VuFind\Db\Row\User::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods($methods)
-            ->getMock();
+        return $this->createMock(UserEntityInterface::class);
     }
 
     /**


### PR DESCRIPTION
This cleans up a few more outdated references to Laminas Db\Row classes; the most substantial work has to do with using appropriate getters in the login token code. Most of the other changes only impact comments, typehints or tests.