### PR TITLE
Remove useless and invalid pagination color overrides.

### DIFF
--- a/themes/bootstrap3/less/variables.less
+++ b/themes/bootstrap3/less/variables.less
@@ -2,9 +2,6 @@
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 @zindex-cookie-consent: (@zindex-dropdown - 10);
 
-@pagination-active-bg: @brand-primary;
-@pagination-active-border: @brand-primary;
-
 // Variables used in Sidebar Menu Lists
 @myresearch-menu-ul-margin-bottom: 0;
 @myresearch-menu-ul-padding-left: 0;
@@ -12,9 +9,6 @@
 /* #SCSS>
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 $zindex-cookie-consent: (@zindex-dropdown - 10) !default;
-
-$pagination-active-bg: @brand-primary !default;
-$pagination-active-border: @brand-primary !default;
 
 $myresearch-menu-ul-margin-bottom: 0 !default;
 $myresearch-menu-ul-padding-left: 0 !default;

--- a/themes/bootstrap3/scss/variables.scss
+++ b/themes/bootstrap3/scss/variables.scss
@@ -2,9 +2,6 @@
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 $zindex-cookie-consent: ($zindex-dropdown - 10);
 
-$pagination-active-bg: $brand-primary;
-$pagination-active-border: $brand-primary;
-
 // Variables used in Sidebar Menu Lists
 $myresearch-menu-ul-margin-bottom: 0;
 $myresearch-menu-ul-padding-left: 0;
@@ -12,9 +9,6 @@ $myresearch-menu-ul-padding-left: 0;
 /* #SCSS> */
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 $zindex-cookie-consent: ($zindex-dropdown - 10) !default;
-
-$pagination-active-bg: $brand-primary !default;
-$pagination-active-border: $brand-primary !default;
 
 $myresearch-menu-ul-margin-bottom: 0 !default;
 $myresearch-menu-ul-padding-left: 0 !default;

--- a/themes/bootstrap5/scss/bootstrap-variable-overrides.scss
+++ b/themes/bootstrap5/scss/bootstrap-variable-overrides.scss
@@ -47,9 +47,6 @@ $form-switch-bg-image-dark:         none !default;
 $navbar-dark-toggler-icon-bg:       none !default;
 $navbar-light-toggler-icon-bg:      none !default;
 
-$pagination-active-bg:              $primary !default;
-$pagination-active-border:          $primary !default;
-
 $link-hover-decoration:             underline !default;
 $icon-link-underline-offset:        inherit !default;
 

--- a/themes/bootstrap5/scss/variables.scss
+++ b/themes/bootstrap5/scss/variables.scss
@@ -2,9 +2,6 @@
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 $zindex-cookie-consent: ($zindex-dropdown - 10);
 
-$pagination-active-bg: $brand-primary;
-$pagination-active-border: $brand-primary;
-
 // Variables used in Sidebar Menu Lists
 $myresearch-menu-ul-margin-bottom: 0;
 $myresearch-menu-ul-padding-left: 0;
@@ -12,9 +9,6 @@ $myresearch-menu-ul-padding-left: 0;
 /* #SCSS> */
 // Cookie consent dialog should have a z-index low enough to stay below dropdowns and modals
 $zindex-cookie-consent: ($zindex-dropdown - 10) !default;
-
-$pagination-active-bg: $brand-primary !default;
-$pagination-active-border: $brand-primary !default;
 
 $myresearch-menu-ul-margin-bottom: 0 !default;
 $myresearch-menu-ul-padding-left: 0 !default;


### PR DESCRIPTION
- The settings were not needed because the default is already $primary (or $brand-primary in bootstrap 3).
- The settings in bootstrap5's variables.scss were invalid as $brand-primary (a BS3 thing) isn't actually defined (but `!default` masked the mistake).