### PR TITLE
Drop legacy 1.x compatibility from SolrMarc code.

### DIFF
--- a/import/index_java/src/org/vufind/index/ConfigManager.java
+++ b/import/index_java/src/org/vufind/index/ConfigManager.java
@@ -100,10 +100,6 @@ public class ConfigManager
             }
         }
         file = new File(vufindHome + "/" + relativeConfigPath + "/" + filename);
-        if (file.exists()) {
-            return file;
-        }
-        file = new File(vufindHome + "/web/conf/" + filename); // legacy from VuFind 1.x
         return file;
     }
 

--- a/import/vufind.properties
+++ b/import/vufind.properties
@@ -3,8 +3,8 @@
 
 # A path relative to the VUFIND_HOME or VUFIND_LOCAL_DIR environment variable
 # where VuFind's configuration files can be found. By default, SolrMarc will
-# look in the VuFind 2.x-style directory path, but you can uncomment the line
-# below for compatibility with VuFind 1.x.
+# look in the config/vufind directory path, but you can uncomment the line below
+# in the unlikely situation that you store configs using a different pattern.
 #vufind.config.relative_path = web/conf
 
 # coordinate error log location - where to put coordinate indexing error logs


### PR DESCRIPTION
While working on #4233, I noticed that we still had some legacy 1.x logic in our custom SolrMarc extensions. I think the time has come to cut the cord and simplify it out!