### PR TITLE
Make FallbackLoaderTest more robust.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/RetryClickTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/RetryClickTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Trait adding functionality to retry failed clicks.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Feature;
+
+use Behat\Mink\Element\Element;
+use Behat\Mink\Session;
+
+/**
+ * Trait adding functionality to retry failed clicks.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+trait RetryClickTrait
+{
+    /**
+     * After a failed button click has been detected, resize the window and try again.
+     *
+     * @param Session $session  Mink session
+     * @param Element $page     Current page element
+     * @param string  $selector Selector to click
+     *
+     * @return void
+     */
+    protected function retryClickWithResizedWindow(Session $session, Element $page, string $selector): void
+    {
+        // For some reason, the click action does not always succeed here; resizing
+        // the window and retrying seems to prevent intermittent test failures.
+        echo "\n\nMink click failed; retrying with resized window!\n";
+        $session->resizeWindow(1280, 200, 'current');
+        $this->clickCss($page, $selector);
+        $session->resizeWindow(1280, 768, 'current');
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -30,7 +30,6 @@
 namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
-use Behat\Mink\Session;
 
 /**
  * Mink bulk action test class.
@@ -46,6 +45,7 @@ use Behat\Mink\Session;
 final class BulkTest extends \VuFindTest\Integration\MinkTestCase
 {
     use \VuFindTest\Feature\LiveDatabaseTrait;
+    use \VuFindTest\Feature\RetryClickTrait;
     use \VuFindTest\Feature\UserCreationTrait;
 
     /**
@@ -291,25 +291,6 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
             'top button' => [''],
             'bottom button' => ['bottom_'],
         ];
-    }
-
-    /**
-     * After a failed button click has been detected, resize the window and try again.
-     *
-     * @param Session $session  Mink session
-     * @param Element $page     Current page element
-     * @param string  $selector Selector to click
-     *
-     * @return void
-     */
-    protected function retryClickWithResizedWindow(Session $session, Element $page, string $selector): void
-    {
-        // For some reason, the click action does not always succeed here; resizing
-        // the window and retrying seems to prevent intermittent test failures.
-        echo "\n\nMink click failed; retrying with resized window!\n";
-        $session->resizeWindow(1280, 200, 'current');
-        $this->clickCss($page, $selector);
-        $session->resizeWindow(1280, 768, 'current');
     }
 
     /**


### PR DESCRIPTION
I have been noticing some intermittent failures of FallbackLoaderTest in my local environment. The problem appears to be a missed click in Mink similar to the issue discussed in #4222. In rare cases, one of the comments was not getting added correctly, which was causing a failure. This PR adds an assertion to confirm that the comment is added successfully, and refactors the retry mechanism from BulkTest into a trait so it can be reused here.

I wish there was a better solution to this problem, but at least creating a trait means that we can find all instances of the hack if we can improve upon this fix in future.