### PR TITLE
[10.1] Fix clearing of account status cache.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -278,15 +278,14 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->login();
         // Seed some fines
         $this->setJSStorage(['fines' => ['value' => 30.5, 'display' => '$30.50']]);
+        // Check storage
         $storage = $this->getJSStorage();
         $this->assertNotNull($storage['fines']);
-        // Clear all cache
+        // Clear all cached data
         $session->evaluateScript('VuFind.account.clearCache();');
-        // Wait for reload
-        $this->waitForPageLoad($this->getMinkSession()->getPage());
+        // Check storage again
         $storage = $this->getJSStorage();
-        // Status code MISSING is -2 * Math.PI, but we just round it here to avoid trouble
-        $this->assertEquals(-6, ceil($storage['fines']));
+        $this->assertNull($storage['fines']);
     }
 
     /**

--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -35,7 +35,15 @@ VuFind.register('account', function Account() {
   // Forward declaration for clearAllCaches
   var clearAllCaches = function clearAllCachesForward() {};
 
-  // Clearing save forces AJAX update next page load
+  /**
+   * Clear the specified client data cache; pass in empty/undefined value to clear
+   * all caches. Note that clearing all caches will prevent further data from loading
+   * on the current page, and should only be performed when exiting the page via a
+   * link, form submission, etc. Cleared data will be reloaded by AJAX on the next
+   * page load.
+   *
+   * @param {string|undefined} name Cache to clear (undefined/empty for all)
+   */
   var clearCache = function clearCache(name) {
     if (typeof name === "undefined" || name === '') {
       clearAllCaches();
@@ -180,6 +188,11 @@ VuFind.register('account', function Account() {
     }
   };
 
+  /**
+   * Clear all account status data cached in the client's browser. This will prevent future data from
+   * loading on the current page and should only be called when exiting the page by clicking a link,
+   * submitting a form, etc.
+   */
   clearAllCaches = function clearAllCachesReal() {
     // Set a flag so that any modules yet to be loaded are cleared as well
     _clearCaches = true;

--- a/themes/bootstrap3/js/account_ajax.js
+++ b/themes/bootstrap3/js/account_ajax.js
@@ -114,6 +114,7 @@ VuFind.register('account', function Account() {
   var _load = function _load(module) {
     if (_clearCaches) {
       sessionStorage.removeItem(_sessionDataPrefix + module);
+      return;
     }
     var $element = $(_submodules[module].selector);
     if (!$element) {

--- a/themes/bootstrap5/js/account_ajax.js
+++ b/themes/bootstrap5/js/account_ajax.js
@@ -115,6 +115,7 @@ VuFind.register('account', function Account() {
   var _load = function _load(module) {
     if (_clearCaches) {
       sessionStorage.removeItem(_sessionDataPrefix + module);
+      return;
     }
     var $element = $(_submodules[module].selector);
     if (!$element) {

--- a/themes/bootstrap5/js/account_ajax.js
+++ b/themes/bootstrap5/js/account_ajax.js
@@ -35,7 +35,15 @@ VuFind.register('account', function Account() {
   // Forward declaration for clearAllCaches
   var clearAllCaches = function clearAllCachesForward() {};
 
-  // Clearing save forces AJAX update next page load
+  /**
+   * Clear the specified client data cache; pass in empty/undefined value to clear
+   * all caches. Note that clearing all caches will prevent further data from loading
+   * on the current page, and should only be performed when exiting the page via a
+   * link, form submission, etc. Cleared data will be reloaded by AJAX on the next
+   * page load.
+   *
+   * @param {string|undefined} name Cache to clear (undefined/empty for all)
+   */
   var clearCache = function clearCache(name) {
     if (typeof name === "undefined" || name === '') {
       clearAllCaches();
@@ -181,6 +189,11 @@ VuFind.register('account', function Account() {
     }
   };
 
+  /**
+   * Clear all account status data cached in the client's browser. This will prevent future data from
+   * loading on the current page and should only be called when exiting the page by clicking a link,
+   * submitting a form, etc.
+   */
   clearAllCaches = function clearAllCachesReal() {
     // Set a flag so that any modules yet to be loaded are cleared as well
     _clearCaches = true;


### PR DESCRIPTION
There was a possibility for the _load method to retrieve old data before the actual function that requested the cache to be cleared was performed.