### PR TITLE
Combined jump links: configurable linking modes

### DIFF
--- a/config/vufind/combined.ini
+++ b/config/vufind/combined.ini
@@ -99,6 +99,11 @@ columns = 3
 stack_placement = distributed
 ; Jump links appear above the search results and link to each result module
 ;jump_links = true
+; If jump_links is true, this setting can control what types of links are used:
+; 'anchor' will create anchor links that jump to the matching column on the page
+; 'link' will link directly to the expanded search results
+; The default is 'anchor'
+;jump_links_mode = anchor
 
 [Solr]
 label = Catalog

--- a/themes/bootstrap3/templates/combined/jump-links.phtml
+++ b/themes/bootstrap3/templates/combined/jump-links.phtml
@@ -2,8 +2,24 @@
   <span><?=$this->translate('combined_jump_links_intro')?></span>
   <ul>
     <?php foreach ($combinedResults as $section) : ?>
+      <?php
+        // If we're in link mode, try to directly link to results, but fail back to the anchor if we don't
+        // have access to results, or if the results object is "combined" (indicating we're in AJAX mode
+        // and don't have results yet):
+        if (
+          ($mode ?? 'anchor') === 'link'
+          && ($results = $section['view']->results ?? null)
+          && !($results instanceof \VuFind\Search\Combined\Results)
+        ) {
+          $params = $results->getParams();
+          $lookfor = $results->getUrlQuery()->isQuerySuppressed() ? '' : $params->getDisplayQuery();
+          $href = $this->url($params->getOptions()->getSearchAction()) . $results->getUrlQuery()->setPage(1)->setLimit($params->getOptions()->getDefaultLimit());
+        } else {
+          $href = '#' . $section['domId'];
+        }
+      ?>
       <li class="<?= $this->escapeHtmlAttr($section['domId']) ?>">
-        <a href="#<?= $this->escapeHtmlAttr($section['domId']) ?>"><?= $this->transEsc($section['label']) ?></a>
+        <a href="<?= $this->escapeHtmlAttr($href) ?>" data-link-mode="<?= $this->escapeHtmlAttr($mode) ?>"><?= $this->transEsc($section['label']) ?></a>
       </li>
     <?php endforeach; ?>
   </ul>

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -43,7 +43,7 @@
         JS;
   };
 
-  // Update result counts in jump links
+  // Update result counts (and, if necessary, href attributes) in jump links
   $classId = $this->escapeHtml($domId ?? 'combined_' . $searchClassId);
   $jsMoreUrl = $this->escapeJs(html_entity_decode($moreUrl));
   $countsJs = <<<JS

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -45,19 +45,24 @@
 
   // Update result counts in jump links
   $classId = $this->escapeHtml($domId ?? 'combined_' . $searchClassId);
+  $jsMoreUrl = $this->escapeJs(html_entity_decode($moreUrl));
   $countsJs = <<<JS
       function updateJumpLink_$classId() {
         const combinedJumpLinks = document.querySelector('.combined-jump-links');
-        const link = combinedJumpLinks?.querySelector('.$classId');
-        if (link) {
+        const linkContainer = combinedJumpLinks?.querySelector('.$classId');
+        if (linkContainer) {
           let count = $recordTotal;
           count = count.toLocaleString();
           const spanText = document.createTextNode('(' + count + ')');
           const totalSpan = document.createElement('span');
           totalSpan.className = 'record-total';
           totalSpan.append(spanText);
-          link.append(totalSpan);
-          link.style.display = "inline";
+          linkContainer.append(totalSpan);
+          linkContainer.style.display = "inline";
+          const link = linkContainer.querySelector('a');
+          if (link.dataset.linkMode === 'link') {
+            link.href = "$jsMoreUrl";
+          };
           combinedJumpLinks.style.visibility = "inherit";
         }
       }

--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -54,7 +54,15 @@
   </div>
 <?php endif; ?>
 <?php if ($config['Layout']['jump_links'] ?? false): ?>
-  <?=$this->render('combined/jump-links.phtml', ['combinedResults' => $this->combinedResults])?>
+  <?=
+    $this->render(
+        'combined/jump-links.phtml',
+        [
+        'combinedResults' => $this->combinedResults,
+        'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
+      ]
+    )
+  ?>
 <?php endif; ?>
 <form id="search-cart-form" class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
   <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>

--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -58,9 +58,9 @@
     $this->render(
         'combined/jump-links.phtml',
         [
-        'combinedResults' => $this->combinedResults,
-        'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
-      ]
+          'combinedResults' => $this->combinedResults,
+          'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
+        ]
     )
   ?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/combined/jump-links.phtml
