### PR TITLE
Switch to less extensive escaping of HTML attributes

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -185,10 +185,11 @@ allowSavedSearches = true
 nonJavascriptSupportEnabled = false
 ; Generator value to display in an HTML header <meta> tag:
 generator = "VuFind 10.1"
-; The following setting can be set to true in case a need arises for extended HTML
-; attribute escaping. Default is false. Extended escaping is slower and results in
-; larger HTML responses than normal escaping, so this setting should normally be
-; left disabled.
+; The following setting can be set to true in case extended HTML attribute
+; escaping is needed. Default is false. Extended escaping is slower and
+; results in larger HTML responses than normal escaping, so this setting
+; should normally be left disabled, but must be enabled if there are unquoted
+; HTML attributes in local templates.
 ;extendedHtmlAttributeEscaping = false
 
 ; This section allows you to configure the mechanism used for storing user

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -185,6 +185,11 @@ allowSavedSearches = true
 nonJavascriptSupportEnabled = false
 ; Generator value to display in an HTML header <meta> tag:
 generator = "VuFind 10.1"
+; The following setting can be set to true in case a need arises for extended HTML
+; attribute escaping. Default is false. Extended escaping is slower and results in
+; larger HTML responses than normal escaping, so this setting should normally be
+; left disabled.
+;extendedHtmlAttributeEscaping = false
 
 ; This section allows you to configure the mechanism used for storing user
 ; sessions.  Available types: File, Memcache, Database, Redis.

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -543,8 +543,6 @@ $config = [
             'VuFind\ServiceManager\ServiceInitializer',
         ],
         'aliases' => [
-            'League\CommonMark\MarkdownConverterInterface' => 'League\CommonMark\ConverterInterface',
-            'Request' => 'VuFind\Http\PhpEnvironment\Request',
             'VuFind\AccountCapabilities' => 'VuFind\Config\AccountCapabilities',
             'VuFind\AuthManager' => 'VuFind\Auth\Manager',
             'VuFind\AuthPluginManager' => 'VuFind\Auth\PluginManager',
@@ -603,9 +601,14 @@ $config = [
             'VuFind\Tags' => 'VuFind\Tags\TagsService',
             'VuFind\Translator' => 'Laminas\Mvc\I18n\Translator',
             'VuFind\YamlReader' => 'VuFind\Config\YamlReader',
-            'Laminas\Validator\Csrf' => 'VuFind\Validator\SessionCsrf',
             'VuFind\Validator\Csrf' => 'VuFind\Validator\SessionCsrf',
             'VuFind\Validator\CsrfInterface' => 'VuFind\Validator\SessionCsrf',
+
+            // Overrides:
+            'Laminas\Escaper\Escaper' => 'VuFind\Escaper\Escaper',
+            'Laminas\Validator\Csrf' => 'VuFind\Validator\SessionCsrf',
+            'League\CommonMark\MarkdownConverterInterface' => 'League\CommonMark\ConverterInterface',
+            'Request' => 'VuFind\Http\PhpEnvironment\Request',
         ],
         'shared' => [
             'VuFind\Form\Form' => false,

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -445,6 +445,7 @@ $config = [
             'VuFind\Db\Table\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\DigitalContent\OverdriveConnector' => 'VuFind\DigitalContent\OverdriveConnectorFactory',
             'VuFind\DoiLinker\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
+            'VuFind\Escaper\Escaper' => 'VuFind\Escaper\EscaperFactory',
             'VuFind\Export' => 'VuFind\ExportFactory',
             'VuFind\Favorites\FavoritesService' => 'VuFind\Favorites\FavoritesServiceFactory',
             'VuFind\Form\Form' => 'VuFind\Form\FormFactory',

--- a/module/VuFind/src/VuFind/Escaper/Escaper.php
+++ b/module/VuFind/src/VuFind/Escaper/Escaper.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Escaper with configurable HTML attribute handling.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Escaper
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Escaper;
+
+/**
+ * Escaper with configurable HTML attribute handling.
+ *
+ * @category VuFind
+ * @package  Escaper
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Escaper extends \Laminas\Escaper\Escaper
+{
+    /**
+     * Constructor
+     *
+     * @param bool $extendedHtmlAttrEscaping Use Laminas' extended HTML attribute escaping?
+     */
+    public function __construct(protected bool $extendedHtmlAttrEscaping)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Escape a string for the HTML Attribute context.
+     *
+     * @param string $string String to escape
+     *
+     * @return string
+     */
+    public function escapeHtmlAttr(string $string)
+    {
+        return $this->extendedHtmlAttrEscaping
+            ? parent::escapeHtmlAttr($string)
+            : parent::escapeHtml($string);
+    }
+}

--- a/module/VuFind/src/VuFind/Escaper/Escaper.php
+++ b/module/VuFind/src/VuFind/Escaper/Escaper.php
@@ -45,7 +45,7 @@ class Escaper extends \Laminas\Escaper\Escaper
      *
      * @param bool $extendedHtmlAttrEscaping Use Laminas' extended HTML attribute escaping?
      */
-    public function __construct(protected bool $extendedHtmlAttrEscaping)
+    public function __construct(protected bool $extendedHtmlAttrEscaping = false)
     {
         parent::__construct();
     }

--- a/module/VuFind/src/VuFind/Escaper/EscaperFactory.php
+++ b/module/VuFind/src/VuFind/Escaper/EscaperFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Escaper factory.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Escaper
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Escaper;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Escaper helper factory.
+ *
+ * @category VuFind
+ * @package  Escaper
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class EscaperFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory.');
+        }
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
+        return new $requestedName((bool)($config->Site->extendedHtmlAttributeEscaping ?? false));
+    }
+}

