### PR TITLE
Make it possible to retrieve user's saved searches only

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/SearchServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/SearchServiceInterface.php
@@ -99,7 +99,7 @@ interface SearchServiceInterface extends DbServiceInterface
     /**
      * Get an array of rows for the specified user.
      *
-     * @param string                       $sessionId Session ID of current user.
+     * @param ?string                      $sessionId Session ID of current user or null to ignore searches in session.
      * @param UserEntityInterface|int|null $userOrId  User entity or ID of current user (optional).
      *
      * @return SearchEntityInterface[]


### PR DESCRIPTION
While there's no need for this in the core code, we need to be able to retrieve just the saved searches for a user, and since session id can also be null in the database, I think it makes sense to allow now also in the getSearches method.