### PR TITLE
Disable browser language detection with Mink tests.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -686,6 +686,7 @@
           <regexp pattern=";file\s+= /var/log/vufind.log:alert,error,notice,debug" replace="file = ${srcdir}/vufind-exception.log:alert-5,error-5" />
           <regexp pattern="(\[System\]\s+)" replace="\1runningTestSuite=1" />
           <regexp pattern="(url\s+= http://localhost):8983/solr" replace="\1:${solr_port}/solr" />
+          <regexp pattern="browserDetectLanguage = true" replace="browserDetectLanguage = false" />
         </replaceregexp>
       </filterchain>
     </copy>


### PR DESCRIPTION
This will avoid problems when the browser has non-English language as default.