### PR TITLE
KohaRest: Fix holdings with older Koha DI plugin versions.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2056,8 +2056,9 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             return [];
         }
 
-        // Return total number of results for pagination.
-        $results['total'] = (int)$result['data']['items_total'];
+        // Return total number of results for pagination (with fallback for older
+        // Koha DI plugin versions that don't support paging).
+        $results['total'] = (int)($result['data']['items_total'] ?? count($result['data']['item_availabilities']));
 
         foreach ($result['data']['item_availabilities'] as $i => $item) {
             $avail = $item['availability'];


### PR DESCRIPTION
Older Koha REST DI plugins don't return the item count, but it's still needed for all items to display in holdings even if paging isn't enabled.

The issue was introduced in #3839.