### PR TITLE
Streamline favorite deletion from a list.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -270,13 +270,13 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#modal input[type="submit"]');
         $this->waitForPageLoad($page);
 
-        // If all records were deleted, success message should be visible in
-        // lightbox, and delete button should be gone after lightbox is closed.
+        // If all records were deleted, success message should be visible, and delete button should be gone after
+        // lightbox is closed.
+        $this->waitForLightboxHidden();
         $this->assertEquals(
             'Your saved item(s) were deleted.',
-            $this->findCssAndGetText($page, '.modal .alert-success')
+            $this->findCssAndGetText($page, '.alert-success')
         );
-        $this->closeLightbox($page, true);
         $this->unfindCss($page, 'button[name="delete"]');
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -969,11 +969,11 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $button->click();
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message
+        $this->waitForLightboxHidden();
         $this->assertEquals(
             'Your saved item(s) were deleted.',
-            $this->findCssAndGetText($page, '.modal .alert-success')
+            $this->findCssAndGetText($page, '.alert-success')
         );
-        $this->closeLightbox($page);
         $this->unFindCss($page, '.result');
     }
 

--- a/themes/bootstrap5/templates/myresearch/delete.phtml
+++ b/themes/bootstrap5/templates/myresearch/delete.phtml
@@ -1,5 +1,5 @@
 <h2><?=$this->transEsc('delete_selected_favorites')?></h2>
- <form action="<?=$this->url('myresearch-delete')?>" method="post" name="bulkDelete" data-lightbox-onclose="VuFind.refreshPage">
+ <form action="<?=$this->url('myresearch-delete')?>" method="post" name="bulkDelete" data-lightbox-ignore>
   <div id="popupMessages"><?=$this->flashmessages()?></div>
   <div id="popupDetails">
     <?php if (!$this->list): ?>


### PR DESCRIPTION
Eliminates an extra lightbox with the success/failure message and displays it as a simple flash message on top of the main page instead.