### PR TITLE
Add sub to OIDC user info response

### DIFF
--- a/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/OAuth2Controller.php
@@ -278,8 +278,9 @@ class OAuth2Controller extends AbstractBase implements LoggerAwareInterface
                     OAuthServerException::accessDenied('User does not exist anymore')
                 );
             }
-            $result = $this->claimExtractor
-                ->extract($scopes, $userEntity->getClaims());
+            $result = $this->claimExtractor->extract($scopes, $userEntity->getClaims());
+            // The sub claim must always be returned:
+            $result['sub'] = $userId;
             return $this->getJsonResponse($result);
         } catch (OAuthServerException $e) {
             return $this->handleOAuth2Exception('User info request', $e);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -276,6 +276,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         );
 
         $userInfo = json_decode($response->getBody(), true);
+        $this->assertEquals($idToken->sub, $userInfo['sub']);
         $this->assertEquals($nonce, $userInfo['nonce']);
         $this->assertEquals('Tester McTestenson', $userInfo['name']);
         $this->assertEquals('Tester', $userInfo['given_name']);


### PR DESCRIPTION
According to the [specification](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) sub (subject, user id) is a mandatory claim in the user info response.