### PR TITLE
Fix CurrencyFormatter and remove invalid tests.

### DIFF
--- a/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
@@ -61,15 +61,13 @@ class CurrencyFormatter
     /**
      * Constructor
      *
-     * @param string $defaultCurrency Default currency format (ISO 4217) to use (null
-     * for default from system locale)
-     * @param string $locale          Locale to use for number formatting (null for
-     * default system locale)
+     * @param string  $defaultCurrency Default currency format (ISO 4217) to use (null for default from system locale)
+     * @param ?string $locale          Locale to use for number formatting (null for default system locale)
      */
     public function __construct($defaultCurrency = null, $locale = null)
     {
         // Initialize number formatter:
-        $locale ??= setlocale(LC_MONETARY, 0);
+        $locale ??= setlocale(LC_MONETARY, '');
         $this->formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
 
         // Initialize default currency:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -31,6 +31,8 @@
 
 namespace VuFindTest\Service;
 
+use NumberFormatter;
+
 /**
  * CurrencyFormatter Test Class
  *
@@ -50,10 +52,30 @@ class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormatting()
     {
+        // test default settings
+        $locale = setlocale(LC_MONETARY, '');
+        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        $defaultCurrencyCode = trim($formatter->getTextAttribute(NumberFormatter::CURRENCY_CODE) ?: '') ?: 'USD';
+        $cc = new \VuFind\Service\CurrencyFormatter();
+        $this->assertEquals(
+            $formatter->formatCurrency(3000, $defaultCurrencyCode),
+            $cc->convertToDisplayFormat(3000)
+        );
+        $this->assertEquals(
+            $formatter->formatCurrency(3000, 'EUR'),
+            $cc->convertToDisplayFormat(3000, 'EUR')
+        );
+
         // test overriding default currency
-        $cc = new \VuFind\Service\CurrencyFormatter('EUR', 'en_US');
-        $this->assertEquals('€3,000.00', $cc->convertToDisplayFormat(3000));
-        $this->assertEquals('$3,000.00', $cc->convertToDisplayFormat(3000, 'USD'));
+        $cc = new \VuFind\Service\CurrencyFormatter('EUR');
+        $this->assertEquals(
+            $formatter->formatCurrency(3000, 'EUR'),
+            $cc->convertToDisplayFormat(3000)
+        );
+        $this->assertEquals(
+            $formatter->formatCurrency(3000, 'USD'),
+            $cc->convertToDisplayFormat(3000, 'USD')
+        );
 
         // test overriding default locale
         $cc = new \VuFind\Service\CurrencyFormatter(null, 'de_DE');

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -44,58 +44,25 @@ namespace VuFindTest\Service;
 class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Locale (for restoration after testing)
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
-     * Standard setup method
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        // store current default and set a value for consistency in testing
-        $this->locale = setlocale(LC_MONETARY, 0);
-        $locales = ['en_US.UTF8', 'en_US.UTF-8', 'en_US'];
-        if (false === setlocale(LC_MONETARY, $locales)) {
-            $this->markTestSkipped('Problem setting up locale');
-        }
-    }
-
-    /**
-     * Standard teardown method
-     *
-     * @return void
-     */
-    public function tearDown(): void
-    {
-        // restore current default
-        setlocale(LC_MONETARY, $this->locale);
-    }
-
-    /**
      * Test the class
      *
      * @return void
      */
     public function testFormatting()
     {
-        // test default settings
-        $cc = new \VuFind\Service\CurrencyFormatter();
-        $this->assertEquals('$3,000.00', $cc->convertToDisplayFormat(3000));
-        $this->assertEquals('€3,000.00', $cc->convertToDisplayFormat(3000, 'EUR'));
-
-        // test override default currency
-        $cc = new \VuFind\Service\CurrencyFormatter('EUR');
+        // test overriding default currency
+        $cc = new \VuFind\Service\CurrencyFormatter('EUR', 'en_US');
         $this->assertEquals('€3,000.00', $cc->convertToDisplayFormat(3000));
         $this->assertEquals('$3,000.00', $cc->convertToDisplayFormat(3000, 'USD'));
 
-        // test override default locale
+        // test overriding default locale
         $cc = new \VuFind\Service\CurrencyFormatter(null, 'de_DE');
         $this->assertEquals("3.000,00\u{a0}€", $cc->convertToDisplayFormat(3000));
+        $this->assertEquals("3.000,00\u{a0}\$", $cc->convertToDisplayFormat(3000, 'USD'));
+
+        // test overriding both
+        $cc = new \VuFind\Service\CurrencyFormatter('AUD', 'de_DE');
+        $this->assertEquals("3.000,00\u{a0}AU$", $cc->convertToDisplayFormat(3000));
         $this->assertEquals("3.000,00\u{a0}\$", $cc->convertToDisplayFormat(3000, 'USD'));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
@@ -49,7 +49,7 @@ class SafeMoneyFormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testFormatting()
     {
-        // test en_US
+        // test default currency in en_US locale
         $smf = new SafeMoneyFormat(
             new \VuFind\Service\CurrencyFormatter(null, 'en_US'),
             new \Laminas\View\Helper\EscapeHtml()

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SafeMoneyFormatTest.php
@@ -43,48 +43,15 @@ use VuFind\View\Helper\Root\SafeMoneyFormat;
 class SafeMoneyFormatTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Locale (for restoration after testing)
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
-     * Standard setup method
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        // store current default and set a value for consistency in testing
-        $this->locale = setlocale(LC_MONETARY, 0);
-        $locales = ['en_US.UTF8', 'en_US.UTF-8', 'en_US'];
-        if (false === setlocale(LC_MONETARY, $locales)) {
-            $this->markTestSkipped('Problem setting up locale');
-        }
-    }
-
-    /**
-     * Standard teardown method
-     *
-     * @return void
-     */
-    public function tearDown(): void
-    {
-        // restore current default
-        setlocale(LC_MONETARY, $this->locale);
-    }
-
-    /**
      * Test the helper
      *
      * @return void
      */
     public function testFormatting()
     {
-        // test default settings
+        // test en_US
         $smf = new SafeMoneyFormat(
-            new \VuFind\Service\CurrencyFormatter(),
+            new \VuFind\Service\CurrencyFormatter(null, 'en_US'),
             new \Laminas\View\Helper\EscapeHtml()
         );
         $this->assertEquals('$3.00', $smf(3));
@@ -92,7 +59,7 @@ class SafeMoneyFormatTest extends \PHPUnit\Framework\TestCase
 
         // test override default currency
         $smf = new SafeMoneyFormat(
-            new \VuFind\Service\CurrencyFormatter('EUR'),
+            new \VuFind\Service\CurrencyFormatter('EUR', 'en_US'),
             new \Laminas\View\Helper\EscapeHtml()
         );
         $this->assertEquals('€3.00', $smf(3));


### PR DESCRIPTION
We used to rely on setlocale returning the previously set locale value, but this is not the case with PHP 8.4 (and isn't documented either). As far as I can see there's no way for the test to set the default locale anymore, so the tests relying on it don't work properly anymore with PHP 8.4.

The change from 0 to an empty string is crucial, otherwise setlocale returns 'C' as the locale.

This is part three of improving PHP 8.4 compatibility.