--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeHtmlAttrFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeHtmlAttrFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * EscapeHtmlAttr helper factory.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\View\Helper\Root;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * EscapeHtmlAttr helper factory.
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class EscapeHtmlAttrFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory.');
+        }
+        return new $requestedName($container->get(\VuFind\Escaper\Escaper::class));
+    }
+}

--- a/module/VuFind/src/VuFind/View/Helper/Root/HelperInitializer.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/HelperInitializer.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * View Helper Initializer
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\View\Helper\Root;
+
+use Laminas\ServiceManager\Initializer\InitializerInterface;
+use Laminas\View\Helper\Placeholder\Container\AbstractStandalone;
+use Psr\Container\ContainerInterface;
+
+/**
+ * View Helper Initializer
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class HelperInitializer implements InitializerInterface
+{
+    /**
+     * Given an instance and a Service Manager, initialize the instance.
+     *
+     * @param ContainerInterface $container Service manager
+     * @param object             $instance  Instance to initialize
+     *
+     * @return object
+     */
+    public function __invoke(ContainerInterface $container, $instance)
+    {
+        if ($instance instanceof AbstractStandalone) {
+            $instance->setEscaper($container->get(\VuFind\Escaper\Escaper::class));
+        }
+        return $instance;
+    }
+}

--- a/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
@@ -51,7 +51,7 @@ abstract class AbstractMakeTagTestCase extends \PHPUnit\Framework\TestCase
     {
         $helpers = [
             'escapehtml' => new \Laminas\View\Helper\EscapeHtml(),
-            'escapehtmlattr' => new \Laminas\View\Helper\EscapeHtmlAttr(),
+            'escapehtmlattr' => new \Laminas\View\Helper\EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
             'htmlattributes' => new \Laminas\View\Helper\HtmlAttributes(),
             'maketag' => new \VuFind\View\Helper\Root\MakeTag(),
         ];

--- a/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractMakeTagTestCase.php
@@ -51,7 +51,7 @@ abstract class AbstractMakeTagTestCase extends \PHPUnit\Framework\TestCase
     {
         $helpers = [
             'escapehtml' => new \Laminas\View\Helper\EscapeHtml(),
-            'escapehtmlattr' => new \Laminas\View\Helper\EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
+            'escapehtmlattr' => new \Laminas\View\Helper\EscapeHtmlAttr(new \VuFind\Escaper\Escaper()),
             'htmlattributes' => new \Laminas\View\Helper\HtmlAttributes(),
             'maketag' => new \VuFind\View\Helper\Root\MakeTag(),
         ];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
@@ -212,7 +212,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
         };
 
         $plugins = [
-            'escapeHtmlAttr' => new EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
+            'escapeHtmlAttr' => new EscapeHtmlAttr(new \VuFind\Escaper\Escaper()),
             'layout' => $layout,
             'serverUrl' => $serverUrl,
             'url' => $url,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
@@ -30,7 +30,6 @@
 namespace VuFindTest\View\Helper\Root;
 
 use Laminas\View\Helper\EscapeHtmlAttr;
-use Laminas\View\Helper\Layout;
 use Laminas\View\Helper\ServerUrl;
 use Laminas\View\Renderer\PhpRenderer;
 use Symfony\Component\Yaml\Yaml;
@@ -213,7 +212,7 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
         };
 
         $plugins = [
-            'escapeHtmlAttr' => new EscapeHtmlAttr(),
+            'escapeHtmlAttr' => new EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
             'layout' => $layout,
             'serverUrl' => $serverUrl,
             'url' => $url,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -128,15 +128,16 @@ class IconTest extends \PHPUnit\Framework\TestCase
         array $plugins = [],
         $rtl = false
     ): Icon {
+        $escaper = new Escaper();
         $icon = new Icon(
             $config ?? $this->getDefaultTestConfig(),
             $cache ?? new BlackHole(),
-            new EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
+            new EscapeHtmlAttr($escaper),
             $rtl
         );
         $plugins = array_merge(
             [
-                'escapeHtmlAttr' => new EscapeHtmlAttr(new Escaper(false)),
+                'escapeHtmlAttr' => new EscapeHtmlAttr($escaper),
             ],
             $plugins
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/IconTest.php
@@ -32,6 +32,7 @@ namespace VuFindTest\View\Helper\Root;
 use Laminas\Cache\Storage\Adapter\BlackHole;
 use Laminas\Cache\Storage\StorageInterface;
 use Laminas\View\Helper\EscapeHtmlAttr;
+use VuFind\Escaper\Escaper;
 use VuFind\View\Helper\Root\Icon;
 use VuFindTheme\View\Helper\ImageLink;
 
@@ -130,8 +131,14 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $icon = new Icon(
             $config ?? $this->getDefaultTestConfig(),
             $cache ?? new BlackHole(),
-            new EscapeHtmlAttr(),
+            new EscapeHtmlAttr(new \VuFind\Escaper\Escaper(false)),
             $rtl
+        );
+        $plugins = array_merge(
+            [
+                'escapeHtmlAttr' => new EscapeHtmlAttr(new Escaper(false)),
+            ],
+            $plugins
         );
         $icon->setView($this->getPhpRenderer($plugins));
         return $icon;
@@ -145,7 +152,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIcon(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
+        $expected = '<span class="icon icon--font fa fa-foo" '
             . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo')));
     }
@@ -158,7 +165,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIconWithExtraClass(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-spinner&#x20;extraClass" '
+        $expected = '<span class="icon icon--font fa fa-spinner extraClass" '
             . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('classy')));
     }
@@ -171,12 +178,12 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testFontIconWithExtras(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
+        $expected = '<span class="icon icon--font fa fa-foo" '
             . 'bar="baz" role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo', ['bar' => 'baz'])));
 
         // Add class to class
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo&#x20;foo-bar" '
+        $expected = '<span class="icon icon--font fa fa-foo foo-bar" '
             . 'role="img" aria-hidden="true"></span>';
         $this->assertEquals($expected, trim($helper('foo', ['class' => 'foo-bar'])));
 
