### PR TITLE
[VUFIND-1713] Refactor custom CSRF logic for compatibility with future laminas-validator releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "laminas/laminas-session": "2.21.0",
         "laminas/laminas-stdlib": "3.19.0",
         "laminas/laminas-text": "2.11.0",
-        "laminas/laminas-validator": "2.55.0",
+        "laminas/laminas-validator": "2.64.2",
         "laminas/laminas-view": "2.27.0",
         "league/commonmark": "2.6.0",
         "league/oauth2-client": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a11b1b8757fba47cad77f6aeffb4bfa",
+    "content-hash": "707506f308fdbe34c207f2313bd5addf",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -4397,22 +4397,22 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.55.0",
+            "version": "2.64.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "dc3f2609d41b1e21bc24e3e147d7dd284e8a1556"
+                "reference": "771e504760448ac7af660710237ceb93be602e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/dc3f2609d41b1e21bc24e3e147d7dd284e8a1556",
-                "reference": "dc3f2609d41b1e21bc24e3e147d7dd284e8a1556",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
+                "reference": "771e504760448ac7af660710237ceb93be602e08",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.13",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "laminas/laminas-stdlib": "^3.19",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
@@ -4477,7 +4477,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-12T15:00:19+00:00"
+            "time": "2024-11-26T21:29:17+00:00"
         },
         {
             "name": "laminas/laminas-view",

--- a/module/VuFind/src/VuFind/Validator/SessionCsrf.php
+++ b/module/VuFind/src/VuFind/Validator/SessionCsrf.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Decorator for Laminas\Validator\Csrf with token counting/clearing functions added.
+ * Decorator for Laminas CSRF validator to add token counting/clearing functions.
  *
  * PHP version 8
  *
@@ -35,7 +35,7 @@ use function array_slice;
 use function count;
 
 /**
- * Decorator for Laminas\Validator\Csrf with token counting/clearing functions added.
+ * Decorator for Laminas CSRF validator to add token counting/clearing functions.
  *
  * @category VuFind
  * @package  Solr

--- a/module/VuFind/src/VuFind/Validator/SessionCsrf.php
+++ b/module/VuFind/src/VuFind/Validator/SessionCsrf.php
@@ -29,14 +29,10 @@
 
 namespace VuFind\Validator;
 
-use Laminas\Validator\Csrf;
-use Laminas\Validator\Translator\TranslatorAwareInterface;
-use Laminas\Validator\Translator\TranslatorInterface;
-use Laminas\Validator\ValidatorInterface;
+use Laminas\Session\Validator\Csrf;
 
 use function array_slice;
 use function count;
-use function is_callable;
 
 /**
  * Decorator for Laminas\Validator\Csrf with token counting/clearing functions added.
@@ -47,7 +43,7 @@ use function is_callable;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SessionCsrf implements CsrfInterface, ValidatorInterface, TranslatorAwareInterface
+class SessionCsrf implements CsrfInterface
 {
     /**
      * Laminas CSRF class.
@@ -112,96 +108,11 @@ class SessionCsrf implements CsrfInterface, ValidatorInterface, TranslatorAwareI
     }
 
     /**
-     * Sets translator to use in helper
+     * Returns true if the CSRF token is valid.
      *
-     * @param TranslatorInterface $translator [optional] translator.
-     * Default is null, which sets no translator.
-     * @param string              $textDomain [optional] text domain
-     * Default is null, which skips setTranslatorTextDomain
-     *
-     * @return self
-     */
-    public function setTranslator(?TranslatorInterface $translator = null, $textDomain = null)
-    {
-        return $this->csrf->setTranslator($translator, $textDomain);
-    }
-
-    /**
-     * Returns translator used in object
-     *
-     * @return TranslatorInterface|null
-     */
-    public function getTranslator()
-    {
-        return $this->csrf->getTranslator();
-    }
-
-    /**
-     * Checks if the object has a translator
+     * @param mixed $value Token to validate
      *
      * @return bool
-     */
-    public function hasTranslator()
-    {
-        return $this->csrf->hasTranslator();
-    }
-
-    /**
-     * Sets whether translator is enabled and should be used
-     *
-     * @param bool $enabled [optional] whether translator should be used.
-     * Default is true.
-     *
-     * @return self
-     */
-    public function setTranslatorEnabled($enabled = true)
-    {
-        return $this->csrf->setTranslatorEnabled($enabled);
-    }
-
-    /**
-     * Returns whether translator is enabled and should be used
-     *
-     * @return bool
-     */
-    public function isTranslatorEnabled()
-    {
-        return $this->csrf->isTranslatorEnabled();
-    }
-
-    /**
-     * Set translation text domain
-     *
-     * @param string $textDomain New text domain
-     *
-     * @return TranslatorAwareInterface
-     */
-    public function setTranslatorTextDomain($textDomain = 'default')
-    {
-        return $this->csrf->setTranslatorTextDomain($textDomain);
-    }
-
-    /**
-     * Return the translation text domain
-     *
-     * @return string
-     */
-    public function getTranslatorTextDomain()
-    {
-        return $this->csrf->getTranslatorTextDomain();
-    }
-
-    /**
-     * Returns true if and only if $value meets the validation requirements
-     *
-     * If $value fails validation, then this method returns false, and
-     * getMessages() will return an array of messages that explain why the
-     * validation failed.
-     *
-     * @param mixed $value Value to validate
-     *
-     * @return bool
-     * @throws Exception\RuntimeException If validation of $value is impossible.
      */
     public function isValid($value)
     {
@@ -221,22 +132,5 @@ class SessionCsrf implements CsrfInterface, ValidatorInterface, TranslatorAwareI
     public function getMessages()
     {
         return $this->csrf->getMessages();
-    }
-
-    /**
-     * Proxy all other calls to the CSRF object.
-     *
-     * @param string $method Method being called
-     * @param array  $args   Argument list
-     *
-     * @return mixed
-     * @throws \Exception
-     */
-    public function __call(string $method, array $args = []): mixed
-    {
-        if (is_callable([$this->csrf, 'method'])) {
-            return ($this->csrf->$method)(...$args);
-        }
-        throw new \Exception("Undefined method: $method");
     }
 }

--- a/module/VuFind/src/VuFind/Validator/SessionCsrf.php
+++ b/module/VuFind/src/VuFind/Validator/SessionCsrf.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Extension of Laminas\Validator\Csrf with token counting/clearing functions added.
+ * Decorator for Laminas\Validator\Csrf with token counting/clearing functions added.
  *
  * PHP version 8
  *
@@ -29,11 +29,17 @@
 
 namespace VuFind\Validator;
 
+use Laminas\Validator\Csrf;
+use Laminas\Validator\Translator\TranslatorAwareInterface;
+use Laminas\Validator\Translator\TranslatorInterface;
+use Laminas\Validator\ValidatorInterface;
+
 use function array_slice;
 use function count;
+use function is_callable;
 
 /**
- * Extension of Laminas\Validator\Csrf with token counting/clearing functions added.
+ * Decorator for Laminas\Validator\Csrf with token counting/clearing functions added.
  *
  * @category VuFind
  * @package  Solr
@@ -41,8 +47,25 @@ use function count;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class SessionCsrf extends \Laminas\Validator\Csrf implements CsrfInterface
+class SessionCsrf implements CsrfInterface, ValidatorInterface, TranslatorAwareInterface
 {
+    /**
+     * Laminas CSRF class.
+     *
+     * @var Csrf
+     */
+    protected Csrf $csrf;
+
+    /**
+     * Constructor
+     *
+     * @param array $options Options to pass to CSRF validator
+     */
+    public function __construct(array $options = [])
+    {
+        $this->csrf = new Csrf($options);
+    }
+
     /**
      * Keep only the most recent N tokens.
      *
@@ -52,7 +75,7 @@ class SessionCsrf extends \Laminas\Validator\Csrf implements CsrfInterface
      */
     public function trimTokenList($limit)
     {
-        $session = $this->getSession();
+        $session = $this->csrf->getSession();
         if ($limit < 1) {
             // Reset the array if necessary:
             $session->tokenList = [];
@@ -70,6 +93,150 @@ class SessionCsrf extends \Laminas\Validator\Csrf implements CsrfInterface
      */
     public function getTokenCount()
     {
-        return count($this->getSession()->tokenList ?? []);
+        return count($this->csrf->getSession()->tokenList ?? []);
+    }
+
+    /**
+     * Retrieve CSRF token
+     *
+     * If no CSRF token currently exists, or should be regenerated,
+     * generates one.
+     *
+     * @param bool $regenerate regenerate hash, default false
+     *
+     * @return string
+     */
+    public function getHash($regenerate = false)
+    {
+        return $this->csrf->getHash($regenerate);
+    }
+
+    /**
+     * Sets translator to use in helper
+     *
+     * @param TranslatorInterface $translator [optional] translator.
+     * Default is null, which sets no translator.
+     * @param string              $textDomain [optional] text domain
+     * Default is null, which skips setTranslatorTextDomain
+     *
+     * @return self
+     */
+    public function setTranslator(?TranslatorInterface $translator = null, $textDomain = null)
+    {
+        return $this->csrf->setTranslator($translator, $textDomain);
+    }
+
+    /**
+     * Returns translator used in object
+     *
+     * @return TranslatorInterface|null
+     */
+    public function getTranslator()
+    {
+        return $this->csrf->getTranslator();
+    }
+
+    /**
+     * Checks if the object has a translator
+     *
+     * @return bool
+     */
+    public function hasTranslator()
+    {
+        return $this->csrf->hasTranslator();
+    }
+
+    /**
+     * Sets whether translator is enabled and should be used
+     *
+     * @param bool $enabled [optional] whether translator should be used.
+     * Default is true.
+     *
+     * @return self
+     */
+    public function setTranslatorEnabled($enabled = true)
+    {
+        return $this->csrf->setTranslatorEnabled($enabled);
+    }
+
+    /**
+     * Returns whether translator is enabled and should be used
+     *
+     * @return bool
+     */
+    public function isTranslatorEnabled()
+    {
+        return $this->csrf->isTranslatorEnabled();
+    }
+
+    /**
+     * Set translation text domain
+     *
+     * @param string $textDomain New text domain
+     *
+     * @return TranslatorAwareInterface
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        return $this->csrf->setTranslatorTextDomain($textDomain);
+    }
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->csrf->getTranslatorTextDomain();
+    }
+
+    /**
+     * Returns true if and only if $value meets the validation requirements
+     *
+     * If $value fails validation, then this method returns false, and
+     * getMessages() will return an array of messages that explain why the
+     * validation failed.
+     *
+     * @param mixed $value Value to validate
+     *
+     * @return bool
+     * @throws Exception\RuntimeException If validation of $value is impossible.
+     */
+    public function isValid($value)
+    {
+        return $this->csrf->isValid($value);
+    }
+
+    /**
+     * Returns an array of messages that explain why the most recent isValid()
+     * call returned false. The array keys are validation failure message identifiers,
+     * and the array values are the corresponding human-readable message strings.
+     *
+     * If isValid() was never called or if the most recent isValid() call
+     * returned true, then this method returns an empty array.
+     *
+     * @return array<string, string>
+     */
+    public function getMessages()
+    {
+        return $this->csrf->getMessages();
+    }
+
+    /**
+     * Proxy all other calls to the CSRF object.
+     *
+     * @param string $method Method being called
+     * @param array  $args   Argument list
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function __call(string $method, array $args = []): mixed
+    {
+        if (is_callable([$this->csrf, 'method'])) {
+            return ($this->csrf->$method)(...$args);
+        }
+        throw new \Exception("Undefined method: $method");
     }
 }


### PR DESCRIPTION
The laminas-validator package is dropping its CSRF validator (in favor of a new version found in laminas-session). The new class is final, so it cannot be extended. This PR redesigns our SessionCsrf class as a proxy around the new Laminas class.

TODO
- [x] Run full test suite
- [x] Resolve [VUFIND-1713](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1713) when merging