### PR TITLE
[VUFIND-1718] minor updates to LC class/subclass to subject label mapping

### DIFF
--- a/import/translation_maps/callnumber_subject_map.properties
+++ b/import/translation_maps/callnumber_subject_map.properties
@@ -1,3 +1,4 @@
+A = A - General Works
 AC = AC - Collections and Collected Works
 AE = AE - Encyclopedias
 AG = AG - Dictionaries and Reference
@@ -23,7 +24,7 @@ BS = BS - The Bible
 BT = BT - Doctrinal Theology
 BV = BV - Practical Theology
 BX = BX - Christian Denominations
-C = C - General History
+C = C - Historical Sciences
 CB = CB - History of Civilization
 CC = CC - Archaeology
 CD = CD - Diplomatics, Archives, Seals


### PR DESCRIPTION
This patch adds a label for class "A" and disambiguates the labels for "C" and "D".

In the course of making this patch, I did a quick skim and did not find any newly created subclasses missing from the mapping. No attempt was made to make the labels match the LC schedules exactly or to otherwise make editorial judgements on the existing labels.