### PR TITLE
Fix clearing of account status cache.

### DIFF
--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -154,6 +154,7 @@ VuFind.register('account', function Account() {
   var _load = function _load(module) {
     if (_clearCaches) {
       _clearSessionData(module);
+      return;
     }
     var $element = $(_submodules[module].selector);
     if (!$element) {

--- a/themes/bootstrap5/js/account_ajax.js
+++ b/themes/bootstrap5/js/account_ajax.js
@@ -156,6 +156,7 @@ VuFind.register('account', function Account() {
   var _load = function _load(module) {
     if (_clearCaches) {
       _clearSessionData(module);
+      return;
     }
     var $element = $(_submodules[module].selector);
     if (!$element) {


### PR DESCRIPTION
There was a possibility for the _load method to retrieve old data before the actual function that requested the cache to be cleared was performed.

For some reason the problem was more prominent with Chromium based browsers.