### PR TITLE
Fix account tooltip with Bootstrap 5.

### DIFF
--- a/themes/bootstrap5/js/account_ajax.js
+++ b/themes/bootstrap5/js/account_ajax.js
@@ -84,8 +84,7 @@ VuFind.register('account', function Account() {
         accountIconEl.dataset.bsToggle = 'tooltip';
         accountIconEl.dataset.bsPlacement = 'bottom';
         accountIconEl.title = VuFind.translate('account_has_alerts');
-        const tooltip = bootstrap.Tooltip.getOrCreateInstance(accountIconEl);
-        tooltip.show();
+        bootstrap.Tooltip.getOrCreateInstance(accountIconEl);
       } else {
         const tooltip = bootstrap.Tooltip.getOrCreateInstance(accountIconEl);
         tooltip.dispose();


### PR DESCRIPTION
Fixes flickering and makes tooltip initially hidden like it was with Bootstrap 3. 