### PR TITLE
Fix broken combined search jump menu.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -240,6 +240,30 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that the jump menu can be enabled.
+     *
+     * @return void
+     */
+    public function testJumpMenu(): void
+    {
+        $config = $this->getCombinedIniOverrides();
+        $config['Solr:one']['ajax'] = true; // use mixed AJAX mode for more thorough test
+        $config['Layout']['jump_links'] = true;
+        $this->changeConfigs(
+            ['combined' => $config],
+            ['combined']
+        );
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
+        $expectedContent = 'Jump to Results: Solr One (1) Solr Two (1)';
+        $getText = "document.getElementsByClassName('combined-jump-links')[0].textContent.replace(/\s+/g, ' ').trim()";
+        $this->waitStatement("$getText === '$expectedContent'");
+        $this->assertEquals(
+            $expectedContent,
+            $this->findCssAndGetText($page, '.combined-jump-links')
+        );
+    }
+
+    /**
      * Test that DOI results work in various AJAX/non-AJAX modes.
      *
      * @param bool $leftAjax  Should left column load via AJAX?

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -255,6 +255,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
         );
         $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $expectedContent = 'Jump to Results: Solr One (1) Solr Two (1)';
+        // The AJAX count may not load right away, so wait to be sure we assert on the final value:
         $getText = "document.getElementsByClassName('combined-jump-links')[0].textContent.replace(/\s+/g, ' ').trim()";
         $this->waitStatement("$getText === '$expectedContent'");
         $this->assertEquals(

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -52,8 +52,7 @@
         if (link) {
           let count = $recordTotal;
           count = count.toLocaleString();
-          const spanText = document.createTextNode();
-          spanText.textContent = '(' + count + ')';
+          const spanText = document.createTextNode('(' + count + ')');
           const totalSpan = document.createElement('span');
           totalSpan.className = 'record-total';
           totalSpan.append(spanText);

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -52,8 +52,7 @@
         if (link) {
           let count = $recordTotal;
           count = count.toLocaleString();
-          const spanText = document.createTextNode();
-          spanText.textContent = '(' + count + ')';
+          const spanText = document.createTextNode('(' + count + ')');
           const totalSpan = document.createElement('span');
           totalSpan.className = 'record-total';
           totalSpan.append(spanText);


### PR DESCRIPTION
This fixes a bug introduced by #4065: createTextNode() requires an argument, and calling it without one was causing a fatal error and preventing the combined search jump menu from appearing (at least in Firefox).

This also adds a Mink test to prevent regressions.