### PR TITLE
Prevent empty breadcrumb when record title is missing.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
@@ -260,11 +260,12 @@ class RecordLinker extends \Laminas\View\Helper\AbstractHelper
      */
     public function getBreadcrumbHtml($driver)
     {
-        $truncateHelper = $this->getView()->plugin('truncate');
         $escapeHelper = $this->getView()->plugin('escapeHtml');
-        return '<a href="' . $this->getUrl($driver) . '">' .
-            $escapeHelper($truncateHelper($driver->getBreadcrumb(), 30))
-            . '</a>';
+        $breadcrumb = $driver->getBreadcrumb();
+        $breadcrumbText = empty($breadcrumb)
+            ? ($this->getView()->plugin('translate'))('Title not available')
+            : ($this->getView()->plugin('truncate'))($breadcrumb, 30);
+        return '<a href="' . $this->getUrl($driver) . '">' . $escapeHelper($breadcrumbText) . '</a>';
     }
 
     /**


### PR DESCRIPTION
As discussed in #4258, a record with a blank title can display an empty breadcrumb link. This PR replaces missing breadcrumb titles with the standard "Title not available" text for consistency with search result listings. This can be tested in the standard test environment by looking at records from the geo_titles.mrc set, since two of those are missing titles and two are not.