### PR TITLE
Eliminate double-escaping from searchTabs.phtml

### DIFF
--- a/themes/bootstrap3/templates/search/searchTabs.phtml
+++ b/themes/bootstrap3/templates/search/searchTabs.phtml
@@ -8,7 +8,7 @@
       <?php if ($this->permission()->allowDisplay($tab['permission'])): ?>
         <?php
           $linkAttributes = [
-            'data-source' => $this->escapeHtmlAttr($tab['class']),
+            'data-source' => $tab['class'],
           ];
           if ($tab['selected']) {
             $hasSelectedTab = true;

--- a/themes/bootstrap5/templates/search/searchTabs.phtml
+++ b/themes/bootstrap5/templates/search/searchTabs.phtml
@@ -8,7 +8,7 @@
       <?php if ($this->permission()->allowDisplay($tab['permission'])): ?>
         <?php
           $linkAttributes = [
-            'data-source' => $this->escapeHtmlAttr($tab['class']),
+            'data-source' => $tab['class'],
           ];
           if ($tab['selected']) {
             $hasSelectedTab = true;


### PR DESCRIPTION
When we're using the htmlAttributes helper, we don't need to also use escape helpers. I don't think there are generally escapable characters in the tab class, so I don't think this was likely to cause issues, but we might as well clean it up!