### PR TITLE
Use UserEntityInterface on new password form.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -2007,7 +2007,7 @@ class MyResearchController extends AbstractBase
      * already been loaded from an existing hash, this resets the hash and updates
      * the form so that the user can try again.
      *
-     * @param ?UserEntityInterface $userFromHash User loaded from database, or false if none.
+     * @param ?UserEntityInterface $userFromHash User loaded from database, or null if none.
      * @param ViewModel            $view         View object
      *
      * @return ViewModel

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -2007,17 +2007,17 @@ class MyResearchController extends AbstractBase
      * already been loaded from an existing hash, this resets the hash and updates
      * the form so that the user can try again.
      *
-     * @param mixed     $userFromHash User loaded from database, or false if none.
-     * @param ViewModel $view         View object
+     * @param ?UserEntityInterface $userFromHash User loaded from database, or false if none.
+     * @param ViewModel            $view         View object
      *
      * @return ViewModel
      */
-    protected function resetNewPasswordForm($userFromHash, ViewModel $view)
+    protected function resetNewPasswordForm(?UserEntityInterface $userFromHash, ViewModel $view)
     {
         if ($userFromHash) {
             $this->getAuthManager()->updateUserVerifyHash($userFromHash);
-            $view->username = $userFromHash->username;
-            $view->hash = $userFromHash->verify_hash;
+            $view->username = $userFromHash->getUsername();
+            $view->hash = $userFromHash->getVerifyHash();
         }
         return $view;
     }
@@ -2041,7 +2041,7 @@ class MyResearchController extends AbstractBase
         // Verify hash
         $userFromHash = isset($post->hash)
             ? $this->getDbService(UserServiceInterface::class)->getUserByField('verify_hash', $post->hash)
-            : false;
+            : null;
         // View, password policy and Captcha
         $view = $this->createViewModel($post);
         $view->passwordPolicy = $this->getAuthManager()->getPasswordPolicy();
@@ -2051,12 +2051,12 @@ class MyResearchController extends AbstractBase
             return $this->resetNewPasswordForm($userFromHash, $view);
         }
         // Missing or invalid hash
-        if (false == $userFromHash) {
+        if (!$userFromHash) {
             $this->flashMessenger()->addMessage('recovery_user_not_found', 'error');
             // Force login or restore hash
             $post->username = false;
             return $this->forwardTo('MyResearch', 'Recover');
-        } elseif ($userFromHash->username !== $post->username) {
+        } elseif ($userFromHash->getUsername() !== $post->username) {
             $this->flashMessenger()
                 ->addMessage('authentication_error_invalid', 'error');
             return $this->resetNewPasswordForm($userFromHash, $view);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -49,6 +49,7 @@ use function count;
  */
 final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use \VuFindTest\Feature\EmailTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\UserCreationTrait;
     use \VuFindTest\Feature\DemoDriverTestTrait;
@@ -452,6 +453,67 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->submitLoginForm($page, false);
         $this->waitForPageLoad($page);
         $this->assertEquals('Invalid login -- please try again.', $this->findCssAndGetText($page, '.alert-danger'));
+    }
+
+    /**
+     * Test recovering a password by username.
+     *
+     * @return void
+     *
+     * @depends testChangePassword
+     */
+    public function testRecoverPasswordByUsername(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Authentication' => [
+                        'recover_password' => true,
+                        'recover_interval' => 0,
+                    ],
+                    'Mail' => [
+                        'testOnly' => true,
+                        'message_log' => $this->getEmailLogPath(),
+                    ],
+                ],
+            ]
+        );
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl());
+        $page = $session->getPage();
+        $this->resetEmailLog();
+
+        // Recover account
+        $this->clickCss($page, '#loginOptions a');
+        $this->clickCss($page, '.modal-body .recoverAccountLink');
+        $this->findCssAndSetValue($page, '#recovery_username', 'bad');
+        $this->clickCss($page, '.modal-body input[type="submit"]');
+        $this->assertEquals('We could not find your account', $this->findCssAndGetText($page, '.alert-danger'));
+        $this->findCssAndSetValue($page, '#recovery_username', 'username1');
+        $this->clickCss($page, '.modal-body input[type="submit"]');
+        $this->assertEquals(
+            'Password recovery instructions have been sent to the email address registered with this account.',
+            $this->findCssAndGetText($page, '.alert-success')
+        );
+
+        // Extract URL from email:
+        $email = file_get_contents($this->getEmailLogPath());
+        preg_match('/You can reset your password at this URL: (http.*)/', $email, $matches);
+        $link = $matches[1];
+
+        // Reset the password:
+        $session->visit($link);
+        $this->assertEquals('username1', $this->findCssAndGetText($page, '.form-control-static'));
+        $this->findCssAndSetValue($page, '#password', 'recovered');
+        $this->findCssAndSetValue($page, '#password2', 'recovered');
+        $this->clickCss($page, '.form-new-password .btn-primary');
+        $this->assertEquals(
+            'Your password has successfully been changed',
+            $this->findCssAndGetText($page, '.alert-success')
+        );
+
+        $this->resetEmailLog();
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -486,7 +486,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Recover account
         $this->clickCss($page, '#loginOptions a');
