### PR TITLE
Fix bug: allow display of facet value of 0.

### DIFF
--- a/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/single-facet.phtml
@@ -16,11 +16,10 @@
   if ($this->facet['operator'] == 'AND') {
     $classList[] = 'facetAND';
   }
-
   $displayText = '-';
-  if (!empty($this->facet['displayText'])) {
+  if ('' !== (string)($this->facet['displayText'] ?? '')) {
     $displayText = $this->escapeHtml($this->facet['displayText']);
-  } elseif (!empty($this->facet['value'])) {
+  } elseif ('' !== (string)($this->facet['value'] ?? '')) {
     $displayText = $this->escapeHtml($this->facet['value']);
   }
   $displayText = '<span class="facet-value' . ($hasCheckbox ? ' icon-link__label' : '') . '">' . $displayText . '</span>';

--- a/themes/bootstrap5/templates/Recommend/SideFacets/single-facet.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets/single-facet.phtml
@@ -16,11 +16,10 @@
   if ($this->facet['operator'] == 'AND') {
     $classList[] = 'facetAND';
   }
-
   $displayText = '-';
-  if (!empty($this->facet['displayText'])) {
+  if ('' !== (string)($this->facet['displayText'] ?? '')) {
     $displayText = $this->escapeHtml($this->facet['displayText']);
-  } elseif (!empty($this->facet['value'])) {
+  } elseif ('' !== (string)($this->facet['value'] ?? '')) {
     $displayText = $this->escapeHtml($this->facet['value']);
   }
   $displayText = '<span class="facet-value' . ($hasCheckbox ? ' icon-link__label' : '') . '">' . $displayText . '</span>';


### PR DESCRIPTION
Empty checks in the facet templates resulted in a facet value of `0` being displayed as `-`. This PR makes the check more specific, so only truly empty (i.e. blank string) values are replaced.