### PR TITLE
OIDC: Add option to limit scopes per client

### DIFF
--- a/config/vufind/OAuth2Server.yaml
+++ b/config/vufind/OAuth2Server.yaml
@@ -59,6 +59,11 @@ Clients:
     # Note that a secret can only be used with confidential clients since public
     # ones have no way of using it securely.
     secret: ""
+    # By default a client can request all scopes. This setting can be used to limit
+    # the allowed scopes to a subset of all available ones.
+    #allowedScopes:
+    #  - openid
+    #  - email
 
 # Scope configuration. Keys are scope identifiers. Each identifier should include a
 # description (translation key) to be displayed to the user. The ils field should be

--- a/module/VuFind/src/VuFind/OAuth2/Repository/ScopeRepository.php
+++ b/module/VuFind/src/VuFind/OAuth2/Repository/ScopeRepository.php
@@ -33,6 +33,8 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use VuFind\OAuth2\Entity\ScopeEntity;
 
+use function in_array;
+
 /**
  * OAuth2 scope repository implementation.
  *
@@ -98,6 +100,18 @@ class ScopeRepository implements ScopeRepositoryInterface
         ClientEntityInterface $clientEntity,
         $userIdentifier = null
     ) {
+        $clientId = $clientEntity->getIdentifier();
+        // Apply any client-specific filter to scopes:
+        if ($allowedScopes = $this->oauth2Config['Clients'][$clientId]['allowedScopes'] ?? null) {
+            $scopes = array_values(
+                array_filter(
+                    $scopes,
+                    function ($scope) use ($allowedScopes) {
+                        return in_array($scope->getIdentifier(), $allowedScopes);
+                    }
+                )
+            );
+        }
         return $scopes;
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -31,6 +31,8 @@ declare(strict_types=1);
 
 namespace VuFindTest\Mink;
 
+use function count;
+
 /**
  * OAuth2/OIDC test class.
  *
@@ -115,6 +117,16 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
                     'isConfidential' => true,
                     'secret' => password_hash('mysecret', PASSWORD_DEFAULT),
                 ],
+                'test_limited' => [
+                    'name' => 'Integration Test',
+                    'redirectUri' => $redirectUri,
+                    'isConfidential' => true,
+                    'secret' => password_hash('mysecret', PASSWORD_DEFAULT),
+                    'allowedScopes' => [
+                        'openid',
+                        'profile',
+                    ],
+                ],
             ],
         ];
     }
@@ -141,23 +153,60 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Data provider for testOAuth2Authorization
+     *
+     * @return array
+     */
+    public static function oauth2AuthorizationProvider(): array
+    {
+        return [
+            'test client' => [
+                'test',
+                [
+                    'Read your user identifier',
+                    'Read your basic profile information (name, language, birthdate)',
+                    'Read a unique hash based on your library user identifier',
+                    'Read your age',
+                ],
+                false,
+            ],
+            'limited test client' => [
+                'test_limited',
+                [
+                    'Read your user identifier',
+                    'Read your basic profile information (name, language, birthdate)',
+                ],
+                true,
+            ],
+        ];
+    }
+
+    /**
      * Test OAuth2 authorization.
      *
+     * @param string $clientId            Client ID
+     * @param array  $expectedPermissions Expected permissions in the request
+     * @param bool   $limited             Whether the permission set has been limited by the server
+     *
      * @return void
+     *
+     * @dataProvider oauth2AuthorizationProvider
      */
