### PR TITLE
Add file extensions to BibTeX and RIS exports

### DIFF
--- a/config/vufind/export.ini
+++ b/config/vufind/export.ini
@@ -86,8 +86,10 @@ headers[] = "Content-type: application/rdf+xml"
 requiredMethods[] = getTitle
 ;limit = 100
 headers[] = "Content-type: application/x-bibtex; charset=utf-8"
+headers[] = "Content-Disposition: attachment; filename=\"VuFindExport.bibtex\";"
 
 [RIS]
 requiredMethods[] = getTitle
 ;limit = 100
 headers[] = "Content-type: application/x-research-info-systems; charset=utf-8"
+headers[] = "Content-Disposition: attachment; filename=\"VuFindExport.ris\";"


### PR DESCRIPTION
These extensions are associated with Zotero (and probably any other reference managers installed locally that can support them), so executing the downloaded file launches the app.  There are already file extensions set for most of the other downloaded types.