### PR TITLE
Fix holds Mink test

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -107,7 +107,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
             . urlencode("id:($id)")
         );
         $page = $session->getPage();
-        $this->clickCss($page, '#result0 a.record-cover-link');
+        $this->clickCss($page, '#result0 a.getFull');
         $this->waitForPageLoad($page);
         return $page;
     }


### PR DESCRIPTION
The test was using cover image to go to record page, which isn't working anymore.