### PR TITLE
Improve subject indexing (omit numeric subfields)

### DIFF
--- a/import/index_java/src/org/vufind/index/FieldSpecTools.java
+++ b/import/index_java/src/org/vufind/index/FieldSpecTools.java
@@ -199,6 +199,8 @@ public class FieldSpecTools
      */
     public static Set<String> getAllAlphaSubfieldsUTF8Delimited(final Record record, String fieldSpec, String separatorWithEscapes)
     {
+        // getAllAlphaSubfields has a signature that's inconsistent with getAllSubfields (above); we need to
+        // construct a join modifier using the separator instead of directly providing the separator as a result.
         return org.solrmarc.index.SolrIndexer.instance().getAllAlphaSubfields(record, fieldSpec, "join(\"" + getUnescapedSeparator(separatorWithEscapes) + "\")");
     }
 }

--- a/import/index_java/src/org/vufind/index/FieldSpecTools.java
+++ b/import/index_java/src/org/vufind/index/FieldSpecTools.java
@@ -144,6 +144,27 @@ public class FieldSpecTools
     private static Pattern unicodeEscape = Pattern.compile("(?i)\\\\u([0-9a-f]{4})");
 
     /**
+     * Convert an escaped separator into its actual String value.
+     *
+     * @param separatorWithEscapes  a string representing the delimiter to use between subfields,
+     *                              which can contain Unicode escape sequences in the format \\uXXXX.
+     * @return                      The string version of the escaped separator
+     */
+    private static String getUnescapedSeparator(String separatorWithEscapes)
+    {
+        StringBuilder separator = new StringBuilder(separatorWithEscapes);
+        Matcher m = unicodeEscape.matcher(separator);
+
+        while (m.find()) {
+            int codepoint = Integer.parseInt(m.group(1), 16);
+            separator.replace(m.start(), m.end(), new String(Character.toChars(codepoint)));
+            m.reset();
+        }
+
+        return separator.toString();
+    }
+
+    /**
      * Retrieves all subfields from a record, separated by a specified UTF-8 delimiter.
      *
      * This method takes a MARC record and a specification for the fields to extract, and returns
@@ -159,15 +180,25 @@ public class FieldSpecTools
      */
     public static Set<String> getAllSubfieldsUTF8Delimited(final Record record, String fieldSpec, String separatorWithEscapes)
     {
-        StringBuilder separator = new StringBuilder(separatorWithEscapes);
-        Matcher m = unicodeEscape.matcher(separator);
+        return org.solrmarc.index.SolrIndexer.instance().getAllSubfields(record, fieldSpec, getUnescapedSeparator(separatorWithEscapes));
+    }
 
-        while (m.find()) {
-            int codepoint = Integer.parseInt(m.group(1), 16);
-            separator.replace(m.start(), m.end(), new String(Character.toChars(codepoint)));
-            m.reset();
-        }
-
-        return org.solrmarc.index.SolrIndexer.instance().getAllSubfields(record, fieldSpec, separator.toString());
+    /**
+     * Retrieves all alphabetic subfields from a record, separated by a specified UTF-8 delimiter.
+     *
+     * This method takes a MARC record and a specification for the fields to extract, and returns
+     * a set of strings representing the subfields found, concatenated with a specified separator.
+     * The separator can include Unicode escape sequences, which will be converted to their corresponding
+     * characters.
+     *
+     * @param record                the MARC record from which to extract subfields.
+     * @param fieldSpec             a string specifying the fields and subfields to retrieve.
+     * @param separatorWithEscapes  a string representing the delimiter to use between subfields,
+     *                              which can contain Unicode escape sequences in the format \\uXXXX.
+     * @return                      a set of strings with the concatenated subfields, separated by the given delimiter.
+     */
+    public static Set<String> getAllAlphaSubfieldsUTF8Delimited(final Record record, String fieldSpec, String separatorWithEscapes)
+    {
+        return org.solrmarc.index.SolrIndexer.instance().getAllAlphaSubfields(record, fieldSpec, getUnescapedSeparator(separatorWithEscapes));
     }
 }

--- a/import/index_java/src/org/vufind/index/FieldSpecTools.java
+++ b/import/index_java/src/org/vufind/index/FieldSpecTools.java
@@ -199,6 +199,6 @@ public class FieldSpecTools
      */
     public static Set<String> getAllAlphaSubfieldsUTF8Delimited(final Record record, String fieldSpec, String separatorWithEscapes)
     {
-        return org.solrmarc.index.SolrIndexer.instance().getAllAlphaSubfields(record, fieldSpec, getUnescapedSeparator(separatorWithEscapes));
+        return org.solrmarc.index.SolrIndexer.instance().getAllAlphaSubfields(record, fieldSpec, "join(\"" + getUnescapedSeparator(separatorWithEscapes) + "\")");
     }
 }

--- a/import/marc.properties
+++ b/import/marc.properties
@@ -91,11 +91,11 @@ callnumber-label = custom, getCallNumberLabel(090a:050a)
 callnumber-sort = custom, getLCSortable(099ab:090ab:050ab)
 callnumber-raw = 099ab:090ab:050ab
 
-topic = custom, getAllSubfields(600:610:611:630:650:653:656, " ")
-topic_browse = custom, getAllSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002")
-genre = custom, getAllSubfields(655, " ")
-geographic = custom, getAllSubfields(651, " ")
-era = custom, getAllSubfields(648, " ")
+topic = custom, getAllAlphaSubfields(600:610:611:630:650:653:656, " ")
+topic_browse = custom, getAllAlphaSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002")
+genre = custom, getAllAlphaSubfields(655, " ")
+geographic = custom, getAllAlphaSubfields(651, " ")
+era = custom, getAllAlphaSubfields(648, " ")
 
 topic_facet = 600x:610x:611x:630x:648x:650a:650x:651x:655x
 genre_facet = 600v:610v:611v:630v:648v:650v:651v:655a:655v

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AlphabrowseTest.php
@@ -113,4 +113,18 @@ class AlphabrowseTest extends \VuFindTest\Integration\MinkTestCase
         $text = $this->findCssAndGetText($page, 'table.alphabrowse td.lcc ~ td');
         $this->assertStringContainsString('<HTML> The Basics', $text);
     }
+
+    /**
+     * Test that topic separators are applied correctly.
+     *
+     * @return void
+     */
+    public function testTopicSeparators(): void
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Alphabrowse/Home?source=topic&from=peat+bogs');
+        $page = $session->getPage();
+        $text = $this->findCssAndGetText($page, 'table.alphabrowse td.topic b');
+        $this->assertStringContainsString('Peat bogs > Ireland', $text);
+    }
 }


### PR DESCRIPTION
As recently discussed: default subject indexing has historically included numeric subfields, but this is causing hidden fields to be displayed to end users in undesirable ways (e.g. revealing URIs and heading types in alphabrowse).

This PR adjusts the default import rules to use only alphabetic subfields.

This required a bit of refactoring of custom Java to keep the custom separators working as expected; a Mink test has been added to catch regressions related to custom separators.