### PR TITLE
Add SpecBuilder->removeLine() method

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatter/SpecBuilder.php
@@ -91,6 +91,18 @@ class SpecBuilder
     }
 
     /**
+     * Remove a previously set generic spec line.
+     *
+     * @param string $key Label associated with this spec line
+     *
+     * @return void
+     */
+    public function removeLine($key)
+    {
+        unset($this->spec[$key]);
+    }
+
+    /**
      * Construct a multi-function template spec line.
      *
      * @param string   $key        Label to associate with this spec line

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatter/SpecBuilderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatter/SpecBuilderTest.php
@@ -51,6 +51,7 @@ class SpecBuilderTest extends \PHPUnit\Framework\TestCase
      */
     public function testBuilder()
     {
+        // Test building a spec:
         $builder = new SpecBuilder();
         $builder->setLine('foo', 'getFoo');
         $builder->setLine('bar', 'getBar');
@@ -74,6 +75,7 @@ class SpecBuilderTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         $this->assertEquals($expected, $builder->getArray());
+        // Test various methods of reordering the spec:
         $builder->reorderKeys(['xyzzy', 'bar']);
         $expected['xyzzy']['pos'] = 100;
         $expected['bar']['pos'] = 200;
@@ -87,5 +89,9 @@ class SpecBuilderTest extends \PHPUnit\Framework\TestCase
         $expected['bar']['pos'] = 400;
         $expected['foo']['pos'] = 100;
         $this->assertEquals($expected, $builder->getArray());
+        // Test that we can remove lines from the spec:
+        $builder->removeLine('bar');
+        $builder->removeLine('foo');
+        $this->assertEquals(['xyzzy' => $expected['xyzzy']], $builder->getArray());
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatter/SpecBuilderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatter/SpecBuilderTest.php
@@ -49,7 +49,7 @@ class SpecBuilderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testBuilder()
+    public function testBuilder(): void
     {
         // Test building a spec:
         $builder = new SpecBuilder();


### PR DESCRIPTION
SpecBuilder should have the ability to remove a previously added specification line, so that RecordDataFormatterFactory subclasses can call `parent::getDefaultXXXSpecs()` and then remove fields added by the parent method.