### PR TITLE
Force page refresh with GET request after modifying holds

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -868,12 +868,19 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
      * Construct an HTTP 205 (refresh) response. Useful for reporting success
      * in the lightbox without actually rendering content.
      *
+     * @param bool $forceGet If true, sends a custom header indicating that the page should be reloaded with a GET
+     * request. This can be useful when it is known that the current page only receives transient params in a POST
+     * request (such as canceling of holds).
+     *
      * @return \Laminas\Http\Response
      */
-    protected function getRefreshResponse()
+    protected function getRefreshResponse(bool $forceGet = false)
     {
         $response = $this->getResponse();
         $response->setStatusCode(205);
+        if ($forceGet) {
+            $response->getHeaders()->addHeaderLine('X-VuFind-Refresh-Method', 'GET');
+        }
         return $response;
     }
 

--- a/module/VuFind/src/VuFind/Controller/HoldsController.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsController.php
@@ -99,8 +99,7 @@ class HoldsController extends AbstractBase
         // Process cancel requests if necessary:
         $cancelStatus = $catalog->checkFunction('cancelHolds', compact('patron'));
         $view = $this->createViewModel();
-        $view->cancelResults = $cancelStatus
-            ? $this->holds()->cancelHolds($catalog, $patron) : [];
+        $view->cancelResults = $cancelStatus ? $this->holds()->cancelHolds($catalog, $patron) : [];
         // If we need to confirm
         if (!is_array($view->cancelResults)) {
             return $view->cancelResults;
@@ -281,7 +280,7 @@ class HoldsController extends AbstractBase
                     $this->flashMessenger()->addErrorMessage($msg);
                 }
                 return $this->inLightbox()
-                    ? $this->getRefreshResponse()
+                    ? $this->getRefreshResponse(true)
                     : $this->redirect()->toRoute('holds-list');
             }
         }

--- a/themes/bootstrap3/js/common.js
+++ b/themes/bootstrap3/js/common.js
@@ -254,15 +254,19 @@ var VuFind = (function VuFind() {
   /**
    * Reload the page without causing trouble with POST parameters while keeping hash
    */
-  var refreshPage = function refreshPage() {
+  var refreshPage = function refreshPage(forceGet) {
     var parts = window.location.href.split('#');
-    if (typeof parts[1] === 'undefined') {
+    const hasHash = typeof parts[1] !== 'undefined';
+    if (!hasHash && !forceGet) {
       window.location.reload();
     } else {
       var href = parts[0];
       // Force reload with a timestamp
       href += href.indexOf('?') === -1 ? '?_=' : '&_=';
-      href += new Date().getTime() + '#' + parts[1];
+      href += new Date().getTime();
+      if (hasHash) {
+        href += '#' + parts[1];
+      }
       window.location.href = href;
     }
   };

--- a/themes/bootstrap3/js/lightbox.js
+++ b/themes/bootstrap3/js/lightbox.js
@@ -227,7 +227,7 @@ VuFind.register('lightbox', function Lightbox() {
           _currentUrl = _originalUrl; // Now that we're logged in, where were we?
         }
         if (jq_xhr.status === 205) {
-          VuFind.refreshPage();
+          VuFind.refreshPage(jq_xhr.getResponseHeader('X-VuFind-Refresh-Method') === 'GET');
           return;
         }
         render(content);

--- a/themes/bootstrap5/js/common.js
+++ b/themes/bootstrap5/js/common.js
@@ -254,15 +254,19 @@ var VuFind = (function VuFind() {
   /**
    * Reload the page without causing trouble with POST parameters while keeping hash
    */
-  var refreshPage = function refreshPage() {
+  var refreshPage = function refreshPage(forceGet) {
     var parts = window.location.href.split('#');
-    if (typeof parts[1] === 'undefined') {
+    const hasHash = typeof parts[1] !== 'undefined';
+    if (!hasHash && !forceGet) {
       window.location.reload();
     } else {
       var href = parts[0];
       // Force reload with a timestamp
       href += href.indexOf('?') === -1 ? '?_=' : '&_=';
-      href += new Date().getTime() + '#' + parts[1];
+      href += new Date().getTime();
+      if (hasHash) {
+        href += '#' + parts[1];
+      }
       window.location.href = href;
     }
   };

--- a/themes/bootstrap5/js/lightbox.js
+++ b/themes/bootstrap5/js/lightbox.js
@@ -229,7 +229,7 @@ VuFind.register('lightbox', function Lightbox() {
           _currentUrl = _originalUrl; // Now that we're logged in, where were we?
         }
         if (jq_xhr.status === 205) {
-          VuFind.refreshPage();
+          VuFind.refreshPage(jq_xhr.getResponseHeader('X-VuFind-Refresh-Method') === 'GET');
           return;
         }
         render(content);


### PR DESCRIPTION
This ensures that any previous hold cancellation doesn't get submitted again.