### PR TITLE
Eliminate references to deprecated TranslatorInterface.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "laminas/laminas-text": "2.11.0",
         "laminas/laminas-validator": "2.64.2",
         "laminas/laminas-view": "2.27.0",
+        "laminas/laminas-translator": "^1",
         "league/commonmark": "2.6.0",
         "league/oauth2-client": "^2.7",
         "league/oauth2-server": "8.5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "707506f308fdbe34c207f2313bd5addf",
+    "content-hash": "540c871f9b843a7da019964d94455bf4",
     "packages": [
         {
             "name": "ahand/mobileesp",

--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -543,7 +543,7 @@ $config = [
             'Laminas\Session\SessionManager' => 'VuFind\Session\ManagerFactory',
         ],
         'delegators' => [
-            'Laminas\I18n\Translator\TranslatorInterface' => [
+            'Laminas\Mvc\I18n\Translator' => [
                 'VuFind\I18n\Translator\TranslatorFactory',
             ],
             'SlmLocale\Locale\Detector' => [

--- a/module/VuFind/src/VuFind/I18n/Translator/LanguageInitializerTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/LanguageInitializerTrait.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\I18n\Translator;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Mvc\I18n\Translator;
 use VuFind\Config\PathResolver;
 use VuFind\I18n\Locale\LocaleSettings;
 
@@ -101,14 +101,14 @@ trait LanguageInitializerTrait
     /**
      * Configure a translator to support the requested language.
      *
-     * @param TranslatorInterface $translator Translator
-     * @param LocaleSettings      $settings   Locale settings
-     * @param string              $language   Language to set up
+     * @param Translator     $translator Translator
+     * @param LocaleSettings $settings   Locale settings
+     * @param string         $language   Language to set up
      *
      * @return void
      */
     protected function addLanguageToTranslator(
-        TranslatorInterface $translator,
+        Translator $translator,
         LocaleSettings $settings,
         string $language
     ): void {

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareInterface.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareInterface.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\I18n\Translator;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Translator\TranslatorInterface;
 
 /**
  * Lightweight translator aware marker interface (used as an alternative to

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorAwareTrait.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\I18n\Translator;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Translator\TranslatorInterface;
 
 use function count;
 use function is_array;
@@ -50,7 +50,7 @@ trait TranslatorAwareTrait
     /**
      * Translator
      *
-     * @var \Laminas\I18n\Translator\TranslatorInterface
+     * @var TranslatorInterface
      */
     protected $translator = null;
 
@@ -70,7 +70,7 @@ trait TranslatorAwareTrait
     /**
      * Get translator object.
      *
-     * @return \Laminas\I18n\Translator\TranslatorInterface
+     * @return TranslatorInterface
      */
     public function getTranslator()
     {

--- a/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
+++ b/module/VuFind/src/VuFind/I18n/Translator/TranslatorFactory.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\I18n\Translator;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Mvc\I18n\Translator;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
@@ -94,13 +94,13 @@ class TranslatorFactory implements DelegatorFactoryInterface
     /**
      * Add caching to a translator object
      *
-     * @param TranslatorInterface $translator Translator object
-     * @param ContainerInterface  $container  Service manager
+     * @param Translator         $translator Translator object
+     * @param ContainerInterface $container  Service manager
      *
      * @return void
      */
     protected function enableCaching(
-        TranslatorInterface $translator,
+        Translator $translator,
         ContainerInterface $container
     ): void {
         // Set up language caching for better performance:

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -39,7 +39,7 @@
 
 namespace VuFind\ILS\Driver;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Mvc\I18n\Translator;
 use VuFind\Date\DateException;
 use VuFind\Exception\ILS as ILSException;
 
@@ -77,27 +77,6 @@ class Aleph extends AbstractBase implements
      * @var Aleph\Translator
      */
     protected $alephTranslator = false;
-
-    /**
-     * Cache manager
-     *
-     * @var \VuFind\Cache\Manager
-     */
-    protected $cacheManager;
-
-    /**
-     * Translator
-     *
-     * @var TranslatorInterface
-     */
-    protected $translator;
-
-    /**
-     * Date converter object
-     *
-     * @var \VuFind\Date\Converter
-     */
-    protected $dateConverter = null;
 
     /**
      * The base URL, where the REST DLF API is running
@@ -240,16 +219,13 @@ class Aleph extends AbstractBase implements
      *
      * @param \VuFind\Date\Converter $dateConverter Date converter
      * @param ?\VuFind\Cache\Manager $cacheManager  Cache manager (optional)
-     * @param ?TranslatorInterface   $translator    Translator (optional)
+     * @param ?Translator            $translator    Translator (optional)
      */
     public function __construct(
-        \VuFind\Date\Converter $dateConverter,
-        ?\VuFind\Cache\Manager $cacheManager = null,
-        ?TranslatorInterface $translator = null
+        protected \VuFind\Date\Converter $dateConverter,
+        protected ?\VuFind\Cache\Manager $cacheManager = null,
+        protected ?Translator $translator = null
     ) {
-        $this->dateConverter = $dateConverter;
-        $this->cacheManager = $cacheManager;
-        $this->translator = $translator;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
+++ b/module/VuFind/src/VuFind/Recommend/AuthorInfo.php
@@ -30,7 +30,7 @@
 namespace VuFind\Recommend;
 
 use Exception;
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Translator\TranslatorInterface;
 use VuFind\Connection\Wikipedia;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFindSearch\Query\Query;

--- a/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOption.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DisplayLanguageOption.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\View\Helper\Root;
 
-use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Translator\TranslatorInterface;
 
 /**
  * DisplayLanguageOption view helper
@@ -43,20 +43,12 @@ use Laminas\I18n\Translator\TranslatorInterface;
 class DisplayLanguageOption extends \Laminas\View\Helper\AbstractHelper
 {
     /**
-     * Translator (or null if unavailable)
-     *
-     * @var TranslatorInterface
-     */
-    protected $translator = null;
-
-    /**
      * Constructor
      *
-     * @param TranslatorInterface $translator Main VuFind translator
+     * @param TranslatorInterface $translator Translator
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(protected TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
     /**

--- a/module/VuFind/src/VuFindTest/Feature/TranslatorTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/TranslatorTrait.php
@@ -29,6 +29,9 @@
 
 namespace VuFindTest\Feature;
 
+use Laminas\Mvc\I18n\Translator;
+use PHPUnit\Framework\MockObject\MockObject;
+
 /**
  * Trait for tests involving Laminas Translator.
  *
@@ -46,21 +49,20 @@ trait TranslatorTrait
      * @param array  $translations Key => value translation map.
      * @param string $locale       Locale, default to 'en'
      *
-     * @return \Laminas\I18n\Translator\TranslatorInterface
+     * @return MockObject&Translator
      */
-    protected function getMockTranslator(array $translations, string $locale = 'en')
+    protected function getMockTranslator(array $translations, string $locale = 'en'): MockObject&Translator
     {
         $callback = function ($str, $domain) use ($translations) {
             return $translations[$domain][$str] ?? $str;
         };
-        $translator
-            = $this->getMockBuilder(\Laminas\I18n\Translator\TranslatorInterface::class)
-                ->addMethods(['getLocale'])
-                ->getMockForAbstractClass();
-        $translator->expects($this->any())->method('translate')
-            ->will($this->returnCallback($callback));
-        $translator->expects($this->any())->method('getLocale')
-            ->will($this->returnValue($locale));
+        $translator = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['translate'])
+            ->addMethods(['getLocale'])
+            ->getMock();
+        $translator->expects($this->any())->method('translate')->willReturnCallback($callback);
+        $translator->expects($this->any())->method('getLocale')->willReturn($locale);
         return $translator;
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/EmailAuthenticatorTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/EmailAuthenticatorTest.php
@@ -31,7 +31,6 @@ namespace VuFindTest\Auth;
 
 use DateTime;
 use Laminas\Http\Request;
-use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Session\SessionManager;
 use Laminas\View\Renderer\PhpRenderer;
 use PHPUnit\Event\NoPreviousThrowableException;
@@ -44,6 +43,7 @@ use VuFind\Db\Service\AuthHashServiceInterface;
 use VuFind\Mailer\Mailer;
 use VuFind\Net\UserIpReader;
 use VuFind\Validator\CsrfInterface;
+use VuFindTest\Feature\TranslatorTrait;
 
 /**
  * Email Authenticator Manager Test Class
@@ -56,6 +56,8 @@ use VuFind\Validator\CsrfInterface;
  */
 class EmailAuthenticatorTest extends \PHPUnit\Framework\TestCase
 {
+    use TranslatorTrait;
+
     /**
      * Get an EmailAuthenticator to test.
      *
@@ -90,13 +92,7 @@ class EmailAuthenticatorTest extends \PHPUnit\Framework\TestCase
             new Config($config),
             $authHashService ?? $this->createMock(AuthHashServiceInterface::class)
         );
-        $mockTranslator = $this->createMock(TranslatorInterface::class);
-        $mockTranslator->method('translate')->willReturnCallback(
-            function ($str) {
-                return $str;
-            }
-        );
-        $authenticator->setTranslator($mockTranslator);
+        $authenticator->setTranslator($this->getMockTranslator([]));
         return $authenticator;
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/TranslateTest.php
@@ -457,10 +457,7 @@ class TranslateTest extends \PHPUnit\Framework\TestCase
     public function testLocaleWithTranslator(): void
     {
         $translate = new Translate();
-        $translator = $this->createMock(\Laminas\I18n\Translator\Translator::class);
-        $translator->expects($this->once())->method('getLocale')
-            ->will($this->returnValue('foo'));
-        $translate->setTranslator($translator);
+        $translate->setTranslator($this->getMockTranslator([], 'foo'));
         $this->assertEquals('foo', $translate->getTranslatorLocale());
     }
 
@@ -472,7 +469,7 @@ class TranslateTest extends \PHPUnit\Framework\TestCase
     public function testGetTranslator(): void
     {
         $translate = new Translate();
-        $translator = $this->createMock(\Laminas\I18n\Translator\TranslatorInterface::class);
+        $translator = $this->createMock(\Laminas\Translator\TranslatorInterface::class);
         $translate->setTranslator($translator);
         $this->assertEquals($translator, $translate->getTranslator());
     }


### PR DESCRIPTION
Laminas has deprecated Laminas\I18n\Translator\TranslatorInterface in favor of Laminas\Translator\TranslatorInterface. The new interface lives in the laminas-translator package, and the laminas-i18n package implements it. This allows Laminas components to depend on a translator without requiring the full laminas-i18n package.

This PR replaces all references to the deprecated interface with the new interface, or with the actual Translator class in cases where more specific methods are required by code.

TODO
- [x] Run full test suite
- [x] Update changelog when merging