### PR TITLE
Use static as return type in db entity interfaces

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/AccessTokenEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AccessTokenEntityInterface.php
@@ -45,18 +45,18 @@ interface AccessTokenEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User owning token
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): AccessTokenEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * Set data.
      *
      * @param string $data Data
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setData(string $data): AccessTokenEntityInterface;
+    public function setData(string $data): static;
 
     /**
      * Is the access token revoked?
@@ -70,7 +70,7 @@ interface AccessTokenEntityInterface extends EntityInterface
      *
      * @param bool $revoked Revoked
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setRevoked(bool $revoked): AccessTokenEntityInterface;
+    public function setRevoked(bool $revoked): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/AuthHashEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AuthHashEntityInterface.php
@@ -61,9 +61,9 @@ interface AuthHashEntityInterface extends EntityInterface
      *
      * @param ?string $sessionId PHP Session id string
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sessionId): AuthHashEntityInterface;
+    public function setSessionId(?string $sessionId): static;
 
     /**
      * Get hash value.
@@ -77,9 +77,9 @@ interface AuthHashEntityInterface extends EntityInterface
      *
      * @param string $hash Hash Value
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setHash(string $hash): AuthHashEntityInterface;
+    public function setHash(string $hash): static;
 
     /**
      * Get type of hash.
@@ -93,9 +93,9 @@ interface AuthHashEntityInterface extends EntityInterface
      *
      * @param ?string $type Hash Type
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setHashType(?string $type): AuthHashEntityInterface;
+    public function setHashType(?string $type): static;
 
     /**
      * Get data.
@@ -109,9 +109,9 @@ interface AuthHashEntityInterface extends EntityInterface
      *
      * @param ?string $data Data
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setData(?string $data): AuthHashEntityInterface;
+    public function setData(?string $data): static;
 
     /**
      * Get created date.
@@ -125,7 +125,7 @@ interface AuthHashEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): AuthHashEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/ChangeTrackerEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ChangeTrackerEntityInterface.php
@@ -47,9 +47,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param string $id Id
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setId(string $id): ChangeTrackerEntityInterface;
+    public function setId(string $id): static;
 
     /**
      * Getter for identifier.
@@ -63,9 +63,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param string $name Index name
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setIndexName(string $name): ChangeTrackerEntityInterface;
+    public function setIndexName(string $name): static;
 
     /**
      * Getter for index name (formerly core).
@@ -79,9 +79,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param ?DateTime $dateTime Time first added to index.
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setFirstIndexed(?DateTime $dateTime): ChangeTrackerEntityInterface;
+    public function setFirstIndexed(?DateTime $dateTime): static;
 
     /**
      * FirstIndexed getter.
@@ -95,9 +95,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param ?DateTime $dateTime Last time changed in index.
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setLastIndexed(?DateTime $dateTime): ChangeTrackerEntityInterface;
+    public function setLastIndexed(?DateTime $dateTime): static;
 
     /**
      * LastIndexed getter.
@@ -111,9 +111,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param ?DateTime $dateTime Last time original record was edited
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setLastRecordChange(?DateTime $dateTime): ChangeTrackerEntityInterface;
+    public function setLastRecordChange(?DateTime $dateTime): static;
 
     /**
      * LastRecordChange getter.
@@ -127,9 +127,9 @@ interface ChangeTrackerEntityInterface extends EntityInterface
      *
      * @param ?DateTime $dateTime Time record was removed from index
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setDeleted(?DateTime $dateTime): ChangeTrackerEntityInterface;
+    public function setDeleted(?DateTime $dateTime): static;
 
     /**
      * Deleted getter.

--- a/module/VuFind/src/VuFind/Db/Entity/CommentsEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/CommentsEntityInterface.php
@@ -54,9 +54,9 @@ interface CommentsEntityInterface extends EntityInterface
      *
      * @param string $comment Comment
      *
-     * @return Comments
+     * @return static
      */
-    public function setComment(string $comment): CommentsEntityInterface;
+    public function setComment(string $comment): static;
 
     /**
      * Comment getter
@@ -70,9 +70,9 @@ interface CommentsEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return Comments
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): CommentsEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Created getter
@@ -86,9 +86,9 @@ interface CommentsEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User that created comment
      *
-     * @return Comments
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): CommentsEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * User getter
@@ -102,7 +102,7 @@ interface CommentsEntityInterface extends EntityInterface
      *
      * @param ResourceEntityInterface $resource Resource id.
      *
-     * @return Comments
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): CommentsEntityInterface;
+    public function setResource(ResourceEntityInterface $resource): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/ExternalSessionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ExternalSessionEntityInterface.php
@@ -61,9 +61,9 @@ interface ExternalSessionEntityInterface extends EntityInterface
      *
      * @param string $sessionId PHP session id string
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setSessionId(string $sessionId): ExternalSessionEntityInterface;
+    public function setSessionId(string $sessionId): static;
 
     /**
      * Get external session id string.
@@ -77,9 +77,9 @@ interface ExternalSessionEntityInterface extends EntityInterface
      *
      * @param string $externalSessionId External session id string
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setExternalSessionId(string $externalSessionId): ExternalSessionEntityInterface;
+    public function setExternalSessionId(string $externalSessionId): static;
 
     /**
      * Get created date.
@@ -93,7 +93,7 @@ interface ExternalSessionEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): ExternalSessionEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/FeedbackEntityInterface.php
@@ -54,9 +54,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param string $message Message
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setMessage(string $message): FeedbackEntityInterface;
+    public function setMessage(string $message): static;
 
     /**
      * Message getter
@@ -70,9 +70,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param array $data Form data
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setFormData(array $data): FeedbackEntityInterface;
+    public function setFormData(array $data): static;
 
     /**
      * Form data getter
@@ -86,9 +86,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param string $name Form name
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setFormName(string $name): FeedbackEntityInterface;
+    public function setFormName(string $name): static;
 
     /**
      * Form name getter
@@ -102,9 +102,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): FeedbackEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Created getter
@@ -118,9 +118,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Last update date
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUpdated(DateTime $dateTime): FeedbackEntityInterface;
+    public function setUpdated(DateTime $dateTime): static;
 
     /**
      * Updated getter
@@ -134,9 +134,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param string $status Status
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setStatus(string $status): FeedbackEntityInterface;
+    public function setStatus(string $status): static;
 
     /**
      * Status getter
@@ -150,9 +150,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param string $url Site URL
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setSiteUrl(string $url): FeedbackEntityInterface;
+    public function setSiteUrl(string $url): static;
 
     /**
      * Site URL getter
@@ -166,9 +166,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User that created request
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): FeedbackEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * User getter
@@ -182,9 +182,9 @@ interface FeedbackEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User that updated request
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUpdatedBy(?UserEntityInterface $user): FeedbackEntityInterface;
+    public function setUpdatedBy(?UserEntityInterface $user): static;
 
     /**
      * Updatedby getter

--- a/module/VuFind/src/VuFind/Db/Entity/LoginTokenEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/LoginTokenEntityInterface.php
@@ -54,9 +54,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param UserEntityInterface $user User to set
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): LoginTokenEntityInterface;
+    public function setUser(UserEntityInterface $user): static;
 
     /**
      * User getter (only null if entity has not been populated yet).
@@ -70,9 +70,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param string $token Token
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setToken(string $token): LoginTokenEntityInterface;
+    public function setToken(string $token): static;
 
     /**
      * Get token string.
@@ -86,9 +86,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param string $series Series
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setSeries(string $series): LoginTokenEntityInterface;
+    public function setSeries(string $series): static;
 
     /**
      * Get series string.
@@ -102,9 +102,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Last login date/time
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setLastLogin(DateTime $dateTime): LoginTokenEntityInterface;
+    public function setLastLogin(DateTime $dateTime): static;
 
     /**
      * Get last login date/time.
@@ -118,9 +118,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param ?string $browser Browser details (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setBrowser(?string $browser): LoginTokenEntityInterface;
+    public function setBrowser(?string $browser): static;
 
     /**
      * Get browser details (or null for none).
@@ -134,9 +134,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param ?string $platform Platform details (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setPlatform(?string $platform): LoginTokenEntityInterface;
+    public function setPlatform(?string $platform): static;
 
     /**
      * Get platform details (or null for none).
@@ -150,9 +150,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param int $expires Expiration timestamp
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setExpires(int $expires): LoginTokenEntityInterface;
+    public function setExpires(int $expires): static;
 
     /**
      * Get expiration timestamp.
@@ -166,9 +166,9 @@ interface LoginTokenEntityInterface extends EntityInterface
      *
      * @param ?string $sid Last session ID (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setLastSessionId(?string $sid): LoginTokenEntityInterface;
+    public function setLastSessionId(?string $sid): static;
 
     /**
      * Get last session ID (or null for none).

--- a/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
@@ -54,9 +54,9 @@ interface OaiResumptionEntityInterface extends EntityInterface
      *
      * @param ?string $params Resumption parameters.
      *
-     * @return OaiResumptionEntityInterface
+     * @return static
      */
