### PR TITLE
Disable !important  rule in lessToSass.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,7 @@ module.exports = function(grunt) {
           }
         ],
         options: {
+          excludes: ['important'],
           replacements: [
             // Activate SCSS
             {

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/consent-modal.scss
@@ -689,7 +689,7 @@ $cc-footer-links-gap: 1.3rem !default;
             max-width: none!important;
             min-width: auto!important;
             border-left: none!important;
-            border-top: 1px solid var(--cc-separator-border-color !important);
+            border-top: 1px solid var(--cc-separator-border-color)!important;
         }
 
         .cm__btn + .cm__btn,

--- a/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
+++ b/themes/bootstrap3/scss/components/cookie-consent/core/components/preferences-modal.scss
@@ -1000,6 +1000,6 @@ $cc-service-toggle-knob-icon-width: 1.7px !default;
     }
 
     .show--preferences #cc-main .cc--anim .pm{
-        transform: translateY(0 !important);
+        transform: translateY(0)!important;
     }
 }

--- a/themes/bootstrap5/scss/components/cookie-consent/core/components/consent-modal.scss
+++ b/themes/bootstrap5/scss/components/cookie-consent/core/components/consent-modal.scss
@@ -689,7 +689,7 @@ $cc-footer-links-gap: 1.3rem !default;
             max-width: none!important;
             min-width: auto!important;
             border-left: none!important;
-            border-top: 1px solid var(--cc-separator-border-color !important);
+            border-top: 1px solid var(--cc-separator-border-color)!important;
         }
 
         .cm__btn + .cm__btn,

--- a/themes/bootstrap5/scss/components/cookie-consent/core/components/preferences-modal.scss
+++ b/themes/bootstrap5/scss/components/cookie-consent/core/components/preferences-modal.scss
@@ -1000,6 +1000,6 @@ $cc-service-toggle-knob-icon-width: 1.7px !default;
     }
 
     .show--preferences #cc-main .cc--anim .pm{
-        transform: translateY(0 !important);
+        transform: translateY(0)!important;
     }
 }


### PR DESCRIPTION
We don't have rules that need it, and it messes up plain CSS functions such as var().