-        $this->clickCss($page, '.modal-body .recoverAccountLink');
+        $this->clickCss($page, '.modal-body .recover-account-link');
         $this->findCssAndSetValue($page, '#recovery_username', 'bad');
         $this->clickCss($page, '.modal-body input[type="submit"]');
         $this->assertEquals('We could not find your account', $this->findCssAndGetText($page, '.alert-danger'));

--- a/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
@@ -19,7 +19,7 @@
         <a class="btn btn-link createAccountLink" href="<?=$this->url('myresearch-account') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Create New Account')?></a>
       <?php endif; ?>
       <?php if ($account->supportsRecovery()): ?>
-        <a class="btn btn-link" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
+        <a class="btn btn-link recoverAccountLink" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
       <?php endif; ?>
     </div>
   </form>

--- a/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap3/templates/Auth/AbstractBase/login.phtml
@@ -19,7 +19,7 @@
         <a class="btn btn-link createAccountLink" href="<?=$this->url('myresearch-account') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Create New Account')?></a>
       <?php endif; ?>
       <?php if ($account->supportsRecovery()): ?>
-        <a class="btn btn-link recoverAccountLink" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
+        <a class="btn btn-link recover-account-link" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
       <?php endif; ?>
     </div>
   </form>

--- a/themes/bootstrap5/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap5/templates/Auth/AbstractBase/login.phtml
@@ -19,7 +19,7 @@
         <a class="btn btn-link createAccountLink" href="<?=$this->url('myresearch-account') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Create New Account')?></a>
       <?php endif; ?>
       <?php if ($account->supportsRecovery()): ?>
-        <a class="btn btn-link" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
+        <a class="btn btn-link recoverAccountLink" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
       <?php endif; ?>
     </div>
   </form>

--- a/themes/bootstrap5/templates/Auth/AbstractBase/login.phtml
+++ b/themes/bootstrap5/templates/Auth/AbstractBase/login.phtml
@@ -19,7 +19,7 @@
         <a class="btn btn-link createAccountLink" href="<?=$this->url('myresearch-account') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Create New Account')?></a>
       <?php endif; ?>
       <?php if ($account->supportsRecovery()): ?>
-        <a class="btn btn-link recoverAccountLink" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
+        <a class="btn btn-link recover-account-link" href="<?=$this->url('myresearch-recover') ?>?auth_method=<?=$account->getAuthMethod()?>"><?=$this->transEsc('Forgot Password')?></a>
       <?php endif; ?>
     </div>
   </form>


### PR DESCRIPTION
This fixes some new minor issues with missing UserEntityInterface calls discovered while testing #2233.

This also adds a Mink test for recover password functionality. This could be fleshed out, but it covers the bare minimum "happy path" for now.