### PR TITLE
ExtendClass generator: Strip leading slashes from class names

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
@@ -85,7 +85,7 @@ class ExtendClassCommand extends AbstractContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // Normalize class name to exclude leading slashes; a FQCN doesn't need it:
+        // Normalize class name to exclude leading slashes; a FQCN doesn't need them:
         $class = ltrim($input->getArgument('class_name'), '\\');
         $target = $input->getArgument('target_module');
         $extendFactory = $input->getOption('extendfactory');

--- a/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Generate/ExtendClassCommand.php
@@ -85,7 +85,8 @@ class ExtendClassCommand extends AbstractContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $class = $input->getArgument('class_name');
+        // Normalize class name to exclude leading slashes; a FQCN doesn't need it:
+        $class = ltrim($input->getArgument('class_name'), '\\');
         $target = $input->getArgument('target_module');
         $extendFactory = $input->getOption('extendfactory');
 


### PR DESCRIPTION
I confused myself today by including a leading slash on a class name when running the extendclass generator. This PR just strips leading slashes to normalize input to the expected class name format.