### PR TITLE
Add option to use resumptionToken in REST

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -903,7 +903,7 @@ searchAccessPermission = access.api.Search
 maxLimit = 100
 ; Uncomment to change the maximum amount of records returned when using resumption token in REST API.
 ; Default is 200.
-;cursorMaxLimit = 500
+;cursorLimit = 500
 ; This section provides settings for optional caching of search requests. This
 ; affects the primary Solr backend only; for caching of other backends, see the
 ; appropriate backend-specific configuration files (Search2.ini, website.ini, etc.).

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -899,7 +899,7 @@ recordAccessPermission = access.api.Record
 searchAccessPermission = access.api.Search
 
 ; This is the maximum number of results that can be returned in a single response.
-; Applies to searches not using resumption token:
+; Applies to searches not using resumption token.
 maxLimit = 100
 ; Uncomment to change the maximum amount of records returned when using resumption token in REST API.
 ; Default is 200.

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -900,7 +900,8 @@ searchAccessPermission = access.api.Search
 
 ; This is the maximum number of results that can be returned in a single response:
 maxLimit = 100
-
+; This is the maximum number of results that can be returned with resumption token in a single response:
+;cursorMaxLimit = 500
 ; This section provides settings for optional caching of search requests. This
 ; affects the primary Solr backend only; for caching of other backends, see the
 ; appropriate backend-specific configuration files (Search2.ini, website.ini, etc.).

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -898,9 +898,11 @@ content[] = FacetList
 recordAccessPermission = access.api.Record
 searchAccessPermission = access.api.Search
 
-; This is the maximum number of results that can be returned in a single response:
+; This is the maximum number of results that can be returned in a single response.
+; Applies to searches not using resumption token:
 maxLimit = 100
-; This is the maximum number of results that can be returned with resumption token in a single response:
+; Uncomment to change the maximum amount of records returned when using resumption token in REST API.
+; Default is 200.
 ;cursorMaxLimit = 500
 ; This section provides settings for optional caching of search requests. This
 ; affects the primary Solr backend only; for caching of other backends, see the

--- a/module/VuFind/sql/migrations/pgsql/11.0/002-modify-oai-resumption-columns.sql
+++ b/module/VuFind/sql/migrations/pgsql/11.0/002-modify-oai-resumption-columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "oai_resumption"
+  ADD COLUMN token varchar(255) DEFAULT NULL;
+
+CREATE UNIQUE INDEX token ON "oai_resumption" (token);

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -75,9 +75,11 @@ CREATE TABLE `ratings` (
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oai_resumption` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `hash` varchar(255) NOT NULL,
   `params` text,
   `expires` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`hash`),
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -75,11 +75,11 @@ CREATE TABLE `ratings` (
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oai_resumption` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `hash` varchar(255) NOT NULL,
+  `token` varchar(255) NOT NULL,
   `params` text,
   `expires` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`hash`),
+  UNIQUE KEY (`token`),
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -79,7 +79,7 @@ CREATE TABLE `oai_resumption` (
   `params` text,
   `expires` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`token`),
