### PR TITLE
Add key files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ themes/bootstrap5/scss/vendor/bootstrap
 local/DirLocations.ini
 local/config/vufind/*.ini
 local/config/vufind/*.json
+local/config/vufind/*.key
 local/config/vufind/*.yaml


### PR DESCRIPTION
To prevent accidentally adding private key files like `oauth2_private.key`.