### PR TITLE
Add a configurable console menu for ease of use

### DIFF
--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -128,14 +128,9 @@ main:
           arguments:
             - label: Harvest subdirectory
               required: true
-            - label: Properties file
-              required: false
           options:
-            - label: Use the directory path as-is, do not append it to /usr/local/vufind/local/harvest.
+            - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
               switch: -d
-              type: no-value
-            - label: Print this message.
-              switch: -h
               type: no-value
             - label: Do not move the data files after importing.
               switch: -m
@@ -159,11 +154,8 @@ main:
             - label: SolrMARC properties file
               required: true
           options:
-            - label: Use the directory path as-is, do not append it to /usr/local/vufind/local/harvest.
+            - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
               switch: -d
-              type: no-value
-            - label: Print this message.
-              switch: -h
               type: no-value
             - label: Do not move the data files after importing.
               switch: -m

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -102,12 +102,50 @@ main:
     - label: Harvest Options
       type: menu
       contents:
+        - label: Batch import harvested authority records
+          type: external-command
+          command: harvest/batch-import-marc-auth.sh
+          winCommand: harvest/batch-import-marc-auth.bat
+          arguments:
+            - label: Harvest subdirectory
+              required: true
+            - label: SolrMARC properties file
+              required: true
+          options:
+            - label: Use the directory path as-is, do not append it to /usr/local/vufind/local/harvest.
+              switch: -d
+              type: no-value
+            - label: Print this message.
+              switch: -h
+              type: string
+            - label: Do not move the data files after importing.
+              switch: -m
+              type: no-value
+            - label: No logging.
+              switch: -z
+              type: no-value
         - label: Harvest metadata using OAI-PMH
           type: internal-command
           command: harvest/harvest-oai
         - label: Merge harvested MARCXML files into a collection
           type: internal-command
           command: harvest/merge-marc
+        - label: Batch delete records based on files created by the OAI-PMH harvester
+          type: external-command
+          command: harvest/batch-delete.sh
+          winCommand: harvest/batch-delete.bat
+          arguments:
+            - label: Harvest subdirectory
+              required: true
+            - label: Index type
+              required: false
+          options:
+            - label: Skip optimize
+              switch: -s
+              type: no-value
+            - label: Specify ID prefix
+              switch: --id-prefix
+              type: string
     - label: Help Options
       type: menu
       contents:

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -247,6 +247,13 @@ main:
     - label: Utility Options
       type: menu
       contents:
+        - label: Run Solr commands
+          type: external-command
+          command: solr.sh
+          winCommand: solr.bat
+          arguments:
+            - label: Action to take (start, stop, restart, or status)
+              required: true
         - label: Index all alphabetic browse entries
           type: external-command
           command: index-alphabetic-browse.sh

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -51,3 +51,174 @@ main:
         - label: Import XML
           type: internal-command
           command: import/import-xsl
+        - label: Import CSV
+          type: internal-command
+          command: import/import-csv
+        - label: Import via webcrawl
+          type: internal-command
+          command: import/webcrawl
+    - label: Compile Options
+      type: menu
+      contents:
+        - label: Compile theme (flatten hierarchy)
+          type: internal-command
+          command: compile/theme
+    - label: Completion Options
+      type: menu
+      contents:
+        - label: Dump the shell completion script to enable shell autocompletion
+          type: internal command
+          command: completion
+    - label: Generate Options
+      type: menu
+      contents:
+        - label: Generate a dynamic route
+          type: internal-command
+          command: generate/dynamicroute
+        - label: Generate a subclass, with lookup by class name
+          type: internal-command
+          command: generate/extendclass
+        - label: Generate a service (override with a new child class)
+          type: internal-command
+          command: generate/extendservice
+        - label: Generate a non-tab record action route
+          type: internal-command
+          command: generate/nontabrecordaction
+        - label: Generate a new plugin class
+          type: internal-command
+          command: generate/plugin
+        - label: Generate a record route
+          type: internal-command
+          command: generate/recordroute
+        - label: Generate a static route
+          type: internal-command
+          command: generate/staticroute
+        - label: Generate and configure a new theme
+          type: internal-command
+          command: generate/theme
+        - label: Generate and configure a new theme mixin
+          type: internal-command
+          command: generate/thememixin
+    - label: Harvest Options
+      type: menu
+      contents:
+        - label: Harvest metadata using OAI-PMH
+          type: internal-command
+          command: harvest/harvest-oai
+        - label: Merge harvested MARCXML files into a collection
+          type: internal-command
+          command: harvest/merge-marc
+    - label: Help Options
+      type: menu
+      contents:
+        - label: Display help for a command
+          type: internal-command
+          command: help
+    - label: Install Options
+      type: menu
+      contents:
+        - label: Install VuFind
+          type: internal-command
+          command: install/install
+    - label: Language options
+      type: menu
+      contents:
+        - label: Add new language strings based on existing ones, using a template
+          type: internal-command
+          command: language/addusingtemplate
+        - label: Copy a language string
+          type: internal-command
+          command: language/copystring
+        - label: Remove a language string from all files
+          type: internal-command
+          command: language/delete
+        - label: Load and normalize language strings from Lokalise export files
+          type: internal-command
+          command: language/importlokalise
+        - label: Normalize a file or directory of language strings
+          type: internal-command
+          command: language/normalize
+    - label: List Options
+      type: menu
+      contents:
+        - label: Display a list of commands
+          type: internal-command
+          command: list
+    - label: Menu Options
+      type: menu
+      contents:
+        - label: Display this interactive menu of commands
+          type: internal-command
+          command: menu/menu
+    - label: Scheduled Search Notification Options
+      type: menu
+      contents:
+        - label: Send scheduled search email notifications
+          type: internal-command
+          command: scheduledsearch/notify
+    - label: Utility Options
+      type: menu
+      contents:
+        - label: Manage the browscap cache
+          type: internal-command
+          command: util/browscap
+        - label: Remove unused cached records from the database
+          type: internal-command
+          command: util/cleanup_record_cache
+        - label: Send a commit command to a Solr index
+          type: internal-command
+          command: util/commit
+        - label: Populate the hierarchy tree cache
+          type: internal-command
+          command: util/createHierarchyTrees
+        - label: Deduplicate lines in a sorted file
+          type: internal-command
+          command: util/dedupe
+        - label: Delete a set of records from the Solr index
+          type: internal-command
+          command: util/deletes
+        - label: Populate the course reserves Solr index
+          type: internal-command
+          command: util/index_reserves
+        - label: Validate MARC file contents
+          type: internal-command
+          command: util/lint_marc
+        - label: Send an optimize command to a Solr index
+          type: internal-command
+          command: util/optimize
+        - label: Purge a cached record (and optionally a resource) from the database
+          type: internal-command
+          command: util/purge_cached_record
+        - label: Compile CSS files from SCSS
+          type: internal-command
+          command: util/scssBuilder
+        - label: Generate XML sitemap files
+          type: internal-command
+          command: util/sitemap
+        - label: Remove ILS-suppressed records from Solr
+          type: internal-command
+          command: util/suppressed
+        - label: Switch the encryption algorithm in the database and config
+          type: internal-command
+          command: switch_db_hash
+    - label: Expire Options
+      type: menu
+      contents:
+        - label: Expire old access tokens in the database
+          type: internal-command
+          command: util/expire_access_tokens
+        - label: Expire old authentication hashes in the database
+          type: internal-command
+          command: util/expire_auth_hashes
+        - label: Expire old external sessions in the database
+          type: internal-command
+          command: util/expire_external_sessions
+        - label: Expire old login tokens in the database
+          type: internal-command
+          command: util/expire_login_tokens
+        - label: Expire old searches in the database
+          type: internal-command
+          command: util/expire_searches
+        - label: Expire old sessions in the database
+          type: internal-command
+          command: util/expire_sessions

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -258,7 +258,7 @@ main:
       - label: Solr Management Tools
         type: menu
         contents:
-        - label: Run Solr commands
+        - label: Manage Solr service
           type: external-command
           command: solr.sh
           winCommand: solr.bat

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -14,6 +14,7 @@
 #   Purpose: Run a command-line command
 #   Attributes:
 #     - command (required): the command to run (relative to VUFIND_HOME)
+#     - winCommand (optional): an override of command to use on Windows platforms.
 #     - arguments (optional): a list of arguments for the command. Each entry contains:
 #         - label (required): A description of the argument
 #         - required (optional): Set to true if the argument is required
@@ -39,6 +40,7 @@ main:
         - label: Import MARC
           type: external-command
           command: import-marc.sh
+          winCommand: import-marc.bat
           arguments:
             - label: Filename
               required: true

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -34,53 +34,9 @@ main:
   label: Main Menu
   type: menu
   contents:
-    - label: Import Options
-      type: menu
-      contents:
-        - label: Import MARC
-          type: external-command
-          command: import-marc.sh
-          winCommand: import-marc.bat
-          arguments:
-            - label: Filename
-              required: true
-          options:
-            - label: Properties File
-              switch: -p
-              type: string
-        - label: Import MARC authority records
-          type: external-command
-          command: import-marc-auth.sh
-          winCommand: import-marc-auth.bat
-          arguments:
-            - label: Filename
-              required: true
-            - label: Properties file
-              required: false
-        - label: Import XML
-          type: internal-command
-          command: import/import-xsl
-        - label: Import CSV
-          type: internal-command
-          command: import/import-csv
-        - label: Import via webcrawl
-          type: internal-command
-          command: import/webcrawl
-    - label: Compile Options
-      type: menu
-      contents:
-        - label: Compile theme (flatten hierarchy)
-          type: internal-command
-          command: compile/theme
-    - label: Completion Options
-      type: menu
-      contents:
-        - label: Dump the shell completion script to enable shell autocompletion
-          type: internal command
-          command: completion
-    - label: Generate Options
-      type: menu
-      contents:
+      - label: Code Generation Tools
+        type: menu
+        contents:
         - label: Generate a dynamic route
           type: internal-command
           command: generate/dynamicroute
@@ -108,9 +64,63 @@ main:
         - label: Generate and configure a new theme mixin
           type: internal-command
           command: generate/thememixin