+  UNIQUE KEY (`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -75,7 +75,7 @@ CREATE TABLE `ratings` (
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oai_resumption` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `token` varchar(255) NOT NULL,
+  `token` varchar(255) DEFAULT NULL,
   `params` text,
   `expires` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -280,7 +280,7 @@ DROP TABLE IF EXISTS "oai_resumption";
 
 CREATE TABLE oai_resumption (
 id SERIAL,
-token varchar(255) NOT NULL,
+token varchar(255) DEFAULT NULL,
 params text,
 expires timestamp NOT NULL default '1970-01-01 00:00:00',
 PRIMARY KEY (id),

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -280,9 +280,11 @@ DROP TABLE IF EXISTS "oai_resumption";
 
 CREATE TABLE oai_resumption (
 id SERIAL,
+token varchar(255) NOT NULL,
 params text,
 expires timestamp NOT NULL default '1970-01-01 00:00:00',
-PRIMARY KEY (id)
+PRIMARY KEY (id),
+UNIQUE(token)
 );
 
 -- --------------------------------------------------------

--- a/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
@@ -66,6 +66,22 @@ interface OaiResumptionEntityInterface extends EntityInterface
     public function getResumptionParameters(): ?string;
 
     /**
+     * Set hash used to identify the token
+     *
+     * @param string $hash Generated hash
+     *
+     * @return static
+     */
+    public function setHash(string $hash): static;
+
+    /**
+     * Get hash used to identify the token
+     *
+     * @return ?string
+     */
+    public function getHash(): ?string;
+
+    /**
      * Expiry date setter.
      *
      * @param DateTime $dateTime Expiration date

--- a/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/OaiResumptionEntityInterface.php
@@ -66,20 +66,20 @@ interface OaiResumptionEntityInterface extends EntityInterface
     public function getResumptionParameters(): ?string;
 
     /**
-     * Set hash used to identify the token
+     * Set token used for identifying.
      *
-     * @param string $hash Generated hash
+     * @param string $token Generated token.
      *
      * @return static
      */
-    public function setHash(string $hash): static;
+    public function setToken(string $token): static;
 
     /**
-     * Get hash used to identify the token
+     * Get token used for identifying.
      *
      * @return ?string
      */
-    public function getHash(): ?string;
+    public function getToken(): ?string;
 
     /**
      * Expiry date setter.

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -45,7 +45,7 @@ use VuFind\Db\Entity\OaiResumptionEntityInterface;
  *
  * @property int    $id
  * @property string $params
- * @property string $hash
+ * @property string $token
  * @property string $expires
  */
 class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
@@ -133,26 +133,26 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
     }
 
     /**
-     * Set hash used to identify the token
+     * Set token used for identifying.
      *
-     * @param string $hash Generated hash
+     * @param string $token Generated token.
      *
      * @return static
      */
-    public function setHash(string $hash): static
+    public function setToken(string $token): static
     {
-        $this->hash = $hash;
+        $this->token = $token;
         return $this;
     }
 
     /**
-     * Get hash used to identify the token
+     * Get token used for identifying.
      *
      * @return ?string
      */
-    public function getHash(): ?string
+    public function getToken(): ?string
     {
-        return $this->hash;
+        return $this->token;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Row/OaiResumption.php
@@ -23,6 +23,7 @@
  * @category VuFind
  * @package  Db_Row
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
@@ -38,11 +39,13 @@ use VuFind\Db\Entity\OaiResumptionEntityInterface;
  * @category VuFind
  * @package  Db_Row
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  *
  * @property int    $id
  * @property string $params
+ * @property string $hash
  * @property string $expires
  */
 class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
@@ -127,6 +130,29 @@ class OaiResumption extends RowGateway implements OaiResumptionEntityInterface
     public function getResumptionParameters(): ?string
     {
         return $this->params;
+    }
+
+    /**
+     * Set hash used to identify the token
+     *
+     * @param string $hash Generated hash
+     *
+     * @return static
+     */
+    public function setHash(string $hash): static
+    {
+        $this->hash = $hash;
+        return $this;
+    }
+
+    /**
+     * Get hash used to identify the token
+     *
+     * @return ?string
+     */
+    public function getHash(): ?string
+    {
+        return $this->hash;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/AbstractDbService.php
+++ b/module/VuFind/src/VuFind/Db/Service/AbstractDbService.php
@@ -44,6 +44,14 @@ use VuFind\Db\Entity\EntityInterface;
 abstract class AbstractDbService implements DbServiceInterface
 {
     /**
+     * Variable to allow multiple functions to use the same retry count if necessary.
+     * How many times can a function try, before continuing?
+     *
+     * @var int
+     */
+    protected int $retryCount = 5;
+
+    /**
      * Persist an entity.
      *
      * @param EntityInterface $entity Entity to persist.

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -113,7 +113,7 @@ class OaiResumptionService extends AbstractDbService implements
     final public function findWithTokenOrLegacyIdToken(string $tokenOrId): ?OaiResumptionEntityInterface
     {
         return $this->findWithToken($tokenOrId)
-            ?? $this->getDbTable('oairesumption')->findWithTokenOrLegacyIdToken($tokenOrId);
+            ?? $this->getDbTable('oairesumption')->findWithLegacyIdToken($tokenOrId);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -107,12 +107,13 @@ class OaiResumptionService extends AbstractDbService implements
      *
      * @param string $tokenOrId Token or id
      *
-     * @return     ?OaiResumptionEntityInterface
-     * @deprecated This function is for BC and can be removed in the future.
+     * @return ?OaiResumptionEntityInterface
+     * @todo   In future, we should migrate data to prevent null token fields, which will make this method obsolete.
      */
-    final public function findWithIdOrTokenBc(string $tokenOrId): ?OaiResumptionEntityInterface
+    final public function findWithTokenOrLegacyIdToken(string $tokenOrId): ?OaiResumptionEntityInterface
     {
-        return $this->findWithToken($tokenOrId) ?? $this->getDbTable('oairesumption')->findWithIdBc($tokenOrId);
+        return $this->findWithToken($tokenOrId)
+            ?? $this->getDbTable('oairesumption')->findWithTokenOrLegacyIdToken($tokenOrId);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -35,6 +35,8 @@ use VuFind\Db\Table\DbTableAwareInterface;
 use VuFind\Db\Table\DbTableAwareTrait;
 use VuFind\Log\LoggerAwareTrait;
 
+use function intval;
+
 /**
  * Database service for OaiResumption.
  *
@@ -112,8 +114,14 @@ class OaiResumptionService extends AbstractDbService implements
      */
     final public function findWithTokenOrLegacyIdToken(string $tokenOrId): ?OaiResumptionEntityInterface
     {
-        return $this->findWithToken($tokenOrId)
-            ?? $this->getDbTable('oairesumption')->findWithLegacyIdToken($tokenOrId);
+        $result = $this->findWithToken($tokenOrId);
+        if (!$result && is_numeric($tokenOrId)) {
+            $idInt = intval($tokenOrId);
+            if ($idInt > 0) {
+                $result = $this->getDbTable('oairesumption')->findWithLegacyIdToken($idInt);
+            }
+        }
+        return $result;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -103,6 +103,19 @@ class OaiResumptionService extends AbstractDbService implements
     }
 
     /**
+     * Try to find with token first, if not found then try to find with id where the token is null.
+     *
+     * @param string $tokenOrId Token or id
+     *
+     * @return     ?OaiResumptionEntityInterface
+     * @deprecated This function is for BC and can be removed in the future.
+     */
+    final public function findWithIdOrTokenBc(string $tokenOrId): ?OaiResumptionEntityInterface
+    {
+        return $this->findWithToken($tokenOrId) ?? $this->getDbTable('oairesumption')->findWithIdBc($tokenOrId);
+    }
+
+    /**
      * Generate a random token using random_bytes and bin2hex
      *
      * @return string

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -126,7 +126,7 @@ class OaiResumptionService extends AbstractDbService implements
         $row = null;
         // In extremely rare cases it might be possible that the generated random token already exists in the
         // database. Try 5 times, but the possibility for this to happen is close to 0.
-        for ($i = 1; $i <= 5; $i++) {
+        for ($i = 1; $i <= $this->retryCount; $i++) {
             try {
                 $row = $this->createEntity()
                     ->setToken($this->createRandomToken())
@@ -137,7 +137,7 @@ class OaiResumptionService extends AbstractDbService implements
             } catch (\Exception $e) {
                 $this->logError('Could not save token: ' . $e->getMessage() . ', attempt: ' . $i);
                 // Actually throw the error if this is the last attempt and it still did not work.
-                if ($i >= 5) {
+                if ($i >= $this->retryCount) {
                     throw $e;
                 }
             }

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -68,24 +68,48 @@ class OaiResumptionService extends AbstractDbService implements
      *
      * @param string $token The resumption token to retrieve.
      *
-     * @return ?OaiResumptionEntityInterface
+     * @return     ?OaiResumptionEntityInterface
+     * @deprecated Use OaiResumptionService::findWithId
      */
     public function findToken(string $token): ?OaiResumptionEntityInterface
     {
-        return $this->getDbTable('oairesumption')->findToken($token);
+        return $this->findWithId($token);
     }
 
     /**
-     * Retrieve a row from the database based on hash; return null if it
+     * Retrieve a row from the database based on primary key; return null if it
      * is not found.
      *
-     * @param string $hash Hash used to search for a resumption token.
+     * @param string $id Id to use for the search.
      *
      * @return ?OaiResumptionEntityInterface
      */
-    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface
+    public function findWithId(string $id): ?OaiResumptionEntityInterface
     {
-        return $this->getDbTable('oairesumption')->findTokenWithHash($hash);
+        return $this->getDbTable('oairesumption')->findWithId($id);
+    }
+
+    /**
+     * Retrieve a row from the database based on token; return null if it
+     * is not found.
+     *
+     * @param string $token Token used for the search.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findWithToken(string $token): ?OaiResumptionEntityInterface
+    {
+        return $this->getDbTable('oairesumption')->findWithToken($token);
+    }
+
+    /**
+     * Generate a random token using random_bytes and bin2hex
+     *
+     * @return string
+     */
+    protected function createRandomToken(): string
+    {
+        return bin2hex(random_bytes(32));
     }
 
     /**
@@ -99,15 +123,24 @@ class OaiResumptionService extends AbstractDbService implements
      */
     public function createAndPersistToken(array $params, int $expire): OaiResumptionEntityInterface
     {
-        $row = $this->createEntity()
-            ->setHash(bin2hex(random_bytes(32)))
-            ->setResumptionParameters($this->encodeParams($params))
-            ->setExpiry(\DateTime::createFromFormat('U', $expire));
-        try {
-            $this->persistEntity($row);
-        } catch (\Exception $e) {
-            $this->logError('Could not save token: ' . $e->getMessage());
-            throw $e;
+        $row = null;
+        // In extremely rare cases it might be possible that the generated random token already exists in the
+        // database. Try 5 times, but the possibility for this to happen is close to 0.
+        for ($i = 1; $i <= 5; $i++) {
+            try {
+                $row = $this->createEntity()
+                    ->setToken($this->createRandomToken())
+                    ->setResumptionParameters($this->encodeParams($params))
+                    ->setExpiry(\DateTime::createFromFormat('U', $expire));
+                $this->persistEntity($row);
+                break;
+            } catch (\Exception $e) {
+                $this->logError('Could not save token: ' . $e->getMessage() . ', attempt: ' . $i);
+                // Actually throw the error if this is the last attempt and it still did not work.
+                if ($i >= 5) {
+                    throw $e;
+                }
+            }
         }
         return $row;
     }

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -76,6 +76,19 @@ class OaiResumptionService extends AbstractDbService implements
     }
 
     /**
+     * Retrieve a row from the database based on hash; return null if it
+     * is not found.
+     *
+     * @param string $hash Hash used to search for a resumption token.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface
+    {
+        return $this->getDbTable('oairesumption')->findTokenWithHash($hash);
+    }
+
+    /**
      * Create and persist a new resumption token.
      *
      * @param array $params Parameters associated with the token.
@@ -87,6 +100,7 @@ class OaiResumptionService extends AbstractDbService implements
     public function createAndPersistToken(array $params, int $expire): OaiResumptionEntityInterface
     {
         $row = $this->createEntity()
+            ->setHash(bin2hex(random_bytes(32)))
             ->setResumptionParameters($this->encodeParams($params))
             ->setExpiry(\DateTime::createFromFormat('U', $expire));
         try {

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionService.php
@@ -125,7 +125,7 @@ class OaiResumptionService extends AbstractDbService implements
     {
         $row = null;
         // In extremely rare cases it might be possible that the generated random token already exists in the
-        // database. Try 5 times, but the possibility for this to happen is close to 0.
+        // database. Retry up to the limit, but the possibility for this to happen is close to 0.
         for ($i = 1; $i <= $this->retryCount; $i++) {
             try {
                 $row = $this->createEntity()

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -83,6 +83,16 @@ interface OaiResumptionServiceInterface
     public function findWithToken(string $token): ?OaiResumptionEntityInterface;
 
     /**
+     * Try to find with token first, if not found then try to find with id where the token is null.
+     *
+     * @param string $tokenOrId Token or id
+     *
+     * @return     ?OaiResumptionEntityInterface
+     * @deprecated This function is for BC and can be removed in the future.
+     */
+    public function findWithIdOrTokenBc(string $tokenOrId): ?OaiResumptionEntityInterface;
+
+    /**
      * Create and persist a new resumption token.
      *
      * @param array $params Parameters associated with the token.

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -87,10 +87,10 @@ interface OaiResumptionServiceInterface
      *
      * @param string $tokenOrId Token or id
      *
-     * @return     ?OaiResumptionEntityInterface
-     * @deprecated This function is for BC and can be removed in the future.
+     * @return ?OaiResumptionEntityInterface
+     * @todo   In future, we should migrate data to prevent null token fields, which will make this method obsolete.
      */
-    public function findWithIdOrTokenBc(string $tokenOrId): ?OaiResumptionEntityInterface;
+    public function findWithTokenOrLegacyIdToken(string $tokenOrId): ?OaiResumptionEntityInterface;
 
     /**
      * Create and persist a new resumption token.

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -57,19 +57,30 @@ interface OaiResumptionServiceInterface
      *
      * @param string $token The resumption token to retrieve.
      *
-     * @return ?OaiResumptionEntityInterface
+     * @return     ?OaiResumptionEntityInterface
+     * @deprecated Use OaiResumptionService::findWithId
      */
     public function findToken(string $token): ?OaiResumptionEntityInterface;
 
     /**
-     * Retrieve a row from the database based on hash; return null if it
+     * Retrieve a row from the database based on primary key; return null if it
      * is not found.
      *
-     * @param string $hash Hash used to search for a resumption token.
+     * @param string $id Id to use for the search.
      *
      * @return ?OaiResumptionEntityInterface
      */
-    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface;
+    public function findWithId(string $id): ?OaiResumptionEntityInterface;
+
+    /**
+     * Retrieve a row from the database based on token; return null if it
+     * is not found.
+     *
+     * @param string $token Token used for the search.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findWithToken(string $token): ?OaiResumptionEntityInterface;
 
     /**
      * Create and persist a new resumption token.

--- a/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/OaiResumptionServiceInterface.php
@@ -62,6 +62,16 @@ interface OaiResumptionServiceInterface
     public function findToken(string $token): ?OaiResumptionEntityInterface;
 
     /**
+     * Retrieve a row from the database based on hash; return null if it
+     * is not found.
+     *
+     * @param string $hash Hash used to search for a resumption token.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface;
+
+    /**
      * Create and persist a new resumption token.
      *
      * @param array $params Parameters associated with the token.

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -108,6 +108,19 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
     }
 
     /**
+     * Retrieve a row from the database based on primary key and where the token is null.
+     *
+     * @param string $id Id used for the search.
+     *
+     * @return     ?\VuFind\Db\Row\OaiResumption
+     * @deprecated This function is for BC and can be removed in the future.
+     */
+    final public function findWithIdBc(string $id): ?OaiResumptionEntityInterface
+    {
+        return $this->select(['id' => $id, 'token' => null])->current();
+    }
+
+    /**
      * Retrieve a row from the database based on token; return null if it
      * is not found.
      *

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -86,24 +86,38 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
      *
      * @param string $token The resumption token to retrieve.
      *
-     * @return ?\VuFind\Db\Row\OaiResumption
+     * @return     ?\VuFind\Db\Row\OaiResumption
+     * @deprecated Use OaiResumption::findWithId
      */
     public function findToken($token)
     {
-        return $this->select(['id' => $token])->current();
+        return $this->findWithId($token);
     }
 
     /**
-     * Retrieve a row from the database based on hash; return null if it
+     * Retrieve a row from the database based on primary key; return null if it
      * is not found.
      *
-     * @param string $hash Hash used to search for a resumption token.
+     * @param string $id Id used for the search.
+     *
+     * @return ?\VuFind\Db\Row\OaiResumption
+     */
+    public function findWithId(string $id): ?OaiResumptionEntityInterface
+    {
+        return $this->select(['id' => $id])->current();
+    }
+
+    /**
+     * Retrieve a row from the database based on token; return null if it
+     * is not found.
+     *
+     * @param string $token Token used for the search.
      *
      * @return ?OaiResumptionEntityInterface
      */
-    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface
+    public function findWithToken(string $token): ?OaiResumptionEntityInterface
     {
-        return $this->select(['hash' => $hash])->current();
+        return $this->select(['token' => $token])->current();
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -112,10 +112,10 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
      *
      * @param string $id Id used for the search.
      *
-     * @return     ?\VuFind\Db\Row\OaiResumption
-     * @deprecated This function is for BC and can be removed in the future.
+     * @return ?\VuFind\Db\Row\OaiResumption
+     * @todo   In future, we should migrate data to prevent null token fields, which will make this method obsolete.
      */
-    final public function findWithIdBc(string $id): ?OaiResumptionEntityInterface
+    final public function findWithTokenOrLegacyIdToken(string $id): ?OaiResumptionEntityInterface
     {
         return $this->select(['id' => $id, 'token' => null])->current();
     }

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -115,7 +115,7 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
      * @return ?\VuFind\Db\Row\OaiResumption
      * @todo   In future, we should migrate data to prevent null token fields, which will make this method obsolete.
      */
-    final public function findWithTokenOrLegacyIdToken(string $id): ?OaiResumptionEntityInterface
+    final public function findWithLegacyIdToken(string $id): ?OaiResumptionEntityInterface
     {
         return $this->select(['id' => $id, 'token' => null])->current();
     }

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -110,12 +110,12 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
     /**
      * Retrieve a row from the database based on primary key and where the token is null.
      *
-     * @param string $id Id used for the search.
+     * @param int $id Id used for the search.
      *
      * @return ?\VuFind\Db\Row\OaiResumption
      * @todo   In future, we should migrate data to prevent null token fields, which will make this method obsolete.
      */
-    final public function findWithLegacyIdToken(string $id): ?OaiResumptionEntityInterface
+    final public function findWithLegacyIdToken(int $id): ?OaiResumptionEntityInterface
     {
         return $this->select(['id' => $id, 'token' => null])->current();
     }

--- a/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Table/OaiResumption.php
@@ -30,6 +30,7 @@
 namespace VuFind\Db\Table;
 
 use Laminas\Db\Adapter\Adapter;
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
 use VuFind\Db\Row\RowGateway;
 use VuFind\Db\Service\DbServiceAwareInterface;
 
@@ -90,6 +91,19 @@ class OaiResumption extends Gateway implements DbServiceAwareInterface
     public function findToken($token)
     {
         return $this->select(['id' => $token])->current();
+    }
+
+    /**
+     * Retrieve a row from the database based on hash; return null if it
+     * is not found.
+     *
+     * @param string $hash Hash used to search for a resumption token.
+     *
+     * @return ?OaiResumptionEntityInterface
+     */
+    public function findTokenWithHash(string $hash): ?OaiResumptionEntityInterface
+    {
+        return $this->select(['hash' => $hash])->current();
     }
 
     /**

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -1313,7 +1313,7 @@ class Server
         $oldCursor = $params['cursor'];
         $resumptionToken = $this->createResumptionToken($params, $currentCursor, $cursorMark);
         // Add details to the xml:
-        $token = $xml->addChild('resumptionToken', $resumptionToken->getId());
+        $token = $xml->addChild('resumptionToken', $resumptionToken->getHash());
         $token->addAttribute('cursor', $oldCursor);
         $token->addAttribute('expirationDate', date($this->iso8601, $resumptionToken->getExpiry()->getTimestamp()));
         $token->addAttribute('completeListSize', $listSize);

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -59,6 +59,8 @@ use function strlen;
  */
 class Server
 {
+    use \VuFind\ResumptionToken\ResumptionTokenTrait;
+
     /**
      * Repository base URL
      *
@@ -1250,28 +1252,6 @@ class Server
     }
 
     /**
-     * Load parameters associated with a resumption token.
-     *
-     * @param string $token The resumption token to look up
-     *
-     * @return array        Parameters associated with token
-     */
-    protected function loadResumptionToken($token)
-    {
-        // Clean up expired records before doing our search:
-        $this->resumptionService->removeExpired();
-
-        // Load the requested token if it still exists:
-        if ($row = $this->resumptionService->findToken($token)) {
-            parse_str($row->getResumptionParameters(), $params);
-            return $params;
-        }
-
-        // If we got this far, the token is invalid or expired:
-        return false;
-    }
-
-    /**
      * Normalize a date to a Unix timestamp.
      *
      * @param string $date Date (ISO-8601 or YYYY-MM-DD HH:MM:SS)
@@ -1330,17 +1310,11 @@ class Server
         // Save the old cursor position before overwriting it for storage in the
         // database!
         $oldCursor = $params['cursor'];
-        $params['cursor'] = $currentCursor;
-        $params['cursorMark'] = $cursorMark;
-
-        // Save everything to the database:
-        $expire = time() + 24 * 60 * 60;
-        $token = $this->resumptionService->createAndPersistToken($params, $expire)->getId();
-
+        $resumptionToken = $this->createResumptionToken($params, $currentCursor, $cursorMark);
         // Add details to the xml:
-        $token = $xml->addChild('resumptionToken', $token);
+        $token = $xml->addChild('resumptionToken', $resumptionToken->getId());
         $token->addAttribute('cursor', $oldCursor);
-        $token->addAttribute('expirationDate', date($this->iso8601, $expire));
+        $token->addAttribute('expirationDate', date($this->iso8601, $resumptionToken->getExpiry()->getTimestamp()));
         $token->addAttribute('completeListSize', $listSize);
     }
 

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -225,8 +225,9 @@ class Server
         protected \VuFind\Search\Results\PluginManager $resultsManager,
         protected \VuFind\Record\Loader $recordLoader,
         protected ChangeTrackerServiceInterface $trackerService,
-        protected OaiResumptionServiceInterface $resumptionService
+        OaiResumptionServiceInterface $resumptionService
     ) {
+        $this->setResumptionService($resumptionService);
     }
 
     /**
@@ -1070,7 +1071,7 @@ class Server
         // parameters or fail if it is invalid.
         if (!empty($this->params['resumptionToken'])) {
             $params = $this->loadResumptionToken($this->params['resumptionToken']);
-            if ($params === false) {
+            if (null === $params) {
                 throw new \Exception(
                     'badResumptionToken:Invalid or expired resumption token'
                 );

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -1313,7 +1313,7 @@ class Server
         $oldCursor = $params['cursor'];
         $resumptionToken = $this->createResumptionToken($params, $currentCursor, $cursorMark);
         // Add details to the xml:
-        $token = $xml->addChild('resumptionToken', $resumptionToken->getHash());
+        $token = $xml->addChild('resumptionToken', $resumptionToken->getToken());
         $token->addAttribute('cursor', $oldCursor);
         $token->addAttribute('expirationDate', date($this->iso8601, $resumptionToken->getExpiry()->getTimestamp()));
         $token->addAttribute('completeListSize', $listSize);

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -97,7 +97,7 @@ trait ResumptionTokenTrait
         $this->resumptionService->removeExpired();
 
         // Load the requested token if it still exists:
-        if ($row = $this->resumptionService->findWithIdOrTokenBc($token)) {
+        if ($row = $this->resumptionService->findWithTokenOrLegacyIdToken($token)) {
             parse_str($row->getResumptionParameters(), $params);
             return $params;
         }

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -97,7 +97,7 @@ trait ResumptionTokenTrait
         $this->resumptionService->removeExpired();
 
         // Load the requested token if it still exists:
-        if ($row = $this->resumptionService->findWithToken($token)) {
+        if ($row = $this->resumptionService->findWithIdOrTokenBc($token)) {
             parse_str($row->getResumptionParameters(), $params);
             return $params;
         }

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -68,17 +68,19 @@ trait ResumptionTokenTrait
      * @param array  $params     Params to be saved for the resumption token
      * @param int    $cursor     Cursor to be saved for the resumption token
      * @param string $cursorMark Cursor mark to be saved for the resumption token
+     * @param int    $lifetime   [Optional] How many seconds until token is expired. Default is 86400.
      *
      * @return OaiResumptionEntityInterface
      */
     public function createResumptionToken(
         array $params,
         int $cursor,
-        string $cursorMark
+        string $cursorMark,
+        int $lifetime = 86400
     ): OaiResumptionEntityInterface {
         $params['cursor'] = $cursor;
         $params['cursorMark'] = $cursorMark;
-        $expire = time() + 24 * 60 * 60;
+        $expire = time() + $lifetime;
         return $this->resumptionService->createAndPersistToken($params, $expire);
     }
 
@@ -87,9 +89,9 @@ trait ResumptionTokenTrait
      *
      * @param string $token The resumption token to look up
      *
-     * @return array|false Parameters associated with token or false if invalid or expired
+     * @return ?array Parameters associated with token or null if invalid or expired
      */
-    protected function loadResumptionToken(string $token): array|false
+    protected function loadResumptionToken(string $token): ?array
     {
         // Clean up expired records before doing our search:
         $this->resumptionService->removeExpired();
@@ -101,6 +103,6 @@ trait ResumptionTokenTrait
         }
 
         // If we got this far, the token is invalid or expired:
-        return false;
+        return null;
     }
 }

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -97,7 +97,7 @@ trait ResumptionTokenTrait
         $this->resumptionService->removeExpired();
 
         // Load the requested token if it still exists:
-        if ($row = $this->resumptionService->findTokenWithHash($token)) {
+        if ($row = $this->resumptionService->findWithToken($token)) {
             parse_str($row->getResumptionParameters(), $params);
             return $params;
         }

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -97,7 +97,7 @@ trait ResumptionTokenTrait
         $this->resumptionService->removeExpired();
 
         // Load the requested token if it still exists:
-        if ($row = $this->resumptionService->findToken($token)) {
+        if ($row = $this->resumptionService->findTokenWithHash($token)) {
             parse_str($row->getResumptionParameters(), $params);
             return $params;
         }

--- a/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
+++ b/module/VuFind/src/VuFind/ResumptionToken/ResumptionTokenTrait.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Resumption token trait.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
+ */
+
+namespace VuFind\ResumptionToken;
+
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
+use VuFind\Db\Service\OaiResumptionServiceInterface;
+
+/**
+ * Resumption token trait.
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:controllers Wiki
+ */
+trait ResumptionTokenTrait
+{
+    /**
+     * Resumption service for managing resumption tokens.
+     *
+     * @var OaiResumptionServiceInterface
+     */
+    protected OaiResumptionServiceInterface $resumptionService;
+
+    /**
+     * Set resumption service
+     *
+     * @param OaiResumptionServiceInterface $resumptionService Resumption service
+     *
+     * @return void
+     */
+    public function setResumptionService(OaiResumptionServiceInterface $resumptionService): void
+    {
+        $this->resumptionService = $resumptionService;
+    }
+
+    /**
+     * Generate and return a new resumption token
+     *
+     * @param array  $params     Params to be saved for the resumption token
+     * @param int    $cursor     Cursor to be saved for the resumption token
+     * @param string $cursorMark Cursor mark to be saved for the resumption token
+     *
+     * @return OaiResumptionEntityInterface
+     */
+    public function createResumptionToken(
+        array $params,
+        int $cursor,
+        string $cursorMark
+    ): OaiResumptionEntityInterface {
+        $params['cursor'] = $cursor;
+        $params['cursorMark'] = $cursorMark;
+        $expire = time() + 24 * 60 * 60;
+        return $this->resumptionService->createAndPersistToken($params, $expire);
+    }
+
+    /**
+     * Load parameters associated with a resumption token.
+     *
+     * @param string $token The resumption token to look up
+     *
+     * @return array|false Parameters associated with token or false if invalid or expired
+     */
+    protected function loadResumptionToken(string $token): array|false
+    {
+        // Clean up expired records before doing our search:
+        $this->resumptionService->removeExpired();
+
+        // Load the requested token if it still exists:
+        if ($row = $this->resumptionService->findToken($token)) {
+            parse_str($row->getResumptionParameters(), $params);
+            return $params;
+        }
+
+        // If we got this far, the token is invalid or expired:
+        return false;
+    }
+}

--- a/module/VuFind/src/VuFind/Search/SearchRunner.php
+++ b/module/VuFind/src/VuFind/Search/SearchRunner.php
@@ -135,7 +135,7 @@ class SearchRunner
         $params->initFromRequest($request);
 
         if (is_callable($setupCallback)) {
-            $setupCallback($this, $params, $runningSearchId);
+            $setupCallback($this, $params, $runningSearchId, $results);
         }
 
         // Trigger the "configuration done" event.

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
@@ -31,10 +31,13 @@ namespace VuFindTest\Service;
 
 use Exception;
 use Generator;
+use Laminas\Db\ResultSet\AbstractResultSet;
+use VuFind\Db\Row\OaiResumption;
 use VuFind\Db\Service\OaiResumptionService;
 use VuFindTest\Container\MockContainer;
 
 use function count;
+use function intval;
 
 /**
  * Oai resumption service test case.
@@ -170,5 +173,99 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
             $oaiResumptionService->createAndPersistToken(['params' => $token['params']], $token['timestamp']);
         }
         $this->assertEmpty($randomTokenSequence, 'Used all the tokens in random token generation.');
+    }
+
+    /**
+     * Test simple get tokens data provider
+     *
+     * @return Generator
+     */
+    public static function getTestTokenRetrieval(): Generator
+    {
+        yield 'get token with random generated string' => [
+          '694ae4fb77426d7b72fff63b584a39a77e37339440d291b55da78352220ece57',
+          'param1=dog',
+        ];
+        yield 'get token with legacy id' => [
+          '25',
+          'param1=cat',
+        ];
+        yield 'get non-existing token' => [
+          '512',
+          null,
+        ];
+    }
+
+    /**
+     * Very simple array acting as a database
+     *
+     * @var array
+     */
+    protected array $mockEntities = [
+      [
+        'id' => 25,
+        'token' => null,
+        'params' => 'param1=cat',
+        'expires' => 99999999,
+      ],
+      [
+        'id' => 26,
+        'token' => '694ae4fb77426d7b72fff63b584a39a77e37339440d291b55da78352220ece57',
+        'params' => 'param1=dog',
+        'expires' => 99999999,
+      ],
+    ];
+
+    /**
+     * Test legacy retrieval
+     *
+     * @param string  $token          Token used to search for row
+     * @param ?string $expectedParams Expected parameters to be returned or null for no results
+     *
+     * @return       void
+     * @dataProvider getTestTokenRetrieval
+     */
+    public function testTokenRetrieval(string $token, ?string $expectedParams): void
+    {
+        $mockRow = $this->container->createMock(OaiResumption::class, []);
+        $mockDb = [];
+        foreach ($this->mockEntities as $entity) {
+            $rowClone = clone $mockRow;
+            $rowClone->expects($this->any())->method('getId')->willReturn($entity['id']);
+            $rowClone->setExpiry(\DateTime::createFromFormat('U', $entity['expires']));
+            $rowClone->expects($this->any())->method('getResumptionParameters')->willReturn($entity['params']);
+            if ($entity['token']) {
+                $rowClone->expects($this->any())->method('getToken')->willReturn($entity['token']);
+            }
+            $mockDb[] = $rowClone;
+        }
+        $mockTable = $this->container->createMock(\VuFind\Db\Table\OaiResumption::class, ['select']);
+
+        $mockTable->expects($this->any())->method('select')->willReturnCallback(function ($select) use ($mockDb) {
+            $result = [];
+            foreach ($mockDb as $entry) {
+                if (!empty($select['id'])) {
+                    if ($entry->getId() === intval($select['id']) && $entry->getToken() === $select['token']) {
+                        $result[] = $entry;
+                    }
+                    continue;
+                }
+                if (!empty($select['token'])) {
+                    if ($entry->getToken() === $select['token']) {
+                        $result[] = $entry;
+                    }
+                }
+            }
+            $mockResultSet = $this->container->createMock(AbstractResultSet::class, ['current']);
+            $mockResultSet->expects($this->any())->method('current')->willReturn($result[0] ?? null);
+            return $mockResultSet;
+        });
+        $oaiResumptionService = $this->container->createMock(
+            OaiResumptionService::class,
+            ['getDbTable']
+        );
+        $oaiResumptionService->expects($this->any())->method('getDbTable')->willReturn($mockTable);
+        $token = $oaiResumptionService->findWithTokenOrLegacyIdToken($token);
+        $this->assertEquals($expectedParams, $expectedParams ? $token->getResumptionParameters() : null);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
@@ -32,7 +32,7 @@ namespace VuFindTest\Service;
 use Exception;
 use Generator;
 use Laminas\Db\ResultSet\AbstractResultSet;
-use VuFind\Db\Row\OaiResumption;
+use VuFind\Db\Entity\OaiResumptionEntityInterface;
 use VuFind\Db\Service\OaiResumptionService;
 use VuFindTest\Container\MockContainer;
 
@@ -227,7 +227,7 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
      */
     public function testTokenRetrieval(string $token, ?string $expectedParams): void
     {
-        $mockRow = $this->container->createMock(OaiResumption::class, []);
+        $mockRow = $this->container->createMock(OaiResumptionEntityInterface::class, []);
         $mockDb = [];
         foreach ($this->mockEntities as $entity) {
             $rowClone = clone $mockRow;

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Oai resumption service test case.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Service;
+
+use Exception;
+use Generator;
+use VuFind\Db\Service\OaiResumptionService;
+use VuFindTest\Container\MockContainer;
+
+use function count;
+
+/**
+ * Oai resumption service test case.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Mock container
+     *
+     * @var MockContainer
+     */
+    protected MockContainer $container;
+
+    /**
+     * Setup test environment. Always call parent method here.
+     *
+     * @return void
+     */
+    public function setup(): void
+    {
+        $this->container = new MockContainer($this);
+    }
+
+    /**
+     * Data provider for testCreateTokenSuccess
+     *
+     * @return Generator
+     */
+    public static function getTestDuplicatesData(): Generator
+    {
+        yield 'one token and success' => [
+          [
+            'params' => [
+              'param5' => 'cat',
+            ],
+            'timestamp' => 1739870677 + 99999,
+          ],
+          [
+            'onetokenonly',
+          ],
+        ];
+        yield 'token duplicate and success' => [
+          [
+            'params' => [
+              'param1' => 0,
+              'param2' => 'asd',
+              'param3' => 'tesfdfdfs',
+            ],
+            'timestamp' => 1739870677 + 99999,
+          ],
+          [
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokensecondsuccess',
+          ],
+        ];
+        yield 'token 6 duplicates and error' => [
+          [
+            'params' => [
+              'param1' => 0,
+              'param2' => 'asd',
+              'param3' => 'tesfdfdfs',
+            ],
+            'timestamp' => 1739870677 + 99999,
+          ],
+          [
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+            'testtokenfirstduplicate',
+          ],
+          'Test error: Duplicate token found.',
+        ];
+    }
+
+    /**
+     * Test duplicate tokens but success on the second try
+     *
+     * @param array  $token               Array with params and timestamp
+     * @param array  $randomTokenSequence Array containing strings to simulate duplicate tokens
+     * @param string $error               If set, will expect this iteration to throw this error message
+     *
+     * @return void
+     * @dataProvider getTestDuplicatesData
+     */
+    public function testDuplicates(array $token, array $randomTokenSequence, string $error = ''): void
+    {
+        if ($error) {
+            $this->expectExceptionMessage($error);
+        }
+        $previousToken = '';
+        $row = $this->container->createMock(\VuFind\Db\Row\OaiResumption::class, ['save', 'getToken', 'setToken']);
+        $row->expects($this->any())->method('getToken')->willReturnCallback(
+            function () use (&$previousToken) {
+                return $previousToken;
+            }
+        );
+        $row->expects($this->any())->method('setToken')->willReturnCallback(
+            function ($t) use (&$previousToken, $row) {
+                $previousToken = $t;
+                return $row;
+            }
+        );
+        $oaiResumptionService = $this->container->createMock(OaiResumptionService::class, ['createRandomToken', 'createEntity']);
+        $oaiResumptionService->expects($this->any())->method('createRandomToken')->willReturnCallback(
+            function () use (&$randomTokenSequence, $row) {
+                $newToken = array_shift($randomTokenSequence);
+                if ($newToken === $row->getToken()) {
+                    throw new Exception('Test error: Duplicate token found.');
+                }
+                return $newToken;
+            }
+        );
+        $oaiResumptionService->expects($this->any())->method('createEntity')->willReturn($row);
+
+        // Create first token as baseline
+        $oaiResumptionService->createAndPersistToken(['params' => $token['params']], $token['timestamp']);
+
+        if (count($randomTokenSequence) > 1) {
+            // Create second token and try to assign new random token sequences
+            $oaiResumptionService->createAndPersistToken(['params' => $token['params']], $token['timestamp']);
+        }
+        $this->assertEmpty($randomTokenSequence, 'Used all the tokens in random token generation.');
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
@@ -126,7 +126,7 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
      * @param array  $randomTokenSequence Array containing strings to simulate duplicate tokens
      * @param string $error               If set, will expect this iteration to throw this error message
      *
-     * @return void
+     * @return       void
      * @dataProvider getTestDuplicatesData
      */
     public function testDuplicates(array $token, array $randomTokenSequence, string $error = ''): void
@@ -147,7 +147,10 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
                 return $row;
             }
         );
-        $oaiResumptionService = $this->container->createMock(OaiResumptionService::class, ['createRandomToken', 'createEntity']);
+        $oaiResumptionService = $this->container->createMock(
+            OaiResumptionService::class,
+            ['createRandomToken', 'createEntity']
+        );
         $oaiResumptionService->expects($this->any())->method('createRandomToken')->willReturnCallback(
             function () use (&$randomTokenSequence, $row) {
                 $newToken = array_shift($randomTokenSequence);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Db/Service/OaiResumptionServiceTest.php
@@ -86,8 +86,8 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
           [
             'params' => [
               'param1' => 0,
-              'param2' => 'asd',
-              'param3' => 'tesfdfdfs',
+              'param2' => 'mainecoon',
+              'param3' => 'calico',
             ],
             'timestamp' => 1739870677 + 99999,
           ],
@@ -101,8 +101,8 @@ class OaiResumptionServiceTest extends \PHPUnit\Framework\TestCase
           [
             'params' => [
               'param1' => 0,
-              'param2' => 'asd',
-              'param3' => 'tesfdfdfs',
+              'param2' => 'norwegianforestcat',
+              'param3' => 'turle',
             ],
             'timestamp' => 1739870677 + 99999,
           ],

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiException.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiException.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * API exception
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Exceptions
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:ils_drivers Wiki
+ */
+
+namespace VuFindApi\Controller;
+
+use Exception;
+
+/**
+ * API exception class
+ *
+ * @category VuFind
+ * @package  Exceptions
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class ApiException extends Exception
+{
+    /**
+     * Error if limit is out of bounds < 0 or > max
+     *
+     * @var string
+     */
+    public const INVALID_LIMIT = 'Invalid limit';
+
+    /**
+     * Error if search has encountered an error
+     *
+     * @var string
+     */
+    public const INVALID_SEARCH = 'Invalid search';
+
+    /**
+     * Error if token is invalid or expired
+     *
+     * @var string
+     */
+    public const INVALID_OR_EXPIRED_TOKEN = 'Invalid or expired token';
+}

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiException.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiException.php
@@ -62,4 +62,11 @@ class ApiException extends Exception
      * @var string
      */
     public const INVALID_OR_EXPIRED_TOKEN = 'Invalid or expired token';
+
+    /**
+     * Error if invalid or no record fields were defined
+     *
+     * @var string
+     */
+    public const INVALID_RECORD_FIELDS = 'Invalid record fields defined';
 }

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -488,7 +488,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             $nextCursorMark = $results->getCursorMark();
             $resumptionToken = $this->createResumptionToken($request, $nextCursor, $nextCursorMark);
             $response['resumptionToken'] = [
-                'token' => $resumptionToken->getHash(),
+                'token' => $resumptionToken->getToken(),
                 'expires' => $resumptionToken->getExpiry()->format('Y-m-d H:i:s'),
             ];
         }

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -332,11 +332,9 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
         $isCursorSearch = ($request['resumptionToken'] ?? false);
         try {
-            if ($isCursorSearch) {
-                $response = $this->doCursorSearch($request);
-            } else {
-                $response = $this->doDefaultSearch($request);
-            }
+            $response = $isCursorSearch
+                ? $this->doCursorSearch($request)
+                : $this->doDefaultSearch($request);
         } catch (Exception $e) {
             $message = $e instanceof ApiException ? $e->getMessage() : 'Error occurred.';
             return $this->output([], self::STATUS_ERROR, 400, $message);

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -34,6 +34,7 @@ use Exception;
 use Laminas\Http\Exception\InvalidArgumentException;
 use Laminas\Mvc\Exception\DomainException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use VuFind\Db\Service\OaiResumptionServiceInterface;
 use VuFindApi\Formatter\FacetFormatter;
 use VuFindApi\Formatter\RecordFormatter;
 
@@ -56,20 +57,6 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 {
     use ApiTrait;
     use \VuFind\ResumptionToken\ResumptionTokenTrait;
-
-    /**
-     * Record formatter
-     *
-     * @var RecordFormatter
-     */
-    protected $recordFormatter;
-
-    /**
-     * Facet formatter
-     *
-     * @var FacetFormatter
-     */
-    protected $facetFormatter;
 
     /**
      * Default record fields to return if a request does not define the fields
@@ -160,14 +147,12 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
      */
     public function __construct(
         ServiceLocatorInterface $sm,
-        RecordFormatter $rf,
-        FacetFormatter $ff
+        protected RecordFormatter $recordFormatter,
+        protected FacetFormatter $facetFormatter
     ) {
         parent::__construct($sm);
         $this->setResumptionService($this->getDbService(\VuFind\Db\Service\OaiResumptionServiceInterface::class));
-        $this->recordFormatter = $rf;
-        $this->facetFormatter = $ff;
-        foreach ($rf->getRecordFields() as $fieldName => $fieldSpec) {
+        foreach ($recordFormatter->getRecordFields() as $fieldName => $fieldSpec) {
             if (!empty($fieldSpec['vufind.default'])) {
                 $this->defaultRecordFields[] = $fieldName;
             }

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -122,6 +122,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
     /**
      * Max limit of search results in API response (default 100);
+     * Applies to searches not using resumptionToken.
      *
      * @var int
      */
@@ -129,7 +130,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
     /**
      * Default max limit for cursor based search. Even if cursor search is cheaper in terms of processing in Solr,
-     * PHP memory still has limitations so set the default to be a decent amount.
+     * PHP memory still has limitations so set the default to be a decent amount. (Default 200).
      * Value is adjustable in searches.ini [API] cursorMaxLimit
      *
      * @var int
@@ -336,8 +337,12 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
                 ? $this->doCursorSearch($request)
                 : $this->doDefaultSearch($request);
         } catch (Exception $e) {
-            $message = $e instanceof ApiException ? $e->getMessage() : 'Error occurred.';
-            return $this->output([], self::STATUS_ERROR, 400, $message);
+            // Filter output from exceptions and only allow messages from
+            // ApiExceptions to be sent to user.
+            $isSafeError = $e instanceof ApiException;
+            $message = $isSafeError ? $e->getMessage() : 'Error occurred.';
+            $errorCode = $isSafeError ? $e->getCode() : 500;
+            return $this->output([], self::STATUS_ERROR, $errorCode, $message);
         }
         return $this->output($response, self::STATUS_OK);
     }
@@ -383,6 +388,8 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
                         $params->addFacet($facet);
                     }
                 }
+                // Set limit to 0 if no record fields were requested to
+                // prevent unnecessary loading.
                 $params->setLimit($recordFields ? $limit : 0);
             }
         );
@@ -441,6 +448,10 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         $cursor = $request['cursor'];
         $cursorMark = $request['cursorMark'] ?? '';
         $recordFields = $this->getFieldList($request);
+        // Throw an error here, as there is no reason to search for anything, if no record fields were defined
+        if (!$recordFields) {
+            throw new ApiException(ApiException::INVALID_RECORD_FIELDS, 400);
+        }
         $results = $this->getService(\VuFind\Search\SearchRunner::class)->run(
             $request,
             $this->searchClassId,

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2015-2016.
+ * Copyright (C) The National Library of Finland 2015-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -55,6 +55,14 @@ use function is_array;
 class SearchApiController extends \VuFind\Controller\AbstractSearch implements ApiInterface
 {
     use ApiTrait;
+    use \VuFind\ResumptionToken\ResumptionTokenTrait;
+
+    /**
+     * Default sort used when no sort defined
+     *
+     * @var string
+     */
+    protected const DEFAULT_SORT = 'relevance';
 
     /**
      * Record formatter
@@ -127,6 +135,27 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     protected $maxLimit = 100;
 
     /**
+     * Max limit of cursor search results in API response (default 1000)
+     *
+     * @var int
+     */
+    protected $cursorMaxLimit = 1000;
+
+    /**
+     * Facet configuration
+     *
+     * @var \Laminas\Config\Config
+     */
+    protected $facetConfig;
+
+    /**
+     * Hierarchical facets
+     *
+     * @var array
+     */
+    protected $hierarchicalFacets;
+
+    /**
      * Constructor
      *
      * @param ServiceLocatorInterface $sm Service manager
@@ -139,6 +168,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         FacetFormatter $ff
     ) {
         parent::__construct($sm);
+        $this->setResumptionService($this->getDbService(\VuFind\Db\Service\OaiResumptionServiceInterface::class));
         $this->recordFormatter = $rf;
         $this->facetFormatter = $ff;
         foreach ($rf->getRecordFields() as $fieldName => $fieldSpec) {
@@ -146,7 +176,8 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
                 $this->defaultRecordFields[] = $fieldName;
             }
         }
-
+        $this->facetConfig = $this->getConfig('facets');
+        $this->hierarchicalFacets = $this->facetConfig?->SpecialFacets?->hierarchical?->toArray() ?? [];
         // Load configurations from the search options class:
         $settings = $sm->get(\VuFind\Search\Options\PluginManager::class)
             ->get($this->searchClassId)->getAPISettings();
@@ -304,89 +335,161 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         $request = $this->getRequest()->getQuery()->toArray()
             + $this->getRequest()->getPost()->toArray();
 
-        if (
-            isset($request['limit'])
-            && (!ctype_digit($request['limit'])
-            || $request['limit'] < 0 || $request['limit'] > $this->maxLimit)
-        ) {
-            return $this->output([], self::STATUS_ERROR, 400, 'Invalid limit');
-        }
-
-        // Sort by relevance by default
-        if (!isset($request['sort'])) {
-            $request['sort'] = 'relevance';
-        }
-
-        $requestedFields = $this->getFieldList($request);
-
-        $facetConfig = $this->getConfig('facets');
-        $hierarchicalFacets = isset($facetConfig->SpecialFacets->hierarchical)
-            ? $facetConfig->SpecialFacets->hierarchical->toArray()
-            : [];
-
-        $runner = $this->getService(\VuFind\Search\SearchRunner::class);
+        $isCursorSearch = ($request['resumptionToken'] ?? false);
         try {
-            $results = $runner->run(
-                $request,
-                $this->searchClassId,
-                function (
-                    $runner,
-                    $params,
-                    $searchId
-                ) use (
-                    $hierarchicalFacets,
-                    $request,
-                    $requestedFields
-                ) {
-                    foreach ($request['facet'] ?? [] as $facet) {
-                        if (!isset($hierarchicalFacets[$facet])) {
-                            $params->addFacet($facet);
-                        }
-                    }
-                    if ($requestedFields) {
-                        $limit = $request['limit'] ?? 20;
-                        $params->setLimit($limit);
-                    } else {
-                        $params->setLimit(0);
-                    }
-                }
-            );
+            if ($isCursorSearch) {
+                $response = $this->doCursorSearch($request);
+            } else {
+                $response = $this->doDefaultSearch($request);
+            }
         } catch (Exception $e) {
             return $this->output([], self::STATUS_ERROR, 400, $e->getMessage());
         }
+        return $this->output($response, self::STATUS_OK);
+    }
 
+    /**
+     * Perform a search using page in Solr
+     *
+     * @param array $request Array containing combination of post and get request params
+     *
+     * @return array Response to be sent for the user
+     *               - records: Records found
+     *               - resultCount: Total result count
+     *               - facets: array containing facets for the result
+     */
+    protected function doDefaultSearch(array $request): array
+    {
+        if (
+            isset($request['limit']) && (!ctype_digit($request['limit'])
+            || $request['limit'] < 0 || $request['limit'] > $this->maxLimit)
+        ) {
+            throw new Exception('Invalid limit', 400);
+        }
+        $limit = $request['limit'] ??= 20;
+        $request['sort'] ??= self::DEFAULT_SORT;
+        $facets = $request['facet'] ??= [];
+        $recordFields = $this->getFieldList($request);
+        $hierarchicalFacets = $this->hierarchicalFacets;
+        $results = $this->getService(\VuFind\Search\SearchRunner::class)->run(
+            $request,
+            $this->searchClassId,
+            function (
+                $runner,
+                $params,
+                $searchId
+            ) use (
+                $limit,
+                $facets,
+                $hierarchicalFacets,
+                $recordFields
+            ) {
+                foreach ($facets as $facet) {
+                    if (!isset($hierarchicalFacets[$facet])) {
+                        $params->addFacet($facet);
+                    }
+                }
+                $params->setLimit($recordFields ? $limit : 0);
+            }
+        );
         // If we received an EmptySet back, that indicates that the real search
         // failed due to some kind of syntax error, and we should display a
         // warning to the user; otherwise, we should proceed with normal post-search
         // processing.
         if ($results instanceof \VuFind\Search\EmptySet\Results) {
-            return $this->output([], self::STATUS_ERROR, 400, 'Invalid search');
+            throw new Exception('Invalid search', 400);
         }
-
         $response = ['resultCount' => $results->getResultTotal()];
 
         $records = $this->recordFormatter->format(
             $results->getResults(),
-            $requestedFields
+            $recordFields
         );
         if ($records) {
             $response['records'] = $records;
         }
-
-        $requestedFacets = $request['facet'] ?? [];
-        $hierarchicalFacetData = $this->getHierarchicalFacetData(
-            array_intersect($requestedFacets, $hierarchicalFacets)
-        );
-        $facets = $this->facetFormatter->format(
-            $request,
-            $results,
-            $hierarchicalFacetData
-        );
         if ($facets) {
-            $response['facets'] = $facets;
+            $hierarchicalFacetData = $this->getHierarchicalFacetData(
+                array_intersect($facets, $hierarchicalFacets)
+            );
+            if ($facets = $this->facetFormatter->format($request, $results, $hierarchicalFacetData)) {
+                $response['facets'] = $facets;
+            }
         }
+        return $response;
+    }
 
-        return $this->output($response, self::STATUS_OK);
+    /**
+     * Perform a search using cursor in Solr. Do not send facet information when using cursor
+     *
+     * @param array $request Array containing combination of post and get request params
+     *
+     * @return array Response to be sent for the user.
+     *               - records: Found records
+     *               - resultCount: Total result count
+     *               - resumptionToken: Array containing info about resumption token
+     *                  - token
+     */
+    protected function doCursorSearch(array $request): array
+    {
+        unset($request['page']);
+        // Always discard cursors from requests
+        $request['cursor'] = 0;
+        if ('true' !== $request['resumptionToken']) {
+            // Try to load a resumption token for this request
+            $resumptionTokenParams = $this->loadResumptionToken($request['resumptionToken']);
+            if (false === $resumptionTokenParams) {
+                throw new \Exception('badResumptiontoken:Invalid or expired');
+            }
+            $request = array_merge($request, $resumptionTokenParams);
+        }
+        $limit = $this->cursorMaxLimit;
+        $request['sort'] ??= self::DEFAULT_SORT;
+        $cursor = $request['cursor'];
+        $cursorMark = $request['cursorMark'] ?? '';
+        $recordFields = $this->getFieldList($request);
+        $results = $this->getService(\VuFind\Search\SearchRunner::class)->run(
+            $request,
+            $this->searchClassId,
+            function (
+                $runner,
+                $params,
+                $searchId,
+                $results
+            ) use (
+                $cursorMark,
+                $limit
+            ) {
+                $results->overrideStartRecord(1);
+                $results->setCursorMark($cursorMark);
+                $params->setLimit($limit);
+            }
+        );
+        // If we received an EmptySet back, that indicates that the real search
+        // failed due to some kind of syntax error, and we should display a
+        // warning to the user; otherwise, we should proceed with normal post-search
+        // processing.
+        if ($results instanceof \VuFind\Search\EmptySet\Results) {
+            throw new Exception('Invalid search', 400);
+        }
+        $response = ['resultCount' => $results->getResultTotal()];
+
+        $records = $this->recordFormatter->format(
+            $results->getResults(),
+            $recordFields
+        );
+        if ($records) {
+            $response['records'] = $records;
+            // Save resumption token if results were found
+            $nextCursor = $cursor += count($records);
+            $nextCursorMark = $results->getCursorMark();
+            $resumptionToken = $this->createResumptionToken($request, $nextCursor, $nextCursorMark);
+            $response['resumptionToken'] = [
+                'token' => $resumptionToken->getId(),
+                'expires' => $resumptionToken->getExpiry()->format('Y-m-d H:i:s'),
+            ];
+        }
+        return $response;
     }
 
     /**

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -34,7 +34,6 @@ use Exception;
 use Laminas\Http\Exception\InvalidArgumentException;
 use Laminas\Mvc\Exception\DomainException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
-use VuFind\Db\Service\OaiResumptionServiceInterface;
 use VuFindApi\Formatter\FacetFormatter;
 use VuFindApi\Formatter\RecordFormatter;
 
@@ -141,9 +140,9 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     /**
      * Constructor
      *
-     * @param ServiceLocatorInterface $sm Service manager
-     * @param RecordFormatter         $rf Record formatter
-     * @param FacetFormatter          $ff Facet formatter
+     * @param ServiceLocatorInterface $sm              Service manager
+     * @param RecordFormatter         $recordFormatter Record formatter
+     * @param FacetFormatter          $facetFormatter  Facet formatter
      */
     public function __construct(
         ServiceLocatorInterface $sm,

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -184,7 +184,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
 
         // Apply all supported configurations:
         $configKeys = [
-            'recordAccessPermission', 'searchAccessPermission', 'maxLimit',
+            'recordAccessPermission', 'searchAccessPermission', 'maxLimit', 'cursorMaxLimit',
         ];
         foreach ($configKeys as $key) {
             if (isset($settings[$key])) {
@@ -222,6 +222,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             'indexLabel' => $this->indexLabel,
             'modelPrefix' => $this->modelPrefix,
             'maxLimit' => $this->maxLimit,
+            'cursorMaxLimit' => $this->cursorMaxLimit,
         ];
         $json = $this->getViewRenderer()->render(
             'searchapi/openapi',

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -419,7 +419,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         unset($request['page']);
         // Always discard cursors from requests
         $request['cursor'] = 0;
-        if ('true' !== $request['resumptionToken']) {
+        if ('*' !== $request['resumptionToken']) {
             // Try to load a resumption token for this request
             $resumptionTokenParams = $this->loadResumptionToken($request['resumptionToken']);
             if (null === $resumptionTokenParams) {

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -58,13 +58,6 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     use \VuFind\ResumptionToken\ResumptionTokenTrait;
 
     /**
-     * Default sort used when no sort defined
-     *
-     * @var string
-     */
-    protected const DEFAULT_SORT = 'relevance';
-
-    /**
      * Record formatter
      *
      * @var RecordFormatter
@@ -135,11 +128,13 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     protected $maxLimit = 100;
 
     /**
-     * Max limit of cursor search results in API response (default 1000)
+     * Default max limit for cursor based search. Even if cursor search is cheaper in terms of processing in Solr,
+     * PHP memory still has limitations so set the default to be a decent amount.
+     * Value is adjustable in searches.ini [API] cursorMaxLimit
      *
      * @var int
      */
-    protected $cursorMaxLimit = 1000;
+    protected $cursorMaxLimit = 200;
 
     /**
      * Facet configuration
@@ -176,12 +171,11 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
                 $this->defaultRecordFields[] = $fieldName;
             }
         }
-        $this->facetConfig = $this->getConfig('facets');
-        $this->hierarchicalFacets = $this->facetConfig?->SpecialFacets?->hierarchical?->toArray() ?? [];
         // Load configurations from the search options class:
-        $settings = $sm->get(\VuFind\Search\Options\PluginManager::class)
-            ->get($this->searchClassId)->getAPISettings();
-
+        $options = $sm->get(\VuFind\Search\Options\PluginManager::class)->get($this->searchClassId);
+        $settings = $options->getAPISettings();
+        $this->facetConfig = $this->getConfig($options->getFacetsIni());
+        $this->hierarchicalFacets = $this->facetConfig?->SpecialFacets?->hierarchical?->toArray() ?? [];
         // Apply all supported configurations:
         $configKeys = [
             'recordAccessPermission', 'searchAccessPermission', 'maxLimit', 'cursorMaxLimit',
@@ -344,7 +338,8 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
                 $response = $this->doDefaultSearch($request);
             }
         } catch (Exception $e) {
-            return $this->output([], self::STATUS_ERROR, 400, $e->getMessage());
+            $message = $e instanceof ApiException ? $e->getMessage() : 'Error occurred.';
+            return $this->output([], self::STATUS_ERROR, 400, $message);
         }
         return $this->output($response, self::STATUS_OK);
     }
@@ -362,13 +357,13 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     protected function doDefaultSearch(array $request): array
     {
         if (
-            isset($request['limit']) && (!ctype_digit($request['limit'])
+            isset($request['limit'])
+            && (!ctype_digit($request['limit'])
             || $request['limit'] < 0 || $request['limit'] > $this->maxLimit)
         ) {
-            throw new Exception('Invalid limit', 400);
+            throw new ApiException(ApiException::INVALID_LIMIT, 400);
         }
         $limit = $request['limit'] ??= 20;
-        $request['sort'] ??= self::DEFAULT_SORT;
         $facets = $request['facet'] ??= [];
         $recordFields = $this->getFieldList($request);
         $hierarchicalFacets = $this->hierarchicalFacets;
@@ -398,7 +393,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         // warning to the user; otherwise, we should proceed with normal post-search
         // processing.
         if ($results instanceof \VuFind\Search\EmptySet\Results) {
-            throw new Exception('Invalid search', 400);
+            throw new ApiException(ApiException::INVALID_SEARCH, 400);
         }
         $response = ['resultCount' => $results->getResultTotal()];
 
@@ -439,13 +434,12 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         if ('true' !== $request['resumptionToken']) {
             // Try to load a resumption token for this request
             $resumptionTokenParams = $this->loadResumptionToken($request['resumptionToken']);
-            if (false === $resumptionTokenParams) {
-                throw new \Exception('badResumptiontoken:Invalid or expired');
+            if (null === $resumptionTokenParams) {
+                throw new ApiException(ApiException::INVALID_OR_EXPIRED_TOKEN, 400);
             }
             $request = array_merge($request, $resumptionTokenParams);
         }
         $limit = $this->cursorMaxLimit;
-        $request['sort'] ??= self::DEFAULT_SORT;
         $cursor = $request['cursor'];
         $cursorMark = $request['cursorMark'] ?? '';
         $recordFields = $this->getFieldList($request);
@@ -471,7 +465,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         // warning to the user; otherwise, we should proceed with normal post-search
         // processing.
         if ($results instanceof \VuFind\Search\EmptySet\Results) {
-            throw new Exception('Invalid search', 400);
+            throw new ApiException(ApiException::INVALID_SEARCH, 400);
         }
         $response = ['resultCount' => $results->getResultTotal()];
 

--- a/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/SearchApiController.php
@@ -131,11 +131,11 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
     /**
      * Default max limit for cursor based search. Even if cursor search is cheaper in terms of processing in Solr,
      * PHP memory still has limitations so set the default to be a decent amount. (Default 200).
-     * Value is adjustable in searches.ini [API] cursorMaxLimit
+     * Value is adjustable in searches.ini [API] cursorLimit
      *
      * @var int
      */
-    protected $cursorMaxLimit = 200;
+    protected $cursorLimit = 200;
 
     /**
      * Facet configuration
@@ -179,7 +179,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
         $this->hierarchicalFacets = $this->facetConfig?->SpecialFacets?->hierarchical?->toArray() ?? [];
         // Apply all supported configurations:
         $configKeys = [
-            'recordAccessPermission', 'searchAccessPermission', 'maxLimit', 'cursorMaxLimit',
+            'recordAccessPermission', 'searchAccessPermission', 'maxLimit', 'cursorLimit',
         ];
         foreach ($configKeys as $key) {
             if (isset($settings[$key])) {
@@ -217,7 +217,6 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             'indexLabel' => $this->indexLabel,
             'modelPrefix' => $this->modelPrefix,
             'maxLimit' => $this->maxLimit,
-            'cursorMaxLimit' => $this->cursorMaxLimit,
         ];
         $json = $this->getViewRenderer()->render(
             'searchapi/openapi',
@@ -444,7 +443,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             }
             $request = array_merge($request, $resumptionTokenParams);
         }
-        $limit = $this->cursorMaxLimit;
+        $limit = $this->cursorLimit;
         $cursor = $request['cursor'];
         $cursorMark = $request['cursorMark'] ?? '';
         $recordFields = $this->getFieldList($request);
@@ -489,7 +488,7 @@ class SearchApiController extends \VuFind\Controller\AbstractSearch implements A
             $nextCursorMark = $results->getCursorMark();
             $resumptionToken = $this->createResumptionToken($request, $nextCursor, $nextCursorMark);
             $response['resumptionToken'] = [
-                'token' => $resumptionToken->getId(),
+                'token' => $resumptionToken->getHash(),
                 'expires' => $resumptionToken->getExpiry()->format('Y-m-d H:i:s'),
             ];
         }

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -352,6 +352,19 @@
                     }
                 }
             },
+            "ResumptionToken": {
+                "type": "object",
+                "properties": {
+                    "token": {
+                        "description": "Token to use for the next request",
+                        "type": "integer"
+                    },
+                    "expires": {
+                        "description": "Timestamp when the token expires",
+                        "type": "string"
+                    }
+                }
+            },
             "<?=$this->modelPrefix?>SearchResponse": {
                 "type": "object",
                 "properties": {
@@ -374,11 +387,7 @@
                         }
                     },
                     "resumptionToken": {
-                        "description": "New resumption token",
-                        "type": "object",
-                        "items": {
-                            "$ref": "#/components/schemas/ResumptionToken"
-                        }
+                        "$ref": "#/components/schemas/ResumptionToken"
                     },
                     "status": {
                         "description": "Status code",

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -200,6 +200,15 @@
                             "default": 20
                         }
                     },
+                    {
+                        "name": "resumptionToken",
+                        "in": "query",
+                        "description": "Use resumption token for paging the results. Returns <?=$cursorMaxLimit ?> records per request. Using resumption token excludes page setting and returning facets is not possible.",
+                        "schema": {
+                            "type": "integer|boolean",
+                            "default": "false"
+                        }
+                    },
 <?=$commonFields ?>
                 ],
                 "tags": [
@@ -212,6 +221,16 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/<?=$this->modelPrefix?>SearchResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200 (resumption token)": {
+                        "description": "Response containing result count, records and/or resumptionToken.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/<?=$this->modelPrefix?>SearchResponseResumptionToken"
                                 }
                             }
                         }
@@ -371,6 +390,48 @@
                     }
                 },
                 "required": ["resultCount", "status"]
+            },
+            "<?=$this->modelPrefix?>SearchResponseResumptionToken": {
+                "type": "object",
+                "properties": {
+                    "resultCount": {
+                        "description": "Number of results",
+                        "type": "integer"
+                    },
+                    "records": {
+                        "description": "Records",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/<?=$this->modelPrefix?>Record"
+                        }
+                    },
+                    "resumptionToken": {
+                        "description": "New resumption token",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ResumptionToken"
+                        }
+                    },
+                    "status": {
+                        "description": "Status code",
+                        "type": "string",
+                        "enum": ["OK"]
+                    }
+                },
+                "required": ["resultCount", "status"]
+            },
+            "ResumptionToken": {
+                "type": "object",
+                "properties": {
+                    "token": {
+                        "description": "Token to use for the next request",
+                        "type": "integer"
+                    },
+                    "expires": {
+                        "description": "Time stamp when the token expires",
+                        "type": "string"
+                    }
+                }
             },
             "Subject": {
                 "type": "object",

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -357,7 +357,7 @@
                 "properties": {
                     "token": {
                         "description": "Token to use for the next request",
-                        "type": "integer"
+                        "type": "string"
                     },
                     "expires": {
                         "description": "Timestamp when the token expires",

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -203,10 +203,9 @@
                     {
                         "name": "resumptionToken",
                         "in": "query",
-                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to true. Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than true or false. The following parameters are not available with resumptionToken: limit, page, facet[].",
+                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk \"*\". Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than true or false. The following parameters are not available with resumptionToken: limit, page, facet[].",
                         "schema": {
-                            "type": "integer|boolean",
-                            "default": "false"
+                            "type": "string"
                         }
                     },
 <?=$commonFields ?>
@@ -360,8 +359,9 @@
                         "type": "string"
                     },
                     "expires": {
-                        "description": "Timestamp when the token expires",
-                        "type": "string"
+                        "description": "Time when the token expires",
+                        "type": "string",
+                        "format": "date-time"
                     }
                 }
             },

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -203,7 +203,7 @@
                     {
                         "name": "resumptionToken",
                         "in": "query",
-                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk `*`. Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than `*` or omitted. The following parameters are not available with resumptionToken: limit, page, facet[].",
+                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk `*`. Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than `*`. The following parameters are not available with resumptionToken: limit, page, facet[].",
                         "schema": {
                             "type": "string"
                         }

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -225,16 +225,6 @@
                             }
                         }
                     },
-                    "200 (resumption token)": {
-                        "description": "Response containing result count, records and/or resumptionToken.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/<?=$this->modelPrefix?>SearchResponseResumptionToken"
-                                }
-                            }
-                        }
-                    },
                     "default": {
                         "description": "Error",
                         "content": {
@@ -383,31 +373,9 @@
                             "$ref": "#/components/schemas/Facet"
                         }
                     },
-                    "status": {
-                        "description": "Status code",
-                        "type": "string",
-                        "enum": ["OK"]
-                    }
-                },
-                "required": ["resultCount", "status"]
-            },
-            "<?=$this->modelPrefix?>SearchResponseResumptionToken": {
-                "type": "object",
-                "properties": {
-                    "resultCount": {
-                        "description": "Number of results",
-                        "type": "integer"
-                    },
-                    "records": {
-                        "description": "Records",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/<?=$this->modelPrefix?>Record"
-                        }
-                    },
                     "resumptionToken": {
                         "description": "New resumption token",
-                        "type": "array",
+                        "type": "object",
                         "items": {
                             "$ref": "#/components/schemas/ResumptionToken"
                         }
@@ -419,19 +387,6 @@
                     }
                 },
                 "required": ["resultCount", "status"]
-            },
-            "ResumptionToken": {
-                "type": "object",
-                "properties": {
-                    "token": {
-                        "description": "Token to use for the next request",
-                        "type": "integer"
-                    },
-                    "expires": {
-                        "description": "Time stamp when the token expires",
-                        "type": "string"
-                    }
-                }
             },
             "Subject": {
                 "type": "object",

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -203,7 +203,7 @@
                     {
                         "name": "resumptionToken",
                         "in": "query",
-                        "description": "Use resumption token for paging the results. Returns <?=$cursorMaxLimit ?> records per request. Using resumption token excludes page setting and returning facets is not possible.",
+                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to true. Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than true or false. The following parameters are not available with resumptionToken: limit, page, facet[].",
                         "schema": {
                             "type": "integer|boolean",
                             "default": "false"

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -203,7 +203,7 @@
                     {
                         "name": "resumptionToken",
                         "in": "query",
-                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk \"&#42;\". Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than \"&#42;\" or omitted. The following parameters are not available with resumptionToken: limit, page, facet[].",
+                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk `*`. Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than `*` or omitted. The following parameters are not available with resumptionToken: limit, page, facet[].",
                         "schema": {
                             "type": "string"
                         }

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -203,7 +203,7 @@
                     {
                         "name": "resumptionToken",
                         "in": "query",
-                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk \"*\". Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than true or false. The following parameters are not available with resumptionToken: limit, page, facet[].",
+                        "description": "A large result set can only be downloaded in batches. You can initiate a batch download by setting resumptionToken to a single asterisk \"&#42;\". Each batch will then return a resumptionToken value to use for the next batch until no more results are available (note that the last result set can be empty). Other parameters are ignored when resumptionToken is set to any other value than \"&#42;\" or omitted. The following parameters are not available with resumptionToken: limit, page, facet[].",
                         "schema": {
                             "type": "string"
                         }


### PR DESCRIPTION
Adds an option to request a resumption token when using search in REST. 

uses parameter resumptionToken=<true|tokenid> for deciding if the request is new or to use older resumption token. Excludes the possibility to return facets from the result.

Moved resumption token handling to a trait.

TODO
- [x] Make sure PostgreSQL is fully supported in addition to MySQL.
- [x] Update database changelog when merging.
- [x] Make note of removal of deprecated methods on 12.0 deprecation cleanup JIRA ticket.