### PR TITLE
Create element id which also works as a jQuery selector

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -217,6 +217,7 @@
               ? $this->url('myresearch-favorites')
               : $this->url('userList', ['id' => $list_id]);
           $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
+          $md5Id = md5($id);
         ?>
         <?=
           $this->component(
@@ -226,7 +227,7 @@
                   'buttonLink' => $deleteUrlGet,
                   'buttonIcon' => 'user-list-remove',
                   'buttonLabel' => 'Delete',
-                  'confirmId' => 'confirm_delete_item_' . md5($id),
+                  'confirmId' => 'confirm_delete_item_' . $md5id,
               ]
           )
         ?>
@@ -239,7 +240,6 @@
   </div>
   <?php
     $escId = $this->escapeJs($id);
-    $md5Id = md5($id);
     $escSource = $this->escapeJs($source);
     $script = <<<JS
         $('#confirm_delete_item_{$md5Id}').click(function(e) {

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -226,7 +226,7 @@
                   'buttonLink' => $deleteUrlGet,
                   'buttonIcon' => 'user-list-remove',
                   'buttonLabel' => 'Delete',
-                  'confirmId' => 'confirm_delete_item_' . urlencode($id),
+                  'confirmId' => 'confirm_delete_item_' . md5($id),
               ]
           )
         ?>
@@ -239,9 +239,10 @@
   </div>
   <?php
     $escId = $this->escapeJs($id);
+    $md5Id = md5($id);
     $escSource = $this->escapeJs($source);
     $script = <<<JS
-        $('#confirm_delete_item_{$escId}').click(function(e) {
+        $('#confirm_delete_item_{$md5Id}').click(function(e) {
             e.preventDefault();
             $.post('{$deleteUrl}', {
                         'delete':'{$escId}',

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -217,6 +217,7 @@
               ? $this->url('myresearch-favorites')
               : $this->url('userList', ['id' => $list_id]);
           $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
+          $md5Id = md5($id);
         ?>
         <?=
           $this->component(
@@ -226,7 +227,7 @@
                   'buttonLink' => $deleteUrlGet,
                   'buttonIcon' => 'user-list-remove',
                   'buttonLabel' => 'Delete',
-                  'confirmId' => 'confirm_delete_item_' . urlencode($id),
+                  'confirmId' => 'confirm_delete_item_' . $md5id,
               ]
           )
         ?>
@@ -241,7 +242,7 @@
     $escId = $this->escapeJs($id);
     $escSource = $this->escapeJs($source);
     $script = <<<JS
-        $('#confirm_delete_item_{$escId}').click(function(e) {
+        $('#confirm_delete_item_{$md5Id}').click(function(e) {
             e.preventDefault();
             $.post('{$deleteUrl}', {
                         'delete':'{$escId}',


### PR DESCRIPTION
If the id of a record contains e.g. a '.' the jquery selector doesn't work anymore and the delete button for favorites has no function anymore. The '.' stands for a css class. I propose to simply use the md5 sum of the id, which always forms a correct html id.