-    public function setResumptionParameters(?string $params): OaiResumptionEntityInterface;
+    public function setResumptionParameters(?string $params): static;
 
     /**
      * Get resumption parameters.
@@ -70,9 +70,9 @@ interface OaiResumptionEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Expiration date
      *
-     * @return OaiResumptionEntityInterface
+     * @return static
      */
-    public function setExpiry(DateTime $dateTime): OaiResumptionEntityInterface;
+    public function setExpiry(DateTime $dateTime): static;
 
     /**
      * Get expiry date.

--- a/module/VuFind/src/VuFind/Db/Entity/RatingsEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/RatingsEntityInterface.php
@@ -61,9 +61,9 @@ interface RatingsEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): RatingsEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * Get resource.
@@ -77,9 +77,9 @@ interface RatingsEntityInterface extends EntityInterface
      *
      * @param ResourceEntityInterface $resource Resource
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): RatingsEntityInterface;
+    public function setResource(ResourceEntityInterface $resource): static;
 
     /**
      * Get rating.
@@ -93,9 +93,9 @@ interface RatingsEntityInterface extends EntityInterface
      *
      * @param int $rating Rating
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setRating(int $rating): RatingsEntityInterface;
+    public function setRating(int $rating): static;
 
     /**
      * Get created date.
@@ -109,7 +109,7 @@ interface RatingsEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): RatingsEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/RecordEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/RecordEntityInterface.php
@@ -61,9 +61,9 @@ interface RecordEntityInterface extends EntityInterface
      *
      * @param ?string $recordId Record id
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setRecordId(?string $recordId): RecordEntityInterface;
+    public function setRecordId(?string $recordId): static;
 
     /**
      * Get record source.
@@ -77,9 +77,9 @@ interface RecordEntityInterface extends EntityInterface
      *
      * @param ?string $recordSource Record source
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setSource(?string $recordSource): RecordEntityInterface;
+    public function setSource(?string $recordSource): static;
 
     /**
      * Get record version.
@@ -93,9 +93,9 @@ interface RecordEntityInterface extends EntityInterface
      *
      * @param string $recordVersion Record version
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setVersion(string $recordVersion): RecordEntityInterface;
+    public function setVersion(string $recordVersion): static;
 
     /**
      * Get record data.
@@ -109,9 +109,9 @@ interface RecordEntityInterface extends EntityInterface
      *
      * @param ?string $recordData Record data
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setData(?string $recordData): RecordEntityInterface;
+    public function setData(?string $recordData): static;
 
     /**
      * Get updated date.
@@ -125,7 +125,7 @@ interface RecordEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Updated date
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setUpdated(DateTime $dateTime): RecordEntityInterface;
+    public function setUpdated(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/ResourceEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ResourceEntityInterface.php
@@ -52,9 +52,9 @@ interface ResourceEntityInterface extends EntityInterface
      *
      * @param string $recordId recordId
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setRecordId(string $recordId): ResourceEntityInterface;
+    public function setRecordId(string $recordId): static;
 
     /**
      * Record Id getter
@@ -68,9 +68,9 @@ interface ResourceEntityInterface extends EntityInterface
      *
      * @param string $title Title of the record.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setTitle(string $title): ResourceEntityInterface;
+    public function setTitle(string $title): static;
 
     /**
      * Title getter
@@ -84,27 +84,27 @@ interface ResourceEntityInterface extends EntityInterface
      *
      * @param ?string $author Author of the title.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setAuthor(?string $author): ResourceEntityInterface;
+    public function setAuthor(?string $author): static;
 
     /**
      * Year setter
      *
      * @param ?int $year Year title is published.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setYear(?int $year): ResourceEntityInterface;
+    public function setYear(?int $year): static;
 
     /**
      * Source setter
      *
      * @param string $source Source (a search backend ID).
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setSource(string $source): ResourceEntityInterface;
+    public function setSource(string $source): static;
 
     /**
      * Source getter
@@ -118,9 +118,9 @@ interface ResourceEntityInterface extends EntityInterface
      *
      * @param ?string $extraMetadata ExtraMetadata.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setExtraMetadata(?string $extraMetadata): ResourceEntityInterface;
+    public function setExtraMetadata(?string $extraMetadata): static;
 
     /**
      * Extra Metadata getter

--- a/module/VuFind/src/VuFind/Db/Entity/ResourceTagsEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ResourceTagsEntityInterface.php
@@ -61,9 +61,9 @@ interface ResourceTagsEntityInterface extends EntityInterface
      *
      * @param ?ResourceEntityInterface $resource Resource
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setResource(?ResourceEntityInterface $resource): ResourceTagsEntityInterface;
+    public function setResource(?ResourceEntityInterface $resource): static;
 
     /**
      * Get tag.
@@ -77,9 +77,9 @@ interface ResourceTagsEntityInterface extends EntityInterface
      *
      * @param TagsEntityInterface $tag Tag
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setTag(TagsEntityInterface $tag): ResourceTagsEntityInterface;
+    public function setTag(TagsEntityInterface $tag): static;
 
     /**
      * Get user list.
@@ -93,9 +93,9 @@ interface ResourceTagsEntityInterface extends EntityInterface
      *
      * @param ?UserListEntityInterface $list User list
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setUserList(?UserListEntityInterface $list): ResourceTagsEntityInterface;
+    public function setUserList(?UserListEntityInterface $list): static;
 
     /**
      * Get user.
@@ -109,9 +109,9 @@ interface ResourceTagsEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): ResourceTagsEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * Get created date.
@@ -125,7 +125,7 @@ interface ResourceTagsEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setPosted(DateTime $dateTime): ResourceTagsEntityInterface;
+    public function setPosted(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/SearchEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/SearchEntityInterface.php
@@ -61,9 +61,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): SearchEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * Get session identifier.
@@ -77,9 +77,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param ?string $sessionId Session id
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sessionId): SearchEntityInterface;
+    public function setSessionId(?string $sessionId): static;
 
     /**
      * Get created date.
@@ -93,9 +93,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): SearchEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Get title.
@@ -109,9 +109,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param ?string $title Title
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setTitle(?string $title): SearchEntityInterface;
+    public function setTitle(?string $title): static;
 
     /**
      * Get saved.
@@ -125,9 +125,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param bool $saved Saved
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSaved(bool $saved): SearchEntityInterface;
+    public function setSaved(bool $saved): static;
 
     /**
      * Get the search object from the row.
@@ -141,9 +141,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param ?\VuFind\Search\Minified $searchObject Search object
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSearchObject(?\VuFind\Search\Minified $searchObject): SearchEntityInterface;
+    public function setSearchObject(?\VuFind\Search\Minified $searchObject): static;
 
     /**
      * Get checksum.
@@ -157,9 +157,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param ?int $checksum Checksum
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setChecksum(?int $checksum): SearchEntityInterface;
+    public function setChecksum(?int $checksum): static;
 
     /**
      * Get notification frequency.
@@ -173,9 +173,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param int $notificationFrequency Notification frequency
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setNotificationFrequency(int $notificationFrequency): SearchEntityInterface;
+    public function setNotificationFrequency(int $notificationFrequency): static;
 
     /**
      * When was the last notification sent?
@@ -189,9 +189,9 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param DateTime $lastNotificationSent Time when last notification was sent
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setLastNotificationSent(Datetime $lastNotificationSent): SearchEntityInterface;
+    public function setLastNotificationSent(Datetime $lastNotificationSent): static;
 
     /**
      * Get notification base URL.
@@ -205,7 +205,7 @@ interface SearchEntityInterface extends EntityInterface
      *
      * @param string $notificationBaseUrl Notification base URL
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setNotificationBaseUrl(string $notificationBaseUrl): SearchEntityInterface;
+    public function setNotificationBaseUrl(string $notificationBaseUrl): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/SessionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/SessionEntityInterface.php
@@ -54,27 +54,27 @@ interface SessionEntityInterface extends EntityInterface
      *
      * @param ?string $sid Session Id.
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sid): SessionEntityInterface;
+    public function setSessionId(?string $sid): static;
 
     /**
      * Created setter.
      *
      * @param DateTime $dateTime Created date
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): SessionEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Set time the session is last used.
      *
      * @param int $lastUsed Time last used
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setLastUsed(int $lastUsed): SessionEntityInterface;
+    public function setLastUsed(int $lastUsed): static;
 
     /**
      * Get time when the session was last used.
@@ -88,9 +88,9 @@ interface SessionEntityInterface extends EntityInterface
      *
      * @param ?string $data Session data.
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setData(?string $data): SessionEntityInterface;
+    public function setData(?string $data): static;
 
     /**
      * Get session data.

--- a/module/VuFind/src/VuFind/Db/Entity/ShortlinksEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ShortlinksEntityInterface.php
@@ -62,9 +62,9 @@ interface ShortlinksEntityInterface extends EntityInterface
      *
      * @param string $path Path
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setPath(string $path): ShortlinksEntityInterface;
+    public function setPath(string $path): static;
 
     /**
      * Get shortlinks hash.
@@ -78,9 +78,9 @@ interface ShortlinksEntityInterface extends EntityInterface
      *
      * @param ?string $hash Shortlinks hash
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setHash(?string $hash): ShortlinksEntityInterface;
+    public function setHash(?string $hash): static;
 
     /**
      * Get creation timestamp.
@@ -94,7 +94,7 @@ interface ShortlinksEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Creation timestamp
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): ShortlinksEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Entity/TagsEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/TagsEntityInterface.php
@@ -52,9 +52,9 @@ interface TagsEntityInterface extends EntityInterface
      *
      * @param string $tag Tag
      *
-     * @return TagsEntityInterface
+     * @return static
      */
