### PR TITLE
Improve New Items breadcrumbs/search form.

### DIFF
--- a/themes/bootstrap3/templates/search/newitem.phtml
+++ b/themes/bootstrap3/templates/search/newitem.phtml
@@ -5,6 +5,9 @@
     // Set up breadcrumbs:
     $this->layout()->breadcrumbs = '<li class="active">' . $this->transEsc('New Items') . '</li>';
 
+    // Load advanced search Javascript to activate the clear button:
+    $this->headScript()->appendFile('advanced_search.js');
+
     // Convenience variable:
     $offlineMode = $this->ils()->getOfflineMode();
 ?>
@@ -21,7 +24,7 @@
     <div class="btn-group" data-toggle="buttons">
       <?php foreach ($this->ranges as $key => $range): ?>
         <label class="btn btn-primary<?php if ($key == 0): ?> active<?php endif ?>">
-          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked"' : ''?>>
+          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked" data-checked-by-default="true"' : ''?>>
           <?=$this->transEsc('past_days', ['range' => $this->escapeHtml($range)], null, true)?>
         </label>
       <?php endforeach; ?>
@@ -38,5 +41,8 @@
       </select>
     </div>
   <?php endif; ?>
-  <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
+  <div class="adv-submit">
+    <input class="clear-btn btn btn-default" type="button" value="<?= $this->transEscAttr('Clear')?>">
+    <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
+  </div>
 </form>

--- a/themes/bootstrap3/templates/search/newitemresults.phtml
+++ b/themes/bootstrap3/templates/search/newitemresults.phtml
@@ -3,4 +3,5 @@
   $this->slot('head-title')->set($this->translate('New Items'));
   $this->slot('search-heading')->set($this->transEsc('New Items'));
   $this->slot('empty-message')->set($this->transEsc('No new item information is currently available.'));
+  $this->layout()->breadcrumbs = '<li><a href="' . $this->url('search-newitem') . '">' . $this->transEsc('Find New Items') . '</a></li>';
   echo $this->render('search/results.phtml');

--- a/themes/bootstrap5/templates/search/newitem.phtml
+++ b/themes/bootstrap5/templates/search/newitem.phtml
@@ -5,6 +5,9 @@
     // Set up breadcrumbs:
     $this->layout()->breadcrumbs = '<li class="active">' . $this->transEsc('New Items') . '</li>';
 
+    // Load advanced search Javascript to activate the clear button:
+    $this->headScript()->appendFile('advanced_search.js');
+
     // Convenience variable:
     $offlineMode = $this->ils()->getOfflineMode();
 ?>
@@ -21,7 +24,7 @@
     <div class="btn-group" data-bs-toggle="buttons">
       <?php foreach ($this->ranges as $key => $range): ?>
         <label class="btn btn-primary<?php if ($key == 0): ?> active<?php endif ?>">
-          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked"' : ''?>>
+          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked" data-checked-by-default="true"' : ''?>>
           <?=$this->transEsc('past_days', ['range' => $this->escapeHtml($range)], null, true)?>
         </label>
       <?php endforeach; ?>
@@ -38,5 +41,8 @@
       </select>
     </div>
   <?php endif; ?>
-  <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
+  <div class="adv-submit">
+    <input class="clear-btn btn btn-default" type="button" value="<?= $this->transEscAttr('Clear')?>">
+    <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
+  </div>
 </form>

--- a/themes/bootstrap5/templates/search/newitemresults.phtml
+++ b/themes/bootstrap5/templates/search/newitemresults.phtml
@@ -3,4 +3,5 @@
   $this->slot('head-title')->set($this->translate('New Items'));
   $this->slot('search-heading')->set($this->transEsc('New Items'));
   $this->slot('empty-message')->set($this->transEsc('No new item information is currently available.'));
+  $this->layout()->breadcrumbs = '<li><a href="' . $this->url('search-newitem') . '">' . $this->transEsc('Find New Items') . '</a></li>';
   echo $this->render('search/results.phtml');


### PR DESCRIPTION
This PR adds a couple of minor improvements to the New Items search functionality:

- The new items search form can now be reset with a clear button (reusing functionality from Advanced search)
- The new items search results have a breadcrumb linking back to the form