### PR TITLE
Eliminate use of \Laminas\Crypt\Hash.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
+++ b/module/VuFind/src/VuFind/Controller/ExternalAuthController.php
@@ -125,11 +125,10 @@ class ExternalAuthController extends AbstractBase implements LoggerAwareInterfac
         }
 
         $packet = '$u' . time() . '$e';
-        $hash = new \Laminas\Crypt\Hash();
         $algorithm = !empty($config->EZproxy->secret_hash_method)
             ? $config->EZproxy->secret_hash_method : 'SHA512';
         $ticket = $config->EZproxy->secret . $user . $packet;
-        $ticket = $hash->compute($algorithm, $ticket);
+        $ticket = hash($algorithm, $ticket);
         $ticket .= $packet;
         $params = http_build_query(
             ['user' => $user, 'ticket' => $ticket, 'url' => $url]


### PR DESCRIPTION
`\Laminas\Crypt\Hash` is just a thin wrapper around the PHP `hash` function. This PR eliminates our use of it since laminas-crypt is now deprecated.

TODO
- [x] Run full test suite