### PR TITLE
FOLIO: Wrap getPagedResults for items-by-holding-id

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1067,7 +1067,7 @@ class Folio extends AbstractAPI implements
                 $this->warning(
                     "getPagedResults('items', '/inventory/items-by-holdings-id', \$query="
                     . json_encode($query)
-                    . ") returned "
+                    . ') returned '
                     . $e->getMessage()
                 );
             }

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1022,45 +1022,49 @@ class Folio extends AbstractAPI implements
             $nextBatch = [];
             $sortNeeded = false;
             $number = 0;
-            foreach (
-                $this->getPagedResults(
-                    'items',
-                    '/inventory/items-by-holdings-id',
-                    $query
-                ) as $item
-            ) {
-                if ($item->discoverySuppress ?? false) {
-                    continue;
-                }
-                $number++;
-                $currentLoan = null;
-                $dueDateValue = '';
-                $boundWithRecords = null;
-                if (
-                    $item->status->name == 'Checked out'
-                    && $showDueDate
-                    && $dueDateItemCount < $maxNumDueDateItems
+            try {
+                foreach (
+                    $this->getPagedResults(
+                        'items',
+                        '/inventory/items-by-holdings-id',
+                        $query
+                    ) as $item
                 ) {
-                    $currentLoan = $this->getCurrentLoan($item->id);
-                    $dueDateValue = $currentLoan ? $this->getDueDate($currentLoan, $showTime) : '';
-                    $dueDateItemCount++;
+                    if ($item->discoverySuppress ?? false) {
+                        continue;
+                    }
+                    $number++;
+                    $currentLoan = null;
+                    $dueDateValue = '';
+                    $boundWithRecords = null;
+                    if (
+                        $item->status->name == 'Checked out'
+                        && $showDueDate
+                        && $dueDateItemCount < $maxNumDueDateItems
+                    ) {
+                        $currentLoan = $this->getCurrentLoan($item->id);
+                        $dueDateValue = $currentLoan ? $this->getDueDate($currentLoan, $showTime) : '';
+                        $dueDateItemCount++;
+                    }
+                    if ($item->isBoundWith ?? false) {
+                        $boundWithRecords = $this->getBoundWithRecords($item);
+                    }
+                    $nextItem = $this->formatHoldingItem(
+                        $bibId,
+                        $holdingDetails,
+                        $item,
+                        $number,
+                        $dueDateValue,
+                        $boundWithRecords ?? [],
+                        $currentLoan
+                    );
+                    if (!empty($vufindItemSort) && !empty($nextItem[$vufindItemSort])) {
+                        $sortNeeded = true;
+                    }
+                    $nextBatch[] = $nextItem;
                 }
-                if ($item->isBoundWith ?? false) {
-                    $boundWithRecords = $this->getBoundWithRecords($item);
-                }
-                $nextItem = $this->formatHoldingItem(
-                    $bibId,
-                    $holdingDetails,
-                    $item,
-                    $number,
-                    $dueDateValue,
-                    $boundWithRecords ?? [],
-                    $currentLoan
-                );
-                if (!empty($vufindItemSort) && !empty($nextItem[$vufindItemSort])) {
-                    $sortNeeded = true;
-                }
-                $nextBatch[] = $nextItem;
+            } catch (\VuFind\Exception\ILS $e) {
+                $this->warning("getPagedResults('items', '/inventory/items-by-holdings-id', $query=" . json_encode($query) . ') returned ' . $e->getMessage());
             }
 
             // If there are no item records on this holding, we're going to create a fake one,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1064,7 +1064,12 @@ class Folio extends AbstractAPI implements
                     $nextBatch[] = $nextItem;
                 }
             } catch (\VuFind\Exception\ILS $e) {
-                $this->warning("getPagedResults('items', '/inventory/items-by-holdings-id', $query=" . json_encode($query) . ') returned ' . $e->getMessage());
+                $this->warning(
+                    "getPagedResults('items', '/inventory/items-by-holdings-id', \$query=" 
+                    . json_encode($query) 
+                    . ") returned " 
+                    . $e->getMessage()
+                );
             }
 
             // If there are no item records on this holding, we're going to create a fake one,

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1065,9 +1065,9 @@ class Folio extends AbstractAPI implements
                 }
             } catch (\VuFind\Exception\ILS $e) {
                 $this->warning(
-                    "getPagedResults('items', '/inventory/items-by-holdings-id', \$query=" 
-                    . json_encode($query) 
-                    . ") returned " 
+                    "getPagedResults('items', '/inventory/items-by-holdings-id', \$query="
+                    . json_encode($query)
+                    . ") returned "
                     . $e->getMessage()
                 );
             }


### PR DESCRIPTION
Under some conditions (as yet to be figured out), FOLIO will return an HTTP 500 for this call. The resulting ILS exception is not handled by the FOLIO driver, and causes there to be no display in the Holdings tab.