### PR TITLE
EDS: Handle other API error codes

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -273,8 +273,8 @@ class Backend extends AbstractBackend
                         $e
                     );
                 default:
-                    $response = [];
-                    break;
+                    $this->logError("Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}");
+                    throw new BackendException($e->getMessage(), $e->getCode(), $e);
             }
         } catch (Exception $e) {
             $this->debug('Exception found: ' . $e->getMessage());

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -273,8 +273,9 @@ class Backend extends AbstractBackend
                         $e
                     );
                 default:
-                    $this->logError("Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}");
-                    throw new BackendException("Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}", $e->getCode(), $e);
+                    $errorMessage = "Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}";
+                    $this->logError($errorMessage);
+                    throw new BackendException($errorMessage, $e->getCode(), $e);
             }
         } catch (Exception $e) {
             $this->debug('Exception found: ' . $e->getMessage());

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -274,7 +274,7 @@ class Backend extends AbstractBackend
                     );
                 default:
                     $this->logError("Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}");
-                    throw new BackendException($e->getMessage(), $e->getCode(), $e);
+                    throw new BackendException("Unhandled EDS API error {$e->getApiErrorCode()} : {$e->getMessage()}", $e->getCode(), $e);
             }
         } catch (Exception $e) {
             $this->debug('Exception found: ' . $e->getMessage());


### PR DESCRIPTION
How "fortunate" today that the EDS API is throwing error code 106 at me on just about every call, possibly due to the EDS service issue they have going on right now.  So I found that VuFind swallows those silently.  This PR treats an otherwise unhandled API error code like any other EDS API exception.