### PR TITLE
EDS: Match the save-to-list icon and link behavior to DefaultRecord

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
@@ -123,8 +123,10 @@
 
       <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
         <?php /* Add to favorites */ ?>
-        <?=$this->icon('user-list-add') ?> <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" class="save-record" data-lightbox id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEscAttr('Add to favorites')?>"><?=$this->transEsc('Add to favorites')?></a><br>
-
+        <a href="<?=$this->escapeHtmlAttr($recordLinker->getActionUrl($this->driver, 'Save'))?>" data-lightbox class="save-record result-link icon-link" data-lightbox id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
+          <?=$this->icon('user-favorites', 'icon-link__icon') ?>
+          <span class="result-link-label icon-link__label"><?=$this->transEsc('Add to favorites')?></span>
+        </a><br>
         <?php /* Saved lists */ ?>
         <div class="savedLists alert alert-info hidden">
           <strong><?=$this->transEsc('Saved in')?>:</strong>


### PR DESCRIPTION
EDS uses a bookmark icon instead of star, and the icon itself is not linked.  This looks particularly odd when EDS results are blended with others.

This PR reverts those lines to match DefaultRecord.

- [ ] Possibly also get the permissions around save-to-list to work, that's another discrepancy.