### PR TITLE
[VUFIND-1665] Improve link templates across all backends.

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,16 +1,9 @@
 <?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
+  $options = $this->searchOptions($this->driver->getSearchBackendIdentifier());
   $searchRoute = $options->getSearchAction();
   if ($searchRoute === 'search-results') { // override search-results with author module
-    $searchRoute = 'author-home';
     $query = ['author' => $this->lookfor];
+    echo $this->url('author-home', [], compact('query'));
   } else {
-    $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
+    echo $this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor', 'searchRoute') + ['type' => 'Author']);
   }
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-generic.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-generic.phtml
@@ -1,9 +1,6 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  if (!isset($searchRoute)) {
-    $options = $this->searchOptions($searchBackendId);
-    $searchRoute = $options->getSearchAction();
-  }
+  $options = $this->searchOptions($searchBackendId);
   $query = [
     'type' => $this->type,
     'lookfor' => ($this->quoteQuery ?? true) ? '"' . $this->lookfor . '"' : $this->lookfor,
@@ -13,4 +10,4 @@
   ) {
     $query['limit'] = $limit;
   }
-  echo $this->url($searchRoute, [], compact('query'));
+  echo $this->url($this->searchRoute ?? $options->getSearchAction(), [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-generic.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-generic.phtml
@@ -1,0 +1,16 @@
+<?php
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  if (!isset($searchRoute)) {
+    $options = $this->searchOptions($searchBackendId);
+    $searchRoute = $options->getSearchAction();
+  }
+  $query = [
+    'type' => $this->type,
+    'lookfor' => ($this->quoteQuery ?? true) ? '"' . $this->lookfor . '"' : $this->lookfor,
+  ];
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'JournalTitle']);

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Publisher', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Series']);

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject']);

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'author', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search', [], ['query' => ['type' => 'publisher', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'publisher', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=series';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'series']);

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'subject']);

--- a/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Pazpar2/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'title']);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=Author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Author', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-issn.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-issn.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=ISSN';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN']);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-issn.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-issn.phtml
@@ -1,1 +1,1 @@
-<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN']);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-journaltitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-journaltitle.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=AllFields';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'AllFields']);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search', [], ['query' => ['type' => 'AllFields', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'AllFields', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=Subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/Primo/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Primo/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap3/templates/RecordDriver/Summon/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Author']);

--- a/themes/bootstrap3/templates/RecordDriver/Summon/link-journaltitle.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/link-journaltitle.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=PublicationTitle';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'PublicationTitle']);

--- a/themes/bootstrap3/templates/RecordDriver/Summon/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=PublicationSeriesTitle';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'PublicationSeriesTitle']);

--- a/themes/bootstrap3/templates/RecordDriver/Summon/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject']);

--- a/themes/bootstrap3/templates/RecordDriver/Summon/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/Summon/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap3/templates/RecordDriver/WorldCat/link-author.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/WorldCat/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=srw.au';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.au', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/WorldCat/link-publisher.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/WorldCat/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search', [], ['query' => ['type' => 'srw.pb', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.pb', 'quoteQuery' => false]);

--- a/themes/bootstrap3/templates/RecordDriver/WorldCat/link-series.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/WorldCat/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.se';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.se']);

--- a/themes/bootstrap3/templates/RecordDriver/WorldCat/link-subject.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/WorldCat/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.su';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.su']);

--- a/themes/bootstrap3/templates/RecordDriver/WorldCat/link-title.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/WorldCat/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.ti%3Asrw.se';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.ti:srw.se']);

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-author.phtml
@@ -1,16 +1,9 @@
 <?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
+  $options = $this->searchOptions($this->driver->getSearchBackendIdentifier());
   $searchRoute = $options->getSearchAction();
   if ($searchRoute === 'search-results') { // override search-results with author module
-    $searchRoute = 'author-home';
     $query = ['author' => $this->lookfor];
+    echo $this->url('author-home', [], compact('query'));
   } else {
-    $query = ['lookfor' => '"' . $this->lookfor . '"', 'type' => 'Author'];
+    echo $this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor', 'searchRoute') + ['type' => 'Author']);
   }
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-generic.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-generic.phtml
@@ -1,9 +1,6 @@
 <?php
   $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  if (!isset($searchRoute)) {
-    $options = $this->searchOptions($searchBackendId);
-    $searchRoute = $options->getSearchAction();
-  }
+  $options = $this->searchOptions($searchBackendId);
   $query = [
     'type' => $this->type,
     'lookfor' => ($this->quoteQuery ?? true) ? '"' . $this->lookfor . '"' : $this->lookfor,
@@ -13,4 +10,4 @@
   ) {
     $query['limit'] = $limit;
   }
