### PR TITLE
Hide additional controls from print version.

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/data-tags.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/data-tags.phtml
@@ -1,7 +1,7 @@
 <?php $loggedin = $this->auth()->getUserObject(); ?>
 <?php if ($this->usertags()->getMode() !== 'disabled'): ?>
   <?php $tagList = $this->record($this->driver)->getTags(null, null, 'count', $loggedin); ?>
-    <a class="tag-record btn btn-default" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'AddTag'))?>" data-lightbox>
+    <a class="tag-record btn btn-default hidden-print" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'AddTag'))?>" data-lightbox>
       <?=$this->icon('tag-add') ?> <?=$this->transEsc('Add Tag') ?>
     </a>
     <?=$this->context($this)->renderInContext('record/taglist', ['tagList' => $tagList, 'loggedin' => (bool)$loggedin]) ?>

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/result-list.phtml
@@ -113,7 +113,7 @@
       <?php endif; ?>
 
       <?php if ($this->driver->tryMethod('getWorkKeys') && $this->searchOptions($this->driver->getSourceIdentifier())->getVersionsAction()): ?>
-        <div class="record-versions ajax"></div>
+        <div class="record-versions ajax hidden-print"></div>
       <?php endif; ?>
 
       <div class="callnumAndLocation ajax-availability hidden">

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
@@ -15,7 +15,7 @@
     $versions++;
   }
 ?>
-<div class="record-versions">
+<div class="record-versions hidden-print">
   <a class="icon-link" href="<?=$this->escapeHtmlAttr($url)?>">
     <?=$this->icon('more', 'icon-link__icon') ?>
     <span class="icon-link__label"><?=$this->transEsc($translationKey, ['%%count%%' => $versions])?></span>

--- a/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/result-list.phtml
@@ -113,7 +113,7 @@
       <?php endif; ?>
 
       <?php if ($this->driver->tryMethod('getWorkKeys') && $this->searchOptions($this->driver->getSourceIdentifier())->getVersionsAction()): ?>
-        <div class="record-versions ajax"></div>
+        <div class="record-versions ajax hidden-print"></div>
       <?php endif; ?>
 
       <div class="callnumAndLocation ajax-availability hidden">

--- a/themes/bootstrap5/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap5/templates/RecordTab/holdingsils.phtml
@@ -37,7 +37,7 @@
 <?php if (($this->ils()->getHoldsMode() == 'driver' && !empty($holdings['holdings'])) || $this->ils()->getTitleHoldsMode() == 'driver'): ?>
   <?php if ($account->loginEnabled() && $offlineMode != 'ils-offline'): ?>
     <?php if (!$user): ?>
-      <div class="alert alert-info">
+      <div class="alert alert-info hidden-print">
         <a id="hold-login" href="<?=$this->serverUrl($this->url('myresearch-completelogin'))?>" data-lightbox><?=$this->transEsc('hold_login')?></a>
       </div>
     <?php elseif (!$user->getCatUsername()): ?>
@@ -56,7 +56,7 @@
 <?php endif; ?>
 <?php $holdingTitleHold = $this->driver->tryMethod('getRealTimeTitleHold'); ?>
 <?php if (!empty($holdingTitleHold)): ?>
-  <a class="placehold icon-link" data-lightbox title="<?=$this->transEscAttr('request_place_text')?>" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getRequestUrl($holdingTitleHold))?>">
+  <a class="placehold icon-link hidden-print" data-lightbox title="<?=$this->transEscAttr('request_place_text')?>" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getRequestUrl($holdingTitleHold))?>">
     <?=$this->icon('place-hold', 'icon-link__icon') ?>
     <span class="icon-link__label"><?=$this->transEsc('title_hold_place')?></span>
   </a>


### PR DESCRIPTION
While working on Bootstrap style cleanup I noticed that there were some useless controls visible particularly on the record page.