### PR TITLE
Fix setting of HTML contents in JS to run inline scripts properly.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -744,6 +744,7 @@
         <!-- avoid PHP Errors by creating each level separately -->
         <mkdir dir="${themedir}" />
         <mkdir dir="${themedir}/templates" />
+        <mkdir dir="${themedir}/templates/ajax" />
         <mkdir dir="${contentdir}" />
         <mkdir dir="${contentdir}/test" />
         <mkdir dir="${contentdir}/test/sub" />
@@ -754,6 +755,16 @@ return [
     'extends' =&gt; 'sandal',
 ];
 </echo>
+
+    <copy file="${srcdir}/themes/bootstrap3/templates/ajax/status-full.phtml" tofile="${themedir}/templates/ajax/status-full.phtml" overwrite="true" />
+    <!-- Add a script for testing that inline scripts work -->
+    <echo file="${themedir}/templates/ajax/status-full.phtml" append="true">
+&lt;div class="js-status-test hidden"&gt;&lt;/div&gt;
+&lt;script nonce="foo"&gt;
+  document.querySelector('.js-status-test').classList.remove('hidden');
+&lt;/script&gt;
+</echo>
+
     <echo file="${contentdir}/content.phtml">&lt;?php include $this-&gt;parentTemplate('content/content.phtml');?&gt;
 
 &lt;div class="content-footer"&gt;Content page footer&lt;/div&gt;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
@@ -48,7 +48,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Data provider for test methods
      *
-     * @return array
+     * @return array[]
      */
     public static function itemStatusAndHoldingsProvider(): array
     {
@@ -83,6 +83,16 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         return [...$msgSet, ...$groupSet, ...$allSet];
+    }
+
+    /**
+     * Supplemental data provider for testItemStatusFull().
+     *
+     * @return array[]
+     */
+    public static function itemStatusAndHoldingsCustomTemplateProvider(): array
+    {
+        return ['custom template test' => [true, 'On Shelf', 'On Shelf', 'success', 'msg', true]];
     }
 
     /**
@@ -188,8 +198,10 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
      * @param string $expected          Expected availability display status
      * @param string $expectedType      Expected status type (e.g. 'success')
      * @param string $multipleLocations Configuration setting for multiple locations
+     * @param string $customTemplate    Include extra steps to test custom template?
      *
      * @dataProvider itemStatusAndHoldingsProvider
+     * @dataProvider itemStatusAndHoldingsCustomTemplateProvider
      *
      * @return void
      */
@@ -198,11 +210,14 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         string $status,
         string $expected,
         string $expectedType,
-        string $multipleLocations
+        string $multipleLocations,
+        bool $customTemplate = false
     ): void {
         $config = $this->getConfigIniOverrides(true, $multipleLocations);
-        // Switch to the minktest theme:
-        $config['Site']['theme'] = 'minktest';
+        // If testing with the custom template, switch to the minktest theme:
+        if ($customTemplate) {
+            $config['Site']['theme'] = 'minktest';
+        }
         $this->changeConfigs(
             [
                 'config' => $config,
@@ -225,8 +240,11 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
             // No extra items to care for:
             $this->assertEquals('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation'));
         }
-        $this->findCss($page, '.js-status-test');
-        $this->unFindCss($page, '.js-status-test.hidden');
+        // If testing with the custom template, be sure its custom script executed as expected:
+        if ($customTemplate) {
+            $this->findCss($page, '.js-status-test');
+            $this->unFindCss($page, '.js-status-test.hidden');
+        }
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
@@ -200,9 +200,12 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         string $expectedType,
         string $multipleLocations
     ): void {
+        $config = $this->getConfigIniOverrides(true, $multipleLocations);
+        // Switch to the minktest theme:
+        $config['Site']['theme'] = 'minktest';
         $this->changeConfigs(
             [
-                'config' => $this->getConfigIniOverrides(true, $multipleLocations),
+                'config' => $config,
                 'Demo' => $this->getDemoIniOverrides($availability, $status, true),
             ]
         );
@@ -222,6 +225,8 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
             // No extra items to care for:
             $this->assertEquals('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation'));
         }
