### PR TITLE
[VUFIND-1755] Allow FOLIO token sharing between sessions.

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -27,7 +27,8 @@ legacy_authentication = true
 ; If set to true (the default), the driver will cache API tokens so that all end
 ; users share the same active token, to reduce the number of tokens generated in
 ; FOLIO's database. If set to false, each user session will generate its own
-; distinct token.
+; distinct token. Note that this setting will be automatically disabled if the
+; use_user_token setting below is set to true, as the options are incompatible.
 global_token_cache = true
 
 [IDs]

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -24,6 +24,12 @@ debug_get_requests = false
 ; more secure /auth/login-with-expiry method introduced in the Poppy release.
 legacy_authentication = true
 
+; If set to true (the default), the driver will cache API tokens so that all end
+; users share the same active token, to reduce the number of tokens generated in
+; FOLIO's database. If set to false, each user session will generate its own
+; distinct token.
+global_token_cache = true
+
 [IDs]
 ; Which FOLIO ID is VuFind using as its internal bibliographic ID?
 ; Options:

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -352,6 +352,19 @@ class Folio extends AbstractAPI implements
     }
 
     /**
+     * Should we use a global cache for FOLIO API tokens?
+     *
+     * @return bool
+     */
+    protected function useGlobalTokenCache(): bool
+    {
+        // If we're configured to store user-specific tokens, we can't use the global
+        // token cache.
+        $useUserToken = $this->config['User']['use_user_token'] ?? false;
+        return !$useUserToken && ($this->config['API']['global_token_cache'] ?? true);
+    }
+
+    /**
      * Initialize the driver.
      *
      * Check or renew our auth token
@@ -363,7 +376,7 @@ class Folio extends AbstractAPI implements
         $factory = $this->sessionFactory;
         $this->sessionCache = $factory($this->tenant);
         $cacheType = 'session';
-        if ($this->config['API']['global_token_cache'] ?? true) {
+        if ($this->useGlobalTokenCache()) {
             $globalTokenData = (array)($this->getCachedData('token') ?? []);
             if (count($globalTokenData) === 2) {
                 $cacheType = 'global';
@@ -1183,7 +1196,7 @@ class Folio extends AbstractAPI implements
         if ($this->token != null && $this->tokenExpiration != null) {
             $this->sessionCache->folio_token = $this->token;
             $this->sessionCache->folio_token_expiration = $this->tokenExpiration;
-            if ($this->config['API']['global_token_cache'] ?? true) {
+            if ($this->useGlobalTokenCache()) {
                 $this->putCachedData('token', [$this->token, $this->tokenExpiration], $tokenCacheLifetime);
             }
         } else {

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -363,10 +363,12 @@ class Folio extends AbstractAPI implements
         $factory = $this->sessionFactory;
         $this->sessionCache = $factory($this->tenant);
         $cacheType = 'session';
-        $globalTokenData = (array)($this->getCachedData('token') ?? []);
-        if (($this->config['API']['global_token_cache'] ?? true) && count($globalTokenData) === 2) {
-            $cacheType = 'global';
-            [$this->sessionCache->folio_token, $this->sessionCache->folio_token_expiration] = $globalTokenData;
+        if ($this->config['API']['global_token_cache'] ?? true) {
+            $globalTokenData = (array)($this->getCachedData('token') ?? []);
+            if (count($globalTokenData) === 2) {
+                $cacheType = 'global';
+                [$this->sessionCache->folio_token, $this->sessionCache->folio_token_expiration] = $globalTokenData;
+            }
         }
         if ($this->sessionCache->folio_token ?? false) {
             $this->token = $this->sessionCache->folio_token;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1173,7 +1173,7 @@ class Folio extends AbstractAPI implements
         if ($this->useLegacyAuthentication()) {
             $this->token = $response->getHeaders()->get('X-Okapi-Token')->getFieldValue();
             $this->tokenExpiration = gmdate('D, d-M-Y H:i:s T', strtotime('now'));
-            $tokenCacheLifetime = 10 * 60; // cache old-fashioned tokens for 10 minutes
+            $tokenCacheLifetime = 600; // cache old-fashioned tokens for 10 minutes
         } elseif ($cookie = $this->getCookieByName($response, 'folioAccessToken')) {
             $this->token = $cookie->getValue();
             $this->tokenExpiration = $cookie->getExpires();

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1173,7 +1173,7 @@ class Folio extends AbstractAPI implements
         if ($this->useLegacyAuthentication()) {
             $this->token = $response->getHeaders()->get('X-Okapi-Token')->getFieldValue();
             $this->tokenExpiration = gmdate('D, d-M-Y H:i:s T', strtotime('now'));
-            $tokenCacheLifetime = 10 * 60 * 60; // cache old-fashioned tokens for 10 minutes
+            $tokenCacheLifetime = 10 * 60; // cache old-fashioned tokens for 10 minutes
         } elseif ($cookie = $this->getCookieByName($response, 'folioAccessToken')) {
             $this->token = $cookie->getValue();
             $this->tokenExpiration = $cookie->getExpires();

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -362,11 +362,17 @@ class Folio extends AbstractAPI implements
     {
         $factory = $this->sessionFactory;
         $this->sessionCache = $factory($this->tenant);
+        $cacheType = 'session';
+        $globalTokenData = (array)($this->getCachedData('token') ?? []);
+        if (($this->config['API']['global_token_cache'] ?? true) && count($globalTokenData) === 2) {
+            $cacheType = 'global';
+            [$this->sessionCache->folio_token, $this->sessionCache->folio_token_expiration] = $globalTokenData;
+        }
         if ($this->sessionCache->folio_token ?? false) {
             $this->token = $this->sessionCache->folio_token;
             $this->tokenExpiration = $this->sessionCache->folio_token_expiration ?? null;
             $this->debug(
-                'Token taken from cache: ' . substr($this->token, 0, 30) . '...'
+                'Token taken from ' . $cacheType . ' cache: ' . substr($this->token, 0, 30) . '...'
             );
         }
         if ($this->token == null) {
@@ -1165,13 +1171,19 @@ class Folio extends AbstractAPI implements
         if ($this->useLegacyAuthentication()) {
             $this->token = $response->getHeaders()->get('X-Okapi-Token')->getFieldValue();
             $this->tokenExpiration = gmdate('D, d-M-Y H:i:s T', strtotime('now'));
+            $tokenCacheLifetime = 10 * 60 * 60; // cache old-fashioned tokens for 10 minutes
         } elseif ($cookie = $this->getCookieByName($response, 'folioAccessToken')) {
             $this->token = $cookie->getValue();
             $this->tokenExpiration = $cookie->getExpires();
+            // cache RTR tokens using their known lifetime:
+            $tokenCacheLifetime = strtotime($this->tokenExpiration) - strtotime('now');
         }
         if ($this->token != null && $this->tokenExpiration != null) {
             $this->sessionCache->folio_token = $this->token;
             $this->sessionCache->folio_token_expiration = $this->tokenExpiration;
+            if ($this->config['API']['global_token_cache'] ?? true) {
+                $this->putCachedData('token', [$this->token, $this->tokenExpiration], $tokenCacheLifetime);
+            }
         } else {
             throw new \Exception('Could not find token data in response');
         }


### PR DESCRIPTION
This is designed to address a problem where VuFind's RTR implementation caused generation of an unreasonable number of tokens in FOLIO's database.

TODO
- [x] Make sure this solves the problem in a production environment before merging.
- [x] Resolve [VUFIND-1755](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1755) when merging.