-    public function testOAuth2Authorization(): void
+    public function testOAuth2Authorization(string $clientId, array $expectedPermissions, bool $limited): void
     {
         // Bogus redirect URI, but it doesn't matter since the page won't handle the
         // authorization response:
         $redirectUri = $this->getVuFindUrl() . '/Content/faq';
         $this->setUpTest($redirectUri);
 
+        static::removeUsers(['username1']);
+
         $nonce = time();
         $state = md5((string)$nonce);
 
         // Go to OAuth2 authorization screen:
         $params = [
-            'client_id' => 'test',
+            'client_id' => $clientId,
             'scope' => 'openid profile library_user_id age',
             'response_type' => 'code',
             'redirect_uri' => $redirectUri,
@@ -184,18 +233,14 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'catuser' . $oauth2ConfigOverrides['Server']['hashSalt']
         );
 
-        $expectedPermissions = [
-            'Read your user identifier',
-            'Read your basic profile information (name, language, birthdate)',
-            'Read a unique hash based on your library user identifier',
-            'Read your age',
-        ];
         foreach ($expectedPermissions as $index => $permission) {
             $this->assertEquals(
                 $permission,
                 $this->findCssAndGetText($page, 'div.oauth2-prompt li', null, $index)
             );
         }
+        // Ensure that there are no more permissions:
+        $this->unFindCss($page, 'div.oauth2-prompt li', null, count($expectedPermissions));
 
         $this->clickCss($page, '.form-oauth2-authorize button.btn.btn-primary');
 
@@ -213,7 +258,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
             'code' => $queryParams['code'],
             'grant_type' => 'authorization_code',
             'redirect_uri' => $redirectUri,
-            'client_id' => 'test',
+            'client_id' => $clientId,
             'client_secret' => 'mysecret',
         ];
         $response = $this->httpPost(
@@ -243,21 +288,26 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         );
 
         $this->assertInstanceOf(\stdClass::class, $idToken);
-        $this->assertEquals('test', $idToken->aud);
+        $this->assertEquals($clientId, $idToken->aud);
         $this->assertEquals($nonce, $idToken->nonce);
         $this->assertEquals('Tester McTestenson', $idToken->name);
         $this->assertEquals('Tester', $idToken->given_name);
         $this->assertEquals('McTestenson', $idToken->family_name);
-        $this->assertEquals($catIdHash, $idToken->library_user_id);
         $this->assertMatchesRegularExpression(
             '/^\d{4}-\d{2}-\d{2}$/',
             $idToken->birthdate
         );
-        $this->assertEquals(
-            \DateTime::createFromFormat('Y-m-d', $idToken->birthdate)
-                ->diff(new \DateTimeImmutable())->format('%y'),
-            $idToken->age
-        );
+        if ($limited) {
+            $this->assertObjectNotHasProperty('library_user_id', $idToken);
+            $this->assertObjectNotHasProperty('age', $idToken);
+        } else {
+            $this->assertEquals($catIdHash, $idToken->library_user_id);
+            $this->assertEquals(
+                \DateTime::createFromFormat('Y-m-d', $idToken->birthdate)
+                    ->diff(new \DateTimeImmutable())->format('%y'),
+                $idToken->age
+            );
+        }
 
         // Test the userinfo endpoint:
         $response = $this->httpGet(
@@ -281,11 +331,21 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('Tester McTestenson', $userInfo['name']);
         $this->assertEquals('Tester', $userInfo['given_name']);
         $this->assertEquals('McTestenson', $userInfo['family_name']);
-        $this->assertEquals($catIdHash, $userInfo['library_user_id']);
         $this->assertMatchesRegularExpression(
             '/^\d{4}-\d{2}-\d{2}$/',
             $userInfo['birthdate']
         );
+        if ($limited) {
+            $this->assertObjectNotHasProperty('library_user_id', $idToken);
+            $this->assertObjectNotHasProperty('age', $idToken);
+        } else {
+            $this->assertEquals($catIdHash, $userInfo['library_user_id']);
+            $this->assertEquals(
+                \DateTime::createFromFormat('Y-m-d', $userInfo['birthdate'])
+                    ->diff(new \DateTimeImmutable())->format('%y'),
+                $userInfo['age']
+            );
+        }
 
         // Test token request with bad credentials:
         $tokenParams['client_secret'] = 'badsecret';


### PR DESCRIPTION
There are OpenID Connect clients that ask for all possible scopes even if they don't need them. The allowedScopes settings allows VuFind to limit the available scopes on a per-client basis.