-    - label: Harvest Options
-      type: menu
-      contents:
+        - label: Compile theme (flatten hierarchy)
+          type: internal-command
+          command: compile/theme
+      - label: Configuration and Installation Tools
+        type: menu
+        contents:
+        - label: Manage VuFind installation
+          type: internal-command
+          command: install/install
+        - label: Manage the browscap cache
+          type: internal-command
+          command: util/browscap
+        - label: Switch the encryption algorithm in the database and config
+          type: internal-command
+          command: switch_db_hash
+      - label: Data Cleanup and Expiration Tools
+        type: menu
+        contents:
+        - label: Remove unused cached records from the database
+          type: internal-command
+          command: util/cleanup_record_cache
+        - label: Purge a cached record (and optionally a resource) from the database
+          type: internal-command
+          command: util/purge_cached_record
+        - label: Expire old access tokens in the database
+          type: internal-command
+          command: util/expire_access_tokens
+        - label: Expire old authentication hashes in the database
+          type: internal-command
+          command: util/expire_auth_hashes
+        - label: Expire old external sessions in the database
+          type: internal-command
+          command: util/expire_external_sessions
+        - label: Expire old login tokens in the database
+          type: internal-command
+          command: util/expire_login_tokens
+        - label: Expire old searches in the database
+          type: internal-command
+          command: util/expire_searches
+        - label: Expire old sessions in the database
+          type: internal-command
+          command: util/expire_sessions
+      - label: Data Management Tools
+        type: menu
+        contents:
+        - label: Populate the hierarchy tree cache
+          type: internal-command
+          command: util/createHierarchyTrees
+        - label: Generate XML sitemap files
+          type: internal-command
+          command: util/sitemap
+        - label: Send scheduled search email notifications
+          type: internal-command
+          command: scheduledsearch/notify
+      - label: Harvest Tools
+        type: menu
+        contents:
         - label: Batch import harvested MARC records
           type: external-command
           command: harvest/batch-import-marc.sh
@@ -196,21 +206,48 @@ main:
             - label: Specify ID prefix
               switch: --id-prefix
               type: string
-    - label: Help Options
-      type: menu
-      contents:
-        - label: Display help for a command
+      - label: Import Tools
+        type: menu
+        contents:
+        - label: Import MARC
+          type: external-command
+          command: import-marc.sh
+          winCommand: import-marc.bat
+          arguments:
+            - label: Filename
+              required: true
+          options:
+            - label: Properties File
+              switch: -p
+              type: string
+        - label: Import MARC authority records
+          type: external-command
+          command: import-marc-auth.sh
+          winCommand: import-marc-auth.bat
+          arguments:
+            - label: Filename
+              required: true
+            - label: Properties file
+              required: false
+        - label: Import XML
           type: internal-command
-          command: help
-    - label: Install Options
-      type: menu
-      contents:
-        - label: Install VuFind
+          command: import/import-xsl
+        - label: Import CSV
           type: internal-command
-          command: install/install
-    - label: Language options
-      type: menu
-      contents:
+          command: import/import-csv
+        - label: Import via webcrawl
+          type: internal-command
+          command: import/webcrawl
+        - label: Index all alphabetic browse entries
+          type: external-command
+          command: index-alphabetic-browse.sh
+          winCommand: index-alphabetic-browse.bat
+        - label: Populate the course reserves Solr index
+          type: internal-command
+          command: util/index_reserves
+      - label: Language Tools
+        type: menu
+        contents:
         - label: Add new language strings based on existing ones, using a template
           type: internal-command
           command: language/addusingtemplate
@@ -226,15 +263,9 @@ main:
         - label: Normalize a file or directory of language strings
           type: internal-command
           command: language/normalize
-    - label: Scheduled Search Notification Options
-      type: menu
-      contents:
-        - label: Send scheduled search email notifications
-          type: internal-command
-          command: scheduledsearch/notify
-    - label: Utility Options
-      type: menu
-      contents:
+      - label: Solr Management Tools
+        type: menu
+        contents:
         - label: Run Solr commands
           type: external-command
           command: solr.sh
@@ -242,70 +273,24 @@ main:
           arguments:
             - label: Action to take (start, stop, restart, or status)
               required: true
-        - label: Index all alphabetic browse entries
-          type: external-command
-          command: index-alphabetic-browse.sh
-          winCommand: index-alphabetic-browse.bat
-        - label: Manage the browscap cache
-          type: internal-command
-          command: util/browscap
-        - label: Remove unused cached records from the database
-          type: internal-command
-          command: util/cleanup_record_cache
         - label: Send a commit command to a Solr index
           type: internal-command
           command: util/commit
-        - label: Populate the hierarchy tree cache
-          type: internal-command
-          command: util/createHierarchyTrees
-        - label: Deduplicate lines in a sorted file
-          type: internal-command
-          command: util/dedupe
         - label: Delete a set of records from the Solr index
           type: internal-command
           command: util/deletes
-        - label: Populate the course reserves Solr index
-          type: internal-command
-          command: util/index_reserves
-        - label: Validate MARC file contents
-          type: internal-command
-          command: util/lint_marc
         - label: Send an optimize command to a Solr index
           type: internal-command
           command: util/optimize
-        - label: Purge a cached record (and optionally a resource) from the database
-          type: internal-command
-          command: util/purge_cached_record
-        - label: Compile CSS files from SCSS
-          type: internal-command
-          command: util/scssBuilder
-        - label: Generate XML sitemap files
-          type: internal-command
-          command: util/sitemap
         - label: Remove ILS-suppressed records from Solr
           type: internal-command
           command: util/suppressed
-        - label: Switch the encryption algorithm in the database and config
+      - label: Utilities
+        type: menu
+        contents:
+        - label: Deduplicate lines in a sorted file
           type: internal-command
-          command: switch_db_hash
-    - label: Expire Options
-      type: menu
-      contents:
-        - label: Expire old access tokens in the database
+          command: util/dedupe
+        - label: Validate MARC file contents
           type: internal-command
-          command: util/expire_access_tokens
-        - label: Expire old authentication hashes in the database
-          type: internal-command
-          command: util/expire_auth_hashes
-        - label: Expire old external sessions in the database
-          type: internal-command
-          command: util/expire_external_sessions
-        - label: Expire old login tokens in the database
-          type: internal-command
-          command: util/expire_login_tokens
-        - label: Expire old searches in the database
-          type: internal-command
-          command: util/expire_searches
-        - label: Expire old sessions in the database
-          type: internal-command
-          command: util/expire_sessions
+          command: util/lint_marc

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -1,4 +1,4 @@
-# This configuration file controls the menu displayed by thhe menu/menu console command.
+# This configuration file controls the menu displayed by the menu/menu console command.
 # It must begin with a "main:" container; all of its contents must be either nested submenus
 # or commands.
 #

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -1,0 +1,51 @@
+# This configuration file controls the menu displayed by thhe menu/menu console command.
+# It must begin with a "main:" container; all of its contents must be either nested submenus
+# or commands.
+#
+# Every section of the configuration MUST have a label and a type. Each supported type has
+# different requirements.
+#
+# type = menu
+#   Purpose: Display a sub-menu
+#   Attributes:
+#     - contents (required): a list of sub-menus and/or commands in the menu
+#
+# type = external-command
+#   Purpose: Run a command-line command
+#   Attributes:
+#     - command (required): the command to run (relative to VUFIND_HOME)
+#     - arguments (optional): a list of arguments for the command. Each entry contains:
+#         - label (required): A description of the argument
+#         - required (optional): Set to true if the argument is required
+#         - default (optional): A default value to use
+#     - options (optional): a list of options for the command. Each entry contains:
+#         - label (required): A description of the option
+#         - switch (required): The switch text to add to the command line for the option
+#         - type (optional, defaults to 'string'): 'string' for arguments that require
+#           a string value; 'no-value' for arguments that are simple toggle switches.
+#         - default (optional): A default value to use
+#
+# type = internal-command
+#   Purpose: Run an internal Symfony console command
+#   Attributes:
+#     - command (required): the name of the command in the plugin manager
+main:
+  label: Main Menu
+  type: menu
+  contents:
+    - label: Import Options
+      type: menu
+      contents:
+        - label: Import MARC
+          type: external-command
+          command: import-marc.sh
+          arguments:
+            - label: Filename
+              required: true
+          options:
+            - label: Properties File
+              switch: -p
+              type: string
+        - label: Import XML
+          type: internal-command
+          command: import/import-xsl

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -30,259 +30,264 @@
 #   Purpose: Run an internal Symfony console command
 #   Attributes:
 #     - command (required): the name of the command in the plugin manager
+#
+# type = summary
+#   Purpose: Output a summary of the full menu structure
 main:
   label: Main Menu
   type: menu
   contents:
