### PR TITLE
Avoid error with MLT when record does not exist

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -511,7 +511,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
                     $msgParts[] = $msg;
                 }
                 throw new RequestErrorException(
-                    implode(' ' , $msgParts),
+                    implode(' ', $msgParts),
                     400,
                     $response
                 );

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -235,6 +235,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
             if (str_contains($e->getMessage(), 'Could not fetch document with id')) {
                 return '{}';
             }
+            throw $e;
         }
     }
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -506,8 +506,12 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
             // Return a more detailed error message for a 400 error:
             if ($response->getStatusCode() === 400) {
                 $json = json_decode($response->getBody(), true);
+                $msgParts = ['400', $response->getReasonPhrase()];
+                if ($msg = $json['error']['msg'] ?? '') {
+                    $msgParts[] = $msg;
+                }
                 throw new RequestErrorException(
-                    '400 ' . $response->getReasonPhrase() . ' ' . $json['error']['msg'],
+                    implode(' ' , $msgParts),
                     400,
                     $response
                 );


### PR DESCRIPTION
Since a record could remain in cache we might be able show the record page, but similar records retrieval could fail because the record no longer exists in the Solr index. This checks for this specific situation and returns an empty reply instead of throwing an error. This is the actual error Solr's MLT handler returns:

```
  "error":{
    "metadata":[["error-class","org.apache.solr.common.SolrException"],["root-error-class","org.apache.solr.common.SolrException"]],
    "msg":"Error completing MLT request. Could not fetch document with id [<record id>]",
    "code":400
  }
```