### PR TITLE
Fix bug: Explain broke mixed-AJAX combined search.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -62,6 +62,24 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Start a session, perform a combined search, and return the resulting page.
+     *
+     * @param string $query Combined search query to perform.
+     *
+     * @return Element
+     */
+    protected function performCombinedSearch(string $query): Element
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Combined');
+        $page = $session->getPage();
+        $this->findCss($page, '#searchForm_lookfor')->setValue($query);
+        $this->clickCss($page, '.btn.btn-primary');
+        $this->waitForPageLoad($page);
+        return $page;
+    }
+
+    /**
      * Several different methods perform the same query against different
      * configurations of the combined feature; this support method makes a
      * standard set of assertions against the final results.
@@ -108,13 +126,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             ['combined' => $this->getCombinedIniOverrides()],
             ['combined']
         );
-        $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Combined');
-        $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('id:"testsample1" OR id:"theplus+andtheminus-"');
-        $this->clickCss($page, '.btn.btn-primary');
-        $this->waitForPageLoad($page);
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $this->unFindCss($page, '.fa-spinner.icon--spin');
         $this->assertResultsForDefaultQuery($page);
     }
@@ -148,13 +160,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             ['combined' => $config],
             ['combined']
         );
-        $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Combined');
-        $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('id:"testsample1" OR id:"theplus+andtheminus-"');
-        $this->clickCss($page, '.btn.btn-primary');
-        $this->waitForPageLoad($page);
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $this->assertResultsForDefaultQuery($page);
     }
 
@@ -171,13 +177,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             ['combined' => $config, 'searches' => ['Explain' => ['enabled' => true]]],
             ['combined']
         );
-        $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Combined');
-        $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('id:"testsample1" OR id:"theplus+andtheminus-"');
-        $this->clickCss($page, '.btn.btn-primary');
-        $this->waitForPageLoad($page);
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $this->assertResultsForDefaultQuery($page);
     }
 
@@ -194,13 +194,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             ['combined' => $config],
             ['combined']
         );
-        $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Combined');
-        $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('id:"testsample1" OR id:"theplus+andtheminus-"');
-        $this->clickCss($page, '.btn.btn-primary');
-        $this->waitForPageLoad($page);
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $this->assertResultsForDefaultQuery($page);
     }
 
@@ -232,13 +226,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             ],
             ['combined']
         );
-        $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Combined');
-        $page = $session->getPage();
-        $this->findCss($page, '#searchForm_lookfor')
-            ->setValue('*:*');
-        $this->clickCss($page, '.btn.btn-primary');
-        $this->waitForPageLoad($page);
+        $page = $this->performCombinedSearch('*:*');
         // Whether the combined column was loaded inline or via AJAX, it should
         // now include a DOI link:
         $this->assertStringStartsWith(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -159,6 +159,29 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that combined results work in mixed AJAX mode when Explain is turned on.
+     *
+     * @return void
+     */
+    public function testCombinedSearchResultsMixedAjaxWithExplain(): void
+    {
+        $config = $this->getCombinedIniOverrides();
+        $config['Solr:two']['ajax'] = true;
+        $this->changeConfigs(
+            ['combined' => $config, 'searches' => ['Explain' => ['enabled' => true]]],
+            ['combined']
+        );
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Combined');
+        $page = $session->getPage();
+        $this->findCss($page, '#searchForm_lookfor')
+            ->setValue('id:"testsample1" OR id:"theplus+andtheminus-"');
+        $this->clickCss($page, '.btn.btn-primary');
+        $this->waitForPageLoad($page);
+        $this->assertResultsForDefaultQuery($page);
+    }
+
+    /**
      * Test that combined results work in mixed AJAX/non-AJAX mode.
      *
      * @return void

--- a/themes/bootstrap3/js/explain.js
+++ b/themes/bootstrap3/js/explain.js
@@ -25,7 +25,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _setupResultListChart(container = document) {
-    container?.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -205,7 +205,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _resultsInitCallback(params = null) {
-    _setupResultListChart(params?.container);
+    _setupResultListChart(params && params.container ? params.container : document);
   }
 
   function init() {

--- a/themes/bootstrap3/js/explain.js
+++ b/themes/bootstrap3/js/explain.js
@@ -136,7 +136,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _setupExplainColumnChart() {
-    const columnChart = document.querySelector('#js-explain-column-chart');
+    const columnChart = document.getElementById('js-explain-column-chart');
     if (!columnChart) {
       return;
     }

--- a/themes/bootstrap3/js/explain.js
+++ b/themes/bootstrap3/js/explain.js
@@ -24,8 +24,8 @@ VuFind.register('explain', function explain() {
     };
   }
 
-  function _setupResultListChart() {
-    document.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+  function _setupResultListChart(container) {
+    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -91,8 +91,8 @@ VuFind.register('explain', function explain() {
   }
 
 
-  function _setupExplainPieChart() {
-    const pieChart = document.getElementById('js-explain-pie-chart');
+  function _setupExplainPieChart(container) {
+    const pieChart = container.querySelector('#js-explain-pie-chart');
     if (!pieChart) {
       return;
     }
@@ -135,8 +135,8 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function _setupExplainColumnChart() {
-    const columnChart = document.getElementById('js-explain-column-chart');
+  function _setupExplainColumnChart(container) {
+    const columnChart = container.querySelector('#js-explain-column-chart');
     if (!columnChart) {
       return;
     }
@@ -204,14 +204,15 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function updateContainer() {
-    _setupResultListChart();
-    _setupExplainPieChart();
-    _setupExplainColumnChart();
+  function updateContainer(params = null) {
+    console.log(params);
+    _setupResultListChart(params.container);
+    _setupExplainPieChart(params.container);
+    _setupExplainColumnChart(params.container);
   }
 
   function init() {
-    updateContainer();
+    updateContainer({ container: document });
     VuFind.listen('results-init', updateContainer);
   }
 

--- a/themes/bootstrap3/js/explain.js
+++ b/themes/bootstrap3/js/explain.js
@@ -24,8 +24,8 @@ VuFind.register('explain', function explain() {
     };
   }
 
-  function _setupResultListChart(container) {
-    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+  function _setupResultListChart(container = document) {
+    container?.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -91,8 +91,8 @@ VuFind.register('explain', function explain() {
   }
 
 
-  function _setupExplainPieChart(container) {
-    const pieChart = container.querySelector('#js-explain-pie-chart');
+  function _setupExplainPieChart() {
+    const pieChart = document.getElementById('js-explain-pie-chart');
     if (!pieChart) {
       return;
     }
@@ -135,8 +135,8 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function _setupExplainColumnChart(container) {
-    const columnChart = container.querySelector('#js-explain-column-chart');
+  function _setupExplainColumnChart() {
+    const columnChart = document.querySelector('#js-explain-column-chart');
     if (!columnChart) {
       return;
     }
@@ -204,15 +204,15 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function updateContainer(params = null) {
-    _setupResultListChart(params.container);
-    _setupExplainPieChart(params.container);
-    _setupExplainColumnChart(params.container);
+  function _resultsInitCallback(params = null) {
+    _setupResultListChart(params?.container);
   }
 
   function init() {
-    updateContainer({ container: document });
-    VuFind.listen('results-init', updateContainer);
+    _setupExplainPieChart();
+    _setupExplainColumnChart();
+    _setupResultListChart();
+    VuFind.listen('results-init', _resultsInitCallback);
   }
 
   return {

--- a/themes/bootstrap3/js/explain.js
+++ b/themes/bootstrap3/js/explain.js
@@ -205,7 +205,6 @@ VuFind.register('explain', function explain() {
   }
 
   function updateContainer(params = null) {
-    console.log(params);
     _setupResultListChart(params.container);
     _setupExplainPieChart(params.container);
     _setupExplainColumnChart(params.container);

--- a/themes/bootstrap5/js/explain.js
+++ b/themes/bootstrap5/js/explain.js
@@ -24,8 +24,8 @@ VuFind.register('explain', function explain() {
     };
   }
 
-  function _setupResultListChart() {
-    document.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+  function _setupResultListChart(container) {
+    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -91,8 +91,8 @@ VuFind.register('explain', function explain() {
   }
 
 
-  function _setupExplainPieChart() {
-    const pieChart = document.getElementById('js-explain-pie-chart');
+  function _setupExplainPieChart(container) {
+    const pieChart = container.querySelector('#js-explain-pie-chart');
     if (!pieChart) {
       return;
     }
@@ -135,8 +135,8 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function _setupExplainColumnChart() {
-    const columnChart = document.getElementById('js-explain-column-chart');
+  function _setupExplainColumnChart(container) {
+    const columnChart = container.querySelector('#js-explain-column-chart');
     if (!columnChart) {
       return;
     }
@@ -204,14 +204,14 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function updateContainer() {
-    _setupResultListChart();
-    _setupExplainPieChart();
-    _setupExplainColumnChart();
+  function updateContainer(params = null) {
+    _setupResultListChart(params.container);
+    _setupExplainPieChart(params.container);
+    _setupExplainColumnChart(params.container);
   }
 
   function init() {
-    updateContainer();
+    updateContainer({ container: document });
     VuFind.listen('results-init', updateContainer);
   }
 

--- a/themes/bootstrap5/js/explain.js
+++ b/themes/bootstrap5/js/explain.js
@@ -25,7 +25,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _setupResultListChart(container = document) {
-    container?.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -205,7 +205,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _resultsInitCallback(params = null) {
-    _setupResultListChart(params?.container);
+    _setupResultListChart(params && params.container ? params.container : document);
   }
 
   function init() {

--- a/themes/bootstrap5/js/explain.js
+++ b/themes/bootstrap5/js/explain.js
@@ -136,7 +136,7 @@ VuFind.register('explain', function explain() {
   }
 
   function _setupExplainColumnChart() {
-    const columnChart = document.querySelector('#js-explain-column-chart');
+    const columnChart = document.getElementById('js-explain-column-chart');
     if (!columnChart) {
       return;
     }

--- a/themes/bootstrap5/js/explain.js
+++ b/themes/bootstrap5/js/explain.js
@@ -24,8 +24,8 @@ VuFind.register('explain', function explain() {
     };
   }
 
-  function _setupResultListChart(container) {
-    container.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
+  function _setupResultListChart(container = document) {
+    container?.querySelectorAll('.js-result-list-explain .bar-chart').forEach(function createResultListChart(barChart) {
       const maxScore = barChart.dataset.maxScore;
       const score = barChart.dataset.score;
       const diff = Math.abs(maxScore - score);
@@ -91,8 +91,8 @@ VuFind.register('explain', function explain() {
   }
 
 
-  function _setupExplainPieChart(container) {
-    const pieChart = container.querySelector('#js-explain-pie-chart');
+  function _setupExplainPieChart() {
+    const pieChart = document.getElementById('js-explain-pie-chart');
     if (!pieChart) {
       return;
     }
@@ -135,8 +135,8 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function _setupExplainColumnChart(container) {
-    const columnChart = container.querySelector('#js-explain-column-chart');
+  function _setupExplainColumnChart() {
+    const columnChart = document.querySelector('#js-explain-column-chart');
     if (!columnChart) {
       return;
     }
@@ -204,15 +204,15 @@ VuFind.register('explain', function explain() {
     });
   }
 
-  function updateContainer(params = null) {
-    _setupResultListChart(params.container);
-    _setupExplainPieChart(params.container);
-    _setupExplainColumnChart(params.container);
+  function _resultsInitCallback(params = null) {
+    _setupResultListChart(params?.container);
   }
 
   function init() {
-    updateContainer({ container: document });
-    VuFind.listen('results-init', updateContainer);
+    _setupExplainPieChart();
+    _setupExplainColumnChart();
+    _setupResultListChart();
+    VuFind.listen('results-init', _resultsInitCallback);
   }
 
   return {


### PR DESCRIPTION
While upgrading one of my local VuFind instances to 10.0, I encountered a problem related to turning on explain while using mixed-AJAX-mode combined search. This PR seems to solve the problem (and also includes a test case to prevent regressions).