### PR TITLE
Update setup-node GitHub action to v4.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup node
         if: ${{ matrix.phing_tasks == 'qa-console' }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
I noticed that GitHub was warning about v3 being out of date, so I'm upgrading this tool.