### PR TITLE
results-tools.phtml: Add rel="nofollow" to multiple links

### DIFF
--- a/themes/bootstrap3/templates/search/controls/results-tools.phtml
+++ b/themes/bootstrap3/templates/search/controls/results-tools.phtml
@@ -8,7 +8,7 @@
       </a>
     </li>
     <li>
-      <a class="icon-link mailSearch" href="<?=$this->url('search-email')?>" data-lightbox id="mailSearch<?=$this->escapeHtmlAttr($this->results->getSearchId())?>">
+      <a class="icon-link mailSearch" href="<?=$this->url('search-email')?>" data-lightbox id="mailSearch<?=$this->escapeHtmlAttr($this->results->getSearchId())?>" rel="nofollow">
         <?=$this->icon('send-email', 'icon-link__icon') ?>
         <span class="icon-link__label"><?=$this->transEsc('Email this Search')?></span>
       </a>
@@ -21,7 +21,7 @@
             <span class="icon-link__label"><?=$this->transEsc('save_search_remove')?></span>
           </a>
         <?php else: ?>
-          <a class="icon-link" href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($this->results->getSearchId())?>">
+          <a class="icon-link" href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($this->results->getSearchId())?>" rel="nofollow">
             <?=$this->icon('search-save', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('save_search')?></span>
           </a>
@@ -29,7 +29,7 @@
       </li>
       <?php if ($this->accountCapabilities()->isScheduledSearchEnabled() && !empty($this->scheduleOptions)): ?>
         <li>
-          <a class="manageSchedule icon-link" href="<?=$this->url('myresearch-schedulesearch')?>?searchid=<?=urlencode($this->results->getSearchId())?>">
+          <a class="manageSchedule icon-link" href="<?=$this->url('myresearch-schedulesearch')?>?searchid=<?=urlencode($this->results->getSearchId())?>" rel="nofollow">
             <?=$this->icon('search-schedule-alert', 'icon-link__icon') ?>
             <span class="icon-link__label">
               <?=$this->transEsc('history_schedule')?>:

--- a/themes/bootstrap5/templates/search/controls/results-tools.phtml
+++ b/themes/bootstrap5/templates/search/controls/results-tools.phtml
@@ -8,7 +8,7 @@
       </a>
     </li>
     <li>
-      <a class="icon-link mailSearch" href="<?=$this->url('search-email')?>" data-lightbox id="mailSearch<?=$this->escapeHtmlAttr($this->results->getSearchId())?>">
+      <a class="icon-link mailSearch" href="<?=$this->url('search-email')?>" data-lightbox id="mailSearch<?=$this->escapeHtmlAttr($this->results->getSearchId())?>" rel="nofollow">
         <?=$this->icon('send-email', 'icon-link__icon') ?>
         <span class="icon-link__label"><?=$this->transEsc('Email this Search')?></span>
       </a>
@@ -21,7 +21,7 @@
             <span class="icon-link__label"><?=$this->transEsc('save_search_remove')?></span>
           </a>
         <?php else: ?>
-          <a class="icon-link" href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($this->results->getSearchId())?>">
+          <a class="icon-link" href="<?=$this->url('myresearch-savesearch')?>?save=<?=urlencode($this->results->getSearchId())?>" rel="nofollow">
             <?=$this->icon('search-save', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('save_search')?></span>
           </a>
@@ -29,7 +29,7 @@
       </li>
       <?php if ($this->accountCapabilities()->isScheduledSearchEnabled() && !empty($this->scheduleOptions)): ?>
         <li>
-          <a class="manageSchedule icon-link" href="<?=$this->url('myresearch-schedulesearch')?>?searchid=<?=urlencode($this->results->getSearchId())?>">
+          <a class="manageSchedule icon-link" href="<?=$this->url('myresearch-schedulesearch')?>?searchid=<?=urlencode($this->results->getSearchId())?>" rel="nofollow">
             <?=$this->icon('search-schedule-alert', 'icon-link__icon') ?>
             <span class="icon-link__label">
               <?=$this->transEsc('history_schedule')?>:


### PR DESCRIPTION
We noticed that several crawlers (especially ClaudeBot)  try to crawl these pages from our live servers right now ~50-100k times per day, especially SaveSearch, but it makes no sense because the target page is restricted to logged-in users.