### PR TITLE
Fix issue where versions link does not shift focus to the tab.

### DIFF
--- a/themes/bootstrap3/js/record.js
+++ b/themes/bootstrap3/js/record.js
@@ -338,6 +338,7 @@ function applyRecordTabHash(scrollToTabs) {
         $('html, body').animate({
           scrollTop: $('.record-tabs').offset().top
         }, 500);
+        $tabLink.trigger("focus");
       }
     }
   }

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -338,6 +338,7 @@ function applyRecordTabHash(scrollToTabs) {
         $('html, body').animate({
           scrollTop: $('.record-tabs').offset().top
         }, 500);
+        $tabLink.trigger("focus");
       }
     }
   }


### PR DESCRIPTION
Currently, the browser focus is not shifted to the linked content. Instead, the focus remains in place, which complicates screen reader users understanding of the link's purpose.