### PR TITLE
Improve empty collection detection for similar records display

### DIFF
--- a/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
@@ -1,6 +1,6 @@
 <h2><?=$this->transEsc('Similar Items')?></h2>
 <?php $similarRecords = $this->tab->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
   <?php $perPage = 4 ?>
   <div id="similar-items-carousel" class="carousel slide" data-ride="carousel">
     <!-- Indicators -->

--- a/themes/bootstrap3/templates/Related/MoreByAuthorSolr.phtml
+++ b/themes/bootstrap3/templates/Related/MoreByAuthorSolr.phtml
@@ -1,5 +1,5 @@
 <?php $similarRecords = $this->related->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
     <h2><?=$this->transEsc('more_by_author', ['%%name%%' => $this->related->getName()])?></h2>
     <ul class="list-group">
         <?php foreach ($similarRecords as $data): ?>

--- a/themes/bootstrap3/templates/Related/Similar.phtml
+++ b/themes/bootstrap3/templates/Related/Similar.phtml
@@ -1,6 +1,6 @@
 <h2><?=$this->transEsc('Similar Items')?></h2>
 <?php $similarRecords = $this->related->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
   <ul class="list-group">
     <?php foreach ($similarRecords as $data): ?>
       <li class="list-group-item"><?=$this->render('Related/Similar/item.phtml', compact('data'))?></li>

--- a/themes/bootstrap5/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap5/templates/RecordTab/similaritemscarousel.phtml
@@ -1,6 +1,6 @@
 <h2><?=$this->transEsc('Similar Items')?></h2>
 <?php $similarRecords = $this->tab->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
   <?php $perPage = 4 ?>
   <div id="similar-items-carousel" class="carousel slide" data-bs-ride="carousel">
     <!-- Indicators -->

--- a/themes/bootstrap5/templates/Related/MoreByAuthorSolr.phtml
+++ b/themes/bootstrap5/templates/Related/MoreByAuthorSolr.phtml
@@ -1,5 +1,5 @@
 <?php $similarRecords = $this->related->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
     <h2><?=$this->transEsc('more_by_author', ['%%name%%' => $this->related->getName()])?></h2>
     <ul class="list-group">
         <?php foreach ($similarRecords as $data): ?>

--- a/themes/bootstrap5/templates/Related/Similar.phtml
+++ b/themes/bootstrap5/templates/Related/Similar.phtml
@@ -1,6 +1,6 @@
 <h2><?=$this->transEsc('Similar Items')?></h2>
 <?php $similarRecords = $this->related->getResults(); ?>
-<?php if (!empty($similarRecords)): ?>
+<?php if (count($similarRecords)): ?>
   <ul class="list-group">
     <?php foreach ($similarRecords as $data): ?>
       <li class="list-group-item"><?=$this->render('Related/Similar/item.phtml', compact('data'))?></li>


### PR DESCRIPTION
Hi! First PR here, so let me know what I'm doing wrong :-)

Our Solr instance is currently responding with empty result sets to "morelikethis" queries. In investigating that problem, we noticed that the 'Cannot find similar records' text is never displayed.

This PR appears to fix the display problem, which was caused by the PHP empty() function being called on an object rather than having an isEmpty() method.