### PR TITLE
Add missing colon after 'Description' in Create a List form

### DIFF
--- a/themes/bootstrap5/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap5/templates/myresearch/editlist.phtml
@@ -25,7 +25,7 @@
     <input id="list_title" class="form-control" type="text" name="title" value="<?=$this->escapeHtmlAttr($this->list->getTitle())?>">
   </div>
   <div class="form-group">
-    <label class="form-label" for="list_desc"><?=$this->transEsc('Description') ?></label>
+    <label class="form-label" for="list_desc"><?=$this->transEsc('Description') ?>:</label>
     <textarea id="list_desc" class="form-control" name="desc" rows="3"><?=$this->escapeHtml($this->list->getDescription() ?? '')?></textarea>
   </div>
   <?php if ($this->usertags()->getListMode() === 'enabled'): ?>


### PR DESCRIPTION
While reviewing other PRs, I showed Demian a breadcrumb problem in the Create a List form. He noticed an inconsistency between the two fields on the screen: **List** has a colon but **Description** has no punctuation. This PR fixes this.

![image](https://github.com/user-attachments/assets/cdcb9668-9152-45a8-b269-f3511e549b2b)

I will fix the breadcrumb problem when I work through all of the breadcrumbs across the project.


