### PR TITLE
OAI server: improve exception handling

### DIFF
--- a/module/VuFind/src/VuFind/Controller/OaiController.php
+++ b/module/VuFind/src/VuFind/Controller/OaiController.php
@@ -114,7 +114,10 @@ class OaiController extends AbstractBase
             $xml = $server->getResponse();
         } catch (\Exception $e) {
             $response->setStatusCode(500);
-            $response->setContent($e->getMessage());
+            $error = APPLICATION_ENV === 'development'
+                ? $e->getMessage()
+                : $this->translate('An error has occurred');
+            $response->setContent($error);
             return $response;
         }
 

--- a/module/VuFind/src/VuFind/OAI/Server.php
+++ b/module/VuFind/src/VuFind/OAI/Server.php
@@ -211,6 +211,22 @@ class Server
     protected $useCursorMark = true;
 
     /**
+     * List of possible valid OAI-PMH error codes
+     *
+     * @var string[]
+     */
+    protected $legalErrorCodes = [
+        'cannotDisseminateFormat',
+        'idDoesNotExist',
+        'badArgument',
+        'badVerb',
+        'noMetadataFormats',
+        'noRecordsMatch',
+        'badResumptionToken',
+        'noSetHierarchy',
+    ];
+
+    /**
      * Constructor
      *
      * @param \VuFind\Search\Results\PluginManager $resultsManager    Search manager for retrieving records
@@ -777,7 +793,7 @@ class Server
             $params = $this->listRecordsGetParams();
         } catch (\Exception $e) {
             $parts = explode(':', $e->getMessage(), 2);
-            if (count($parts) != 2) {
+            if (count($parts) != 2 || !in_array($parts[0], $this->legalErrorCodes)) {
                 throw $e;
             }
             return $this->showError($parts[0], $parts[1]);


### PR DESCRIPTION
While testing #4225, I noticed that the OaiController potentially outputs unfiltered error messages regardless of mode. While I don't think an information disclosure vulnerability is especially likely here, we should nonetheless display a more generic message in production mode for safety's sake. This PR fixes the issue.

Additionally, I found that our internal mechanism for passing OAI codes through exceptions could cause weird error message leaks if the error messages happened to include colons (which was the case for some database errors I encountered while troubleshooting #4225). I've added a validation step so we only output OAI error messages when the code is from the list in the OAI specification.