### PR TITLE
ConfigManager.java: add default local dir support; modernize comments.

### DIFF
--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -70,25 +70,28 @@ public class ConfigManager
     private File findConfigFile(String filename) throws IllegalStateException
     {
         // Find VuFind's home directory in the environment; if it's not available,
-        // try using a relative path on the assumption that we are currently in
-        // VuFind's import subdirectory:
+        // we cannot proceed:
         String vufindHome = System.getenv("VUFIND_HOME");
         if (vufindHome == null) {
             // this shouldn't happen since import-marc.sh and .bat always set VUFIND_HOME
             throw new IllegalStateException("VUFIND_HOME must be set");
         }
 
-        // Check for VuFind 2.0's local directory environment variable:
+        // Check for VuFind's local directory environment variable:
         String vufindLocal = System.getenv("VUFIND_LOCAL_DIR");
 
-        // Get the relative VuFind path from the properties file, defaulting to
-        // the 2.0-style config/vufind if necessary.
+        // If VUFIND_LOCAL_DIR is not set, issue a warning and try to derive it from VUFIND_HOME
+        if (vufindLocal == null || vufindLocal.length() == 0) {
+            vufindLocal = vufindHome + "/local";
+            logger.warn("The VUFIND_LOCAL_DIR environment variable is missing. Defaulting to " + vufindLocal);
+        }
+
+        // Get the relative VuFind path from the properties file, defaulting to config/vufind if necessary.
         String relativeConfigPath = PropertyUtils.getProperty(
             vuFindConfigs, "vufind.config.relative_path", "config/vufind"
         );
 
-        // Try several different locations for the file -- VuFind 2 local dir,
-        // VuFind 2 base dir, VuFind 1 base dir.
+        // Try several different locations for the file -- VuFind local dir, VuFind base dir, legacy base dir.
         File file;
         if (vufindLocal != null) {
             file = new File(vufindLocal + "/" + relativeConfigPath + "/" + filename);
@@ -100,7 +103,7 @@ public class ConfigManager
         if (file.exists()) {
             return file;
         }
-        file = new File(vufindHome + "/web/conf/" + filename);
+        file = new File(vufindHome + "/web/conf/" + filename); // legacy from VuFind 1.x
         return file;
     }
 


### PR DESCRIPTION
This PR adds logic to check for the default $VUFIND_LOCAL_DIR and issue a warning if the environment variable is unset. It also modernizes comments that were either inaccurate or focused on the old VuFind 1.x/2.x dichotomy.

Thanks to Abid Fakhre Alam for valuable input.