### PR TITLE
Fix ChoiceAuth getUsernamePolicy and getPasswordPolicy when not logged in.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
@@ -312,7 +312,7 @@ class ChoiceAuth extends AbstractBase
      */
     public function getUsernamePolicy()
     {
-        return $this->proxyAuthMethod('getUsernamePolicy', func_get_args());
+        return $this->proxyAuthMethod('getUsernamePolicy', func_get_args()) ?: [];
     }
 
     /**
@@ -322,7 +322,7 @@ class ChoiceAuth extends AbstractBase
      */
     public function getPasswordPolicy()
     {
-        return $this->proxyAuthMethod('getPasswordPolicy', func_get_args());
+        return $this->proxyAuthMethod('getPasswordPolicy', func_get_args()) ?: [];
     }
 
     /**


### PR DESCRIPTION
If an authentication strategy is not set, proxyAuthMethod returns false. This does not normally happen, but could be encountered e.g. when trying to refresh a password change form while the session has timed out or user has logged out in another browser window.