### PR TITLE
Fix bug with multiple call number message handling

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -241,10 +241,15 @@ class GetItemStatuses extends AbstractBase implements
 
         $callnumberHandler = $this->getCallnumberHandler($callnumbers, $callnumberSetting);
         foreach ($callnumbers as $number) {
-            $displayCallnumber = $actualCallnumber = $number['callnumber'];
+            // Call number is usually an array, but it could be a flat string if we're in "msg" mode:
+            if (is_array($number)) {
+                $displayCallnumber = $actualCallnumber = $number['callnumber'];
 
-            if (!empty($number['prefix'])) {
-                $displayCallnumber = $number['prefix'] . ' ' . $displayCallnumber;
+                if (!empty($number['prefix'])) {
+                    $displayCallnumber = $number['prefix'] . ' ' . $displayCallnumber;
+                }
+            } else {
+                $displayCallnumber = $actualCallnumber = $number;
             }
 
             $html[] = $this->renderer->render(


### PR DESCRIPTION
Recent refactoring of item status AJAX handling broke the "msg" setting for multiple call numbers. This PR fixes it and adds a test case to prevent regressions. The test currently fails on the dev branch and passes here.