### PR TITLE
Filter empty values in combine-alt.phtml

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -2,7 +2,7 @@
   $values = array_filter(
     [$this->stdValue ?? '', $this->altValue ?? ''],
     fn ($value) => $value !== ''
-);
+  );
   if ($this->prioritizeAlt) {
     $values = array_reverse($values);
   }

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -1,11 +1,11 @@
 <?php
-  $values = array_filter(
+$values = array_filter(
     [$this->stdValue ?? '', $this->altValue ?? ''],
     fn ($value) => $value !== ''
-  );
-  if ($this->prioritizeAlt) {
-    $values = array_reverse($values);
-  }
+);
+if ($this->prioritizeAlt) {
+  $values = array_reverse($values);
+}
 ?>
 <?php foreach ($values as $value): ?>
   <div>

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -1,10 +1,16 @@
-<div>
-  <bdi>
-    <?= $prioritizeAlt ? $altValue : $stdValue ?>
-  </bdi>
-</div>
-<div>
-  <bdi>
-    <?= $prioritizeAlt ? $stdValue : $altValue ?>
-  </bdi>
-</div>
+<?php
+  $values = array_filter(
+    [$this->stdValue ?? '', $this->altValue ?? ''],
+    fn ($value) => $value !== ''
+);
+  if ($this->prioritizeAlt) {
+    $values = array_reverse($values);
+  }
+?>
+<?php foreach ($values as $value): ?>
+  <div>
+    <bdi>
+      <?=$value?>
+    </bdi>
+  </div>
+<?php endforeach; ?>

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -6,6 +6,7 @@ $values = array_filter(
 if ($this->prioritizeAlt) {
   $values = array_reverse($values);
 }
+// We don't have to escape the values here, because the original data has already been rendered and escaped.
 ?>
 <?php foreach ($values as $value): ?>
   <div>


### PR DESCRIPTION
If `stdValue` or `altValue` is empty in combine-alt.phtml there are empty `div` and `bdi` tags still being created. This PR fixes that.