### PR TITLE
BrowZine covers: skip over default images.

### DIFF
--- a/config/vufind/BrowZine.ini
+++ b/config/vufind/BrowZine.ini
@@ -30,6 +30,14 @@ load_results_with_js = true
 ; full                   Full pagination alike to the one at the bottom of results
 ;top_paginator = simple
 
+; This section contains settings related to the BrowZine cover image loader.
+[Covers]
+; Any URLs in this list will be ignored when using the BrowZine cover image; this
+; allows "no match" images to be skipped so that other cover providers can fill in
+; BrowZine's gaps. If this setting is omitted, the default value below will be used.
+; If you want to disable skipping of generic images, set the value to an empty string.
+ignored_images[] = "https://assets.thirdiron.com/default-journal-cover.png"
+
 ; This section controls the behavior of the BrowZine DOI handler; see also
 ; the [DOI] section of config.ini to activate the handler.
 [DOI]

--- a/module/VuFind/src/VuFind/Content/Covers/BrowZine.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BrowZine.php
@@ -32,6 +32,8 @@ namespace VuFind\Content\Covers;
 use VuFindSearch\Backend\BrowZine\Command\LookupIssnsCommand;
 use VuFindSearch\Service;
 
+use function in_array;
+
 /**
  * BrowZine cover content loader.
  *
@@ -44,20 +46,19 @@ use VuFindSearch\Service;
 class BrowZine extends \VuFind\Content\AbstractCover
 {
     /**
-     * Search service
+     * Cover image URLs to ignore (we don't want to display third-party generic images).
      *
-     * @var Service
+     * @var string[]
      */
-    protected $searchService;
+    protected $ignoreList = ['https://assets.thirdiron.com/default-journal-cover.png'];
 
     /**
      * Constructor
      *
      * @param Service $searchService Search service
      */
-    public function __construct(Service $searchService)
+    public function __construct(protected Service $searchService)
     {
-        $this->searchService = $searchService;
         $this->supportsIssn = true;
     }
 
@@ -82,6 +83,7 @@ class BrowZine extends \VuFind\Content\AbstractCover
 
         $command = new LookupIssnsCommand('BrowZine', $ids['issn']);
         $result = $this->searchService->invoke($command)->getResult();
-        return $result['data'][0]['coverImageUrl'] ?? false;
+        $url = $result['data'][0]['coverImageUrl'] ?? false;
+        return ($url && in_array($url, $this->ignoreList)) ? false : $url;
     }
 }

--- a/module/VuFind/src/VuFind/Content/Covers/BrowZine.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BrowZine.php
@@ -46,18 +46,12 @@ use function in_array;
 class BrowZine extends \VuFind\Content\AbstractCover
 {
     /**
-     * Cover image URLs to ignore (we don't want to display third-party generic images).
-     *
-     * @var string[]
-     */
-    protected $ignoreList = ['https://assets.thirdiron.com/default-journal-cover.png'];
-
-    /**
      * Constructor
      *
-     * @param Service $searchService Search service
+     * @param Service  $searchService Search service
+     * @param string[] $ignoreList    Cover image URLs to ignore (we don't want to display third-party generic images)
      */
-    public function __construct(protected Service $searchService)
+    public function __construct(protected Service $searchService, protected array $ignoreList)
     {
         $this->supportsIssn = true;
     }

--- a/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/BrowZineFactory.php
@@ -69,6 +69,9 @@ class BrowZineFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        return new $requestedName($container->get(\VuFindSearch\Service::class));
+        $config = $container->get(\VuFind\Config\PluginManager::class)->get('BrowZine')?->toArray() ?? [];
+        $defaultIgnoreList = ['https://assets.thirdiron.com/default-journal-cover.png'];
+        $ignoreList = $config['Covers']['ignored_images'] ?? $defaultIgnoreList;
+        return new $requestedName($container->get(\VuFindSearch\Service::class), $ignoreList);
     }
 }

