### PR TITLE
Include user when fetching saved search for hidden filters.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -31,6 +31,7 @@ namespace VuFind\Search;
 
 use Laminas\Http\Request;
 use Laminas\Session\Container;
+use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Service\SearchServiceInterface;
 use VuFind\Search\Results\PluginManager as ResultsManager;
 
@@ -254,16 +255,18 @@ class Memory
     /**
      * Get a search by id
      *
-     * @param int $id Search ID
+     * @param int                  $id   Search ID
+     * @param ?UserEntityInterface $user Currently logged-in user to also check saved searches
      *
      * @return ?\VuFind\Search\Base\Results
      */
-    public function getSearchById(int $id): ?\VuFind\Search\Base\Results
+    public function getSearchById(int $id, ?UserEntityInterface $user = null): ?\VuFind\Search\Base\Results
     {
-        if (!array_key_exists($id, $this->searchCache)) {
-            $search = $this->searchService->getSearchByIdAndOwner($id, $this->sessionId, null);
-            $this->searchCache[$id] = $search?->getSearchObject()?->deminify($this->resultsManager);
+        $cacheKey = $id . '_' . ($user?->getId() ?? '');
+        if (!array_key_exists($cacheKey, $this->searchCache)) {
+            $search = $this->searchService->getSearchByIdAndOwner($id, $this->sessionId, $user);
+            $this->searchCache[$cacheKey] = $search?->getSearchObject()?->deminify($this->resultsManager);
         }
-        return $this->searchCache[$id];
+        return $this->searchCache[$cacheKey];
     }
 }

--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -262,7 +262,8 @@ class Memory
      */
     public function getSearchById(int $id, ?UserEntityInterface $user = null): ?\VuFind\Search\Base\Results
     {
-        $cacheKey = $id . '_' . ($user?->getId() ?? '');
+        $userId = $user?->getId();
+        $cacheKey = $userId ? "{$id}_$userId" : $id;
         if (!array_key_exists($cacheKey, $this->searchCache)) {
             $search = $this->searchService->getSearchByIdAndOwner($id, $this->sessionId, $user);
             $this->searchCache[$cacheKey] = $search?->getSearchObject()?->deminify($this->resultsManager);

--- a/module/VuFind/src/VuFind/View/Helper/Root/Record.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Record.php
@@ -486,9 +486,13 @@ class Record extends \Laminas\View\Helper\AbstractHelper implements DbServiceAwa
         $hiddenFilters = null;
         // Try to get hidden filters for the current search:
         if ($this->searchMemory) {
+            $view = $this->getView();
             $searchId = $this->driver->getExtraDetail('searchId')
-                ?? $this->getView()->plugin('searchMemory')->getLastSearchId();
-            if ($searchId && ($search = $this->searchMemory->getSearchById($searchId))) {
+                ?? $view->plugin('searchMemory')->getLastSearchId();
+            if (
+                $searchId
+                && ($search = $this->searchMemory->getSearchById($searchId, $view->plugin('auth')->getUserObject()))
+            ) {
                 $filters = UrlQueryHelper::buildQueryString(
                     [
                         'hiddenFilters' => $search->getParams()->getHiddenFiltersAsQueryParams(),


### PR DESCRIPTION
This allows the search to be found even when it's one that has been saved in a previous session.