### PR TITLE
Fix bug: dashes in theme names could break SCSS build.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
       }
 
       // Now move up to parent theme:
-      var matches = config.match(/["']extends["']\s*=>\s*['"](\w+)['"]/);
+      var matches = config.match(/["']extends["']\s*=>\s*['"]([\w-]+)['"]/);
 
       // "extends" set to "false" or missing entirely? We've hit the end of the line:
       if (matches === null || matches[1] === 'false') {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
       }
 
       // Now move up to parent theme:
-      var matches = config.match(/["']extends["']\s*=>\s*['"]([\w-]+)['"]/);
+      var matches = config.match(/["']extends["']\s*=>\s*['"]([\w\-]+)['"]/);
 
       // "extends" set to "false" or missing entirely? We've hit the end of the line:
       if (matches === null || matches[1] === 'false') {


### PR DESCRIPTION
@dltj reported that SCSS did not compile correctly when extending a theme containing a dash character. This PR fixes the problem. It's possible that an even broader regex would be more appropriate here, but I wanted to keep my fix targeted for starters.