### PR TITLE
Only display CollectionList if record is a collection

### DIFF
--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -118,6 +118,16 @@ class CollectionList extends AbstractBase
     }
 
     /**
+     * Is this tab active?
+     *
+     * @return bool
+     */
+    public function isActive()
+    {
+        return parent::isActive() && $this->getRecordDriver()->tryMethod('isCollection');
+    }
+
+    /**
      * Get the processed search results.
      *
      * @return \VuFind\Search\SolrCollection\Results

--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -124,7 +124,7 @@ class CollectionList extends AbstractBase
      */
     public function isActive()
     {
-        return parent::isActive() && $this->getRecordDriver()->tryMethod('getHierarchyTrees');
+        return parent::isActive() && $this->getRecordDriver()->tryMethod('isCollection');
     }
 
     /**

--- a/module/VuFind/src/VuFind/RecordTab/CollectionList.php
+++ b/module/VuFind/src/VuFind/RecordTab/CollectionList.php
@@ -124,7 +124,7 @@ class CollectionList extends AbstractBase
      */
     public function isActive()
     {
-        return parent::isActive() && $this->getRecordDriver()->tryMethod('isCollection');
+        return parent::isActive() && $this->getRecordDriver()->tryMethod('getHierarchyTrees');
     }
 
     /**


### PR DESCRIPTION
Adds an isActive function for CollectionList.php tab. Uses getHierarchyTrees to check if should be active. Tried with isCollection, but isCollection might be too limited for this case.