### PR TITLE
Handle empty cat_password columns in user row

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -961,7 +961,7 @@ class User extends RowGateway implements
      */
     public function getRawCatPassword(): ?string
     {
-        return $this->cat_password;
+        return $this->cat_password ?? null;
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
@@ -68,14 +68,41 @@ final class SsoTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Data provider for testLogin()
+     *
+     * @return array[]
+     */
+    public static function loginConfigProvider(): array
+    {
+        return [
+            'with cat_username mapping' => [ // test for regression of #3992
+                [
+                    'General' => [
+                        'attributes' => [
+                            'cat_username' => 'foo',
+                        ],
+                    ],
+                ],
+            ],
+            'defaults' => [],
+        ];
+    }
+
+    /**
      * Test SSO login
      *
+     * @param array $extraSsoConfigs Extra configurations for SimulatedSSO.ini
+     *
      * @return void
+     *
+     * @dataProvider loginConfigProvider
      */
-    public function testLogin(): void
+    public function testLogin(array $extraSsoConfigs = []): void
     {
         // Set up configs
-        $this->changeConfigs($this->getConfigIniOverrides());
+        $configs = $this->getConfigIniOverrides();
+        $configs['SimulatedSSO'] = array_merge_recursive($configs['SimulatedSSO'], $extraSsoConfigs);
+        $this->changeConfigs($configs);
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl());
         $page = $session->getPage();


### PR DESCRIPTION
This corrects a problem with new VuFind users being created from a Shibboleth login. Without this change, we see this exception and stack trace:

```
2024-10-07T14:04:23-04:00 ERR (3): VuFind\Auth\Manager: Laminas\Db\RowGateway\Exception\InvalidArgumentException: Not a valid column in this row: cat_password in /usr/local/vufind-pmalibrary/vendor/laminas/laminas-db/src/RowGateway/AbstractRowGateway.php:294
Stack trace:
#0 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Db/Row/User.php(964): Laminas\Db\RowGateway\AbstractRowGateway->__get()
#1 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php(224): VuFind\Db\Row\User->getRawCatPassword()
#2 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Auth/Shibboleth.php(240): VuFind\Auth\ILSAuthenticator->getCatPasswordForUser()
#3 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Auth/Manager.php(743): VuFind\Auth\Shibboleth->authenticate()
#4 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Controller/MyResearchController.php(217): VuFind\Auth\Manager->login()
#5 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-mvc/src/Controller/AbstractActionController.php(72): VuFind\Controller\MyResearchController->homeAction()
#6 /usr/local/vufind-pmalibrary/module/VuFind/src/VuFind/Controller/Feature/CatchIlsExceptionsTrait.php(76): Laminas\Mvc\Controller\AbstractActionController->onDispatch()
#7 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-eventmanager/src/EventManager.php(319): VuFind\Controller\MyResearchController->onDispatch()
#8 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-eventmanager/src/EventManager.php(177): Laminas\EventManager\EventManager->triggerListeners()
#9 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-mvc/src/Controller/AbstractController.php(105): Laminas\EventManager\EventManager->triggerEventUntil()
#10 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-mvc/src/DispatchListener.php(117): Laminas\Mvc\Controller\AbstractController->dispatch()
#11 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-eventmanager/src/EventManager.php(319): Laminas\Mvc\DispatchListener->onDispatch()
#12 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-eventmanager/src/EventManager.php(177): Laminas\EventManager\EventManager->triggerListeners()
#13 /usr/local/vufind-pmalibrary/vendor/laminas/laminas-mvc/src/Application.php(319): Laminas\EventManager\EventManager->triggerEventUntil()
#14 /usr/local/vufind-pmalibrary/public/index.php(71): Laminas\Mvc\Application->run()
```