-      - label: Code Generation Tools
-        type: menu
-        contents:
-        - label: Generate a dynamic route
-          type: internal-command
-          command: generate/dynamicroute
-        - label: Generate a subclass, with lookup by class name
-          type: internal-command
-          command: generate/extendclass
-        - label: Generate a service (override with a new child class)
-          type: internal-command
-          command: generate/extendservice
-        - label: Generate a non-tab record action route
-          type: internal-command
-          command: generate/nontabrecordaction
-        - label: Generate a new plugin class
-          type: internal-command
-          command: generate/plugin
-        - label: Generate a record route
-          type: internal-command
-          command: generate/recordroute
-        - label: Generate a static route
-          type: internal-command
-          command: generate/staticroute
-        - label: Generate and configure a new theme
-          type: internal-command
-          command: generate/theme
-        - label: Generate and configure a new theme mixin
-          type: internal-command
-          command: generate/thememixin
-        - label: Compile theme (flatten hierarchy)
-          type: internal-command
-          command: compile/theme
-      - label: Configuration and Installation Tools
-        type: menu
-        contents:
-        - label: Manage VuFind installation
-          type: internal-command
-          command: install/install
-        - label: Manage the browscap cache
-          type: internal-command
-          command: util/browscap
-        - label: Switch the encryption algorithm in the database and config
-          type: internal-command
-          command: switch_db_hash
-      - label: Data Cleanup and Expiration Tools
-        type: menu
-        contents:
-        - label: Remove unused cached records from the database
-          type: internal-command
-          command: util/cleanup_record_cache
-        - label: Purge a cached record (and optionally a resource) from the database
-          type: internal-command
-          command: util/purge_cached_record
-        - label: Expire old access tokens in the database
-          type: internal-command
-          command: util/expire_access_tokens
-        - label: Expire old authentication hashes in the database
-          type: internal-command
-          command: util/expire_auth_hashes
-        - label: Expire old external sessions in the database
-          type: internal-command
-          command: util/expire_external_sessions
-        - label: Expire old login tokens in the database
-          type: internal-command
-          command: util/expire_login_tokens
-        - label: Expire old searches in the database
-          type: internal-command
-          command: util/expire_searches
-        - label: Expire old sessions in the database
-          type: internal-command
-          command: util/expire_sessions
-      - label: Data Management Tools
-        type: menu
-        contents:
-        - label: Populate the hierarchy tree cache
-          type: internal-command
-          command: util/createHierarchyTrees
-        - label: Generate XML sitemap files
-          type: internal-command
-          command: util/sitemap
-        - label: Send scheduled search email notifications
-          type: internal-command
-          command: scheduledsearch/notify
-      - label: Harvest Tools
-        type: menu
-        contents:
-        - label: Batch import harvested MARC records
-          type: external-command
-          command: harvest/batch-import-marc.sh
-          winCommand: harvest/batch-import-marc.bat
-          arguments:
-            - label: Harvest subdirectory
-              required: true
-          options:
-            - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
-              switch: -d
-              type: no-value
-            - label: Do not move the data files after importing.
-              switch: -m
-              type: no-value
-            - label: Use specified SolrMarc configuration properties file.
-              switch: -p
-              type: string
-            - label: Maximum number of files to send in batches to import-marc.sh (default is MAX_BATCH_COUNT or 10)
-              switch: -x
-              type: string
-            - label: No logging.
-              switch: -z
-              type: no-value
-        - label: Batch import harvested MARC authority records
-          type: external-command
-          command: harvest/batch-import-marc-auth.sh
-          winCommand: harvest/batch-import-marc-auth.bat
-          arguments:
-            - label: Harvest subdirectory
-              required: true
-            - label: SolrMARC properties file
-              required: true
-          options:
-            - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
-              switch: -d
-              type: no-value
-            - label: Do not move the data files after importing.
-              switch: -m
-              type: no-value
-            - label: No logging.
-              switch: -z
-              type: no-value
-        - label: Batch import harvested XML records
-          type: external-command
-          command: harvest/batch-import-xsl.sh
-          winCommand: harvest/batch-import-xsl.bat
-          arguments:
-            - label: Harvest subdirectory
-              required: true
-            - label: Properties file
-              required: true
-          options:
-            - label: Skip optimize operation after importing.
-              switch: -s
-              type: no-value
-        - label: Harvest metadata using OAI-PMH
-          type: internal-command
-          command: harvest/harvest-oai
-        - label: Merge harvested MARCXML files into a collection
-          type: internal-command
-          command: harvest/merge-marc
-        - label: Batch delete records based on files created by the OAI-PMH harvester
-          type: external-command
-          command: harvest/batch-delete.sh
-          winCommand: harvest/batch-delete.bat
-          arguments:
-            - label: Harvest subdirectory
-              required: true
-            - label: Index type
-              required: false
-          options:
-            - label: Skip optimize
-              switch: -s
-              type: no-value
-            - label: Specify ID prefix
-              switch: --id-prefix
-              type: string
-      - label: Import Tools
-        type: menu
-        contents:
-        - label: Import MARC
-          type: external-command
-          command: import-marc.sh
-          winCommand: import-marc.bat
-          arguments:
-            - label: Filename
-              required: true
-          options:
-            - label: Properties File
-              switch: -p
-              type: string
-        - label: Import MARC authority records
-          type: external-command
-          command: import-marc-auth.sh
-          winCommand: import-marc-auth.bat
-          arguments:
-            - label: Filename
-              required: true
-            - label: Properties file
-              required: false
-        - label: Import XML
-          type: internal-command
-          command: import/import-xsl
-        - label: Import CSV
-          type: internal-command
-          command: import/import-csv
-        - label: Import via webcrawl
-          type: internal-command
-          command: import/webcrawl
-        - label: Index all alphabetic browse entries
-          type: external-command
-          command: index-alphabetic-browse.sh
-          winCommand: index-alphabetic-browse.bat
-        - label: Populate the course reserves Solr index
-          type: internal-command
-          command: util/index_reserves
-      - label: Language Tools
-        type: menu
-        contents:
-        - label: Add new language strings based on existing ones, using a template
-          type: internal-command
-          command: language/addusingtemplate
-        - label: Copy a language string
-          type: internal-command
-          command: language/copystring
-        - label: Remove a language string from all files
-          type: internal-command
-          command: language/delete
-        - label: Load and normalize language strings from Lokalise export files
-          type: internal-command
-          command: language/importlokalise
-        - label: Normalize a file or directory of language strings
-          type: internal-command
-          command: language/normalize
-      - label: Solr Management Tools
-        type: menu
-        contents:
-        - label: Manage Solr service
-          type: external-command
-          command: solr.sh
-          winCommand: solr.bat
-          arguments:
-            - label: Action to take (start, stop, restart, or status)
-              required: true
-        - label: Send a commit command to a Solr index
-          type: internal-command
-          command: util/commit
-        - label: Delete a set of records from the Solr index
-          type: internal-command
-          command: util/deletes
-        - label: Send an optimize command to a Solr index
-          type: internal-command
-          command: util/optimize
-        - label: Remove ILS-suppressed records from Solr
-          type: internal-command
-          command: util/suppressed
-      - label: Utilities
-        type: menu
-        contents:
-        - label: Deduplicate lines in a sorted file
-          type: internal-command
-          command: util/dedupe
-        - label: Validate MARC file contents
-          type: internal-command
-          command: util/lint_marc
+    - label: List All Menu Contents
+      type: summary
+    - label: Code Generation Tools
+      type: menu
+      contents:
+      - label: Generate a dynamic route
+        type: internal-command
+        command: generate/dynamicroute
+      - label: Generate a subclass, with lookup by class name
+        type: internal-command
+        command: generate/extendclass
+      - label: Generate a service (override with a new child class)
+        type: internal-command
+        command: generate/extendservice
+      - label: Generate a non-tab record action route
+        type: internal-command
+        command: generate/nontabrecordaction
+      - label: Generate a new plugin class
+        type: internal-command
+        command: generate/plugin
+      - label: Generate a record route
+        type: internal-command
+        command: generate/recordroute
+      - label: Generate a static route
+        type: internal-command
+        command: generate/staticroute
+      - label: Generate and configure a new theme
+        type: internal-command
+        command: generate/theme
+      - label: Generate and configure a new theme mixin
+        type: internal-command
+        command: generate/thememixin
+      - label: Compile theme (flatten hierarchy)
+        type: internal-command
+        command: compile/theme
+    - label: Configuration and Installation Tools
+      type: menu
+      contents:
+      - label: Manage VuFind installation
+        type: internal-command
+        command: install/install
+      - label: Manage the browscap cache
+        type: internal-command
+        command: util/browscap
+      - label: Switch the encryption algorithm in the database and config
+        type: internal-command
+        command: switch_db_hash
+    - label: Data Cleanup and Expiration Tools
+      type: menu
+      contents:
+      - label: Remove unused cached records from the database
+        type: internal-command
+        command: util/cleanup_record_cache
+      - label: Purge a cached record (and optionally a resource) from the database
+        type: internal-command
+        command: util/purge_cached_record
+      - label: Expire old access tokens in the database
+        type: internal-command
+        command: util/expire_access_tokens
+      - label: Expire old authentication hashes in the database
+        type: internal-command
+        command: util/expire_auth_hashes
+      - label: Expire old external sessions in the database
+        type: internal-command
+        command: util/expire_external_sessions
+      - label: Expire old login tokens in the database
+        type: internal-command
+        command: util/expire_login_tokens
+      - label: Expire old searches in the database
+        type: internal-command
+        command: util/expire_searches
+      - label: Expire old sessions in the database
+        type: internal-command
+        command: util/expire_sessions
+    - label: Data Management Tools
+      type: menu
+      contents:
+      - label: Populate the hierarchy tree cache
+        type: internal-command
+        command: util/createHierarchyTrees
+      - label: Generate XML sitemap files
+        type: internal-command
+        command: util/sitemap
+      - label: Send scheduled search email notifications
+        type: internal-command
+        command: scheduledsearch/notify
+    - label: Harvest Tools
+      type: menu
+      contents:
+      - label: Batch import harvested MARC records
+        type: external-command
+        command: harvest/batch-import-marc.sh
+        winCommand: harvest/batch-import-marc.bat
+        arguments:
+          - label: Harvest subdirectory
+            required: true
+        options:
+          - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
+            switch: -d
+            type: no-value
+          - label: Do not move the data files after importing.
+            switch: -m
+            type: no-value
+          - label: Use specified SolrMarc configuration properties file.
+            switch: -p
+            type: string
+          - label: Maximum number of files to send in batches to import-marc.sh (default is MAX_BATCH_COUNT or 10)
+            switch: -x
+            type: string
+          - label: No logging.
+            switch: -z
+            type: no-value
+      - label: Batch import harvested MARC authority records
+        type: external-command
+        command: harvest/batch-import-marc-auth.sh
+        winCommand: harvest/batch-import-marc-auth.bat
+        arguments:
+          - label: Harvest subdirectory
+            required: true
+          - label: SolrMARC properties file
+            required: true
+        options:
+          - label: Use the directory path as-is, do not append it to $VUFIND_LOCAL_DIR/harvest.
+            switch: -d
+            type: no-value
+          - label: Do not move the data files after importing.
+            switch: -m
+            type: no-value
+          - label: No logging.
+            switch: -z
+            type: no-value
+      - label: Batch import harvested XML records
+        type: external-command
+        command: harvest/batch-import-xsl.sh
+        winCommand: harvest/batch-import-xsl.bat
+        arguments:
+          - label: Harvest subdirectory
+            required: true
+          - label: Properties file
+            required: true
+        options:
+          - label: Skip optimize operation after importing.
+            switch: -s
+            type: no-value
+      - label: Harvest metadata using OAI-PMH
+        type: internal-command
+        command: harvest/harvest-oai
+      - label: Merge harvested MARCXML files into a collection
+        type: internal-command
+        command: harvest/merge-marc
+      - label: Batch delete records based on files created by the OAI-PMH harvester
+        type: external-command
+        command: harvest/batch-delete.sh
+        winCommand: harvest/batch-delete.bat
+        arguments:
+          - label: Harvest subdirectory
+            required: true
+          - label: Index type
+            required: false
+        options:
+          - label: Skip optimize
+            switch: -s
+            type: no-value
+          - label: Specify ID prefix
+            switch: --id-prefix
+            type: string
+    - label: Import Tools
+      type: menu
+      contents:
+      - label: Import MARC
+        type: external-command
+        command: import-marc.sh
+        winCommand: import-marc.bat
+        arguments:
+          - label: Filename
+            required: true
+        options:
+          - label: Properties File
+            switch: -p
+            type: string
+      - label: Import MARC authority records
+        type: external-command
+        command: import-marc-auth.sh
+        winCommand: import-marc-auth.bat
+        arguments:
+          - label: Filename
+            required: true
+          - label: Properties file
+            required: false
+      - label: Import XML
+        type: internal-command
+        command: import/import-xsl
+      - label: Import CSV
+        type: internal-command
+        command: import/import-csv
+      - label: Import via webcrawl
+        type: internal-command
+        command: import/webcrawl
+      - label: Index all alphabetic browse entries
+        type: external-command
+        command: index-alphabetic-browse.sh
+        winCommand: index-alphabetic-browse.bat
+      - label: Populate the course reserves Solr index
+        type: internal-command
+        command: util/index_reserves
+    - label: Language Tools
+      type: menu
+      contents:
+      - label: Add new language strings based on existing ones, using a template
+        type: internal-command
+        command: language/addusingtemplate
+      - label: Copy a language string
+        type: internal-command
+        command: language/copystring
+      - label: Remove a language string from all files
+        type: internal-command
+        command: language/delete
+      - label: Load and normalize language strings from Lokalise export files
+        type: internal-command
+        command: language/importlokalise
+      - label: Normalize a file or directory of language strings
+        type: internal-command
+        command: language/normalize
+    - label: Solr Management Tools
+      type: menu
+      contents:
+      - label: Manage Solr service
+        type: external-command
+        command: solr.sh
+        winCommand: solr.bat
+        arguments:
+          - label: Action to take (start, stop, restart, or status)
+            required: true
+      - label: Send a commit command to a Solr index
+        type: internal-command
+        command: util/commit
+      - label: Delete a set of records from the Solr index
+        type: internal-command
+        command: util/deletes
+      - label: Send an optimize command to a Solr index
+        type: internal-command
+        command: util/optimize
+      - label: Remove ILS-suppressed records from Solr
+        type: internal-command
+        command: util/suppressed
+    - label: Utilities
+      type: menu
+      contents:
+      - label: Deduplicate lines in a sorted file
+        type: internal-command
+        command: util/dedupe
+      - label: Validate MARC file contents
+        type: internal-command
+        command: util/lint_marc

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -48,6 +48,15 @@ main:
             - label: Properties File
               switch: -p
               type: string
