### PR TITLE
Add public method AvailabilityStatusInterface::getPriority.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Logic/AvailabilityStatus.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/AvailabilityStatus.php
@@ -158,7 +158,7 @@ class AvailabilityStatus implements AvailabilityStatusInterface
      *
      * @param AvailabilityStatusInterface $other Other Availability Status
      *
-     * @return int
+     * @return int -1 if $other has lower priority, 0 if same, 1 if higher
      */
     public function compareTo(AvailabilityStatusInterface $other): int
     {
@@ -170,7 +170,7 @@ class AvailabilityStatus implements AvailabilityStatusInterface
      *
      * @return int
      */
-    protected function getPriority(): int
+    public function getPriority(): int
     {
         switch ($this->availability) {
             case AvailabilityStatusInterface::STATUS_UNKNOWN:

--- a/module/VuFind/src/VuFind/ILS/Logic/AvailabilityStatusInterface.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/AvailabilityStatusInterface.php
@@ -122,4 +122,11 @@ interface AvailabilityStatusInterface
      * @return int
      */
     public function compareTo(AvailabilityStatusInterface $other): int;
+
+    /**
+     * Get status priority.
+     *
+     * @return int
+     */
+    public function getPriority(): int;
 }


### PR DESCRIPTION
Due to the protected method call, AvailabilityStatus::compareTo method currently only works when `$other` is an instance of AvailabilityStatus class, but it could be any class implementing AvailabilityStatusInterface. 