### PR TITLE
[VUFIND-1722] Add tests for web index

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -659,6 +659,7 @@
 
     <phingcall target="import_biblios" />
     <phingcall target="import_authorities" />
+    <phingcall target="import_website" />
     <phingcall target="delete_fake_records" />
     <phingcall target="build_alphabrowse" />
   </target>
@@ -944,6 +945,20 @@ return [
         </foreach>
       </then>
     </if>
+  </target>
+
+  <!-- Import website data -->
+  <target name="import_website" description="import web index data">
+    <exec executable="php" checkreturn="true" passthru="true">
+      <arg line="${srcdir}/import/import-xsl.php ${srcdir}/tests/data/website/solr.xml raw.properties --index SolrWeb" />
+      <env key="VUFIND_HOME" value="${srcdir}" />
+      <env key="VUFIND_LOCAL_DIR" value="${localdir}" />
+    </exec>
+    <exec executable="php" checkreturn="true" passthru="true">
+      <arg line="${srcdir}/util/commit.php SolrWeb" />
+      <env key="VUFIND_HOME" value="${srcdir}" />
+      <env key="VUFIND_LOCAL_DIR" value="${localdir}" />
+    </exec>
   </target>
 
   <!-- Delete some fake record IDs so we have deleted records to test with -->

--- a/import/raw.properties
+++ b/import/raw.properties
@@ -1,0 +1,9 @@
+; XSLT Import Settings for passing raw XML through to Solr
+[General]
+; REQUIRED: Name of XSLT file to apply.  Path is relative to the import/xsl directory
+; of the VuFind installation (or your local override directory).
+xslt = raw.xsl
+
+; XSLT parameters -- any key/value pairs set here will be passed as parameters to
+; the XSLT file, allowing local values to be set without modifying XSLT code.
+[Parameters]

--- a/import/xsl/raw.xsl
+++ b/import/xsl/raw.xsl
@@ -1,0 +1,5 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:copy-of select="." />
+  </xsl:template>
+</xsl:stylesheet>

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Mink web search test class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+use function intval;
+
+/**
+ * Mink web search test class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class WebSearchTest extends \VuFindTest\Integration\MinkTestCase
+{
+    /**
+     * Data provider for testWebSearch()
+     *
+     * @return array[]
+     */
+    public static function webSearchProvider(): array
+    {
+        return [
+            'blank search' => ['', 3, '', ['Fact', 'Fantasy', 'Fiction']],
+            'search in full text' => ['"second record"', 1, 'second record', ['Fact']],
+            'search in description' => ['three', 1, 'three', ['Fantasy']],
+        ];
+    }
+
+    /**
+     * Test performing a Web search
+     *
+     * @param string   $query                  Search query
+     * @param int      $expectedCount          Expected search result count
+     * @param string   $expectedFirstHighlight Expected first highlighted text on page
+     * @param string[] $expectedSubjectFacets  Expected subject facet values
+     *
+     * @return void
+     *
+     * @dataProvider webSearchProvider
+     */
+    public function testWebSearch(
+        string $query,
+        int $expectedCount,
+        string $expectedFirstHighlight,
+        array $expectedSubjectFacets
+    ): void {
+        // Perform the search:
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Web');
+        $page = $session->getPage();
+        $this->findCssAndSetValue($page, '#searchForm_lookfor', $query);
+        $this->findCss($page, '.btn-primary')->click();
+        $this->waitForPageLoad($page);
+
+        // Confirm the result count:
+        $this->assertEquals(
+            $expectedCount,
+            intval($this->findCssAndGetText($page, '.js-search-stats strong', index: 1))
+        );
+
+        // Confirm highlighting:
+        if ($expectedFirstHighlight) {
+            $this->assertEquals($expectedFirstHighlight, $this->findCssAndGetText($page, '#result0 mark'));
+        }
+
+        // Confirm facet values:
+        $subjectText = [];
+        $subjects = $page->findAll('css', '#side-panel-subject .facet-value');
+        foreach ($subjects as $subject) {
+            $subjectText[] = $subject->getText();
+        }
+        $this->assertEquals($expectedSubjectFacets, $subjectText);
+    }
+}

--- a/tests/data/website/solr.xml
+++ b/tests/data/website/solr.xml
@@ -1,0 +1,35 @@
+<add>
+  <doc>
+    <field name="id">001</field>
+    <field name="fulltext">This is the content of the first record.</field>
+    <field name="description">This is the description of record number one.</field>
+    <field name="keywords">one first</field>
+    <field name="title">First Web Page</field>
+    <field name="url">http://localhost/1</field>
+    <field name="category">Test Pages</field>
+    <field name="linktype">Fake Link</field>
+    <field name="subject">Fiction</field>
+  </doc>
+  <doc>
+    <field name="id">002</field>
+    <field name="fulltext">This is the content of the second record.</field>
+    <field name="description">This is the description of record number two.</field>
+    <field name="keywords">two second</field>
+    <field name="title">Second Web Page</field>
+    <field name="url">http://localhost/2</field>
+    <field name="category">Test Pages</field>
+    <field name="linktype">Fake Link</field>
+    <field name="subject">Fact</field>
+  </doc>
+  <doc>
+    <field name="id">003</field>
+    <field name="fulltext">This is the content of the third record.</field>
+    <field name="description">This is the description of record number three.</field>
+    <field name="keywords">three third</field>
+    <field name="title">Third Web Page</field>
+    <field name="url">http://localhost/3</field>
+    <field name="category">Test Pages</field>
+    <field name="linktype">Fake Link</field>
+    <field name="subject">Fantasy</field>
+  </doc>
+</add>


### PR DESCRIPTION
This PR adds some basic integration tests for the web search functionality.

It also adds a simple configuration to use the import-xsl tool to load raw Solr XML directly into the index, allowing us to populate the test instance with sample data in a very simple way.

TODO:
- [x] Resolve [VUFIND-1722](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1722) when merging.