### PR TITLE
FOLIO: fix missing item ID bug for title-level requests

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2155,22 +2155,24 @@ class Folio extends AbstractAPI implements
      */
     public function checkRequestIsValid($id, $data, $patron)
     {
-        // Check outstanding loans
-        $currentLoan = $this->getCurrentLoan($data['item_id']);
-        if (!$currentLoan || $this->isHoldableByCurrentLoan($currentLoan)) {
-            $allowed = $this->getAllowedServicePoints($this->getInstanceByBibId($id)->id, $patron['id']);
-            return [
-                // If we got this far, it's valid if we can't obtain allowed service point
-                // data, or if the allowed service point data is non-empty:
-                'valid' => null === $allowed || !empty($allowed),
-                'status' => 'request_place_text',
-            ];
-        } else {
+        // First check outstanding loans:
+        $currentLoan = empty($data['item_id'])
+            ? null
+            : $this->getCurrentLoan($data['item_id']);
+        if ($currentLoan && !$this->isHoldableByCurrentLoan($currentLoan)) {
             return [
                 'valid' => false,
                 'status' => 'hold_error_current_loan_patron_group',
             ];
         }
+
+        $allowed = $this->getAllowedServicePoints($this->getInstanceByBibId($id)->id, $patron['id']);
+        return [
+            // If we got this far, it's valid if we can't obtain allowed service point
+            // data, or if the allowed service point data is non-empty:
+            'valid' => null === $allowed || !empty($allowed),
+            'status' => 'request_place_text',
+        ];
     }
 
     /**


### PR DESCRIPTION
This also includes minor refactoring for clarity -- I thought returning early for the first check was easier to follow than having a big if/else with nested checks.

The actual fix here was contributed by Donna Barber in Slack -- thanks, Donna!