-    public function setTag(string $tag): TagsEntityInterface;
+    public function setTag(string $tag): static;
 
     /**
      * Tag getter

--- a/module/VuFind/src/VuFind/Db/Entity/UserCardEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserCardEntityInterface.php
@@ -54,9 +54,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param string $cardName User card name.
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCardName(string $cardName): UserCardEntityInterface;
+    public function setCardName(string $cardName): static;
 
     /**
      * Get user card name.
@@ -70,9 +70,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param string $catUsername Catalog username
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCatUsername(string $catUsername): UserCardEntityInterface;
+    public function setCatUsername(string $catUsername): static;
 
     /**
      * Get catalog username.
@@ -86,9 +86,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param ?string $catPassword Cat password
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setRawCatPassword(?string $catPassword): UserCardEntityInterface;
+    public function setRawCatPassword(?string $catPassword): static;
 
     /**
      * Get raw catalog password.
@@ -102,9 +102,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param ?string $passEnc Encrypted password
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCatPassEnc(?string $passEnc): UserCardEntityInterface;
+    public function setCatPassEnc(?string $passEnc): static;
 
     /**
      * Get encrypted catalog password.
@@ -118,9 +118,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param ?string $homeLibrary Home library
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setHomeLibrary(?string $homeLibrary): UserCardEntityInterface;
+    public function setHomeLibrary(?string $homeLibrary): static;
 
     /**
      * Get home library.
@@ -134,9 +134,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserCardEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Get created date.
@@ -150,9 +150,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Saved date and time
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setSaved(DateTime $dateTime): UserCardEntityInterface;
+    public function setSaved(DateTime $dateTime): static;
 
     /**
      * Get saved time.
@@ -166,9 +166,9 @@ interface UserCardEntityInterface extends EntityInterface
      *
      * @param UserEntityInterface $user User that owns card
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): UserCardEntityInterface;
+    public function setUser(UserEntityInterface $user): static;
 
     /**
      * User getter

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -54,9 +54,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $username Username
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setUsername(string $username): UserEntityInterface;
+    public function setUsername(string $username): static;
 
     /**
      * Get username.
@@ -70,9 +70,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $password Password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setRawPassword(string $password): UserEntityInterface;
+    public function setRawPassword(string $password): static;
 
     /**
      * Get raw (unhashed) password (if available). This should only be used when hashing is disabled.
@@ -86,9 +86,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $hash Password hash
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setPasswordHash(?string $hash): UserEntityInterface;
+    public function setPasswordHash(?string $hash): static;
 
     /**
      * Get hashed password. This should only be used when hashing is enabled.
@@ -102,9 +102,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $firstName New first name
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setFirstname(string $firstName): UserEntityInterface;
+    public function setFirstname(string $firstName): static;
 
     /**
      * Get firstname.
@@ -118,9 +118,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $lastName New last name
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastname(string $lastName): UserEntityInterface;
+    public function setLastname(string $lastName): static;
 
     /**
      * Get lastname.
@@ -134,9 +134,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $email Email address
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setEmail(string $email): UserEntityInterface;
+    public function setEmail(string $email): static;
 
     /**
      * Get email.
@@ -150,9 +150,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $email New pending email
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setPendingEmail(string $email): UserEntityInterface;
+    public function setPendingEmail(string $email): static;
 
     /**
      * Get pending email.
@@ -166,9 +166,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $catId Catalog id
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatId(?string $catId): UserEntityInterface;
+    public function setCatId(?string $catId): static;
 
     /**
      * Get catalog id.
@@ -182,9 +182,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $catUsername Catalog username
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatUsername(?string $catUsername): UserEntityInterface;
+    public function setCatUsername(?string $catUsername): static;
 
     /**
      * Get catalog username.
@@ -198,9 +198,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $homeLibrary Home library
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setHomeLibrary(?string $homeLibrary): UserEntityInterface;
+    public function setHomeLibrary(?string $homeLibrary): static;
 
     /**
      * Get home library.
@@ -214,9 +214,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $catPassword Cat password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setRawCatPassword(?string $catPassword): UserEntityInterface;
+    public function setRawCatPassword(?string $catPassword): static;
 
     /**
      * Get raw catalog password.
@@ -230,9 +230,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $passEnc Encrypted password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatPassEnc(?string $passEnc): UserEntityInterface;
+    public function setCatPassEnc(?string $passEnc): static;
 
     /**
      * Get encrypted catalog password.
@@ -246,9 +246,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $college College
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCollege(string $college): UserEntityInterface;
+    public function setCollege(string $college): static;
 
     /**
      * Get college.
@@ -262,9 +262,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $major Major
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setMajor(string $major): UserEntityInterface;
+    public function setMajor(string $major): static;
 
     /**
      * Get major.
@@ -278,9 +278,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $hash Hash value to save
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setVerifyHash(string $hash): UserEntityInterface;
+    public function setVerifyHash(string $hash): static;
 
     /**
      * Get verification hash for recovery.
@@ -294,9 +294,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?string $authMethod New value (null for none)
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setAuthMethod(?string $authMethod): UserEntityInterface;
+    public function setAuthMethod(?string $authMethod): static;
 
     /**
      * Get active authentication method (if any).
@@ -310,9 +310,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param string $lang Last language
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastLanguage(string $lang): UserEntityInterface;
+    public function setLastLanguage(string $lang): static;
 
     /**
      * Get last language.
@@ -333,18 +333,18 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param bool $userProvided New value
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setHasUserProvidedEmail(bool $userProvided): UserEntityInterface;
+    public function setHasUserProvidedEmail(bool $userProvided): static;
 
     /**
      * Last login setter.
      *
      * @param DateTime $dateTime Last login date
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastLogin(DateTime $dateTime): UserEntityInterface;
+    public function setLastLogin(DateTime $dateTime): static;
 
     /**
      * Last login getter
@@ -358,9 +358,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Last login date
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Created getter
@@ -374,9 +374,9 @@ interface UserEntityInterface extends EntityInterface
      *
      * @param ?DateTime $dateTime Verification date (or null)
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setEmailVerified(?DateTime $dateTime): UserEntityInterface;
+    public function setEmailVerified(?DateTime $dateTime): static;
 
     /**
      * Get email verification date (or null for unverified).

--- a/module/VuFind/src/VuFind/Db/Entity/UserListEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserListEntityInterface.php
@@ -54,9 +54,9 @@ interface UserListEntityInterface extends EntityInterface
      *
      * @param string $title Title
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setTitle(string $title): UserListEntityInterface;
+    public function setTitle(string $title): static;
 
     /**
      * Get title.
@@ -70,9 +70,9 @@ interface UserListEntityInterface extends EntityInterface
      *
      * @param ?string $description Description
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setDescription(?string $description): UserListEntityInterface;
+    public function setDescription(?string $description): static;
 
     /**
      * Get description.
@@ -86,9 +86,9 @@ interface UserListEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserListEntityInterface;
+    public function setCreated(DateTime $dateTime): static;
 
     /**
      * Get created date.
@@ -102,9 +102,9 @@ interface UserListEntityInterface extends EntityInterface
      *
      * @param bool $public Is the list public?
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setPublic(bool $public): UserListEntityInterface;
+    public function setPublic(bool $public): static;
 
     /**
      * Is this a public list?
@@ -118,9 +118,9 @@ interface UserListEntityInterface extends EntityInterface
      *
      * @param ?UserEntityInterface $user User owning the list.
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): UserListEntityInterface;
+    public function setUser(?UserEntityInterface $user): static;
 
     /**
      * Get user.

--- a/module/VuFind/src/VuFind/Db/Entity/UserResourceEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserResourceEntityInterface.php
@@ -61,9 +61,9 @@ interface UserResourceEntityInterface extends EntityInterface
      *
      * @param UserEntityInterface $user User
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): UserResourceEntityInterface;
+    public function setUser(UserEntityInterface $user): static;
 
     /**
      * Get resource.
@@ -77,9 +77,9 @@ interface UserResourceEntityInterface extends EntityInterface
      *
      * @param ResourceEntityInterface $resource Resource
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): UserResourceEntityInterface;
+    public function setResource(ResourceEntityInterface $resource): static;
 
     /**
      * Get user list.
@@ -93,9 +93,9 @@ interface UserResourceEntityInterface extends EntityInterface
      *
      * @param ?UserListEntityInterface $list User list
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setUserList(?UserListEntityInterface $list): UserResourceEntityInterface;
+    public function setUserList(?UserListEntityInterface $list): static;
 
     /**
      * Get notes.
@@ -109,9 +109,9 @@ interface UserResourceEntityInterface extends EntityInterface
      *
      * @param ?string $notes Notes associated with the resource
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setNotes(?string $notes): UserResourceEntityInterface;
+    public function setNotes(?string $notes): static;
 
     /**
      * Get saved date.
@@ -125,7 +125,7 @@ interface UserResourceEntityInterface extends EntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setSaved(DateTime $dateTime): UserResourceEntityInterface;
+    public function setSaved(DateTime $dateTime): static;
 }

--- a/module/VuFind/src/VuFind/Db/Row/AccessToken.php
+++ b/module/VuFind/src/VuFind/Db/Row/AccessToken.php
@@ -59,9 +59,9 @@ class AccessToken extends RowGateway implements AccessTokenEntityInterface
      *
      * @param ?UserEntityInterface $user User owning token
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): AccessTokenEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->__set('user_id', $user?->getId());
         return $this;
@@ -72,9 +72,9 @@ class AccessToken extends RowGateway implements AccessTokenEntityInterface
      *
      * @param string $data Data
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setData(string $data): AccessTokenEntityInterface
+    public function setData(string $data): static
     {
         $this->__set('data', $data);
         return $this;
@@ -95,9 +95,9 @@ class AccessToken extends RowGateway implements AccessTokenEntityInterface
      *
      * @param bool $revoked Revoked
      *
-     * @return AccessTokenEntityInterface
+     * @return static
      */
