### PR TITLE
Fix bug with lightbox modal failing to close on bootstrap3-based themes.

### DIFF
--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -64,7 +64,7 @@
     ?>
     <?=$this->render('search/facet-list-content.phtml', $params) ?>
   </div>
-  <button class="btn btn-default lightbox-only" data-bs-dismiss="modal"><?=$this->translate('close') ?></button>
+  <button class="btn btn-default lightbox-only" data-dismiss="modal"><?=$this->translate('close') ?></button>
 </div>
 
 <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.facetList.setup();', 'SET')?>


### PR DESCRIPTION
This fixes a problem with facet modal close buttons failing in bootstrap3-based themes, caused by an overlooked `update-bootstrap3` task.