### PR TITLE
Eliminate laminas-dom dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "laminas/laminas-config": "3.9.0",
         "laminas/laminas-db": "2.20.0",
         "laminas/laminas-diactoros": "3.5.0",
-        "laminas/laminas-dom": "2.14.0",
         "laminas/laminas-escaper": "2.13.0",
         "laminas/laminas-eventmanager": "3.13.1",
         "laminas/laminas-feed": "2.23.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfdfd4f62797c85b1695af0e424044cc",
+    "content-hash": "e87574a60bbeb22b4f1dcd571b088d92",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -2391,71 +2391,6 @@
                 }
             ],
             "time": "2024-10-14T11:59:49+00:00"
-        },
-        {
-            "name": "laminas/laminas-dom",
-            "version": "2.14.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-dom.git",
-                "reference": "25a062132573f8e812e298ad046b75fb9eb90461"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-dom/zipball/25a062132573f8e812e298ad046b75fb9eb90461",
-                "reference": "25a062132573f8e812e298ad046b75fb9eb90461",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-dom": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5.0",
-                "phpunit/phpunit": "^9.6.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev",
-                    "dev-develop": "2.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Dom\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides tools for working with DOM documents and structures",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "dom",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-dom/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-dom/issues",
-                "rss": "https://github.com/laminas/laminas-dom/releases.atom",
-                "source": "https://github.com/laminas/laminas-dom"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": "symfony/dom-crawler",
-            "time": "2023-11-20T20:45:23+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -14472,7 +14407,7 @@
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1"
     },

--- a/module/VuFind/src/VuFind/Resolver/Driver/Redi.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Redi.php
@@ -32,7 +32,7 @@
 namespace VuFind\Resolver\Driver;
 
 use DOMDocument;
-use Laminas\Dom\DOMXPath;
+use DOMXPath;
 
 use function chr;
 use function count;


### PR DESCRIPTION
The laminas-dom library has been abandoned and should no longer be used. At least this one is easy to fix! We only use one class from laminas-dom in one place, and that class simply manipulated some error handling behavior in a core PHP class. This PR gets rid of the customization and uses the core PHP class instead; it shouldn't make a meaningful difference for our purposes.