### PR TITLE
Fix advanced search breadcrumb

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -107,8 +107,9 @@ class AbstractSearch extends AbstractBase
 
         // Handle request to edit existing saved search:
         $view->saved = false;
-        $searchId = $this->params()->fromQuery('edit', false);
-        if ($searchId !== false) {
+        // 'edit' query parameter is added for legacy template support
+        $searchId = $this->params()->fromQuery('sid') ?? $this->params()->fromQuery('edit');
+        if ($searchId !== null) {
             $view->saved = $this->restoreAdvancedSearch($searchId);
         }
 

--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -211,7 +211,8 @@ class Memory
     public function getCurrentSearchId(): ?int
     {
         $sid = $this->request->getQuery('sid')
-            ?? $this->request->getPost('sid');
+            ?? $this->request->getPost('sid')
+            ?? $this->request->getQuery('edit');
         return intval($sid) ?: null;
     }
 

--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -210,10 +210,8 @@ class Memory
      */
     public function getCurrentSearchId(): ?int
     {
-        // 'edit' query parameter is added for advanced search legacy template support
         $sid = $this->request->getQuery('sid')
-            ?? $this->request->getPost('sid')
-            ?? $this->request->getQuery('edit');
+            ?? $this->request->getPost('sid');
         return intval($sid) ?: null;
     }
 

--- a/module/VuFind/src/VuFind/Search/Memory.php
+++ b/module/VuFind/src/VuFind/Search/Memory.php
@@ -210,6 +210,7 @@ class Memory
      */
     public function getCurrentSearchId(): ?int
     {
+        // 'edit' query parameter is added for advanced search legacy template support
         $sid = $this->request->getQuery('sid')
             ?? $this->request->getPost('sid')
             ?? $this->request->getQuery('edit');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -203,6 +203,38 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that the advanced search breadcrumb is operational.
+     *
+     * @return void
+     */
+    public function testAdvancedSearchBreadcrumb()
+    {
+        $session = $this->getMinkSession();
+        $page = $this->goToAdvancedSearch($session);
+
+        // Check breadcrumb without link
+        $this->assertEquals('Search', $this->findCssAndGetHtml($page, '.breadcrumb-item'));
+
+        // Enter and submit search
+        $this->findCssAndSetValue($page, '#search_lookfor0_0', 'miller');
+        $this->findCss($page, '[type=submit]')->press();
+
+        // Check for proper search
+        $this->assertEquals(
+            '(All Fields:miller)',
+            $this->findCssAndGetHtml($page, '.adv_search_terms strong')
+        );
+
+        // Test breadcrumb link
+        $this->editAdvancedSearch($page);
+        $this->clickCss($page, '.breadcrumb-item a');
+        $this->assertEquals(
+            '(All Fields:miller)',
+            $this->findCssAndGetHtml($page, '.adv_search_terms strong')
+        );
+    }
+
+    /**
      * Test that the advanced search form works correctly with a NOT group combined
      * with another group.
      *

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -12,7 +12,7 @@
   $advancedSearchAction = ($currentSearch['advanced_link_bottom'] ?? false)
     ? $params->getOptions()->getAdvancedSearchAction() : false;
   $advancedSearchUrl = $advancedSearchAction
-    ? $this->url($advancedSearchAction, [], ['query' => ['edit' => $results->getSearchId()]])
+    ? $this->url($advancedSearchAction, [], ['query' => ['sid' => $results->getSearchId()]])
     : false;
 
   // Generate JS code that will move a given recommendation module over to the sidebar

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -63,7 +63,7 @@
     <?php if (!empty($tabs)): ?><?=$tabs ?><div class="tab-content clearfix"><?php endif; ?>
       <p class="adv_search_terms"><?=$this->transEsc('Your search terms')?>: "<strong><?=$this->escapeHtml($this->lookfor)?></strong>"</p>
       <p class="adv_search_links">
-        <a href="<?=$this->url($advSearch)?>?sid=<?=$this->escapeHtmlAttr($this->searchId)?>"><?=$this->transEsc('Edit this Advanced Search')?></a> |
+        <a href="<?=$this->url($advSearch, [], ['query' => ['sid' => $this->searchId]])?>"><?=$this->transEsc('Edit this Advanced Search')?></a> |
         <a href="<?=$this->url($advSearch, [], ['query' => $hiddenFilters])?>"><?=$this->transEsc('Start a new Advanced Search')?></a> |
         <a href="<?=$this->url($searchHome, [], ['query' => $hiddenFilters])?>"><?=$this->transEsc('Start a new Basic Search')?></a>
       </p>

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -63,7 +63,7 @@
     <?php if (!empty($tabs)): ?><?=$tabs ?><div class="tab-content clearfix"><?php endif; ?>
       <p class="adv_search_terms"><?=$this->transEsc('Your search terms')?>: "<strong><?=$this->escapeHtml($this->lookfor)?></strong>"</p>
       <p class="adv_search_links">
-        <a href="<?=$this->url($advSearch)?>?edit=<?=$this->escapeHtmlAttr($this->searchId)?>"><?=$this->transEsc('Edit this Advanced Search')?></a> |
+        <a href="<?=$this->url($advSearch)?>?sid=<?=$this->escapeHtmlAttr($this->searchId)?>"><?=$this->transEsc('Edit this Advanced Search')?></a> |
         <a href="<?=$this->url($advSearch, [], ['query' => $hiddenFilters])?>"><?=$this->transEsc('Start a new Advanced Search')?></a> |
         <a href="<?=$this->url($searchHome, [], ['query' => $hiddenFilters])?>"><?=$this->transEsc('Start a new Basic Search')?></a>
       </p>
@@ -172,7 +172,7 @@
       <button type="submit" class="btn btn-primary"><?=$this->icon('search') ?> <?=$this->transEsc('Find')?></button>
       <?php if ($advSearch): ?>
         <?php
-          $advSearchQuery = $results ? ['edit' => $results->getSearchId()] : $hiddenFilters;
+          $advSearchQuery = $results ? ['sid' => $results->getSearchId()] : $hiddenFilters;
           $advSearchLink = $this->url($advSearch, [], ['query' => $advSearchQuery]);
         ?>
         <a href="<?=$advSearchLink?>" class="advanced-search-link btn btn-link" rel="nofollow"><?=$this->transEsc('Advanced')?></a>


### PR DESCRIPTION
We realized that the breadcrumb in advanced searches does not include a link back to the search anymore.

Here is a quick fix, but I'm not sure if this is the best way to do it and if there are unwanted side effects. So I created this as a draft and as a starting point for a discussion.

Should we maybe instead call the query parameter for advanced searches `sid` instead of `edit`?