@@ -207,14 +214,14 @@ class IconTest extends \PHPUnit\Framework\TestCase
                 '',
             ],
             [
-                'super&#x20;wry',
+                'super wry',
                 '',
                 '1F600',
                 'wrySmile',
                 'super',
             ],
             [
-                'super&#x20;wry',
+                'super wry',
                 '',
                 '1F600',
                 'wrySmile',
@@ -222,7 +229,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 'wry',
-                'foo="b&#x2B;r"',
+                'foo="b+r"',
                 '1F600',
                 'wrySmile',
                 [
@@ -230,8 +237,8 @@ class IconTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             [
-                'super&#x20;wry',
-                'foo="b&#x2B;r"',
+                'super wry',
+                'foo="b+r"',
                 '1F600',
                 'wrySmile',
                 [
@@ -270,8 +277,8 @@ class IconTest extends \PHPUnit\Framework\TestCase
         string|array $attrs
     ): void {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon&#x20;icon--font&#x20;icon--unicode'
-            . ($expectedClasses ? "&#x20;$expectedClasses" : '') . '"'
+        $expected = '<span class="icon icon--font icon--unicode'
+            . ($expectedClasses ? " $expectedClasses" : '') . '"'
             . ($expectedAttrs ? " $expectedAttrs" : '')
             . ' role="img" aria-hidden="true" data-icon="&#x' . $expectedIcon . ';"></span>';
         $this->assertEquals($expected, trim($helper($icon, $attrs)));
@@ -284,7 +291,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
      */
     public function testCaching(): void
     {
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
+        $expected = '<span class="icon icon--font fa fa-foo" '
             . 'bar="baz" role="img" aria-hidden="true"></span>';
         $key = 'foo+c0dc783820069fb9337be7366f7945bf';
 
@@ -314,7 +321,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/baz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon&#x20;icon--img" src="baz.png" aria-hidden="true"'
+        $expected = '<img class="icon icon--img" src="baz.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('bar'));
     }
@@ -328,7 +335,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/"quoted".png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon&#x20;icon--img" src="&quot;quoted&quot;.png" aria-hidden="true"'
+        $expected = '<img class="icon icon--img" src="&quot;quoted&quot;.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('quoted'));
     }
@@ -343,7 +350,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/zzz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon&#x20;icon--img&#x20;weird&#x3A;class&#x20;foo" src="zzz.png"'
+        $expected = '<img class="icon icon--img weird:class foo" src="zzz.png"'
             . ' aria-hidden="true" alt="">';
         $this->assertEquals($expected, $helper('extraClassy'));
     }
@@ -357,7 +364,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     {
         $plugins = ['imageLink' => $this->getMockImageLink('icons/baz.png')];
         $helper = $this->getIconHelper(null, null, $plugins);
-        $expected = '<img class="icon&#x20;icon--img&#x20;myclass" src="baz.png"'
+        $expected = '<img class="icon icon--img myclass" src="baz.png"'
             . ' aria-hidden="true" alt="">';
         // Send a string, validating the shortcut where strings are treated as
         // classes, in addition to confirming that extras work for image icons.
@@ -374,14 +381,14 @@ class IconTest extends \PHPUnit\Framework\TestCase
         // RTL exists
         $plugins = ['imageLink' => $this->getMockImageLink('icons/zab.png')];
         $helper = $this->getIconHelper(null, null, $plugins, true);
-        $expected = '<img class="icon&#x20;icon--img" src="zab.png" aria-hidden="true"'
+        $expected = '<img class="icon icon--img" src="zab.png" aria-hidden="true"'
             . ' alt="">';
         $this->assertEquals($expected, $helper('bar'));
 
         // RTL does not exist
         $plugins = ['imageLink' => $this->getMockImageLink('icons/ltronly.png')];
         $helper = $this->getIconHelper(null, null, $plugins, true);
-        $expected = '<img class="icon&#x20;icon--img" src="ltronly.png"'
+        $expected = '<img class="icon icon--img" src="ltronly.png"'
             . ' aria-hidden="true" alt="">';
         $this->assertEquals($expected, $helper('ltronly'));
     }
@@ -394,7 +401,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
     public function testAlias(): void
     {
         $helper = $this->getIconHelper();
-        $expected = '<span class="icon&#x20;icon--font&#x20;fa&#x20;fa-foo" '
+        $expected = '<span class="icon icon--font fa fa-foo" '
             . 'role="img" aria-hidden="true"></span>';
         // same is an alias for foo!
         $this->assertEquals($expected, $helper('same'));
@@ -432,7 +439,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $plugins = ['imageLink' => $this->getMockImageLink('mysprites.svg')];
         $helper = $this->getIconHelper(null, null, $plugins);
         $expected = <<<EXPECTED
-            <svg class="icon&#x20;icon--svg" aria-hidden="true">
+            <svg class="icon icon--svg" aria-hidden="true">
                 <use xlink:href="mysprites.svg#sprite"></use>
             </svg>
             EXPECTED;
@@ -449,7 +456,7 @@ class IconTest extends \PHPUnit\Framework\TestCase
         $plugins = ['imageLink' => $this->getMockImageLink('mysprites.svg')];
         $helper = $this->getIconHelper(null, null, $plugins);
         $expected = <<<EXPECTED
-            <svg class="icon&#x20;icon--svg&#x20;myclass" data-foo="bar" aria-hidden="true">
+            <svg class="icon icon--svg myclass" data-foo="bar" aria-hidden="true">
                 <use xlink:href="mysprites.svg#sprite"></use>
             </svg>
             EXPECTED;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -31,6 +31,7 @@ namespace VuFindTest\View\Helper\Root;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
+use VuFind\Escaper\Escaper;
 use VuFind\RecordDriver\Response\PublicationDetails;
 use VuFind\Tags\TagsService;
 use VuFind\View\Helper\Root\RecordDataFormatter;
@@ -99,7 +100,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'icon' => new \VuFind\View\Helper\Root\Icon(
                 [],
                 new \Laminas\Cache\Storage\Adapter\BlackHole(),
-                new \Laminas\View\Helper\EscapeHtmlAttr(),
+                new \Laminas\View\Helper\EscapeHtmlAttr(new Escaper(false)),
             ),
             'openUrl' => new \VuFind\View\Helper\Root\OpenUrl(
                 $context,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -100,7 +100,7 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
             'icon' => new \VuFind\View\Helper\Root\Icon(
                 [],
                 new \Laminas\Cache\Storage\Adapter\BlackHole(),
-                new \Laminas\View\Helper\EscapeHtmlAttr(new Escaper(false)),
+                new \Laminas\View\Helper\EscapeHtmlAttr(new Escaper()),
             ),
             'openUrl' => new \VuFind\View\Helper\Root\OpenUrl(
                 $context,

--- a/themes/root/theme.config.php
+++ b/themes/root/theme.config.php
@@ -99,7 +99,12 @@ return [
             'VuFind\View\Helper\Root\Url' => 'VuFind\View\Helper\Root\UrlFactory',
             'VuFind\View\Helper\Root\UserList' => 'VuFind\View\Helper\Root\UserListFactory',
             'VuFind\View\Helper\Root\UserTags' => 'VuFind\View\Helper\Root\UserTagsFactory',
+
+            'Laminas\View\Helper\EscapeHtmlAttr' => 'VuFind\View\Helper\Root\EscapeHtmlAttrFactory',
             'Laminas\View\Helper\ServerUrl' => 'VuFind\View\Helper\Root\ServerUrlFactory',
+        ],
+        'initializers' => [
+            \VuFind\View\Helper\Root\HelperInitializer::class,
         ],
         'aliases' => [
             'accountCapabilities' => 'VuFind\View\Helper\Root\AccountCapabilities',
@@ -196,6 +201,7 @@ return [
             'truncate' => 'VuFind\View\Helper\Root\Truncate',
             'userlist' => 'VuFind\View\Helper\Root\UserList',
             'usertags' => 'VuFind\View\Helper\Root\UserTags',
+
             'Laminas\View\Helper\Url' => 'VuFind\View\Helper\Root\Url',
         ],
     ],


### PR DESCRIPTION
The old extended style can still be enabled via configuration.