### PR TITLE
Fix resending of email change confirmation request.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -1288,8 +1288,8 @@ class MyResearchController extends AbstractBase
         if ($this->params()->fromQuery('reverify')) {
             $change = false;
             // Case 1: new user:
-            $user = $this->getDbService(UserServiceInterface::class)
-                ->getUserByUsername($this->getUserVerificationContainer()->user);
+            $username = $this->getUserVerificationContainer()->user;
+            $user = $username ? $this->getDbService(UserServiceInterface::class)->getUserByUsername($username) : null;
             // Case 2: pending email change:
             if (!$user) {
                 $user = $this->getUser();


### PR DESCRIPTION
getUserByUsername has stronger typing than the old methods it replaced, and this caused an error when user verification container did not contain a username.