### PR TITLE
Fix BrowZine grid template images for consistency.

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/BrowZine/result-grid.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/BrowZine/result-grid.phtml
@@ -1,7 +1,7 @@
 <?php
   $urls = $this->driver->getURLs();
   $url = isset($urls[0]) ? $urls[0]['url'] : null;
-  $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $url);
+  $coverDetails = $this->record($this->driver)->getCoverDetails('result-grid', 'small', $url);
 ?>
 
 <div class="grid-result">

--- a/themes/bootstrap5/templates/RecordDriver/BrowZine/result-grid.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/BrowZine/result-grid.phtml
@@ -1,7 +1,7 @@
 <?php
   $urls = $this->driver->getURLs();
   $url = isset($urls[0]) ? $urls[0]['url'] : null;
-  $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $url);
+  $coverDetails = $this->record($this->driver)->getCoverDetails('result-grid', 'small', $url);
 ?>
 
 <div class="grid-result">


### PR DESCRIPTION
While reviewing cover images in record driver templates, I noticed that the BrowZine grid template definitions did not match the DefaultRecord grid template definitions, likely due to a copy-and-paste error. This PR makes things more consistent. I have confirmed that the grid view still displays correctly:

![image](https://github.com/user-attachments/assets/ab3c5ac5-7dc0-47ea-9802-8994ba97a1bc)
