### PR TITLE
Refactor the details dialog of feedback admin to use normal lightbox.

### DIFF
--- a/module/VuFindAdmin/config/module.config.php
+++ b/module/VuFindAdmin/config/module.config.php
@@ -58,6 +58,16 @@ $config = [
                             ],
                         ],
                     ],
+                    'feedback-details' => [
+                        'type' => 'Laminas\Router\Http\Segment',
+                        'options' => [
+                            'route'    => '/Feedback/Details/:id',
+                            'defaults' => [
+                                'controller' => 'AdminFeedback',
+                                'action'     => 'Details',
+                            ],
+                        ],
+                    ],
                     'feedback' => [
                         'type' => 'Laminas\Router\Http\Segment',
                         'options' => [

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/FeedbackController.php
@@ -94,6 +94,20 @@ class FeedbackController extends AbstractAdmin
     }
 
     /**
+     * Feedback details action
+     *
+     * @return \Laminas\View\Model\ViewModel
+     */
+    public function detailsAction()
+    {
+        $feedbackService = $this->getDbService(FeedbackServiceInterface::class);
+        $feedbackEntity = $feedbackService->getFeedbackById((int)$this->params()->fromRoute('id'));
+        $view = $this->createViewModel(compact('feedbackEntity'));
+        $view->setTemplate('admin/feedback/details');
+        return $view;
+    }
+
+    /**
      * Delete action
      *
      * @return \Laminas\Http\Response
@@ -224,7 +238,9 @@ class FeedbackController extends AbstractAdmin
         try {
             $feedback = $feedbackService->getFeedbackById($id);
             if ($feedback) {
-                $feedback->setStatus($newStatus);
+                $feedback
+                    ->setStatus($newStatus)
+                    ->setUpdatedBy($this->getUser());
                 $feedbackService->persistEntity($feedback);
                 $success = true;
             }

--- a/themes/bootstrap5/templates/admin/feedback/details.phtml
+++ b/themes/bootstrap5/templates/admin/feedback/details.phtml
@@ -1,0 +1,16 @@
+<h2><?=$this->transEsc('Additional data')?></h2>
+
+<?php foreach ($feedbackEntity->getFormData() as $key => $value): ?>
+    <strong><?=$this->escapeHtml($key)?></strong>: <?=$this->escapeHtml($value)?><br>
+<?php endforeach; ?>
+<strong><?=$this->transEsc('Created')?></strong>:
+<?=$this->escapeHtml($feedbackEntity->getCreated()->format($this->config()->dateTimeFormat()))?>
+<?php if ($user = $feedbackEntity->getUser()): ?>
+  <?=$this->transEsc('by')?> <?=$this->escapeHtml($user->getFirstName() . ' ' . $user->getLastName())?> (<?=$this->escapeHtml($user->getId())?>)
+<?php endif; ?>
+<br>
+<strong><?=$this->transEsc('Updated')?></strong>:
+<?=$this->escapeHtml($feedbackEntity->getUpdated()->format($this->config()->dateTimeFormat()))?>
+<?php if ($manager = $feedbackEntity->getUpdatedBy()): ?>
+  <?=$this->transEsc('by')?> <?=$this->escapeHtml($manager->getFirstName() . ' ' . $manager->getLastName())?> (<?=$this->escapeHtml($manager->getId())?>)
+<?php endif;?>

--- a/themes/bootstrap5/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap5/templates/admin/feedback/home.phtml
@@ -93,33 +93,10 @@ $this->headTitle($this->translate('VuFind Administration - Feedback Management')
             </td>
             <td>
               <?php if (!empty($data)): ?>
-                <a href="#" class="btn btn-default btn-info" data-bs-toggle="modal" data-bs-target="#feedback-<?=$feedbackEntity->getId()?>">
+                <a href="<?=$this->url('admin/feedback-details', ['id' => $feedbackEntity->getId()])?>" class="btn btn-default btn-info" data-lightbox>
                   <?=$this->transEsc('Show')?>
                 </a>
-                <div class="modal" id="feedback-<?=$feedbackEntity->getId()?>" tabindex="-1" role="dialog" aria-hidden="true">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-bs-dismiss="modal" aria-hidden="true">
-                          <?=$this->icon('lightbox-close', ['aria-label' => $this->translate('Close')])?>
-                        </button>
-                        <h4 class="modal-title"><?=$this->transEsc('Additional data')?></h4>
-                      </div>
-                      <div class="modal-body">
-                        <?php foreach ($data as $key => $value): ?>
-                          <strong><?=$this->escapeHtml($key)?></strong>: <?=$this->escapeHtml($value)?><br>
-                        <?php endforeach; ?>
-                        <strong><?=$this->transEsc('Created')?></strong>:
-                        <?=$this->escapeHtml($feedbackEntity->getCreated()->format($this->config()->dateTimeFormat()))?>
-                        <?=$feedbackItem['user_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['user_name']) . ' (' . $feedbackEntity->getUser()->getId() . ')') : ''?>
-                        <br>
-                        <strong><?=$this->transEsc('Updated')?></strong>:
-                        <?=$this->escapeHtml($feedbackEntity->getUpdated()->format($this->config()->dateTimeFormat()))?>
-                        <?=$feedbackItem['manager_name'] ? (' ' . $this->transEsc('by') . ' ' . $this->escapeHtml($feedbackItem['manager_name']) . ' (' . $feedbackEntity->getUpdatedBy() . ')') : ''?>
-                      </div>
-                    </div>
-                  </div>
-                <?php endif; ?>
+              <?php endif; ?>
             </td>
             <td>
               <select class="form-control form-select status_update" name="status_update">


### PR DESCRIPTION
While working on Bootstrap style cleanup I noticed that the modals on feedback admin page looked pretty bad and also had some HTML validation issues. This set of changes simplifies things and uses the normal lightbox for the dialog.