### PR TITLE
Write check:scss task results to temp dir

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 module.exports = function(grunt) {
   const fs = require("fs");
+  const os = require("node:os");
 
   // Load dart-sass
   grunt.loadNpmTasks('grunt-dart-sass');
@@ -275,7 +276,7 @@ module.exports = function(grunt) {
             expand: true,
             cwd: path.join('themes', themeList[i], 'scss'),
             src: ['compiled.scss'],
-            dest: checkOnly ? null : path.join('themes', themeList[i], 'css'),
+            dest: path.join(checkOnly ? os.tmpdir() : 'themes', themeList[i], 'css'),
             ext: '.css'
           }]
         };


### PR DESCRIPTION
Currently the css is written to the project root. The null target that worked for the old Grunt sass task doesn't work with the dart-sass task.