### PR TITLE
FOLIO: Limit request pickupLocation options by item location

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -116,6 +116,11 @@ defaultRequiredDate = 0:1:0
 ; "pickUpLocation", "proxiedUsers" and "requestGroup"
 extraHoldFields = requiredByDate:pickUpLocation
 
+; When the extra hold field pickUpLocation is used, this can be used to limit the
+; pickup location (service point) options to those whose assigned locations include the
+; requested item's effective location.
+limitPickupLocations = itemEffectiveLocation
+
 ; By default, a "Hold" type request is placed when an item is unavailable and a Page
 ; when an item is available. This setting overrides the default behavior for
 ; unavailable items and for all title-level requests. Legal values: "Page", "Hold" or

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -118,7 +118,7 @@ extraHoldFields = requiredByDate:pickUpLocation
 
 ; When the extra hold field pickUpLocation is used, this can be used to limit the
 ; pickup location (service point) options to those whose assigned locations include the
-; requested item's effective location.
+; requested item's effective location. Only applicable to item-level requests.
 ;limitPickupLocations = itemEffectiveLocation
 
 ; By default, a "Hold" type request is placed when an item is unavailable and a Page

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -119,7 +119,7 @@ extraHoldFields = requiredByDate:pickUpLocation
 ; When the extra hold field pickUpLocation is used, this can be used to limit the
 ; pickup location (service point) options to those whose assigned locations include the
 ; requested item's effective location.
-limitPickupLocations = itemEffectiveLocation
+;limitPickupLocations = itemEffectiveLocation
 
 ; By default, a "Hold" type request is placed when an item is unavailable and a Page
 ; when an item is available. This setting overrides the default behavior for

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -375,7 +375,7 @@ class Folio extends AbstractAPI implements
      *
      * @param string $itemId UUID
      *
-     * @return stdClass The item
+     * @return \stdClass The item
      */
     protected function getItemById($itemId)
     {

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -573,6 +573,7 @@ class Folio extends AbstractAPI implements
         $name = '';
         $code = '';
         $isActive = true;
+        $servicePointIds = [];
         if (array_key_exists($locationId, $locationMap)) {
             return $locationMap[$locationId];
         } else {

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1400,6 +1400,8 @@ class Folio extends AbstractAPI implements
         $limitedServicePoints = null;
         if (
             str_contains($this->config['Holds']['limitPickupLocations'] ?? '', 'itemEffectiveLocation')
+            // If there's no item ID, it must be a title-level hold,
+            // so limiting by itemEffectiveLocation does not apply
             && $holdInfo['item_id'] ?? false
         ) {
             $response = $this->makeRequest(

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -353,11 +353,7 @@ class Folio extends AbstractAPI implements
                 if ($itemId == null) {
                     throw new \Exception('No IDs provided to getInstanceObject.');
                 }
-                $response = $this->makeRequest(
-                    'GET',
-                    '/item-storage/items/' . $itemId
-                );
-                $item = json_decode($response->getBody());
+                $item = $this->getItemById($itemId);
                 $holdingId = $item->holdingsRecordId;
             }
             $response = $this->makeRequest(
@@ -372,6 +368,23 @@ class Folio extends AbstractAPI implements
             '/inventory/instances/' . $instanceId
         );
         return json_decode($response->getBody());
+    }
+
+    /**
+     * Get an item record by its UUID.
+     *
+     * @param string $itemId UUID
+     *
+     * @return stdClass The item
+     */
+    protected function getItemById($itemId)
+    {
+        $response = $this->makeRequest(
+            'GET',
+            '/item-storage/items/' . $itemId
+        );
+        $item = json_decode($response->getBody());
+        return $item;
     }
 
     /**
@@ -1404,11 +1417,7 @@ class Folio extends AbstractAPI implements
             // so limiting by itemEffectiveLocation does not apply
             && $holdInfo['item_id'] ?? false
         ) {
-            $response = $this->makeRequest(
-                'GET',
-                '/item-storage/items/' . $holdInfo['item_id']
-            );
-            $item = json_decode($response->getBody());
+            $item = $this->getItemById($holdInfo['item_id']);
             $itemLocationId = $item->effectiveLocationId;
             $limitedServicePoints = $this->getLocationData($itemLocationId)['servicePointIds'];
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1397,7 +1397,7 @@ class Folio extends AbstractAPI implements
      */
     public function getPickupLocations($patron, $holdInfo = null)
     {
-        $limitedServicePoints = false;
+        $limitedServicePoints = null;
         if (
             str_contains($this->config['Holds']['limitPickupLocations'] ?? '', 'itemEffectiveLocation')
             && $holdInfo['item_id'] ?? false


### PR DESCRIPTION
FOLIO defines a relationship between each service point and the specific item locations that it is meant to service.  When a patron places a hold for an item, we would like them to have to pick it up at the nearest service location -- not ship it to another library.