### PR TITLE
Fix limit options for EDS if unset

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -400,7 +400,6 @@ abstract class Options implements TranslatorAwareInterface
      */
     public function __construct(\VuFind\Config\PluginManager $configLoader)
     {
-        $this->limitOptions = [$this->defaultLimit];
         $this->setConfigLoader($configLoader);
 
         $id = $this->getSearchClassId();
@@ -545,6 +544,9 @@ abstract class Options implements TranslatorAwareInterface
      */
     public function getLimitOptions()
     {
+        if (empty($this->limitOptions)) {
+            $this->limitOptions = [$this->getDefaultLimit()];
+        }
         return $this->limitOptions;
     }
 


### PR DESCRIPTION
When commenting out limit_options in EDS.ini the limit options should be set to the default_limit. This PR fixes that by setting the default limit_options in the 'getLimitOptions' method instead of the constructor.