### PR TITLE
Combined search: add setting to disable default filters.

### DIFF
--- a/config/vufind/combined.ini
+++ b/config/vufind/combined.ini
@@ -51,6 +51,9 @@
 ;          ([SearchTabsFilters] in config.ini). In this case, make sure the filters
 ;          are equal in both configurations to make the correct tab active when
 ;          clicking more results from the combined view.
+; disable_default_filters = If set to false (the default), any default filters
+;                           configured for the current backend will be applied to
+;                           combined results. Set to true to omit default filters.
 ; permission = The name of a permission which must be granted in order to display
 ;              results in this column. This permission must also have an appropriate
 ;              deniedTemplateBehavior defined in permissionBehavior.ini.

--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -303,6 +303,11 @@ class CombinedController extends AbstractSearch
         $query = $this->getRequest()->getQuery();
         $query->limit = $settings['limit'] ?? null;
 
+        // Disable default filters, if requested:
+        if ($settings['disable_default_filters'] ?? false) {
+            $query->dfApplied = 1;
+        }
+
         // Apply filters, if any:
         $query->filter = isset($settings['filter'])
             ? (array)$settings['filter'] : null;


### PR DESCRIPTION
There are some situations where it might be useful for a combined search column to disable/override default filters configured for a backend. This PR adds a setting to enable that possibility through combined.ini configuration.