### PR TITLE
Fix and improve SystemStatus handler

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/SystemStatus.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/SystemStatus.php
@@ -92,26 +92,30 @@ class SystemStatus extends AbstractBase implements \Laminas\Log\LoggerAwareInter
         $this->log('info', 'SystemStatus log check', [], true);
 
         // Test search index
-        try {
-            $results = $this->resultsManager->get(DEFAULT_SEARCH_BACKEND);
-            $paramsObj = $results->getParams();
-            $paramsObj->setQueryIDs(['healthcheck' . date('His')]);
-            $results->performAndProcessSearch();
-        } catch (\Exception $e) {
-            return $this->formatResponse(
-                'Search index error: ' . $e->getMessage(),
-                self::STATUS_HTTP_ERROR
-            );
+        if ($params->fromPost('index') ?? $params->fromQuery('index', 1)) {
+            try {
+                $results = $this->resultsManager->get(DEFAULT_SEARCH_BACKEND);
+                $paramsObj = $results->getParams();
+                $paramsObj->setQueryIDs(['healthcheck' . date('His')]);
+                $results->performAndProcessSearch();
+            } catch (\Exception $e) {
+                return $this->formatResponse(
+                    'Search index error: ' . $e->getMessage(),
+                    self::STATUS_HTTP_ERROR
+                );
+            }
         }
 
         // Test database connection
-        try {
-            $this->sessionService->getSessionById('healthcheck', false);
-        } catch (\Exception $e) {
-            return $this->formatResponse(
-                'Database error: ' . $e->getMessage(),
-                self::STATUS_HTTP_ERROR
-            );
+        if ($params->fromPost('database') ?? $params->fromQuery('database', 1)) {
+            try {
+                $this->sessionService->getSessionById('healthcheck', false);
+            } catch (\Exception $e) {
+                return $this->formatResponse(
+                    'Database error: ' . $e->getMessage(),
+                    self::STATUS_HTTP_ERROR
+                );
+            }
         }
 
         // This may be called frequently, don't leave sessions dangling

--- a/module/VuFind/src/VuFind/AjaxHandler/SystemStatus.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/SystemStatus.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * "Keep Alive" AJAX handler
+ * "System Status" AJAX handler
  *
  * PHP version 8
  *
@@ -23,6 +23,7 @@
  * @category VuFind
  * @package  AJAX
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -36,14 +37,12 @@ use VuFind\Db\Service\SessionServiceInterface;
 use VuFind\Search\Results\PluginManager as ResultsManager;
 
 /**
- * "Keep Alive" AJAX handler
- *
- * This is responsible for keeping the session alive whenever called
- * (via JavaScript)
+ * "System Status" AJAX handler
  *
  * @category VuFind
  * @package  AJAX
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
@@ -94,9 +93,9 @@ class SystemStatus extends AbstractBase implements \Laminas\Log\LoggerAwareInter
 
         // Test search index
         try {
-            $results = $this->resultsManager->get('Solr');
+            $results = $this->resultsManager->get(DEFAULT_SEARCH_BACKEND);
             $paramsObj = $results->getParams();
-            $paramsObj->setQueryIDs(['healthcheck']);
+            $paramsObj->setQueryIDs(['healthcheck' . date('His')]);
             $results->performAndProcessSearch();
         } catch (\Exception $e) {
             return $this->formatResponse(


### PR DESCRIPTION
- Adds timestamp to Solr health check request so that it doesn't return possibly stale status from search cache.
- Adds options to bypass index and/or database health checks for more fine-grained status handling.