### PR TITLE
SierraRest: improve extractVolume compatibility

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1784,7 +1784,9 @@ class SierraRest extends AbstractBase implements
     {
         foreach ($item['varFields'] ?? [] as $varField) {
             if ($varField['fieldTag'] == 'v') {
-                return trim($varField['subfields'][0]['content'] ?? '');
+                // Depending on Sierra version/configuration, the content may be in a couple
+                // of different places. This logic checks both possibilities.
+                return trim($varField['subfields'][0]['content'] ?? $varField['content'] ?? '');
             }
         }
         return '';


### PR DESCRIPTION
This PR is a follow-up to @bpalme's [comment](https://github.com/vufind-org/vufind/commit/f95b85da017c78f8107a81bc8758da3feb2e215d#commitcomment-143908766) about #3619.

I can't test this myself, and I'm not sure if any of the other `'content'` references in the code may need similar treatment, but I think this should at least qualify as an improvement.