### PR TITLE
FOLIO: only pull due dates from open loans.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -889,7 +889,7 @@ class Folio extends AbstractAPI implements
      */
     protected function getDueDate($itemId, $showTime)
     {
-        $query = 'itemId==' . $itemId;
+        $query = 'itemId==' . $itemId . ' AND status.name==Open';
         foreach (
             $this->getPagedResults(
                 'loans',

--- a/module/VuFind/tests/fixtures/folio/responses/get-holding-checkedout.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-holding-checkedout.json
@@ -188,7 +188,7 @@
         "expectedMethod": "GET",
         "expectedPath": "\/circulation\/loans",
         "expectedParams": {
-            "query": "itemId==itemid",
+            "query": "itemId==itemid AND status.name==Open",
             "offset": 0,
             "limit": 1000
         },


### PR DESCRIPTION
It was recently discovered that items with long loan histories could sometimes display the wrong due date. This PR ensures that we only retrieve loans from open loans.

Question for FOLIO experts: do we need to make the name of open loans configurable, or is this guaranteed to always be `Open` in all FOLIO instances?