### PR TITLE
Fix printing search with deactivated batchwise status checking

### DIFF
--- a/themes/bootstrap3/js/check_item_statuses.js
+++ b/themes/bootstrap3/js/check_item_statuses.js
@@ -197,7 +197,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
 
     // queue the element into the queue
     let payload = { el, id: hiddenIdEl.value };
-    if (VuFind.config.get('item-status:load-batch-wise', true)) {
+    if (VuFind.isPrinting() || VuFind.config.get('item-status:load-batch-wise', true)) {
       _checkItemHandlers[handlerName].add(payload);
     } else {
       let runFunc = getItemStatusPromise({handlerName: handlerName});

--- a/themes/bootstrap5/js/check_item_statuses.js
+++ b/themes/bootstrap5/js/check_item_statuses.js
@@ -197,7 +197,7 @@ VuFind.register('itemStatuses', function ItemStatuses() {
 
     // queue the element into the queue
     let payload = { el, id: hiddenIdEl.value };
-    if (VuFind.config.get('item-status:load-batch-wise', true)) {
+    if (VuFind.isPrinting() || VuFind.config.get('item-status:load-batch-wise', true)) {
       _checkItemHandlers[handlerName].add(payload);
     } else {
       let runFunc = getItemStatusPromise({handlerName: handlerName});


### PR DESCRIPTION
Currently, the searches will get printed prematurely when batchwise status checking is deactivated in the configs, because the "item-status-done" is emitted after the first loaded instance.

This is fixed by always activating batchwise status checking when printing.