### PR TITLE
Fix bug: prevent undefined  variable.

### DIFF
--- a/themes/bootstrap3/templates/search/filters.phtml
+++ b/themes/bootstrap3/templates/search/filters.phtml
@@ -11,7 +11,7 @@
   $options = $this->searchOptions($this->searchClassId);
   $hasDefaultsApplied = $params->hasDefaultsApplied();
   $filterCount = $this->searchbox()->getFilterCount($this->checkboxFilters, $this->filterList);
-  $fromSearchMemory = $fromSearchMemory ?? false;
+  $fromSearchMemory ??= false;
 
   // Determine whether the only filters applied are the default ones; this controls
   // when we display or hide the reset button:

--- a/themes/bootstrap3/templates/search/filters.phtml
+++ b/themes/bootstrap3/templates/search/filters.phtml
@@ -11,6 +11,7 @@
   $options = $this->searchOptions($this->searchClassId);
   $hasDefaultsApplied = $params->hasDefaultsApplied();
   $filterCount = $this->searchbox()->getFilterCount($this->checkboxFilters, $this->filterList);
+  $fromSearchMemory = $fromSearchMemory ?? false;
 
   // Determine whether the only filters applied are the default ones; this controls
   // when we display or hide the reset button:

--- a/themes/bootstrap5/templates/search/filters.phtml
+++ b/themes/bootstrap5/templates/search/filters.phtml
@@ -11,7 +11,7 @@
   $options = $this->searchOptions($this->searchClassId);
   $hasDefaultsApplied = $params->hasDefaultsApplied();
   $filterCount = $this->searchbox()->getFilterCount($this->checkboxFilters, $this->filterList);
-  $fromSearchMemory = $fromSearchMemory ?? false;
+  $fromSearchMemory ??= false;
 
   // Determine whether the only filters applied are the default ones; this controls
   // when we display or hide the reset button:

--- a/themes/bootstrap5/templates/search/filters.phtml
+++ b/themes/bootstrap5/templates/search/filters.phtml
@@ -11,6 +11,7 @@
   $options = $this->searchOptions($this->searchClassId);
   $hasDefaultsApplied = $params->hasDefaultsApplied();
   $filterCount = $this->searchbox()->getFilterCount($this->checkboxFilters, $this->filterList);
+  $fromSearchMemory = $fromSearchMemory ?? false;
 
   // Determine whether the only filters applied are the default ones; this controls
   // when we display or hide the reset button:


### PR DESCRIPTION
The bug fix in #4258 introduced an issue with undefined variable warnings. This PR just ensures that the offending variable defaults to false if it is otherwise unset.