### PR TITLE
Allow copying to clipboard in HTML format

### DIFF
--- a/themes/bootstrap3/templates/Helpers/copy-to-clipboard-button.phtml
+++ b/themes/bootstrap3/templates/Helpers/copy-to-clipboard-button.phtml
@@ -10,19 +10,28 @@
 $script = <<<JS
       $(document).ready(function copyToClipboard() {
         if (navigator.clipboard) {
+          function copySuccess() {
+            $("#copyFailureMessage{$buttonNumber}").addClass("hidden");
+            $("#copySuccessMessage{$buttonNumber}").removeClass("hidden");
+          }
+          function copyFailure() {
+            $("#copySuccessMessage{$buttonNumber}").addClass("hidden");
+            $("#copyFailureMessage{$buttonNumber}").removeClass("hidden");
+          }
           const button = $("#copyToClipboard{$buttonNumber}");
           button.removeClass('hidden');
           button.click(function copyToClipboard() {
-            navigator.clipboard.writeText($('{$selector}').text()).then(
-                function copySuccess() {
-                    $("#copyFailureMessage{$buttonNumber}").addClass("hidden");
-                    $("#copySuccessMessage{$buttonNumber}").removeClass("hidden");
-                },
-                function copyFailure() {
-                    $("#copySuccessMessage{$buttonNumber}").addClass("hidden");
-                    $("#copyFailureMessage{$buttonNumber}").removeClass("hidden");
-                }
-            );
+            const text = $('{$selector}').text();
+            if (typeof ClipboardItem === 'undefined') {
+              navigator.clipboard.writeText(text).then(copySuccess, copyFailure);
+              return;
+            }
+            const html = $('{$selector}').html();
+            const data = [ new ClipboardItem({
+              ['text/plain']: new Blob([text], {type: 'text/plain'}),
+              ['text/html']: new Blob([html], {type: 'text/html'})
+            })];
+            navigator.clipboard.write(data).then(copySuccess, copyFailure);
           });
         }
       });

--- a/themes/bootstrap5/templates/Helpers/copy-to-clipboard-button.phtml
+++ b/themes/bootstrap5/templates/Helpers/copy-to-clipboard-button.phtml
@@ -10,19 +10,28 @@
 $script = <<<JS
       $(document).ready(function copyToClipboard() {
         if (navigator.clipboard) {
+          function copySuccess() {
+            $("#copyFailureMessage{$buttonNumber}").addClass("hidden");
+            $("#copySuccessMessage{$buttonNumber}").removeClass("hidden");
+          }
+          function copyFailure() {
+            $("#copySuccessMessage{$buttonNumber}").addClass("hidden");
+            $("#copyFailureMessage{$buttonNumber}").removeClass("hidden");
+          }
           const button = $("#copyToClipboard{$buttonNumber}");
           button.removeClass('hidden');
           button.click(function copyToClipboard() {
-            navigator.clipboard.writeText($('{$selector}').text()).then(
-                function copySuccess() {
-                    $("#copyFailureMessage{$buttonNumber}").addClass("hidden");
-                    $("#copySuccessMessage{$buttonNumber}").removeClass("hidden");
-                },
-                function copyFailure() {
-                    $("#copySuccessMessage{$buttonNumber}").addClass("hidden");
-                    $("#copyFailureMessage{$buttonNumber}").removeClass("hidden");
-                }
-            );
+            const text = $('{$selector}').text();
+            if (typeof ClipboardItem === 'undefined') {
+              navigator.clipboard.writeText(text).then(copySuccess, copyFailure);
+              return;
+            }
+            const html = $('{$selector}').html();
+            const data = [ new ClipboardItem({
+              ['text/plain']: new Blob([text], {type: 'text/plain'}),
+              ['text/html']: new Blob([html], {type: 'text/html'})
+            })];
+            navigator.clipboard.write(data).then(copySuccess, copyFailure);
           });
         }
       });


### PR DESCRIPTION
Use case:
We are using citations in ISO 690 format, this mean the title should be formatted in italic. For proper copying the citation into text editor including formatting, the clipboard data should be in HTML.

Please note, that this does not work in Firefox as it does not support ClipboardItem. In that case data are copied as text.