### PR TITLE
Adding record-tab-init event

### DIFF
--- a/themes/bootstrap3/js/embedded_record.js
+++ b/themes/bootstrap3/js/embedded_record.js
@@ -66,6 +66,7 @@ VuFind.register('embedded', function embedded() {
           if (html.length > 0) {
             $('#' + tabid + '-content').html(VuFind.updateCspNonce(html));
             registerTabEvents();
+            VuFind.emit('record-tab-init', {container: document.querySelector('#' + tabid + '-content')});
           } else {
             $('#' + tabid + '-content').html(VuFind.translate('collection_empty'));
           }

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -393,7 +393,7 @@ function recordDocReady() {
   VuFind.truncate.initTruncate('.truncate-subjects', '.subject-line');
   VuFind.truncate.initTruncate('table.truncate-field', 'tr.holding-row', function createTd(m) { return '<td colspan="2">' + m + '</td>'; });
   registerTabEvents();
-  VuFind.emit('record-tab-init', {container: document});
+  VuFind.emit('record-tab-init', {container: document.querySelector( '.record-tabs')});
   applyRecordTabHash(false);
 }
 

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -226,6 +226,7 @@ ajaxLoadTab = function ajaxLoadTabReal($newTab, tabid, setHash, tabUrl) {
         $newTab.html(VuFind.updateCspNonce(data));
       }
       registerTabEvents();
+      VuFind.emit('record-tab-init', {container: $newTab.get(0)});
       if (typeof syn_get_widget === "function") {
         syn_get_widget();
       }

--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -393,6 +393,7 @@ function recordDocReady() {
   VuFind.truncate.initTruncate('.truncate-subjects', '.subject-line');
   VuFind.truncate.initTruncate('table.truncate-field', 'tr.holding-row', function createTd(m) { return '<td colspan="2">' + m + '</td>'; });
   registerTabEvents();
+  VuFind.emit('record-tab-init', {container: document});
   applyRecordTabHash(false);
 }
 

--- a/themes/bootstrap5/js/embedded_record.js
+++ b/themes/bootstrap5/js/embedded_record.js
@@ -66,6 +66,7 @@ VuFind.register('embedded', function embedded() {
           if (html.length > 0) {
             $('#' + tabid + '-content').html(VuFind.updateCspNonce(html));
             registerTabEvents();
+            VuFind.emit('record-tab-init', {container: document.querySelector('#' + tabid + '-content')});
           } else {
             $('#' + tabid + '-content').html(VuFind.translate('collection_empty'));
           }

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -393,7 +393,7 @@ function recordDocReady() {
   VuFind.truncate.initTruncate('.truncate-subjects', '.subject-line');
   VuFind.truncate.initTruncate('table.truncate-field', 'tr.holding-row', function createTd(m) { return '<td colspan="2">' + m + '</td>'; });
   registerTabEvents();
-  VuFind.emit('record-tab-init', {container: document});
+  VuFind.emit('record-tab-init', {container: document.querySelector( '.record-tabs')});
   applyRecordTabHash(false);
 }
 

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -226,6 +226,7 @@ ajaxLoadTab = function ajaxLoadTabReal($newTab, tabid, setHash, tabUrl) {
         $newTab.html(VuFind.updateCspNonce(data));
       }
       registerTabEvents();
+      VuFind.emit('record-tab-init', {container: $newTab.get(0)});
       if (typeof syn_get_widget === "function") {
         syn_get_widget();
       }

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -393,6 +393,7 @@ function recordDocReady() {
   VuFind.truncate.initTruncate('.truncate-subjects', '.subject-line');
   VuFind.truncate.initTruncate('table.truncate-field', 'tr.holding-row', function createTd(m) { return '<td colspan="2">' + m + '</td>'; });
   registerTabEvents();
+  VuFind.emit('record-tab-init', {container: document});
   applyRecordTabHash(false);
 }
 


### PR DESCRIPTION
Similar to the `results-init` event this event allows to listen for loaded record tabs.