### PR TITLE
Ensure boundWithRecords is clear each time through the loop

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -825,6 +825,7 @@ class Folio extends AbstractAPI implements
                 }
                 $number++;
                 $dueDateValue = '';
+                $boundWithRecords = null;
                 if (
                     $item->status->name == 'Checked out'
                     && $showDueDate


### PR DESCRIPTION
If a FOLIO instance has multiple items on one holding and only one of the items has bound-with information, the `$boundWithRecords` variable for subsequent items has that item's bound-with information.