-  echo $this->url($searchRoute, [], compact('query'));
+  echo $this->url($this->searchRoute ?? $options->getSearchAction(), [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-generic.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-generic.phtml
@@ -1,0 +1,16 @@
+<?php
+  $searchBackendId = $this->driver->getSearchBackendIdentifier();
+  if (!isset($searchRoute)) {
+    $options = $this->searchOptions($searchBackendId);
+    $searchRoute = $options->getSearchAction();
+  }
+  $query = [
+    'type' => $this->type,
+    'lookfor' => ($this->quoteQuery ?? true) ? '"' . $this->lookfor . '"' : $this->lookfor,
+  ];
+  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
+    && $limit !== $options->getDefaultLimit()
+  ) {
+    $query['limit'] = $limit;
+  }
+  echo $this->url($searchRoute, [], compact('query'));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-journaltitle.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'JournalTitle', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'JournalTitle']);

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-publisher.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Publisher', 'lookfor' => $this->lookfor];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Publisher', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-series.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Series', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Series']);

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-subject.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Subject', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject']);

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/link-title.phtml
@@ -1,11 +1,1 @@
-<?php
-  $searchBackendId = $this->driver->getSearchBackendIdentifier();
-  $options = $this->searchOptions($searchBackendId);
-  $searchRoute = $options->getSearchAction();
-  $query = ['type' => 'Title', 'lookfor' => '"' . $this->lookfor . '"'];
-  if (($limit = $this->searchMemory()->getLastLimit($searchBackendId))
-    && $limit !== $options->getDefaultLimit()
-  ) {
-    $query['limit'] = $limit;
-  }
-  echo $this->url($searchRoute, [], compact('query'));
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'author', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search', [], ['query' => ['type' => 'publisher', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'publisher', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=series';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'series']);

--- a/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'subject']);

--- a/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Pazpar2/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('pazpar2-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'title']);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=Author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Author', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-issn.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-issn.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=ISSN';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN']);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-issn.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-issn.phtml
@@ -1,1 +1,1 @@
-<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN']);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'ISSN', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-journaltitle.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-journaltitle.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=AllFields';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'AllFields']);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search', [], ['query' => ['type' => 'AllFields', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'AllFields', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=Subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/Primo/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Primo/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('primo-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap5/templates/RecordDriver/Summon/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Summon/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Author';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Author']);

--- a/themes/bootstrap5/templates/RecordDriver/Summon/link-journaltitle.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Summon/link-journaltitle.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=PublicationTitle';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'PublicationTitle']);

--- a/themes/bootstrap5/templates/RecordDriver/Summon/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Summon/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=PublicationSeriesTitle';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'PublicationSeriesTitle']);

--- a/themes/bootstrap5/templates/RecordDriver/Summon/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Summon/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Subject';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Subject']);

--- a/themes/bootstrap5/templates/RecordDriver/Summon/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/Summon/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('summon-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=Title';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'Title']);

--- a/themes/bootstrap5/templates/RecordDriver/WorldCat/link-author.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/WorldCat/link-author.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=' . urlencode($this->lookfor) . '&amp;type=srw.au';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.au', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/WorldCat/link-publisher.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/WorldCat/link-publisher.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search', [], ['query' => ['type' => 'srw.pb', 'lookfor' => $this->lookfor]]);
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.pb', 'quoteQuery' => false]);

--- a/themes/bootstrap5/templates/RecordDriver/WorldCat/link-series.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/WorldCat/link-series.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.se';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.se']);

--- a/themes/bootstrap5/templates/RecordDriver/WorldCat/link-subject.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/WorldCat/link-subject.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.su';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.su']);

--- a/themes/bootstrap5/templates/RecordDriver/WorldCat/link-title.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/WorldCat/link-title.phtml
@@ -1,1 +1,1 @@
-<?php echo $this->url('worldcat-search') . '?lookfor=%22' . urlencode($this->lookfor) . '%22&amp;type=srw.ti%3Asrw.se';
+<?=$this->render('RecordDriver/DefaultRecord/link-generic.phtml', compact('driver', 'lookfor') + ['type' => 'srw.ti:srw.se']);


### PR DESCRIPTION
This is a follow-up to #3834, making link templates less redundant and extending consistent limit support across all backends.

I can't easily test Pazpar2, Primo or Summon, but since I can test WorldCat, and the other changes are basically identical, I feel reasonably confident that this is all good. If @EreMaijala can try Primo links and anyone with spare time can double-check that I got all my details right, all available help is appreciated. :-)

TODO
- [x] Resolve [VUFIND-1665](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1665) when merging.
- [x] Update #2612 to match after merging.