+        - label: Import MARC authority records
+          type: external-command
+          command: import-marc-auth.sh
+          winCommand: import-marc-auth.bat
+          arguments:
+            - label: Filename
+              required: true
+            - label: Properties file
+              required: false
         - label: Import XML
           type: internal-command
           command: import/import-xsl
@@ -102,7 +111,35 @@ main:
     - label: Harvest Options
       type: menu
       contents:
-        - label: Batch import harvested authority records
+        - label: Batch import harvested MARC records
+          type: external-command
+          command: harvest/batch-import-marc.sh
+          winCommand: harvest/batch-import-marc.bat
+          arguments:
+            - label: Harvest subdirectory
+              required: true
+            - label: Properties file
+              required: false
+          options:
+            - label: Use the directory path as-is, do not append it to /usr/local/vufind/local/harvest.
+              switch: -d
+              type: no-value
+            - label: Print this message.
+              switch: -h
+              type: no-value
+            - label: Do not move the data files after importing.
+              switch: -m
+              type: no-value
+            - label: Use specified SolrMarc configuration properties file.
+              switch: -p
+              type: string
+            - label: Maximum number of files to send in batches to import-marc.sh (default is MAX_BATCH_COUNT or 10)
+              switch: -x
+              type: string
+            - label: No logging.
+              switch: -z
+              type: no-value
+        - label: Batch import harvested MARC authority records
           type: external-command
           command: harvest/batch-import-marc-auth.sh
           winCommand: harvest/batch-import-marc-auth.bat
@@ -117,12 +154,25 @@ main:
               type: no-value
             - label: Print this message.
               switch: -h
-              type: string
+              type: no-value
             - label: Do not move the data files after importing.
               switch: -m
               type: no-value
             - label: No logging.
               switch: -z
+              type: no-value
+        - label: Batch import harvested XML records
+          type: external-command
+          command: harvest/batch-import-xsl.sh
+          winCommand: harvest/batch-import-xsl.bat
+          arguments:
+            - label: Harvest subdirectory
+              required: true
+            - label: Properties file
+              required: true
+          options:
+            - label: Skip optimize operation after importing.
+              switch: -s
               type: no-value
         - label: Harvest metadata using OAI-PMH
           type: internal-command
@@ -197,6 +247,10 @@ main:
     - label: Utility Options
       type: menu
       contents:
+        - label: Index all alphabetic browse entries
+          type: external-command
+          command: index-alphabetic-browse.sh
+          winCommand: index-alphabetic-browse.bat
         - label: Manage the browscap cache
           type: internal-command
           command: util/browscap

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -226,18 +226,6 @@ main:
         - label: Normalize a file or directory of language strings
           type: internal-command
           command: language/normalize
-    - label: List Options
-      type: menu
-      contents:
-        - label: Display a list of commands
-          type: internal-command
-          command: list
-    - label: Menu Options
-      type: menu
-      contents:
-        - label: Display this interactive menu of commands
-          type: internal-command
-          command: menu/menu
     - label: Scheduled Search Notification Options
       type: menu
       contents:

--- a/config/vufind/ConsoleMenu.yaml
+++ b/config/vufind/ConsoleMenu.yaml
@@ -183,7 +183,7 @@ main:
             type: no-value
       - label: Harvest metadata using OAI-PMH
         type: internal-command
-        command: harvest/harvest-oai
+        command: harvest/harvest_oai
       - label: Merge harvested MARCXML files into a collection
         type: internal-command
         command: harvest/merge-marc

--- a/menu.php
+++ b/menu.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Command-line tool to launch menu.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Utilities
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/installation Wiki
+ */
+
+// Manipulate command line to load correct route, then run the main index page:
+array_unshift($_SERVER['argv'], array_shift($_SERVER['argv']), 'menu', 'menu');
+$_SERVER['argc'] += 2;
+require_once __DIR__ . '/public/index.php';

--- a/menu.php
+++ b/menu.php
@@ -23,7 +23,7 @@
  * @package  Utilities
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/installation Wiki
+ * @link     https://vufind.org/wiki/administration:command_line_utilities Wiki
  */
 
 // Manipulate command line to load correct route, then run the main index page:

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2024.
+ * Copyright (C) Villanova University 2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -291,7 +291,11 @@ class MenuCommand extends Command
                             $optionValues[$index] = $helper->ask($input, $output, $valueQuestion);
                             break;
                         case 'no-value':
-                            $optionValues[$index] = !($optionValues[$index] ?? false);
+                            if (!($optionValues[$index] ?? false)) {
+                                $optionValues[$index] = true;
+                            } else {
+                                unset($optionValues[$index]);
+                            }
                             break;
                         default:
                             throw new Exception("Unknown option type {$option['type']}.");

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -24,7 +24,7 @@
  * @package  Console
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     https://vufind.org/wiki/administration:command_line_utilities Wiki
  */
 
 namespace VuFindConsole\Command\Menu;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -157,7 +157,7 @@ class MenuCommand extends Command
                 $menu = [];
                 if (count($options) > 0) {
                     foreach ($options as $i => $currentOption) {
-                        if ($currentOption['type'] ?? 'string' === 'no-value') {
+                        if (($currentOption['type'] ?? 'string') === 'no-value') {
                             $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? false) ? 'ON' : 'OFF';
                         } else {
                             $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? '--unset--');

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -128,7 +128,7 @@ class MenuCommand extends Command
         while (true) {
             $choice = $this->getHelper('question')->ask($input, $output, $question);
             if ($choice === $exitOption) {
-                return 0;
+                return Command::SUCCESS;
             }
             $index = array_search($choice, $legalOptions);
             if ($index !== false) {
@@ -264,7 +264,7 @@ class MenuCommand extends Command
                 $fullCommand
             );
             if ($result === $this->exitCommand) {
-                return 0;
+                return Command::SUCCESS;
             }
             $resultParts = explode(' ', $result);
             $index = $resultParts[2] ?? null;
@@ -302,7 +302,7 @@ class MenuCommand extends Command
                 $success = $passthruSuccess !== false && $resultCode === 0;
                 $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
                 if ($success || (empty($arguments) && empty($options))) {
-                    return $success ? 0 : 1;
+                    return $success ? Command::SUCCESS : Command::FAILURE;
                 }
             }
         }
@@ -364,7 +364,7 @@ class MenuCommand extends Command
                 $this->displaySummary($output, $content, $indent . '    ');
             }
         }
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**
@@ -393,7 +393,7 @@ class MenuCommand extends Command
                 return $this->displaySummary($output, $this->config['main']);
             default:
                 $output->writeln("Unknown menu type '$type' with label '$label'");
