### PR TITLE
Prevent "new item" hidden filters from bleeding beyond scope

### DIFF
--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -316,6 +316,7 @@ class SearchController extends AbstractSolrSearch
         }
 
         // We don't want new items hidden filters to propagate to other searches:
+        $this->serviceLocator->get('ViewHelperManager')->get('searchTabs')->disableHiddenFilterParams();
         $view->ignoreHiddenFiltersInRequest = true;
 
         return $view;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -297,8 +297,10 @@ class SearchController extends AbstractSolrSearch
             $this->getRequest()->getQuery()->set('hiddenFilters', $hiddenFilters);
         }
 
-        // Don't save to history -- history page doesn't handle correctly:
+        // Don't save to history or memory -- history page doesn't handle correctly
+        // and we don't want hidden filters bleeding to weird places:
         $this->saveToHistory = false;
+        $this->getSearchMemory()->disable();
 
         // Call rather than forward, so we can use custom template
         $view = $this->resultsAction();
@@ -314,7 +316,6 @@ class SearchController extends AbstractSolrSearch
         }
 
         // We don't want new items hidden filters to propagate to other searches:
-        $view->ignoreHiddenFilterMemory = true;
         $view->ignoreHiddenFiltersInRequest = true;
 
         return $view;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -297,6 +297,10 @@ class SearchController extends AbstractSolrSearch
             $this->getRequest()->getQuery()->set('hiddenFilters', $hiddenFilters);
         }
 
+        // Flag this as a specialized search to avoid bleeding defaults into the
+        // standard search box:
+        $this->getRequest()->getQuery()->set('specializedSearch', true);
+
         // Don't save to history or memory -- history page doesn't handle correctly
         // and we don't want hidden filters bleeding to weird places:
         $this->saveToHistory = false;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -316,7 +316,7 @@ class SearchController extends AbstractSolrSearch
         }
 
         // We don't want new items hidden filters to propagate to other searches:
-        $this->serviceLocator->get('ViewHelperManager')->get('searchTabs')->disableHiddenFilterParams();
+        $this->serviceLocator->get('ViewHelperManager')->get('searchTabs')->disableCurrentHiddenFilterParams();
         $view->ignoreHiddenFiltersInRequest = true;
 
         return $view;

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -312,6 +312,7 @@ class SearchController extends AbstractSolrSearch
             $view->results->getUrlQuery()
                 ->setDefaultParameter('range', $range)
                 ->setDefaultParameter('department', $dept)
+                ->disableHiddenFilters()
                 ->setSuppressQuery(true);
         }
 

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -2116,7 +2116,7 @@ class Params
      * Is this a specialized search (i.e. a customized scenario like new items,
      * rather than a "normal" backend search)?
      *
-     * @var bool
+     * @return bool
      */
     public function isSpecializedSearch(): bool
     {

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -242,6 +242,14 @@ class Params
     protected $queryAdapterClass = QueryAdapter::class;
 
     /**
+     * Is this a specialized search (i.e. a customized scenario like new items,
+     * rather than a "normal" backend search)?
+     *
+     * @var bool
+     */
+    protected $isSpecializedSearch = false;
+
+    /**
      * Constructor
      *
      * @param \VuFind\Search\Base\Options  $options      Options to use
@@ -369,6 +377,7 @@ class Params
         $this->initSort($request);
         $this->initFilters($request);
         $this->initHiddenFilters($request);
+        $this->isSpecializedSearch = $request->get('specializedSearch', false);
     }
 
     /**
@@ -2101,5 +2110,16 @@ class Params
     {
         $translatedFacets = $this->getOptions()->getTranslatedFacets();
         return method_exists($this, 'setFacetContains') && !in_array($facet, $translatedFacets);
+    }
+
+    /**
+     * Is this a specialized search (i.e. a customized scenario like new items,
+     * rather than a "normal" backend search)?
+     *
+     * @var bool
+     */
+    public function isSpecializedSearch(): bool
+    {
+        return $this->isSpecializedSearch;
     }
 }

