### PR TITLE
Fix hierarchical facet sort options and add tests

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
+++ b/module/VuFind/src/VuFind/Search/Base/FacetCacheFactory.php
@@ -35,6 +35,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use VuFind\I18n\Locale\LocaleSettings;
+use VuFind\Search\Solr\HierarchicalFacetHelper;
 
 use function count;
 
@@ -91,6 +92,8 @@ class FacetCacheFactory implements FactoryInterface
         $results = $this->getResults($container, $requestedNamespace);
         $cacheManager = $container->get(\VuFind\Cache\Manager::class);
         $language = $container->get(LocaleSettings::class)->getUserLocale();
-        return new $requestedName($results, $cacheManager, $language);
+        $hierarchicalFacetHelper = $container->get(HierarchicalFacetHelper::class);
+        $configManager = $container->get(\VuFind\Config\PluginManager::class);
+        return new $requestedName($results, $cacheManager, $language, $hierarchicalFacetHelper, $configManager);
     }
 }

--- a/module/VuFind/src/VuFindTest/Feature/CacheManagementTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/CacheManagementTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Trait adding the ability to clear object cache.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Feature;
+
+use Laminas\Http\Request;
+use VuFindHttp\HttpService;
+
+/**
+ * Trait adding the ability to clear object cache.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait CacheManagementTrait
+{
+    /**
+     * Get configuration required for cache clear permission
+     *
+     * @return array
+     */
+    protected function getCacheClearPermissionConfig(): array
+    {
+        return [
+            'permissions' => [
+                'enable-admin-cache-api' => [
+                    'permission' => 'access.api.admin.cache',
+                    'require' => 'ANY',
+                    'role' => 'guest',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Call the API to clear object cache
+     *
+     * @return voi
+     */
+    protected function clearObjectCache(): void
+    {
+        $http = new HttpService();
+        $client = $http->createClient($this->getVuFindUrl('/api/v1/admin/cache?id=object'), Request::METHOD_DELETE);
+        $response = $client->send();
+        if (200 !== $response->getStatusCode()) {
+            throw new \Exception('Could not clear object cache: ' . $response->getBody());
+        }
+    }
+}

--- a/module/VuFind/src/VuFindTest/Feature/SearchFacetFilterTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/SearchFacetFilterTrait.php
@@ -105,6 +105,212 @@ trait SearchFacetFilterTrait
     protected $facetSecondLevelExcludeLinkSelector = '.facet-tree button[aria-expanded=true] ~ ul a.exclude';
 
     /**
+     * Expected hierarchical facet options by sort setting
+     *
+     * @var array
+     */
+    protected $expectedHierarchicalFacetOptions = [
+        'count' => [
+            [
+                'filter' => '0/level1a/',
+                'displayText' => 'Top Level, Sorted Last',
+                'children' => [
+                    [
+                        'filter' => '1/level1a/level2a/',
+                        'displayText' => 'level2a',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2a/level3a/',
+                                'displayText' => 'level3a',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3b/',
+                                'displayText' => 'level3b',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3d/',
+                                'displayText' => 'level3d',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1a/level2b/',
+                        'displayText' => 'level2b',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2b/level3c/',
+                                'displayText' => 'level3c',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2b/level3e/',
+                                'displayText' => 'level3e',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'filter' => '0/level1z/',
+                'displayText' => 'Top Level, Sorted First',
+                'children' => [
+                    [
+                        'filter' => '1/level1z/level2y/',
+                        'displayText' => 'Second Level, Sorted Last',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2y/level3g/',
+                                'displayText' => 'level3g',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1z/level2z/',
+                        'displayText' => 'Second Level, Sorted First',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2z/level3z/',
+                                'displayText' => 'level3z',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'top' => [
+            [
+                'filter' => '0/level1z/',
+                'displayText' => 'Top Level, Sorted First',
+                'children' => [
+                    [
+                        'filter' => '1/level1z/level2y/',
+                        'displayText' => 'Second Level, Sorted Last',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2y/level3g/',
+                                'displayText' => 'level3g',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1z/level2z/',
+                        'displayText' => 'Second Level, Sorted First',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2z/level3z/',
+                                'displayText' => 'level3z',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'filter' => '0/level1a/',
+                'displayText' => 'Top Level, Sorted Last',
+                'children' => [
+                    [
+                        'filter' => '1/level1a/level2a/',
+                        'displayText' => 'level2a',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2a/level3a/',
+                                'displayText' => 'level3a',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3b/',
+                                'displayText' => 'level3b',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3d/',
+                                'displayText' => 'level3d',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1a/level2b/',
+                        'displayText' => 'level2b',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2b/level3c/',
+                                'displayText' => 'level3c',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2b/level3e/',
+                                'displayText' => 'level3e',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'all' => [
+            [
+                'filter' => '0/level1z/',
+                'displayText' => 'Top Level, Sorted First',
+                'children' => [
+                    [
+                        'filter' => '1/level1z/level2z/',
+                        'displayText' => 'Second Level, Sorted First',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2z/level3z/',
+                                'displayText' => 'level3z',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1z/level2y/',
+                        'displayText' => 'Second Level, Sorted Last',
+                        'children' => [
+                            [
+                                'filter' => '2/level1z/level2y/level3g/',
+                                'displayText' => 'level3g',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'filter' => '0/level1a/',
+                'displayText' => 'Top Level, Sorted Last',
+                'children' => [
+                    [
+                        'filter' => '1/level1a/level2a/',
+                        'displayText' => 'level2a',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2a/level3a/',
+                                'displayText' => 'level3a',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3b/',
+                                'displayText' => 'level3b',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2a/level3d/',
+                                'displayText' => 'level3d',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => '1/level1a/level2b/',
+                        'displayText' => 'level2b',
+                        'children' => [
+                            [
+                                'filter' => '2/level1a/level2b/level3c/',
+                                'displayText' => 'level3c',
+                            ],
+                            [
+                                'filter' => '2/level1a/level2b/level3e/',
+                                'displayText' => 'level3e',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
      * Check that a filter is applied
      *
      * @param Element $page           Page
@@ -259,5 +465,131 @@ trait SearchFacetFilterTrait
             $this->clickCss($container, 'input[type="submit"]');
         }
         $this->waitForPageLoad($page);
+    }
+
+    /**
+     * Get expected <select> field options for a hierarchical facet
+     *
+     * @param string $sort Sort setting
+     *
+     * @return array
+     */
+    protected function getExpectedHierarchicalFacetOptions(string $sort): array
+    {
+        $result = [];
+        if (null === ($hierarchy = $this->expectedHierarchicalFacetOptions[$sort] ?? null)) {
+            throw new \Exception("Invalid sort '$sort'");
+        }
+        foreach ($this->flattenFacetHierarchy($hierarchy) as $current) {
+            [$level] = explode('/', $current['filter']);
+            $result['~hierarchical_facet_str_mv:"' . $current['filter'] . '"'] = str_repeat('&nbsp;', 4 * $level)
+                . $current['displayText'];
+        }
+        return $result;
+    }
+
+    /**
+     * Get expected facet tree contents as a list for a hierarchical facet
+     *
+     * @param string $sort Sort setting
+     *
+     * @return array
+     */
+    protected function getExpectedHierarchicalFacetTreeItems(string $sort): array
+    {
+        $result = [];
+        if (null === ($hierarchy = $this->expectedHierarchicalFacetOptions[$sort] ?? null)) {
+            throw new \Exception("Invalid sort '$sort'");
+        }
+        foreach ($this->flattenFacetHierarchy($hierarchy) as $current) {
+            $result[] = $current['displayText'];
+        }
+        return $result;
+    }
+
+    /**
+     * Get expected display text for a hierarchical facet filter
+     *
+     * @param string $sort  Sort setting
+     * @param int    $index Item index
+     *
+     * @return string
+     */
+    protected function getExpectedHierarchicalFacetFilterText(string $sort, int $index): string
+    {
+        if (null === ($hierarchy = $this->expectedHierarchicalFacetOptions[$sort] ?? null)) {
+            throw new \Exception("Invalid sort '$sort'");
+        }
+        $facetValues = array_values($this->flattenFacetHierarchy($hierarchy));
+        if (null === ($facetValue = $facetValues[$index] ?? null)) {
+            throw new \Exception("Facet index $index out of bounds");
+        }
+        $display = [$facetValue['displayText']];
+        [$level] = explode('/', $facetValue['filter']);
+        while ($level > 0) {
+            --$index;
+            if (null === ($facetValue = $facetValues[$index] ?? null)) {
+                throw new \Exception("Facet index $index out of bounds");
+            }
+            array_unshift($display, $facetValue['displayText']);
+            [$level] = explode('/', $facetValue['filter']);
+        }
+        return implode('/', $display);
+    }
+
+    /**
+     * Flatten a hierarchical facet list to a simple array
+     *
+     * @param array $facetList Facet list
+     *
+     * @return array Simple array of facets
+     */
+    protected function flattenFacetHierarchy($facetList)
+    {
+        $results = [];
+        foreach ($facetList as $facetItem) {
+            $children = !empty($facetItem['children'])
+                ? $facetItem['children']
+                : [];
+            unset($facetItem['children']);
+            $results[] = $facetItem;
+            if ($children) {
+                $results = array_merge(
+                    $results,
+                    $this->flattenFacetHierarchy($children)
+                );
+            }
+        }
+        return $results;
+    }
+
+    /**
+     * Return a displayed hierarchical facet as a list of items
+     *
+     * @param Element $page                  Mink page object
+     * @param string  $treeContainerSelector Tree container element selector (ul needs to be an immediate child of this)
+     *
+     * @return array
+     */
+    protected function getHierarchicalFacetTreeItems(Element $page, string $treeContainerSelector): array
+    {
+        return $this->processFacetLevel($this->findCss($page, $treeContainerSelector));
+    }
+
+    /**
+     * Recursive helper for getHierarchicalFacetTreeItems to return a facet level and its children
+     *
+     * @param Element $node Container element for the list
+     *
+     * @return array
+     */
+    protected function processFacetLevel(Element $node): array
+    {
+        $result = [];
+        foreach ($node->findAll('css', ':scope > ul > li a.text') as $item) {
+            $result[] = $item->getText();
+            $result = [...$result, ...$this->processFacetLevel($item)];
+        }
+        return $result;
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -33,6 +33,7 @@ namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
 use Behat\Mink\Session;
+use VuFindTest\Feature\CacheManagementTrait;
 use VuFindTest\Feature\SearchFacetFilterTrait;
 
 /**
@@ -47,6 +48,7 @@ use VuFindTest\Feature\SearchFacetFilterTrait;
  */
 class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use CacheManagementTrait;
     use SearchFacetFilterTrait;
 
     /**
@@ -328,27 +330,98 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Data provider for testHierarchicalFacetsFilters
+     *
+     * @return array
+     */
+    public static function hierarchicalFacetFiltersProvider(): array
+    {
+        return [
+            'default sort' => [
+                null,
+                null,
+                'top',
+            ],
+            'top level alphabetical' => [
+                'top',
+                'all',
+                'top',
+            ],
+            'all alphabetical' => [
+                'all',
+                'top',
+                'all',
+            ],
+            'count' => [
+                'count',
+                'all',
+                'count',
+            ],
+            'default sort (inherited)' => [
+                null,
+                'top',
+                'top',
+            ],
+            'top level alphabetical (inherited)' => [
+                null,
+                'top',
+                'top',
+            ],
+            'all alphabetical (inherited)' => [
+                null,
+                'all',
+                'all',
+            ],
+            'count (inherited)' => [
+                null,
+                'count',
+                'count',
+            ],
+        ];
+    }
+
+    /**
      * Test that hierarchical facet filters work properly.
+     *
+     * @param ?string $sort         Sort option
+     * @param ?string $defaultSort  Default sort option
+     * @param string  $expectedSort Expected sort order of options
+     *
+     * @dataProvider hierarchicalFacetFiltersProvider
      *
      * @return void
      */
-    public function testHierarchicalFacetsFilters(): void
+    public function testHierarchicalFacetsFilters(?string $sort, ?string $defaultSort, string $expectedSort): void
     {
-        $this->changeConfigs(
-            [
-                'facets' => [
-                    'Results' => [
-                        'hierarchical_facet_str_mv' => 'hierarchy',
-                    ],
-                    'SpecialFacets' => [
-                        'hierarchical[]' => 'hierarchical_facet_str_mv',
-                    ],
-                    'Advanced' => [
-                        'hierarchical_facet_str_mv' => 'Hierarchy',
-                    ],
+        $config = [
+            'facets' => [
+                'Results' => [
+                    'hierarchical_facet_str_mv' => 'hierarchy',
                 ],
-            ]
-        );
+                'SpecialFacets' => [
+                    'hierarchical[]' => 'hierarchical_facet_str_mv',
+                ],
+                'Advanced' => [
+                    'hierarchical_facet_str_mv' => 'Hierarchy',
+                ],
+                'Advanced_Settings' => [
+                    'translated_facets[]' => 'hierarchical_facet_str_mv:Facets',
+                ],
+            ],
+        ];
+
+        if (null !== $sort) {
+            $config['facets']['Advanced_Settings']['hierarchicalFacetSortOptions']['hierarchical_facet_str_mv'] = $sort;
+        }
+        if (null !== $defaultSort) {
+            $config['facets']['SpecialFacets']['hierarchicalFacetSortOptions']['hierarchical_facet_str_mv']
+                = $defaultSort;
+        }
+        $this->changeConfigs($config + $this->getCacheClearPermissionConfig());
+
+        // Clear object cache to ensure clean state:
+        $this->clearObjectCache();
+
         $session = $this->getMinkSession();
         $page = $this->goToAdvancedSearch($session);
 
@@ -358,35 +431,14 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         foreach ($filter->findAll('css', 'option') as $option) {
             $options[$option->getValue()] = $option->getHtml();
         }
-        $expected = [
-            '~hierarchical_facet_str_mv:"0/level1a/"' => 'level1a',
-            '~hierarchical_facet_str_mv:"1/level1a/level2a/"' => '&nbsp;&nbsp;&nbsp;&nbsp;level2a',
-            '~hierarchical_facet_str_mv:"2/level1a/level2a/level3a/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3a',
-            '~hierarchical_facet_str_mv:"2/level1a/level2a/level3b/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3b',
-            '~hierarchical_facet_str_mv:"2/level1a/level2a/level3d/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3d',
-            '~hierarchical_facet_str_mv:"1/level1a/level2b/"' => '&nbsp;&nbsp;&nbsp;&nbsp;level2b',
-            '~hierarchical_facet_str_mv:"2/level1a/level2b/level3c/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3c',
-            '~hierarchical_facet_str_mv:"2/level1a/level2b/level3e/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3e',
-            '~hierarchical_facet_str_mv:"0/level1z/"' => 'level1z',
-            '~hierarchical_facet_str_mv:"1/level1z/level2y/"' => '&nbsp;&nbsp;&nbsp;&nbsp;level2y',
-            '~hierarchical_facet_str_mv:"2/level1z/level2y/level3g/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3g',
-            '~hierarchical_facet_str_mv:"1/level1z/level2z/"' => '&nbsp;&nbsp;&nbsp;&nbsp;level2z',
-            '~hierarchical_facet_str_mv:"2/level1z/level2z/level3z/"'
-                => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level3z',
-        ];
-
-        $this->assertEquals($expected, $options);
+        $expectedOptions = $this->getExpectedHierarchicalFacetOptions($expectedSort);
+        $this->assertSame($expectedOptions, $options);
 
         // Select second options, do a search and verify that the filter is active:
         $this->clickCss($page, '#limit_hierarchical_facet_str_mv option', null, 1);
         $this->clickCss($page, '.btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertAppliedFilter($page, 0, 'hierarchy', 'level1a/level2a');
+        $expectedValue = $this->getExpectedHierarchicalFacetFilterText($expectedSort, 1);
+        $this->assertAppliedFilter($page, 0, 'hierarchy', $expectedValue);
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RateLimiterTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RateLimiterTest.php
@@ -33,6 +33,7 @@ namespace VuFindTest\Mink;
 
 use Laminas\Http\Request;
 use VuFindHttp\HttpService;
+use VuFindTest\Feature\CacheManagementTrait;
 
 /**
  * Rate Limiter test class.
@@ -45,6 +46,8 @@ use VuFindHttp\HttpService;
  */
 class RateLimiterTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use CacheManagementTrait;
+
     /**
      * Standard setup method.
      *
@@ -54,25 +57,8 @@ class RateLimiterTest extends \VuFindTest\Integration\MinkTestCase
     {
         parent::setUp();
 
-        $this->changeConfigs(
-            [
-                'permissions' => [
-                    'enable-admin-cache-api' => [
-                        'permission' => 'access.api.admin.cache',
-                        'require' => 'ANY',
-                        'role' => 'guest',
-                    ],
-                ],
-            ]
-        );
-
-        // Clear object cache to ensure clean state:
-        $http = new HttpService();
-        $client = $http->createClient($this->getVuFindUrl('/api/v1/admin/cache?id=object'), Request::METHOD_DELETE);
-        $response = $client->send();
-        if (200 !== $response->getStatusCode()) {
-            throw new \Exception('Could not clear object cache: ' . $response->getBody());
-        }
+        $this->changeConfigs($this->getCacheClearPermissionConfig());
+        $this->clearObjectCache();
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -798,60 +798,19 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         return [
             [
                 null,
-                [
-                    [
-                        'value' => 'Top Level, Sorted Last',
-                        'children' => [
-                            'level2a',
-                            'level2b',
-                        ],
-                    ],
-                    [
-                        'value' => 'Top Level, Sorted First',
-                        'children' => [
-                            'Second Level, Sorted Last',
-                            'Second Level, Sorted First',
-                        ],
-                    ],
-                ],
+                'count',
+            ],
+            [
+                'count',
+                'count',
             ],
             [
                 'top',
-                [
-                    [
-                        'value' => 'Top Level, Sorted First',
-                        'children' => [
-                            'Second Level, Sorted Last',
-                            'Second Level, Sorted First',
-                        ],
-                    ],
-                    [
-                        'value' => 'Top Level, Sorted Last',
-                        'children' => [
-                            'level2a',
-                            'level2b',
-                        ],
-                    ],
-                ],
+                'top',
             ],
             [
                 'all',
-                [
-                    [
-                        'value' => 'Top Level, Sorted First',
-                        'children' => [
-                            'Second Level, Sorted First',
-                            'Second Level, Sorted Last',
-                        ],
-                    ],
-                    [
-                        'value' => 'Top Level, Sorted Last',
-                        'children' => [
-                            'level2a',
-                            'level2b',
-                        ],
-                    ],
-                ],
+                'all',
             ],
         ];
     }
@@ -859,14 +818,14 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Test that hierarchical facet sort options work properly.
      *
-     * @param ?string $sort     Sort option
-     * @param array   $expected Expected facet values in order
+     * @param ?string $sort         Sort option
+     * @param string  $expectedSort Expected sort order of facet hierarchy
      *
      * @dataProvider hierarchicalFacetSortProvider
      *
      * @return void
      */
-    public function testHierarchicalFacetSort(?string $sort, array $expected): void
+    public function testHierarchicalFacetSort(?string $sort, string $expectedSort): void
     {
         $facetConfig = [
             'Results' => [
@@ -888,22 +847,10 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
             ]
         );
         $page = $this->performSearch('building:"hierarchy.mrc"');
-        foreach ($expected as $index => $facet) {
-            $topLi = $this->findCss($page, '#side-collapse-hierarchical_facet_str_mv ul.facet-tree > li', null, $index);
-            $this->assertEquals(
-                $facet['value'],
-                $this->findCssAndGetText($topLi, '.facet-value'),
-                "Hierarchical facet item $index"
-            );
-            foreach ($facet['children'] as $childIndex => $childFacet) {
-                $childLi = $this->findCss($topLi, 'ul > li.facet-tree__parent', null, $childIndex);
-                $this->assertEquals(
-                    $childFacet,
-                    $this->findCssAndGetText($childLi, '.facet-value'),
-                    "Hierarchical facet item $index child $childIndex"
-                );
-            }
-        }
+
+        $expected = $this->getExpectedHierarchicalFacetTreeItems($expectedSort);
+        $actual = $this->getHierarchicalFacetTreeItems($page, '#side-collapse-hierarchical_facet_str_mv');
+        $this->assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
The tests should be clean for dev as well, but the actual sorting implementation is just a minimal fix for release-10.1 and needs some further refactoring in dev branch later on.

TODO
- [x] Add changelog note when merging (signature change to \VuFind\Search\Base\FacetCache constructor)