-                return 1;
+                return Command::FAILURE;
         }
     }
 

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -171,6 +171,59 @@ class MenuCommand extends Command
     }
 
     /**
+     * Determine which action to take on an external command, using user input when appropriate.
+     *
+     * @param InputInterface  $input          Input object
+     * @param OutputInterface $output         Output object
+     * @param array           $options        Option configuration
+     * @param array           $optionValues   User-provided option values
+     * @param array           $arguments      Argument configuration
+     * @param array           $argumentValues User-provided argument values
+     * @param string          $fullCommand    Command to run based on current settings
+     *
+     * @return string
+     */
+    protected function getExternalCommandAction(
+        InputInterface $input,
+        OutputInterface $output,
+        array $options,
+        array $optionValues,
+        array $arguments,
+        array $argumentValues,
+        string $fullCommand
+    ): string {
+        // If there are no arguments or options to prompt the user about, run the command immediately:
+        if (count($options) === 0 && count($arguments) === 0) {
+            return $this->runCommand;
+        }
+        $helper = $this->getHelper('question');
+        $menu = [];
+        if (count($options) > 0) {
+            foreach ($options as $i => $currentOption) {
+                if (($currentOption['type'] ?? 'string') === 'no-value') {
+                    $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? false) ? 'ON' : 'OFF';
+                } else {
+                    $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? '--unset--');
+                }
+                $menu[] = "Set Option $i ({$currentOption['label']}); current value: " . $currentValue;
+            }
+        }
+        if (count($arguments) > 0) {
+            foreach ($arguments as $i => $currentArgument) {
+                $menu[] = "Set Argument $i ({$currentArgument['label']}); current value: "
+                    . ($argumentValues[$i] ?? $currentArgument['default'] ?? '--unset--');
+            }
+        }
+        $menu[] = $this->exitCommand;
+        $menu[] = $this->runCommand . ': ' . $fullCommand;
+        $question = new ChoiceQuestion(
+            'Choose an option: ',
+            $menu
+        );
+        return $helper->ask($input, $output, $question);
+    }
+
+    /**
      * Run an external (non-Symfony) command.
      *
      * @param InputInterface  $input  Input object
@@ -199,69 +252,52 @@ class MenuCommand extends Command
             }
         }
         // Collect any additional optional details from the user:
-        if (count($options) > 0 || count($arguments) > 0) {
-            do {
-                $menu = [];
-                if (count($options) > 0) {
-                    foreach ($options as $i => $currentOption) {
-                        if (($currentOption['type'] ?? 'string') === 'no-value') {
-                            $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? false) ? 'ON' : 'OFF';
-                        } else {
-                            $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? '--unset--');
-                        }
-                        $menu[] = "Set Option $i ({$currentOption['label']}); current value: " . $currentValue;
+        do {
+            $fullCommand = $this->buildExternalCommand($config, $argumentValues, $optionValues);
+            $result = $this->getExternalCommandAction(
+                $input,
+                $output,
+                $options,
+                $optionValues,
+                $arguments,
+                $argumentValues,
+                $fullCommand
+            );
+            if ($result === $this->exitCommand) {
+                return 0;
+            }
+            $resultParts = explode(' ', $result);
+            $index = $resultParts[2] ?? null;
+            switch ($resultParts[1] ?? '') {
+                case 'Option':
+                    $option = $options[$index];
+                    switch ($option['type'] ?? 'string') {
+                        case 'string':
+                            $valueQuestion = new Question(
+                                "Enter new value for {$option['label']}: ",
+                                $option['default'] ?? null
+                            );
+                            $optionValues[$index] = $helper->ask($input, $output, $valueQuestion);
+                            break;
+                        case 'no-value':
+                            $optionValues[$index] = !($optionValues[$index] ?? false);
+                            break;
+                        default:
+                            throw new Exception("Unknown option type {$option['type']}.");
                     }
-                }
-                if (count($arguments) > 0) {
-                    foreach ($arguments as $i => $currentArgument) {
-                        $menu[] = "Set Argument $i ({$currentArgument['label']}); current value: "
-                            . ($argumentValues[$i] ?? $currentArgument['default'] ?? '--unset--');
-                    }
-                }
-                $menu[] = $this->exitCommand;
-                $menu[] = $this->runCommand;
-                $question = new ChoiceQuestion(
-                    'Choose an option: ',
-                    $menu
-                );
-                $result = $helper->ask($input, $output, $question);
-                if ($result === $this->exitCommand) {
-                    return 0;
-                }
-                $resultParts = explode(' ', $result);
-                $index = $resultParts[2] ?? null;
-                switch ($resultParts[1] ?? '') {
-                    case 'Option':
-                        $option = $options[$index];
-                        switch ($option['type'] ?? 'string') {
-                            case 'string':
-                                $valueQuestion = new Question(
-                                    "Enter new value for {$option['label']}: ",
-                                    $option['default'] ?? null
-                                );
-                                $optionValues[$index] = $helper->ask($input, $output, $valueQuestion);
-                                break;
-                            case 'no-value':
-                                $optionValues[$index] = !($optionValues[$index] ?? false);
-                                break;
-                            default:
-                                throw new Exception("Unknown option type {$option['type']}.");
-                        }
-                        break;
-                    case 'Argument':
-                        $argument = $arguments[$index];
-                        $valueQuestion = new Question(
-                            "Enter new value for {$argument['label']}: ",
-                            $argument['default'] ?? null
-                        );
-                        $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
-                        break;
-                }
-            } while ($result !== $this->runCommand);
-        }
+                    break;
+                case 'Argument':
+                    $argument = $arguments[$index];
+                    $valueQuestion = new Question(
+                        "Enter new value for {$argument['label']}: ",
+                        $argument['default'] ?? null
+                    );
+                    $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
+                    break;
+            }
+        } while (!str_starts_with($result, $this->runCommand));
 
         // Run the command:
-        $fullCommand = $this->buildExternalCommand($config, $argumentValues, $optionValues);
         $output->writeln("Running command: $fullCommand");
         passthru($fullCommand);
         return 0;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -210,7 +210,9 @@ class MenuCommand extends Command
         }
 
         // Run the command:
-        if (isset($config['command'])) {
+        if (PHP_OS_FAMILY === 'Windows' && isset($config['winCommand'])) {
+            $baseCommand = APPLICATION_PATH . '\\' . $config['winCommand'];
+        } elseif (isset($config['command'])) {
             $baseCommand = APPLICATION_PATH . '/' . $config['command'];
         } elseif (isset($config['phpCommand'])) {
             $baseCommand = 'php ' . APPLICATION_PATH . '/' . $config['phpCommand'];

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -252,7 +252,7 @@ class MenuCommand extends Command
             }
         }
         // Collect any additional optional details from the user:
-        do {
+        while (true) {
             $fullCommand = $this->buildExternalCommand($config, $argumentValues, $optionValues);
             $result = $this->getExternalCommandAction(
                 $input,
@@ -295,12 +295,17 @@ class MenuCommand extends Command
                     $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
                     break;
             }
-        } while (!str_starts_with($result, $this->runCommand));
 
-        // Run the command:
-        $output->writeln("Running command: $fullCommand");
-        passthru($fullCommand);
-        return 0;
+            // Run the command if ready!
+            if (str_starts_with($result, $this->runCommand)) {
+                $passthruSuccess = passthru($fullCommand, $resultCode);
+                $success = $passthruSuccess !== false && $resultCode === 0;
+                $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
+                if ($success || (empty($arguments) && empty($options))) {
+                    return $success ? 0 : 1;
+                }
+            }
+        }
     }
 
     /**

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -193,7 +193,7 @@ class MenuCommand extends Command
                 );
                 $result = $helper->ask($input, $output, $question);
                 if ($result === $this->exitCommand) {
-                    return 1;
+                    return 0;
                 }
                 $resultParts = explode(' ', $result);
                 $index = $resultParts[2] ?? null;
@@ -308,7 +308,7 @@ class MenuCommand extends Command
                 $this->displaySummary($output, $content, $indent . '    ');
             }
         }
-        return 1;
+        return 0;
     }
 
     /**

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -167,7 +167,7 @@ class MenuCommand extends Command
                 }
             }
         }
-        return $baseCommand . $optionsString . ' ' . implode(' ', $argumentValues);
+        return trim($baseCommand . $optionsString . ' ' . implode(' ', $argumentValues));
     }
 
     /**
@@ -283,7 +283,7 @@ class MenuCommand extends Command
             // Run the command if ready!
             if (str_starts_with($result, $this->runCommand)) {
                 $success = $this->runCommand($fullCommand);
-                $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
+                $output->writeln($success ? '<info>Command successful.</info>' : '<error>Command failed.</error>');
                 if ($success || (empty($arguments) && empty($options))) {
                     return $success ? Command::SUCCESS : Command::FAILURE;
                 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -138,6 +138,39 @@ class MenuCommand extends Command
     }
 
     /**
+     * Build the external command string from configuration and user input.
+     *
+     * @param array $config         Command configuration
+     * @param array $argumentValues User argument values
+     * @param array $optionValues   User option values
+     *
+     * @return string
+     * @throws Exception
+     */
+    protected function buildExternalCommand(array $config, array $argumentValues, array $optionValues): string
+    {
+        if (PHP_OS_FAMILY === 'Windows' && isset($config['winCommand'])) {
+            $baseCommand = APPLICATION_PATH . '\\' . $config['winCommand'];
+        } elseif (isset($config['command'])) {
+            $baseCommand = APPLICATION_PATH . '/' . $config['command'];
+        } elseif (isset($config['phpCommand'])) {
+            $baseCommand = 'php ' . APPLICATION_PATH . DIRECTORY_SEPARATOR . $config['phpCommand'];
+        } else {
+            throw new Exception('No actionable command found in configuration.');
+        }
+        $optionsString = '';
+        foreach ($config['options'] ?? [] as $i => $option) {
+            if (isset($optionValues[$i])) {
+                $optionsString .= ' ' . $option['switch'];
+                if (($option['type'] ?? 'string') !== 'no-value') {
+                    $optionsString .= ' ' . $optionValues[$i];
+                }
+            }
+        }
+        return $baseCommand . $optionsString . ' ' . implode(' ', $argumentValues);
+    }
+
+    /**
      * Run an external (non-Symfony) command.
      *
      * @param InputInterface  $input  Input object
@@ -228,25 +261,7 @@ class MenuCommand extends Command
         }
 
         // Run the command:
-        if (PHP_OS_FAMILY === 'Windows' && isset($config['winCommand'])) {
-            $baseCommand = APPLICATION_PATH . '\\' . $config['winCommand'];
-        } elseif (isset($config['command'])) {
-            $baseCommand = APPLICATION_PATH . '/' . $config['command'];
-        } elseif (isset($config['phpCommand'])) {
-            $baseCommand = 'php ' . APPLICATION_PATH . '/' . $config['phpCommand'];
-        } else {
-            throw new Exception('No actionable command found in configuration.');
-        }
-        $optionsString = '';
-        foreach ($options as $i => $option) {
-            if (isset($optionValues[$i])) {
-                $optionsString .= ' ' . $option['switch'];
-                if (($option['type'] ?? 'string') !== 'no-value') {
-                    $optionsString .= ' ' . $optionValues[$i];
-                }
-            }
-        }
-        $fullCommand = $baseCommand . $optionsString . ' ' . implode(' ', $argumentValues);
+        $fullCommand = $this->buildExternalCommand($config, $argumentValues, $optionValues);
         $output->writeln("Running command: $fullCommand");
         passthru($fullCommand);
         return 0;
@@ -268,7 +283,7 @@ class MenuCommand extends Command
         $newConfig = [
             'label' => $config['label'],
             'type' => 'external-command',
-            'phpCommand' => 'public/index.php ' . $config['command'],
+            'phpCommand' => 'public' . DIRECTORY_SEPARATOR . 'index.php ' . $config['command'],
             'arguments' => [],
             'options' => [],
         ];

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -224,6 +224,19 @@ class MenuCommand extends Command
     }
 
     /**
+     * Run the provided command line; return true on success or false if it fails.
+     *
+     * @param string $command Command to run
+     *
+     * @return bool
+     */
+    protected function runCommand(string $command): bool
+    {
+        $passthruSuccess = passthru($command, $resultCode);
+        return $passthruSuccess !== false && $resultCode === 0;
+    }
+
+    /**
      * Run an external (non-Symfony) command.
      *
      * @param InputInterface  $input  Input object
@@ -269,8 +282,7 @@ class MenuCommand extends Command
             }
             // Run the command if ready!
             if (str_starts_with($result, $this->runCommand)) {
-                $passthruSuccess = passthru($fullCommand, $resultCode);
-                $success = $passthruSuccess !== false && $resultCode === 0;
+                $success = $this->runCommand($fullCommand);
                 $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
                 if ($success || (empty($arguments) && empty($options))) {
                     return $success ? Command::SUCCESS : Command::FAILURE;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -292,6 +292,26 @@ class MenuCommand extends Command
     }
 
     /**
+     * Display a summary of the menu system.
+     *
+     * @param OutputInterface $output Output object
+     * @param array           $config Configuration of option to summarize
+     * @param string          $indent Indentation level to apply (used for recursion)
+     *
+     * @return int
+     */
+    protected function displaySummary(OutputInterface $output, array $config, string $indent = ''): int
+    {
+        $output->writeln($indent . ($config['label'] ?? ''));
+        foreach ($config['contents'] ?? [] as $content) {
+            if (($content['type'] ?? '') !== 'summary') {
+                $this->displaySummary($output, $content, $indent . '    ');
+            }
+        }
+        return 1;
+    }
+
+    /**
      * Display a menu or prompt for the provided configuration.
      *
      * @param InputInterface  $input  Input object
@@ -312,6 +332,9 @@ class MenuCommand extends Command
                 return $this->runExternalCommand($input, $output, $config);
             case 'internal-command':
                 return $this->runInternalCommand($input, $output, $config);
+            case 'summary':
+                $output->writeln('');
+                return $this->displaySummary($output, $this->config['main']);
             default:
                 $output->writeln("Unknown menu type '$type' with label '$label'");
                 return 1;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Console command: interactive menu.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Console
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFindConsole\Command\Menu;
+
+use Exception;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+use VuFindConsole\Command\PluginManager;
+
+use function count;
+use function in_array;
+
+/**
+ * Console command: interactive menu.
+ *
+ * @category VuFind
+ * @package  Console
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+#[AsCommand(
+    name: 'menu/menu',
+    description: 'Interactive menu'
+)]
+class MenuCommand extends Command
+{
+    /**
+     * Constructor
+     *
+     * @param array         $config         Menu configuration
+     * @param PluginManager $commandManager Plugin manager for internal console commands
+     * @param string|null   $name           The name of the command; passing null means it must
+     * be set in configure()
+     */
+    public function __construct(protected array $config, protected PluginManager $commandManager, $name = null)
+    {
+        parent::__construct($name);
+    }
+
+    /**
+     * Configure the command.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setHelp('Display an interactive menu of commands.');
+    }
+
+    /**
+     * Display a submenu.
+     *
+     * @param InputInterface  $input   Input object
+     * @param OutputInterface $output  Output object
+     * @param array           $options Menu options
+     *
+     * @return int
+     */
+    protected function displaySubmenu(InputInterface $input, OutputInterface $output, array $options): int
+    {
+        $legalOptions = [];
+        foreach ($options as $i => $option) {
+            if (!isset($option['label'])) {
+                throw new Exception("Option $i is unlabeled!");
+            }
+            if (in_array($option['label'], $legalOptions)) {
+                throw new Exception('Duplicate label!');
+            }
+            $legalOptions[] = $option['label'];
+        }
+        $exitOption = 'Exit Menu';
+        if (in_array($exitOption, $legalOptions)) {
+            throw new Exception("Reserved label '$exitOption' used in configuration.");
+        }
+        $legalOptions[] = $exitOption;
+
+        $question = new ChoiceQuestion(
+            'Choose an option: ',
+            $legalOptions,
+            count($legalOptions) - 1
+        );
+        while (true) {
+            $choice = $this->getHelper('question')->ask($input, $output, $question);
+            if ($choice === $exitOption) {
+                return 0;
+            }
+            $index = array_search($choice, $legalOptions);
+            if ($index !== false) {
+                $this->displayOptions($input, $output, $options[$index]);
+            }
+        }
+    }
+
+    /**
+     * Run an external (non-Symfony) command.
+     *
+     * @param InputInterface  $input  Input object
+     * @param OutputInterface $output Output object
+     * @param array           $config Configuration of command to run
+     *
+     * @return int
+     */
+    protected function runExternalCommand(InputInterface $input, OutputInterface $output, array $config): int
+    {
+        $options = $config['options'] ?? [];
+        $optionValues = [];
+        $arguments = $config['arguments'] ?? [];
+        $argumentValues = [];
+        $helper = $this->getHelper('question');
+        // Collect default and required arguments:
+        foreach ($arguments as $i => $arg) {
+            if (!isset($arg['label'])) {
+                throw new Exception("Configuration error: argument $i missing label.");
+            }
+            if (isset($arg['default'])) {
+                $argumentValues[$i] = $arg['default'];
+            } elseif ($arg['required'] ?? false) {
+                $question = new Question($arg['label'] . ': ');
+                $argumentValues[$i] = $helper->ask($input, $output, $question);
+            }
+        }
+        // Collect any additional optional details from the user:
+        if (count($options) > 0 || count($arguments) > 0) {
+            do {
+                $menu = [];
+                if (count($options) > 0) {
+                    foreach ($options as $i => $currentOption) {
+                        if ($currentOption['type'] ?? 'string' === 'no-value') {
+                            $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? false) ? 'ON' : 'OFF';
+                        } else {
+                            $currentValue = ($optionValues[$i] ?? $currentOption['default'] ?? '--unset--');
+                        }
+                        $menu[] = "Set Option $i ({$currentOption['label']}); current value: " . $currentValue;
+                    }
+                }
+                if (count($arguments) > 0) {
+                    foreach ($arguments as $i => $currentArgument) {
+                        $menu[] = "Set Argument $i ({$currentArgument['label']}); current value: "
+                            . ($argumentValues[$i] ?? $currentArgument['default'] ?? '--unset--');
+                    }
+                }
+                $menu[] = 'Run Command';
+                $question = new ChoiceQuestion(
+                    'Choose an option: ',
+                    $menu
+                );
+                $result = $helper->ask($input, $output, $question);
+                $resultParts = explode(' ', $result);
+                $index = $resultParts[2] ?? null;
+                switch ($resultParts[1] ?? '') {
+                    case 'Option':
+                        $option = $options[$index];
+                        switch ($option['type'] ?? 'string') {
+                            case 'string':
+                                $valueQuestion = new Question(
+                                    "Enter new value for {$option['label']}: ",
+                                    $option['default'] ?? null
+                                );
+                                $optionValues[$index] = $helper->ask($input, $output, $valueQuestion);
+                                break;
+                            case 'no-value':
+                                $optionValues[$index] = !($optionValues[$index] ?? false);
+                                break;
+                            default:
+                                throw new Exception("Unknown option type {$option['type']}.");
+                        }
+                        break;
+                    case 'Argument':
+                        $argument = $arguments[$index];
+                        $valueQuestion = new Question(
+                            "Enter new value for {$argument['label']}: ",
+                            $argument['default'] ?? null
+                        );
+                        $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
+                        break;
+                }
+            } while ($result !== 'Run Command');
+        }
+
+        // Run the command:
+        if (isset($config['command'])) {
+            $baseCommand = APPLICATION_PATH . '/' . $config['command'];
+        } elseif (isset($config['phpCommand'])) {
+            $baseCommand = 'php ' . APPLICATION_PATH . '/' . $config['phpCommand'];
+        } else {
+            throw new Exception('No actionable command found in configuration.');
+        }
+        $optionsString = '';
+        foreach ($options as $i => $option) {
+            if (isset($optionValues[$i])) {
+                $optionsString .= ' ' . $option['switch'];
+                if (($option['type'] ?? 'string') !== 'no-value') {
+                    $optionsString .= ' ' . $optionValues[$i];
+                }
+            }
+        }
+        $fullCommand = $baseCommand . $optionsString . ' ' . implode(' ', $argumentValues);
+        $output->writeln("Running command: $fullCommand");
+        passthru($fullCommand);
+        return 0;
+    }
+
+    /**
+     * Run an internal (Symfony) command.
+     *
+     * @param InputInterface  $input  Input object
+     * @param OutputInterface $output Output object
+     * @param array           $config Configuration of command to run
+     *
+     * @return int
+     */
+    protected function runInternalCommand(InputInterface $input, OutputInterface $output, array $config): int
+    {
+        // Get the command object, and use it to create an external command configuration:
+        $command = $this->commandManager->get($config['command']);
+        $newConfig = [
+            'label' => $config['label'],
+            'type' => 'external-command',
+            'phpCommand' => 'public/index.php ' . $config['command'],
+            'arguments' => [],
+            'options' => [],
+        ];
+        $definition = $command->getDefinition();
+        foreach ($definition->getArguments() as $argument) {
+            $newConfig['arguments'][] = [
+                'label' => $argument->getDescription(),
+                'required' => $argument->isRequired(),
+                'default' => $argument->getDefault(),
+            ];
+        }
+        foreach ($definition->getOptions() as $option) {
+            $newConfig['options'][] = [
+                'label' => $option->getDescription(),
+                'switch' => '--' . $option->getName(),
+                'type' => $option->acceptValue() ? 'string' : 'no-value',
+                'default' => $option->getDefault(),
+            ];
+        }
+        return $this->runExternalCommand($input, $output, $newConfig);
+    }
+
+    /**
+     * Display a menu or prompt for the provided configuration.
+     *
+     * @param InputInterface  $input  Input object
+     * @param OutputInterface $output Output object
+     * @param array           $config Configuration of option to display
+     *
+     * @return int
+     */
+    protected function displayOptions(InputInterface $input, OutputInterface $output, array $config): int
+    {
+        $output->writeln($config['label'] ?? '');
+        $type = $config['type'] ?? 'unknown';
+        $label = $config['label'] ?? 'none';
+        switch ($type) {
+            case 'menu':
+                return $this->displaySubmenu($input, $output, $config['contents'] ?? []);
+            case 'external-command':
+                return $this->runExternalCommand($input, $output, $config);
+            case 'internal-command':
+                return $this->runInternalCommand($input, $output, $config);
+            default:
+                $output->writeln("Unknown menu type '$type' with label '$label'");
+                return 1;
+        }
+    }
+
+    /**
+     * Run the command.
+     *
+     * @param InputInterface  $input  Input object
+     * @param OutputInterface $output Output object
+     *
+     * @return int 0 for success
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        return $this->displayOptions($input, $output, $this->config['main']);
+    }
+}

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -78,7 +78,7 @@ class MenuCommand extends Command
      * @param string|null   $name           The name of the command; passing null means it must
      * be set in configure()
      */
