### PR TITLE
Ensure that query string is not null when deminifying a search

### DIFF
--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -72,7 +72,7 @@ class QueryAdapter implements QueryAdapterInterface
             // Basic search
             $handler = $search['i'] ?? $search['f'];
             return new Query(
-                $search['l'],
+                $search['l'] ?? '',
                 $handler,
                 $search['o'] ?? null
             );
@@ -92,7 +92,7 @@ class QueryAdapter implements QueryAdapterInterface
                 );
             } else {
                 // Simple query
-                return new Query($search[0]['l'], $search[0]['i']);
+                return new Query($search[0]['l'] ?? '', $search[0]['i']);
             }
         }
     }


### PR DESCRIPTION
Old minified searches may have null in the l (lookfor) field, but Query expects a string even though it isn't enforced.

Without this fix, QueryBuilder passes null to getSearchHandler causing a PHP fatal error e.g. during scheduled search notifications.