### PR TITLE
Allow 404 response from Solr to be retried.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -366,8 +366,9 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
      */
     protected function isRethrowableSolrException($ex)
     {
+        // Solr can return 404 when the instance hasn't completed startup, so allow that to be retried:
         return $ex instanceof TimeoutException
-            || $ex instanceof RequestErrorException;
+            || (($ex instanceof RequestErrorException) && $ex->getResponse()->getStatusCode() !== 404);
     }
 
     /**


### PR DESCRIPTION
We just had a hickup during a server upgrade due to Solr returning a 404 error during recovery. This allows 404 to be retried when multiple Solr url's are configured.