### PR TITLE
Preprocess query string before normalization

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -157,7 +157,6 @@ class QueryBuilder implements QueryBuilderInterface
         $highlight = !empty($this->fieldsToHighlight);
 
         if ($handler = $this->getSearchHandler($finalQuery->getHandler(), $string)) {
-            $string = $handler->preprocessQueryString($string);
             if (
                 !$handler->hasExtendedDismax()
                 && $this->getLuceneHelper()->containsAdvancedLuceneSyntax($string)
@@ -577,9 +576,13 @@ class QueryBuilder implements QueryBuilderInterface
      */
     protected function getNormalizedQueryString($query)
     {
+        $queryString = $query->getString();
+        if ($handler = $this->getSearchHandler($query->getHandler(), $queryString)) {
+            $queryString = $handler->preprocessQueryString($queryString);
+        }
         return $this->fixTrailingQuestionMarks(
             $this->getLuceneHelper()->normalizeSearchString(
-                $query->getString()
+                $queryString
             )
         );
     }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -983,4 +983,41 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
             $response->get('q')
         );
     }
+
+    /**
+     * Test dismax munge.
+     *
+     * @return void
+     */
+    public function testDismaxMunge()
+    {
+        // Set up an array of expected inputs and outputs:
+        $tests = [
+            ['title - sub', 'title sub'],        // normalization of freestanding hyphen
+            ['test + test', 'test and test'],    // freestanding plus with munge
+            ['test+test', 'test+test'],          // non-freestanding plus
+            ['test~0.9', 'test0.9'],             // munge for removing char
+            ['test~10', 'test 10'],              // more specific munge followed by normalization
+            ['TEST', 'test'],                    // lc munge
+        ];
+        $specs = [
+            'test' => [
+                'DismaxFields' => ['foo'],
+                'DismaxMunge' => [
+                    ['preg_replace', '/\s[\+]\s/', ' and '],
+                    ['preg_replace', '/~1/', ' + 1'],
+                    ['preg_replace', '/~/', ''],
+                    ['lowercase'],
+                ],
+            ],
+        ];
+        $qb = new QueryBuilder($specs);
+        foreach ($tests as $test) {
+            [$input, $output] = $test;
+            $q = new Query($input, 'test');
+            $response = $qb->build($q);
+            $processedQ = $response->get('q');
+            $this->assertEquals($output, $processedQ[0]);
+        }
+    }
 }


### PR DESCRIPTION
We want to use "DismaxMunge" to change freestanding plusses into something else. But currently that is not possible because freestanding plusses get removed by normalization before the dismax munge is applied. 

This PR changes the order of those operations.