+        $this->findCss($page, '.js-status-test');
+        $this->unFindCss($page, '.js-status-test.hidden');
     }
 
     /**

--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -45,7 +45,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
     ) {
       // Full status mode is on -- display the HTML and hide extraneous junk:
       callnumAndLocations.forEach((callnumAndLocation) => {
-        callnumAndLocation.innerHTML = VuFind.updateCspNonce(result.full_status);
+        VuFind.setElementContents(callnumAndLocation, VuFind.updateCspNonce(result.full_status));
       });
       el.querySelectorAll('.callnumber,.hideIfDetailed,.location,.status').forEach((e) => { e.classList.add('hidden'); });
     } else if (typeof(result.missing_data) !== 'undefined'

--- a/themes/bootstrap3/js/hierarchy_tree.js
+++ b/themes/bootstrap3/js/hierarchy_tree.js
@@ -25,7 +25,7 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
     const queryParams = new URLSearchParams({id: id, source: treeEl.dataset.source});
     fetch(VuFind.path + '/Hierarchy/GetRecord?' + queryParams.toString())
       .then((response) => response.text())
-      .then((content) => recordEl.innerHTML = VuFind.updateCspNonce(content) );
+      .then((content) => VuFind.setElementContents(recordEl, VuFind.updateCspNonce(content)) );
     return true;
   }
 
@@ -239,7 +239,7 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
         if (loadIndicatorEl) {
           loadIndicatorEl.classList.add('hidden');
         }
-        treePlaceholderEl.outerHTML = VuFind.updateCspNonce(json.html);
+        VuFind.setElementContents(treePlaceholderEl, VuFind.updateCspNonce(json.html), {}, 'outerHTML');
         setupTree(containerEl);
       })
       .catch(() => {

--- a/themes/bootstrap5/js/check_item_statuses.js
+++ b/themes/bootstrap5/js/check_item_statuses.js
@@ -45,7 +45,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
     ) {
       // Full status mode is on -- display the HTML and hide extraneous junk:
       callnumAndLocations.forEach((callnumAndLocation) => {
-        callnumAndLocation.innerHTML = VuFind.updateCspNonce(result.full_status);
+        VuFind.setElementContents(callnumAndLocation, VuFind.updateCspNonce(result.full_status));
       });
       el.querySelectorAll('.callnumber,.hideIfDetailed,.location,.status').forEach((e) => { e.classList.add('hidden'); });
     } else if (typeof(result.missing_data) !== 'undefined'

--- a/themes/bootstrap5/js/hierarchy_tree.js
+++ b/themes/bootstrap5/js/hierarchy_tree.js
@@ -25,7 +25,7 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
     const queryParams = new URLSearchParams({id: id, source: treeEl.dataset.source});
     fetch(VuFind.path + '/Hierarchy/GetRecord?' + queryParams.toString())
       .then((response) => response.text())
-      .then((content) => recordEl.innerHTML = VuFind.updateCspNonce(content) );
+      .then((content) => VuFind.setElementContents(recordEl, VuFind.updateCspNonce(content)) );
     return true;
   }
 
@@ -239,7 +239,7 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
         if (loadIndicatorEl) {
           loadIndicatorEl.classList.add('hidden');
         }
-        treePlaceholderEl.outerHTML = VuFind.updateCspNonce(json.html);
+        VuFind.setElementContents(treePlaceholderEl, VuFind.updateCspNonce(json.html), {}, 'outerHTML');
         setupTree(containerEl);
       })
       .catch(() => {


### PR DESCRIPTION
Where updateCspNonce is used it is expected that there could be inline scripts alongside the HTML snippet. These cannot be simply assigned to innerHTML or outerHTML property, since scripts won't be executed in those cases. setElementContents should be used instead.