### PR TITLE
Fix prepend in getCurrentHiddenFilterParams.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -219,10 +219,8 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
      * Get current hidden filters as a string suitable for search URLs
      *
      * @param string $searchClassId            Active search class
-     * @param bool   $ignoreHiddenFilterMemory Whether to ignore hidden filters in
-     * search memory
-     * @param string $prepend                  String to prepend to the hidden
-     * filters if they're not empty
+     * @param bool   $ignoreHiddenFilterMemory Whether to ignore hidden filters in search memory
+     * @param string $prepend                  String to prepend to the hidden filters if they're not empty
      *
      * @return string
      */
@@ -263,7 +261,10 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
                 $this->cachedHiddenFilterParams[$searchClassId] = '';
             }
         }
-        return $prepend . $this->cachedHiddenFilterParams[$searchClassId];
+        if ('' !== ($filters = $this->cachedHiddenFilterParams[$searchClassId])) {
+            return $prepend . $filters;
+        }
+        return '';
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
@@ -121,7 +121,7 @@ class SearchTabsTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertEquals(
-            "&amp;$expected",
+            $expected ? "&amp;$expected" : '',
             $helper->getCurrentHiddenFilterParams('Solr')
         );
         $this->assertEquals(


### PR DESCRIPTION
This is a minor issue but shows up as trailing `?` or `&` in the "Start a new ... search" links in Versions search results page (and record links if `\VuFind\View\Helper\Root\Record::getLink()` can't find the search in memory) when the current search tab does not have filters.