### PR TITLE
Better integrate RelativePathTrait and ConcatTrait.

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadLink.php
@@ -168,7 +168,7 @@ class HeadLink extends \Laminas\View\Helper\HeadLink implements \Laminas\Log\Log
     protected function isExcludedFromConcat($item)
     {
         return !isset($item->rel) || $item->rel != 'stylesheet'
-            || strpos($item->href, '://');
+            || !$this->isRelativePath($item->href);
     }
 
     /**

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/HeadScript.php
@@ -166,7 +166,7 @@ class HeadScript extends \Laminas\View\Helper\HeadScript implements \Laminas\Log
     {
         return empty($item->attributes['src'])
             || isset($item->attributes['conditional'])
-            || strpos($item->attributes['src'], '://');
+            || !$this->isRelativePath($item->attributes['src']);
     }
 
     /**


### PR DESCRIPTION
The work in #3617 to prevent unwanted theme searching of relative paths and URLs was incompletely implemented, since it did not account for the asset pipeline being activated. This PR integrates the new RelativePathTrait with the existing ConcatTrait::isExcludedFromConcat() method implementations to prevent unwanted false positive warnings caused by relative paths (while maintaining the existing support for skipping absolute URLs).