### PR TITLE
Fix screen reader issues in hierarchy tree

### DIFF
--- a/themes/bootstrap5/scss/components/trees.scss
+++ b/themes/bootstrap5/scss/components/trees.scss
@@ -135,7 +135,9 @@
     margin-top: 0.5rem;
     // Use padding to ensure focus rectangles display properly:
     padding-top: 0.3rem;
+    max-height: 75vh;
     overflow-x: hidden;
+    overflow-y: auto;
     border-right: 1px solid $gray-lighter;
   }
 

--- a/themes/bootstrap5/scss/components/trees.scss
+++ b/themes/bootstrap5/scss/components/trees.scss
@@ -40,6 +40,10 @@
       }
     }
 
+    .hierarchy-tree__item {
+      padding-left: 1.7rem;
+    }
+
     .facet-tree__item-container, .hierarchy-tree__item-container {
       // Leave space for the open/close icon (see above):
       width: calc(100% - 1.5em);

--- a/themes/bootstrap5/scss/components/trees.scss
+++ b/themes/bootstrap5/scss/components/trees.scss
@@ -40,10 +40,6 @@
       }
     }
 
-    .hierarchy-tree__item {
-      padding-left: 1.7rem;
-    }
-
     .facet-tree__item-container, .hierarchy-tree__item-container {
       // Leave space for the open/close icon (see above):
       width: calc(100% - 1.5em);

--- a/themes/bootstrap5/scss/components/trees.scss
+++ b/themes/bootstrap5/scss/components/trees.scss
@@ -135,9 +135,7 @@
     margin-top: 0.5rem;
     // Use padding to ensure focus rectangles display properly:
     padding-top: 0.3rem;
-    max-height: 75vh;
     overflow-x: hidden;
-    overflow-y: auto;
     border-right: 1px solid $gray-lighter;
   }
 

--- a/themes/bootstrap5/templates/hierarchy/tree.phtml
+++ b/themes/bootstrap5/templates/hierarchy/tree.phtml
@@ -85,8 +85,8 @@
         echo '</ul></li>';
       } else {
         echo '<li' . ($liClasses ? ' class="' . implode(' ', $liClasses) . '"' : '') . '>'
-        . '<button class="hierarchy-tree__toggle-expanded" disabled aria-hidden="true"></button> '
-        . $itemHtml;
+          . '<button class="hierarchy-tree__toggle-expanded" disabled aria-hidden="true"></button> '
+          . $itemHtml;
         echo '</li>';
       }
     }

--- a/themes/bootstrap5/templates/hierarchy/tree.phtml
+++ b/themes/bootstrap5/templates/hierarchy/tree.phtml
@@ -80,7 +80,7 @@
           . '</button>';
 
         echo " $itemHtml ";
-        echo '<ul id="' . $childUlIdEsc . '" class="hierarchy-tree__children">';
+        echo '<ul id="' . $childUlIdEsc . '" class="hierarchy-tree__children" role="group" >';
         ($this->renderTreeLevel[0])($node->children, $context, $hierarchyID, $driver, $selectedID, "{$parentNodeId}_$nodeId");
         echo '</ul></li>';
       } else {

--- a/themes/bootstrap5/templates/hierarchy/tree.phtml
+++ b/themes/bootstrap5/templates/hierarchy/tree.phtml
@@ -80,7 +80,7 @@
           . '</button>';
 
         echo " $itemHtml ";
-        echo '<ul id="' . $childUlIdEsc . '" class="hierarchy-tree__children" role="group" >';
+        echo '<ul id="' . $childUlIdEsc . '" class="hierarchy-tree__children" role="group">';
         ($this->renderTreeLevel[0])($node->children, $context, $hierarchyID, $driver, $selectedID, "{$parentNodeId}_$nodeId");
         echo '</ul></li>';
       } else {

--- a/themes/bootstrap5/templates/hierarchy/tree.phtml
+++ b/themes/bootstrap5/templates/hierarchy/tree.phtml
@@ -36,6 +36,8 @@
       $openTopLevel = false;
       if ($hasChildren) {
         $liClasses[] = 'hierarchy-tree__parent';
+      } else {
+        $liClasses[] = 'hierarchy-tree__item';
       }
       if ('collection' === $node->type) {
         $liClasses[] = 'hierarchy-tree__collection';
@@ -69,7 +71,6 @@
         $childUlIdEsc = $escapeAttr('hierarchy_' . $context . '_' . $parentNodeId . '_' . $nodeId);
         echo '<button class="hierarchy-tree__toggle-expanded js-toggle-expanded"'
           . ' aria-expanded="' . ($node->hasSelectedChild || $openTopLevel ? 'true' : 'false') . '"'
-          . ' aria-controls="' . $childUlIdEsc . '"'
           // Use node title as button label so that a screen reader can read it as
           // "Expanded <text>" or "Collapsed <text>":
           . ' aria-label="' . $escapeAttr($node->title) . '"'
@@ -86,7 +87,6 @@
         echo '</ul></li>';
       } else {
         echo '<li' . ($liClasses ? ' class="' . implode(' ', $liClasses) . '"' : '') . '>'
-          . '<button class="hierarchy-tree__toggle-expanded" disabled aria-label="' . $escape($node->title) . '"></button> '
           . $itemHtml;
         echo '</li>';
       }

--- a/themes/bootstrap5/templates/hierarchy/tree.phtml
+++ b/themes/bootstrap5/templates/hierarchy/tree.phtml
@@ -36,8 +36,6 @@
       $openTopLevel = false;
       if ($hasChildren) {
         $liClasses[] = 'hierarchy-tree__parent';
-      } else {
-        $liClasses[] = 'hierarchy-tree__item';
       }
       if ('collection' === $node->type) {
         $liClasses[] = 'hierarchy-tree__collection';
@@ -87,7 +85,8 @@
         echo '</ul></li>';
       } else {
         echo '<li' . ($liClasses ? ' class="' . implode(' ', $liClasses) . '"' : '') . '>'
-          . $itemHtml;
+        . '<button class="hierarchy-tree__toggle-expanded" disabled aria-hidden="true"></button> '
+        . $itemHtml;
         echo '</li>';
       }
     }


### PR DESCRIPTION
A couple of noted accessibility issues when using JAWS reader specifically:

On the first element (when entering the tree) it reads:
“Use JawsKey+Alt+M to move to controlled element”
aria-controls seemed to be the cause of this.
Could it be removed?

Also at the end points of hierarchy tree, it unnecessarily reads the disabled button.
Could the whole button be removed?