--- a/module/VuFind/tests/fixtures/browzine/cover-default.json
+++ b/module/VuFind/tests/fixtures/browzine/cover-default.json
@@ -1,0 +1,1 @@
+{"data":[{"id":1,"type":"journals","title":"Default Cover Journal","issn":"12345678","sjrValue":0,"coverImageUrl":"https:\/\/assets.thirdiron.com\/default-journal-cover.png","browzineEnabled":false,"externalLink":"https:\/\/fake-external-link.com"}]}

--- a/module/VuFind/tests/fixtures/browzine/cover-non-default.json
+++ b/module/VuFind/tests/fixtures/browzine/cover-non-default.json
@@ -1,0 +1,1 @@
+{"data":[{"id":1,"type":"journals","title":"Non-default Cover Journal","issn":"12345678","sjrValue":0,"coverImageUrl":"https:\/\/assets.thirdiron.com\/simulated-real-cover.png","browzineEnabled":false,"externalLink":"https:\/\/fake-external-link.com"}]}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
@@ -30,6 +30,8 @@
 namespace VuFindTest\Content\Covers;
 
 use VuFind\Content\Covers\BrowZine;
+use VuFind\Content\Covers\BrowZineFactory;
+use VuFindTest\Container\MockContainer;
 
 /**
  * Unit tests for BrowZine cover loader.
@@ -86,7 +88,10 @@ class BrowZineTest extends \PHPUnit\Framework\TestCase
                 }
             );
         }
-        $loader = new BrowZine($service);
+        $factory = new BrowZineFactory();
+        $container = new MockContainer($this);
+        $container->set(\VuFindSearch\Service::class, $service);
+        $loader = ($factory)($container, BrowZine::class);
         $this->assertEquals($expected, $loader->getUrl('', 'small', $ids));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
@@ -66,7 +66,7 @@ class BrowZineTest extends \PHPUnit\Framework\TestCase
      * Test cover loading
      *
      * @param array       $ids      Array of IDs to look up
-     * @param ?string     $fixture  Fixture to return from backend
+     * @param ?string     $fixture  Fixture to return from backend (null to assume backend will not be called)
      * @param string|bool $expected Expected cover URL
      *
      * @return void

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/BrowZineTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Unit tests for BrowZine cover loader.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFindTest\Content\Covers;
+
+use VuFind\Content\Covers\BrowZine;
+
+/**
+ * Unit tests for BrowZine cover loader.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class BrowZineTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\FixtureTrait;
+
+    /**
+     * Data provider for testCoverLoading.
+     *
+     * @return array[]
+     */
+    public static function coverProvider(): array
+    {
+        return [
+            'no issn' => [[], null, false],
+            'default cover' => [['issn' => '12345678'], 'browzine/cover-default.json', false],
+            'non-default cover' => [
+                ['issn' => '12345678'],
+                'browzine/cover-non-default.json',
+                'https://assets.thirdiron.com/simulated-real-cover.png',
+            ],
+        ];
+    }
+
+    /**
+     * Test cover loading
+     *
+     * @param array       $ids      Array of IDs to look up
+     * @param ?string     $fixture  Fixture to return from backend
+     * @param string|bool $expected Expected cover URL
+     *
+     * @return void
+     *
+     * @dataProvider coverProvider
+     */
+    public function testCoverLoading(array $ids, ?string $fixture, string|bool $expected): void
+    {
+        $service = $this->createMock(\VuFindSearch\Service::class);
+        if ($fixture) {
+            $service->method('invoke')->willReturnCallback(
+                function ($command) use ($fixture, $ids) {
+                    $this->assertEquals([$ids['issn']], $command->getArguments());
+                    $fakeCommand = $this->createMock($command::class);
+                    $fakeCommand->method('getResult')->willReturn($this->getJsonFixture($fixture));
+                    return $fakeCommand;
+                }
+            );
+        }
+        $loader = new BrowZine($service);
+        $this->assertEquals($expected, $loader->getUrl('', 'small', $ids));
+    }
+}


### PR DESCRIPTION
Sometimes the BrowZine cover API returns a default image, which will prevent other cover providers from being chained together. This PR skips over default images so that VuFind can handle defaults on its end.