-    public function __construct(protected array $config, protected PluginManager $commandManager, $name = null)
+    public function __construct(protected array $config, protected PluginManager $commandManager, ?string $name = null)
     {
         parent::__construct($name);
     }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -121,7 +121,7 @@ class MenuCommand extends Command
         $legalOptions[] = $exitOption;
 
         $question = new ChoiceQuestion(
-            'Choose an option: ',
+            'Choose an option:',
             $legalOptions,
             count($legalOptions) - 1
         );

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -263,9 +263,20 @@ class MenuCommand extends Command
                 $argumentValues,
                 $fullCommand
             );
+            // Bail out if the user wants to exit:
             if ($result === $this->exitCommand) {
                 return Command::SUCCESS;
             }
+            // Run the command if ready!
+            if (str_starts_with($result, $this->runCommand)) {
+                $passthruSuccess = passthru($fullCommand, $resultCode);
+                $success = $passthruSuccess !== false && $resultCode === 0;
+                $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
+                if ($success || (empty($arguments) && empty($options))) {
+                    return $success ? Command::SUCCESS : Command::FAILURE;
+                }
+            }
+            // If we got this far, we need to process additional user input:
             $resultParts = explode(' ', $result);
             $index = $resultParts[2] ?? null;
             switch ($resultParts[1] ?? '') {
@@ -294,16 +305,6 @@ class MenuCommand extends Command
                     );
                     $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
                     break;