+++ b/themes/bootstrap5/templates/combined/jump-links.phtml
@@ -2,8 +2,24 @@
   <span><?=$this->translate('combined_jump_links_intro')?></span>
   <ul>
     <?php foreach ($combinedResults as $section) : ?>
+      <?php
+        // If we're in link mode, try to directly link to results, but fail back to the anchor if we don't
+        // have access to results, or if the results object is "combined" (indicating we're in AJAX mode
+        // and don't have results yet):
+        if (
+          ($mode ?? 'anchor') === 'link'
+          && ($results = $section['view']->results ?? null)
+          && !($results instanceof \VuFind\Search\Combined\Results)
+        ) {
+          $params = $results->getParams();
+          $lookfor = $results->getUrlQuery()->isQuerySuppressed() ? '' : $params->getDisplayQuery();
+          $href = $this->url($params->getOptions()->getSearchAction()) . $results->getUrlQuery()->setPage(1)->setLimit($params->getOptions()->getDefaultLimit());
+        } else {
+          $href = '#' . $section['domId'];
+        }
+      ?>
       <li class="<?= $this->escapeHtmlAttr($section['domId']) ?>">
-        <a href="#<?= $this->escapeHtmlAttr($section['domId']) ?>"><?= $this->transEsc($section['label']) ?></a>
+        <a href="<?= $this->escapeHtmlAttr($href) ?>" data-link-mode="<?= $this->escapeHtmlAttr($mode) ?>"><?= $this->transEsc($section['label']) ?></a>
       </li>
     <?php endforeach; ?>
   </ul>

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -43,7 +43,7 @@
         JS;
   };
 
-  // Update result counts in jump links
+  // Update result counts (and, if necessary, href attributes) in jump links
   $classId = $this->escapeHtml($domId ?? 'combined_' . $searchClassId);
   $jsMoreUrl = $this->escapeJs(html_entity_decode($moreUrl));
   $countsJs = <<<JS

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -45,19 +45,24 @@
 
   // Update result counts in jump links
   $classId = $this->escapeHtml($domId ?? 'combined_' . $searchClassId);
+  $jsMoreUrl = $this->escapeJs(html_entity_decode($moreUrl));
   $countsJs = <<<JS
       function updateJumpLink_$classId() {
         const combinedJumpLinks = document.querySelector('.combined-jump-links');
-        const link = combinedJumpLinks?.querySelector('.$classId');
-        if (link) {
+        const linkContainer = combinedJumpLinks?.querySelector('.$classId');
+        if (linkContainer) {
           let count = $recordTotal;
           count = count.toLocaleString();
           const spanText = document.createTextNode('(' + count + ')');
           const totalSpan = document.createElement('span');
           totalSpan.className = 'record-total';
           totalSpan.append(spanText);
-          link.append(totalSpan);
-          link.style.display = "inline";
+          linkContainer.append(totalSpan);
+          linkContainer.style.display = "inline";
+          const link = linkContainer.querySelector('a');
+          if (link.dataset.linkMode === 'link') {
+            link.href = "$jsMoreUrl";
+          };
           combinedJumpLinks.style.visibility = "inherit";
         }
       }

--- a/themes/bootstrap5/templates/combined/results.phtml
+++ b/themes/bootstrap5/templates/combined/results.phtml
@@ -54,7 +54,15 @@
   </div>
 <?php endif; ?>
 <?php if ($config['Layout']['jump_links'] ?? false): ?>
-  <?=$this->render('combined/jump-links.phtml', ['combinedResults' => $this->combinedResults])?>
+  <?=
+    $this->render(
+        'combined/jump-links.phtml',
+        [
+        'combinedResults' => $this->combinedResults,
+        'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
+      ]
+    )
+  ?>
 <?php endif; ?>
 <form id="search-cart-form" class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
   <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => ''])?>

--- a/themes/bootstrap5/templates/combined/results.phtml
+++ b/themes/bootstrap5/templates/combined/results.phtml
@@ -58,9 +58,9 @@
     $this->render(
         'combined/jump-links.phtml',
         [
-        'combinedResults' => $this->combinedResults,
-        'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
-      ]
+          'combinedResults' => $this->combinedResults,
+          'mode' => $config['Layout']['jump_links_mode'] ?? 'anchor',
+        ]
     )
   ?>
 <?php endif; ?>


### PR DESCRIPTION
We had a request to make the jump links in the combined search results link directly to the searches, instead of jumping down to anchors on the page. This PR adds a config setting to make that behavior adjustable (and adds Mink test coverage as well).