### PR TITLE
Fix KeepAlive error in trigger-print.js

### DIFF
--- a/themes/bootstrap3/js/check_save_statuses.js
+++ b/themes/bootstrap3/js/check_save_statuses.js
@@ -132,13 +132,9 @@ VuFind.register("saveStatuses", function ItemStatuses() {
     }
 
     const records = container.querySelectorAll(".result,.record");
-
-    if (records.length === 0) {
-      VuFind.emit("save-status-done");
-      return;
-    }
-
     records.forEach(checkSaveStatus);
+
+    VuFind.emit("save-status-done");
   }
 
   function refresh() {

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -788,6 +788,7 @@ function setupMultiILSLoginFields(loginMethods, idPrefix) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  VuFind.emit("ready");
   // Start up all of our submodules
   VuFind.init();
   // Off canvas

--- a/themes/bootstrap3/js/trigger_print.js
+++ b/themes/bootstrap3/js/trigger_print.js
@@ -3,18 +3,19 @@
 function waitForItemStatuses(fn) {
   var itemDone = typeof VuFind.itemStatuses === "undefined";
   var saveDone = typeof VuFind.saveStatuses === "undefined";
+
   var fnCalled = false;
-
-  if (itemDone && saveDone) {
-    fn();
-    return;
-  }
-
   function checkBoth() {
     if (!fnCalled && itemDone && saveDone) {
       fn();
       fnCalled = true;
+      return true;
     }
+    return false;
+  }
+
+  if (checkBoth()) {
+    return;
   }
 
   VuFind.listen("item-status-done", function listenForItemStatusDone() {
@@ -38,33 +39,28 @@ function waitForItemStatuses(fn) {
   }
 
   waitForItemStatuses(function waitForAjax() {
-    $(document).one('ajaxStop', function doTriggerPrint() {
-      // Print dialogs cause problems during testing, so disable them
-      // when the "test mode" cookie is set. This should never happen
-      // under normal usage outside of the Phing startup process.
-      if (document.cookie.indexOf('VuFindTestSuiteRunning=') > -1) {
-        console.log("Printing disabled due to test mode."); // eslint-disable-line no-console
-        return;
-      }
+    // Print dialogs cause problems during testing, so disable them
+    // when the "test mode" cookie is set. This should never happen
+    // under normal usage outside of the Phing startup process.
+    if (document.cookie.indexOf('VuFindTestSuiteRunning=') > -1) {
+      console.log("Printing disabled due to test mode."); // eslint-disable-line no-console
+      return;
+    }
 
-      window.addEventListener(
-        "afterprint",
-        function doAfterPrint() {
-          // Return to previous page after a minimal timeout. This is
-          // done to avoid problems with some browsers, which fire the
-          // afterprint event while the print dialog is still open.
-          defer(function doGoBack() { history.back(); });
-        },
-        { once: true }
-      );
+    window.addEventListener(
+      "afterprint",
+      function doAfterPrint() {
+        // Return to previous page after a minimal timeout. This is
+        // done to avoid problems with some browsers, which fire the
+        // afterprint event while the print dialog is still open.
+        defer(function doGoBack() { history.back(); });
+      },
+      { once: true }
+    );
 
-      // Trigger print after a minimal timeout. This is done to avoid
-      // problems with some browsers, which might not fully update
-      // ajax loaded page content before showing the print dialog.
-      defer(function doPrint() { window.print(); });
-    });
-
-    // Make an ajax call to ensure that ajaxStop is triggered
-    $.getJSON(VuFind.path + '/AJAX/JSON', {method: 'keepAlive'});
+    // Trigger print after a minimal timeout. This is done to avoid
+    // problems with some browsers, which might not fully update
+    // ajax loaded page content before showing the print dialog.
+    defer(function doPrint() { window.print(); });
   });
 })();

--- a/themes/bootstrap3/js/trigger_print.js
+++ b/themes/bootstrap3/js/trigger_print.js
@@ -29,7 +29,7 @@ function waitForItemStatuses(fn) {
   });
 }
 
-(function triggerPrint() {
+VuFind.listen("ready", function triggerPrint() {
   if (!VuFind.isPrinting()) {
     return;
   }
@@ -63,4 +63,4 @@ function waitForItemStatuses(fn) {
     // ajax loaded page content before showing the print dialog.
     defer(function doPrint() { window.print(); });
   });
-})();
+});

