### PR TITLE
Fix bug: lightbox covers interfered with preview links

### DIFF
--- a/themes/bootstrap3/js/preview.js
+++ b/themes/bootstrap3/js/preview.js
@@ -45,9 +45,9 @@ function applyPreviewUrl($link, url) {
   // Update associated record thumbnail, if any:
   $link.parents('.result,.record')
     .find('.recordcover[data-linkpreview="true"]').parents('a').attr('href', url)
-    .off('click')                       // disable custom click handling
-    .attr('data-lightbox-image', null)  // disable opening in lightbox
-    .attr('target', '_blank')           // open consistently with preview button
+    .off('click') // disable custom click handling
+    .attr('data-lightbox-image', null) // disable opening in lightbox
+    .attr('target', '_blank') // open consistently with preview button
     .attr('rel', 'noopener');
 }
 

--- a/themes/bootstrap3/js/preview.js
+++ b/themes/bootstrap3/js/preview.js
@@ -45,6 +45,9 @@ function applyPreviewUrl($link, url) {
   // Update associated record thumbnail, if any:
   $link.parents('.result,.record')
     .find('.recordcover[data-linkpreview="true"]').parents('a').attr('href', url)
+    .off('click')                       // disable custom click handling
+    .attr('data-lightbox-image', null)  // disable opening in lightbox
+    .attr('target', '_blank')           // open consistently with preview button
     .attr('rel', 'noopener');
 }
 

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -45,9 +45,9 @@ function applyPreviewUrl($link, url) {
   // Update associated record thumbnail, if any:
   $link.parents('.result,.record')
     .find('.recordcover[data-linkpreview="true"]').parents('a').attr('href', url)
-    .off('click')                       // disable custom click handling
-    .attr('data-lightbox-image', null)  // disable opening in lightbox
-    .attr('target', '_blank')           // open consistently with preview button
+    .off('click') // disable custom click handling
+    .attr('data-lightbox-image', null) // disable opening in lightbox
+    .attr('target', '_blank') // open consistently with preview button
     .attr('rel', 'noopener');
 }
 

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -45,6 +45,9 @@ function applyPreviewUrl($link, url) {
   // Update associated record thumbnail, if any:
   $link.parents('.result,.record')
     .find('.recordcover[data-linkpreview="true"]').parents('a').attr('href', url)
+    .off('click')                       // disable custom click handling
+    .attr('data-lightbox-image', null)  // disable opening in lightbox
+    .attr('target', '_blank')           // open consistently with preview button
     .attr('rel', 'noopener');
 }
 


### PR DESCRIPTION
The support of lightbox images broke the feature where book previews would update the thumbnail to link directly to the preview. This PR fixes the problem by making some additional adjustments to the image link.

To test:

In the `[Content]` section of config.ini, set `previews=Google`

Do a search for `title:html` to bring up one of the records that should have a working Google preview.

You'll see that cover thumbnails are clickable in this PR but do not work in the plain release-10.1 branch.