### PR TITLE
Fix actual problem with hiding combined search elements.

### DIFF
--- a/themes/bootstrap3/js/combined-search.js
+++ b/themes/bootstrap3/js/combined-search.js
@@ -4,14 +4,11 @@ VuFind.combinedSearch = (function CombinedSearch() {
   function init(container, url) {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
       if (!responseText || responseText.length === 0) {
-        if (container.style) {
-          container.style.display = "none";
-        }
-        let parent = container.parentNode;
+        var element = typeof container === 'string' ? document.querySelector(container) : container;
+        element.style.display = "none";
+        let parent = element.parentNode;
         while (parent && parent.classList.contains('js-hide-if-empty')) {
-          if (parent.style) {
-            parent.style.display = "none";
-          }
+          parent.style.display = "none";
           parent = parent.parentNode;
         }
       } else {

--- a/themes/bootstrap3/js/combined-search.js
+++ b/themes/bootstrap3/js/combined-search.js
@@ -5,11 +5,13 @@ VuFind.combinedSearch = (function CombinedSearch() {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
       if (!responseText || responseText.length === 0) {
         var element = typeof container === 'string' ? document.querySelector(container) : container;
-        element.style.display = "none";
-        let parent = element.parentNode;
-        while (parent && parent.classList.contains('js-hide-if-empty')) {
-          parent.style.display = "none";
-          parent = parent.parentNode;
+        if (element) {
+          element.style.display = "none";
+          let parent = element.parentNode;
+          while (parent && parent.classList.contains('js-hide-if-empty')) {
+            parent.style.display = "none";
+            parent = parent.parentNode;
+          }
         }
       } else {
         VuFind.initResultScripts(container);

--- a/themes/bootstrap5/js/combined-search.js
+++ b/themes/bootstrap5/js/combined-search.js
@@ -4,14 +4,11 @@ VuFind.combinedSearch = (function CombinedSearch() {
   function init(container, url) {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
       if (!responseText || responseText.length === 0) {
-        if (container.style) {
-          container.style.display = "none";
-        }
-        let parent = container.parentNode;
+        var element = typeof container === 'string' ? document.querySelector(container) : container;
+        element.style.display = "none";
+        let parent = element.parentNode;
         while (parent && parent.classList.contains('js-hide-if-empty')) {
-          if (parent.style) {
-            parent.style.display = "none";
-          }
+          parent.style.display = "none";
           parent = parent.parentNode;
         }
       } else {

--- a/themes/bootstrap5/js/combined-search.js
+++ b/themes/bootstrap5/js/combined-search.js
@@ -5,11 +5,13 @@ VuFind.combinedSearch = (function CombinedSearch() {
     VuFind.loadHtml(container, url, '', function containerLoad(responseText) {
       if (!responseText || responseText.length === 0) {
         var element = typeof container === 'string' ? document.querySelector(container) : container;
-        element.style.display = "none";
-        let parent = element.parentNode;
-        while (parent && parent.classList.contains('js-hide-if-empty')) {
-          parent.style.display = "none";
-          parent = parent.parentNode;
+        if (element) {
+          element.style.display = "none";
+          let parent = element.parentNode;
+          while (parent && parent.classList.contains('js-hide-if-empty')) {
+            parent.style.display = "none";
+            parent = parent.parentNode;
+          }
         }
       } else {
         VuFind.initResultScripts(container);


### PR DESCRIPTION
I took time to do a more thorough investigation of the combined-search.js errors and discovered the root cause was that we were treating a selector string as if it were a DOM element. Here's a better fix to address the real issue.