### PR TITLE
Simplify LibGuidesProfile config handling and test; fix types.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -69,7 +69,7 @@ class LibGuidesProfile implements
     /**
      * List of strategies enabled to find a matching LibGuides profile
      *
-     * @var int
+     * @var array
      */
     protected $strategies = [];
 
@@ -119,14 +119,14 @@ class LibGuidesProfile implements
         // Cache the data related to profiles for up to 10 minutes:
         $this->cacheLifetime = intval($config->GetAccounts->cache_lifetime ?? 600);
 
-        if ($profile = $config->Profile) {
-            $strategies = $profile->get('strategies', []);
+        if ($profile = $config->Profile->toArray()) {
+            $strategies = $profile['strategies'] ?? [];
             $this->strategies = is_string($strategies) ? [$strategies] : $strategies;
 
-            $this->callNumberToAlias = $profile->call_numbers ? $profile->call_numbers->toArray() : [];
-            $this->aliasToAccountId = $profile->profile_aliases ? $profile->profile_aliases->toArray() : [];
-            $this->callNumberField = $profile->get('call_number_field', 'callnumber-first');
-            $this->callNumberLength = $profile->get('call_number_length', 3);
+            $this->callNumberToAlias = $profile['call_numbers'] ?? [];
+            $this->aliasToAccountId = $profile['profile_aliases'] ?? [];
+            $this->callNumberField = $profile['call_number_field'] ?? 'callnumber-first';
+            $this->callNumberLength = $profile['call_number_length'] ?? 3;
         }
     }
 
@@ -179,7 +179,7 @@ class LibGuidesProfile implements
     /**
      * Get terms related to the query.
      *
-     * @return array
+     * @return mixed
      */
     public function getResults()
     {

--- a/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
+++ b/module/VuFind/src/VuFind/Recommend/LibGuidesProfile.php
@@ -211,7 +211,7 @@ class LibGuidesProfile implements
      *
      * @param \VuFind\Search\Base\Results $results Search results object
      *
-     * @return array LibGuides account
+     * @return mixed LibGuides account object or false
      */
     protected function findBestMatchByCallNumber($results)
     {
@@ -269,7 +269,7 @@ class LibGuidesProfile implements
      *
      * @param \VuFind\Search\Base\Results $results Search results object
      *
-     * @return array LibGuides account
+     * @return mixed LibGuides account object or false
      */
     protected function findBestMatchBySubject($results)
     {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesProfileTest.php
@@ -83,9 +83,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
     public function setUp(): void
     {
         // Mock LibGuides connector
-        $this->connector = $this->getMockBuilder(LibGuides::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->connector = $this->createMock(LibGuides::class);
         $accountsFixture = $this->getFixture('libguides/api/accounts');
         $accounts = json_decode(substr($accountsFixture, strpos($accountsFixture, '[')));
         $this->connector->method('getAccounts')->willReturn($accounts);
@@ -231,9 +229,7 @@ class LibGuidesProfileTest extends \PHPUnit\Framework\TestCase
         $queryResults = new Results(
             $queryParams,
             $this->createStub(\VuFindSearch\Service::class),
-            $this->getMockBuilder(\VuFind\Record\Loader::class)
-                ->disableOriginalConstructor()
-                ->getMock(),
+            $this->createMock(\VuFind\Record\Loader::class),
             null,
             $facets
         );


### PR DESCRIPTION
@maccabeelevine, while working on replacing the abandoned laminas-config library, I stumbled upon some issues in the LibGuidesProfile recommendation module: the configuration loading in the constructor was a bit unnecessarily complicated, and some of the typehints were incorrect. While in the area, I also simplified a couple of mock calls in the associated test to shave off lines of code.

Please let me know if you have any concerns about these adjustments, or if we can do anything to improve the return type of the `getResults` method. It reports returning an array, but it actually appears to return either an object or boolean false in some situations. I just changed it to `mixed` here, but it would obviously be better to be more specific if at all possible!