### PR TITLE
EPF: Fix electronic ISSNs and ISBNs

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EPF.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EPF.php
@@ -68,6 +68,26 @@ class EPF extends EDS
     }
 
     /**
+     * Get ISSNs (of containing record)
+     *
+     * @return array
+     */
+    public function getISSNs()
+    {
+        return $this->getFilteredIdentifiers(['issn-print', 'issn-online']);
+    }
+
+    /**
+     * Get an array of ISBNs
+     *
+     * @return array
+     */
+    public function getISBNs()
+    {
+        return $this->getFilteredIdentifiers(['isbn-print', 'isbn-online']);
+    }
+
+    /**
      * Get the list of full text holdings for the record
      *
      * @return array

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
@@ -115,7 +115,7 @@ class EPFTest extends \PHPUnit\Framework\TestCase
                                     'Type' => 'ejsid',
                                     'Value' => '723124',
                                 ],
-                            ]
+                            ],
                         ],
                     ],
                 ],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
@@ -73,6 +73,15 @@ class EPFTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testGetIssns(): void
+    {
+        $issns = $this->getDriverWithIdentifierData()->getISSNs();
+        $this->assertEquals(
+            ['19494998', '19495005'],
+            $issns
+        );
+    }
+
     /**
      * Get a record driver with fake identifier data.
      *
@@ -84,6 +93,26 @@ class EPFTest extends \PHPUnit\Framework\TestCase
             [
                 'Header' => [
                     'PublicationId' => '1234-5678',
+                ],
+                'RecordInfo' => [
+                    'BibRecord' => [
+                        'BibEntity' => [
+                            'Identifiers' => [
+                                [
+                                    'Type' => 'issn-print',
+                                    'Value' => '19494998',
+                                ],
+                                [
+                                    'Type' => 'issn-online',
+                                    'Value' => '19495005',
+                                ],
+                                [
+                                    'Type' => 'ejsid',
+                                    'Value' => '723124',
+                                ],
+                            ]
+                        ],
+                    ],
                 ],
                 'FullTextHoldings' => [
                     [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EPFTest.php
@@ -73,6 +73,11 @@ class EPFTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * Test getIssns for a record.
+     *
+     * @return void
+     */
     public function testGetIssns(): void
     {
         $issns = $this->getDriverWithIdentifierData()->getISSNs();


### PR DESCRIPTION
Although the EDS and EPF APIs both return their identifiers within a structure like 

```
 "RecordInfo": {
   "BibRecord": {
     "BibEntity": {
       "Identifiers": [
         {
           "Type": "issn-print",
           "Value": "00991333"
         },
```

it turns out that the Type metadata is not the same.  Both use `isxn-print` for print.  But for digital items, EPF uses `isxn-online` instead of EDS's `isxn-electronic`.  Go figure.