-    public function setRevoked(bool $revoked): AccessTokenEntityInterface
+    public function setRevoked(bool $revoked): static
     {
         $this->__set('revoked', $revoked);
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/AuthHash.php
+++ b/module/VuFind/src/VuFind/Db/Row/AuthHash.php
@@ -93,9 +93,9 @@ class AuthHash extends RowGateway implements AuthHashEntityInterface, DbServiceA
      *
      * @param ?string $sessionId PHP Session id string
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sessionId): AuthHashEntityInterface
+    public function setSessionId(?string $sessionId): static
     {
         $this->session_id = $sessionId;
         return $this;
@@ -116,9 +116,9 @@ class AuthHash extends RowGateway implements AuthHashEntityInterface, DbServiceA
      *
      * @param string $hash Hash Value
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setHash(string $hash): AuthHashEntityInterface
+    public function setHash(string $hash): static
     {
         $this->hash = $hash;
         return $this;
@@ -139,9 +139,9 @@ class AuthHash extends RowGateway implements AuthHashEntityInterface, DbServiceA
      *
      * @param ?string $type Hash Type
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setHashType(?string $type): AuthHashEntityInterface
+    public function setHashType(?string $type): static
     {
         $this->type = $type;
         return $this;
@@ -162,9 +162,9 @@ class AuthHash extends RowGateway implements AuthHashEntityInterface, DbServiceA
      *
      * @param ?string $data Data
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setData(?string $data): AuthHashEntityInterface
+    public function setData(?string $data): static
     {
         $this->__set('data', $data);
         return $this;
@@ -185,9 +185,9 @@ class AuthHash extends RowGateway implements AuthHashEntityInterface, DbServiceA
      *
      * @param DateTime $dateTime Created date
      *
-     * @return AuthHashEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): AuthHashEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Row/ChangeTracker.php
@@ -65,9 +65,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param string $id Id
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setId(string $id): ChangeTrackerEntityInterface
+    public function setId(string $id): static
     {
         $this->id = $id;
         return $this;
@@ -88,9 +88,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param string $name Index name
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setIndexName(string $name): ChangeTrackerEntityInterface
+    public function setIndexName(string $name): static
     {
         $this->core = $name;
         return $this;
@@ -111,9 +111,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param ?DateTime $dateTime Time first added to index.
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setFirstIndexed(?DateTime $dateTime): ChangeTrackerEntityInterface
+    public function setFirstIndexed(?DateTime $dateTime): static
     {
         $this->first_indexed = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -134,9 +134,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param ?DateTime $dateTime Last time changed in index.
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setLastIndexed(?DateTime $dateTime): ChangeTrackerEntityInterface
+    public function setLastIndexed(?DateTime $dateTime): static
     {
         $this->last_indexed = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -157,9 +157,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param ?DateTime $dateTime Last time original record was edited
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setLastRecordChange(?DateTime $dateTime): ChangeTrackerEntityInterface
+    public function setLastRecordChange(?DateTime $dateTime): static
     {
         $this->last_record_change = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -180,9 +180,9 @@ class ChangeTracker extends RowGateway implements ChangeTrackerEntityInterface
      *
      * @param ?DateTime $dateTime Time record was removed from index
      *
-     * @return ChangeTrackerEntityInterface
+     * @return static
      */
-    public function setDeleted(?DateTime $dateTime): ChangeTrackerEntityInterface
+    public function setDeleted(?DateTime $dateTime): static
     {
         $this->deleted = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Row/Comments.php
@@ -80,9 +80,9 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
      *
      * @param string $comment Comment
      *
-     * @return Comments
+     * @return static
      */
-    public function setComment(string $comment): CommentsEntityInterface
+    public function setComment(string $comment): static
     {
         $this->comment = $comment;
         return $this;
@@ -103,9 +103,9 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
      *
      * @param DateTime $dateTime Created date
      *
-     * @return Comments
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): CommentsEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -126,9 +126,9 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
      *
      * @param ?UserEntityInterface $user User that created comment
      *
-     * @return Comments
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): CommentsEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user ? $user->getId() : null;
         return $this;
@@ -151,9 +151,9 @@ class Comments extends RowGateway implements CommentsEntityInterface, DbServiceA
      *
      * @param ResourceEntityInterface $resource Resource id.
      *
-     * @return Comments
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): CommentsEntityInterface
+    public function setResource(ResourceEntityInterface $resource): static
     {
         $this->resource_id = $resource->getId();
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/ExternalSession.php
+++ b/module/VuFind/src/VuFind/Db/Row/ExternalSession.php
@@ -49,7 +49,7 @@ use VuFind\Db\Entity\ExternalSessionEntityInterface;
  * @property string $external_session_id
  * @property string $created
  */
-class ExternalSession extends RowGateway implements \VuFind\Db\Entity\ExternalSessionEntityInterface
+class ExternalSession extends RowGateway implements ExternalSessionEntityInterface
 {
     /**
      * Constructor
@@ -86,9 +86,9 @@ class ExternalSession extends RowGateway implements \VuFind\Db\Entity\ExternalSe
      *
      * @param string $sessionId PHP session id string
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setSessionId(string $sessionId): ExternalSessionEntityInterface
+    public function setSessionId(string $sessionId): static
     {
         $this->session_id = $sessionId;
         return $this;
@@ -109,9 +109,9 @@ class ExternalSession extends RowGateway implements \VuFind\Db\Entity\ExternalSe
      *
      * @param string $externalSessionId External session id string
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setExternalSessionId(string $externalSessionId): ExternalSessionEntityInterface
+    public function setExternalSessionId(string $externalSessionId): static
     {
         $this->external_session_id = $externalSessionId;
         return $this;
@@ -132,9 +132,9 @@ class ExternalSession extends RowGateway implements \VuFind\Db\Entity\ExternalSe
      *
      * @param DateTime $dateTime Created date
      *
-     * @return ExternalSessionEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): ExternalSessionEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Row/Feedback.php
@@ -87,9 +87,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param string $message Message
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setMessage(string $message): FeedbackEntityInterface
+    public function setMessage(string $message): static
     {
         $this->message = $message;
         return $this;
@@ -110,9 +110,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param array $data Form data
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setFormData(array $data): FeedbackEntityInterface
+    public function setFormData(array $data): static
     {
         $this->form_data = json_encode($data);
         return $this;
@@ -133,9 +133,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param string $name Form name
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setFormName(string $name): FeedbackEntityInterface
+    public function setFormName(string $name): static
     {
         $this->form_name = $name;
         return $this;
@@ -156,9 +156,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param DateTime $dateTime Created date
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): FeedbackEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -179,9 +179,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param DateTime $dateTime Last update date
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUpdated(DateTime $dateTime): FeedbackEntityInterface
+    public function setUpdated(DateTime $dateTime): static
     {
         $this->updated = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -202,9 +202,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param string $status Status
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setStatus(string $status): FeedbackEntityInterface
+    public function setStatus(string $status): static
     {
         $this->status = $status;
         return $this;
@@ -225,9 +225,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param string $url Site URL
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setSiteUrl(string $url): FeedbackEntityInterface
+    public function setSiteUrl(string $url): static
     {
         $this->site_url = $url;
         return $this;
@@ -248,9 +248,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param ?UserEntityInterface $user User that created request
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): FeedbackEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user?->getId();
         return $this;
@@ -273,9 +273,9 @@ class Feedback extends RowGateway implements FeedbackEntityInterface, DbServiceA
      *
      * @param ?UserEntityInterface $user User that updated request
      *
-     * @return FeedbackEntityInterface
+     * @return static
      */
-    public function setUpdatedBy(?UserEntityInterface $user): FeedbackEntityInterface
+    public function setUpdatedBy(?UserEntityInterface $user): static
     {
         $this->updated_by = $user ? $user->getId() : null;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/LoginToken.php
+++ b/module/VuFind/src/VuFind/Db/Row/LoginToken.php
@@ -84,9 +84,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param UserEntityInterface $user User to set
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): LoginTokenEntityInterface
+    public function setUser(UserEntityInterface $user): static
     {
         $this->user_id = $user->getId();
         return $this;
@@ -109,9 +109,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param string $token Token
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setToken(string $token): LoginTokenEntityInterface
+    public function setToken(string $token): static
     {
         $this->token = $token;
         return $this;
@@ -132,9 +132,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param string $series Series
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setSeries(string $series): LoginTokenEntityInterface
+    public function setSeries(string $series): static
     {
         $this->series = $series;
         return $this;
@@ -155,9 +155,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param DateTime $dateTime Last login date/time
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setLastLogin(DateTime $dateTime): LoginTokenEntityInterface
+    public function setLastLogin(DateTime $dateTime): static
     {
         $this->last_login = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -178,9 +178,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param ?string $browser Browser details (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setBrowser(?string $browser): LoginTokenEntityInterface
+    public function setBrowser(?string $browser): static
     {
         $this->browser = $browser;
         return $this;
@@ -201,9 +201,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param ?string $platform Platform details (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setPlatform(?string $platform): LoginTokenEntityInterface
+    public function setPlatform(?string $platform): static
     {
         $this->platform = $platform;
         return $this;
@@ -224,9 +224,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param int $expires Expiration timestamp
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setExpires(int $expires): LoginTokenEntityInterface
+    public function setExpires(int $expires): static
     {
         $this->expires = $expires;
         return $this;
@@ -247,9 +247,9 @@ class LoginToken extends RowGateway implements DbServiceAwareInterface, LoginTok
      *
      * @param ?string $sid Last session ID (or null for none)
      *
-     * @return LoginTokenEntityInterface
+     * @return static
      */
-    public function setLastSessionId(?string $sid): LoginTokenEntityInterface
+    public function setLastSessionId(?string $sid): static
     {
         $this->last_session_id = $sid;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -111,9 +111,9 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
      *
      * @param ?string $params Resumption parameters.
      *
-     * @return OaiResumptionEntityInterface
+     * @return static
      */
-    public function setResumptionParameters(?string $params): OaiResumptionEntityInterface
+    public function setResumptionParameters(?string $params): static
     {
         $this->params = $params;
         return $this;
@@ -134,9 +134,9 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
      *
      * @param DateTime $dateTime Expiration date
      *
-     * @return OaiResumptionEntityInterface
+     * @return static
      */
-    public function setExpiry(DateTime $dateTime): OaiResumptionEntityInterface
+    public function setExpiry(DateTime $dateTime): static
     {
         $this->expires = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Ratings.php
+++ b/module/VuFind/src/VuFind/Db/Row/Ratings.php
@@ -54,7 +54,7 @@ use VuFind\Db\Service\UserServiceInterface;
  * @property string $created
  */
 class Ratings extends RowGateway implements
-    \VuFind\Db\Entity\RatingsEntityInterface,
+    RatingsEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     DbServiceAwareInterface
 {
@@ -98,9 +98,9 @@ class Ratings extends RowGateway implements
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): RatingsEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user?->getId();
         return $this;
@@ -123,9 +123,9 @@ class Ratings extends RowGateway implements
      *
      * @param ResourceEntityInterface $resource Resource
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): RatingsEntityInterface
+    public function setResource(ResourceEntityInterface $resource): static
     {
         $this->resource_id = $resource->getId();
         return $this;
@@ -146,9 +146,9 @@ class Ratings extends RowGateway implements
      *
      * @param int $rating Rating
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setRating(int $rating): RatingsEntityInterface
+    public function setRating(int $rating): static
     {
         $this->rating = $rating;
         return $this;
@@ -169,9 +169,9 @@ class Ratings extends RowGateway implements
      *
      * @param DateTime $dateTime Created date
      *
-     * @return RatingsEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): RatingsEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Record.php
+++ b/module/VuFind/src/VuFind/Db/Row/Record.php
@@ -85,9 +85,9 @@ class Record extends RowGateway implements RecordEntityInterface
      *
      * @param ?string $recordId Record id
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setRecordId(?string $recordId): RecordEntityInterface
+    public function setRecordId(?string $recordId): static
     {
         $this->record_id = $recordId;
         return $this;
@@ -108,9 +108,9 @@ class Record extends RowGateway implements RecordEntityInterface
      *
      * @param ?string $recordSource Record source
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setSource(?string $recordSource): RecordEntityInterface
+    public function setSource(?string $recordSource): static
     {
         $this->source = $recordSource;
         return $this;
@@ -131,9 +131,9 @@ class Record extends RowGateway implements RecordEntityInterface
      *
      * @param string $recordVersion Record version
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setVersion(string $recordVersion): RecordEntityInterface
+    public function setVersion(string $recordVersion): static
     {
         $this->version = $recordVersion;
         return $this;
@@ -158,9 +158,9 @@ class Record extends RowGateway implements RecordEntityInterface
      *
      * @param ?string $recordData Record data
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setData(?string $recordData): RecordEntityInterface
+    public function setData(?string $recordData): static
     {
         $this->__set('data', $recordData);
         return $this;
@@ -181,9 +181,9 @@ class Record extends RowGateway implements RecordEntityInterface
      *
      * @param DateTime $dateTime Updated date
      *
-     * @return RecordEntityInterface
+     * @return static
      */
-    public function setUpdated(DateTime $dateTime): RecordEntityInterface
+    public function setUpdated(DateTime $dateTime): static
     {
         $this->updated = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Resource.php
+++ b/module/VuFind/src/VuFind/Db/Row/Resource.php
@@ -294,9 +294,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param string $recordId recordId
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setRecordId(string $recordId): ResourceEntityInterface
+    public function setRecordId(string $recordId): static
     {
         $this->record_id = $recordId;
         return $this;
@@ -317,9 +317,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param string $title Title of the record.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setTitle(string $title): ResourceEntityInterface
+    public function setTitle(string $title): static
     {
         $this->title = $title;
         return $this;
@@ -340,9 +340,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param ?string $author Author of the title.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setAuthor(?string $author): ResourceEntityInterface
+    public function setAuthor(?string $author): static
     {
         $this->author = $author;
         return $this;
@@ -353,9 +353,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param ?int $year Year title is published.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setYear(?int $year): ResourceEntityInterface
+    public function setYear(?int $year): static
     {
         $this->year = $year;
         return $this;
@@ -366,9 +366,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param string $source Source (a search backend ID).
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setSource(string $source): ResourceEntityInterface
+    public function setSource(string $source): static
     {
         $this->source = $source;
         return $this;
@@ -389,9 +389,9 @@ class Resource extends RowGateway implements DbServiceAwareInterface, DbTableAwa
      *
      * @param ?string $extraMetadata ExtraMetadata.
      *
-     * @return ResourceEntityInterface
+     * @return static
      */
-    public function setExtraMetadata(?string $extraMetadata): ResourceEntityInterface
+    public function setExtraMetadata(?string $extraMetadata): static
     {
         $this->extra_metadata = $extraMetadata;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Row/ResourceTags.php
@@ -59,7 +59,7 @@ use VuFind\Db\Service\UserServiceInterface;
  * @property string $posted
  */
 class ResourceTags extends RowGateway implements
-    \VuFind\Db\Entity\ResourceTagsEntityInterface,
+    ResourceTagsEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     DbServiceAwareInterface
 {
@@ -103,9 +103,9 @@ class ResourceTags extends RowGateway implements
      *
      * @param ?ResourceEntityInterface $resource Resource
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setResource(?ResourceEntityInterface $resource): ResourceTagsEntityInterface
+    public function setResource(?ResourceEntityInterface $resource): static
     {
         $this->resource_id = $resource?->getId();
         return $this;
@@ -128,9 +128,9 @@ class ResourceTags extends RowGateway implements
      *
      * @param TagsEntityInterface $tag Tag
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setTag(TagsEntityInterface $tag): ResourceTagsEntityInterface
+    public function setTag(TagsEntityInterface $tag): static
     {
         $this->tag_id = $tag->getId();
         return $this;
@@ -153,9 +153,9 @@ class ResourceTags extends RowGateway implements
      *
      * @param ?UserListEntityInterface $list User list
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setUserList(?UserListEntityInterface $list): ResourceTagsEntityInterface
+    public function setUserList(?UserListEntityInterface $list): static
     {
         $this->list_id = $list?->getId();
         return $this;
@@ -178,9 +178,9 @@ class ResourceTags extends RowGateway implements
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): ResourceTagsEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user?->getId();
         return $this;
@@ -201,9 +201,9 @@ class ResourceTags extends RowGateway implements
      *
      * @param DateTime $dateTime Created date
      *
-     * @return ResourceTagsEntityInterface
+     * @return static
      */
-    public function setPosted(DateTime $dateTime): ResourceTagsEntityInterface
+    public function setPosted(DateTime $dateTime): static
     {
         $this->posted = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Search.php
+++ b/module/VuFind/src/VuFind/Db/Row/Search.php
@@ -61,7 +61,7 @@ use function is_resource;
  * @property string  $notification_base_url
  */
 class Search extends RowGateway implements
-    \VuFind\Db\Entity\SearchEntityInterface,
+    SearchEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     DbServiceAwareInterface
 {
@@ -217,9 +217,9 @@ class Search extends RowGateway implements
      *
      * @param ?UserEntityInterface $user User
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): SearchEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user?->getId();
         return $this;
@@ -240,9 +240,9 @@ class Search extends RowGateway implements
      *
      * @param ?string $sessionId Session id
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sessionId): SearchEntityInterface
+    public function setSessionId(?string $sessionId): static
     {
         $this->session_id = $sessionId;
         return $this;
@@ -263,9 +263,9 @@ class Search extends RowGateway implements
      *
      * @param DateTime $dateTime Created date
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): SearchEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -286,9 +286,9 @@ class Search extends RowGateway implements
      *
      * @param ?string $title Title
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setTitle(?string $title): SearchEntityInterface
+    public function setTitle(?string $title): static
     {
         $this->title = $title;
         return $this;
@@ -309,9 +309,9 @@ class Search extends RowGateway implements
      *
      * @param bool $saved Saved
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSaved(bool $saved): SearchEntityInterface
+    public function setSaved(bool $saved): static
     {
         $this->saved = $saved ? 1 : 0;
         return $this;
@@ -322,9 +322,9 @@ class Search extends RowGateway implements
      *
      * @param ?\VuFind\Search\Minified $searchObject Search object
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setSearchObject(?\VuFind\Search\Minified $searchObject): SearchEntityInterface
+    public function setSearchObject(?\VuFind\Search\Minified $searchObject): static
     {
         $this->search_object = $searchObject ? serialize($searchObject) : null;
         return $this;
@@ -345,9 +345,9 @@ class Search extends RowGateway implements
      *
      * @param ?int $checksum Checksum
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setChecksum(?int $checksum): SearchEntityInterface
+    public function setChecksum(?int $checksum): static
     {
         $this->checksum = $checksum;
         return $this;
@@ -368,9 +368,9 @@ class Search extends RowGateway implements
      *
      * @param int $notificationFrequency Notification frequency
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setNotificationFrequency(int $notificationFrequency): SearchEntityInterface
+    public function setNotificationFrequency(int $notificationFrequency): static
     {
         $this->notification_frequency = $notificationFrequency;
         return $this;
@@ -391,9 +391,9 @@ class Search extends RowGateway implements
      *
      * @param DateTime $lastNotificationSent Time when last notification was sent
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setLastNotificationSent(Datetime $lastNotificationSent): SearchEntityInterface
+    public function setLastNotificationSent(Datetime $lastNotificationSent): static
     {
         $this->last_notification_sent = $lastNotificationSent->format('Y-m-d H:i:s');
         return $this;
@@ -414,9 +414,9 @@ class Search extends RowGateway implements
      *
      * @param string $notificationBaseUrl Notification base URL
      *
-     * @return SearchEntityInterface
+     * @return static
      */
-    public function setNotificationBaseUrl(string $notificationBaseUrl): SearchEntityInterface
+    public function setNotificationBaseUrl(string $notificationBaseUrl): static
     {
         $this->notification_base_url = $notificationBaseUrl;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Session.php
+++ b/module/VuFind/src/VuFind/Db/Row/Session.php
@@ -74,9 +74,9 @@ class Session extends RowGateway implements SessionEntityInterface
      *
      * @param ?string $sid Session Id.
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setSessionId(?string $sid): SessionEntityInterface
+    public function setSessionId(?string $sid): static
     {
         $this->session_id = $sid;
         return $this;
@@ -87,9 +87,9 @@ class Session extends RowGateway implements SessionEntityInterface
      *
      * @param DateTime $dateTime Created date
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): SessionEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -100,9 +100,9 @@ class Session extends RowGateway implements SessionEntityInterface
      *
      * @param int $lastUsed Time last used
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setLastUsed(int $lastUsed): SessionEntityInterface
+    public function setLastUsed(int $lastUsed): static
     {
         $this->last_used = $lastUsed;
         return $this;
@@ -123,9 +123,9 @@ class Session extends RowGateway implements SessionEntityInterface
      *
      * @param ?string $data Session data.
      *
-     * @return SessionEntityInterface
+     * @return static
      */
-    public function setData(?string $data): SessionEntityInterface
+    public function setData(?string $data): static
     {
         $this->data = $data;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Shortlinks.php
+++ b/module/VuFind/src/VuFind/Db/Row/Shortlinks.php
@@ -46,7 +46,7 @@ use VuFind\Db\Entity\ShortlinksEntityInterface;
  * @property string $hash
  * @property string $created
  */
-class Shortlinks extends RowGateway implements \VuFind\Db\Entity\ShortlinksEntityInterface
+class Shortlinks extends RowGateway implements ShortlinksEntityInterface
 {
     /**
      * Constructor
@@ -84,9 +84,9 @@ class Shortlinks extends RowGateway implements \VuFind\Db\Entity\ShortlinksEntit
      *
      * @param string $path Path
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setPath(string $path): ShortlinksEntityInterface
+    public function setPath(string $path): static
     {
         $this->path = $path;
         return $this;
@@ -107,9 +107,9 @@ class Shortlinks extends RowGateway implements \VuFind\Db\Entity\ShortlinksEntit
      *
      * @param ?string $hash Shortlinks hash
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setHash(?string $hash): ShortlinksEntityInterface
+    public function setHash(?string $hash): static
     {
         $this->hash = $hash;
         return $this;
@@ -130,9 +130,9 @@ class Shortlinks extends RowGateway implements \VuFind\Db\Entity\ShortlinksEntit
      *
      * @param DateTime $dateTime Creation timestamp
      *
-     * @return ShortlinksEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): ShortlinksEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/Tags.php
+++ b/module/VuFind/src/VuFind/Db/Row/Tags.php
@@ -129,9 +129,9 @@ class Tags extends RowGateway implements \VuFind\Db\Table\DbTableAwareInterface,
      *
      * @param string $tag Tag
      *
-     * @return TagsEntityInterface
+     * @return static
      */
-    public function setTag(string $tag): TagsEntityInterface
+    public function setTag(string $tag): static
     {
         $this->tag = $tag;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -716,9 +716,9 @@ class User extends RowGateway implements
      *
      * @param string $username Username
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setUsername(string $username): UserEntityInterface
+    public function setUsername(string $username): static
     {
         $this->username = $username;
         return $this;
@@ -739,9 +739,9 @@ class User extends RowGateway implements
      *
      * @param string $password Password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setRawPassword(string $password): UserEntityInterface
+    public function setRawPassword(string $password): static
     {
         $this->password = $password;
         return $this;
@@ -762,9 +762,9 @@ class User extends RowGateway implements
      *
      * @param ?string $hash Password hash
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setPasswordHash(?string $hash): UserEntityInterface
+    public function setPasswordHash(?string $hash): static
     {
         $this->pass_hash = $hash;
         return $this;
@@ -785,9 +785,9 @@ class User extends RowGateway implements
      *
      * @param string $firstName New first name
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setFirstname(string $firstName): UserEntityInterface
+    public function setFirstname(string $firstName): static
     {
         $this->firstname = $firstName;
         return $this;
@@ -808,9 +808,9 @@ class User extends RowGateway implements
      *
      * @param string $lastName New last name
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastname(string $lastName): UserEntityInterface
+    public function setLastname(string $lastName): static
     {
         $this->lastname = $lastName;
         return $this;
@@ -831,9 +831,9 @@ class User extends RowGateway implements
      *
      * @param string $email Email address
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setEmail(string $email): UserEntityInterface
+    public function setEmail(string $email): static
     {
         $this->email = $email;
         return $this;
@@ -854,9 +854,9 @@ class User extends RowGateway implements
      *
      * @param string $email New pending email
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setPendingEmail(string $email): UserEntityInterface
+    public function setPendingEmail(string $email): static
     {
         $this->pending_email = $email;
         return $this;
@@ -877,9 +877,9 @@ class User extends RowGateway implements
      *
      * @param ?string $catId Catalog id
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatId(?string $catId): UserEntityInterface
+    public function setCatId(?string $catId): static
     {
         $this->cat_id = $catId;
         return $this;
@@ -900,9 +900,9 @@ class User extends RowGateway implements
      *
      * @param ?string $catUsername Catalog username
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatUsername(?string $catUsername): UserEntityInterface
+    public function setCatUsername(?string $catUsername): static
     {
         $this->cat_username = $catUsername;
         return $this;
@@ -923,9 +923,9 @@ class User extends RowGateway implements
      *
      * @param ?string $homeLibrary Home library
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setHomeLibrary(?string $homeLibrary): UserEntityInterface
+    public function setHomeLibrary(?string $homeLibrary): static
     {
         $this->home_library = $homeLibrary;
         return $this;
@@ -946,9 +946,9 @@ class User extends RowGateway implements
      *
      * @param ?string $catPassword Cat password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setRawCatPassword(?string $catPassword): UserEntityInterface
+    public function setRawCatPassword(?string $catPassword): static
     {
         $this->cat_password = $catPassword;
         return $this;
@@ -969,9 +969,9 @@ class User extends RowGateway implements
      *
      * @param ?string $passEnc Encrypted password
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCatPassEnc(?string $passEnc): UserEntityInterface
+    public function setCatPassEnc(?string $passEnc): static
     {
         $this->cat_pass_enc = $passEnc;
         return $this;
@@ -992,9 +992,9 @@ class User extends RowGateway implements
      *
      * @param string $college College
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCollege(string $college): UserEntityInterface
+    public function setCollege(string $college): static
     {
         $this->college = $college;
         return $this;
@@ -1015,9 +1015,9 @@ class User extends RowGateway implements
      *
      * @param string $major Major
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setMajor(string $major): UserEntityInterface
+    public function setMajor(string $major): static
     {
         $this->major = $major;
         return $this;
@@ -1038,9 +1038,9 @@ class User extends RowGateway implements
      *
      * @param string $hash Hash value to save
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setVerifyHash(string $hash): UserEntityInterface
+    public function setVerifyHash(string $hash): static
     {
         $this->verify_hash = $hash;
         return $this;
@@ -1061,9 +1061,9 @@ class User extends RowGateway implements
      *
      * @param ?string $authMethod New value (null for none)
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setAuthMethod(?string $authMethod): UserEntityInterface
+    public function setAuthMethod(?string $authMethod): static
     {
         $this->auth_method = $authMethod;
         return $this;
@@ -1084,9 +1084,9 @@ class User extends RowGateway implements
      *
      * @param string $lang Last language
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastLanguage(string $lang): UserEntityInterface
+    public function setLastLanguage(string $lang): static
     {
         $this->last_language = $lang;
         return $this;
@@ -1117,9 +1117,9 @@ class User extends RowGateway implements
      *
      * @param bool $userProvided New value
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setHasUserProvidedEmail(bool $userProvided): UserEntityInterface
+    public function setHasUserProvidedEmail(bool $userProvided): static
     {
         $this->user_provided_email = $userProvided ? 1 : 0;
         return $this;
@@ -1130,9 +1130,9 @@ class User extends RowGateway implements
      *
      * @param DateTime $dateTime Last login date
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setLastLogin(DateTime $dateTime): UserEntityInterface
+    public function setLastLogin(DateTime $dateTime): static
     {
         $this->last_login = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -1153,9 +1153,9 @@ class User extends RowGateway implements
      *
      * @param DateTime $dateTime Creation date
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -1176,9 +1176,9 @@ class User extends RowGateway implements
      *
      * @param ?DateTime $dateTime Verification date (or null)
      *
-     * @return UserEntityInterface
+     * @return static
      */
-    public function setEmailVerified(?DateTime $dateTime): UserEntityInterface
+    public function setEmailVerified(?DateTime $dateTime): static
     {
         $this->email_verified = $dateTime?->format('Y-m-d H:i:s');
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/UserCard.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserCard.php
@@ -82,9 +82,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param string $cardName User card name.
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCardName(string $cardName): UserCardEntityInterface
+    public function setCardName(string $cardName): static
     {
         $this->card_name = $cardName;
         return $this;
@@ -105,9 +105,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param string $catUsername Catalog username
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCatUsername(string $catUsername): UserCardEntityInterface
+    public function setCatUsername(string $catUsername): static
     {
         $this->cat_username = $catUsername;
         return $this;
@@ -128,9 +128,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param ?string $catPassword Cat password
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setRawCatPassword(?string $catPassword): UserCardEntityInterface
+    public function setRawCatPassword(?string $catPassword): static
     {
         $this->cat_password = $catPassword;
         return $this;
@@ -151,9 +151,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param ?string $passEnc Encrypted password
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCatPassEnc(?string $passEnc): UserCardEntityInterface
+    public function setCatPassEnc(?string $passEnc): static
     {
         $this->cat_pass_enc = $passEnc;
         return $this;
@@ -174,9 +174,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param ?string $homeLibrary Home library
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setHomeLibrary(?string $homeLibrary): UserCardEntityInterface
+    public function setHomeLibrary(?string $homeLibrary): static
     {
         $this->home_library = $homeLibrary;
         return $this;
@@ -197,9 +197,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserCardEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -220,9 +220,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param DateTime $dateTime Saved date and time
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setSaved(DateTime $dateTime): UserCardEntityInterface
+    public function setSaved(DateTime $dateTime): static
     {
         $this->saved = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -243,9 +243,9 @@ class UserCard extends RowGateway implements DbServiceAwareInterface, UserCardEn
      *
      * @param UserEntityInterface $user User that owns card
      *
-     * @return UserCardEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): UserCardEntityInterface
+    public function setUser(UserEntityInterface $user): static
     {
         $this->user_id = $user->getId();
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserList.php
@@ -263,9 +263,9 @@ class UserList extends RowGateway implements
      *
      * @param string $title Title
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setTitle(string $title): UserListEntityInterface
+    public function setTitle(string $title): static
     {
         $this->title = $title;
         return $this;
@@ -286,9 +286,9 @@ class UserList extends RowGateway implements
      *
      * @param ?string $description Description
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setDescription(?string $description): UserListEntityInterface
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
         return $this;
@@ -309,9 +309,9 @@ class UserList extends RowGateway implements
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setCreated(DateTime $dateTime): UserListEntityInterface
+    public function setCreated(DateTime $dateTime): static
     {
         $this->created = $dateTime->format('Y-m-d H:i:s');
         return $this;
@@ -332,9 +332,9 @@ class UserList extends RowGateway implements
      *
      * @param bool $public Is the list public?
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setPublic(bool $public): UserListEntityInterface
+    public function setPublic(bool $public): static
     {
         $this->public = $public ? '1' : '0';
         return $this;
@@ -345,9 +345,9 @@ class UserList extends RowGateway implements
      *
      * @param ?UserEntityInterface $user User owning the list.
      *
-     * @return UserListEntityInterface
+     * @return static
      */
-    public function setUser(?UserEntityInterface $user): UserListEntityInterface
+    public function setUser(?UserEntityInterface $user): static
     {
         $this->user_id = $user?->getId();
         return $this;

--- a/module/VuFind/src/VuFind/Db/Row/UserResource.php
+++ b/module/VuFind/src/VuFind/Db/Row/UserResource.php
@@ -57,7 +57,7 @@ use VuFind\Db\Service\UserServiceInterface;
  * @property string $saved
  */
 class UserResource extends RowGateway implements
-    \VuFind\Db\Entity\UserResourceEntityInterface,
+    UserResourceEntityInterface,
     \VuFind\Db\Table\DbTableAwareInterface,
     DbServiceAwareInterface
 {
@@ -100,9 +100,9 @@ class UserResource extends RowGateway implements
      *
      * @param UserEntityInterface $user User
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setUser(UserEntityInterface $user): UserResourceEntityInterface
+    public function setUser(UserEntityInterface $user): static
     {
         $this->user_id = $user->getId();
         return $this;
@@ -124,9 +124,9 @@ class UserResource extends RowGateway implements
      *
      * @param ResourceEntityInterface $resource Resource
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setResource(ResourceEntityInterface $resource): UserResourceEntityInterface
+    public function setResource(ResourceEntityInterface $resource): static
     {
         $this->resource_id = $resource->getId();
         return $this;
@@ -149,9 +149,9 @@ class UserResource extends RowGateway implements
      *
      * @param ?UserListEntityInterface $list User list
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setUserList(?UserListEntityInterface $list): UserResourceEntityInterface
+    public function setUserList(?UserListEntityInterface $list): static
     {
         $this->list_id = $list?->getId();
         return $this;
@@ -172,9 +172,9 @@ class UserResource extends RowGateway implements
      *
      * @param ?string $notes Notes associated with the resource
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setNotes(?string $notes): UserResourceEntityInterface
+    public function setNotes(?string $notes): static
     {
         $this->notes = $notes;
         return $this;
@@ -195,9 +195,9 @@ class UserResource extends RowGateway implements
      *
      * @param DateTime $dateTime Created date
      *
-     * @return UserResourceEntityInterface
+     * @return static
      */
-    public function setSaved(DateTime $dateTime): UserResourceEntityInterface
+    public function setSaved(DateTime $dateTime): static
     {
         $this->saved = $dateTime->format('Y-m-d H:i:s');
         return $this;


### PR DESCRIPTION
Using `static` allows child classes/interfaces to continue to use the fluent interfaces.