### PR TITLE
Add escape parameter to fgetcsv for PHP 8.4 compatibility.

### DIFF
--- a/module/VuFind/src/VuFind/CSV/Importer.php
+++ b/module/VuFind/src/VuFind/CSV/Importer.php
@@ -93,7 +93,7 @@ class Importer
         $encoding = $config->getEncoding();
         $data = [];
         $output = '';
-        while ($line = fgetcsv($in)) {
+        while ($line = fgetcsv($in, escape: '\\')) {
             $data[] = $this->collectValuesFromLine(
                 $this->adjustEncoding($line, $encoding),
                 $config
@@ -177,14 +177,14 @@ class Importer
         switch (strtolower(trim($mode))) {
             case 'fields':
                 // Load configuration from the header row:
-                $row = fgetcsv($in);
+                $row = fgetcsv($in, escape: '\\');
                 foreach ($row as $i => $field) {
                     $config->configureColumn($i, ['field' => $field]);
                 }
                 break;
             case 'skip':
                 //  Just skip a row:
-                fgetcsv($in);
+                fgetcsv($in, escape: '\\');
                 break;
             case 'none':
             default:

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -435,7 +435,7 @@ class XCNCIP2 extends AbstractBase implements
             );
         }
         if (($handle = fopen($pickupLocationsFile, 'r')) !== false) {
-            while (($data = fgetcsv($handle)) !== false) {
+            while (($data = fgetcsv($handle, escape: '\\')) !== false) {
                 $agencyId = $data[0] . '|' . $data[1];
                 $this->pickupLocations[$agencyId] = [
                     'locationID' => $agencyId,

--- a/module/VuFind/src/VuFind/RecordTab/Map.php
+++ b/module/VuFind/src/VuFind/RecordTab/Map.php
@@ -247,7 +247,7 @@ class Map extends AbstractBase
                 : \VuFind\Config\Locator::getConfigPath($mapLabelData[1]);
             if (file_exists($file)) {
                 $fp = fopen($file, 'r');
-                while (($line = fgetcsv($fp, 0, "\t")) !== false) {
+                while (($line = fgetcsv($fp, 0, "\t", escape: '\\')) !== false) {
                     if (count($line) > 1) {
                         $label_lookup[$line[0]] = $line[1];
                     }

--- a/module/VuFind/src/VuFind/Reserves/CsvReader.php
+++ b/module/VuFind/src/VuFind/Reserves/CsvReader.php
@@ -162,7 +162,7 @@ class CsvReader
             throw new \Exception("Could not open $fn!");
         }
         $lineNo = $goodLines = 0;
-        while ($line = fgetcsv($fh, 0, $this->delimiter)) {
+        while ($line = fgetcsv($fh, 0, $this->delimiter, escape: '\\')) {
             $lineNo++;
 
             if (count($line) < count($this->template)) {


### PR DESCRIPTION
This keeps the backslash as escape character as has been the default.

See https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism for more information.

This is part four of improving PHP 8.4 compatibility.