### PR TITLE
Add scopes to OIDC well-known configuration.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -366,6 +366,9 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
         if ($url = $this->oauth2Config['Server']['documentationUrl'] ?? null) {
             $configuration['service_documentation'] = $url;
         }
+        if ($scopes = $this->oauth2Config['Scopes'] ?? []) {
+            $configuration['scopes_supported'] = array_keys($scopes);
+        }
 
         return $this->getJsonResponse($configuration);
     }


### PR DESCRIPTION
While scopes are not mandatory, there are apparently services that check for the `openid` scope to be available.