### PR TITLE
Remove obsolete patching logic from build.xml.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1265,17 +1265,7 @@ ${git_status}
   </target>
 
   <target name="patch-dependencies" description="apply fixes to dependencies">
-    <!-- Fix for PHP 8 incompatibility in chrome-mink-driver 2.8.0: -->
-    <reflexive>
-      <fileset dir="vendor/dmore/chrome-mink-driver/src">
-        <include pattern="ChromeDriver.php" />
-      </fileset>
-      <filterchain>
-        <replaceregexp>
-          <regexp pattern="\$base_url," replace="\$base_url = &apos;&apos;," />
-        </replaceregexp>
-      </filterchain>
-    </reflexive>
+    <!-- No patching needed at present; leaving hook here for future use. -->
   </target>
 
   <!-- Update bootstrap3 templates from bootstrap5 -->

--- a/build.xml
+++ b/build.xml
@@ -1264,10 +1264,6 @@ ${git_status}
     <delete file="${localdir}/import/import-${BASENAME}.properties" />
   </target>
 
-  <target name="patch-dependencies" description="apply fixes to dependencies">
-    <!-- No patching needed at present; leaving hook here for future use. -->
-  </target>
-
   <!-- Update bootstrap3 templates from bootstrap5 -->
   <!-- N.B. This destroys any existing bootstrap3 templates (except explicitly excluded ones) -->
   <target name="update-bootstrap3">

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
     },
     "scripts": {
         "fix": "phing fix-php",
-        "phing-install-dependencies": ["phing patch-dependencies", "phing installsolr installswaggerui"],
+        "phing-install-dependencies": ["phing installsolr installswaggerui"],
         "post-install-cmd": "@phing-install-dependencies",
         "post-update-cmd": "@phing-install-dependencies",
         "qa": "phing qa-console -Ddefaultconfigs=true",


### PR DESCRIPTION
I noticed that we were still monkey patching Mink ChromeDriver even though the underlying problem was fixed some time ago. This PR removes the unnecessary transformation. I originally left the patching target in place in build.xml as a future integration point, but this caused multiple "empty target" warning messages, so I just entirely removed it instead.