### PR TITLE
Revise TopRecommendations config defaults.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -555,9 +555,13 @@ WorkKeys = year
 ;Subject[]          = OpenLibrarySubjectsDeferred:lookfor:5:true:topic,place,person,time
 
 [TopRecommendations]
-Author[]            = AuthorFacets
-Author[]            = SpellingSuggestions
-CallNumber[]        = "TopFacets:ResultsTop"    ; disable spelling in this context
+; You can uncomment the following lines to replace default TopFacets recommendations
+; with a list of matching author names when users perform an Author search:
+;Author[]            = AuthorFacets
+;Author[]            = SpellingSuggestions
+; We override the CallNumber settings here to exclude SpellingSuggestions, which are
+; not relevant in the context of a call number search.
+CallNumber[]        = "TopFacets:ResultsTop"
 ; Do not show top recommendations for the Versions (WorkKeys) search by default
 WorkKeys[]          = false
 


### PR DESCRIPTION
As discussed on the [February, 2025 Community Call](https://vufind.org/wiki/community_call:minutes20250204), the AuthorFacets default top recommendation for author searches is unpopular and potentially confusing. This PR comments it out by default. It also revises the comments on the CallNumber custom defaults to better explain their purpose.

TODO
- [x] Add changelog note when merging