### PR TITLE
testBulkExport: improve reliability.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -339,7 +339,11 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
 
         // Select EndNote option
         try {
-            $select = $this->findCss($page, '#format', 100);
+            // We don't want to wait the full default timeout here since that wastes a lot
+            // of time if a click failed to register; however, we shouldn't wait for too
+            // short of a time, or else a slow response can break the test by causing a
+            // double form submission.
+            $select = $this->findCss($page, '#format', 1500);
         } catch (\Exception $e) {
             $this->retryClickWithResizedWindow($session, $page, $buttonSelector);
             $select = $this->findCss($page, '#format');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -347,10 +347,9 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         $select->selectOption('EndNote');
 
         // Do the export:
-        $submit = $this->findCss($page, '.modal-body input[name=submitButton]');
-        $submit->click();
-        $result = $this->findCss($page, '.modal-body .alert .text-center .btn');
-        $this->assertEquals('Download File', $result->getText());
+        $this->clickCss($page, '.form-cart-export input[name=submitButton]');
+        $buttonText = $this->findCssAndGetText($page, '.alert .text-center .btn');
+        $this->assertEquals('Download File', $buttonText);
     }
 
     /**


### PR DESCRIPTION
This test is unexpectedly failing in Jenkins. #4253 was a first attempt to solve the problem, but it didn't help. This second attempt reduces lightbox dependency from selectors, tweaks timing, and uses combined helper methods to improve stability. Whether or not this fixes the current Jenkins problem, these improvements seem worth making.