### PR TITLE
Disable jumpto for last search urls

### DIFF
--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -572,11 +572,11 @@ class UrlQueryHelper
      * Return HTTP parameters to render the current page with a different jumpto
      * parameter.
      *
-     * @param bool $jumpto If results page is skipped when a search has only one hit
+     * @param null|false|int $jumpto If results page is skipped when a search has only one hit
      *
      * @return UrlQueryHelper
      */
-    public function setJumpto($jumpto)
+    public function setJumpto(null|false|int $jumpto): UrlQueryHelper
     {
         return $this->updateQueryString(
             'jumpto',

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -340,7 +340,7 @@ class UrlQueryHelper
     /**
      * Remove all filters.
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function removeAllFilters()
     {
@@ -354,7 +354,7 @@ class UrlQueryHelper
     /**
      * Reset default filter state.
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function resetDefaultFilters()
     {
@@ -474,7 +474,7 @@ class UrlQueryHelper
      *
      * @param string $filter Filter to add
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function removeFilter($filter)
     {
@@ -488,7 +488,7 @@ class UrlQueryHelper
      *
      * @param string $p New page parameter (null for NO page parameter)
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setPage($p)
     {
@@ -501,7 +501,7 @@ class UrlQueryHelper
      *
      * @param string $s New sort parameter (null for NO sort parameter)
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setSort($s)
     {
@@ -519,7 +519,7 @@ class UrlQueryHelper
      *
      * @param string $handler new Handler.
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setHandler($handler)
     {
@@ -540,7 +540,7 @@ class UrlQueryHelper
      *
      * @param string $v New sort parameter (null for NO view parameter)
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setViewParam($v)
     {
@@ -556,7 +556,7 @@ class UrlQueryHelper
      *
      * @param string $l New limit parameter (null for NO limit parameter)
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setLimit($l)
     {
@@ -569,12 +569,28 @@ class UrlQueryHelper
     }
 
     /**
+     * Return HTTP parameters to render the current page with a different jumpto
+     * parameter.
+     *
+     * @param bool $jumpto If results page is skipped when a search has only one hit
+     *
+     * @return UrlQueryHelper
+     */
+    public function setJumpto($jumpto)
+    {
+        return $this->updateQueryString(
+            'jumpto',
+            $jumpto
+        );
+    }
+
+    /**
      * Return HTTP parameters to render the current page with a different set
      * of search terms.
      *
      * @param string $lookfor New search terms
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     public function setSearchTerms($lookfor)
     {
@@ -664,7 +680,7 @@ class UrlQueryHelper
      *                          for no default).
      * @param bool   $clearPage Should we clear the page number, if any?
      *
-     * @return string
+     * @return UrlQueryHelper
      */
     protected function updateQueryString(
         $field,
@@ -673,7 +689,7 @@ class UrlQueryHelper
         $clearPage = false
     ) {
         $params = $this->urlParams;
-        if (null === $value || $value == $default) {
+        if (null === $value || $value === $default) {
             unset($params[$field]);
         } else {
             $params[$field] = $value;

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
@@ -111,6 +111,7 @@ class SearchMemory extends AbstractHelper
             if (!empty($searchContext['page'])) {
                 $queryHelper = $queryHelper->setPage($searchContext['page']);
             }
+            $queryHelper = $queryHelper->setJumpto(false);
 
             $url .= $queryHelper->getParams(false);
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/JumpToRecordTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/JumpToRecordTest.php
@@ -57,6 +57,16 @@ class JumpToRecordTest extends \VuFindTest\Integration\MinkTestCase
             'La congiura dei Principi Napoletani 1701 : (prima e seconda stesura) /',
             trim($this->findCssAndGetText($page, 'h1'))
         );
+
+        // check if jump to is disabled on breadcrumb link
+        $this->clickCss($page, '.breadcrumb li:first-child');
+        $this->waitForPageLoad($page);
+
+        $expected = 'Showing 1 - 1 results of 1';
+        $this->assertStringStartsWith(
+            $expected,
+            $this->findCssAndGetText($page, '.search-stats')
+        );
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchMemoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchMemoryTest.php
@@ -94,6 +94,7 @@ class SearchMemoryTest extends \PHPUnit\Framework\TestCase
         $solrOptions = $solrParams->getOptions();
         $solrOptions->expects($this->once())->method('getSearchAction')->willReturn($this->searchRoute);
         $mockQueryHelper = $this->createMock(UrlQueryHelper::class);
+        $mockQueryHelper->expects($this->any())->method('setJumpto')->willReturn($mockQueryHelper);
         $results = $this->createMock(Results::class);
         $results->expects($this->any())->method('getOptions')->willReturn($solrOptions);
         $results->expects($this->any())->method('getParams')->willReturn($solrParams);


### PR DESCRIPTION
When `jump_to_single_search_result` is enabled the breadcrumb link back to the search on the record page will also effectively link to the single record.

With this PR that will be changed to the actual result list with one entry.