### PR TITLE
Phing: Add parameters for more generic BS5 conversion.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,6 +65,8 @@
   <property name="solr_pid_file" value="${localdir}/solr-${solr_port}.pid" />
   <property name="marc_bib_dir" value="${srcdir}/tests/data" /><!-- directory containing MARC bib records for test environment -->
   <property name="marc_authority_dir" value="${marc_bib_dir}/authority" /><!-- directory containing MARC authority records for test environment -->
+  <property name="bootstrap3_theme" value="bootstrap3" /><!-- base Bootstrap 3 theme (used for theme update tasks) -->
+  <property name="bootstrap5_theme" value="bootstrap5" /><!-- base Bootstrap 5 theme (used for theme update tasks) -->
 
   <property name="version" value="10.0" />
 
@@ -1269,7 +1271,7 @@ ${git_status}
   <!-- Update bootstrap3 templates from bootstrap5 -->
   <!-- N.B. This destroys any existing bootstrap3 templates (except explicitly excluded ones) -->
   <target name="update-bootstrap3">
-    <property name="templatesdir" value="${srcdir}/themes/bootstrap3/templates" />
+    <property name="templatesdir" value="${srcdir}/themes/${bootstrap3_theme}/templates" />
     <if>
       <available file="${templatesdir}"></available>
       <then>
@@ -1287,7 +1289,7 @@ ${git_status}
     </if>
     <mkdir dir="${templatesdir}"></mkdir>
     <copy todir="${templatesdir}">
-      <fileset dir="${srcdir}/themes/bootstrap5/templates">
+      <fileset dir="${srcdir}/themes/${bootstrap5_theme}/templates">
         <exclude name="header.phtml" />
         <exclude name="RecordTab/similaritemscarousel.phtml" />
       </fileset>
@@ -1313,7 +1315,7 @@ ${git_status}
   <!-- Update bootstrap5 templates from bootstrap3 -->
   <!-- N.B. This destroys any existing bootstrap5 templates (except explicitly excluded ones) -->
   <target name="update-bootstrap5">
-    <property name="templatesdir" value="${srcdir}/themes/bootstrap5/templates" />
+    <property name="templatesdir" value="${srcdir}/themes/${bootstrap5_theme}/templates" />
     <if>
       <available file="${templatesdir}"></available>
       <then>
@@ -1331,7 +1333,7 @@ ${git_status}
     </if>
     <mkdir dir="${templatesdir}"></mkdir>
     <copy todir="${templatesdir}">
-      <fileset dir="${srcdir}/themes/bootstrap3/templates">
+      <fileset dir="${srcdir}/themes/${bootstrap3_theme}/templates">
         <exclude name="header.phtml" />
         <exclude name="RecordTab/similaritemscarousel.phtml" />
       </fileset>
@@ -1354,8 +1356,8 @@ ${git_status}
 
   <!-- Check that bootstrap5 is up to date with bootstrap3 -->
   <target name="check-bootstrap5">
-    <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/templates" />
-    <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/templates" />
+    <property override="true" name="check_dir_base" value="${srcdir}/themes/${bootstrap3_theme}/templates" />
+    <property override="true" name="check_dir_compare" value="${srcdir}/themes/${bootstrap5_theme}/templates" />
     <foreach target="check-dir-single-file" param="filename" inheritall="true">
       <fileset dir="${check_dir_base}">
         <type type="file" />
@@ -1365,8 +1367,8 @@ ${git_status}
       </fileset>
     </foreach>
 
-    <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/scss" />
-    <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/scss" />
+    <property override="true" name="check_dir_base" value="${srcdir}/themes/${bootstrap3_theme}/scss" />
+    <property override="true" name="check_dir_compare" value="${srcdir}/themes/${bootstrap5_theme}/scss" />
     <foreach target="check-dir-single-file" param="filename" inheritall="true">
       <fileset dir="${check_dir_base}">
         <type type="file" />
@@ -1377,8 +1379,8 @@ ${git_status}
       </fileset>
     </foreach>
 
-    <property override="true" name="check_dir_base" value="${srcdir}/themes/bootstrap3/js" />
-    <property override="true" name="check_dir_compare" value="${srcdir}/themes/bootstrap5/js" />
+    <property override="true" name="check_dir_base" value="${srcdir}/themes/${bootstrap3_theme}/js" />
+    <property override="true" name="check_dir_compare" value="${srcdir}/themes/${bootstrap5_theme}/js" />
     <foreach target="check-dir-single-file" param="filename" inheritall="true">
       <fileset dir="${check_dir_base}">
         <type type="file" />


### PR DESCRIPTION
This PR adds some new Phing properties so that the update-bootstrap3/update-bootstrap5 tasks can be used to convert local themes as well as the default core ones. I used this task to set up the bootstrap5-based themes for the [public demo](https://vufind.org/demo).