### PR TITLE
Tolerate missing cat_pass_enc value in user row.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Row/User.php
+++ b/module/VuFind/src/VuFind/Db/Row/User.php
@@ -984,7 +984,7 @@ class User extends RowGateway implements
      */
     public function getCatPassEnc(): ?string
     {
-        return $this->cat_pass_enc;
+        return $this->cat_pass_enc ?? null;
     }
 
     /**


### PR DESCRIPTION
If you call getCatPassEnc on a user object that hasn't been fully populated yet, it should return null instead of throwing a Laminas error. This PR corrects the problem.