### PR TITLE
Stop using laminas-config-specific exceptions.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractMultiDriver.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractMultiDriver.php
@@ -189,7 +189,7 @@ abstract class AbstractMultiDriver extends AbstractBase implements \Laminas\Log\
                 ? $name
                 : $this->driversConfigPath . '/' . $name;
             $config = $this->configLoader->get($path);
-        } catch (\Laminas\Config\Exception\RuntimeException $e) {
+        } catch (\Exception $e) {
             // Configuration loading failed; probably means file does not
             // exist -- just return an empty array in that case:
             $this->error("Could not load config for $name");

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AbstractMultiDriverTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AbstractMultiDriverTestCase.php
@@ -32,7 +32,7 @@
 
 namespace VuFindTest\ILS\Driver;
 
-use Laminas\Config\Exception\RuntimeException;
+use RuntimeException;
 use VuFind\ILS\Driver\AbstractMultiDriver;
 
 use function call_user_func_array;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/ComposedDriverTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/ComposedDriverTest.php
@@ -29,7 +29,7 @@
 
 namespace VuFindTest\ILS\Driver;
 
-use Laminas\Config\Exception\RuntimeException;
+use RuntimeException;
 use VuFind\ILS\Driver\ComposedDriver;
 use VuFind\ILS\Logic\AvailabilityStatusInterface;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiBackendTest.php
@@ -31,7 +31,7 @@
 
 namespace VuFindTest\ILS\Driver;
 
-use Laminas\Config\Exception\RuntimeException;
+use RuntimeException;
 use VuFind\Exception\ILS as ILSException;
 use VuFind\ILS\Driver\MultiBackend;
 


### PR DESCRIPTION
Since laminas-config has been abandoned, we need to stop using its specific exceptions so that we can remove the package.