### PR TITLE
Deal with bad theme config more gracefully.

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -241,12 +241,20 @@ class Bootstrapper
      */
     protected function initTheme(): void
     {
-        // Attach remaining theme configuration to the dispatch event at high
-        // priority (TODO: use priority constant once defined by framework):
+        // Attach remaining theme configuration to the dispatch event at high priority:
         $config = $this->config->Site;
         $callback = function ($event) use ($config) {
             $theme = new \VuFindTheme\Initializer($config, $event);
-            $theme->init();
+            try {
+                $theme->init();
+            } catch (\Exception $e) {
+                // Try to display an error page if the theme fails to initialize:
+                $config = $this->container->get('config');
+                $model = $event->getViewModel();
+                $model->setTemplate('error/index');
+                $model->display_exceptions = $config['view_manager']['display_exceptions'] ?? false;
+                $model->exception = $e;
+            }
         };
         $this->events->attach('dispatch.error', $callback, 9000);
         $this->events->attach('dispatch', $callback, 9000);

--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -242,17 +242,17 @@ class Bootstrapper
     protected function initTheme(): void
     {
         // Attach remaining theme configuration to the dispatch event at high priority:
-        $config = $this->config->Site;
-        $callback = function ($event) use ($config) {
-            $theme = new \VuFindTheme\Initializer($config, $event);
+        $siteConfig = $this->config->Site;
+        $callback = function ($event) use ($siteConfig) {
+            $theme = new \VuFindTheme\Initializer($siteConfig, $event);
             try {
                 $theme->init();
             } catch (\Exception $e) {
                 // Try to display an error page if the theme fails to initialize:
-                $config = $this->container->get('config');
+                $appConfig = $this->container->get('config');
                 $model = $event->getViewModel();
                 $model->setTemplate('error/index');
-                $model->display_exceptions = $config['view_manager']['display_exceptions'] ?? false;
+                $model->display_exceptions = $appConfig['view_manager']['display_exceptions'] ?? false;
                 $model->exception = $e;
             }
         };

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
@@ -48,7 +48,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
     public function testHomePage(): void
     {
         $page = $this->getSearchHomePage();
-        $this->assertTrue(false !== strstr($page->getContent(), 'VuFind'));
+        $this->assertStringContainsString('VuFind', $page->getContent());
     }
 
     /**
@@ -140,6 +140,31 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
             'Welcome to your custom theme!',
             $this->findCssAndGetHtml($page, 'h1')
         );
+    }
+
+    /**
+     * Test graceful handling of an invalid theme.
+     *
+     * Note that HTML validation is disabled on this test because an improperly initialized
+     * theme will not generate a fully-formed page; but we still want to confirm that it
+     * at least outputs a human-readable error message.
+     *
+     * @return void
+     */
+    #[\VuFindTest\Attribute\HtmlValidation(false)]
+    public function testBadThemeConfig(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Site' => [
+                        'theme' => 'not-a-valid-theme',
+                    ],
+                ],
+            ]
+        );
+        $page = $this->getSearchHomePage();
+        $this->assertStringContainsString('An error has occurred', $page->getContent());
     }
 
     /**

--- a/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
+++ b/module/VuFindTheme/src/VuFindTheme/ThemeInfoFactory.php
@@ -71,7 +71,7 @@ class ThemeInfoFactory implements FactoryInterface
 
         $themeInfo = new $requestedName(
             realpath(APPLICATION_PATH . '/themes'),
-            'bootprint3'
+            'sandal5'
         );
 
         // As of release 1.1.0, the memory storage adapter has a flaw which can cause


### PR DESCRIPTION
@sturkel89 noticed that, following the removal of the bootstrap3 themes, putting an invalid theme value in config.ini resulted in a blank white screen in browser due to an uncaught exception. Investigating that revealed an orphaned bootprint3 reference in the code. I updated that and added some logic to attempt to display the error page if an exception is thrown during theme initialization. This doesn't result in full valid HTML, but it should be better than a blank white screen for troubleshooting purposes.