--- a/themes/bootstrap5/js/check_save_statuses.js
+++ b/themes/bootstrap5/js/check_save_statuses.js
@@ -132,13 +132,9 @@ VuFind.register("saveStatuses", function ItemStatuses() {
     }
 
     const records = container.querySelectorAll(".result,.record");
-
-    if (records.length === 0) {
-      VuFind.emit("save-status-done");
-      return;
-    }
-
     records.forEach(checkSaveStatus);
+
+    VuFind.emit("save-status-done");
   }
 
   function refresh() {

--- a/themes/bootstrap5/js/common.js
+++ b/themes/bootstrap5/js/common.js
@@ -788,6 +788,7 @@ function setupMultiILSLoginFields(loginMethods, idPrefix) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  VuFind.emit("ready");
   // Start up all of our submodules
   VuFind.init();
   // Off canvas

--- a/themes/bootstrap5/js/trigger_print.js
+++ b/themes/bootstrap5/js/trigger_print.js
@@ -3,18 +3,19 @@
 function waitForItemStatuses(fn) {
   var itemDone = typeof VuFind.itemStatuses === "undefined";
   var saveDone = typeof VuFind.saveStatuses === "undefined";
+
   var fnCalled = false;
-
-  if (itemDone && saveDone) {
-    fn();
-    return;
-  }
-
   function checkBoth() {
     if (!fnCalled && itemDone && saveDone) {
       fn();
       fnCalled = true;
+      return true;
     }
+    return false;
+  }
+
+  if (checkBoth()) {
+    return;
   }
 
   VuFind.listen("item-status-done", function listenForItemStatusDone() {
@@ -38,33 +39,28 @@ function waitForItemStatuses(fn) {
   }
 
   waitForItemStatuses(function waitForAjax() {
-    $(document).one('ajaxStop', function doTriggerPrint() {
-      // Print dialogs cause problems during testing, so disable them
-      // when the "test mode" cookie is set. This should never happen
-      // under normal usage outside of the Phing startup process.
-      if (document.cookie.indexOf('VuFindTestSuiteRunning=') > -1) {
-        console.log("Printing disabled due to test mode."); // eslint-disable-line no-console
-        return;
-      }
+    // Print dialogs cause problems during testing, so disable them
+    // when the "test mode" cookie is set. This should never happen
+    // under normal usage outside of the Phing startup process.
+    if (document.cookie.indexOf('VuFindTestSuiteRunning=') > -1) {
+      console.log("Printing disabled due to test mode."); // eslint-disable-line no-console
+      return;
+    }
 
-      window.addEventListener(
-        "afterprint",
-        function doAfterPrint() {
-          // Return to previous page after a minimal timeout. This is
-          // done to avoid problems with some browsers, which fire the
-          // afterprint event while the print dialog is still open.
-          defer(function doGoBack() { history.back(); });
-        },
-        { once: true }
-      );
+    window.addEventListener(
+      "afterprint",
+      function doAfterPrint() {
+        // Return to previous page after a minimal timeout. This is
+        // done to avoid problems with some browsers, which fire the
+        // afterprint event while the print dialog is still open.
+        defer(function doGoBack() { history.back(); });
+      },
+      { once: true }
+    );
 
-      // Trigger print after a minimal timeout. This is done to avoid
-      // problems with some browsers, which might not fully update
-      // ajax loaded page content before showing the print dialog.
-      defer(function doPrint() { window.print(); });
-    });
-
-    // Make an ajax call to ensure that ajaxStop is triggered
-    $.getJSON(VuFind.path + '/AJAX/JSON', {method: 'keepAlive'});
+    // Trigger print after a minimal timeout. This is done to avoid
+    // problems with some browsers, which might not fully update
+    // ajax loaded page content before showing the print dialog.
+    defer(function doPrint() { window.print(); });
   });
 })();

--- a/themes/bootstrap5/js/trigger_print.js
+++ b/themes/bootstrap5/js/trigger_print.js
@@ -29,7 +29,7 @@ function waitForItemStatuses(fn) {
   });
 }
 
-(function triggerPrint() {
+VuFind.listen("ready", function triggerPrint() {
   if (!VuFind.isPrinting()) {
     return;
   }
@@ -63,4 +63,4 @@ function waitForItemStatuses(fn) {
     // ajax loaded page content before showing the print dialog.
     defer(function doPrint() { window.print(); });
   });
-})();
+});


### PR DESCRIPTION
`trigger-print.js` was refactored 5 months ago to use a new mechanism to wait for the AJAX content for save status and availability. That mechanism should have replaced this previous waitForAjax method. This fixes that and cleans up the file.