### PR TITLE
[10.1] Make database upgrade work better without root credentials.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -579,6 +579,12 @@ class UpgradeController extends AbstractBase
                 }
             }
 
+            // If we have SQL to show, stop at this point to allow the changes to be made before progressing any
+            // further:
+            if (!empty($this->session->sql)) {
+                return $this->forwardTo('Upgrade', 'ShowSql');
+            }
+
             // Now that database structure is addressed, we can fix database
             // content -- the checks below should be platform-independent.
 
@@ -622,9 +628,6 @@ class UpgradeController extends AbstractBase
         }
 
         $this->cookie->databaseOkay = true;
-        if (!empty($this->session->sql)) {
-            return $this->forwardTo('Upgrade', 'ShowSql');
-        }
         return $this->redirect()->toRoute('upgrade-home');
     }
 
@@ -635,6 +638,11 @@ class UpgradeController extends AbstractBase
      */
     public function showsqlAction()
     {
+        $recheck = $this->params()->fromPost('recheck');
+        if ($recheck) {
+            unset($this->session->sql);
+            return $this->redirect()->toRoute('upgrade-fixdatabase');
+        }
         $continue = $this->params()->fromPost('continue', 'nope');
         if ($continue == 'Next') {
             unset($this->session->sql);

--- a/themes/bootstrap3/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap3/templates/upgrade/showsql.phtml
@@ -18,6 +18,8 @@
 
 <textarea class="pre" rows="20"><?=trim($this->sql) ?></textarea>
 
+<p>Please re-check the database after applying the above changes above.</p>
 <form method="post" action="<?=$this->url('upgrade-showsql')?>">
-  <input class="btn btn-primary" type="submit" name="continue" value="Next">
+  <input class="btn btn-primary" type="submit" name="recheck" value="Re-check">
+  <input class="btn btn-default" type="submit" name="continue" value="Skip to Next Step">
 </form>

--- a/themes/bootstrap5/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap5/templates/upgrade/showsql.phtml
@@ -18,6 +18,8 @@
 
 <textarea class="pre" rows="20"><?=trim($this->sql) ?></textarea>
 
+<p>Please re-check the database after applying the above changes above.</p>
 <form method="post" action="<?=$this->url('upgrade-showsql')?>">
-  <input class="btn btn-primary" type="submit" name="continue" value="Next">
+  <input class="btn btn-primary" type="submit" name="recheck" value="Re-check">
+  <input class="btn btn-default" type="submit" name="continue" value="Skip to Next Step">
 </form>


### PR DESCRIPTION
This makes it possible to upgrade a VuFind instance with the SQL dump and then run the rest of the checks that may depend on the database changes.