### PR TITLE
KohaRest: Fix wrong function return value when no items exist

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2104,14 +2104,14 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         }
         $result = $this->makeRequest($requestParams);
         if (404 == $result['code']) {
-            return [];
+            return $results;
         }
         if (200 != $result['code']) {
             throw new ILSException('Problem with Koha REST API.');
         }
 
         if (empty($result['data']['item_availabilities'])) {
-            return [];
+            return $results;
         }
 
         // Return total number of results for pagination (with fallback for older


### PR DESCRIPTION
There was already a default return value in getItemStatusesForBiblio, but it wasn't used in all cases.