### PR TITLE
Fix bug: passing isn=0 to cover loader caused error.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CoverController.php
+++ b/module/VuFind/src/VuFind/Controller/CoverController.php
@@ -106,12 +106,11 @@ class CoverController extends \Laminas\Mvc\Controller\AbstractActionController
         // Legacy support for "isn", "isbn" param which has been superseded by isbns:
         foreach (['isbns', 'isbn', 'isn'] as $identification) {
             if ($isbns = $params()->fromQuery($identification)) {
-                $isbns = (array)$isbns;
                 break;
             }
         }
         return [
-            'isbns' => $isbns,
+            'isbns' => $isbns ? (array)$isbns : null,
             'size' => $params()->fromQuery('size'),
             'type' => $params()->fromQuery('contenttype'),
             'title' => $params()->fromQuery('title'),


### PR DESCRIPTION
There was a small bug in the cover loader code: because of the way ISBNs were validated, passing a "falsy" value like "0" as the ISBN would bypass the array formatting and lead to a fatal error. This minor refactoring avoids that problem and fully ignores falsy ISBN values (since they will never be valid or useful).