### PR TITLE
Remove direct dependency on laminas/laminas-text.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,6 @@
         "laminas/laminas-servicemanager": "3.22.1",
         "laminas/laminas-session": "2.21.0",
         "laminas/laminas-stdlib": "3.19.0",
-        "laminas/laminas-text": "2.11.0",
         "laminas/laminas-validator": "2.64.2",
         "laminas/laminas-view": "2.27.0",
         "laminas/laminas-translator": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "540c871f9b843a7da019964d94455bf4",
+    "content-hash": "d1765a7b30d0a5f737a778342035f65a",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -4226,31 +4226,31 @@
         },
         {
             "name": "laminas/laminas-text",
-            "version": "2.11.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-text.git",
-                "reference": "d799f3ccb3547e9e6ab313447138bae7009c7cc7"
+                "reference": "3f36bbf7517b66448fcbd82c6c03d0110431ba1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-text/zipball/d799f3ccb3547e9e6ab313447138bae7009c7cc7",
-                "reference": "d799f3ccb3547e9e6ab313447138bae7009c7cc7",
+                "url": "https://api.github.com/repos/laminas/laminas-text/zipball/3f36bbf7517b66448fcbd82c6c03d0110431ba1f",
+                "reference": "3f36bbf7517b66448fcbd82c6c03d0110431ba1f",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-servicemanager": "^3.22.0",
                 "laminas/laminas-stdlib": "^3.7.1",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-text": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "phpunit/phpunit": "^9.5",
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "phpunit/phpunit": "^10.5.38",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.1"
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "autoload": {
@@ -4282,7 +4282,8 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-07T16:45:45+00:00"
+            "abandoned": true,
+            "time": "2024-12-05T16:44:33+00:00"
         },
         {
             "name": "laminas/laminas-translator",
@@ -14408,7 +14409,7 @@
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },


### PR DESCRIPTION
The laminas-text package has been abandoned. We no longer directly use it in our code base, so we should not reference it in our composer.json. (It was used long ago as part of our console interface, but since that has migrated to Symfony, it is no longer needed). The package is still being installed as part of laminas-captcha, but hopefully that issue will be addressed upstream sooner or later.