### PR TITLE
Configuration upgrade fixes.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -218,8 +218,8 @@ class Upgrade
     /**
      * Support function -- merge the contents of two arrays parsed from ini files.
      *
-     * @param string $config_ini The base config array.
-     * @param string $custom_ini Overrides to apply on top of the base array.
+     * @param array $config_ini The base config array.
+     * @param array $custom_ini Overrides to apply on top of the base array.
      *
      * @return array             The merged results.
      */

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -674,9 +674,15 @@ class Upgrade
             $newConfig['Session']['type'] = 'Database';
         }
 
-        // Eliminate obsolete database settings:
-        $newConfig['Database']
-            = ['database' => $newConfig['Database']['database']];
+        // If we have granular database settings, disable the legacy version:
+        if (isset($newConfig['Database']['database_driver'])
+            && isset($newConfig['Database']['database_username'])
+            && isset($newConfig['Database']['database_password'])
+            && isset($newConfig['Database']['database_host'])
+            && isset($newConfig['Database']['database_name'])
+        ) {
+            unset($newConfig['Database']['database']);
+        }
 
         // Eliminate obsolete config override settings:
         unset($newConfig['Extra_Config']);

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -675,12 +675,13 @@ class Upgrade
         }
 
         // If we have granular database settings, disable the legacy version:
+        $databaseKeys = array_keys($newConfig['Database'] ?? []);
         if (
-            isset($newConfig['Database']['database_driver'])
-            && isset($newConfig['Database']['database_username'])
-            && isset($newConfig['Database']['database_password'])
-            && isset($newConfig['Database']['database_host'])
-            && isset($newConfig['Database']['database_name'])
+            in_array('database_driver', $databaseKeys)
+            && in_array('database_username', $databaseKeys)
+            && (in_array('database_password', $databaseKeys) || in_array('database_password_file', $databaseKeys))
+            && in_array('database_host', $databaseKeys)
+            && in_array('database_name', $databaseKeys)
         ) {
             unset($newConfig['Database']['database']);
         }

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -675,7 +675,8 @@ class Upgrade
         }
 
         // If we have granular database settings, disable the legacy version:
-        if (isset($newConfig['Database']['database_driver'])
+        if (
+            isset($newConfig['Database']['database_driver'])
             && isset($newConfig['Database']['database_username'])
             && isset($newConfig['Database']['database_password'])
             && isset($newConfig['Database']['database_host'])

--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -236,7 +236,7 @@ class UpgradeController extends AbstractBase
     public function fixconfigAction()
     {
         $localConfig = dirname($this->getForcedLocalConfigPath('config.ini'));
-        $confDir = $this->cookie->oldVersion < 2
+        $confDir = Comparator::lessThan($this->cookie->oldVersion, '2.0')
             ? $this->getSourceDir() . '/web/conf'
             : $localConfig;
         $upgrader = new Upgrade(

--- a/module/VuFind/tests/fixtures/configs/database-both-formats/config.ini
+++ b/module/VuFind/tests/fixtures/configs/database-both-formats/config.ini
@@ -1,0 +1,19 @@
+[Database]
+; Connection string format is [platform]://[username]:[password]@[host]:[port]/[db]
+; where:
+; [platform/driver] = database platform (mysql, oci8 or pgsql)
+; [username] = username for connection
+; [password] = password for connection (optional)
+; [host] = host of database server
+; [port] = port of database server (optional)
+; [db] = database name
+; For more granular configuration, comment out the database setting and use the individual parameters below.
+database          = "mysql://root@localhost/vufind"
+database_driver = "mysql"
+database_username = "notroot"
+database_password = "password"
+; database_password_file will be used in priority over database_password
+;database_password_file = "/path/to/secret"
+database_host = "localhost"
+database_port = "3306"
+database_name = "vufind"

--- a/module/VuFind/tests/fixtures/configs/database-legacy-format/config.ini
+++ b/module/VuFind/tests/fixtures/configs/database-legacy-format/config.ini
@@ -1,0 +1,19 @@
+[Database]
+; Connection string format is [platform]://[username]:[password]@[host]:[port]/[db]
+; where:
+; [platform/driver] = database platform (mysql, oci8 or pgsql)
+; [username] = username for connection
+; [password] = password for connection (optional)
+; [host] = host of database server
+; [port] = port of database server (optional)
+; [db] = database name
+; For more granular configuration, comment out the database setting and use the individual parameters below.
+database          = "mysql://user:pass@localhost/vufind_custom"
+;database_driver = "mysql"
+;database_username = "notroot"
+;database_password = "password"
+; database_password_file will be used in priority over database_password
+;database_password_file = "/path/to/secret"
+;database_host = "localhost"
+;database_port = "3306"
+;database_name = "vufind"

--- a/module/VuFind/tests/fixtures/configs/database-new-format-password-file/config.ini
+++ b/module/VuFind/tests/fixtures/configs/database-new-format-password-file/config.ini
@@ -1,0 +1,19 @@
+[Database]
+; Connection string format is [platform]://[username]:[password]@[host]:[port]/[db]
+; where:
+; [platform/driver] = database platform (mysql, oci8 or pgsql)
+; [username] = username for connection
+; [password] = password for connection (optional)
+; [host] = host of database server
+; [port] = port of database server (optional)
+; [db] = database name
+; For more granular configuration, comment out the database setting and use the individual parameters below.
+;database          = mysql://root@localhost/vufind
+database_driver = "mysql"
+database_username = "notroot"
+;database_password = "password"
+; database_password_file will be used in priority over database_password
+database_password_file = "/path/to/secret"
+database_host = "localhost"
+database_port = "3306"
+database_name = "vufind"

--- a/module/VuFind/tests/fixtures/configs/database-new-format/config.ini
+++ b/module/VuFind/tests/fixtures/configs/database-new-format/config.ini
@@ -1,0 +1,19 @@
+[Database]
+; Connection string format is [platform]://[username]:[password]@[host]:[port]/[db]
+; where:
+; [platform/driver] = database platform (mysql, oci8 or pgsql)
+; [username] = username for connection
+; [password] = password for connection (optional)
+; [host] = host of database server
+; [port] = port of database server (optional)
+; [db] = database name
+; For more granular configuration, comment out the database setting and use the individual parameters below.
+;database          = mysql://root@localhost/vufind
+database_driver = "mysql"
+database_username = "notroot"
+database_password = "password"
+; database_password_file will be used in priority over database_password
+;database_password_file = "/path/to/secret"
+database_host = "localhost"
+database_port = "3306"
+database_name = "vufind"

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -240,6 +240,83 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testDatabaseUpgrade().
+     *
+     * @return array[]
+     */
+    public static function databaseUpgradeProvider(): array
+    {
+        return [
+            'legacy and new formats' => [
+                'database-both-formats',
+                // New format should take precedence:
+                [
+                    'use_ssl' => '',
+                    'verify_server_certificate' => '',
+                    'database_driver' => 'mysql',
+                    'database_username' => 'notroot',
+                    'database_password' => 'password',
+                    'database_host' => 'localhost',
+                    'database_port' => '3306',
+                    'database_name' => 'vufind',
+                ],
+            ],
+            'legacy format only' => [
+                'database-legacy-format',
+                [
+                    'use_ssl' => '',
+                    'verify_server_certificate' => '',
+                    'database' => 'mysql://user:pass@localhost/vufind_custom',
+                ],
+            ],
+            'new format only' => [
+                'database-new-format',
+                [
+                    'use_ssl' => '',
+                    'verify_server_certificate' => '',
+                    'database_driver' => 'mysql',
+                    'database_username' => 'notroot',
+                    'database_password' => 'password',
+                    'database_host' => 'localhost',
+                    'database_port' => '3306',
+                    'database_name' => 'vufind',
+                ],
+            ],
+            'new format only, with file-based password' => [
+                'database-new-format-password-file',
+                [
+                    'use_ssl' => '',
+                    'verify_server_certificate' => '',
+                    'database_driver' => 'mysql',
+                    'database_username' => 'notroot',
+                    'database_password_file' => '/path/to/secret',
+                    'database_host' => 'localhost',
+                    'database_port' => '3306',
+                    'database_name' => 'vufind',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test database upgrade in config.ini
+     *
+     * @param string $fixture  Fixture file
+     * @param array  $expected Expected result
+     *
+     * @return void
+     *
+     * @dataProvider databaseUpgradeProvider
+     */
+    public function testDatabaseUpgrade(string $fixture, array $expected): void
+    {
+        $upgrader = $this->getUpgrader($fixture);
+        $upgrader->run();
+        $results = $upgrader->getNewConfigs();
+        $this->assertEquals($expected, $results['config.ini']['Database']);
+    }
+
+    /**
      * Test generator upgrade.
      *
      * @return void


### PR DESCRIPTION
This PR fixes a few upgrade-related issues discovered while releasing 10.1.2:

- Some type annotations in the VuFind\Config\Upgrade class were incorrect
- The new granular database configuration logic could get reverted/corrupted by upgrade logic
- An inappropriate version number check could cause incorrect configurations to get loaded by the upgrade process

Note that I don't believe these problems are actually new to 10.1.2; they likely affected earlier 10.1.x releases as well. I'm not sure why I only ran into them this time, but I think behavior is at least partially dependent on the value you put in the "old version" box on the upgrade page, so I probably just did things slightly differently this time.