### PR TITLE
Add abstract field to record page display

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -191,6 +191,7 @@ class RecordDataFormatterFactory implements FactoryInterface
             $this->getAuthorFunction()
         );
         $spec->setLine('Summary', 'getSummary');
+        $spec->setLine('Abstract', 'getAbstractNotes');
         $spec->setLine(
             'Format',
             'getFormats',
@@ -255,6 +256,7 @@ class RecordDataFormatterFactory implements FactoryInterface
     {
         $spec = new RecordDataFormatter\SpecBuilder();
         $spec->setLine('Summary', 'getSummary');
+        $spec->setLine('Abstract', 'getAbstractNotes');
         $spec->setMultiLine(
             'Authors',
             'getDeduplicatedAuthors',
@@ -369,6 +371,7 @@ class RecordDataFormatterFactory implements FactoryInterface
     {
         $spec = new RecordDataFormatter\SpecBuilder();
         $spec->setTemplateLine('Summary', true, 'data-summary.phtml');
+        $spec->setLine('Abstract', 'getAbstractNotes');
         $spec->setLine('Published', 'getDateSpan');
         $spec->setLine('Item Description', 'getGeneralNotes');
         $spec->setLine('Physical Description', 'getPhysicalDescriptions');


### PR DESCRIPTION
Based on the discussion and work done in [PR 3954](https://github.com/vufind-org/vufind/pull/3954), this is adding the Abstract field to the record page since it was separated out from the general Summary field.

As mentioned in the linked PR, `Abstract` already has an entry in the languages files; let me know if I missed some other place that needs updating besides just the `RecordDataFormatterFactory.php`.