### PR TITLE
Fix incorrect ID encoding when jumping to records.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -508,7 +508,10 @@ class AbstractSearch extends AbstractBase
         return $this->redirect()->toRoute(
             $details['route'],
             $details['params'],
-            ['query' => $queryParams]
+            array_merge_recursive(
+                $details['options'] ?? [],
+                ['query' => $queryParams]
+            )
         );
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
@@ -82,6 +82,25 @@ class AlphabrowseTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that we can jump to a record with an ID containing slashes
+     *
+     * @return void
+     */
+    public function testJumpToRecordWithIdContainingSlashes(): void
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Alphabrowse/Home');
+        $page = $session->getPage();
+        $this->findCssAndSetValue($page, '#alphaBrowseForm_source', 'author');
+        $this->findCssAndSetValue($page, '#alphaBrowseForm_from', 'will b. broke');
+        $this->clickCss($page, '#alphaBrowseForm .btn-primary');
+        $this->waitForPageLoad($page);
+        $this->clickCss($page, 'td.author a');
+        $this->waitForPageLoad($page);
+        $this->assertStringContainsString('Record/dollar$ign%2Fslashcombo', $session->getCurrentUrl());
+    }
+
+    /**
      * Test that extra attributes are escaped correctly.
      *
      * @return void


### PR DESCRIPTION
The VuFind\Controller\AbstractSearch::getRedirectForRecord() method was not correctly accounting for options provided by the record router, which resulted in record IDs with special characters generating incorrect URLs and redirecting to error pages. This fixes the problem.

TODO
- [x] Run full test suite