### PR TITLE
Pin sass package to 1.72.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt": "^1.0.4",
     "grunt-dart-sass": "^2.0.1",
     "jit-grunt": "^0.10.0",
-    "sass": "^1.69.5"
+    "sass": "1.72.0"
   },
   "devDependencies": {
     "all-iso-language-codes": "^1.0.13",


### PR DESCRIPTION
Newer versions of the NPM sass package are causing SASS build problems due to deprecations. This PR pins the package to a known stable version until we can address the underlying problems.