### PR TITLE
Bug fixes related to favorite list creation.

### DIFF
--- a/themes/bootstrap3/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap3/templates/myresearch/editlist.phtml
@@ -18,7 +18,7 @@
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-list" method="post" name="<?=$this->newList ? 'newList' : 'editListForm'?>" action="<?=$this->url('editList'); ?>">
-  <input type="hidden" name="id" value="<?=empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
+  <input type="hidden" name="id" value="<?=$this->newList || empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
   <?=$this->context($this)->renderInContext('cart/form-record-hidden-inputs.phtml', []); ?>
   <div class="form-group">
     <label class="control-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>

--- a/themes/bootstrap3/templates/record/save.phtml
+++ b/themes/bootstrap3/templates/record/save.phtml
@@ -40,7 +40,7 @@
       <?php endif; ?>
       </select>
     <?php endif; ?>
-    <button type="submit" name="newList" class="btn btn-link" id="make-list"><?=$showLists ? $this->transEsc('or create a new list') : $this->transEsc('Create a List'); ?></button>
+    <button type="submit" name="newList" value="1" class="btn btn-link" id="make-list"><?=$showLists ? $this->transEsc('or create a new list') : $this->transEsc('Create a List'); ?></button>
   </div>
 
   <?php if ($showLists): ?>

--- a/themes/bootstrap5/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap5/templates/myresearch/editlist.phtml
@@ -18,7 +18,7 @@
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-list" method="post" name="<?=$this->newList ? 'newList' : 'editListForm'?>" action="<?=$this->url('editList'); ?>">
-<input type="hidden" name="id" value="<?=$this->newList || empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
+  <input type="hidden" name="id" value="<?=$this->newList || empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
   <?=$this->context($this)->renderInContext('cart/form-record-hidden-inputs.phtml', []); ?>
   <div class="form-group">
     <label class="control-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>

--- a/themes/bootstrap5/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap5/templates/myresearch/editlist.phtml
@@ -18,7 +18,7 @@
 <h2><?=$this->transEsc($pageTitle); ?></h2>
 
 <form class="form-edit-list" method="post" name="<?=$this->newList ? 'newList' : 'editListForm'?>" action="<?=$this->url('editList'); ?>">
-  <input type="hidden" name="id" value="<?=empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
+<input type="hidden" name="id" value="<?=$this->newList || empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
   <?=$this->context($this)->renderInContext('cart/form-record-hidden-inputs.phtml', []); ?>
   <div class="form-group">
     <label class="control-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>

--- a/themes/bootstrap5/templates/record/save.phtml
+++ b/themes/bootstrap5/templates/record/save.phtml
@@ -40,7 +40,7 @@
       <?php endif; ?>
       </select>
     <?php endif; ?>
-    <button type="submit" name="newList" class="btn btn-link" id="make-list"><?=$showLists ? $this->transEsc('or create a new list') : $this->transEsc('Create a List'); ?></button>
+    <button type="submit" name="newList" value="1" class="btn btn-link" id="make-list"><?=$showLists ? $this->transEsc('or create a new list') : $this->transEsc('Create a List'); ?></button>
   </div>
 
   <?php if ($showLists): ?>


### PR DESCRIPTION
This fixes two semi-related list editing bugs that I discovered while testing #4149:

Bug 1: With Javascript disabled, the "create list" form doesn't work, because the button for creating lists does not have an assigned value.

Bug 2: When using PostgreSQL to create lists, the empty entity objects generated by Laminas include IDs which should not be used, and these were triggering the wrong code path. (I believe this is related to the way Laminas uses sequences; I suspect this problem will go away entirely when we switch to Doctrine, but it shouldn't hurt to fix the problem for now). The form now explicitly stays in "new list" mode when the appropriate flag is set; it no longer exclusively relies on the ID in the new list object being empty.