### PR TITLE
Add support for filtered backends in the combined search drop-down.

### DIFF
--- a/config/vufind/searchbox.ini
+++ b/config/vufind/searchbox.ini
@@ -25,7 +25,11 @@ defaultGroupLabel = false
 ; of settings with the following keys:
 ;
 ; type[] = "VuFind" for an internal search module or "External" for an external URL
-; target[] = Search class ID for "VuFind" type, URL for "External" type; by default,
+; target[] = When type is set to "VuFind": Search backend ID (optionally with a
+;            colon-delimited suffix indicating a filtered view; if provided,
+;            [SearchTabsFilters] in config.ini and relevant sections of combined.ini
+;            will be searched to find the first matching set of hidden filters).
+;            When type is set to "External": URL to redirect to; by default,
 ;            the user's search terms will be appended to the end of the URL in
 ;            "External" mode. You may use a %%lookfor%% placeholder string in the
 ;            URL to force the query to be injected at a specific position.
@@ -46,6 +50,12 @@ type[] = VuFind
 target[] = Solr
 label[] = Catalog
 group[] = false
+
+; Example to complement the [SearchTabsFilters] example in config.ini
+;type[] = VuFind
+;target[] = "Solr:filtered"
+;label[] = "Catalog (Main Building Books)"
+;group[] = false
 
 type[] = VuFind
 target[] = Summon

--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -32,6 +32,7 @@
 namespace VuFind\Controller;
 
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use VuFind\Config\Config;
 use VuFind\Search\SearchRunner;
 
 use function count;
@@ -252,7 +253,8 @@ class CombinedController extends AbstractSearch
         [$type, $target] = explode(':', $this->params()->fromQuery('type'), 2);
         switch ($type) {
             case 'VuFind':
-                [$searchClassId, $type] = explode('|', $target);
+                [$fullSearchClassId, $type] = explode('|', $target);
+                [$searchClassId] = explode(':', $fullSearchClassId);
                 $params = $this->getRequest()->getQuery()->toArray();
                 $params['type'] = $type;
 
@@ -264,6 +266,19 @@ class CombinedController extends AbstractSearch
                 // We don't need to pass activeSearchClassId forward:
                 unset($params['activeSearchClassId']);
 
+                // If we are using a filtered section, apply appropriate filters:
+                if ($fullSearchClassId !== $searchClassId) {
+                    // Try to find matching filter settings first in [SearchTabsFilters] in config.ini, and then
+                    // in the combined.ini filters setting.
+                    $hiddenFilters = $this->getConfig()->SearchTabsFilters->$fullSearchClassId
+                        ?? $this->getConfig('combined')->$fullSearchClassId->filter
+                        ?? [];
+                    // Account for all possible configuration formats -- a Config object, an array, or a string:
+                    $params['hiddenFilters']
+                        = (array)($hiddenFilters instanceof Config ? $hiddenFilters->toArray() : $hiddenFilters);
+                } else {
+                    unset($params['hiddenFilters']);
+                }
                 $route = $this->getService(\VuFind\Search\Options\PluginManager::class)
                     ->get($searchClassId)->getSearchAction();
                 $base = $this->url()->fromRoute($route);

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -38,7 +38,8 @@
     $keyboardLayouts = $this->searchbox()->getKeyboardLayouts();
     $handlers = $this->searchbox()->getHandlers(
         $this->searchClassId,
-        $this->searchIndex ?? null
+        $this->searchIndex ?? null,
+        $hiddenFilters
     );
     $handlerCount = count($handlers);
     $basicSearch = $this->searchbox()->combinedHandlersActive() ? 'combined-searchbox' : $options->getSearchAction();


### PR DESCRIPTION
We can filter backends in combined search boxes and search tabs, but we can't in the combined drop-down. This PR attempts to address that shortcoming.

At this stage, some of the logic is a bit redundant, and it does a bit more hidden filter processing than I'm entirely comfortable with, so there's definitely room for improvement... but this is a first round proof of concept. Feedback is welcome!