### PR TITLE
Ensure that back-compatible logic is commented with the word "legacy"

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/IdentifierLinksLookup.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/IdentifierLinksLookup.php
@@ -87,7 +87,7 @@ class IdentifierLinksLookup extends AbstractBase
         protected RendererInterface $viewRenderer,
         array $config
     ) {
-        // DOI config section is supported as a fallback for back-compatibility:
+        // DOI config section is supported as a legacy fallback for back-compatibility:
         $idConfig = $config['IdentifierLinks'] ?? $config['DOI'] ?? [];
         $this->resolvers
             = array_map('trim', explode(',', $idConfig['resolver'] ?? ''));

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -217,7 +217,7 @@ class Manager implements LoggerAwareInterface
     public function getCacheDir($allowCliOverride = true)
     {
         if (isset($this->defaults['cache_dir'])) {
-            // cache_dir setting in config.ini is obsolete
+            // Handle legacy configuration: cache_dir setting in config.ini is obsolete
             throw new \Exception(
                 'Obsolete cache_dir setting found in config.ini - please use '
                 . 'Apache environment variable VUFIND_CACHE_DIR in '

--- a/module/VuFind/src/VuFind/Cart.php
+++ b/module/VuFind/src/VuFind/Cart.php
@@ -275,7 +275,7 @@ class Cart
             $items = explode(self::CART_COOKIE_DELIM, $cookie);
 
             if (!isset($cookies[self::CART_COOKIE_SOURCES])) {
-                // Backward compatibility with VuFind 1.x -- if no source cookie, all
+                // Backward compatibility with VuFind 1.x legacy code -- if no source cookie, all
                 // items come from the default source:
                 for ($i = 0; $i < count($items); $i++) {
                     $items[$i] = DEFAULT_SEARCH_BACKEND . '|' . $items[$i];

--- a/module/VuFind/src/VuFind/Content/Covers/Deprecated.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Deprecated.php
@@ -2,7 +2,7 @@
 
 /**
  * Deprecated cover content loader (for backward-compatibility with deprecated
- * settings).
+ * legacy settings).
  *
  * PHP version 8
  *
@@ -32,7 +32,7 @@ namespace VuFind\Content\Covers;
 
 /**
  * Deprecated cover content loader (for backward-compatibility with deprecated
- * settings).
+ * legacy settings).
  *
  * @category VuFind
  * @package  Content

--- a/module/VuFind/src/VuFind/Content/Deprecated.php
+++ b/module/VuFind/src/VuFind/Content/Deprecated.php
@@ -2,7 +2,7 @@
 
 /**
  * Deprecated content loader (used for backward compatibility with deprecated
- * settings).
+ * legacy settings).
  *
  * PHP version 8
  *
@@ -32,7 +32,7 @@ namespace VuFind\Content;
 
 /**
  * Deprecated content loader (used for backward compatibility with deprecated
- * settings).
+ * legacy settings).
  *
  * @category VuFind
  * @package  Content

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -575,7 +575,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
     ) {
         $buttonFound = false;
         // Use of 'submit' as an input name was deprecated in release 10.0, but the
-        // check is retained for backward compatibility with custom templates.
+        // check is retained for backward compatibility with legacy custom templates.
         $defaultSubmitElements = ['submitButton', 'submit'];
         foreach ((array)($submitElements ?? $defaultSubmitElements) as $submitElement) {
             if ($this->params()->fromPost($submitElement, false)) {

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -259,7 +259,7 @@ trait HoldsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->getHomeLibrary() : '';
-        // helpText is only for backward compatibility:
+        // helpText is only for backward compatibility with legacy code:
         $helpText = $helpTextHtml = $checkHolds['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/ILLRequestsTrait.php
@@ -166,7 +166,7 @@ trait ILLRequestsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->getHomeLibrary() : '';
-        // helpText is only for backward compatibility:
+        // helpText is only for backward compatibility with legacy code:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -188,7 +188,7 @@ class MyResearchController extends AbstractBase
     }
 
     /**
-     * Maintaining this method for backwards compatibility;
+     * Maintaining this method for backwards compatibility with legacy code;
      * logic moved to parent and method re-named
      *
      * @return void

--- a/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
+++ b/module/VuFind/src/VuFind/Controller/Plugin/Holds.php
@@ -122,7 +122,7 @@ class Holds extends AbstractRequestBase
         if (!empty($all)) {
             $details = $params->fromPost('cancelAllIDS');
         } elseif (!empty($selected)) {
-            // Include cancelSelectedIDS for backwards-compatibility:
+            // Include cancelSelectedIDS for backwards-compatibility with legacy code:
             $details = $params->fromPost('selectedIDS')
                 ?? $params->fromPost('cancelSelectedIDS');
         } else {

--- a/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/StorageRetrievalRequestsTrait.php
@@ -171,7 +171,7 @@ trait StorageRetrievalRequestsTrait
         $config = $this->getConfig();
         $homeLibrary = ($config->Account->set_home_library ?? true)
             ? $this->getUser()->getHomeLibrary() : '';
-        // helpText is only for backward compatibility:
+        // helpText is only for backward compatibility with legacy code:
         $helpText = $helpTextHtml = $checkRequests['helpText'];
 
         $view = $this->createViewModel(

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/PluginManager.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/PluginManager.php
@@ -47,7 +47,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      */
     protected $aliases = [
         'htmltree' => HTMLTree::class,
-        // Keep jstree as an alias for back-compatibility:
+        // Keep jstree as an alias for legacy back-compatibility:
         'jstree' => 'htmltree',
     ];
 

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1163,7 +1163,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
         $config = $this->checkCapability('getConfig', ['Holdings', $params])
             ? $this->getDriver()->getConfig('Holdings', $params) : [];
         if (empty($config['itemLimit'])) {
-            // Use itemLimit in Holds as fallback for backward compatibility:
+            // Use itemLimit in Holds as fallback for backward compatibility with legacy configs:
             $config
                 = $this->checkCapability('getConfig', ['Holds', $params])
                 ? $this->getDriver()->getConfig('Holds', $params) : [];

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -417,7 +417,7 @@ class Alma extends AbstractBase implements
                     'item_notes' => $itemNotes ?? null,
                     'item_id' => $itemId,
                     'holdings_id' => $holdingId,
-                    'holding_id' => $holdingId, // deprecated, retained for backward compatibility
+                    'holding_id' => $holdingId, // deprecated, retained for legacy backward compatibility
                     'holdtype' => 'auto',
                     'addLink' => $patron ? 'check' : false,
                     // For Alma title-level hold requests
@@ -464,7 +464,7 @@ class Alma extends AbstractBase implements
         $level = $data['level'] ?? 'copy';
         if ('copy' === $level) {
             // Call the request-options API for the logged-in user; note that holding_id
-            // is deprecated but retained for backward compatibility.
+            // is deprecated but retained for legacy backward compatibility.
             $requestOptionsPath = '/bibs/' . rawurlencode($id)
                 . '/holdings/' . rawurlencode($data['holdings_id'] ?? $data['holding_id'])
                 . '/items/' . rawurlencode($data['item_id']) . '/request-options?user_id='
@@ -1453,7 +1453,7 @@ class Alma extends AbstractBase implements
 
             // Set default value for "itemLimit" in Alma driver
             if ($function === 'Holdings') {
-                // Use itemLimit in Holds as fallback for backward compatibility
+                // Use itemLimit in Holds as fallback for backward compatibility with legacy configs
                 $functionConfig['itemLimit'] = ($functionConfig['itemLimit']
                     ?? $this->config['Holds']['itemLimit']
                     ?? 10) ?: 10;
@@ -1495,7 +1495,7 @@ class Alma extends AbstractBase implements
         // Get information that is valid for both, item level requests and title
         // level requests.
         $mmsId = $holdDetails['id'];
-        // The holding_id value is deprecated but retained for back-compatibility
+        // The holding_id value is deprecated but retained for legacy back-compatibility
         $holId = $holdDetails['holdings_id'] ?? $holdDetails['holding_id'];
         $itmId = $holdDetails['item_id'];
         $patronId = $holdDetails['patron']['id'];

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -1114,7 +1114,7 @@ class Folio extends AbstractAPI implements
      * current loan, adjusting the timezone and formatting in universal
      * time with or without due time
      *
-     * @param \stdClass|string $loan     The current loan, or its itemId for backwards compatibility
+     * @param \stdClass|string $loan     The current loan, or its itemId for legacy backwards compatibility
      * @param bool             $showTime Determines if date or date & time is returned
      *
      * @return string

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -126,7 +126,7 @@ class Unicorn extends AbstractBase implements
         // allow user to specify the full url to the Sirsi side perl script
         $this->url = $this->config['Catalog']['url'];
 
-        // host/port/search_prog kept for backward compatibility
+        // host/port/search_prog kept for backward compatibility with legacy configs
         if (
             isset($this->config['Catalog']['host'])
             && isset($this->config['Catalog']['port'])

--- a/module/VuFind/src/VuFind/ILS/Logic/Holds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/Holds.php
@@ -582,7 +582,7 @@ class Holds
 
         // Multiple keys may be used here (delimited by comma)
         foreach (array_map('trim', explode(',', $grouping)) as $key) {
-            // backwards-compatibility:
+            // Legacy backwards-compatibility:
             // The config.ini file originally expected only
             //   two possible settings: holdings_id and location_name.
             // However, when location_name was set, the code actually

--- a/module/VuFind/src/VuFind/IdentifierLinker/BrowZineFactory.php
+++ b/module/VuFind/src/VuFind/IdentifierLinker/BrowZineFactory.php
@@ -100,7 +100,7 @@ class BrowZineFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
         }
         $search = $container->get(\VuFindSearch\Service::class);
         $fullConfig = $container->get(\VuFind\Config\PluginManager::class)->get('BrowZine')->toArray();
-        // DOI config section is supported as a fallback for back-compatibility:
+        // DOI config section is supported as a fallback for legacy back-compatibility:
         $config = $fullConfig['IdentifierLinks'] ?? $fullConfig['DOI'] ?? [];
 
         return new $requestedName(

--- a/module/VuFind/src/VuFind/Navigation/AccountMenu.php
+++ b/module/VuFind/src/VuFind/Navigation/AccountMenu.php
@@ -69,7 +69,7 @@ class AccountMenu extends AbstractMenu
         protected ?OverdriveConnector $overdriveConnector,
     ) {
         if (isset($config['MenuItems'])) {
-            // backward compatibility for outdated AccountMenu configurations
+            // backward compatibility for outdated legacy AccountMenu configurations
             $default = static::getDefaultMenuConfig();
             $default['Account']['MenuItems'] = $config['MenuItems'];
             $config = $default;

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -516,7 +516,7 @@ class Params
             $lookfor = $lookfor[0];
         }
 
-        // Flatten type arrays for backward compatibility:
+        // Flatten type arrays for backward compatibility with legacy URLs:
         $handler = $request->get('type');
         if (is_array($handler)) {
             $handler = $handler[0];

--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -194,7 +194,7 @@ class QueryAdapter implements QueryAdapterInterface
      */
     public function fromRequest(Parameters $request, $defaultHandler)
     {
-        // Check for a work keys query first (id and keys included for back-compatibility):
+        // Check for a work keys query first (id and keys included for back-compatibility with legacy code):
         if (
             $request->get('search') === 'versions'
             || ($request->offsetExists('id') && $request->offsetExists('keys'))

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -119,7 +119,7 @@ class HierarchicalFacetHelper implements
     public function sortFacetList(&$facetList, $order = null)
     {
         // Map $order to a sort setting that's simple and fast to compare (boolean values of $order are
-        // supported for backward compatibility):
+        // supported for backward compatibility with legacy code):
         $sort = match ($order) {
             true, 'top' => static::SORT_TOP,
             false, 'all' => static::SORT_ALL,

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountMenu.php
@@ -71,7 +71,7 @@ class AccountMenu extends AbstractMenuHelper
                 'menu' => $menu,
                 'active' => $activeItem,
                 'idPrefix' => $idPrefix,
-                // set items for backward compatibility, might be removed in future releases
+                // set items for legacy backward compatibility, might be removed in future releases
                 'items' => $menu['Account']['MenuItems'],
             ]
         );

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -70,7 +70,7 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
     public function __construct($key, $options = [])
     {
         // The second constructor parameter used to be a boolean representing
-        // the "universal" setting, so convert to an array for back-compatibility:
+        // the "universal" setting, so convert to an array for legacy compatibility:
         if (!is_array($options)) {
             $options = ['universal' => (bool)$options];
         }

--- a/module/VuFind/src/VuFind/View/Helper/Root/IdentifierLinkerFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/IdentifierLinkerFactory.php
@@ -70,7 +70,7 @@ class IdentifierLinkerFactory implements FactoryInterface
         }
         $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
         $helpers = $container->get('ViewHelperManager');
-        // DOI config section is supported as a fallback for back-compatibility:
+        // DOI config section is supported as a fallback for legacy back-compatibility:
         $idConfig = $config?->IdentifierLinks?->toArray() ?? $config?->DOI?->toArray() ?? [];
         return new $requestedName($helpers->get('context'), $idConfig);
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -120,7 +120,7 @@ class Piwik extends \Laminas\View\Helper\AbstractHelper
      * @param string|bool                         $url        Piwik address
      * (false if disabled)
      * @param int|array                           $options    Options array (or,
-     * if a single value, the Piwik site ID -- for backward compatibility)
+     * if a single value, the Piwik site ID -- for legacy backward compatibility)
      * @param bool                                $customVars Whether to track
      * additional information in custom variables
      * @param Laminas\Router\Http\RouteMatch      $router     Request

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -102,7 +102,7 @@ class RecordDataFormatterFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         $specPluginManager = $container->get(\VuFind\RecordDataFormatter\Specs\PluginManager::class);
-        // for backward compatibility check if getDefault*Specs methods got overridden.
+        // for legacy backward compatibility check if getDefault*Specs methods got overridden.
         $this->schemaOrgHelper = $container->get('ViewHelperManager')->get('schemaOrg');
         $this->defaultRecordSpec = $specPluginManager->get(DefaultRecordSpec::class);
         $methodMapping = [

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Connector.php
@@ -217,7 +217,7 @@ class Connector implements \Laminas\Log\LoggerAwareInterface
      * Uses MoreLikeThis Request Component or MoreLikeThis Handler
      *
      * @param string   $id     ID of given record (not currently used, but
-     * retained for backward compatibility / extensibility).
+     * retained for legacy backward compatibility / extensibility).
      * @param ParamBag $params Parameters
      *
      * @return string

--- a/module/VuFindSearch/src/VuFindSearch/Feature/SearchBackendEventManagerTrait.php
+++ b/module/VuFindSearch/src/VuFindSearch/Feature/SearchBackendEventManagerTrait.php
@@ -59,9 +59,8 @@ trait SearchBackendEventManagerTrait
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        // Using the class name as the event namespace is recommended; the
-        // VuFind\Search and VuFindSearch values are only retained for backward
-        // compatibility.
+        // Using the class name as the event namespace is recommended; the VuFind\Search and VuFindSearch
+        // values are only retained for legacy backward compatibility.
         $events->setIdentifiers([\VuFindSearch\Service::class, 'VuFind\Search', 'VuFindSearch']);
         $this->events = $events;
     }

--- a/themes/bootstrap5/templates/RecordTab/holdingsils.phtml
+++ b/themes/bootstrap5/templates/RecordTab/holdingsils.phtml
@@ -115,7 +115,7 @@
   <?php endif; ?>
   <?php foreach ($holding['textfields'] ?? [] as $textFieldName => $textFields): ?>
     <tr>
-      <?php // Translation for summary is a special case for backwards-compatibility ?>
+      <?php // Translation for summary is a special case for legacy backwards-compatibility ?>
       <th><?=$textFieldName == 'summary' ? $this->transEsc('Volume Holdings') : $this->transEsc(ucfirst($textFieldName))?>:</th>
       <td>
         <?php foreach ($textFields as $current): ?>

--- a/themes/bootstrap5/theme.config.php
+++ b/themes/bootstrap5/theme.config.php
@@ -19,7 +19,7 @@ return [
          * - media: e.g. 'print'
          * - extras: array of additional attributes
          *
-         * Strings are supported for backwards compatibility reasons. examples:
+         * Strings are supported for legacy backwards compatibility reasons. examples:
          * - 'example.css' => same as ['file' => 'example.css']
          * - 'example.css:print' => same as
          *   ['file' => 'example.css', 'media' => 'print']
@@ -48,7 +48,7 @@ return [
          * Entries with neither priority nor load_after will be loaded after all
          * other entries.
          *
-         * Strings are supported for backwards compatibility reasons. example:
+         * Strings are supported for legacy backwards compatibility reasons. example:
          * - 'example.js' => same as ['file' => 'example.js']
          */
         ['file' => 'polyfills.js', 'priority' => 100],


### PR DESCRIPTION
As discussed in the Community Call, we should use the word "legacy" in comments talking about compatibility with outdated code or configuration, so these things are easier to find and clean up when appropriate. This PR identifies and updates a number of comments that were previously missing that keyword. It may still not be comprehensive, but it's at least a significant step forward.