### PR TITLE
Fix reply-to name handling in form email handler.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -117,7 +117,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
 
         $replyToName = $params->fromPost(
             'name',
-            $user ? trim($user->getFirstname() . ' ' . $user->getLastname()) : null
+            $user ? trim($user->getFirstname() . ' ' . $user->getLastname()) : ''
         );
         $replyToEmail = $params->fromPost('email', $user?->getEmail());
         $recipients = $form->getRecipient($postParams);


### PR DESCRIPTION
Name must always be a string, even if empty.

This is one more case I missed during the switch to Symfony Mailer.