### PR TITLE
Use correct id in scheduled search list.

### DIFF
--- a/module/VuFind/src/VuFind/Search/History.php
+++ b/module/VuFind/src/VuFind/Search/History.php
@@ -99,7 +99,7 @@ class History
                 $unsaved[] = $search;
             }
             if ($search->getOptions()->supportsScheduledSearch()) {
-                $schedule[$search->getSearchId()] = $current->getNotificationFrequency();
+                $schedule[$current->getId()] = $current->getNotificationFrequency();
             }
         }
 


### PR DESCRIPTION
While the ID stored in the search should match the id of the database entity, the database entity is the authoritative one.