### PR TITLE
Add a "remove prefix" option to record deletes

### DIFF
--- a/harvest/batch-delete.sh
+++ b/harvest/batch-delete.sh
@@ -28,6 +28,13 @@ do
         id-prefix=*)
           PREFIX=${OPTARG#*=}
           ;;
+        rm-prefix)
+          RMPREFIX="${!OPTIND}";
+          OPTIND=$(( $OPTIND + 1 ))
+          ;;
+        rm-prefix=*)
+          RMPREFIX=${OPTARG#*=}
+          ;;
         *)
           echo "Unknown option -- ${OPTARG}" >&2
           ;;
@@ -60,6 +67,7 @@ then
   echo "Options:"
   echo "-s:  Skip optimize operation after importing."
   echo "--id-prefix [prefix]: Specify a prefix to prepend to all IDs."
+  echo "--rm-prefix [prefix]: Specify a prefix to remove from the beginning of all IDs."
   exit 1
 fi
 
@@ -93,7 +101,7 @@ do
       FOUNDSOME=1
     fi
     echo "Processing $file ..."
-    php deletes.php $file flat $2 --id-prefix=$PREFIX
+    php deletes.php $file flat $2 --id-prefix=$PREFIX --rm-prefix=$RMPREFIX
     mv $file $BASEPATH/processed/`basename $file`
   fi
 done

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/DeletesCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/DeletesCommand.php
@@ -89,6 +89,12 @@ class DeletesCommand extends AbstractSolrCommand
                 InputOption::VALUE_REQUIRED,
                 'Prefix to prepend to all IDs',
                 ''
+            )->addOption(
+                'rm-prefix',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Prefix to remove from all IDs',
+                ''
             );
     }
 
@@ -164,6 +170,7 @@ class DeletesCommand extends AbstractSolrCommand
         $mode = $input->getArgument('format');
         $index = $input->getArgument('index');
         $prefix = $input->getOption('id-prefix');
+        $rmprefix = $input->getOption('rm-prefix');
 
         // File doesn't exist?
         if (!file_exists($filename)) {
@@ -191,6 +198,12 @@ class DeletesCommand extends AbstractSolrCommand
             if (!empty($prefix)) {
                 $callback = function ($id) use ($prefix) {
                     return $prefix . $id;
+                };
+                $ids = array_map($callback, $ids);
+            }
+            if (!empty($rmprefix)) {
+                $callback = function($id) use ($rmprefix) {
+                    return str_starts_with($id, $rmprefix) ? substr($id, strlen($rmprefix)) : $id;
                 };
                 $ids = array_map($callback, $ids);
             }


### PR DESCRIPTION
Adds a `--rm-prefix` option that will remove a prefix from identifiers. For example, given an identifier of `KOHA-OAI-TEST:2752849` then using `--rm-prefix KOHA-OAI-TEST:` will result in `2752849` as an identifier passed to Solr to be removed.