### PR TITLE
Extend account menu to support configuration of groups, static urls and special templates to render.

### DIFF
--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -1,9 +1,18 @@
 # If this file is empty or missing, default settings will be used, matching
 # the examples provided below. The format of this configuration is as follows:
+# array keys for every group are:
+#   - name: name of a group
+#   - label: text shown as group header - required
+#   - id: html id for the group - required
+#   - class: class for the list of items
+#   - MenuItems: items shown in the menu - required
 # array keys for every menu item could be:
 #   - name: name of an item
 #   - label: the text shown as link, will be translated - required
-#   - route: route name used to generate link target - required
+#   - route: route name used to generate link target - route or url required
+#   - url: target url, alternative to route - route or url required
+#   - template: item has special rendering in template (menu-special-[value])
+#               does not require label, route and url
 #   - icon: icon used for the item, has to be defined in theme config
 #   - iconMethod: method to dynamically create the icon name; ignored when
 #     icon is explicitly set.
@@ -11,79 +20,99 @@
 #     a check whether to show the item. If omitted, item will always display.
 #   - status: whether to show status label, defaults to false
 
-MenuItems:
-  - name: favorites
-    label: saved_items
-    route: myresearch-favorites
-    icon: user-favorites
-    checkMethod: checkFavorites
+Account:
+  label: Your Account
+  id: acc-menu-acc-header
+  class: account-menu
+  MenuItems:
+    - name: checkedout
+      label: Checked Out Items
+      route: myresearch-checkedout
+      icon: user-checked-out
+      status: true
+      checkMethod: checkCheckedout
 
-  - name: checkedout
-    label: Checked Out Items
-    route: myresearch-checkedout
-    icon: user-checked-out
-    status: true
-    checkMethod: checkCheckedout
+    - name: historicloans
+      label: Loan History
+      route: checkouts-history
+      icon: user-loan-history
+      checkMethod: checkHistoricloans
 
-  - name: historicloans
-    label: Loan History
-    route: checkouts-history
-    icon: user-loan-history
-    checkMethod: checkHistoricloans
+    - name: holds
+      label: Holds and Recalls
+      route: holds-list
+      icon: user-holds
+      status: true
+      checkMethod: checkHolds
 
-  - name: holds
-    label: Holds and Recalls
-    route: holds-list
-    icon: user-holds
-    status: true
-    checkMethod: checkHolds
+    - name: storageRetrievalRequests
+      label: Storage Retrieval Requests
+      route: myresearch-storageretrievalrequests
+      icon: user-storage-retrievals
+      status: true
+      checkMethod: checkStorageRetrievalRequests
 
-  - name: storageRetrievalRequests
-    label: Storage Retrieval Requests
-    route: myresearch-storageretrievalrequests
-    icon: user-storage-retrievals
-    status: true
-    checkMethod: checkStorageRetrievalRequests
+    - name: ILLRequests
+      label: Interlibrary Loan Requests
+      route: myresearch-illrequests
+      icon: user-ill-requests
+      status: true
+      checkMethod: checkILLRequests
 
-  - name: ILLRequests
-    label: Interlibrary Loan Requests
-    route: myresearch-illrequests
-    icon: user-ill-requests
-    status: true
-    checkMethod: checkILLRequests
+    - name: fines
+      label: Fines
+      route: myresearch-fines
+      status: true
+      checkMethod: checkFines
+      iconMethod: finesIcon
 
-  - name: fines
-    label: Fines
-    route: myresearch-fines
-    status: true
-    checkMethod: checkFines
-    iconMethod: finesIcon
+    - name: profile
+      label: Profile
+      route: myresearch-profile
+      icon: profile
 
-  - name: profile
-    label: Profile
-    route: myresearch-profile
-    icon: profile
+    - name: librarycards
+      label: Library Cards
+      route: librarycards-home
+      icon: barcode
+      checkMethod: checkLibraryCards
 
-  - name: librarycards
-    label: Library Cards
-    route: librarycards-home
-    icon: barcode
-    checkMethod: checkLibraryCards
+    - name: dgcontent
+      label: Overdrive Content
+      route: overdrive-mycontent
+      icon: overdrive
+      checkMethod: checkOverdrive
 
-  - name: dgcontent
-    label: Overdrive Content
-    route: overdrive-mycontent
-    icon: overdrive
-    checkMethod: checkOverdrive
+    - name: history
+      label: Search History
+      route: search-history
+      icon: search
+      checkMethod: checkHistory
 
