### PR TITLE
Reduce warnings from combined-search.js.

### DIFF
--- a/themes/bootstrap3/js/combined-search.js
+++ b/themes/bootstrap3/js/combined-search.js
@@ -3,11 +3,15 @@ VuFind.combinedSearch = (function CombinedSearch() {
 
   function init(container, url) {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
-      if (responseText.length === 0) {
-        container.style.display = "none";
+      if (!responseText || responseText.length === 0) {
+        if (container.style) {
+          container.style.display = "none";
+        }
         let parent = container.parentNode;
         while (parent && parent.classList.contains('js-hide-if-empty')) {
-          parent.style.display = "none";
+          if (parent.style) {
+            parent.style.display = "none";
+          }
           parent = parent.parentNode;
         }
       } else {

--- a/themes/bootstrap5/js/combined-search.js
+++ b/themes/bootstrap5/js/combined-search.js
@@ -3,11 +3,15 @@ VuFind.combinedSearch = (function CombinedSearch() {
 
   function init(container, url) {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
-      if (responseText.length === 0) {
-        container.style.display = "none";
+      if (!responseText || responseText.length === 0) {
+        if (container.style) {
+          container.style.display = "none";
+        }
         let parent = container.parentNode;
         while (parent && parent.classList.contains('js-hide-if-empty')) {
-          parent.style.display = "none";
+          if (parent.style) {
+            parent.style.display = "none";
+          }
           parent = parent.parentNode;
         }
       } else {


### PR DESCRIPTION
I'm troubleshooting a problem where one column in an AJAX combined search throws an exception, and this causes a number of warnings to be issued from the combined search Javascript due to expected things being absent. This PR just makes the Javascript code a little more error-tolerant. I'll fix the underlying problem in a separate PR.