### PR TITLE
Include status string in holds link.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -534,6 +534,13 @@ class Holds
         // Include request type in the details
         $details['requestType'] = $action;
 
+        if (
+            ($details['availability'] ?? null) instanceof AvailabilityStatusInterface
+            && empty($details['status'])
+        ) {
+            $details['status'] = $details['availability']->getStatusDescription();
+        }
+
         // Generate HMAC
         $HMACkey = $this->hmac->generate($HMACKeys, $details);
 


### PR DESCRIPTION
In #4003, @maccabeelevine observed that the 'status' field was no longer getting passed through to the ILS driver's placeHold() method correctly. I suspect this was broken somewhere along the way by availability status refactoring. I believe this change should restore the missing value.

The logic for placing holds is quite complex and tangled, and large portions of it are legacy code that I did not write, so it's possible that this is not the best solution. I'm open to alternatives, but this is my first attempt at a solution!