### PR TITLE
RateLimiter: Apply policy to IP ranges except a list

### DIFF
--- a/config/vufind/RateLimiter.yaml
+++ b/config/vufind/RateLimiter.yaml
@@ -54,6 +54,10 @@ Storage:
 #                       denotes 192.168.0.0-192.168.255.255), and IPv6 addresses are
 #                       also supported (unless PHP is compiled with IPv6 disabled).
 #
+# ipRangesExcept        The opposite of ipRanges: limit the policy to IP ranges that
+#                       are *not* in this list. For example, list local IP ranges to
+#                       exclude them from the policy.
+#
 # loggedIn              Whether to limit the policy to logged-in users (true) or
 #                       anonymous users (false). Default is null for no limit.
 #

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -217,6 +217,11 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                     continue;
                 }
             }
+            if ($ipRangesExcept = $settings['ipRangesExcept'] ?? null) {
+                if ($this->ipUtils->isInRange($this->clientIp, (array)$ipRangesExcept)) {
+                    continue;
+                }
+            }
 
             if (!($filters = $settings['filters'] ?? null)) {
                 return $name;


### PR DESCRIPTION
This config does the opposite of `ipRanges`, so the policy can be applied to any incoming IPs *except* for a given list.  I.e. don't rate-limit on-campus uses of VuFind.