-            }
-
-            // Run the command if ready!
-            if (str_starts_with($result, $this->runCommand)) {
-                $passthruSuccess = passthru($fullCommand, $resultCode);
-                $success = $passthruSuccess !== false && $resultCode === 0;
-                $output->writeln($success ? '<info>Commmand successful.</info>' : '<error>Command failed.</error>');
-                if ($success || (empty($arguments) && empty($options))) {
-                    return $success ? Command::SUCCESS : Command::FAILURE;
-                }
             }
         }
     }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommand.php
@@ -57,6 +57,20 @@ use function in_array;
 class MenuCommand extends Command
 {
     /**
+     * Menu option for running a command.
+     *
+     * @var string
+     */
+    protected string $runCommand = 'Run Command';
+
+    /**
+     * Menu option for exiting a command without running it.
+     *
+     * @var string
+     */
+    protected string $exitCommand = 'Exit Command';
+
+    /**
      * Constructor
      *
      * @param array         $config         Menu configuration
@@ -171,12 +185,16 @@ class MenuCommand extends Command
                             . ($argumentValues[$i] ?? $currentArgument['default'] ?? '--unset--');
                     }
                 }
-                $menu[] = 'Run Command';
+                $menu[] = $this->exitCommand;
+                $menu[] = $this->runCommand;
                 $question = new ChoiceQuestion(
                     'Choose an option: ',
                     $menu
                 );
                 $result = $helper->ask($input, $output, $question);
+                if ($result === $this->exitCommand) {
+                    return 1;
+                }
                 $resultParts = explode(' ', $result);
                 $index = $resultParts[2] ?? null;
                 switch ($resultParts[1] ?? '') {
@@ -206,7 +224,7 @@ class MenuCommand extends Command
                         $argumentValues[$index] = $helper->ask($input, $output, $valueQuestion);
                         break;
                 }
-            } while ($result !== 'Run Command');
+            } while ($result !== $this->runCommand);
         }
 
         // Run the command:

--- a/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Menu/MenuCommandFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Factory for Menu/Menu command.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Console
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFindConsole\Command\Menu;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+use VuFind\Config\YamlReader;
+
+/**
+ * Factory for Menu/Menu command.
+ *
+ * @category VuFind
+ * @package  Console
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class MenuCommandFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        $config = $container->get(YamlReader::class)->get('ConsoleMenu.yaml');
+        $commandManager = $container->get(\VuFindConsole\Command\PluginManager::class);
+        return new $requestedName($config, $commandManager, ...($options ?? []));
+    }
+}

--- a/module/VuFindConsole/src/VuFindConsole/Command/PluginManager.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/PluginManager.php
@@ -69,6 +69,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'language/delete' => Language\DeleteCommand::class,
         'language/importlokalise' => Language\ImportLokaliseCommand::class,
         'language/normalize' => Language\NormalizeCommand::class,
+        'menu/menu' => Menu\MenuCommand::class,
         'scheduledsearch/notify' => ScheduledSearch\NotifyCommand::class,
         'util/browscap' => Util\BrowscapCommand::class,
         'util/cleanuprecordcache' => Util\CleanUpRecordCacheCommand::class,
@@ -100,67 +101,47 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      */
     protected $factories = [
         Compile\ThemeCommand::class => Compile\ThemeCommandFactory::class,
-        Generate\DynamicRouteCommand::class =>
-            Generate\AbstractRouteCommandFactory::class,
-        Generate\ExtendClassCommand::class =>
-            Generate\AbstractContainerAwareCommandFactory::class,
-        Generate\ExtendServiceCommand::class =>
-            Generate\AbstractCommandFactory::class,
-        Generate\NonTabRecordActionCommand::class =>
-            Generate\NonTabRecordActionCommandFactory::class,
-        Generate\PluginCommand::class =>
-            Generate\AbstractContainerAwareCommandFactory::class,
-        Generate\RecordRouteCommand::class =>
-            Generate\AbstractRouteCommandFactory::class,
-        Generate\StaticRouteCommand::class =>
-            Generate\AbstractRouteCommandFactory::class,
-        Generate\ThemeCommand::class =>
-            Generate\ThemeCommandFactory::class,
-        Generate\ThemeMixinCommand::class =>
-            Generate\ThemeMixinCommandFactory::class,
+        Generate\DynamicRouteCommand::class => Generate\AbstractRouteCommandFactory::class,
+        Generate\ExtendClassCommand::class => Generate\AbstractContainerAwareCommandFactory::class,
+        Generate\ExtendServiceCommand::class => Generate\AbstractCommandFactory::class,
+        Generate\NonTabRecordActionCommand::class => Generate\NonTabRecordActionCommandFactory::class,
+        Generate\PluginCommand::class => Generate\AbstractContainerAwareCommandFactory::class,
+        Generate\RecordRouteCommand::class => Generate\AbstractRouteCommandFactory::class,
+        Generate\StaticRouteCommand::class => Generate\AbstractRouteCommandFactory::class,
+        Generate\ThemeCommand::class => Generate\ThemeCommandFactory::class,
+        Generate\ThemeMixinCommand::class => Generate\ThemeMixinCommandFactory::class,
         Harvest\MergeMarcCommand::class => InvokableFactory::class,
         Harvest\HarvestOaiCommand::class => Harvest\HarvestOaiCommandFactory::class,
         Import\ImportCsvCommand::class => Import\ImportCsvCommandFactory::class,
         Import\ImportXslCommand::class => Import\ImportXslCommandFactory::class,
         Import\WebCrawlCommand::class => Import\WebCrawlCommandFactory::class,
         Install\InstallCommand::class => InvokableFactory::class,
-        Language\AddUsingTemplateCommand::class =>
-            Language\AbstractCommandFactory::class,
+        Language\AddUsingTemplateCommand::class => Language\AbstractCommandFactory::class,
         Language\CopyStringCommand::class => Language\AbstractCommandFactory::class,
         Language\DeleteCommand::class => Language\AbstractCommandFactory::class,
         Language\ImportLokaliseCommand::class => Language\AbstractCommandFactory::class,
         Language\NormalizeCommand::class => Language\AbstractCommandFactory::class,
-        ScheduledSearch\NotifyCommand::class =>
-            ScheduledSearch\NotifyCommandFactory::class,
+        Menu\MenuCommand::class => Menu\MenuCommandFactory::class,
+        ScheduledSearch\NotifyCommand::class => ScheduledSearch\NotifyCommandFactory::class,
         Util\BrowscapCommand::class => Util\BrowscapCommandFactory::class,
-        Util\CleanUpRecordCacheCommand::class =>
-            Util\CleanUpRecordCacheCommandFactory::class,
+        Util\CleanUpRecordCacheCommand::class => Util\CleanUpRecordCacheCommandFactory::class,
         Util\CommitCommand::class => Util\AbstractSolrCommandFactory::class,
-        Util\CreateHierarchyTreesCommand::class =>
-        Util\CreateHierarchyTreesCommandFactory::class,
+        Util\CreateHierarchyTreesCommand::class => Util\CreateHierarchyTreesCommandFactory::class,
         Util\DedupeCommand::class => InvokableFactory::class,
         Util\DeletesCommand::class => Util\AbstractSolrCommandFactory::class,
-        Util\ExpireAccessTokensCommand::class =>
-            Util\ExpireAccessTokensCommandFactory::class,
-        Util\ExpireAuthHashesCommand::class =>
-            Util\ExpireAuthHashesCommandFactory::class,
-        Util\ExpireExternalSessionsCommand::class =>
-            Util\ExpireExternalSessionsCommandFactory::class,
-        Util\ExpireLoginTokensCommand::class =>
-            Util\ExpireLoginTokensCommandFactory::class,
-        Util\ExpireSearchesCommand::class =>
-            Util\ExpireSearchesCommandFactory::class,
-        Util\ExpireSessionsCommand::class =>
-            Util\ExpireSessionsCommandFactory::class,
-        Util\IndexReservesCommand::class =>
-            Util\AbstractSolrAndIlsCommandFactory::class,
+        Util\ExpireAccessTokensCommand::class => Util\ExpireAccessTokensCommandFactory::class,
+        Util\ExpireAuthHashesCommand::class => Util\ExpireAuthHashesCommandFactory::class,
+        Util\ExpireExternalSessionsCommand::class => Util\ExpireExternalSessionsCommandFactory::class,
+        Util\ExpireLoginTokensCommand::class => Util\ExpireLoginTokensCommandFactory::class,
+        Util\ExpireSearchesCommand::class => Util\ExpireSearchesCommandFactory::class,
+        Util\ExpireSessionsCommand::class => Util\ExpireSessionsCommandFactory::class,
+        Util\IndexReservesCommand::class => Util\AbstractSolrAndIlsCommandFactory::class,
         Util\LintMarcCommand::class => InvokableFactory::class,
         Util\OptimizeCommand::class => Util\AbstractSolrCommandFactory::class,
         Util\PurgeCachedRecordCommand::class => Util\PurgeCachedRecordCommandFactory::class,
         Util\ScssBuilderCommand::class => Util\ScssBuilderCommandFactory::class,
         Util\SitemapCommand::class => Util\SitemapCommandFactory::class,
-        Util\SuppressedCommand::class =>
-            Util\AbstractSolrAndIlsCommandFactory::class,
+        Util\SuppressedCommand::class => Util\AbstractSolrAndIlsCommandFactory::class,
         Util\SwitchDbHashCommand::class => Util\SwitchDbHashCommandFactory::class,
     ];
 

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
@@ -197,7 +197,7 @@ class MenuCommandTest extends \PHPUnit\Framework\TestCase
         $app = new Application();
         $app->addCommands([$command]);
         $tester = new CommandTester($command);
-        $tester->setInputs(['0', '2']);
+        $tester->setInputs(['0', '2']); // choose first menu option, then exit
         $tester->execute([]);
         $expectedSummary = <<<OUTPUT
             Summary

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Menu command test.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Command\Import;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use VuFind\CSV\Importer;
+use VuFindConsole\Command\Import\ImportCsvCommand;
+use VuFindConsole\Command\Menu\MenuCommand;
+use VuFindTest\Feature\ReflectionTrait;
+
+/**
+ * Install command test.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class MenuCommandTest extends \PHPUnit\Framework\TestCase
+{
+    use ReflectionTrait;
+
+    /**
+     * Test that running an internal command translates into running an external command.
+     *
+     * @return void
+     */
+    public function testInternalCommand(): void
+    {
+        $config = [
+            'main' => [
+                'label' => 'Import CSV',
+                'type' => 'internal-command',
+                'command' => 'install/install',
+            ],
+        ];
+        $commandManager = $this->createMock(\VuFindConsole\Command\PluginManager::class);
+        $importCsvCommand = new ImportCsvCommand($this->createMock(Importer::class));
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $commandManager->expects($this->once())->method('get')->with('install/install')->willReturn($importCsvCommand);
+        $command = $this->getMockBuilder(MenuCommand::class)
+            ->setConstructorArgs([$config, $commandManager])
+            ->onlyMethods(['runExternalCommand'])
+            ->getMock();
+        $expectedConfig = [
+            'label' => 'Import CSV',
+            'type' => 'external-command',
+            'phpCommand' => 'public/index.php install/install',
+            'arguments' => [
+                [
+                    'label' => 'source file to index',
+                    'required' => true,
+                    'default' => null,
+                ],
+                [
+                    'label' => "import configuration file (\$VUFIND_LOCAL_DIR/import and  \$VUFIND_HOME/import will\n"
+                        . 'be searched for this filename; see csv.ini for configuration examples)',
+                    'required' => true,
+                    'default' => null,
+
+                ],
+            ],
+            'options' => [
+                [
+                    'label' => 'activates test mode, which displays transformed output without updating Solr',
+                    'switch' => '--test-only',
+                    'type' => 'no-value',
+                    'default' => false,
+                ],
+                [
+                    'label' => "name of search backend to index content into (could be overridden with,\n"
+                        . 'for example, SolrAuth to index authority records)',
+                    'switch' => '--index',
+                    'type' => 'string',
+                    'default' => 'Solr',
+                ],
+            ],
+        ];
+        $command->expects($this->once())
+            ->method('runExternalCommand')
+            ->with($input, $output, $expectedConfig)
+            ->willReturn(Command::SUCCESS);
+        $this->assertEquals(Command::SUCCESS, $this->callMethod($command, 'execute', [$input, $output]));
+    }
+}

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
@@ -32,6 +32,7 @@ namespace VuFindTest\Command\Import;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
 use VuFind\CSV\Importer;
 use VuFindConsole\Command\Import\ImportCsvCommand;
 use VuFindConsole\Command\Menu\MenuCommand;
