### PR TITLE
Auto-select single pickup location for a request group

### DIFF
--- a/themes/bootstrap3/js/hold.js
+++ b/themes/bootstrap3/js/hold.js
@@ -36,12 +36,12 @@ function setUpHoldRequestForm(recordId) {
             // Make sure to compare locationID and defaultValue as Strings since locationID may be an integer
             if (String(this.locationID) === String(defaultValue) ||
               (defaultValue === '' && this.isDefault && $emptyOption.length === 0) ||
-              (response.data.locations.length == 1)) {
+              (response.data.locations.length === 1)) {
               option.attr('selected', 'selected');
             }
             $select.append(option);
           });
-          if (response.data.locations.length == 1) {
+          if (response.data.locations.length === 1) {
             $emptyOption.attr('hidden', 'hidden');
             $emptyOption.removeAttr('selected');
           }

--- a/themes/bootstrap3/js/hold.js
+++ b/themes/bootstrap3/js/hold.js
@@ -34,8 +34,8 @@ function setUpHoldRequestForm(recordId) {
           $.each(response.data.locations, function holdPickupLocationEach() {
             var option = $('<option/>').attr('value', this.locationID).text(this.locationDisplay);
             // Make sure to compare locationID and defaultValue as Strings since locationID may be an integer
-            if (String(this.locationID) === String(defaultValue) || 
-              (defaultValue === '' && this.isDefault && $emptyOption.length === 0) || 
+            if (String(this.locationID) === String(defaultValue) ||
+              (defaultValue === '' && this.isDefault && $emptyOption.length === 0) ||
               (response.data.locations.length == 1)) {
               option.attr('selected', 'selected');
             }

--- a/themes/bootstrap3/js/hold.js
+++ b/themes/bootstrap3/js/hold.js
@@ -34,11 +34,20 @@ function setUpHoldRequestForm(recordId) {
           $.each(response.data.locations, function holdPickupLocationEach() {
             var option = $('<option/>').attr('value', this.locationID).text(this.locationDisplay);
             // Make sure to compare locationID and defaultValue as Strings since locationID may be an integer
-            if (String(this.locationID) === String(defaultValue) || (defaultValue === '' && this.isDefault && $emptyOption.length === 0)) {
+            if (String(this.locationID) === String(defaultValue) || 
+              (defaultValue === '' && this.isDefault && $emptyOption.length === 0) || 
+              (response.data.locations.length == 1)) {
               option.attr('selected', 'selected');
             }
             $select.append(option);
           });
+          if (response.data.locations.length == 1) {
+            $emptyOption.attr('hidden', 'hidden');
+            $emptyOption.removeAttr('selected');
+          }
+          else {
+            $emptyOption.removeAttr('hidden');
+          }
           $select.show();
         } else {
           $select.hide();

--- a/themes/bootstrap5/js/hold.js
+++ b/themes/bootstrap5/js/hold.js
@@ -36,12 +36,12 @@ function setUpHoldRequestForm(recordId) {
             // Make sure to compare locationID and defaultValue as Strings since locationID may be an integer
             if (String(this.locationID) === String(defaultValue) ||
               (defaultValue === '' && this.isDefault && $emptyOption.length === 0) ||
-              (response.data.locations.length == 1)) {
+              (response.data.locations.length === 1)) {
               option.attr('selected', 'selected');
             }
             $select.append(option);
           });
-          if (response.data.locations.length == 1) {
+          if (response.data.locations.length === 1) {
             $emptyOption.attr('hidden', 'hidden');
             $emptyOption.removeAttr('selected');
           }

--- a/themes/bootstrap5/js/hold.js
+++ b/themes/bootstrap5/js/hold.js
@@ -34,11 +34,20 @@ function setUpHoldRequestForm(recordId) {
           $.each(response.data.locations, function holdPickupLocationEach() {
             var option = $('<option/>').attr('value', this.locationID).text(this.locationDisplay);
             // Make sure to compare locationID and defaultValue as Strings since locationID may be an integer
-            if (String(this.locationID) === String(defaultValue) || (defaultValue === '' && this.isDefault && $emptyOption.length === 0)) {
+            if (String(this.locationID) === String(defaultValue) ||
+              (defaultValue === '' && this.isDefault && $emptyOption.length === 0) ||
+              (response.data.locations.length == 1)) {
               option.attr('selected', 'selected');
             }
             $select.append(option);
           });
+          if (response.data.locations.length == 1) {
+            $emptyOption.attr('hidden', 'hidden');
+            $emptyOption.removeAttr('selected');
+          }
+          else {
+            $emptyOption.removeAttr('hidden');
+          }
           $select.show();
         } else {
           $select.hide();


### PR DESCRIPTION
In the request form, if there is a single pickup location, it is normally auto-selected and there is no "Select Pick Up Location" option.  However if the request groups option is visible and after selecting a group there is only one pickup location option, it is not auto-selected.  This fixes that inconsistency.