### PR TITLE
Fix the reset search button to reset only the text input and not the dropdown

### DIFF
--- a/themes/bootstrap5/js/searchbox_controls.js
+++ b/themes/bootstrap5/js/searchbox_controls.js
@@ -269,10 +269,9 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
       // Bind autocomplete auto submit
       if ($searchbox.hasClass("ac-auto-submit")) {
         input.addEventListener("ac-select", (event) => {
-          const value = typeof event.detail === "string"
+          input.value = typeof event.detail === "string"
             ? event.detail
             : event.detail.value;
-          input.value = value;
           input.form.submit();
         });
       }
@@ -294,7 +293,8 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
       _resetButton.classList.toggle("hidden", _textInput.value === "");
     });
 
-    _resetButton.addEventListener("click", function resetOnClick() {
+    _resetButton.addEventListener("click", function resetOnClick(e) {
+      e.preventDefault();
       requestAnimationFrame(() => {
         _textInput.value = "";
         _textInput.dispatchEvent(new Event("input"));

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -119,6 +119,7 @@
             id="searchForm-reset"
             class="searchForm-reset hidden"
             tabindex="-1"
+            type="button"
             title="<?=$this->transEscAttr('searchform_reset_button')?>"
             aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"
           ><?=$this->icon('ui-reset-search');?></button>

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -115,7 +115,13 @@
       <div class="searchForm-query">
         <input<?=$this->htmlAttributes($searchboxAttributes)?>>
         <div id="searchForm_controls">
-          <button id="searchForm-reset" class="searchForm-reset hidden" type="reset" tabindex="-1" aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"><?=$this->icon('ui-reset-search');?></button>
+          <button
+            id="searchForm-reset"
+            class="searchForm-reset hidden"
+            tabindex="-1"
+            title="<?=$this->transEscAttr('searchform_reset_button')?>"
+            aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"
+          ><?=$this->icon('ui-reset-search');?></button>
           <?php if (!empty($keyboardLayouts)): ?>
             <?php
             $this->headScript()->appendFile('vendor/js.cookie.js');


### PR DESCRIPTION
When pressing the cross button within the text field in the main searchbox, it resets the form using native form behaviour; on top of which we clear the text, however from a user point of view, it might seems unexpected to also have the dropdown reset, especially as the button is within the field and the aria label mention "clear query"