@@ -112,5 +113,50 @@ class MenuCommandTest extends \PHPUnit\Framework\TestCase
             ->with($input, $output, $expectedConfig)
             ->willReturn(Command::SUCCESS);
         $this->assertEquals(Command::SUCCESS, $this->callMethod($command, 'execute', [$input, $output]));
+    }
+
+    /**
+     * Data provider for testSimpleExternalCommand().
+     *
+     * @return array[]
+     */
+    public static function simpleExternalCommandProvider(): array
+    {
+        return ['success' => [true], 'failure' => [false]];
+    }
+
+    /**
+     * Test running an external command.
+     *
+     * @param bool $success Should the command succeed?
+     *
+     * @return void
+     *
+     * @dataProvider simpleExternalCommandProvider
+     */
+    public function testSimpleExternalCommand(bool $success): void
+    {
+        $config = [
+            'main' => [
+                'label' => 'sample command',
+                'type' => 'external-command',
+                'command' => 'foo',
+            ],
+        ];
+        $commandManager = $this->createMock(\VuFindConsole\Command\PluginManager::class);
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $command = $this->getMockBuilder(MenuCommand::class)
+            ->setConstructorArgs([$config, $commandManager])
+            ->onlyMethods(['runCommand', 'getHelper'])
+            ->getMock();
+        $command->expects($this->once())->method('runCommand')->with(APPLICATION_PATH . '/foo')->willReturn($success);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+        $this->assertEquals(
+            $success ? "sample command\nCommand successful.\n" : "sample command\nCommand failed.\n",
+            $tester->getDisplay()
+        );
+        $this->assertEquals($success ? Command::SUCCESS : Command::FAILURE, $tester->getStatusCode());
     }
 }

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Menu/MenuCommandTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Command\Import;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -144,8 +145,6 @@ class MenuCommandTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         $commandManager = $this->createMock(\VuFindConsole\Command\PluginManager::class);
-        $input = $this->createMock(InputInterface::class);
-        $output = $this->createMock(OutputInterface::class);
         $command = $this->getMockBuilder(MenuCommand::class)
             ->setConstructorArgs([$config, $commandManager])
             ->onlyMethods(['runCommand', 'getHelper'])
@@ -158,5 +157,56 @@ class MenuCommandTest extends \PHPUnit\Framework\TestCase
             $tester->getDisplay()
         );
         $this->assertEquals($success ? Command::SUCCESS : Command::FAILURE, $tester->getStatusCode());
+    }
+
+    /**
+     * Test the summary feature.
+     *
+     * @return void
+     */
+    public function testSummary(): void
+    {
+        $config = [
+            'main' => [
+                'label' => 'Main Menu',
+                'type' => 'menu',
+                'contents' => [
+                    [
+                        'label' => 'Summary',
+                        'type' => 'summary',
+                    ],
+                    [
+                        'label' => 'Submenu',
+                        'type' => 'menu',
+                        'contents' => [
+                            [
+                                'label' => 'Command',
+                                'type' => 'internal-command',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $commandManager = $this->createMock(\VuFindConsole\Command\PluginManager::class);
+        $command = $this->getMockBuilder(MenuCommand::class)
+            ->setConstructorArgs([$config, $commandManager, 'menu/menu'])
+            ->onlyMethods(['runCommand'])
+            ->getMock();
+        // We need to add the command to an application to set up the question helper:
+        $app = new Application();
+        $app->addCommands([$command]);
+        $tester = new CommandTester($command);
+        $tester->setInputs(['0', '2']);
+        $tester->execute([]);
+        $expectedSummary = <<<OUTPUT
+            Summary
+
+            Main Menu
+                Submenu
+                    Command
+            OUTPUT;
+        $this->assertStringContainsString($expectedSummary, $tester->getDisplay());
+        $this->assertEquals(Command::SUCCESS, $tester->getStatusCode());
     }
 }


### PR DESCRIPTION
This PR creates an interactive menu that can help less-experienced users access console utilities without needing detailed command line knowledge.

TODO
- [x] Build nested menu system
- [x] Create basic mechanism for running external commands
- [x] Create mechanism for running internal (Symfony) commands
- [x] Add full documentation to YAML file.
- [x] Add support for running different commands under Windows
- [x] Add option to exit without running a command if you change your mind
- [x] Populate default menu configuration with all existing commands
- [x] Add test coverage
