### PR TITLE
Display search errors correctly in combined search mode.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -124,6 +124,9 @@ class CombinedController extends AbstractSearch
                 'currentSearch' => $settings,
                 'domId' => 'combined_' . str_replace(':', '____', $sectionId),
             ];
+            if (!empty($settings['view']->extraErrors)) {
+                $viewParams['extraErrors'] = $settings['view']->extraErrors;
+            }
             // Initialize theme resources:
             ($this->getViewRenderer()->plugin('setupThemeResources'))(true);
             // Render content:

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -124,6 +124,10 @@
 </div>
 <?php /* End Listing Options */ ?>
 
+<?php foreach($this->extraErrors ?? [] as $error): ?>
+  <div class="alert alert-danger"><?=$this->transEsc($error)?></div>
+<?php endforeach; ?>
+
 <?php if ($recordTotal < 1): ?>
   <p class="alert alert-danger">
     <?=$this->slot('empty-message')->get($this->translate('nohit_lookfor_html', ['%%lookfor%%' => $this->escapeHtml($lookfor)])); ?>

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -124,6 +124,10 @@
 </div>
 <?php /* End Listing Options */ ?>
 
+<?php foreach($this->extraErrors ?? [] as $error): ?>
+  <div class="alert alert-danger"><?=$this->transEsc($error)?></div>
+<?php endforeach; ?>
+
 <?php if ($recordTotal < 1): ?>
   <p class="alert alert-danger">
     <?=$this->slot('empty-message')->get($this->translate('nohit_lookfor_html', ['%%lookfor%%' => $this->escapeHtml($lookfor)])); ?>


### PR DESCRIPTION
This PR fixes the underlying problem that uncovered the issues addressed in #4136.

The issue is that we pass search backend errors as flash messages, but flash messages cannot be saved when session writing is disabled. Since we disable session writes for AJAX-loaded combined search results, this means that a search backend error will lead to an exception (and a generic "an error has occurred" display in the combined view) instead of returning reasonable results to the user.

A simple way to reproduce: turn on the Worldcat2 backend and perform a blank search through combined search (with AJAX enabled for the Worldcat2 backend). Since blank searches are not allowed, this should display a flash message, but instead it will break the whole column.

This PR just catches exceptions when setting flash messages, and passes those errors directly to the view using a different mechanism. Perhaps there is a more elegant approach, but this at least works!