### PR TITLE
Check ILS credentials on login

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -312,6 +312,12 @@ driver          = Sample
 ; library_cards setting (see below).
 allowUserLogin = true
 
+; If true (default), any ILS credentials stored with the user are checked up-front
+; when the user logs in to VuFind. If the credentials don't work, they're cleared,
+; and the user will be prompted for new credentials when accessing a page that
+; needs them. This setting is ignored if allowUserLogin is false.
+checkILSCredentialsOnLogin = true
+
 ; loadNoILSOnFailure - Whether or not to load the NoILS driver if the main driver fails
 loadNoILSOnFailure = false
 

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -93,6 +93,13 @@ class Manager implements
     protected $hideLogin = null;
 
     /**
+     * ILS Authenticator
+     *
+     * @var ILSAuthenticator
+     */
+    protected $ilsAuthenticator = null;
+
+    /**
      * Constructor
      *
      * @param Config                          $config            VuFind configuration
@@ -121,6 +128,18 @@ class Manager implements
         $method = $config->Authentication->method ?? 'Database';
         $this->legalAuthOptions = [$method];   // mark it as legal
         $this->setAuthMethod($method);         // load it
+    }
+
+    /**
+     * Set ILS Authenticator
+     *
+     * @param ILSAuthenticator $ilsAuthenticator ILS authenticator
+     *
+     * @return void
+     */
+    public function setILSAuthenticator(ILSAuthenticator $ilsAuthenticator): void
+    {
+        $this->ilsAuthenticator = $ilsAuthenticator;
     }
 
     /**
@@ -754,6 +773,25 @@ class Manager implements
                 throw new AuthException('authentication_error_technical', 0, $e);
             }
 
+            // Attempt catalog login so that any bad credentials are cleared before further processing
+            // (avoids e.g. multiple login attempts by account AJAX checks):
+            if ($this->ilsAuthenticator && $username = $user->getCatUsername()) {
+                try {
+                    $patron = $this->ils->patronLogin(
+                        $username,
+                        $this->ilsAuthenticator->getCatPasswordForUser($user)
+                    );
+                    if (empty($patron)) {
+                        // Problem logging in -- clear user credentials so they can be
+                        // prompted again; perhaps their password has changed in the
+                        // system!
+                        $user->setCatUsername(null)->setRawCatPassword(null)->setCatPassEnc(null);
+                    }
+                } catch (\Exception $e) {
+                    // Ignore exceptions here so that the login can continue
+                }
+            }
+
             // Update user object
             $this->updateUser($user, $mainAuthMethod);
 
@@ -765,8 +803,11 @@ class Manager implements
                     throw new AuthException('authentication_error_technical', 0, $e);
                 }
             }
-            // Store the user in the session and send it back to the caller:
+
+            // Store the user in the session:
             $this->updateSession($user);
+
+            // Send user back to caller:
             return $user;
         } catch (\Exception $e) {
             $this->getAuth()->resetState();

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -95,7 +95,7 @@ class Manager implements
     /**
      * ILS Authenticator
      *
-     * @var ILSAuthenticator
+     * @var ?ILSAuthenticator
      */
     protected $ilsAuthenticator = null;
 

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -775,7 +775,7 @@ class Manager implements
 
             // Attempt catalog login so that any bad credentials are cleared before further processing
             // (avoids e.g. multiple login attempts by account AJAX checks):
-            if ($this->ilsAuthenticator && $username = $user->getCatUsername()) {
+            if ($this->ilsAuthenticator && ($username = $user->getCatUsername()) && !$this->ils->getOfflineMode()) {
                 try {
                     $patron = $this->ils->patronLogin(
                         $username,

--- a/module/VuFind/src/VuFind/Auth/ManagerFactory.php
+++ b/module/VuFind/src/VuFind/Auth/ManagerFactory.php
@@ -91,6 +91,7 @@ class ManagerFactory implements FactoryInterface
             $loginTokenManager,
             $ils
         );
+        $manager->setIlsAuthenticator($container->get(\VuFind\Auth\ILSAuthenticator::class));
         $manager->checkForExpiredCredentials();
         return $manager;
     }


### PR DESCRIPTION
Checks stored catalog credentials on login and clears them if they don't work. This avoids problems with account_ajax hammering patronLogin and increasing failed login count in the ILS.