### PR TITLE
Update getHighlightedSnippet to return first non-empty snippet

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -34,6 +34,7 @@ namespace VuFind\RecordDriver;
 
 use VuFindSearch\Command\SearchCommand;
 
+use function array_key_exists;
 use function count;
 use function in_array;
 use function is_array;
@@ -234,11 +235,15 @@ class SolrDefault extends DefaultRecord implements
         if ($this->snippet) {
             // First check for preferred fields:
             foreach ($this->preferredSnippetFields as $current) {
-                if (isset($this->highlightDetails[$current][0])) {
-                    return [
-                        'snippet' => $this->highlightDetails[$current][0],
-                        'caption' => $this->getSnippetCaption($current),
-                    ];
+                if (array_key_exists($current, $this->highlightDetails)) {
+                    foreach ($this->highlightDetails[$current] as $hl) {
+                        if (!empty($hl)) {
+                            return [
+                                'snippet' => $hl,
+                                'caption' => $this->getSnippetCaption($current),
+                            ];
+                        }
+                    }
                 }
             }
 
@@ -249,10 +254,14 @@ class SolrDefault extends DefaultRecord implements
             ) {
                 foreach ($this->highlightDetails as $key => $value) {
                     if ($value && !in_array($key, $this->forbiddenSnippetFields)) {
-                        return [
-                            'snippet' => $value[0],
-                            'caption' => $this->getSnippetCaption($key),
-                        ];
+                        foreach ($value as $hl) {
+                            if (!empty($hl)) {
+                                return [
+                                    'snippet' => $hl,
+                                    'caption' => $this->getSnippetCaption($key),
+                                ];
+                            }
+                        }
                     }
                 }
             }

--- a/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
+++ b/module/VuFind/src/VuFind/RecordDriver/SolrDefault.php
@@ -34,7 +34,6 @@ namespace VuFind\RecordDriver;
 
 use VuFindSearch\Command\SearchCommand;
 
-use function array_key_exists;
 use function count;
 use function in_array;
 use function is_array;
@@ -235,14 +234,12 @@ class SolrDefault extends DefaultRecord implements
         if ($this->snippet) {
             // First check for preferred fields:
             foreach ($this->preferredSnippetFields as $current) {
-                if (array_key_exists($current, $this->highlightDetails)) {
-                    foreach ($this->highlightDetails[$current] as $hl) {
-                        if (!empty($hl)) {
-                            return [
-                                'snippet' => $hl,
-                                'caption' => $this->getSnippetCaption($current),
-                            ];
-                        }
+                foreach ($this->highlightDetails[$current] ?? [] as $hl) {
+                    if (!empty($hl)) {
+                        return [
+                            'snippet' => $hl,
+                            'caption' => $this->getSnippetCaption($current),
+                        ];
                     }
                 }
             }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
@@ -248,7 +248,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
         $details = ['topic' => ['', 'Testing {{{{START_HILITE}}}}Snippets{{{{END_HILITE}}}} highlighting']];
         $driver->setHighlightDetails($details);
         $this->assertEquals(
-            ['snippet' => 'Testing {{{{START_HILITE}}}}Snippets{{{{END_HILITE}}}} highlighting','caption' => false],
+            ['snippet' => 'Testing {{{{START_HILITE}}}}Snippets{{{{END_HILITE}}}} highlighting', 'caption' => false],
             $driver->getHighlightedSnippet()
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
@@ -271,7 +271,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
         $driver->setHighlightDetails($details);
         // Should return the snippet from contents since that is the first item in preferredSnippetFields
         $this->assertEquals(
-            ['snippet' => 'Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
+            ['snippet' => 'Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}', 'caption' => false],
             $driver->getHighlightedSnippet()
         );
     }
@@ -294,7 +294,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
         $driver->setHighlightDetails($details);
         // Should ignore the 'author' snippet since that is forbidden, and return 'toast' instead
         $this->assertEquals(
-            ['snippet' => 'Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
+            ['snippet' => 'Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}', 'caption' => false],
             $driver->getHighlightedSnippet()
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
@@ -269,7 +269,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
             'contents' => ['Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
         ];
         $driver->setHighlightDetails($details);
-        // Should return the snippent from contents since that is the first item in preferredSnippetFields
+        // Should return the snippet from contents since that is the first item in preferredSnippetFields
         $this->assertEquals(
             ['snippet' => 'Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
             $driver->getHighlightedSnippet()
@@ -292,7 +292,7 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
             'toast' => ['Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
         ];
         $driver->setHighlightDetails($details);
-        // Should return the snippent from contents since that is the first item in preferredSnippetFields
+        // Should ignore the 'author' snippet since that is forbidden, and return 'toast' instead
         $this->assertEquals(
             ['snippet' => 'Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
             $driver->getHighlightedSnippet()

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/SolrDefaultTest.php
@@ -208,13 +208,95 @@ class SolrDefaultTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test getHighlightedSnippet for a record.
+     * Test getHighlightedSnippet for an empty record.
      *
      * @return void
      */
-    public function testGetHighlightedSnippet()
+    public function testEmptyGetHighlightedSnippet()
     {
         $this->assertEquals(false, $this->getDriver()->getHighlightedSnippet());
+    }
+
+    /**
+     * Test getHighlightedSnippet for a record when empty snippet data is given.
+     *
+     * @return void
+     */
+    public function testGetHighlightedSnippetAllEmpty()
+    {
+        $overrides = [
+            'General' => ['snippets' => true],
+        ];
+        $driver = $this->getDriver([], $overrides);
+        $details = ['topic' => ['']];
+        $driver->setHighlightDetails($details);
+        $this->assertEquals(false, $driver->getHighlightedSnippet());
+    }
+
+    /**
+     * Test getHighlightedSnippet for a record when the first snippet is empty.
+     *
+     * @return void
+     */
+    public function testGetHighlightedSnippetFirstEmpty()
+    {
+        $overrides = [
+            'General' => ['snippets' => true],
+        ];
+        $driver = $this->getDriver([], $overrides);
+        // Note that the first topic result is empty, it should return the first non-empty one
+        $details = ['topic' => ['', 'Testing {{{{START_HILITE}}}}Snippets{{{{END_HILITE}}}} highlighting']];
+        $driver->setHighlightDetails($details);
+        $this->assertEquals(
+            ['snippet' => 'Testing {{{{START_HILITE}}}}Snippets{{{{END_HILITE}}}} highlighting','caption' => false],
+            $driver->getHighlightedSnippet()
+        );
+    }
+
+    /**
+     * Test getHighlightedSnippet for a record when multiple preferred snippet fields exist.
+     *
+     * @return void
+     */
+    public function testGetHighlightedSnippetInPreferredFieldOrder()
+    {
+        $overrides = [
+            'General' => ['snippets' => true],
+        ];
+        $driver = $this->getDriver([], $overrides);
+        $details = [
+            'topic' => ['', 'Testing topic {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
+            'contents' => ['Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
+        ];
+        $driver->setHighlightDetails($details);
+        // Should return the snippent from contents since that is the first item in preferredSnippetFields
+        $this->assertEquals(
+            ['snippet' => 'Testing content {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
+            $driver->getHighlightedSnippet()
+        );
+    }
+
+    /**
+     * Test getHighlightedSnippet for a record when no preferred snippet fields exist.
+     *
+     * @return void
+     */
+    public function testGetHighlightedSnippetNonForbiddenField()
+    {
+        $overrides = [
+            'General' => ['snippets' => true],
+        ];
+        $driver = $this->getDriver([], $overrides);
+        $details = [
+            'author' => ['', 'Testing author {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
+            'toast' => ['Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}'],
+        ];
+        $driver->setHighlightDetails($details);
+        // Should return the snippent from contents since that is the first item in preferredSnippetFields
+        $this->assertEquals(
+            ['snippet' => 'Testing toast {{{{START_HILITE}}}}snippet{{{{END_HILITE}}}}','caption' => false],
+            $driver->getHighlightedSnippet()
+        );
     }
 
     /**


### PR DESCRIPTION
In our environment, we have a scenario where sometimes the highlight snippets coming back from Solr can have empty strings in the arrays, resulting in headings without values appearing in search results. This fix is to return the first non-empty snippet value. Additionally I added more unit tests to get `getHighlightedSnippet` up to 100% coverage.

Example of our Solr data with this scenario:
```
"highlighting":
...
    "topic": [
       "",
       "{{{{START_HILITE}}}}Robots{{{{END_HILITE}}}} Catalogs."
    ],
...
```

And on our search results it would have displayed `Subjects: ` instead of `Subjects: “…Robots Catalogs.…”`