-  - name: history
-    label: Search History
-    route: search-history
-    icon: search
-    checkMethod: checkHistory
+    - name: logout
+      label: Log Out
+      route: myresearch-logout
+      icon: sign-out
+      checkMethod: checkLogout
 
-  - name: logout
-    label: Log Out
-    route: myresearch-logout
-    icon: sign-out
-    checkMethod: checkLogout
+Lists:
+  label: Your Lists
+  id: acc-menu-lists-header
+  MenuItems:
+    - name: favorites
+      label: saved_items
+      route: myresearch-favorites
+      icon: user-favorites
+      checkMethod: checkFavorites
+
+    - template: myresearch/menu-mylists.phtml
+      icon: user-list
+      checkMethod: checkUserlistMode
+
+    - name: newlist
+      label: Create a List
+      route: editList
+      routeParams:
+        id: NEW
+      icon: ui-add
+      checkMethod: checkUserlistMode

--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -9,10 +9,9 @@
 # array keys for every menu item could be:
 #   - name: name of an item
 #   - label: the text shown as link, will be translated - required
-#   - route: route name used to generate link target - route or url required
-#   - url: target url, alternative to route - route or url required
-#   - template: item has special rendering in template (menu-special-[value])
-#               does not require label, route and url
+#   - route: route name used to generate link target - route, url or template required
+#   - url: target url, alternative to route - route, url or template required
+#   - template: template to render the item with
 #   - icon: icon used for the item, has to be defined in theme config
 #   - iconMethod: method to dynamically create the icon name; ignored when
 #     icon is explicitly set.

--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -24,6 +24,12 @@ Account:
   id: acc-menu-acc-header
   class: account-menu
   MenuItems:
+    - name: favorites
+      label: saved_items
+      route: myresearch-favorites
+      icon: user-favorites
+      checkMethod: checkFavorites
+
     - name: checkedout
       label: Checked Out Items
       route: myresearch-checkedout
@@ -98,12 +104,6 @@ Lists:
   label: Your Lists
   id: acc-menu-lists-header
   MenuItems:
-    - name: favorites
-      label: saved_items
-      route: myresearch-favorites
-      icon: user-favorites
-      checkMethod: checkFavorites
-
     - template: myresearch/menu-mylists.phtml
       icon: user-list
       checkMethod: checkUserlistMode

--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -7,6 +7,7 @@
 #   - class: class for the list of items
 #   - MenuItems: items shown in the menu - required
 #   - checkMethod: the name of an AccountMenu view helper method to perform
+#     a check whether to show the group. If omitted, group will always display.
 # array keys for every menu item could be:
 #   - name: name of an item
 #   - label: the text shown as link, will be translated - required

--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -106,10 +106,10 @@ Account:
 Lists:
   label: Your Lists
   id: acc-menu-lists-header
+  checkMethod: checkUserlistMode
   MenuItems:
     - template: myresearch/menu-mylists.phtml
       icon: user-list
-      checkMethod: checkUserlistMode
 
     - name: newlist
       label: Create a List
@@ -117,4 +117,3 @@ Lists:
       routeParams:
         id: NEW
       icon: ui-add
-      checkMethod: checkUserlistMode

--- a/config/vufind/AccountMenu.yaml
+++ b/config/vufind/AccountMenu.yaml
@@ -6,10 +6,12 @@
 #   - id: html id for the group - required
 #   - class: class for the list of items
 #   - MenuItems: items shown in the menu - required
+#   - checkMethod: the name of an AccountMenu view helper method to perform
 # array keys for every menu item could be:
 #   - name: name of an item
 #   - label: the text shown as link, will be translated - required
 #   - route: route name used to generate link target - route, url or template required
+#   - routeParams: parameters for dynamic routes
 #   - url: target url, alternative to route - route, url or template required
 #   - template: template to render the item with
 #   - icon: icon used for the item, has to be defined in theme config

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -210,9 +210,9 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
                         ],
                         'icon' => 'ui-add',
                         'checkMethod' => 'checkUserlistMode',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -53,14 +53,35 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
-     * Get available menu items
+     * Get all groups with items to display.
      *
      * @return array
      */
