### PR TITLE
Add option to ignore email addresses in linkify view helper

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
@@ -65,10 +65,8 @@ class Linkify extends AbstractHelper
      */
     public function __invoke(string $string, bool $includeEmail = true): string
     {
-        if ($includeEmail) {
-            return $this->urlHighlight->highlightUrls($string);
-        } else {
-            return $this->urlHighlightExceptEmail->highlightUrls($string);
-        }
+        return $includeEmail
+            ? $this->urlHighlight->highlightUrls($string)
+            : $this->urlHighlightExceptEmail->highlightUrls($string);
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Linkify.php
@@ -46,31 +46,29 @@ use VStelmakh\UrlHighlight\UrlHighlight;
 class Linkify extends AbstractHelper
 {
     /**
-     * Url highlighter
-     *
-     * @var UrlHighlight
-     */
-    protected $urlHighlight;
-
-    /**
      * Constructor
      *
-     * @param UrlHighlight $urlHighlight Url highlighter
+     * @param UrlHighlight $urlHighlight            Url highlighter
+     * @param UrlHighlight $urlHighlightExceptEmail Url highlighter that ignores email addresses
      */
-    public function __construct(UrlHighlight $urlHighlight)
+    public function __construct(protected UrlHighlight $urlHighlight, protected UrlHighlight $urlHighlightExceptEmail)
     {
-        $this->urlHighlight = $urlHighlight;
     }
 
     /**
      * Replace urls and emails by html tags
      *
-     * @param string $string String to linkify (must be HTML-escaped)
+     * @param string $string       String to linkify (must be HTML-escaped)
+     * @param bool   $includeEmail If email addresses should also be linkified
      *
      * @return string
      */
-    public function __invoke(string $string): string
+    public function __invoke(string $string, bool $includeEmail = true): string
     {
-        return $this->urlHighlight->highlightUrls($string);
+        if ($includeEmail) {
+            return $this->urlHighlight->highlightUrls($string);
+        } else {
+            return $this->urlHighlightExceptEmail->highlightUrls($string);
+        }
     }
 }

--- a/module/VuFind/src/VuFind/View/Helper/Root/LinkifyFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/LinkifyFactory.php
@@ -71,7 +71,7 @@ class LinkifyFactory implements FactoryInterface
 
         $highlighter = new VuFindHighlighter($proxyUrl);
         $encoder = new HtmlSpecialcharsEncoder();
-        $validatorExceptEmail = new Validator(true, [], [], false);
+        $validatorExceptEmail = new Validator(matchEmails: false);
         $urlHighlight = new UrlHighlight(null, $highlighter, $encoder);
         $urlHighlightExceptEmail = new UrlHighlight($validatorExceptEmail, $highlighter, $encoder);
         return new Linkify($urlHighlight, $urlHighlightExceptEmail);

--- a/module/VuFind/src/VuFind/View/Helper/Root/LinkifyFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/LinkifyFactory.php
@@ -33,6 +33,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use VStelmakh\UrlHighlight\Encoder\HtmlSpecialcharsEncoder;
 use VStelmakh\UrlHighlight\UrlHighlight;
+use VStelmakh\UrlHighlight\Validator\Validator;
 use VuFind\UrlHighlight\VuFindHighlighter;
 
 /**
@@ -70,8 +71,9 @@ class LinkifyFactory implements FactoryInterface
 
         $highlighter = new VuFindHighlighter($proxyUrl);
         $encoder = new HtmlSpecialcharsEncoder();
+        $validatorExceptEmail = new Validator(true, [], [], false);
         $urlHighlight = new UrlHighlight(null, $highlighter, $encoder);
-
-        return new Linkify($urlHighlight);
+        $urlHighlightExceptEmail = new UrlHighlight($validatorExceptEmail, $highlighter, $encoder);
+        return new Linkify($urlHighlight, $urlHighlightExceptEmail);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
@@ -30,7 +30,6 @@
 
 namespace VuFindTest\View\Helper\Root;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use VStelmakh\UrlHighlight\UrlHighlight;
 use VuFind\View\Helper\Root\Linkify;
 
@@ -47,61 +46,31 @@ use VuFind\View\Helper\Root\Linkify;
 class LinkifyTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Mock URL highlighter
-     *
-     * @var UrlHighlight&MockObject
-     */
-    protected $urlHighlight;
-
-    /**
-     * Mock URL highlighter except email
-     *
-     * @var UrlHighlight&MockObject
-     */
-    protected $urlHighlightExceptEmail;
-
-    /**
-     * Linkify helper being tested
-     *
-     * @var Linkify
-     */
-    protected $linkify;
-
-    /**
-     * Setup method
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        $this->urlHighlight = $this->createMock(UrlHighlight::class);
-        $this->urlHighlightExceptEmail = $this->createMock(UrlHighlight::class);
-        $this->linkify = new Linkify($this->urlHighlight, $this->urlHighlightExceptEmail);
-    }
-
-    /**
      * Test that Linkify proxies the UrlHighlight object as expected.
      *
      * @return void
      */
     public function testLinkify(): void
     {
-        $this->urlHighlight
+        $urlHighlight = $this->createMock(UrlHighlight::class);
+        $urlHighlightExceptEmail = $this->createMock(UrlHighlight::class);
+        $linkify = new Linkify($urlHighlight, $urlHighlightExceptEmail);
+        $urlHighlight
             ->expects($this->once())
             ->method('highlightUrls')
             ->with($this->equalTo('input text'))
             ->willReturn('Text with highlighted urls');
 
-        $this->urlHighlightExceptEmail
+        $urlHighlightExceptEmail
             ->expects($this->once())
             ->method('highlightUrls')
             ->with($this->equalTo('input text'))
             ->willReturn('Text with highlighted urls except emails');
 
-        $actual = ($this->linkify)('input text');
+        $actual = ($linkify)('input text');
         $this->assertSame('Text with highlighted urls', $actual);
 
-        $actual = ($this->linkify)('input text', false);
+        $actual = ($linkify)('input text', false);
         $this->assertSame('Text with highlighted urls except emails', $actual);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/LinkifyTest.php
@@ -54,6 +54,13 @@ class LinkifyTest extends \PHPUnit\Framework\TestCase
     protected $urlHighlight;
 
     /**
+     * Mock URL highlighter except email
+     *
+     * @var UrlHighlight&MockObject
+     */
+    protected $urlHighlightExceptEmail;
+
+    /**
      * Linkify helper being tested
      *
      * @var Linkify
@@ -68,7 +75,8 @@ class LinkifyTest extends \PHPUnit\Framework\TestCase
     public function setUp(): void
     {
         $this->urlHighlight = $this->createMock(UrlHighlight::class);
-        $this->linkify = new Linkify($this->urlHighlight);
+        $this->urlHighlightExceptEmail = $this->createMock(UrlHighlight::class);
+        $this->linkify = new Linkify($this->urlHighlight, $this->urlHighlightExceptEmail);
     }
 
     /**
@@ -84,7 +92,16 @@ class LinkifyTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('input text'))
             ->willReturn('Text with highlighted urls');
 
+        $this->urlHighlightExceptEmail
+            ->expects($this->once())
+            ->method('highlightUrls')
+            ->with($this->equalTo('input text'))
+            ->willReturn('Text with highlighted urls except emails');
+
         $actual = ($this->linkify)('input text');
         $this->assertSame('Text with highlighted urls', $actual);
+
+        $actual = ($this->linkify)('input text', false);
+        $this->assertSame('Text with highlighted urls except emails', $actual);
     }
 }


### PR DESCRIPTION
We use the linkify view the helper in #4240 but don't want to linkfiy emails. This PR adds that option.