### PR TITLE
Phing: Adjust PostgreSQL database ownership for compatibility with v16

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -830,6 +830,9 @@ return [
             <exec executable="psql" checkreturn="true">
               <arg line="-c &quot;GRANT ALL ON DATABASE ${vufinddb} TO ${vufinddbuser};&quot; ${pgsqlrootuser}" />
             </exec>
+            <exec executable="psql" checkreturn="true">
+              <arg line="-c &quot;ALTER DATABASE ${vufinddb} OWNER TO ${vufinddbuser};&quot; ${pgsqlrootuser}" />
+            </exec>
           </then>
           <else>
             <exec executable="sudo">
@@ -848,6 +851,9 @@ return [
             </exec>
             <exec executable="sudo" checkreturn="true">
               <arg line="su -c &quot;psql -c 'GRANT ALL ON DATABASE ${vufinddb} TO ${vufinddbuser};'&quot; ${pgsqlrootuser}" />
+            </exec>
+            <exec executable="sudo" checkreturn="true">
+              <arg line="su -c &quot;psql -c 'ALTER DATABASE ${vufinddb} OWNER TO ${vufinddbuser};'&quot; ${pgsqlrootuser}" />
             </exec>
           </else>
         </if>


### PR DESCRIPTION
Since upgrading to Ubuntu 24, my PostgreSQL test setup via Phing stopped working. It appears the cause has to do with changes to permission behavior in PostgreSQL, and this adjustment seems to get things building again. I haven't tested earlier versions, but since the ALTER DATABASE OWNER command has been around since PostgreSQL 8, I think it should be reasonable to assume that this will work for all versions currently still in support.