### PR TITLE
Eliminate mutable configs from tests

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
@@ -31,6 +31,7 @@ namespace VuFindTest\Auth;
 
 use Laminas\Config\Config;
 use Laminas\Http\Headers;
+use Laminas\Http\Request;
 use VuFind\Auth\Shibboleth;
 use VuFind\Auth\Shibboleth\MultiIdPConfigurationLoader;
 use VuFind\Auth\Shibboleth\SingleIdPConfigurationLoader;
@@ -107,21 +108,23 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param Config  $config             Configuration to use (null for default)
-     * @param Config  $shibConfig         Configuration with IdP
-     * @param boolean $useHeaders         use HTTP headers instead of environment variables
-     * @param boolean $requiredAttributes required attributes
+     * @param ?Config $config             Configuration to use (null for default)
+     * @param ?array  $shibConfig         Configuration with IdP
+     * @param bool    $useHeaders         use HTTP headers instead of environment variables
+     * @param bool    $requiredAttributes required attributes
      *
      * @return Shibboleth
      */
-    public function getAuthObject($config = null, $shibConfig = null, $useHeaders = false, $requiredAttributes = true)
-    {
-        if (null === $config) {
-            $config = $this->getAuthConfig($useHeaders, $requiredAttributes);
-        }
-        $loader = ($shibConfig == null)
+    public function getAuthObject(
+        ?Config $config = null,
+        ?array $shibConfig = null,
+        bool $useHeaders = false,
+        bool $requiredAttributes = true
+    ): Shibboleth {
+        $config ??= new Config($this->getAuthConfig($useHeaders, $requiredAttributes));
+        $loader = ($shibConfig === null)
             ? new SingleIdPConfigurationLoader($config)
-            : new MultiIdPConfigurationLoader($config, $shibConfig);
+            : new MultiIdPConfigurationLoader($config, new Config($shibConfig));
         $obj = new Shibboleth(
             $this->createMock(\Laminas\Session\ManagerInterface::class),
             $loader,
@@ -140,9 +143,9 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      * @param bool $useHeaders         Value for use_headers config setting
      * @param bool $requiredAttributes Should we include a required attribute in config?
      *
-     * @return Config
+     * @return array
      */
-    public function getAuthConfig($useHeaders = false, $requiredAttributes = true)
+    public function getAuthConfig(bool $useHeaders = false, bool $requiredAttributes = true): array
     {
         $config = [
             'login' => 'http://myserver',
@@ -156,42 +159,31 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
                 'userattribute_value_1' => 'testpass',
             ];
         }
-        $shibConfig = new Config($config, true);
-        return new Config(['Shibboleth' => $shibConfig], true);
+        return ['Shibboleth' => $config];
     }
 
     /**
      * Get a working configuration for the Shibboleth object
      *
-     * @return Config
+     * @return array
      */
-    public function getShibbolethConfig()
+    public function getShibbolethConfig(): array
     {
-        $example1 = new Config(
-            [
-                'entityId' => 'https://idp1.example.org/',
-                'username' => 'username',
-                'email' => 'email',
-                'cat_username' => 'userLibraryId',
-            ],
-            true
-        );
-        $example2 = new Config(
-            [
-                'entityId' => 'https://idp2.example.org/',
-                'username' => 'eppn',
-                'email' => 'email',
-                'cat_username' => 'alephId',
-                'userattribute_1' => 'eduPersonScopedAffiliation',
-                'userattribute_value_1' => 'member@example.org',
-            ],
-            true
-        );
-        $config = [
-            'example1' => $example1,
-            'example2' => $example2,
+        $example1 = [
+            'entityId' => 'https://idp1.example.org/',
+            'username' => 'username',
+            'email' => 'email',
+            'cat_username' => 'userLibraryId',
         ];
-        return new Config($config, true);
+        $example2 = [
+            'entityId' => 'https://idp2.example.org/',
+            'username' => 'eppn',
+            'email' => 'email',
+            'cat_username' => 'alephId',
+            'userattribute_1' => 'eduPersonScopedAffiliation',
+            'userattribute_value_1' => 'member@example.org',
+        ];
+        return compact('example1', 'example2');
     }
 
     /**
@@ -199,7 +191,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCreateIsDisallowed()
+    public function testCreateIsDisallowed(): void
     {
         $this->assertFalse($this->getAuthObject()->supportsCreation());
     }
@@ -208,12 +200,12 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      * Support method -- get parameters to log into an account (but allow override of
      * individual parameters so we can test different scenarios).
      *
-     * @param array   $overrides  Associative array of parameters to override.
-     * @param boolean $useHeaders Use headers instead of environment variables
+     * @param array $overrides  Associative array of parameters to override.
+     * @param bool  $useHeaders Use headers instead of environment variables
      *
-     * @return \Laminas\Http\Request
+     * @return Request
      */
-    protected function getLoginRequest($overrides = [], $useHeaders = false)
+    protected function getLoginRequest(array $overrides = [], bool $useHeaders = false): Request
     {
         $server = $overrides + [
             'username' => 'testuser', 'email' => 'user@test.com',
@@ -235,7 +227,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankUsername()
+    public function testLoginWithBlankUsername(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -248,7 +240,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLoginWithBlankPassword()
+    public function testLoginWithBlankPassword(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
@@ -261,13 +253,13 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithMissingAttributeValue()
+    public function testWithMissingAttributeValue(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
         $config = $this->getAuthConfig();
-        unset($config->Shibboleth->userattribute_value_1);
-        $this->getAuthObject($config)->authenticate($this->getLoginRequest());
+        unset($config['Shibboleth']['userattribute_value_1']);
+        $this->getAuthObject(new Config($config))->authenticate($this->getLoginRequest());
     }
 
     /**
@@ -275,13 +267,13 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithoutUsername()
+    public function testWithoutUsername(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
         $config = $this->getAuthConfig();
-        unset($config->Shibboleth->username);
-        $this->getAuthObject($config)->authenticate($this->getLoginRequest());
+        unset($config['Shibboleth']['username']);
+        $this->getAuthObject(new Config($config))->authenticate($this->getLoginRequest());
     }
 
     /**
@@ -289,13 +281,13 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithoutLoginSetting()
+    public function testWithoutLoginSetting(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
 
         $config = $this->getAuthConfig();
-        unset($config->Shibboleth->login);
-        $this->getAuthObject($config)->getSessionInitiator('http://target');
+        unset($config['Shibboleth']['login']);
+        $this->getAuthObject(new Config($config))->getSessionInitiator('http://target');
     }
 
     /**
@@ -303,7 +295,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSessionInitiator()
+    public function testSessionInitiator(): void
     {
         $this->assertEquals(
             'http://myserver?target=http%3A%2F%2Ftarget%3Fauth_method%3DShibboleth',
@@ -316,7 +308,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLogin()
+    public function testLogin(): void
     {
         $user = $this->getAuthObject()->authenticate($this->getLoginRequest());
         $this->assertEquals('testuser', $user->username);
@@ -328,7 +320,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLogin1()
+    public function testLogin1(): void
     {
         $user = $this->getAuthObject(null, $this->getShibbolethConfig())
             ->authenticate($this->getLoginRequest($this->user1, false));
@@ -341,7 +333,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLogin2()
+    public function testLogin2(): void
     {
         $user = $this->getAuthObject(null, $this->getShibbolethConfig())
             ->authenticate($this->getLoginRequest($this->user2, false));
@@ -354,7 +346,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testFailedLogin()
+    public function testFailedLogin(): void
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->getAuthObject(null, $this->getShibbolethConfig())
@@ -366,7 +358,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testProxyLogin()
+    public function testProxyLogin(): void
     {
         $user = $this->getAuthObject(null, $this->getShibbolethConfig(), true, false)
             ->authenticate($this->getLoginRequest($this->proxyUser, true));

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ShibbolethTest.php
@@ -108,20 +108,20 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param ?Config $config             Configuration to use (null for default)
-     * @param ?array  $shibConfig         Configuration with IdP
-     * @param bool    $useHeaders         use HTTP headers instead of environment variables
-     * @param bool    $requiredAttributes required attributes
+     * @param ?array $config             Configuration to use (null for default)
+     * @param ?array $shibConfig         Configuration with IdP
+     * @param bool   $useHeaders         use HTTP headers instead of environment variables
+     * @param bool   $requiredAttributes required attributes
      *
      * @return Shibboleth
      */
     public function getAuthObject(
-        ?Config $config = null,
+        ?array $config = null,
         ?array $shibConfig = null,
         bool $useHeaders = false,
         bool $requiredAttributes = true
     ): Shibboleth {
-        $config ??= new Config($this->getAuthConfig($useHeaders, $requiredAttributes));
+        $config = new Config($config ?? $this->getAuthConfig($useHeaders, $requiredAttributes));
         $loader = ($shibConfig === null)
             ? new SingleIdPConfigurationLoader($config)
             : new MultiIdPConfigurationLoader($config, new Config($shibConfig));
@@ -259,7 +259,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
 
         $config = $this->getAuthConfig();
         unset($config['Shibboleth']['userattribute_value_1']);
-        $this->getAuthObject(new Config($config))->authenticate($this->getLoginRequest());
+        $this->getAuthObject($config)->authenticate($this->getLoginRequest());
     }
 
     /**
@@ -273,7 +273,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
 
         $config = $this->getAuthConfig();
         unset($config['Shibboleth']['username']);
-        $this->getAuthObject(new Config($config))->authenticate($this->getLoginRequest());
+        $this->getAuthObject($config)->authenticate($this->getLoginRequest());
     }
 
     /**
@@ -287,7 +287,7 @@ final class ShibbolethTest extends \PHPUnit\Framework\TestCase
 
         $config = $this->getAuthConfig();
         unset($config['Shibboleth']['login']);
-        $this->getAuthObject(new Config($config))->getSessionInitiator('http://target');
+        $this->getAuthObject($config)->getSessionInitiator('http://target');
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
@@ -153,7 +153,6 @@ class CASTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('Valid CAS/service_base_url or Site/url config parameters are required.');
         $cas = $this->getAuthObject();
-        $cas->setConfig(new Config($this->getAuthConfig()));
         $this->callMethod($cas, 'getServiceBaseUrl');
     }
 
@@ -164,9 +163,8 @@ class CASTest extends \PHPUnit\Framework\TestCase
      */
     public function testWorkingBaseUrlConfig(): void
     {
-        $cas = $this->getAuthObject();
         $urls = ['http://foo', 'http://bar'];
-        $cas->setConfig(new Config($this->getAuthConfig(['service_base_url' => $urls])));
+        $cas = $this->getAuthObject($this->getAuthConfig(['service_base_url' => $urls]));
         $this->assertEquals($urls, $this->callMethod($cas, 'getServiceBaseUrl'));
     }
 
@@ -195,9 +193,8 @@ class CASTest extends \PHPUnit\Framework\TestCase
      */
     public function testBaseUrlConfigFallback(string $url, string $host): void
     {
-        $cas = $this->getAuthObject();
-        $config = new Config($this->getAuthConfig([], ['Site' => ['url' => $url]]));
-        $cas->setConfig($config);
+        $config = $this->getAuthConfig([], ['Site' => ['url' => $url]]);
+        $cas = $this->getAuthObject($config);
         $this->assertEquals([$host], $this->callMethod($cas, 'getServiceBaseUrl'));
     }
 
@@ -210,10 +207,9 @@ class CASTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('Valid CAS/service_base_url or Site/url config parameters are required.');
-        $cas = $this->getAuthObject();
         $url = 'not-a-url';
-        $config = new Config($this->getAuthConfig([], ['Site' => ['url' => $url]]));
-        $cas->setConfig($config);
+        $config = $this->getAuthConfig([], ['Site' => ['url' => $url]]);
+        $cas = $this->getAuthObject($config);
         $this->callMethod($cas, 'getServiceBaseUrl');
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
@@ -48,14 +48,14 @@ class CASTest extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param ?Config $config Configuration to use (null for default)
+     * @param ?array $config Configuration to use (null for default)
      *
      * @return CAS
      */
-    public function getAuthObject(?Config $config = null): CAS
+    public function getAuthObject(?array $config = null): CAS
     {
         $obj = new CAS($this->createMock(\VuFind\Auth\ILSAuthenticator::class));
-        $obj->setConfig($config ?? $this->getAuthConfig());
+        $obj->setConfig(new Config($config ?? $this->getAuthConfig()));
         return $obj;
     }
 
@@ -65,22 +65,19 @@ class CASTest extends \PHPUnit\Framework\TestCase
      * @param array $extraCasConfig Extra config parameters to include in [CAS] section
      * @param array $extraTopConfig Extra top-level config settings to include
      *
-     * @return Config
+     * @return array
      */
-    public function getAuthConfig(array $extraCasConfig = [], array $extraTopConfig = []): Config
+    public function getAuthConfig(array $extraCasConfig = [], array $extraTopConfig = []): array
     {
-        $casConfig = new Config(
-            [
-                'server' => 'localhost',
-                'port' => 1234,
-                'context' => 'foo',
-                'CACert' => 'bar',
-                'login' => 'http://cas/login',
-                'logout' => 'http://cas/logout',
-            ] + $extraCasConfig,
-            true
-        );
-        return new Config(['CAS' => $casConfig] + $extraTopConfig, true);
+        $casConfig = [
+            'server' => 'localhost',
+            'port' => 1234,
+            'context' => 'foo',
+            'CACert' => 'bar',
+            'login' => 'http://cas/login',
+            'logout' => 'http://cas/logout',
+        ] + $extraCasConfig;
+        return ['CAS' => $casConfig] + $extraTopConfig;
     }
 
     /**
@@ -114,7 +111,7 @@ class CASTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\VuFind\Exception\Auth::class);
 
         $config = $this->getAuthConfig();
-        unset($config->CAS->$key);
+        unset($config['CAS'][$key]);
         $this->getAuthObject($config)->getConfig();
     }
 
@@ -156,7 +153,7 @@ class CASTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\VuFind\Exception\Auth::class);
         $this->expectExceptionMessage('Valid CAS/service_base_url or Site/url config parameters are required.');
         $cas = $this->getAuthObject();
-        $cas->setConfig($this->getAuthConfig());
+        $cas->setConfig(new Config($this->getAuthConfig()));
         $this->callMethod($cas, 'getServiceBaseUrl');
     }
 
@@ -169,7 +166,7 @@ class CASTest extends \PHPUnit\Framework\TestCase
     {
         $cas = $this->getAuthObject();
         $urls = ['http://foo', 'http://bar'];
-        $cas->setConfig($this->getAuthConfig(['service_base_url' => $urls]));
+        $cas->setConfig(new Config($this->getAuthConfig(['service_base_url' => $urls])));
         $this->assertEquals($urls, $this->callMethod($cas, 'getServiceBaseUrl'));
     }
 
@@ -199,7 +196,7 @@ class CASTest extends \PHPUnit\Framework\TestCase
     public function testBaseUrlConfigFallback(string $url, string $host): void
     {
         $cas = $this->getAuthObject();
-        $config = $this->getAuthConfig([], ['Site' => ['url' => $url]]);
+        $config = new Config($this->getAuthConfig([], ['Site' => ['url' => $url]]));
         $cas->setConfig($config);
         $this->assertEquals([$host], $this->callMethod($cas, 'getServiceBaseUrl'));
     }
@@ -215,7 +212,7 @@ class CASTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Valid CAS/service_base_url or Site/url config parameters are required.');
         $cas = $this->getAuthObject();
         $url = 'not-a-url';
-        $config = $this->getAuthConfig([], ['Site' => ['url' => $url]]);
+        $config = new Config($this->getAuthConfig([], ['Site' => ['url' => $url]]));
         $cas->setConfig($config);
         $this->callMethod($cas, 'getServiceBaseUrl');
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiAuthTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiAuthTest.php
@@ -48,35 +48,32 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param Config $config Configuration to use (null for default)
+     * @param ?array $config Configuration to use (null for default)
      *
      * @return MultiAuth
      */
-    public function getAuthObject(Config $config = null): MultiAuth
+    public function getAuthObject(?array $config = null): MultiAuth
     {
         $container = new \VuFindTest\Container\MockContainer($this);
         $container->set(\VuFind\Log\Logger::class, $this->createMock(\Laminas\Log\LoggerInterface::class));
         $manager = new \VuFind\Auth\PluginManager($container);
         $obj = $manager->get('MultiAuth');
         $obj->setPluginManager($manager);
-        $obj->setConfig($config ?? $this->getAuthConfig());
+        $obj->setConfig(new Config($config ?? $this->getAuthConfig()));
         return $obj;
     }
 
     /**
      * Get a working configuration for the auth object
      *
-     * @return Config
+     * @return array
      */
-    public function getAuthConfig(): Config
+    public function getAuthConfig(): array
     {
-        $config = new Config(
-            [
-                'method_order' => 'Database,ILS',
-            ],
-            true
-        );
-        return new Config(['MultiAuth' => $config], true);
+        $config = [
+            'method_order' => 'Database,ILS',
+        ];
+        return ['MultiAuth' => $config];
     }
 
     /**
@@ -92,7 +89,7 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
         );
 
         $config = $this->getAuthConfig();
-        unset($config->MultiAuth->method_order);
+        unset($config['MultiAuth']['method_order']);
         $this->getAuthObject($config)->getConfig();
     }
 
@@ -128,7 +125,7 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
         );
 
         $config = $this->getAuthConfig();
-        $config->MultiAuth->method_order = 'InappropriateService,Database';
+        $config['MultiAuth']['method_order'] = 'InappropriateService,Database';
 
         $request = $this->getLoginRequest();
         $this->getAuthObject($config)->authenticate($request);
@@ -150,7 +147,7 @@ class MultiAuthTest extends \PHPUnit\Framework\TestCase
         );
 
         $config = $this->getAuthConfig();
-        $config->MultiAuth->method_order = $badClass . ',Database';
+        $config['MultiAuth']['method_order'] = $badClass . ',Database';
 
         $request = $this->getLoginRequest();
         $this->getAuthObject($config)->authenticate($request);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/SIP2Test.php
@@ -48,35 +48,29 @@ class SIP2Test extends \PHPUnit\Framework\TestCase
     /**
      * Get an authentication object.
      *
-     * @param ?Config $config Configuration to use (null for default)
+     * @param ?array $config Configuration to use (null for default)
      *
      * @return SIP2
      */
-    public function getAuthObject(?Config $config = null): SIP2
+    public function getAuthObject(?array $config = null): SIP2
     {
-        if (null === $config) {
-            $config = $this->getAuthConfig();
-        }
         $obj = new SIP2($this->createMock(ILSAuthenticator::class));
-        $obj->setConfig($config);
+        $obj->setConfig(new Config($config ?? $this->getAuthConfig()));
         return $obj;
     }
 
     /**
      * Get a working configuration for the LDAP object
      *
-     * @return Config
+     * @return array
      */
-    public function getAuthConfig(): Config
+    public function getAuthConfig(): array
     {
-        $config = new Config(
-            [
-                'host' => 'my.fake.host',
-                'port' => '6002',
-            ],
-            true
-        );
-        return new Config(['MultiAuth' => $config], true);
+        $config = [
+            'host' => 'my.fake.host',
+            'port' => '6002',
+        ];
+        return ['MultiAuth' => $config];
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ConsortialVuFindTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ConsortialVuFindTest.php
@@ -87,7 +87,7 @@ class ConsortialVuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetResults()
+    public function testGetResults(): void
     {
         $config = $this->buildConfig();
         $consortialVuFind = $this->buildConsortialVuFind($config);
@@ -112,7 +112,7 @@ class ConsortialVuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetMoreResultsUrl()
+    public function testGetMoreResultsUrl(): void
     {
         $config = $this->buildConfig();
         $consortialVuFind = $this->buildConsortialVuFind($config);
@@ -124,30 +124,29 @@ class ConsortialVuFindTest extends \PHPUnit\Framework\TestCase
     /**
      * Build an object representing an ExternalVuFind.ini configuration file
      *
-     * @return ConsortialVuFind
+     * @return array
      */
-    protected function buildConfig()
+    protected function buildConfig(): array
     {
-        $config = new Config([
+        return [
             'ReShare' => [
                 'api_base_url' => 'http://some.url/api',
                 'record_base_url' => 'https://some.url/Record',
                 'results_base_url' => 'https://some.url/Search/Results',
             ],
-        ], true);
-        return $config;
+        ];
     }
 
     /**
      * Build and pre-process a ConsortialVuFind object
      *
-     * @param Config $config The config object
+     * @param array $config The config array
      *
      * @return ConsortialVuFind
      */
-    protected function buildConsortialVuFind($config)
+    protected function buildConsortialVuFind(array $config): ConsortialVuFind
     {
-        $consortialVuFind = new ConsortialVuFind($config, $this->connector);
+        $consortialVuFind = new ConsortialVuFind(new Config($config), $this->connector);
         $consortialVuFind->setConfig('lookfor:3:ReShare');
 
         $queryResults = $this->buildQueryResults('civil war');
@@ -164,7 +163,7 @@ class ConsortialVuFindTest extends \PHPUnit\Framework\TestCase
      *
      * @return Results The Results object
      */
-    protected function buildQueryResults($queryString, $facets = [])
+    protected function buildQueryResults(string $queryString, array $facets = []): Results
     {
         // Build query Params
         $queryParams = new Params(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -32,6 +32,7 @@ namespace VuFindTest\Recommend;
 
 use Laminas\Cache\Storage\StorageInterface as CacheAdapter;
 use Laminas\Config\Config;
+use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Config\PluginManager as ConfigPluginManager;
 use VuFind\Connection\LibGuides;
 use VuFind\Recommend\LibGuidesProfile;
@@ -95,10 +96,9 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSubjectExactMatch()
+    public function testSubjectExactMatch(): void
     {
-        $config = new Config([], true);
-        $config->Profile = ['strategies' =>  ['Subject']];
+        $config = ['Profile' => ['strategies' => ['Subject']]];
         $libGuidesProfile = $this->buildProfile($config);
 
         $queryResults = $this->buildQueryResults('Geography');
@@ -113,10 +113,9 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSubjectSubstring()
+    public function testSubjectSubstring(): void
     {
-        $config = new Config([], true);
-        $config->Profile = ['strategies' =>  ['Subject']];
+        $config = ['Profile' => ['strategies' => ['Subject']]];
         $libGuidesProfile = $this->buildProfile($config);
 
         // Exact match would be "Decimal Classification"
@@ -132,10 +131,9 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSubjectLooseMatch()
+    public function testSubjectLooseMatch(): void
     {
-        $config = new Config([], true);
-        $config->Profile = ['strategies' =>  ['Subject']];
+        $config = ['Profile' => ['strategies' => ['Subject']]];
         $libGuidesProfile = $this->buildProfile($config);
 
         // Exact match would be "Music Theory"
@@ -151,18 +149,19 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCallNumberMatch()
+    public function testCallNumberMatch(): void
     {
-        $config = new Config([], true);
-        $config->Profile = [
-            'strategies' =>  ['CallNumber'],
-            'profile_aliases' => [
-                'Dewey' => 1234,
-                'Eratosthenes' => 5678,
-            ],
-            'call_numbers' => [
-                'D' => 'Eratosthenes',
-                'P' => 'Dewey',
+        $config = [
+            'Profile' => [
+                'strategies' =>  ['CallNumber'],
+                'profile_aliases' => [
+                    'Dewey' => 1234,
+                    'Eratosthenes' => 5678,
+                ],
+                'call_numbers' => [
+                    'D' => 'Eratosthenes',
+                    'P' => 'Dewey',
+                ],
             ],
         ];
         $libGuidesProfile = $this->buildProfile($config);
@@ -192,11 +191,11 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
     /**
      * Build a partially mocked LibGuidesProfile object
      *
-     * @param Config $config The config object
+     * @param array $config The config object
      *
-     * @return LibGuidesProfile
+     * @return LibGuidesProfile&MockObject
      */
-    protected function buildProfile($config)
+    protected function buildProfile(array $config): LibGuidesProfile&MockObject
     {
         // Mock caching logic in LibGuidesProfile.
         // Caching is from a trait, which is not the point of this test suite.
@@ -204,7 +203,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
 
         // For the target class LibGuidesProfile, only mock the caching methods
         $libGuidesProfile = $this->getMockBuilder(LibGuidesProfile::class)
-            ->setConstructorArgs([$this->connector, $config, $this->cacheAdapter])
+            ->setConstructorArgs([$this->connector, new Config($config), $this->cacheAdapter])
             ->onlyMethods(['getCachedData', 'putCachedData'])
             ->getMock();
         $libGuidesProfile->method('getCachedData')->willReturn(null);
@@ -219,7 +218,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
      *
      * @return Results The Results object
      */
-    protected function buildQueryResults($queryString, $facets = [])
+    protected function buildQueryResults($queryString, $facets = []): Results
     {
         // Build query Params
         $queryParams = new Params(


### PR DESCRIPTION
The laminas-config library has been deprecated. As a first step toward eliminating it, I am removing advanced usages from the code, starting with mutable Config objects. This PR simplifies some tests that were previously relying on this feature. I did some general type improvement and simplification while I was working on these files anyway.