### PR TITLE
Prevent malformed links in export-menu.phtml.

### DIFF
--- a/themes/bootstrap3/templates/record/export-menu.phtml
+++ b/themes/bootstrap3/templates/record/export-menu.phtml
@@ -14,7 +14,7 @@
   <ul>
   <?php foreach ($exportFormats as $exportFormat): ?>
     <li>
-      <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export'))?>?style=<?=$this->escapeHtml($exportFormat)?>" rel="nofollow">
+      <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export', ['style' => $exportFormat], '', ['excludeSearchId' => true]))?>" rel="nofollow">
         <?=$this->transEsc('export_to', ['%%target%%' => $this->translate($this->export()->getLabelForFormat($exportFormat))])?>
       </a>
     </li>

--- a/themes/bootstrap5/templates/record/export-menu.phtml
+++ b/themes/bootstrap5/templates/record/export-menu.phtml
@@ -14,7 +14,7 @@
   <ul>
   <?php foreach ($exportFormats as $exportFormat): ?>
     <li>
-      <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export'))?>?style=<?=$this->escapeHtml($exportFormat)?>" rel="nofollow">
+      <a href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export', ['style' => $exportFormat], '', ['excludeSearchId' => true]))?>" rel="nofollow">
         <?=$this->transEsc('export_to', ['%%target%%' => $this->translate($this->export()->getLabelForFormat($exportFormat))])?>
       </a>
     </li>


### PR DESCRIPTION
This fixes a bug reported by Uwe Steinmann on the vufind-tech list.