--- a/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
+++ b/module/VuFind/src/VuFind/Search/UrlQueryHelper.php
@@ -236,6 +236,17 @@ class UrlQueryHelper
     }
 
     /**
+     * Disable hidden filters
+     *
+     * @return UrlQueryHelper
+     */
+    public function disableHiddenFilters()
+    {
+        unset($this->urlParams['hiddenFilters']);
+        return $this;
+    }
+
+    /**
      * Control query suppression
      *
      * @param bool $suppress Should we suppress queries?

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -86,6 +86,13 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
     protected $cachedHiddenFilterParams = [];
 
     /**
+     * Are hidden filter params disabled?
+     *
+     * @var bool
+     */
+    protected $hiddenFilterParamsDisabled = false;
+
+    /**
      * Constructor
      *
      * @param PluginManager    $results Search results plugin manager
@@ -229,6 +236,9 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
         $ignoreHiddenFilterMemory = false,
         $prepend = '&amp;'
     ) {
+        if ($this->hiddenFilterParamsDisabled) {
+            return '';
+        }
         if (!isset($this->cachedHiddenFilterParams[$searchClassId])) {
             $view = $this->getView();
             $hiddenFilters = $this->getHiddenFilters(
@@ -370,5 +380,16 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
             );
         }
         return '';
+    }
+
+    /**
+     * Disable hidden filter params (used in contexts like New Items where we don't
+     * want to persist hidden filters through links).
+     *
+     * @return void
+     */
+    public function disableHiddenFilterParams(): void
+    {
+        $this->hiddenFilterParamsDisabled = true;
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchTabs.php
@@ -86,11 +86,11 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
     protected $cachedHiddenFilterParams = [];
 
     /**
-     * Are hidden filter params disabled?
+     * Should we force getCurrentHiddenFilterParams() to return an empty string?
      *
      * @var bool
      */
-    protected $hiddenFilterParamsDisabled = false;
+    protected $currentHiddenFilterParamsDisabled = false;
 
     /**
      * Constructor
@@ -236,7 +236,7 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
         $ignoreHiddenFilterMemory = false,
         $prepend = '&amp;'
     ) {
-        if ($this->hiddenFilterParamsDisabled) {
+        if ($this->currentHiddenFilterParamsDisabled) {
             return '';
         }
         if (!isset($this->cachedHiddenFilterParams[$searchClassId])) {
@@ -383,13 +383,13 @@ class SearchTabs extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
-     * Disable hidden filter params (used in contexts like New Items where we don't
-     * want to persist hidden filters through links).
+     * Force getCurrentHiddenFilterParams() to return an empty string (used in contexts like
+     * New Items where we don't want to persist hidden filters through links).
      *
      * @return void
      */
-    public function disableHiddenFilterParams(): void
+    public function disableCurrentHiddenFilterParams(): void
     {
-        $this->hiddenFilterParamsDisabled = true;
+        $this->currentHiddenFilterParamsDisabled = true;
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemSolrTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemSolrTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Test Solr-driven new item functionality.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+/**
+ * Test Solr-driven new item functionality.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class NewItemSolrTest extends \VuFindTest\Integration\MinkTestCase
+{
+    /**
+     * Test that Solr-powered new items work as expected (using non-default range settings).
+     *
+     * @return void
+     */
+    public function testNewItems(): void
+    {
+        $this->changeConfigs(
+            [
+                'searches' => [
+                    'NewItem' => [
+                        'method' => 'solr',
+                        'ranges' => '1,15,60',
+                    ],
+                ],
+            ]
+        );
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/NewItem');
+        $page = $session->getPage();
+        // Confirm custom ranges display correctly:
+        $this->assertEquals(
+            'Yesterday Past 15 Days Past 60 Days',
+            $this->findCssAndGetText($page, '.form-search-newitem .btn-group')
+        );
+        // Now perform a search:
+        $this->clickCss($page, '.form-search-newitem .btn-group .btn-primary', index: 1);
+        $this->clickCss($page, '.form-search-newitem input[type="submit"]');
+        $this->waitForPageLoad($page);
+
+        // Confirm that we've reached the custom results page:
+        $this->assertEquals(
+            'Showing 1 - 20 results of 20 New Items',
+            $this->findCssAndGetText($page, '.search-stats')
+        );
+
+        // Make sure that author links do not have inappropriate hidden filters:
+        $authorLink = $this->findAndAssertLink($page, 'Shakespeare, William 1564 - 1616');
+        $this->assertStringEndsWith(
+            '/Author/Home?author=Shakespeare,%20William%201564%20-%201616',
+            $authorLink->getAttribute('href')
+        );
+
+        // Make sure that facet links do not have inappropriate hidden filters:
+        $facetLink = $this->findAndAssertLink($page, 'B - Philosophy, Psychology, Religion');
+        $this->assertEquals(
+            '?range=15&department=&filter%5B%5D=callnumber-first%3A%22B+-+Philosophy%2C+Psychology%2C+Religion%22',
+            $facetLink->getAttribute('href')
+        );
+
+        // Click through to a record and make sure it does not include unexpected hidden filters:
+        $title = 'Englisch-deutsche Studienausgabe der Dramen Shakespeares /';
+        $recordLink = $this->findAndAssertLink($page, $title);
+        $recordLink->click();
+        $this->waitForPageLoad($page);
+        $this->assertEquals($title, $this->findCssAndGetText($page, 'h1'));
+        $recordAuthorLink = $this->findAndAssertLink($page, 'Shakespeare, William 1564 - 1616');
+        $this->assertStringEndsWith(
+            '/Author/Home?author=Shakespeare,%20William%201564%20-%201616',
+            $recordAuthorLink->getAttribute('href')
+        );
+
+        // Perform a fresh search and make sure unwanted hidden filters do not bleed through:
+        $session->back(); // return to new item list
+        $this->clickCss($page, '.search.container .btn-primary');
+        $this->waitForPageLoad($page);
+        $this->assertStringEndsWith(
+            '/Search/Results?lookfor=&type=AllFields',
+            $session->getCurrentUrl()
+        );
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test Solr-driven new item functionality.
+ * Test new item search functionality.
  *
  * PHP version 8
  *
@@ -30,7 +30,7 @@
 namespace VuFindTest\Mink;
 
 /**
- * Test Solr-driven new item functionality.
+ * Test new item search functionality.
  *
  * @category VuFind
  * @package  Tests
@@ -38,14 +38,14 @@ namespace VuFindTest\Mink;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class NewItemSolrTest extends \VuFindTest\Integration\MinkTestCase
+class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
 {
     /**
      * Test that Solr-powered new items work as expected (using non-default range settings).
      *
      * @return void
      */
-    public function testNewItems(): void
+    public function testSolrDrivenNewItemsWithNonDefaultRanges(): void
     {
         $this->changeConfigs(
             [

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -16,7 +16,7 @@
 
 <div class="searchHomeContent">
   <?php $this->slot('search-home-hero')->start() ?>
-    <?=$this->context($this)->renderInContext('search/searchbox.phtml', ['ignoreHiddenFilterMemory' => true])?>
+    <?=$this->render('search/searchbox.phtml')?>
     <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$("#searchForm_lookfor").focus();', 'SET'); ?>
   <?=$this->slot('search-home-hero')->end() ?>
 </div>

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -19,7 +19,6 @@
         'hasDefaultsApplied' => $this->params->hasDefaultsApplied(),
         'selectedShards' => $this->params->getSelectedShards(),
         'ignoreHiddenFiltersInRequest' => $this->ignoreHiddenFiltersInRequest ?? false,
-        'ignoreHiddenFilterMemory' => $this->ignoreHiddenFilterMemory ?? false,
       ]
   );
 

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -9,7 +9,7 @@
         ?? 'Solr';
     }
     // Initialize from current search if eligible, defaults otherwise:
-    if (isset($params) && $this->searchClassId === $params->getSearchClassId()) {
+    if (isset($params) && $this->searchClassId === $params->getSearchClassId() && !$params->isSpecializedSearch()) {
       $hiddenFilters = $params->getHiddenFilters();
       $lastSort = $params->getSort();
       $lastLimit = $params->getLimit();

--- a/themes/bootstrap5/templates/search/home.phtml
+++ b/themes/bootstrap5/templates/search/home.phtml
@@ -16,7 +16,7 @@
 
 <div class="searchHomeContent">
   <?php $this->slot('search-home-hero')->start() ?>
-    <?=$this->context($this)->renderInContext('search/searchbox.phtml', ['ignoreHiddenFilterMemory' => true])?>
+    <?=$this->render('search/searchbox.phtml')?>
     <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$("#searchForm_lookfor").focus();', 'SET'); ?>
   <?=$this->slot('search-home-hero')->end() ?>
 </div>

--- a/themes/bootstrap5/templates/search/results.phtml
+++ b/themes/bootstrap5/templates/search/results.phtml
@@ -19,7 +19,6 @@
         'hasDefaultsApplied' => $this->params->hasDefaultsApplied(),
         'selectedShards' => $this->params->getSelectedShards(),
         'ignoreHiddenFiltersInRequest' => $this->ignoreHiddenFiltersInRequest ?? false,
-        'ignoreHiddenFilterMemory' => $this->ignoreHiddenFilterMemory ?? false,
       ]
   );
 

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -9,7 +9,7 @@
         ?? 'Solr';
     }
     // Initialize from current search if eligible, defaults otherwise:
-    if (isset($params) && $this->searchClassId === $params->getSearchClassId()) {
+    if (isset($params) && $this->searchClassId === $params->getSearchClassId() && !$params->isSpecializedSearch()) {
       $hiddenFilters = $params->getHiddenFilters();
       $lastSort = $params->getSort();
       $lastLimit = $params->getLimit();


### PR DESCRIPTION
At some point in history, refactoring broke the isolation of the "New Items" search hidden filters and allowed them to bleed into regular searches through the search box, the facets, and things like author/subject links. Reviewing code revealed an orphaned and unused $ignoreHiddenFilterMemory template variable. This PR factors out that unused variable and replaces it with several mechanisms needed to solve the problem. In some ways this feels like overkill, but I'm not sure of a simpler way to address the problem.