### PR TITLE
Introduce GetServiceTrait.

### DIFF
--- a/module/VuFind/src/VuFind/CSV/Importer.php
+++ b/module/VuFind/src/VuFind/CSV/Importer.php
@@ -30,6 +30,7 @@
 namespace VuFind\CSV;
 
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use VuFind\Service\GetServiceTrait;
 use VuFindSearch\Backend\Solr\Document\RawJSONDocument;
 
 use function count;
@@ -45,12 +46,7 @@ use function count;
  */
 class Importer
 {
-    /**
-     * Service locator
-     *
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
+    use GetServiceTrait;
 
     /**
      * Base path for loading .ini files
@@ -162,7 +158,7 @@ class Importer
         if ($testMode) {
             return $json;
         }
-        $solr = $this->serviceLocator->get(\VuFind\Solr\Writer::class);
+        $solr = $this->getService(\VuFind\Solr\Writer::class);
         $solr->save($index, new RawJSONDocument($json), 'update');
         return ''; // no output when not in test mode!
     }
@@ -209,7 +205,7 @@ class Importer
     protected function getConfiguration(string $iniFile, $in): ImporterConfig
     {
         // Load properties file:
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         $ini = $resolver->getConfigPath($iniFile, $this->configBaseDir);
         if (!file_exists($ini)) {
             throw new \Exception("Cannot load .ini file: {$ini}.");

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -43,6 +43,7 @@ use VuFind\Exception\ILS as ILSException;
 use VuFind\Http\PhpEnvironment\Request as HttpRequest;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\I18n\Translator\TranslatorAwareTrait;
+use VuFind\Service\GetServiceTrait;
 
 use function intval;
 use function is_object;
@@ -76,6 +77,7 @@ use function is_object;
  */
 class AbstractBase extends AbstractActionController implements AccessPermissionInterface, TranslatorAwareInterface
 {
+    use GetServiceTrait;
     use TranslatorAwareTrait;
 
     /**
@@ -96,13 +98,6 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      * @var string
      */
     protected $accessDeniedBehavior = null;
-
-    /**
-     * Service manager
-     *
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Constructor
@@ -288,7 +283,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getAuthManager()
     {
-        return $this->serviceLocator->get(\VuFind\Auth\Manager::class);
+        return $this->getService(\VuFind\Auth\Manager::class);
     }
 
     /**
@@ -300,8 +295,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getAuthorizationService()
     {
-        return $this->serviceLocator
-            ->get(\LmcRbacMvc\Service\AuthorizationService::class);
+        return $this->getService(\LmcRbacMvc\Service\AuthorizationService::class);
     }
 
     /**
@@ -311,7 +305,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getILSAuthenticator()
     {
-        return $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
+        return $this->getService(\VuFind\Auth\ILSAuthenticator::class);
     }
 
     /**
@@ -331,7 +325,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getViewRenderer()
     {
-        return $this->serviceLocator->get('ViewRenderer');
+        return $this->getService('ViewRenderer');
     }
 
     /**
@@ -459,8 +453,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getConfig($id = 'config')
     {
-        return $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get($id);
+        return $this->getService(\VuFind\Config\PluginManager::class)->get($id);
     }
 
     /**
@@ -470,7 +463,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getILS()
     {
-        return $this->serviceLocator->get(\VuFind\ILS\Connection::class);
+        return $this->getService(\VuFind\ILS\Connection::class);
     }
 
     /**
@@ -480,7 +473,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getRecordLoader()
     {
-        return $this->serviceLocator->get(\VuFind\Record\Loader::class);
+        return $this->getService(\VuFind\Record\Loader::class);
     }
 
     /**
@@ -490,7 +483,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getRecordCache()
     {
-        return $this->serviceLocator->get(\VuFind\Record\Cache::class);
+        return $this->getService(\VuFind\Record\Cache::class);
     }
 
     /**
@@ -500,7 +493,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getRecordRouter()
     {
-        return $this->serviceLocator->get(\VuFind\Record\Router::class);
+        return $this->getService(\VuFind\Record\Router::class);
     }
 
     /**
@@ -512,8 +505,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getTable($table)
     {
-        return $this->serviceLocator->get(\VuFind\Db\Table\PluginManager::class)
-            ->get($table);
+        return $this->getService(\VuFind\Db\Table\PluginManager::class)->get($table);
     }
 
     /**
@@ -527,8 +519,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getDbService(string $name): \VuFind\Db\Service\DbServiceInterface
     {
-        return $this->serviceLocator->get(\VuFind\Db\Service\PluginManager::class)
-            ->get($name);
+        return $this->getService(\VuFind\Db\Service\PluginManager::class)->get($name);
     }
 
     /**
@@ -638,7 +629,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function disableSessionWrites()
     {
-        $this->serviceLocator->get(\VuFind\Session\Settings::class)->disableWrite();
+        $this->getService(\VuFind\Session\Settings::class)->disableWrite();
     }
 
     /**
@@ -648,7 +639,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     public function getSearchMemory()
     {
-        return $this->serviceLocator->get(\VuFind\Search\Memory::class);
+        return $this->getService(\VuFind\Search\Memory::class);
     }
 
     /**
@@ -658,8 +649,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function commentsEnabled()
     {
-        $check = $this->serviceLocator
-            ->get(\VuFind\Config\AccountCapabilities::class);
+        $check = $this->getService(\VuFind\Config\AccountCapabilities::class);
         return $check->getCommentSetting() !== 'disabled';
     }
 
@@ -670,8 +660,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function listsEnabled()
     {
-        $check = $this->serviceLocator
-            ->get(\VuFind\Config\AccountCapabilities::class);
+        $check = $this->getService(\VuFind\Config\AccountCapabilities::class);
         return $check->getListSetting() !== 'disabled';
     }
 
@@ -682,8 +671,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function tagsEnabled()
     {
-        $check = $this->serviceLocator
-            ->get(\VuFind\Config\AccountCapabilities::class);
+        $check = $this->getService(\VuFind\Config\AccountCapabilities::class);
         return $check->getTagSetting() !== 'disabled';
     }
 
@@ -817,7 +805,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      */
     protected function getRecordTabManager()
     {
-        return $this->serviceLocator->get(\VuFind\RecordTab\TabManager::class);
+        return $this->getService(\VuFind\RecordTab\TabManager::class);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -167,7 +167,7 @@ class AbstractRecord extends AbstractBase
         // something has gone wrong (or user submitted blank form) and we
         // should do nothing:
         if (!empty($comment)) {
-            $populator = $this->serviceLocator->get(ResourcePopulator::class);
+            $populator = $this->getService(ResourcePopulator::class);
             $resource = $populator->getOrCreateResourceForDriver($driver);
             $commentsService = $this->getDbService(
                 \VuFind\Db\Service\CommentsServiceInterface::class
@@ -179,7 +179,7 @@ class AbstractRecord extends AbstractBase
                 $driver->isRatingAllowed()
                 && '0' !== ($rating = $this->params()->fromPost('rating', '0'))
             ) {
-                $ratingsService = $this->serviceLocator->get(RatingsService::class);
+                $ratingsService = $this->getService(RatingsService::class);
                 $ratingsService->saveRating($driver, $user->getId(), intval($rating));
             }
 
@@ -241,7 +241,7 @@ class AbstractRecord extends AbstractBase
 
         // Save tags, if any:
         if ($tags = $this->params()->fromPost('tag')) {
-            $this->serviceLocator->get(TagsService::class)->linkTagsToRecord($driver, $user, $tags);
+            $this->getService(TagsService::class)->linkTagsToRecord($driver, $user, $tags);
             $this->flashMessenger()->addMessage(['msg' => 'add_tag_success'], 'success');
             return $this->redirectToRecord();
         }
@@ -274,7 +274,7 @@ class AbstractRecord extends AbstractBase
 
         // Delete tags, if any:
         if ($tag = $this->params()->fromPost('tag')) {
-            $this->serviceLocator->get(TagsService::class)->unlinkTagsFromRecord(
+            $this->getService(TagsService::class)->unlinkTagsFromRecord(
                 $driver,
                 $user,
                 [$tag]
@@ -315,7 +315,7 @@ class AbstractRecord extends AbstractBase
             ) {
                 throw new BadRequestException('error_inconsistent_parameters');
             }
-            $ratingsService = $this->serviceLocator->get(RatingsService::class);
+            $ratingsService = $this->getService(RatingsService::class);
             $ratingsService->saveRating(
                 $driver,
                 $user->getId(),
@@ -330,7 +330,7 @@ class AbstractRecord extends AbstractBase
 
         // Display the "add rating" form:
         $currentRating = $user
-            ? $this->serviceLocator->get(RatingsService::class)->getRatingData($driver, $user->getId())
+            ? $this->getService(RatingsService::class)->getRatingData($driver, $user->getId())
             : null;
         return $this->createViewModel(compact('currentRating'));
     }
@@ -412,9 +412,9 @@ class AbstractRecord extends AbstractBase
         // Perform the save operation:
         $driver = $this->loadRecord();
         $post = $this->getRequest()->getPost()->toArray();
-        $tagsService = $this->serviceLocator->get(TagsService::class);
+        $tagsService = $this->getService(TagsService::class);
         $post['mytags'] = $tagsService->parse($post['mytags'] ?? '');
-        $favorites = $this->serviceLocator->get(\VuFind\Favorites\FavoritesService::class);
+        $favorites = $this->getService(\VuFind\Favorites\FavoritesService::class);
         $results = $favorites->saveRecordToFavorites($post, $user, $driver);
 
         // Display a success status message:
@@ -541,7 +541,7 @@ class AbstractRecord extends AbstractBase
         $driver = $this->loadRecord();
 
         // Create view
-        $mailer = $this->serviceLocator->get(\VuFind\Mailer\Mailer::class);
+        $mailer = $this->getService(\VuFind\Mailer\Mailer::class);
         $view = $this->createEmailViewModel(
             null,
             $mailer->getDefaultRecordSubject($driver)
@@ -584,8 +584,7 @@ class AbstractRecord extends AbstractBase
      */
     protected function smsEnabled()
     {
-        $check = $this->serviceLocator
-            ->get(\VuFind\Config\AccountCapabilities::class);
+        $check = $this->getService(\VuFind\Config\AccountCapabilities::class);
         return $check->getSmsSetting() !== 'disabled';
     }
 
@@ -605,7 +604,7 @@ class AbstractRecord extends AbstractBase
         $driver = $this->loadRecord();
 
         // Load the SMS carrier list:
-        $sms = $this->serviceLocator->get(\VuFind\SMS\SMSInterface::class);
+        $sms = $this->getService(\VuFind\SMS\SMSInterface::class);
         $view = $this->createViewModel();
         $view->carriers = $sms->getCarriers();
         $view->validation = $sms->getValidationType();
@@ -617,7 +616,7 @@ class AbstractRecord extends AbstractBase
         // Process form submission:
         if ($this->formWasSubmitted(useCaptcha: $view->useCaptcha)) {
             // Do CSRF check
-            $csrf = $this->serviceLocator->get(\VuFind\Validator\SessionCsrf::class);
+            $csrf = $this->getService(\VuFind\Validator\SessionCsrf::class);
             if (!$csrf->isValid($this->getRequest()->getPost()->get('csrf'))) {
                 throw new \VuFind\Exception\BadRequest(
                     'error_inconsistent_parameters'
@@ -679,7 +678,7 @@ class AbstractRecord extends AbstractBase
         $format = $this->params()->fromQuery('style');
 
         // Display export menu if missing/invalid option
-        $export = $this->serviceLocator->get(\VuFind\Export::class);
+        $export = $this->getService(\VuFind\Export::class);
         if (empty($format) || !$export->recordSupportsFormat($driver, $format)) {
             if (!empty($format)) {
                 $this->flashMessenger()
@@ -768,8 +767,7 @@ class AbstractRecord extends AbstractBase
             return $view;
         }
 
-        $explanation = $this->serviceLocator
-            ->get(\VuFind\Search\Explanation\PluginManager::class)
+        $explanation = $this->getService(\VuFind\Search\Explanation\PluginManager::class)
             ->get($record->getSourceIdentifier());
 
         $params = $explanation->getParams();

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -115,8 +115,7 @@ class AbstractSearch extends AbstractBase
         // If we have default filters, set them up as a fake "saved" search
         // to properly populate special controls on the advanced screen.
         if (!$view->saved && count($view->options->getDefaultFilters()) > 0) {
-            $view->saved = $this->serviceLocator
-                ->get(\VuFind\Search\Results\PluginManager::class)
+            $view->saved = $this->getService(\VuFind\Search\Results\PluginManager::class)
                 ->get($this->searchClassId);
             $view->saved->getParams()->initFromRequest(
                 new \Laminas\Stdlib\Parameters([])
@@ -234,8 +233,7 @@ class AbstractSearch extends AbstractBase
             return null;
         }
 
-        $rManager = $this->serviceLocator
-            ->get(\VuFind\Recommend\PluginManager::class);
+        $rManager = $this->getService(\VuFind\Recommend\PluginManager::class);
 
         $override = $this->params()->fromQuery('recommendOverride');
 
@@ -269,7 +267,7 @@ class AbstractSearch extends AbstractBase
      */
     public function homeAction()
     {
-        $blocks = $this->serviceLocator->get(\VuFind\ContentBlock\BlockLoader::class)
+        $blocks = $this->getService(\VuFind\ContentBlock\BlockLoader::class)
             ->getFromSearchClassId($this->searchClassId);
         return $this->createViewModel(compact('blocks'));
     }
@@ -325,7 +323,7 @@ class AbstractSearch extends AbstractBase
         $writer->render();
 
         // Apply XSLT if we can find a relevant file:
-        $themeInfo = $this->serviceLocator->get(\VuFindTheme\ThemeInfo::class);
+        $themeInfo = $this->getService(\VuFindTheme\ThemeInfo::class);
         $themeHits = $themeInfo->findInThemes('assets/xsl/rss.xsl');
         if ($themeHits) {
             $xsl = $this->url()->fromRoute('home') . 'themes/'
@@ -364,7 +362,7 @@ class AbstractSearch extends AbstractBase
             return $this->redirectToSavedSearch($savedId);
         }
 
-        $runner = $this->serviceLocator->get(\VuFind\Search\SearchRunner::class);
+        $runner = $this->getService(\VuFind\Search\SearchRunner::class);
 
         // Send both GET and POST variables to search class:
         $request = $this->getRequest()->getQuery()->toArray()
@@ -437,9 +435,7 @@ class AbstractSearch extends AbstractBase
         }
 
         // Schedule options for footer tools
-        $view->scheduleOptions = $this->serviceLocator
-            ->get(\VuFind\Search\History::class)
-            ->getScheduleOptions();
+        $view->scheduleOptions = $this->getService(\VuFind\Search\History::class)->getScheduleOptions();
         $view->saveToHistory = $this->saveToHistory;
         return $view;
     }
@@ -522,7 +518,7 @@ class AbstractSearch extends AbstractBase
      */
     protected function retrieveSearchSecurely($searchId)
     {
-        $sessId = $this->serviceLocator->get(SessionManager::class)->getId();
+        $sessId = $this->getService(SessionManager::class)->getId();
         return $this->getDbService(SearchServiceInterface::class)
             ->getSearchByIdAndOwner($searchId, $sessId, $this->getUser());
     }
@@ -536,8 +532,8 @@ class AbstractSearch extends AbstractBase
      */
     protected function saveSearchToHistory($results)
     {
-        $sessId = $this->serviceLocator->get(SessionManager::class)->getId();
-        $this->serviceLocator->get(\VuFind\Search\SearchNormalizer::class)->saveNormalizedSearch(
+        $sessId = $this->getService(SessionManager::class)->getId();
+        $this->getService(\VuFind\Search\SearchNormalizer::class)->saveNormalizedSearch(
             $results,
             $sessId,
             $this->getUser()?->getId()
@@ -589,8 +585,7 @@ class AbstractSearch extends AbstractBase
      */
     protected function getResultsManager()
     {
-        return $this->serviceLocator
-            ->get(\VuFind\Search\Results\PluginManager::class);
+        return $this->getService(\VuFind\Search\Results\PluginManager::class);
     }
 
     /**
@@ -648,7 +643,7 @@ class AbstractSearch extends AbstractBase
      */
     protected function getRangeFieldList($config, $section, $filter)
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
+        $config = $this->getService(\VuFind\Config\PluginManager::class)
             ->get($config);
         $fields = isset($config->SpecialFacets->$section)
             ? $config->SpecialFacets->$section->toArray() : [];
@@ -820,7 +815,7 @@ class AbstractSearch extends AbstractBase
         $section = $params[1] ?? 'CheckboxFacets';
 
         // Load config file:
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
+        $config = $this->getService(\VuFind\Config\PluginManager::class)
             ->get($config);
 
         // Process checkbox settings in config:
@@ -891,7 +886,7 @@ class AbstractSearch extends AbstractBase
                 ? 'count'
                 : current(array_keys($facetSortOptions));
         }
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
+        $config = $this->getService(\VuFind\Config\PluginManager::class)
             ->get($options->getFacetsIni());
         $limit = $config->Results_Settings->lightboxLimit ?? 50;
         $limit = $this->params()->fromQuery('facetlimit', $limit);
@@ -941,8 +936,6 @@ class AbstractSearch extends AbstractBase
      */
     public function getOptionsForClass(): \VuFind\Search\Base\Options
     {
-        return $this->serviceLocator
-            ->get(\VuFind\Search\Options\PluginManager::class)
-            ->get($this->searchClassId);
+        return $this->getService(\VuFind\Search\Options\PluginManager::class)->get($this->searchClassId);
     }
 }

--- a/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSolrSearch.php
@@ -58,8 +58,7 @@ class AbstractSolrSearch extends AbstractSearch
      */
     protected function addFacetDetailsToView(ViewModel $view, $list = 'Advanced'): void
     {
-        $facets = $this->serviceLocator
-            ->get(\VuFind\Search\FacetCache\PluginManager::class)
+        $facets = $this->getService(\VuFind\Search\FacetCache\PluginManager::class)
             ->get($this->searchClassId)
             ->getList($list);
         $view->hierarchicalFacets
@@ -172,8 +171,7 @@ class AbstractSolrSearch extends AbstractSearch
             if (in_array($facet, $hierarchicalFacets)) {
                 // Process the facets
                 if (!$facetHelper) {
-                    $facetHelper = $this->serviceLocator
-                        ->get(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
+                    $facetHelper = $this->getService(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
                     $options = $this->getOptionsForClass();
                 }
 

--- a/module/VuFind/src/VuFind/Controller/AlmaController.php
+++ b/module/VuFind/src/VuFind/Controller/AlmaController.php
@@ -284,7 +284,7 @@ class AlmaController extends AbstractBase
             $user = $this->userService->getUserByCatId($primaryId);
             if ($user) {
                 try {
-                    $this->serviceLocator->get(UserAccountService::class)->purgeUserData($user);
+                    $this->getService(UserAccountService::class)->purgeUserData($user);
                     $jsonResponse = $this->createJsonResponse(
                         'Successfully deleted user with primary ID \'' . $primaryId .
                         '\' in VuFind.',
@@ -377,7 +377,7 @@ class AlmaController extends AbstractBase
                 ]
             );
             // Send the email
-            $this->serviceLocator->get(\VuFind\Mailer\Mailer::class)->send(
+            $this->getService(\VuFind\Mailer\Mailer::class)->send(
                 $user->getEmail(),
                 $config->Site->email,
                 $this->translate(

--- a/module/VuFind/src/VuFind/Controller/AuthorController.php
+++ b/module/VuFind/src/VuFind/Controller/AuthorController.php
@@ -108,8 +108,7 @@ class AuthorController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/BrowseController.php
+++ b/module/VuFind/src/VuFind/Controller/BrowseController.php
@@ -331,7 +331,7 @@ class BrowseController extends AbstractBase implements
 
         if ($this->params()->fromQuery('findby')) {
             $params = $this->getRequest()->getQuery()->toArray();
-            $tagsService = $this->serviceLocator->get(TagsService::class);
+            $tagsService = $this->getService(TagsService::class);
             // Special case -- display alphabet selection if necessary:
             if ($params['findby'] == 'alphabetical') {
                 $legalLetters = $this->getAlphabetList();
@@ -633,8 +633,7 @@ class BrowseController extends AbstractBase implements
         $sort = 'count',
         $query = '[* TO *]'
     ) {
-        $results = $this->serviceLocator
-            ->get(\VuFind\Search\Results\PluginManager::class)->get('Solr');
+        $results = $this->getService(\VuFind\Search\Results\PluginManager::class)->get('Solr');
         $params = $results->getParams();
         $params->addFacet($facet);
         if ($category != null) {

--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -103,7 +103,7 @@ class CartController extends AbstractBase
      */
     protected function getCart()
     {
-        return $this->serviceLocator->get(\VuFind\Cart::class);
+        return $this->getService(\VuFind\Cart::class);
     }
 
     /**
@@ -316,7 +316,7 @@ class CartController extends AbstractBase
             // Attempt to send the email and show an appropriate flash message:
             try {
                 // If we got this far, we're ready to send the email:
-                $mailer = $this->serviceLocator->get(\VuFind\Mailer\Mailer::class);
+                $mailer = $this->getService(\VuFind\Mailer\Mailer::class);
                 $mailer->setMaxRecipients($view->maxRecipients);
                 $cc = $this->params()->fromPost('ccself') && $view->from != $view->to
                     ? $view->from : null;
@@ -533,7 +533,7 @@ class CartController extends AbstractBase
 
         // Process submission if necessary:
         if (!($submitDisabled ?? false) && $this->formWasSubmitted()) {
-            $results = $this->serviceLocator->get(FavoritesService::class)
+            $results = $this->getService(FavoritesService::class)
                 ->saveRecordsToFavorites($this->getRequest()->getPost()->toArray(), $user);
             $listUrl = $this->url()->fromRoute(
                 'userList',

--- a/module/VuFind/src/VuFind/Controller/CollectionController.php
+++ b/module/VuFind/src/VuFind/Controller/CollectionController.php
@@ -105,8 +105,7 @@ class CollectionController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/CollectionsController.php
+++ b/module/VuFind/src/VuFind/Controller/CollectionsController.php
@@ -180,8 +180,7 @@ class CollectionsController extends AbstractBase implements
 
         $browseField = 'hierarchy_browse';
 
-        $searchObject = $this->serviceLocator
-            ->get(\VuFind\Search\Results\PluginManager::class)->get('Solr');
+        $searchObject = $this->getService(\VuFind\Search\Results\PluginManager::class)->get('Solr');
         foreach ($appliedFilters as $filter) {
             $searchObject->getParams()->addFilter($filter);
         }
@@ -348,7 +347,7 @@ class CollectionsController extends AbstractBase implements
     {
         $title = addcslashes($title, '"');
         $query = new Query("is_hierarchy_title:\"$title\"", 'AllFields');
-        $searchService = $this->serviceLocator->get(\VuFindSearch\Service::class);
+        $searchService = $this->getService(\VuFindSearch\Service::class);
         $command = new SearchCommand(
             'Solr',
             $query,

--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -73,7 +73,7 @@ class CombinedController extends AbstractSearch
     {
         // We need to load blocks differently in this controller since it
         // doesn't follow the usual configuration pattern.
-        $blocks = $this->serviceLocator->get(\VuFind\ContentBlock\BlockLoader::class)
+        $blocks = $this->getService(\VuFind\ContentBlock\BlockLoader::class)
             ->getFromConfig('combined');
         return $this->createViewModel(compact('blocks'));
     }
@@ -92,7 +92,7 @@ class CombinedController extends AbstractSearch
 
         // Validate configuration:
         $sectionId = $this->params()->fromQuery('id');
-        $optionsManager = $this->serviceLocator->get(\VuFind\Search\Options\PluginManager::class);
+        $optionsManager = $this->getService(\VuFind\Search\Options\PluginManager::class);
         $combinedOptions = $optionsManager->get('combined');
         $tabConfig = $combinedOptions->getTabConfig();
         if (!isset($tabConfig[$sectionId])) {
@@ -147,7 +147,7 @@ class CombinedController extends AbstractSearch
         // Set up current request context:
         $request = $this->getRequest()->getQuery()->toArray()
             + $this->getRequest()->getPost()->toArray();
-        $results = $this->serviceLocator->get(SearchRunner::class)->run(
+        $results = $this->getService(SearchRunner::class)->run(
             $request,
             'Combined',
             $this->getSearchSetupCallback()
@@ -160,7 +160,7 @@ class CombinedController extends AbstractSearch
 
         // Gather combined results:
         $combinedResults = [];
-        $optionsManager = $this->serviceLocator->get(\VuFind\Search\Options\PluginManager::class);
+        $optionsManager = $this->getService(\VuFind\Search\Options\PluginManager::class);
         $combinedOptions = $optionsManager->get('combined');
         // Save the initial type value, since it may get manipulated below:
         $initialType = $this->params()->fromQuery('type');
@@ -201,7 +201,7 @@ class CombinedController extends AbstractSearch
         $results->performAndProcessSearch();
 
         $actualMaxColumns = count($combinedResults);
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)->get('combined')->toArray();
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('combined')->toArray();
         $columnConfig = intval($config['Layout']['columns'] ?? $actualMaxColumns);
         $columns = min($columnConfig, $actualMaxColumns);
         $placement = $config['Layout']['stack_placement'] ?? 'distributed';
@@ -212,7 +212,7 @@ class CombinedController extends AbstractSearch
         // Identify if any modules use include_recommendations_side or
         // include_recommendations_noresults_side.
         $columnSideRecommendations = [];
-        $recommendationManager = $this->serviceLocator->get(\VuFind\Recommend\PluginManager::class);
+        $recommendationManager = $this->getService(\VuFind\Recommend\PluginManager::class);
         foreach ($config as $subconfig) {
             foreach (['include_recommendations_side', 'include_recommendations_noresults_side'] as $type) {
                 if (is_array($subconfig[$type] ?? false)) {
@@ -261,8 +261,7 @@ class CombinedController extends AbstractSearch
                 // We don't need to pass activeSearchClassId forward:
                 unset($params['activeSearchClassId']);
 
-                $route = $this->serviceLocator
-                    ->get(\VuFind\Search\Options\PluginManager::class)
+                $route = $this->getService(\VuFind\Search\Options\PluginManager::class)
                     ->get($searchClassId)->getSearchAction();
                 $base = $this->url()->fromRoute($route);
                 return $this->redirect()

--- a/module/VuFind/src/VuFind/Controller/ContentController.php
+++ b/module/VuFind/src/VuFind/Controller/ContentController.php
@@ -81,7 +81,7 @@ class ContentController extends AbstractBase
             }
             $page = substr($page, $p + 1);
         }
-        $pageLocator = $this->serviceLocator->get(\VuFind\Content\PageLocator::class);
+        $pageLocator = $this->getService(\VuFind\Content\PageLocator::class);
         $data = $pageLocator->determineTemplateAndRenderer($pathPrefix, $page);
 
         $method = isset($data) ? 'getViewFor' . ucwords($data['renderer']) : false;

--- a/module/VuFind/src/VuFind/Controller/EITController.php
+++ b/module/VuFind/src/VuFind/Controller/EITController.php
@@ -61,8 +61,7 @@ class EITController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('EIT');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('EIT');
         return $config->Record->next_prev_navigation ?? false;
     }
 

--- a/module/VuFind/src/VuFind/Controller/EITrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/EITrecordController.php
@@ -68,8 +68,7 @@ class EITrecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('EIT');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('EIT');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/EdsController.php
+++ b/module/VuFind/src/VuFind/Controller/EdsController.php
@@ -63,8 +63,7 @@ class EdsController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('EDS');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('EDS');
         return $config->Record->next_prev_navigation ?? false;
     }
 

--- a/module/VuFind/src/VuFind/Controller/EdsrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/EdsrecordController.php
@@ -125,8 +125,7 @@ class EdsrecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('EDS');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('EDS');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
+++ b/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
@@ -69,12 +69,11 @@ class ExternalAuthController extends AbstractBase implements LoggerAwareInterfac
 
         $user = $this->getUser();
 
-        $authService = $this->serviceLocator
-            ->get(\LmcRbacMvc\Service\AuthorizationService::class);
+        $authService = $this->getService(\LmcRbacMvc\Service\AuthorizationService::class);
         if ($authService->isGranted($this->ezproxyRequiredPermission)) {
             // Access granted, redirect to EZproxy
             if (empty($config->EZproxy->disable_ticket_auth_logging)) {
-                $logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+                $logger = $this->getService(\VuFind\Log\Logger::class);
                 $logger->info(
                     "EZproxy login to '" . $config->EZproxy->host
                     . "' for '" . ($user ? $user->getUsername() : 'anonymous')

--- a/module/VuFind/src/VuFind/Controller/Feature/AlphaBrowseTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/AlphaBrowseTrait.php
@@ -59,7 +59,7 @@ trait AlphaBrowseTrait
      */
     protected function alphabeticBrowse()
     {
-        $service = $this->serviceLocator->get(\VuFindSearch\Service::class);
+        $service = $this->getService(\VuFindSearch\Service::class);
         $command = new AlphabeticBrowseCommand(
             $this->alphabrowseBackend,
             ...func_get_args()

--- a/module/VuFind/src/VuFind/Controller/Feature/ConfigPathTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/ConfigPathTrait.php
@@ -49,7 +49,7 @@ trait ConfigPathTrait
      */
     protected function getBaseConfigFilePath(string $filename): string
     {
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         return $resolver->getBaseConfigPath($filename);
     }
 
@@ -62,7 +62,7 @@ trait ConfigPathTrait
      */
     protected function getForcedLocalConfigPath(string $filename): string
     {
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         return $resolver->getLocalConfigPath($filename, null, true);
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Feature/RecordVersionsSearchTrait.php
+++ b/module/VuFind/src/VuFind/Controller/Feature/RecordVersionsSearchTrait.php
@@ -73,7 +73,7 @@ trait RecordVersionsSearchTrait
 
         $view = $this->getSearchResultsView($callback);
         if (null !== $id) {
-            $loader = $this->serviceLocator->get(\VuFind\Record\Loader::class);
+            $loader = $this->getService(\VuFind\Record\Loader::class);
             $view->driver = $loader->load($id, $this->searchClassId);
         }
         return $view;

--- a/module/VuFind/src/VuFind/Controller/FeedbackController.php
+++ b/module/VuFind/src/VuFind/Controller/FeedbackController.php
@@ -67,7 +67,7 @@ class FeedbackController extends AbstractBase implements LoggerAwareInterface
 
         $user = $this->getUser();
 
-        $form = $this->serviceLocator->get($this->formClass);
+        $form = $this->getService($this->formClass);
         $prefill = $this->params()->fromQuery();
         $params = [];
         if ($refererHeader = $this->getRequest()->getHeader('Referer')) {

--- a/module/VuFind/src/VuFind/Controller/HierarchyController.php
+++ b/module/VuFind/src/VuFind/Controller/HierarchyController.php
@@ -122,8 +122,7 @@ class HierarchyController extends AbstractBase
         $lookfor = $this->params()->fromQuery('lookfor', '');
         $searchType = $this->params()->fromQuery('type', 'AllFields');
 
-        $results = $this->serviceLocator
-            ->get(\VuFind\Search\Results\PluginManager::class)->get($source);
+        $results = $this->getService(\VuFind\Search\Results\PluginManager::class)->get($source);
         $results->getParams()->setBasicSearch($lookfor, $searchType);
         $results->getParams()->addFilter('hierarchy_top_id:' . $hierarchyID);
         $facets = $results->getFullFieldFacets(['id'], false, null === $limit ? -1 : $limit + 1);

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -467,7 +467,7 @@ class HoldsController extends AbstractBase
     {
         return new \Laminas\Session\Container(
             'hold_update',
-            $this->serviceLocator->get(\Laminas\Session\SessionManager::class)
+            $this->getService(\Laminas\Session\SessionManager::class)
         );
     }
 

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -227,7 +227,7 @@ trait HoldsTrait
         }
 
         // Set default start date to today:
-        $dateConverter = $this->serviceLocator->get(\VuFind\Date\Converter::class);
+        $dateConverter = $this->getService(\VuFind\Date\Converter::class);
         $defaultStartDate = $dateConverter->convertToDisplayDate('U', time());
 
         // Find and format the default required date:

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -140,8 +140,7 @@ trait ILLRequestsTrait
         // Find and format the default required date:
         $defaultRequiredDate = $this->ILLRequests()
             ->getDefaultRequiredDate($checkRequests);
-        $defaultRequiredDate
-            = $this->serviceLocator->get(\VuFind\Date\Converter::class)
+        $defaultRequiredDate = $this->getService(\VuFind\Date\Converter::class)
             ->convertToDisplayDate('U', $defaultRequiredDate);
 
         // Get pickup libraries

--- a/module/VuFind/src/VuFind/Controller/InstallController.php
+++ b/module/VuFind/src/VuFind/Controller/InstallController.php
@@ -157,7 +157,7 @@ class InstallController extends AbstractBase
      */
     protected function getSolrUrlFromImportConfig()
     {
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         $importConfig = $resolver->getLocalConfigPath('import.properties', 'import');
         if (file_exists($importConfig)) {
             $props = file_get_contents($importConfig);
@@ -212,7 +212,7 @@ class InstallController extends AbstractBase
      */
     protected function checkCache()
     {
-        $cache = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+        $cache = $this->getService(\VuFind\Cache\Manager::class);
         return [
             'title' => 'Cache',
             'status' => !$cache->hasDirectoryCreationError(),
@@ -227,7 +227,7 @@ class InstallController extends AbstractBase
      */
     public function fixcacheAction()
     {
-        $cache = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+        $cache = $this->getService(\VuFind\Cache\Manager::class);
         $view = $this->createViewModel();
         $view->cacheDir = $cache->getCacheDir();
         if (function_exists('posix_getpwuid') && function_exists('posix_geteuid')) {
@@ -413,8 +413,7 @@ class InstallController extends AbstractBase
                 try {
                     $dbName = ($view->driver == 'pgsql')
                         ? 'template1' : $view->driver;
-                    $db = $this->serviceLocator
-                        ->get(\VuFind\Db\AdapterFactory::class)
+                    $db = $this->getService(\VuFind\Db\AdapterFactory::class)
                         ->getAdapterFromConnectionString("{$connection}/{$dbName}");
                 } catch (\Exception $e) {
                     $this->flashMessenger()
@@ -451,8 +450,7 @@ class InstallController extends AbstractBase
                         foreach ($preCommands as $query) {
                             $db->query($query, $db::QUERY_MODE_EXECUTE);
                         }
-                        $dbFactory = $this->serviceLocator
-                            ->get(\VuFind\Db\AdapterFactory::class);
+                        $dbFactory = $this->getService(\VuFind\Db\AdapterFactory::class);
                         $db = $dbFactory->getAdapterFromConnectionString(
                             $connection . '/' . $view->dbname
                         );
@@ -650,7 +648,7 @@ class InstallController extends AbstractBase
     protected function testSearchService()
     {
         // Try to retrieve an arbitrary ID -- this will fail if Solr is down:
-        $searchService = $this->serviceLocator->get(\VuFindSearch\Service::class);
+        $searchService = $this->getService(\VuFindSearch\Service::class);
         $command = new RetrieveCommand('Solr', '1');
         $searchService->invoke($command)->getResult();
     }
@@ -812,7 +810,7 @@ class InstallController extends AbstractBase
 
         // Now we want to loop through the database and update passwords (if
         // necessary).
-        $ilsAuthenticator = $this->serviceLocator->get(\VuFind\Auth\ILSAuthenticator::class);
+        $ilsAuthenticator = $this->getService(\VuFind\Auth\ILSAuthenticator::class);
         $userRows = $this->getDbService(UserServiceInterface::class)->getInsecureRows();
         if (count($userRows) > 0) {
             $bcrypt = new Bcrypt();
@@ -853,7 +851,7 @@ class InstallController extends AbstractBase
     {
         // Try to retrieve an SSL URL; if we're misconfigured, it will fail.
         try {
-            $this->serviceLocator->get(\VuFindHttp\HttpService::class)
+            $this->getService(\VuFindHttp\HttpService::class)
                 ->get('https://google.com');
             $status = true;
         } catch (\VuFindHttp\Exception\RuntimeException $e) {

--- a/module/VuFind/src/VuFind/Controller/LibGuidesAZController.php
+++ b/module/VuFind/src/VuFind/Controller/LibGuidesAZController.php
@@ -62,8 +62,7 @@ class LibGuidesAZController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('LibGuidesAZ');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('LibGuidesAZ');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/LibGuidesController.php
+++ b/module/VuFind/src/VuFind/Controller/LibGuidesController.php
@@ -60,8 +60,7 @@ class LibGuidesController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('LibGuides');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('LibGuides');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
+++ b/module/VuFind/src/VuFind/Controller/LibraryCardsController.php
@@ -325,8 +325,7 @@ class LibraryCardsController extends AbstractBase
                     $info = $patron;
                     $info['cardID'] = $id;
                     $info['cardName'] = $cardName;
-                    $emailAuthenticator = $this->serviceLocator
-                        ->get(\VuFind\Auth\EmailAuthenticator::class);
+                    $emailAuthenticator = $this->getService(\VuFind\Auth\EmailAuthenticator::class);
                     $emailAuthenticator->sendAuthenticationLink(
                         $info['email'],
                         $info,
@@ -366,8 +365,7 @@ class LibraryCardsController extends AbstractBase
      */
     protected function processEmailLink($user, $hash)
     {
-        $emailAuthenticator = $this->serviceLocator
-            ->get(\VuFind\Auth\EmailAuthenticator::class);
+        $emailAuthenticator = $this->getService(\VuFind\Auth\EmailAuthenticator::class);
         try {
             $info = $emailAuthenticator->authenticate($hash);
             $cardService = $this->getDbService(UserCardServiceInterface::class);

--- a/module/VuFind/src/VuFind/Controller/OaiController.php
+++ b/module/VuFind/src/VuFind/Controller/OaiController.php
@@ -103,13 +103,13 @@ class OaiController extends AbstractBase
                 $this->getRequest()->getQuery()->toArray(),
                 $this->getRequest()->getPost()->toArray()
             );
-            $server = $this->serviceLocator->get($serverClass);
+            $server = $this->getService($serverClass);
             $server->init($config, $baseURL, $params);
             $server->setRecordLinkerHelper(
                 $this->getViewRenderer()->plugin('recordLinker')
             );
             $server->setRecordFormatter(
-                $this->serviceLocator->get(RecordFormatter::class)
+                $this->getService(RecordFormatter::class)
             );
             $xml = $server->getResponse();
         } catch (\Exception $e) {

--- a/module/VuFind/src/VuFind/Controller/OverdriveController.php
+++ b/module/VuFind/src/VuFind/Controller/OverdriveController.php
@@ -112,8 +112,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
 
                     try {
                         $this->debug("loading checkout using: $idToLoad");
-                        $mycheckout['record']
-                            = $this->serviceLocator->get(\VuFind\Record\Loader::class)
+                        $mycheckout['record'] = $this->getService(\VuFind\Record\Loader::class)
                             ->load($idToLoad);
                         $checkouts[] = $mycheckout;
                     } catch (\VuFind\Exception\RecordMissing $e) {
@@ -148,7 +147,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
                     $myhold['hold'] = $hold;
                     try {
                         $myhold['record']
-                            = $this->serviceLocator->get(\VuFind\Record\Loader::class)
+                            = $this->getService(\VuFind\Record\Loader::class)
                             ->load(strtolower($hold->reserveId));
                         $holds[] = $myhold;
                     } catch (\VuFind\Exception\RecordMissing $e) {
@@ -241,7 +240,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
 
         $this->debug("ODRC od_id=$od_id rec_id=$rec_id action=$action");
         // Load the Record Driver. Should be a SolrOverdrive driver.
-        $driver = $this->serviceLocator->get(\VuFind\Record\Loader::class)->load(
+        $driver = $this->getService(\VuFind\Record\Loader::class)->load(
             $rec_id
         );
 
@@ -345,7 +344,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
         $od_id = $this->params()->fromQuery('od_id');
         $rec_id = $this->params()->fromQuery('rec_id');
         // Load the Record Driver. Should be a SolrOverdrive driver.
-        $driver = $this->serviceLocator->get(\VuFind\Record\Loader::class)->load(
+        $driver = $this->getService(\VuFind\Record\Loader::class)->load(
             $rec_id
         );
         $formats = $driver->getDigitalFormats();
@@ -473,7 +472,7 @@ class OverdriveController extends AbstractBase implements LoggerAwareInterface
         $result = $this->connector->getResultObject();
         $rec_id = $this->params()->fromQuery('rec_id');
         // Load the SolrOverdrive driver.
-        $driver = $this->serviceLocator->get(\VuFind\Record\Loader::class)->load(
+        $driver = $this->getService(\VuFind\Record\Loader::class)->load(
             $rec_id
         );
         $formats = $driver->getDigitalFormats();

--- a/module/VuFind/src/VuFind/Controller/PrimoController.php
+++ b/module/VuFind/src/VuFind/Controller/PrimoController.php
@@ -64,8 +64,7 @@ class PrimoController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Primo');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Primo');
         return $config->Record->next_prev_navigation ?? false;
     }
 

--- a/module/VuFind/src/VuFind/Controller/PrimorecordController.php
+++ b/module/VuFind/src/VuFind/Controller/PrimorecordController.php
@@ -65,8 +65,7 @@ class PrimorecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Primo');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Primo');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/RecordController.php
+++ b/module/VuFind/src/VuFind/Controller/RecordController.php
@@ -69,8 +69,7 @@ class RecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Search2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/Search2Controller.php
@@ -60,8 +60,7 @@ class Search2Controller extends AbstractSolrSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Search2');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Search2');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/Search2recordController.php
+++ b/module/VuFind/src/VuFind/Controller/Search2recordController.php
@@ -61,8 +61,7 @@ class Search2recordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Search2');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Search2');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -81,7 +81,7 @@ class SearchController extends AbstractSolrSearch
         // Retrieve and manipulate the parameters:
         $searchHelper = $this->getViewRenderer()->plugin('searchMemory');
         $params = $searchHelper->getLastSearchParams($searchClassId);
-        $factory = $this->serviceLocator->get(UrlQueryHelperFactory::class);
+        $factory = $this->getService(UrlQueryHelperFactory::class);
         $initialParams = $factory->fromParams($params);
 
         if ($removeAllFilters) {
@@ -123,7 +123,7 @@ class SearchController extends AbstractSolrSearch
     {
         // If a URL was explicitly passed in, use that; otherwise, try to
         // find the HTTP referrer.
-        $mailer = $this->serviceLocator->get(\VuFind\Mailer\Mailer::class);
+        $mailer = $this->getService(\VuFind\Mailer\Mailer::class);
         $view = $this->createEmailViewModel(null, $mailer->getDefaultLinkSubject());
         $mailer->setMaxRecipients($view->maxRecipients);
         // Set up Captcha
@@ -196,8 +196,7 @@ class SearchController extends AbstractSolrSearch
         }
         $userId = $user?->getId();
 
-        $searchHistoryHelper = $this->serviceLocator
-            ->get(\VuFind\Search\History::class);
+        $searchHistoryHelper = $this->getService(\VuFind\Search\History::class);
 
         if ($this->params()->fromQuery('purge')) {
             $searchHistoryHelper->purgeSearchHistory($userId);
@@ -208,8 +207,7 @@ class SearchController extends AbstractSolrSearch
         $viewData = $searchHistoryHelper->getSearchHistory($userId);
         // Eliminate schedule settings if scheduled searches are disabled; add
         // user email data if scheduled searches are enabled.
-        $scheduleOptions = $this->serviceLocator
-            ->get(\VuFind\Search\History::class)
+        $scheduleOptions = $this->getService(\VuFind\Search\History::class)
             ->getScheduleOptions();
         if (empty($scheduleOptions)) {
             unset($viewData['schedule']);
@@ -240,8 +238,7 @@ class SearchController extends AbstractSolrSearch
             ]
         );
         if ($this->newItems()->includeFacets()) {
-            $view->options = $this->serviceLocator
-                ->get(\VuFind\Search\Options\PluginManager::class)
+            $view->options = $this->getService(\VuFind\Search\Options\PluginManager::class)
                 ->get($this->searchClassId);
             $this->addFacetDetailsToView($view, 'NewItems');
         }
@@ -373,7 +370,7 @@ class SearchController extends AbstractSolrSearch
             + $this->getRequest()->getPost()->toArray()
         );
         $view = $this->createViewModel();
-        $runner = $this->serviceLocator->get(\VuFind\Search\SearchRunner::class);
+        $runner = $this->getService(\VuFind\Search\SearchRunner::class);
         $view->results = $runner->run(
             $request,
             'SolrReserves',
@@ -512,8 +509,7 @@ class SearchController extends AbstractSolrSearch
 
         // Get suggestions and make sure they are an array (we don't want to JSON
         // encode them into an object):
-        $suggester = $this->serviceLocator
-            ->get(\VuFind\Autocomplete\Suggester::class);
+        $suggester = $this->getService(\VuFind\Autocomplete\Suggester::class);
         $suggestions = $suggester->getSuggestions($query, 'type', 'lookfor');
 
         // Send the JSON response:
@@ -533,8 +529,7 @@ class SearchController extends AbstractSolrSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/Controller/ShibbolethLogoutNotificationController.php
+++ b/module/VuFind/src/VuFind/Controller/ShibbolethLogoutNotificationController.php
@@ -119,7 +119,7 @@ class ShibbolethLogoutNotificationController extends AbstractBase
         $rows = $this->getDbService(ExternalSessionServiceInterface::class)
             ->getAllByExternalSessionId(trim($sessionId));
         if ($rows) {
-            $sessionManager = $this->serviceLocator->get(\Laminas\Session\SessionManager::class);
+            $sessionManager = $this->getService(\Laminas\Session\SessionManager::class);
             $handler = $sessionManager->getSaveHandler();
             foreach ($rows as $row) {
                 $handler->destroy($row->getSessionId());

--- a/module/VuFind/src/VuFind/Controller/ShortlinkController.php
+++ b/module/VuFind/src/VuFind/Controller/ShortlinkController.php
@@ -115,7 +115,7 @@ class ShortlinkController extends AbstractBase
     public function redirectAction()
     {
         if ($id = $this->params('id')) {
-            $resolver = $this->serviceLocator->get(UrlShortenerInterface::class);
+            $resolver = $this->getService(UrlShortenerInterface::class);
             if ($url = $resolver->resolve($id)) {
                 $threshRegEx = '"^threshold:(\d+)$"i';
                 if (preg_match($threshRegEx, $this->redirectMethod, $hits)) {

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -159,8 +159,7 @@ trait StorageRetrievalRequestsTrait
         // Find and format the default required date:
         $defaultRequiredDate = $this->storageRetrievalRequests()
             ->getDefaultRequiredDate($checkRequests);
-        $defaultRequiredDate
-            = $this->serviceLocator->get(\VuFind\Date\Converter::class)
+        $defaultRequiredDate = $this->getService(\VuFind\Date\Converter::class)
             ->convertToDisplayDate('U', $defaultRequiredDate);
         try {
             $defaultPickup

--- a/module/VuFind/src/VuFind/Controller/SummonController.php
+++ b/module/VuFind/src/VuFind/Controller/SummonController.php
@@ -61,8 +61,7 @@ class SummonController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Summon');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Summon');
         return $config->Record->next_prev_navigation ?? false;
     }
 
@@ -108,8 +107,8 @@ class SummonController extends AbstractSearch
         $view = parent::advancedAction();
 
         // Set up facet information:
-        $facets = $this->serviceLocator
-            ->get(\VuFind\Search\FacetCache\PluginManager::class)->get('Summon')
+        $facets = $this->getService(\VuFind\Search\FacetCache\PluginManager::class)
+            ->get('Summon')
             ->getList('Advanced');
         $view->facetList = $this->processAdvancedFacets($facets, $view->saved);
         $specialFacets = $this->parseSpecialFacetsSetting(

--- a/module/VuFind/src/VuFind/Controller/SummonrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/SummonrecordController.php
@@ -65,8 +65,7 @@ class SummonrecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('Summon');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('Summon');
         return $config->Record->next_prev_navigation ?? false;
     }
 

--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -273,7 +273,7 @@ class UpgradeController extends AbstractBase
         // subsequent calls.
         static $adapter = false;
         if (!$adapter) {
-            $factory = $this->serviceLocator->get(AdapterFactory::class);
+            $factory = $this->getService(AdapterFactory::class);
             $adapter = $factory->getAdapter(
                 $this->session->dbRootUser,
                 $this->session->dbRootPass
@@ -346,7 +346,7 @@ class UpgradeController extends AbstractBase
      */
     protected function fixSearchChecksumsInDatabase()
     {
-        $manager = $this->serviceLocator->get(ResultsManager::class);
+        $manager = $this->getService(ResultsManager::class);
         $searchService = $this->getDbService(SearchServiceInterface::class);
         $searchRows = $searchService->getSavedSearchesWithMissingChecksums();
         if (count($searchRows) > 0) {
@@ -561,8 +561,7 @@ class UpgradeController extends AbstractBase
                 // If this is a MySQL connection, we can do an automatic upgrade;
                 // if VuFind is using a different database, we have to prompt the
                 // user to check the migrations directory and upgrade manually.
-                $adapter = $this->serviceLocator
-                    ->get(Adapter::class);
+                $adapter = $this->getService(Adapter::class);
                 $platform = $adapter->getDriver()->getDatabasePlatformName();
                 if (strtolower($platform) == 'mysql') {
                     $upgradeResult = $this->upgradeMySQL($adapter);
@@ -589,7 +588,7 @@ class UpgradeController extends AbstractBase
                 $this->getRequest()->getQuery()->set('anonymousCnt', $anonymousTags);
                 return $this->redirect()->toRoute('upgrade-fixanonymoustags');
             }
-            $dupeTags = $this->serviceLocator->get(TagsService::class)->getDuplicateTags();
+            $dupeTags = $this->getService(TagsService::class)->getDuplicateTags();
             if (count($dupeTags) > 0 && !isset($this->cookie->skipDupeTags)) {
                 return $this->redirect()->toRoute('upgrade-fixduplicatetags');
             }
@@ -683,8 +682,7 @@ class UpgradeController extends AbstractBase
                 // Test the connection:
                 try {
                     // Query a table known to exist
-                    $factory = $this->serviceLocator
-                        ->get(AdapterFactory::class);
+                    $factory = $this->getService(AdapterFactory::class);
                     $db = $factory->getAdapter($dbrootuser, $pass);
                     $db->query('SELECT * FROM user;');
                     $this->session->dbRootUser = $dbrootuser;
@@ -757,7 +755,7 @@ class UpgradeController extends AbstractBase
 
         // Handle submit action:
         if ($this->formWasSubmitted()) {
-            $this->serviceLocator->get(TagsService::class)->fixDuplicateTags();
+            $this->getService(TagsService::class)->fixDuplicateTags();
             return $this->forwardTo('Upgrade', 'FixDatabase');
         }
 
@@ -793,7 +791,7 @@ class UpgradeController extends AbstractBase
 
         // Process submit button:
         if ($this->formWasSubmitted()) {
-            $resourcePopulator = $this->serviceLocator->get(ResourcePopulator::class);
+            $resourcePopulator = $this->getService(ResourcePopulator::class);
             foreach ($problems as $problem) {
                 $recordId = $problem->getRecordId();
                 $source = $problem->getSource();
@@ -960,7 +958,7 @@ class UpgradeController extends AbstractBase
     {
         // If the cache is messed up, nothing is going to work right -- check that
         // first:
-        $cache = $this->serviceLocator->get(CacheManager::class);
+        $cache = $this->getService(CacheManager::class);
         if ($cache->hasDirectoryCreationError()) {
             return $this->redirect()->toRoute('install-fixcache');
         }

--- a/module/VuFind/src/VuFind/Controller/WorldcatController.php
+++ b/module/VuFind/src/VuFind/Controller/WorldcatController.php
@@ -60,8 +60,7 @@ class WorldcatController extends AbstractSearch
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('WorldCat');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('WorldCat');
         return $config->Record->next_prev_navigation ?? false;
     }
 

--- a/module/VuFind/src/VuFind/Controller/WorldcatrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/WorldcatrecordController.php
@@ -63,8 +63,7 @@ class WorldcatrecordController extends AbstractRecord
      */
     protected function resultScrollerActive()
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-            ->get('WorldCat');
+        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('WorldCat');
         return $config->Record->next_prev_navigation ?? false;
     }
 }

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
@@ -43,6 +43,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use VuFind\RateLimiter\Storage\CredisStorage;
+use VuFind\Service\GetServiceTrait;
 
 /**
  * Rate limiter manager factory.
@@ -55,12 +56,7 @@ use VuFind\RateLimiter\Storage\CredisStorage;
  */
 class RateLimiterManagerFactory implements FactoryInterface
 {
-    /**
-     * Service locator
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
+    use GetServiceTrait;
 
     /**
      * Create an object
@@ -151,7 +147,7 @@ class RateLimiterManagerFactory implements FactoryInterface
 
         if ('vufind' === $adapterLc) {
             // Use cache manager for "VuFind" cache (only for testing purposes):
-            $cacheManager = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+            $cacheManager = $this->getService(\VuFind\Cache\Manager::class);
             $laminasCache = $cacheManager->getCache('object', $storageConfig['options']['namespace']);
             // Fake the capabilities to include static TTL support:
             $eventManager = $laminasCache->getEventManager();
@@ -178,8 +174,7 @@ class RateLimiterManagerFactory implements FactoryInterface
                 'adapter' => $adapter,
                 'options' => $storageConfig['options'],
             ];
-            $laminasCache = $this->serviceLocator
-                ->get(\Laminas\Cache\Service\StorageAdapterFactory::class)
+            $laminasCache = $this->getService(\Laminas\Cache\Service\StorageAdapterFactory::class)
                 ->createFromArrayConfiguration($settings);
         }
 

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractBackendFactory.php
@@ -33,6 +33,7 @@ use Laminas\Cache\Storage\StorageInterface;
 use Laminas\Config\Config;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
+use VuFind\Service\GetServiceTrait;
 
 /**
  * Abstract factory for backends.
@@ -45,12 +46,7 @@ use Psr\Container\ContainerInterface;
  */
 abstract class AbstractBackendFactory implements FactoryInterface
 {
-    /**
-     * Service container.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
+    use GetServiceTrait;
 
     /**
      * Constructor
@@ -86,8 +82,7 @@ abstract class AbstractBackendFactory implements FactoryInterface
         array $options = [],
         string $url = null
     ): \Laminas\Http\Client {
-        $client = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
-            ->createClient($url);
+        $client = $this->getService(\VuFindHttp\HttpService::class)->createClient($url);
         if (null !== $timeout) {
             $options['timeout'] = $timeout;
         }
@@ -119,8 +114,7 @@ abstract class AbstractBackendFactory implements FactoryInterface
             'adapter' => $cacheConfig['adapter'],
             'options' => $options,
         ];
-        return $this->serviceLocator
-            ->get(\Laminas\Cache\Service\StorageAdapterFactory::class)
+        return $this->getService(\Laminas\Cache\Service\StorageAdapterFactory::class)
             ->createFromArrayConfiguration($settings);
     }
 }

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -200,10 +200,9 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $this->config = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class);
+        $this->config = $this->getService(\VuFind\Config\PluginManager::class);
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -308,7 +307,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
      */
     protected function createListeners(Backend $backend)
     {
-        $events = $this->serviceLocator->get('SharedEventManager');
+        $events = $this->getService('SharedEventManager');
 
         // Load configurations:
         $config = $this->config->get($this->mainConfig);
@@ -616,8 +615,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
      */
     protected function loadSpecs()
     {
-        return $this->serviceLocator->get(\VuFind\Config\SearchSpecsReader::class)
-            ->get($this->searchYaml);
+        return $this->getService(\VuFind\Config\SearchSpecsReader::class)->get($this->searchYaml);
     }
 
     /**
@@ -713,8 +711,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
             $search->ConditionalHiddenFilters->toArray()
         );
         $listener->setAuthorizationService(
-            $this->serviceLocator
-                ->get(\LmcRbacMvc\Service\AuthorizationService::class)
+            $this->getService(\LmcRbacMvc\Service\AuthorizationService::class)
         );
         return $listener;
     }

--- a/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/BrowZineBackendFactory.php
@@ -74,11 +74,10 @@ class BrowZineBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $configReader = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class);
+        $configReader = $this->getService(\VuFind\Config\PluginManager::class);
         $this->browzineConfig = $configReader->get('BrowZine');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
 
         $connector = $this->createConnector();
@@ -145,8 +144,7 @@ class BrowZineBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get('BrowZine');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EITBackendFactory.php
@@ -76,11 +76,9 @@ class EITBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $this->config = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class)
-            ->get('EIT');
+        $this->config = $this->getService(\VuFind\Config\PluginManager::class)->get('EIT');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -142,8 +140,7 @@ class EITBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get('EIT');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/EdsBackendFactory.php
@@ -101,11 +101,10 @@ class EdsBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $this->edsConfig = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class)
+        $this->edsConfig = $this->getService(\VuFind\Config\PluginManager::class)
             ->get($this->getServiceName());
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend = $this->createBackend($connector);
@@ -122,24 +121,23 @@ class EdsBackendFactory extends AbstractBackendFactory
      */
     protected function createBackend(Connector $connector)
     {
-        $auth = $this->serviceLocator
-            ->get(\LmcRbacMvc\Service\AuthorizationService::class);
+        $auth = $this->getService(\LmcRbacMvc\Service\AuthorizationService::class);
         $isGuest = !$auth->isGranted('access.EDSExtendedResults');
         $session = new \Laminas\Session\Container(
             'EBSCO',
-            $this->serviceLocator->get(\Laminas\Session\SessionManager::class)
+            $this->getService(\Laminas\Session\SessionManager::class)
         );
         $backend = new Backend(
             $connector,
             $this->createRecordCollectionFactory(),
-            $this->serviceLocator->get(\VuFind\Cache\Manager::class)
+            $this->getService(\VuFind\Cache\Manager::class)
                 ->getCache('object'),
             $session,
             $this->edsConfig,
             $isGuest
         );
         $backend->setAuthManager(
-            $this->serviceLocator->get(\VuFind\Auth\Manager::class)
+            $this->getService(\VuFind\Auth\Manager::class)
         );
         $backend->setLogger($this->logger);
         $backend->setQueryBuilder($this->createQueryBuilder());
@@ -213,8 +211,7 @@ class EdsBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get($this->getServiceName());
             $driver->setRawData($data);
@@ -232,7 +229,7 @@ class EdsBackendFactory extends AbstractBackendFactory
      */
     protected function createListeners(Backend $backend)
     {
-        $events = $this->serviceLocator->get('SharedEventManager');
+        $events = $this->getService('SharedEventManager');
 
         // Attach hide facet value listener:
         $hfvListener = $this->getHideFacetValueListener($backend, $this->edsConfig);

--- a/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/LibGuidesBackendFactory.php
@@ -84,11 +84,10 @@ class LibGuidesBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $configReader = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class);
+        $configReader = $this->getService(\VuFind\Config\PluginManager::class);
         $this->libGuidesConfig = $configReader->get($this->getServiceName());
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -164,8 +163,7 @@ class LibGuidesBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get($this->getServiceName());
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Pazpar2BackendFactory.php
@@ -74,11 +74,9 @@ class Pazpar2BackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $this->config = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class)
-            ->get('Pazpar2');
+        $this->config = $this->getService(\VuFind\Config\PluginManager::class)->get('Pazpar2');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -140,8 +138,7 @@ class Pazpar2BackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get('Pazpar2');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/PrimoBackendFactory.php
@@ -102,11 +102,10 @@ class PrimoBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $configReader = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class);
+        $configReader = $this->getService(\VuFind\Config\PluginManager::class);
         $this->primoConfig = $configReader->get('Primo');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
 
         if (($this->primoConfig->General->api ?? 'legacy') === 'rest') {
@@ -148,7 +147,7 @@ class PrimoBackendFactory extends AbstractBackendFactory
      */
     protected function createListeners(Backend $backend)
     {
-        $events = $this->serviceLocator->get('SharedEventManager');
+        $events = $this->getService('SharedEventManager');
 
         $this->getInjectOnCampusListener()->attach($events);
 
@@ -211,7 +210,7 @@ class PrimoBackendFactory extends AbstractBackendFactory
 
         $session = new \Laminas\Session\Container(
             'Primo',
-            $this->serviceLocator->get(\Laminas\Session\SessionManager::class)
+            $this->getService(\Laminas\Session\SessionManager::class)
         );
 
         // Create connector:
@@ -254,8 +253,7 @@ class PrimoBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get('Primo');
             $driver->setRawData($data);
@@ -287,7 +285,7 @@ class PrimoBackendFactory extends AbstractBackendFactory
                 $this->primoConfig->Institutions
             );
             $permHandler->setAuthorizationService(
-                $this->serviceLocator->get(AuthorizationService::class)
+                $this->getService(AuthorizationService::class)
             );
             return $permHandler;
         }

--- a/module/VuFind/src/VuFind/Search/Factory/Search2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Search2BackendFactory.php
@@ -59,8 +59,7 @@ class Search2BackendFactory extends SolrDefaultBackendFactory
      */
     protected function getCreateRecordCallback(): ?callable
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         return [$manager, 'getSearch2Record'];
     }
 }

--- a/module/VuFind/src/VuFind/Search/Factory/SolrAuthBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrAuthBackendFactory.php
@@ -63,8 +63,7 @@ class SolrAuthBackendFactory extends AbstractSolrBackendFactory
      */
     protected function getCreateRecordCallback(): ?callable
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         return [$manager, 'getSolrAuthRecord'];
     }
 }

--- a/module/VuFind/src/VuFind/Search/Factory/SolrDefaultBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrDefaultBackendFactory.php
@@ -62,8 +62,7 @@ class SolrDefaultBackendFactory extends AbstractSolrBackendFactory
      */
     protected function getCreateRecordCallback(): ?callable
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         return [$manager, 'getSolrRecord'];
     }
 }

--- a/module/VuFind/src/VuFind/Search/Factory/SolrReservesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrReservesBackendFactory.php
@@ -61,8 +61,7 @@ class SolrReservesBackendFactory extends AbstractSolrBackendFactory
      */
     protected function getCreateRecordCallback(): ?callable
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         return function ($data) use ($manager) {
             $driver = $manager->get('SolrReserves');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/SolrWebBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrWebBackendFactory.php
@@ -61,8 +61,7 @@ class SolrWebBackendFactory extends AbstractSolrBackendFactory
      */
     protected function getCreateRecordCallback(): ?callable
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         return function ($data) use ($manager) {
             $driver = $manager->get('SolrWeb');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -82,12 +82,11 @@ class SummonBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $configReader = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class);
+        $configReader = $this->getService(\VuFind\Config\PluginManager::class);
         $this->config = $configReader->get('config');
         $this->summonConfig = $configReader->get('Summon');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -139,8 +138,7 @@ class SummonBackendFactory extends AbstractBackendFactory
      */
     protected function isAuthed()
     {
-        return $this->serviceLocator
-            ->get(\LmcRbacMvc\Service\AuthorizationService::class)
+        return $this->getService(\LmcRbacMvc\Service\AuthorizationService::class)
             ->isGranted('access.SummonExtendedResults');
     }
 
@@ -166,8 +164,7 @@ class SummonBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $stripSnippets = !($this->summonConfig->General->snippets ?? false);
         $callback = function ($data) use ($manager, $stripSnippets) {
             $driver = $manager->get('Summon');

--- a/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/WorldCatBackendFactory.php
@@ -81,13 +81,10 @@ class WorldCatBackendFactory extends AbstractBackendFactory
     public function __invoke(ContainerInterface $sm, $name, array $options = null)
     {
         $this->setup($sm);
-        $this->config = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class)
-            ->get('config');
-        $this->wcConfig = $this->serviceLocator
-            ->get(\VuFind\Config\PluginManager::class)->get('WorldCat');
+        $this->config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
+        $this->wcConfig = $this->getService(\VuFind\Config\PluginManager::class)->get('WorldCat');
         if ($this->serviceLocator->has(\VuFind\Log\Logger::class)) {
-            $this->logger = $this->serviceLocator->get(\VuFind\Log\Logger::class);
+            $this->logger = $this->getService(\VuFind\Log\Logger::class);
         }
         $connector = $this->createConnector();
         $backend   = $this->createBackend($connector);
@@ -146,8 +143,7 @@ class WorldCatBackendFactory extends AbstractBackendFactory
      */
     protected function createRecordCollectionFactory()
     {
-        $manager = $this->serviceLocator
-            ->get(\VuFind\RecordDriver\PluginManager::class);
+        $manager = $this->getService(\VuFind\RecordDriver\PluginManager::class);
         $callback = function ($data) use ($manager) {
             $driver = $manager->get('WorldCat');
             $driver->setRawData($data);

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -37,6 +37,7 @@ namespace VuFind\Search\Solr;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Psr\Container\ContainerInterface;
+use VuFind\Service\GetServiceTrait;
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\Service;
 
@@ -54,19 +55,14 @@ use function in_array;
  */
 class DeduplicationListener
 {
+    use GetServiceTrait;
+
     /**
      * Backend.
      *
      * @var Backend
      */
     protected $backend;
-
-    /**
-     * Service container.
-     *
-     * @var ContainerInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Search configuration file identifier.
@@ -217,7 +213,7 @@ class DeduplicationListener
      */
     protected function fetchLocalRecords($event)
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class);
+        $config = $this->getService(\VuFind\Config\PluginManager::class);
         $dataSourceConfig = $config->get($this->dataSourceConfig);
         $recordSources = $this->getActiveRecordSources($event);
         $sourcePriority = $this->determineSourcePriority($recordSources);
@@ -343,7 +339,7 @@ class DeduplicationListener
      */
     protected function getActiveRecordSources($event): array
     {
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class);
+        $config = $this->getService(\VuFind\Config\PluginManager::class);
         $searchConfig = $config->get($this->searchConfig);
         return !empty($searchConfig->Records->sources)
             ? explode(',', $searchConfig->Records->sources)

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
@@ -35,6 +35,7 @@ use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFind\I18n\TranslatableString;
+use VuFind\Service\GetServiceTrait;
 use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\Service;
 
@@ -53,19 +54,14 @@ use function is_array;
  */
 class HierarchicalFacetListener
 {
+    use GetServiceTrait;
+
     /**
      * Backend.
      *
      * @var BackendInterface
      */
     protected $backend;
-
-    /**
-     * Service container.
-     *
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
 
     /**
      * Facet configuration.
@@ -126,10 +122,9 @@ class HierarchicalFacetListener
         $this->backend = $backend;
         $this->serviceLocator = $serviceLocator;
 
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class);
+        $config = $this->getService(\VuFind\Config\PluginManager::class);
         $this->facetConfig = $config->get($facetConfig);
-        $this->facetHelper = $this->serviceLocator
-            ->get(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
+        $this->facetHelper = $this->getService(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
 
         $specialFacets = $this->facetConfig->SpecialFacets;
         $this->displayStyles

--- a/module/VuFind/src/VuFind/Service/GetServiceTrait.php
+++ b/module/VuFind/src/VuFind/Service/GetServiceTrait.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Blended Search Controller
+ * Trait implementing generic getter for top-level services.
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2023.
+ * Copyright (C) Villanova University 2024.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,46 +21,45 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Controller
+ * @package  Service
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org Main Site
+ * @link     https://vufind.org/wiki/development Wiki
  */
 
-namespace VuFind\Controller;
+namespace VuFind\Service;
 
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerInterface;
 
 /**
- * Blended Search Controller
+ * Trait implementing generic getter for top-level services.
  *
  * @category VuFind
- * @package  Controller
+ * @package  Service
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org Main Site
+ * @link     https://vufind.org/wiki/development Wiki
  */
-class BlenderController extends AbstractSearch
+trait GetServiceTrait
 {
     /**
-     * Constructor
+     * Service manager
      *
-     * @param ServiceLocatorInterface $sm Service locator
+     * @var ContainerInterface
      */
-    public function __construct(ServiceLocatorInterface $sm)
-    {
-        $this->searchClassId = 'Blender';
-        parent::__construct($sm);
-    }
+    protected $serviceLocator;
 
     /**
-     * Is the result scroller active?
+     * Retrieve a service
      *
-     * @return bool
+     * @param class-string<T> $name Name of service to retrieve
+     *
+     * @template T
+     *
+     * @return T
      */
-    protected function resultScrollerActive()
+    public function getService(string $name)
     {
-        $config = $this->getService(\VuFind\Config\PluginManager::class)->get('config');
-        return $config->Record->next_prev_navigation ?? false;
+        return $this->serviceLocator->get($name);
     }
 }

--- a/module/VuFind/src/VuFind/XSLT/Importer.php
+++ b/module/VuFind/src/VuFind/XSLT/Importer.php
@@ -31,6 +31,7 @@ namespace VuFind\XSLT;
 
 use DOMDocument;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use VuFind\Service\GetServiceTrait;
 use VuFindSearch\Backend\Solr\Document\RawXMLDocument;
 use XSLTProcessor;
 
@@ -47,12 +48,7 @@ use function is_array;
  */
 class Importer
 {
-    /**
-     * Service locator
-     *
-     * @var ServiceLocatorInterface
-     */
-    protected $serviceLocator;
+    use GetServiceTrait;
 
     /**
      * Constructor
@@ -86,7 +82,7 @@ class Importer
 
         // Save the results (or just display them, if in test mode):
         if (!$testMode) {
-            $solr = $this->serviceLocator->get(\VuFind\Solr\Writer::class);
+            $solr = $this->getService(\VuFind\Solr\Writer::class);
             $solr->save($index, new RawXMLDocument($xml));
         }
         return $xml;
@@ -104,7 +100,7 @@ class Importer
     protected function generateXML($xmlFile, $properties)
     {
         // Load properties file:
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         $properties = $resolver->getConfigPath($properties, 'import');
         if (!file_exists($properties)) {
             throw new \Exception("Cannot load properties file: {$properties}.");

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/AbstractAdmin.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/AbstractAdmin.php
@@ -76,8 +76,7 @@ class AbstractAdmin extends \VuFind\Controller\AbstractBase
         // Block access to everyone when module is disabled:
         $config = $this->getConfig();
         if (!isset($config->Site->admin_enabled) || !$config->Site->admin_enabled) {
-            $pluginManager  = $this->serviceLocator
-                ->get(\Laminas\Mvc\Controller\PluginManager::class);
+            $pluginManager  = $this->getService(\Laminas\Mvc\Controller\PluginManager::class);
             $redirectPlugin = $pluginManager->get('redirect');
             return $redirectPlugin->toRoute('admin/disabled');
         }

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/AdminController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/AdminController.php
@@ -60,7 +60,7 @@ class AdminController extends AbstractAdmin
         $config = $this->getConfig();
         $xml = false;
         if (isset($config->Index->url)) {
-            $response = $this->serviceLocator->get(\VuFindHttp\HttpService::class)
+            $response = $this->getService(\VuFindHttp\HttpService::class)
                 ->get($config->Index->url . '/admin/cores?wt=xml');
             $xml = $response->isSuccess() ? $response->getBody() : false;
         }

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
@@ -49,7 +49,7 @@ class ConfigController extends AbstractAdmin
     {
         $view = $this->createViewModel();
         $view->setTemplate('admin/config/home');
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         $view->baseConfigPath = $resolver->getBaseConfigPath('');
         $conf = $this->getConfig();
         $view->showInstallLink
@@ -64,7 +64,7 @@ class ConfigController extends AbstractAdmin
      */
     public function enableautoconfigAction()
     {
-        $resolver = $this->serviceLocator->get(\VuFind\Config\PathResolver::class);
+        $resolver = $this->getService(\VuFind\Config\PathResolver::class);
         if (!($configFile = $resolver->getLocalConfigPath('config.ini'))) {
             $this->flashMessenger()->addErrorMessage(
                 'Could not enable auto-configuration; local '
@@ -85,8 +85,7 @@ class ConfigController extends AbstractAdmin
 
             // Reload config now that it has been edited (otherwise, old setting
             // will persist in cache):
-            $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
-                ->reload('config');
+            $this->getService(\VuFind\Config\PluginManager::class)->reload('config');
         } else {
             $this->flashMessenger()->addErrorMessage(
                 'Could not enable auto-configuration; check permissions on '

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/MaintenanceController.php
@@ -102,7 +102,7 @@ class MaintenanceController extends AbstractAdmin
     public function homeAction()
     {
         $view = $this->createViewModel();
-        $cacheManager = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+        $cacheManager = $this->getService(\VuFind\Cache\Manager::class);
         $view->caches = $cacheManager->getCacheList();
         $view->nonPersistentCaches = $cacheManager->getNonPersistentCacheList();
         $view->scripts = $this->getScripts();
@@ -118,7 +118,7 @@ class MaintenanceController extends AbstractAdmin
     protected function getScripts(): array
     {
         // Load the AdminScripts.ini settings
-        $config = $this->serviceLocator->get(\VuFind\Config\PluginManager::class)
+        $config = $this->getService(\VuFind\Config\PluginManager::class)
             ->get('AdminScripts')->toArray();
         $globalConfig = $config['Global'] ?? [];
         unset($config['Global']);
@@ -169,7 +169,7 @@ class MaintenanceController extends AbstractAdmin
     public function clearcacheAction()
     {
         $cache = null;
-        $cacheManager = $this->serviceLocator->get(\VuFind\Cache\Manager::class);
+        $cacheManager = $this->getService(\VuFind\Cache\Manager::class);
         foreach ($this->params()->fromQuery('cache', []) as $cache) {
             $cacheManager->getCache($cache)->flush();
         }

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/OverdriveController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/OverdriveController.php
@@ -69,8 +69,7 @@ class OverdriveController extends AbstractAdmin
      */
     public function homeAction()
     {
-        $connector  = $this->serviceLocator
-            ->get(\VuFind\DigitalContent\OverdriveConnector::class);
+        $connector  = $this->getService(\VuFind\DigitalContent\OverdriveConnector::class);
 
         $view = $this->createViewModel();
         $view->setTemplate('admin/overdrive/home');

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/SocialstatsController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/SocialstatsController.php
@@ -57,7 +57,7 @@ class SocialstatsController extends AbstractAdmin
         $view->comments = $this->getDbService(CommentsServiceInterface::class)->getStatistics();
         $view->ratings = $this->getDbService(RatingsServiceInterface::class)->getStatistics();
         $view->favorites = $this->getDbService(UserResourceServiceInterface::class)->getStatistics();
-        $view->tags = $this->serviceLocator->get(TagsService::class)->getStatistics();
+        $view->tags = $this->getService(TagsService::class)->getStatistics();
         return $view;
     }
 }

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/TagsController.php
@@ -83,7 +83,7 @@ class TagsController extends AbstractAdmin
     {
         $view = $this->createViewModel();
         $view->setTemplate('admin/tags/home');
-        $view->statistics = $this->serviceLocator->get(TagsService::class)->getStatistics(true);
+        $view->statistics = $this->getService(TagsService::class)->getStatistics(true);
         return $view;
     }
 
@@ -118,7 +118,7 @@ class TagsController extends AbstractAdmin
         $view->uniqueUsers = $this->getUniqueUsers();
         $view->uniqueResources = $this->getUniqueResources();
         $page = intval($this->getParam('page', false, '1'));
-        $view->results = $this->serviceLocator->get(TagsService::class)->getResourceTagsPaginator(
+        $view->results = $this->getService(TagsService::class)->getResourceTagsPaginator(
             $this->convertFilter($this->getParam('user_id', false)),
             $this->convertFilter($this->getParam('resource_id', false)),
             $this->convertFilter($this->getParam('tag_id', false)),
@@ -304,7 +304,7 @@ class TagsController extends AbstractAdmin
      */
     protected function confirmTagsDeleteByFilter($originUrl, $newUrl)
     {
-        $count = $this->serviceLocator->get(TagsService::class)->getResourceTagsPaginator(
+        $count = $this->getService(TagsService::class)->getResourceTagsPaginator(
             $this->convertFilter($this->getParam('user_id')),
             $this->convertFilter($this->getParam('resource_id')),
             $this->convertFilter($this->getParam('tag_id'))
@@ -351,7 +351,7 @@ class TagsController extends AbstractAdmin
      */
     protected function getUniqueTags(): array
     {
-        return $this->serviceLocator->get(TagsService::class)->getUniqueTags(
+        return $this->getService(TagsService::class)->getUniqueTags(
             $this->convertFilter($this->getParam('user_id', false)),
             $this->convertFilter($this->getParam('resource_id', false)),
             $this->convertFilter($this->getParam('tag_id', false))

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiTrait.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiTrait.php
@@ -126,8 +126,7 @@ trait ApiTrait
      */
     protected function isAccessDenied($permission)
     {
-        $auth = $this->serviceLocator
-            ->get(\LmcRbacMvc\Service\AuthorizationService::class);
+        $auth = $this->getService(\LmcRbacMvc\Service\AuthorizationService::class);
         if (!$auth->isGranted($permission)) {
             return $this->output(
                 [],

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -253,7 +253,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             return $this->output([], self::STATUS_ERROR, 400, 'Missing id');
         }
 
-        $loader = $this->serviceLocator->get(\VuFind\Record\Loader::class);
+        $loader = $this->getService(\VuFind\Record\Loader::class);
         $results = [];
         try {
             if (is_array($request['id'])) {
@@ -324,7 +324,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             ? $facetConfig->SpecialFacets->hierarchical->toArray()
             : [];
 
-        $runner = $this->serviceLocator->get(\VuFind\Search\SearchRunner::class);
+        $runner = $this->getService(\VuFind\Search\SearchRunner::class);
         try {
             $results = $runner->run(
                 $request,
@@ -410,8 +410,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
         $facetResults = $results->getFullFieldFacets($facets, false, -1, 'count');
 
-        $facetHelper = $this->serviceLocator
-            ->get(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
+        $facetHelper = $this->getService(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
 
         $facetList = [];
         foreach ($facets as $facet) {

--- a/module/VuFindDevTools/src/VuFindDevTools/Controller/DevtoolsController.php
+++ b/module/VuFindDevTools/src/VuFindDevTools/Controller/DevtoolsController.php
@@ -61,8 +61,7 @@ class DevtoolsController extends \VuFind\Controller\AbstractBase
     {
         $command = new \VuFindSearch\Command\GetQueryBuilderCommand($id);
         try {
-            $this->serviceLocator->get(\VuFindSearch\Service::class)
-                ->invoke($command);
+            $this->getService(\VuFindSearch\Service::class)->invoke($command);
         } catch (\Exception $e) {
             return null;
         }
@@ -83,7 +82,7 @@ class DevtoolsController extends \VuFind\Controller\AbstractBase
         }
         if (isset($view->min) && $view->min) {
             $view->results = $view->min->deminify(
-                $this->serviceLocator->get(ResultsManager::class)
+                $this->getService(ResultsManager::class)
             );
         }
         if (isset($view->results) && $view->results) {
@@ -117,7 +116,7 @@ class DevtoolsController extends \VuFind\Controller\AbstractBase
      */
     public function iconAction()
     {
-        $config = $this->serviceLocator->get(\VuFindTheme\ThemeInfo::class)
+        $config = $this->getService(\VuFindTheme\ThemeInfo::class)
             ->getMergedConfig('icons');
         $aliases = array_keys($config['aliases'] ?? []);
         sort($aliases);
@@ -133,7 +132,7 @@ class DevtoolsController extends \VuFind\Controller\AbstractBase
     {
         // Test languages with no local overrides and no fallback:
         $loader = new ExtendedIni([APPLICATION_PATH . '/languages']);
-        $langs = $this->serviceLocator->get(LocaleSettings::class)
+        $langs = $this->getService(LocaleSettings::class)
             ->getEnabledLocales();
         $helper = new LanguageHelper($loader, $langs);
         return $helper->getAllDetails(


### PR DESCRIPTION
This PR introduces a trait with a getter that wraps around `$this->serviceLocator->get()` in order to improve type validation in the code. Now, fetching a service from the service locator will be associated with the appropriate type, enabling more accurate IDE typehints and static analysis.

This trait can also serve as a marker for classes that currently make direct access to the service locator, since in the long term it would be better to replace many of these retrieval operations with cleaner dependency injection. I expect that this trait will remain useful indefinitely for some of our more complex factories, however!

TODO
- [x] Run full test suite