### PR TITLE
Fix range-related bugs.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -48,8 +48,6 @@ use function in_array;
 use function intval;
 use function is_array;
 use function is_callable;
-use function is_float;
-use function is_int;
 use function is_object;
 use function strlen;
 
@@ -1416,8 +1414,8 @@ class Params
     }
 
     /**
-     * Support method for initNumericRangeFilters() -- normalize a year for use in
-     * a date range.
+     * Support method for initNumericRangeFilters() -- normalize a number for use in
+     * a numeric range.
      *
      * @param ?string $num      Value to format into a number.
      * @param bool    $rangeEnd Is this the end of a range?
@@ -1428,15 +1426,12 @@ class Params
      */
     protected function formatValueForNumericRange($num, $rangeEnd = false)
     {
-        // empty strings are always wildcards:
-        if ($num == '') {
+        // empty strings, null values and non-numeric values are treated as wildcards:
+        if ($num === '' || $num === null || !is_numeric($num)) {
             return '*';
         }
-
-        // it's a string by default so this will kick it into interpreting it as a
-        // number
-        $num = $num + 0;
-        return $num = !is_float($num) && !is_int($num) ? '*' : $num;
+        // If we got this far, it's a number!
+        return $num;
     }
 
     /**

--- a/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
@@ -1,12 +1,11 @@
 <?php
   // Sanitize inputs:
-  $sanitize = 'fulldate' === $this->facet['type']
-    ? function ($val) {
-      return substr($val, 0, 10);
-    }
-    : function ($val) {
-      return preg_replace('/[^\d]*/', '', $val);
-    };
+  $sanitize = match($this->facet['type']) {
+    'date' => fn ($val) => preg_replace('/[^\d]*/', '', $val), // digits only for year-only dates
+    'fulldate' => fn ($val) => substr($val, 0, 10),
+    'numeric' => fn ($val) => preg_replace('/[^\d.]*/', '', $val), // digits/decimal points only for numeric
+    default => fn ($val) => $val, // no sanitization for "generic" ranges
+  };
   $cleanValues = array_map($sanitize, $this->facet['values'] ?? []);
   $safeBaseId = $this->escapeHtmlAttr($this->title);
 ?>

--- a/themes/bootstrap5/templates/Recommend/SideFacets/range-slider.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets/range-slider.phtml
@@ -1,12 +1,11 @@
 <?php
   // Sanitize inputs:
-  $sanitize = 'fulldate' === $this->facet['type']
-    ? function ($val) {
-      return substr($val, 0, 10);
-    }
-    : function ($val) {
-      return preg_replace('/[^\d]*/', '', $val);
-    };
+  $sanitize = match($this->facet['type']) {
+    'date' => fn ($val) => preg_replace('/[^\d]*/', '', $val), // digits only for year-only dates
+    'fulldate' => fn ($val) => substr($val, 0, 10),
+    'numeric' => fn ($val) => preg_replace('/[^\d.]*/', '', $val), // digits/decimal points only for numeric
+    default => fn ($val) => $val, // no sanitization for "generic" ranges
+  };
   $cleanValues = array_map($sanitize, $this->facet['values'] ?? []);
   $safeBaseId = $this->escapeHtmlAttr($this->title);
 ?>


### PR DESCRIPTION
While testing #3761 I discovered a few bugs related to rarely-used specialty range facets: some vaues were being incorrectly sanitized in templates, and the low-level numeric range sanitization was relying on behavior that no longer works correctly in PHP 8. The code has all been modernized to cover gaps and hopefully be more future-proof.

I'm not entirely sure it makes sense to do sanitization in the templates at all, but in the interest of fixing bugs rather than changing architecture, I just improved the logic in place for now.