### PR TITLE
[VUFIND-1665] Persist limit value in DefaultRecord search links.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContainerLinksTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContainerLinksTest.php
@@ -66,10 +66,14 @@ class ContainerLinksTest extends \VuFindTest\Integration\MinkTestCase
     public function testDefaultContainerLinks(): void
     {
         $page = $this->performSearch('id:jnl1-1');
+        $url = $this->findCss($page, '.result-body a.container-link')->getAttribute('href');
         $this->assertMatchesRegularExpression(
-            '{.*/Search/Results\?lookfor=%22Arithmetic\+Facts%22&type=JournalTitle}',
-            $this->findCss($page, '.result-body a.container-link')->getAttribute('href')
+            '{.*/Search/Results}',
+            parse_url($url, PHP_URL_PATH)
         );
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $this->assertEquals('JournalTitle', $query['type']);
+        $this->assertEquals('"Arithmetic Facts"', $query['lookfor']);
     }
 
     /**

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,7 +1,13 @@
-<?php $searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction(); ?>
 <?php
-if ($searchRoute === 'search-results') { // override search-results with author module
-  echo $this->url('author-home') . '?author=' . urlencode($this->lookfor);
-} else {
-  echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Author';
-}
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  if ($searchRoute === 'search-results') { // override search-results with author module
+    $searchRoute = 'author-home';
+    $query = ['author' => $this->lookfor];
+  } else {
+    $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
+  }
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,13 +1,16 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   if ($searchRoute === 'search-results') { // override search-results with author module
     $searchRoute = 'author-home';
     $query = ['author' => $this->lookfor];
   } else {
     $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
   }
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=JournalTitle';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction();
-echo $this->url($searchRoute, [], ['query' => ['type' => 'Publisher', 'lookfor' => $this->lookfor]]);
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Series';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Subject';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,7 +1,13 @@
-<?php $searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction(); ?>
 <?php
-if ($searchRoute === 'search-results') { // override search-results with author module
-  echo $this->url('author-home') . '?author=' . urlencode($this->lookfor);
-} else {
-  echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Author';
-}
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  if ($searchRoute === 'search-results') { // override search-results with author module
+    $searchRoute = 'author-home';
+    $query = ['author' => $this->lookfor];
+  } else {
+    $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
+  }
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,13 +1,16 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   if ($searchRoute === 'search-results') { // override search-results with author module
     $searchRoute = 'author-home';
     $query = ['author' => $this->lookfor];
   } else {
     $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
   }
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=JournalTitle';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction();
-echo $this->url($searchRoute, [], ['query' => ['type' => 'Publisher', 'lookfor' => $this->lookfor]]);
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Series';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSearchBackendIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Subject';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,3 +1,8 @@
 <?php
-$searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction();
-echo $this->url($searchRoute) . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
+  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,8 +1,11 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $searchRoute = $this->searchOptions($searchBackendId)->getSearchAction();
+  $options = $this->searchOptions($searchBackendId);
+  $searchRoute = $options->getSearchAction();
   $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
-  if ($limit = $this->searchMemory()->getLastLimit($searchBackendId)) {
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
     $query['limit'] = $limit;
   }
   echo $this->url($searchRoute, [], compact('query'));


### PR DESCRIPTION
This PR ensures that the user's chosen limit value is persisted through links that perform new searches (e.g. author, series, etc.). It also includes some code improvements to all of the record driver link templates to improve readability by relying on helper logic instead of manually encoding values.

One known limitation: if you change the limit while in the Author module (i.e. /Author/Home URLs), this limit value does not stick. This is because the author module is distinct from the search module and does not use the same persistent values. This is a separate issue that may or may not be worth fixing, but I think if it's a concern, it should be handled through a different PR/ticket.

TODO
- [x] Run Mink tests