-    public function getItems(): array
+    public function getMenu(): array
+    {
+        $availableGroups = [];
+        foreach ($this->config ?? $this->getDefaultMenu() as $group) {
+            // skip groups without items to display
+            if ($items = $this->filterItems($group['MenuItems'])) {
+                $group['MenuItems'] = $items;
+                $availableGroups[] = $group;
+            }
+        }
+
+        return $availableGroups;
+    }
+
+    /**
+     * Get available menu items
+     *
+     * @param array $items Items to filter
+     *
+     * @return array
+     */
+    protected function filterItems(array $items): array
     {
         return array_filter(
-            $this->config['MenuItems'] ?? $this->getDefaultItems(),
+            $items,
             function ($item) {
                 return !isset($item['checkMethod']) || $this->{$item['checkMethod']}();
             }
@@ -72,97 +93,126 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
      *
      * @return array
      */
-    protected function getDefaultItems(): array
+    protected function getDefaultMenu(): array
     {
         return [
-            [
-                'name' => 'favorites',
-                'label' => 'saved_items',
-                'route' => 'myresearch-favorites',
-                'icon' => 'user-favorites',
-                'checkMethod' => 'checkFavorites',
+            'Account' => [
+                'name' => 'acc',
+                'label' => 'Your Account',
+                'id' => 'acc-menu-acc-header',
+                'class' => 'account-menu',
+                'MenuItems' => [
+                    [
+                        'name' => 'favorites',
+                        'label' => 'saved_items',
+                        'route' => 'myresearch-favorites',
+                        'icon' => 'user-favorites',
+                        'checkMethod' => 'checkFavorites',
+                    ],
+                    [
+                        'name' => 'checkedout',
+                        'label' => 'Checked Out Items',
+                        'route' => 'myresearch-checkedout',
+                        'icon' => 'user-checked-out',
+                        'status' => true,
+                        'checkMethod' => 'checkCheckedout',
+                    ],
+                    [
+                        'name' => 'historicloans',
+                        'label' => 'Loan History',
+                        'route' => 'checkouts-history',
+                        'icon' => 'user-loan-history',
+                        'checkMethod' => 'checkHistoricloans',
+                    ],
+                    [
+                        'name' => 'holds',
+                        'label' => 'Holds and Recalls',
+                        'route' => 'holds-list',
+                        'icon' => 'user-holds',
+                        'status' => true,
+                        'checkMethod' => 'checkHolds',
+                    ],
+                    [
+                        'name' => 'storageRetrievalRequests',
+                        'label' => 'Storage Retrieval Requests',
+                        'route' => 'myresearch-storageretrievalrequests',
+                        'icon' => 'user-storage-retrievals',
+                        'status' => true,
+                        'checkMethod' => 'checkStorageRetrievalRequests',
+                    ],
+                    [
+                        'name' => 'ILLRequests',
+                        'label' => 'Interlibrary Loan Requests',
+                        'route' => 'myresearch-illrequests',
+                        'icon' => 'user-ill-requests',
+                        'status' => true,
+                        'checkMethod' => 'checkILLRequests',
+                    ],
+                    [
+                        'name' => 'fines',
+                        'label' => 'Fines',
+                        'route' => 'myresearch-fines',
+                        'status' => true,
+                        'checkMethod' => 'checkFines',
+                        'iconMethod' => 'finesIcon',
+                    ],
+                    [
+                        'name' => 'profile',
+                        'label' => 'Profile',
+                        'route' => 'myresearch-profile',
+                        'icon' => 'profile',
+                    ],
+                    [
+                        'name' => 'librarycards',
+                        'label' => 'Library Cards',
+                        'route' => 'librarycards-home',
+                        'icon' => 'barcode',
+                        'checkMethod' => 'checkLibraryCards',
+                    ],
+                    [
+                        'name' => 'dgcontent',
+                        'label' => 'Overdrive Content',
+                        'route' => 'overdrive-mycontent',
+                        'icon' => 'overdrive',
+                        'checkMethod' => 'checkOverdrive',
+                    ],
+                    [
+                        'name' => 'history',
+                        'label' => 'Search History',
+                        'route' => 'search-history',
+                        'icon' => 'search',
+                        'checkMethod' => 'checkHistory',
+                    ],
+                    [
+                        'name' => 'logout',
+                        'label' => 'Log Out',
+                        'route' => 'myresearch-logout',
+                        'icon' => 'sign-out',
+                        'checkMethod' => 'checkLogout',
+                    ],
+                ],
             ],
-            [
-                'name' => 'checkedout',
-                'label' => 'Checked Out Items',
-                'route' => 'myresearch-checkedout',
-                'icon' => 'user-checked-out',
-                'status' => true,
-                'checkMethod' => 'checkCheckedout',
-            ],
-            [
-                'name' => 'historicloans',
-                'label' => 'Loan History',
-                'route' => 'checkouts-history',
-                'icon' => 'user-loan-history',
-                'checkMethod' => 'checkHistoricloans',
-            ],
-            [
-                'name' => 'holds',
-                'label' => 'Holds and Recalls',
-                'route' => 'holds-list',
-                'icon' => 'user-holds',
-                'status' => true,
-                'checkMethod' => 'checkHolds',
-            ],
-            [
-                'name' => 'storageRetrievalRequests',
-                'label' => 'Storage Retrieval Requests',
-                'route' => 'myresearch-storageretrievalrequests',
-                'icon' => 'user-storage-retrievals',
-                'status' => true,
-                'checkMethod' => 'checkStorageRetrievalRequests',
-            ],
-            [
-                'name' => 'ILLRequests',
-                'label' => 'Interlibrary Loan Requests',
-                'route' => 'myresearch-illrequests',
-                'icon' => 'user-ill-requests',
-                'status' => true,
-                'checkMethod' => 'checkILLRequests',
-            ],
-            [
-                'name' => 'fines',
-                'label' => 'Fines',
-                'route' => 'myresearch-fines',
-                'status' => true,
-                'checkMethod' => 'checkFines',
-                'iconMethod' => 'finesIcon',
-            ],
-            [
-                'name' => 'profile',
-                'label' => 'Profile',
-                'route' => 'myresearch-profile',
-                'icon' => 'profile',
-            ],
-            [
-                'name' => 'librarycards',
-                'label' => 'Library Cards',
-                'route' => 'librarycards-home',
-                'icon' => 'barcode',
-                'checkMethod' => 'checkLibraryCards',
-            ],
-            [
-                'name' => 'dgcontent',
-                'label' => 'Overdrive Content',
-                'route' => 'overdrive-mycontent',
-                'icon' => 'overdrive',
-                'checkMethod' => 'checkOverdrive',
-            ],
-            [
-                'name' => 'history',
-                'label' => 'Search History',
-                'route' => 'search-history',
-                'icon' => 'search',
-                'checkMethod' => 'checkHistory',
-            ],
-            [
-                'name' => 'logout',
-                'label' => 'Log Out',
-                'route' => 'myresearch-logout',
-                'icon' => 'sign-out',
-                'checkMethod' => 'checkLogout',
-            ],
+            'Lists' => [
+                'label' => 'Your Lists',
+                'id' => 'acc-menu-lists-header',
+                'MenuItems' => [
+                    [
+                        'template' => 'myresearch/menu-mylists.phtml',
+                        'icon' => 'user-list',
+                        'checkMethod' => 'checkUserlistMode',
+                    ],
+                    [
+                        'name' => 'newlist',
+                        'label' => 'Create a List',
+                        'route' => 'editlist',
+                        'routeParams' => [
+                            'id' => 'NEW',
+                        ],
+                        'icon' => 'ui-add',
+                        'checkMethod' => 'checkUserlistMode',
+                    ]
+                ]
+            ]
         ];
     }
 
@@ -278,6 +328,17 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
+     * Check whether to show user lists.
+     *
+     * @return bool
+     */
+    public function checkUserlistMode(): bool
+    {
+        return $this->view->auth()->getUserObject()
+            && ($this->view->userlist()->getMode() !== 'disabled');
+    }
+
+    /**
      * Check ILS connection capability
      *
      * @param string $capability Name of then ILS method to check
@@ -370,7 +431,7 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
         return $contextHelper->renderInContext(
             'myresearch/menu.phtml',
             [
-                'items' => $this->getItems(),
+                'menu' => $this->getMenu(),
                 'active' => $activeItem,
                 'idPrefix' => $idPrefix,
             ]

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -60,7 +60,7 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     public function getMenu(): array
     {
         $menu = $this->config;
-        if ($menu ?? false) {
+        if (!$menu) {
             $menu = $this->getDefaultMenu();
         } elseif ($menu['MenuItems'] ?? false) {
             // backward compatibility for outdated configurations

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -70,9 +70,9 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
         }
 
         $availableGroups = [];
-        foreach ($menu as $group) {
+        foreach ($this->filterAvailable($menu) as $group) {
             // skip groups without items to display
-            if ($items = $this->filterItems($group['MenuItems'])) {
+            if ($items = $this->filterAvailable($group['MenuItems'])) {
                 $group['MenuItems'] = $items;
                 $availableGroups[] = $group;
             }
@@ -82,16 +82,16 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
-     * Get available menu items
+     * Get available items from a given list.
      *
-     * @param array $items Items to filter
+     * @param array $list Items to filter
      *
      * @return array
      */
-    protected function filterItems(array $items): array
+    protected function filterAvailable(array $list): array
     {
         return array_filter(
-            $items,
+            $list,
             function ($item) {
                 return !isset($item['checkMethod']) || $this->{$item['checkMethod']}();
             }

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -59,8 +59,18 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
      */
     public function getMenu(): array
     {
+        $menu = $this->config;
+        if ($menu ?? false) {
+            $menu = $this->getDefaultMenu();
+        } elseif ($menu['MenuItems'] ?? false) {
+            // backward compatibility for outdated configurations
+            $default = $this->getDefaultMenu();
+            $default['Account']['MenuItems'] = $menu['MenuItems'];
+            $menu = $default;
+        }
+
         $availableGroups = [];
-        foreach ($this->config ?? $this->getDefaultMenu() as $group) {
+        foreach ($menu as $group) {
             // skip groups without items to display
             if ($items = $this->filterItems($group['MenuItems'])) {
                 $group['MenuItems'] = $items;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -205,11 +205,11 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
             'Lists' => [
                 'label' => 'Your Lists',
                 'id' => 'acc-menu-lists-header',
+                'checkMethod' => 'checkUserlistMode',
                 'MenuItems' => [
                     [
                         'template' => 'myresearch/menu-mylists.phtml',
                         'icon' => 'user-list',
-                        'checkMethod' => 'checkUserlistMode',
                     ],
                     [
                         'name' => 'newlist',
@@ -219,7 +219,6 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
                             'id' => 'NEW',
                         ],
                         'icon' => 'ui-add',
-                        'checkMethod' => 'checkUserlistMode',
                     ],
                 ],
             ],

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -438,12 +438,16 @@ class AccountMenu extends \Laminas\View\Helper\AbstractHelper
     public function render(string $activeItem, string $idPrefix = ''): string
     {
         $contextHelper = $this->getView()->plugin('context');
+        $menu = $this->getMenu();
+
         return $contextHelper->renderInContext(
             'myresearch/menu.phtml',
             [
-                'menu' => $this->getMenu(),
+                'menu' => $menu,
                 'active' => $activeItem,
                 'idPrefix' => $idPrefix,
+                // set items for backward compatibility, might be removed in future releases
+                'items' => $menu['Account']['MenuItems'],
             ]
         );
     }

--- a/themes/bootstrap3/templates/myresearch/menu-item.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu-item.phtml
@@ -2,9 +2,11 @@
   if (isset($this->iconMethod) && !isset($this->icon)) {
     $this->icon = $this->accountMenu()->{$this->iconMethod}();
   }
+
+  $url = $this->url ?: $this->url($this->route, $this->routeParams ?? []);
 ?>
 <li>
-  <a href="<?=$this->url($this->route)?>" class="<?=$this->name?> icon-link<?=$this->active == $this->name ? ' active' : ''?>">
+  <a href="<?=$url?>" class="<?=$this->name?> icon-link<?=$this->active == $this->name ? ' active' : ''?>">
     <?php if (isset($this->icon)): ?>
       <?=$this->icon($this->icon, 'icon-link__icon') ?>
     <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/menu-mylists.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu-mylists.phtml
@@ -1,0 +1,24 @@
+<?php
+  $user = $this->auth()->getUserObject();
+
+  // Use a variable so that we can output this nicely without whitespace that would get underlined:
+  $publicInd = $this->icon(
+      'user-public-list-indicator',
+      [
+          'class' => 'user-list__public-icon',
+          'title' => $this->transEscAttr('public_list_indicator'),
+      ]
+  );
+  $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
+?>
+<?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
+  <?php $list = $current['list_entity']; ?>
+  <li>
+    <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
+      <?=$this->icon($this->icon, 'icon-link__icon') ?>
+      <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
+      <?=$list->isPublic() ? $publicInd : ''?>
+      <span class="badge"><?=$current['count'] ?></span>
+    </a>
+  </li>
+<?php endforeach; ?>

--- a/themes/bootstrap3/templates/myresearch/menu.phtml
+++ b/themes/bootstrap3/templates/myresearch/menu.phtml
@@ -1,48 +1,11 @@
-<?php
-  $user = $this->auth()->getUserObject();
-?>
 <?=$this->component('hide-offcanvas-button')?>
-<h3 id="<?=$this->idPrefix ?? ''?>acc-menu-acc-header"><?=$this->transEsc('Your Account')?></h3>
-<nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?>acc-menu-acc-header">
-  <ul class="account-menu">
-    <?php foreach ($this->items as $item): ?>
-      <?=$this->render('myresearch/menu-item.phtml', ['active' => $this->active, ...$item])?>
-    <?php endforeach; ?>
-  </ul>
-</nav>
-<?php if ($user && $this->userlist()->getMode() !== 'disabled'): ?>
-  <h3 id="<?=$this->idPrefix ?? ''?>acc-menu-lists-header"><?=$this->transEsc('Your Lists')?></h3>
-  <nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?>acc-menu-lists-header">
-    <ul>
-      <?php
-        // Use a variable so that we can output this nicely without whitespace that would get underlined:
-        $publicInd = $this->icon(
-            'user-public-list-indicator',
-            [
-              'class' => 'user-list__public-icon',
-              'title' => $this->transEscAttr('public_list_indicator'),
-            ]
-        );
-        $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
-      ?>
-
-      <?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
-        <?php $list = $current['list_entity']; ?>
-        <li>
-          <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
-            <?=$this->icon('user-list', 'icon-link__icon') ?>
-            <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
-            <?=$list->isPublic() ? $publicInd : ''?>
-            <span class="badge"><?=$current['count'] ?></span>
-          </a>
-        </li>
+<?php foreach ($this->menu as $menuGroup): ?>
+  <h3 id="<?=$this->idPrefix ?? ''?><?=$menuGroup['id']?>"><?=$this->transEsc($menuGroup['label'])?></h3>
+  <nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?><?=$menuGroup['id']?>">
+    <ul <?=$menuGroup['class'] ? 'class="' . $menuGroup['class'] . '"' : ''?>>
+      <?php foreach ($menuGroup['MenuItems'] as $item): ?>
+        <?=$this->render($item['template'] ?? 'myresearch/menu-item.phtml', ['active' => $this->active, ...$item])?>
       <?php endforeach; ?>
-      <li>
-        <a href="<?=$this->url('editList', ['id' => 'NEW'])?>" class="icon-link <?=$this->active == 'editlist/NEW' ? ' active' : ''?>">
-          <?=$this->icon('ui-add', 'icon-link__icon') ?>
-          <span class="icon-link__label"><?=$this->transEsc('Create a List') ?></span>
-        </a>
-      </li>
     </ul>
   </nav>
-<?php endif ?>
+<?php endforeach ?>

--- a/themes/bootstrap5/templates/myresearch/menu-item.phtml
+++ b/themes/bootstrap5/templates/myresearch/menu-item.phtml
@@ -2,9 +2,11 @@
   if (isset($this->iconMethod) && !isset($this->icon)) {
     $this->icon = $this->accountMenu()->{$this->iconMethod}();
   }
+
+  $url = $this->url ?: $this->url($this->route, $this->routeParams ?? []);
 ?>
 <li>
-  <a href="<?=$this->url($this->route)?>" class="<?=$this->name?> icon-link<?=$this->active == $this->name ? ' active' : ''?>">
+  <a href="<?=$url?>" class="<?=$this->name?> icon-link<?=$this->active == $this->name ? ' active' : ''?>">
     <?php if (isset($this->icon)): ?>
       <?=$this->icon($this->icon, 'icon-link__icon') ?>
     <?php endif; ?>

--- a/themes/bootstrap5/templates/myresearch/menu-mylists.phtml
+++ b/themes/bootstrap5/templates/myresearch/menu-mylists.phtml
@@ -1,0 +1,24 @@
+<?php
+  $user = $this->auth()->getUserObject();
+
+  // Use a variable so that we can output this nicely without whitespace that would get underlined:
+  $publicInd = $this->icon(
+      'user-public-list-indicator',
+      [
+          'class' => 'user-list__public-icon',
+          'title' => $this->transEscAttr('public_list_indicator'),
+      ]
+  );
+  $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
+?>
+<?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
+  <?php $list = $current['list_entity']; ?>
+  <li>
+    <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
+      <?=$this->icon($this->icon, 'icon-link__icon') ?>
+      <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
+      <?=$list->isPublic() ? $publicInd : ''?>
+      <span class="badge"><?=$current['count'] ?></span>
+    </a>
+  </li>
+<?php endforeach; ?>

--- a/themes/bootstrap5/templates/myresearch/menu.phtml
+++ b/themes/bootstrap5/templates/myresearch/menu.phtml
@@ -1,48 +1,11 @@
-<?php
-  $user = $this->auth()->getUserObject();
-?>
 <?=$this->component('hide-offcanvas-button')?>
-<h3 id="<?=$this->idPrefix ?? ''?>acc-menu-acc-header"><?=$this->transEsc('Your Account')?></h3>
-<nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?>acc-menu-acc-header">
-  <ul class="account-menu">
-    <?php foreach ($this->items as $item): ?>
-      <?=$this->render('myresearch/menu-item.phtml', ['active' => $this->active, ...$item])?>
-    <?php endforeach; ?>
-  </ul>
-</nav>
-<?php if ($user && $this->userlist()->getMode() !== 'disabled'): ?>
-  <h3 id="<?=$this->idPrefix ?? ''?>acc-menu-lists-header"><?=$this->transEsc('Your Lists')?></h3>
-  <nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?>acc-menu-lists-header">
-    <ul>
-      <?php
-        // Use a variable so that we can output this nicely without whitespace that would get underlined:
-        $publicInd = $this->icon(
-            'user-public-list-indicator',
-            [
-              'class' => 'user-list__public-icon',
-              'title' => $this->transEscAttr('public_list_indicator'),
-            ]
-        );
-        $publicInd .= '<span class="sr-only">(' . $this->transEsc('public_list_indicator') . ')</span>';
-      ?>
-
-      <?php foreach ($this->userlist()->getUserListsAndCountsByUser($user) as $current): ?>
-        <?php $list = $current['list_entity']; ?>
-        <li>
-          <a class="user-list-link icon-link <?=$this->active == 'list' . $list->getId() ? ' active' : ''?>" href="<?=$this->url('userList', ['id' => $list->getId()])?>">
-            <?=$this->icon('user-list', 'icon-link__icon') ?>
-            <span class="icon-link__label"><?=$this->escapeHtml($list->getTitle())?></span>
-            <?=$list->isPublic() ? $publicInd : ''?>
-            <span class="badge"><?=$current['count'] ?></span>
-          </a>
-        </li>
+<?php foreach ($this->menu as $menuGroup): ?>
+  <h3 id="<?=$this->idPrefix ?? ''?><?=$menuGroup['id']?>"><?=$this->transEsc($menuGroup['label'])?></h3>
+  <nav class="myresearch-menu" aria-labelledby="<?=$this->idPrefix ?? ''?><?=$menuGroup['id']?>">
+    <ul <?=$menuGroup['class'] ? 'class="' . $menuGroup['class'] . '"' : ''?>>
+      <?php foreach ($menuGroup['MenuItems'] as $item): ?>
+        <?=$this->render($item['template'] ?? 'myresearch/menu-item.phtml', ['active' => $this->active, ...$item])?>
       <?php endforeach; ?>
-      <li>
-        <a href="<?=$this->url('editList', ['id' => 'NEW'])?>" class="icon-link <?=$this->active == 'editlist/NEW' ? ' active' : ''?>">
-          <?=$this->icon('ui-add', 'icon-link__icon') ?>
-          <span class="icon-link__label"><?=$this->transEsc('Create a List') ?></span>
-        </a>
-      </li>
     </ul>
   </nav>
-<?php endif ?>
+<?php endforeach ?>


### PR DESCRIPTION
Enable configuring of groups aside from `Account Menu` and `Your Lists` in `AccoutnMenu.yaml`.
Route params in VuFind, URLs to third party websites and custom templates can be configured for menu items.

TODO
- [x] Update changelog when merging (config/template/helper changes)