### PR TITLE
Fix deduplication in ParamBag to avoid messing with array params

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/ParamBag.php
+++ b/module/VuFindSearch/src/VuFindSearch/ParamBag.php
@@ -163,11 +163,17 @@ class ParamBag implements \Countable
             $this->params[$name] = [];
         }
         if (is_array($value)) {
-            $this->params[$name] = array_merge($this->params[$name], $value);
+            $this->params[$name] = array_merge_recursive($this->params[$name], $value);
         } else {
             $this->params[$name][] = $value;
         }
         if ($deduplicate) {
+            // Avoid deduplicating associative array params (like Primo filterList):
+            foreach ($this->params[$name] as $key => $current) {
+                if (!is_numeric($key) || is_array($current)) {
+                    return;
+                }
+            }
             $this->params[$name] = array_values(array_unique($this->params[$name]));
         }
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/ParamBagTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/ParamBagTest.php
@@ -127,6 +127,11 @@ class ParamBagTest extends TestCase
         $this->assertEquals(['bar'], $bag->get('foo'));
         $bag->add('foo', ['bar', 'baz', 'bar', 'baz']);
         $this->assertEquals(['bar', 'baz'], $bag->get('foo'));
+        // Associative arrays are not deduplicated:
+        $bag->add('fooz', ['bar' => 'baz']);
+        $bag->add('fooz', ['bar' => 'baz']);
+        $bag->add('fooz', ['bar' => 'haz']);
+        $this->assertEquals(['bar' => ['baz', 'baz', 'haz']], $bag->get('fooz'));
     }
 
     /**


### PR DESCRIPTION
@mtrojan-ub #3368 caused trouble with Primo search when there are two or more active filters and the code tries to deduplicate the filterList array. This PR disables deduplication for associative arrays.