### PR TITLE
Eliminate remaining controller references to getTable().

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -82,11 +82,11 @@ class AlmaController extends AbstractBase
     protected $configAlma;
 
     /**
-     * User table
+     * User database service
      *
-     * @var \VuFind\Db\Table\User
+     * @var UserServiceInterface
      */
-    protected $userTable;
+    protected $userService;
 
     /**
      * Alma Controller constructor.
@@ -100,7 +100,7 @@ class AlmaController extends AbstractBase
         $this->httpHeaders = $this->httpResponse->getHeaders();
         $this->config = $this->getConfig('config');
         $this->configAlma = $this->getConfig('Alma');
-        $this->userTable = $this->getTable('user');
+        $this->userService = $this->getDbService(UserServiceInterface::class);
     }
 
     /**
@@ -237,11 +237,10 @@ class AlmaController extends AbstractBase
             }
 
             if ($method == 'CREATE') {
-                $user = $this->userTable->getByUsername($username, true);
-            }
-
-            if ($method == 'UPDATE') {
-                $user = $this->userTable->getByCatalogId($primaryId);
+                $user = $this->userService->getUserByField('username', $username)
+                    ?? $this->userService->createEntityForUsername($username);
+            } elseif ($method == 'UPDATE') {
+                $user = $this->userService->getUserByField('cat_id', $primaryId);
             }
 
             if ($user) {
@@ -281,7 +280,7 @@ class AlmaController extends AbstractBase
                 );
             }
         } elseif ($method == 'DELETE') {
-            $user = $this->userTable->getByCatalogId($primaryId);
+            $user = $this->userService->getUserByField('cat_id', $primaryId);
             if ($user) {
                 try {
                     $this->serviceLocator->get(UserAccountService::class)->purgeUserData($user);

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -244,15 +244,15 @@ class AlmaController extends AbstractBase
             }
 
             if ($user) {
-                $user->username = $username;
-                $user->firstname = $firstname;
-                $user->lastname = $lastname;
-                $this->getDbService(UserServiceInterface::class)->updateUserEmail($user, $email);
-                $user->cat_id = $primaryId;
-                $user->cat_username = $username;
+                $user->setUsername($username)
+                    ->setFirstname($firstname)
+                    ->setLastname($lastname)
+                    ->setCatId($primaryId)
+                    ->setCatUsername($username);
+                $this->userService->updateUserEmail($user, $email);
 
                 try {
-                    $user->save();
+                    $this->userService->persistEntity($user);
                     if ($method == 'CREATE') {
                         $this->sendSetPasswordEmail($user, $this->config);
                     }

--- a/module/VuFind/src/VuFind/Controller/Feature/SecureDatabaseTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/SecureDatabaseTrait.php
@@ -30,6 +30,7 @@
 namespace VuFind\Controller\Feature;
 
 use VuFind\Db\Service\UserCardServiceInterface;
+use VuFind\Db\Service\UserServiceInterface;
 
 use function count;
 
@@ -73,7 +74,7 @@ trait SecureDatabaseTrait
         // If we're correctly configured, check that the data in the database is ok:
         if ($status) {
             try {
-                $userRows = $this->getTable('user')->getInsecureRows();
+                $userRows = $this->getDbService(UserServiceInterface::class)->getInsecureRows();
                 $cardRows = $this->getDbService(UserCardServiceInterface::class)->getInsecureRows();
                 $status = (count($userRows) + count($cardRows) == 0);
             } catch (\Exception $e) {

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -34,6 +34,7 @@ use Laminas\Mvc\MvcEvent;
 use VuFind\Config\Writer as ConfigWriter;
 use VuFind\Db\Service\TagServiceInterface;
 use VuFind\Db\Service\UserCardServiceInterface;
+use VuFind\Db\Service\UserServiceInterface;
 use VuFindSearch\Command\RetrieveCommand;
 
 use function count;
@@ -773,7 +774,7 @@ class InstallController extends AbstractBase
         }
 
         // If we don't need to prompt the user, or if they confirmed, do the fix:
-        $userRows = $this->getTable('user')->getInsecureRows();
+        $userRows = $this->getDbService(UserServiceInterface::class)->getInsecureRows();
         $cardRows = $this->getDbService(UserCardServiceInterface::class)->getInsecureRows();
         if (count($userRows) + count($cardRows) == 0 || $userConfirmation == 'Yes') {
             return $this->forwardTo('Install', 'performsecurityfix');
@@ -812,7 +813,7 @@ class InstallController extends AbstractBase
         // Now we want to loop through the database and update passwords (if
         // necessary).
         $ilsAuthenticator = $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
-        $userRows = $this->getTable('user')->getInsecureRows();
+        $userRows = $this->getDbService(UserServiceInterface::class)->getInsecureRows();
         if (count($userRows) > 0) {
             $bcrypt = new Bcrypt();
             foreach ($userRows as $row) {

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -104,7 +104,7 @@ class UserService extends AbstractDbService implements
 
     /**
      * Retrieve a user object from the database based on the given field.
-     * Field name must be id, username, email or cat_id.
+     * Field name must be id, username, email, verify_hash or cat_id.
      *
      * @param string          $fieldName  Field name
      * @param int|string|null $fieldValue Field value
@@ -120,6 +120,8 @@ class UserService extends AbstractDbService implements
                 return $this->getDbTable('User')->getById($fieldValue);
             case 'username':
                 return $this->getDbTable('User')->getByUsername($fieldValue, false);
+            case 'verify_hash':
+                return $this->getDbTable('User')->getByVerifyHash($fieldValue);
             case 'cat_id':
                 return $this->getDbTable('User')->getByCatalogId($fieldValue);
         }

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -239,6 +239,16 @@ class UserService extends AbstractDbService implements
     }
 
     /**
+     * Get user rows with insecure catalog passwords.
+     *
+     * @return UserEntityInterface[]
+     */
+    public function getInsecureRows(): array
+    {
+        return iterator_to_array($this->getDbTable('User')->getInsecureRows());
+    }
+
+    /**
      * Create a new user entity.
      *
      * @return UserEntityInterface

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
@@ -71,7 +71,7 @@ interface UserServiceInterface extends DbServiceInterface
 
     /**
      * Retrieve a user object from the database based on the given field.
-     * Field name must be id, username, email or cat_id.
+     * Field name must be id, username, email, verify_hash or cat_id.
      *
      * @param string          $fieldName  Field name
      * @param int|string|null $fieldValue Field value

--- a/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserServiceInterface.php
@@ -106,6 +106,13 @@ interface UserServiceInterface extends DbServiceInterface
     public function getAllUsersWithCatUsernames(): array;
 
     /**
+     * Get user rows with insecure catalog passwords.
+     *
+     * @return UserEntityInterface[]
+     */
+    public function getInsecureRows(): array;
+
+    /**
      * Create a new user entity.
      *
      * @return UserEntityInterface


### PR DESCRIPTION
This fixes a few more stray details that hadn't been refactored to use services and entities.

It's probably a good idea in the long term to create getUserByUsername, getUserByVerifyHash, etc., etc. instead of using getUserByField everywhere... but I didn't want to add lots of new methods at this late stage.