### PR TITLE
[release-10.2] Introduce AssetManager view helper.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/ViewTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/ViewTrait.php
@@ -29,7 +29,9 @@
 
 namespace VuFindTest\Feature;
 
+use Laminas\View\Renderer\PhpRenderer;
 use VuFind\View\Helper\Root\SearchMemory;
+use VuFindTheme\View\Helper\AssetManager;
 
 /**
  * Trait for tests involving Laminas Views.
@@ -43,12 +45,26 @@ use VuFind\View\Helper\Root\SearchMemory;
 trait ViewTrait
 {
     /**
+     * Get a working AssetManager helper.
+     *
+     * @param PhpRenderer $renderer View for helper
+     *
+     * @return AssetManager
+     */
+    protected function getAssetManager(PhpRenderer $renderer): AssetManager
+    {
+        $helper = new AssetManager();
+        $helper->setView($renderer);
+        return $helper;
+    }
+
+    /**
      * Get a working renderer.
      *
      * @param array  $plugins Custom VuFind plug-ins to register
      * @param string $theme   Theme directory to load from
      *
-     * @return \Laminas\View\Renderer\PhpRenderer
+     * @return PhpRenderer
      */
     protected function getPhpRenderer($plugins = [], $theme = 'bootstrap3')
     {
@@ -63,13 +79,14 @@ trait ViewTrait
                 $this->getPathForTheme($theme),
             ]
         );
-        $renderer = new \Laminas\View\Renderer\PhpRenderer();
+        $renderer = new PhpRenderer();
         $renderer->setResolver($resolver);
-        if (!empty($plugins)) {
-            $pluginManager = $renderer->getHelperPluginManager();
-            foreach ($plugins as $key => $value) {
-                $pluginManager->setService($key, $value);
-            }
+        $pluginManager = $renderer->getHelperPluginManager();
+        if (!isset($plugins['assetManager'])) {
+            $plugins['assetManager'] = $this->getAssetManager($renderer);
+        }
+        foreach ($plugins as $key => $value) {
+            $pluginManager->setService($key, $value);
         }
         return $renderer;
     }

--- a/module/VuFindTheme/Module.php
+++ b/module/VuFindTheme/Module.php
@@ -124,6 +124,7 @@ class Module
     {
         return [
             'factories' => [
+                View\Helper\AssetManager::class => InvokableFactory::class,
                 View\Helper\FootScript::class =>
                     View\Helper\PipelineInjectorFactory::class,
                 View\Helper\ImageLink::class => View\Helper\ImageLinkFactory::class,
@@ -143,6 +144,7 @@ class Module
                     View\Helper\SetupThemeResourcesFactory::class,
             ],
             'aliases' => [
+                'assetManager' => View\Helper\AssetManager::class,
                 'footScript' => View\Helper\FootScript::class,
                 // Legacy alias for compatibility with pre-8.0 templates:
                 'headThemeResources' => View\Helper\SetupThemeResources::class,

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
@@ -127,24 +127,22 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
-     * Apply the appropriate arbitraryAttributesAllowed value to the provided view helper, using global
-     * default and any override options. If the value was changed, return the original value that should be
-     * restored after processing.
+     * Turn on the arbitraryAttributesAllowed behavior only if necessary.
      *
      * @param HeadScript $helper  View helper to configure (supports InlineScript and FootScript as well)
      * @param array      $options Options array to evaluate
      *
-     * @return ?bool
+     * @return void
      */
-    protected function applyArbitraryScriptAttributesOption(HeadScript $helper, array $options): ?bool
+    protected function applyArbitraryScriptAttributesOption(HeadScript $helper, array $options): void
     {
+        // Because of the workflow of the 10.x code, we have to turn the setting on and leave it on if ANY
+        // scripts require it. This logic will be refined and better restricted when things are refactored
+        // in 11.0.
         $newValue = $options['allow_arbitrary_attributes'] ?? $this->allowArbitraryScriptAttributesByDefault;
-        $resetValue = null;
-        if ($helper->arbitraryAttributesAllowed() !== $newValue) {
+        if ($newValue && $helper->arbitraryAttributesAllowed() !== $newValue) {
             $helper->setAllowArbitraryAttributes($newValue);
-            $resetValue = !$newValue;
         }
-        return $resetValue;
     }
 
     /**
@@ -167,13 +165,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
+        $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->appendScript($script, $type, $attrs);
-        if ($resetArbitraryAttributes !== null) {
-            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $this;
     }
 
@@ -197,13 +192,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
+        $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->appendFile($src, $type, $attrs);
-        if ($resetArbitraryAttributes !== null) {
-            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $this;
     }
 
@@ -227,13 +219,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
+        $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->forcePrependFile($src, $type, $attrs);
-        if ($resetArbitraryAttributes !== null) {
-            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $this;
     }
 
@@ -257,13 +246,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
+        $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->prependScript($script, $type, $attrs);
-        if ($resetArbitraryAttributes !== null) {
-            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $this;
     }
 
@@ -306,14 +292,11 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
         array $options = []
     ): string {
         $inlineScript = $this->getView()->plugin('inlineScript');
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
+        $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setScript($script, $type, $attrs);
         $result = ($inlineScript)();
-        if ($resetArbitraryAttributes !== null) {
-            $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $result;
     }
 
@@ -332,14 +315,11 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
         array $options = []
     ): string {
         $inlineScript = $this->getView()->plugin('inlineScript');
-        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
+        $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setFile($src, $type, $attrs);
         $result = ($inlineScript)();
-        if ($resetArbitraryAttributes !== null) {
-            $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
-        }
         return $result;
     }
 

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ * Asset manager view helper (for pre-processing, combining when appropriate, etc.)
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFindTheme\View\Helper;
+
+/**
+ * Asset manager view helper (for pre-processing, combining when appropriate, etc.)
+ *
+ * @category VuFind
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class AssetManager extends \Laminas\View\Helper\AbstractHelper
+{
+    /**
+     * Add raw CSS to the pipeline.
+     *
+     * @param string $css        Raw CSS.
+     * @param array  $attributes Extra attributes for style tag
+     *
+     * @return static
+     */
+    public function appendStyleString(string $css, array $attributes = []): static
+    {
+        $this->getView()->plugin('headStyle')->appendStyle($css, $attributes);
+        return $this;
+    }
+
+    /**
+     * Add an entry to the list of stylesheets.
+     *
+     * @param string $href                  Stylesheet href
+     * @param string $media                 Media
+     * @param string $conditionalStylesheet Any conditions
+     * @param array  $extras                Array of extra attributes
+     *
+     * @return void
+     */
+    public function appendStyleLink(
+        string $href,
+        string $media = 'screen',
+        string $conditionalStylesheet = '',
+        array $extras = []
+    ): static {
+        $this->getView()->plugin('headLink')->appendStylesheet($href, $media, $conditionalStylesheet, $extras);
+        return $this;
+    }
+
+    /**
+     * Forcibly prepend a stylesheet, removing it from any existing position
+     *
+     * @param string $href                  Stylesheet href
+     * @param string $media                 Media
+     * @param string $conditionalStylesheet Any conditions
+     * @param array  $extras                Array of extra attributes
+     *
+     * @return static
+     */
+    public function forcePrependStyleLink(
+        string $href,
+        string $media = 'screen',
+        string $conditionalStylesheet = '',
+        array $extras = []
+    ): static {
+        $this->getView()->plugin('headLink')->forcePrependStylesheet($href, $media, $conditionalStylesheet, $extras);
+        return $this;
+    }
+
+    /**
+     * Clear the list of styles and stylesheets.
+     *
+     * @return static
+     */
+    public function clearStyleList(): static
+    {
+        $this->getView()->plugin('headStyle')->deleteContainer();
+        $this->getView()->plugin('headLink')->deleteContainer();
+        return $this;
+    }
+
+    /**
+     * Append raw script code.
+     *
+     * @param string $script              Script code
+     * @param array  $attrs               Additional attributes for the script tag
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $position            Position to output script (header or footer)
+     *
+     * @return static
+     */
+    public function appendScriptString(
+        string $script,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false,
+        string $position = 'header'
+    ): static {
+        $helperName = $position === 'header' ? 'headScript' : 'footScript';
+        $helper = $this->getView()->plugin($helperName);
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
+            $helper->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $helper->appendScript($script, $type, $attrs);
+        if ($resetArbitraryAttributes) {
+            $helper->setAllowArbitraryAttributes(false);
+        }
+        return $this;
+    }
+
+    /**
+     * Add an entry to the list of script files.
+     *
+     * @param string $src                 Script src
+     * @param array  $attrs               Additional attributes for the script tag
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $position            Position to output script (header or footer)
+     *
+     * @return static
+     */
+    public function appendScriptLink(
+        string $src,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false,
+        string $position = 'header'
+    ): static {
+        $helperName = $position === 'header' ? 'headScript' : 'footScript';
+        $helper = $this->getView()->plugin($helperName);
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
+            $helper->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $helper->appendFile($src, $type, $attrs);
+        if ($resetArbitraryAttributes) {
+            $helper->setAllowArbitraryAttributes(false);
+        }
+        return $this;
+    }
+
+    /**
+     * Forcibly prepend a file, removing it from any existing position.
+     *
+     * @param string $src                 Script src
+     * @param array  $attrs               Additional attributes for the script tag
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $position            Position to output script (header or footer)
+     *
+     * @return static
+     */
+    public function forcePrependScriptLink(
+        string $src,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false,
+        string $position = 'header'
+    ): static {
+        $helperName = $position === 'header' ? 'headScript' : 'footScript';
+        $helper = $this->getView()->plugin($helperName);
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
+            $helper->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $helper->forcePrependFile($src, $type, $attrs);
+        if ($resetArbitraryAttributes) {
+            $helper->setAllowArbitraryAttributes(false);
+        }
+        return $this;
+    }
+
+    /**
+     * Prepend raw script code.
+     *
+     * @param string $script              Script code
+     * @param array  $attrs               Additional attributes for the script tag
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $position            Position to output script (header or footer)
+     *
+     * @return static
+     */
+    public function prependScriptString(
+        string $script,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false,
+        string $position = 'header'
+    ): static {
+        $helperName = $position === 'header' ? 'headScript' : 'footScript';
+        $helper = $this->getView()->plugin($helperName);
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
+            $helper->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $helper->prependScript($script, $type, $attrs);
+        if ($resetArbitraryAttributes) {
+            $helper->setAllowArbitraryAttributes(false);
+        }
+        return $this;
+    }
+
+    /**
+     * Clear the list of scripts.
+     *
+     * @return static
+     */
+    public function clearScriptList(): static
+    {
+        $this->getView()->plugin('headScript')->deleteContainer();
+        $this->getView()->plugin('footScript')->deleteContainer();
+        return $this;
+    }
+
+    /**
+     * Output the collected assets for the header.
+     *
+     * @return string
+     */
+    public function outputHeaderAssets(): string
+    {
+        return ($this->getView()->plugin('headLink'))() . "\n"
+            . ($this->getView()->plugin('headStyle'))() . "\n"
+            . ($this->getView()->plugin('headScript'))();
+    }
+
+    /**
+     * Output an inline script.
+     *
+     * @param string $script              Script code
+     * @param array  $attrs               Additional attributes for the script tag
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     *
+     * @return string
+     */
+    public function outputInlineScriptString(
+        string $script,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false
+    ): string {
+        $inlineScript = $this->getView()->plugin('inlineScript');
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$inlineScript->arbitraryAttributesAllowed()) {
+            $inlineScript->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $inlineScript->setScript($script, $type, $attrs);
+        $result = ($inlineScript)();
+        if ($resetArbitraryAttributes) {
+            $inlineScript->setAllowArbitraryAttributes(false);
+        }
+        return $result;
+    }
+
+    /**
+     * Output an inline script file.
+     *
+     * @param string $src                 Script src
+     * @param array  $attrs               Array of script attributes
+     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     *
+     * @return string
+     */
+    public function outputInlineScriptLink(
+        string $src,
+        array $attrs = [],
+        bool $allowArbitraryAttrs = false
+    ): string {
+        $inlineScript = $this->getView()->plugin('inlineScript');
+        $resetArbitraryAttributes = false;
+        if ($allowArbitraryAttrs && !$inlineScript->arbitraryAttributesAllowed()) {
+            $inlineScript->setAllowArbitraryAttributes(true);
+            $resetArbitraryAttributes = true;
+        }
+        $type = $attrs['type'] ?? 'text/javascript';
+        unset($attrs['type']);
+        $inlineScript->setFile($src, $type, $attrs);
+        $result = ($inlineScript)();
+        if ($resetArbitraryAttributes) {
+            $inlineScript->setAllowArbitraryAttributes(false);
+        }
+        return $result;
+    }
+
+    /**
+     * Output the collected assets for the footer.
+     *
+     * @return string
+     */
+    public function outputFooterAssets(): string
+    {
+        return ($this->getView()->plugin('footScript'))();
+    }
+}

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTheme\View\Helper;
 
+use Laminas\View\Helper\HeadScript;
+
 /**
  * Asset manager view helper (for pre-processing, combining when appropriate, etc.)
  *
@@ -40,6 +42,13 @@ namespace VuFindTheme\View\Helper;
  */
 class AssetManager extends \Laminas\View\Helper\AbstractHelper
 {
+    /**
+     * Should we allow arbitrary attributes on scripts by default?
+     *
+     * @var bool
+     */
+    protected bool $allowArbitraryScriptAttributesByDefault = false;
+
     /**
      * Add raw CSS to the pipeline.
      *
@@ -118,13 +127,33 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
+     * Apply the appropriate arbitraryAttributesAllowed value to the provided view helper, using global
+     * default and any override options. If the value was changed, return the original value that should be
+     * restored after processing.
+     *
+     * @param HeadScript $helper  View helper to configure (supports InlineScript and FootScript as well)
+     * @param array      $options Options array to evaluate
+     *
+     * @return ?bool
+     */
+    protected function applyArbitraryScriptAttributesOption(HeadScript $helper, array $options): ?bool
+    {
+        $newValue = $options['allow_arbitrary_attributes'] ?? $this->allowArbitraryScriptAttributesByDefault;
+        $resetValue = null;
+        if ($helper->arbitraryAttributesAllowed() !== $newValue) {
+            $helper->setAllowArbitraryAttributes($newValue);
+            $resetValue = !$newValue;
+        }
+        return $resetValue;
+    }
+
+    /**
      * Append raw script code.
      *
-     * @param string $script              Script code
-     * @param array  $attrs               Additional attributes for the script tag
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
-     * @param string $position            Position to output script (header or footer)
-     * @param array  $options             Additional options (not yet used; for forward-compatibility)
+     * @param string $script   Script code
+     * @param array  $attrs    Additional attributes for the script tag
+     * @param string $position Position to output script (header or footer)
+     * @param array  $options  Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return static
      *
@@ -133,22 +162,17 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     public function appendScriptString(
         string $script,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false,
         string $position = 'header',
         array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
-            $helper->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->appendScript($script, $type, $attrs);
-        if ($resetArbitraryAttributes) {
-            $helper->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $this;
     }
@@ -156,11 +180,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     /**
      * Add an entry to the list of script files.
      *
-     * @param string $src                 Script src
-     * @param array  $attrs               Additional attributes for the script tag
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
-     * @param string $position            Position to output script (header or footer)
-     * @param array  $options             Additional options (not yet used; for forward-compatibility)
+     * @param string $src      Script src
+     * @param array  $attrs    Additional attributes for the script tag
+     * @param string $position Position to output script (header or footer)
+     * @param array  $options  Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return static
      *
@@ -169,22 +192,17 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     public function appendScriptLink(
         string $src,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false,
         string $position = 'header',
         array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
-            $helper->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->appendFile($src, $type, $attrs);
-        if ($resetArbitraryAttributes) {
-            $helper->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $this;
     }
@@ -192,11 +210,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     /**
      * Forcibly prepend a file, removing it from any existing position.
      *
-     * @param string $src                 Script src
-     * @param array  $attrs               Additional attributes for the script tag
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
-     * @param string $position            Position to output script (header or footer)
-     * @param array  $options             Additional options (not yet used; for forward-compatibility)
+     * @param string $src      Script src
+     * @param array  $attrs    Additional attributes for the script tag
+     * @param string $position Position to output script (header or footer)
+     * @param array  $options  Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return static
      *
@@ -205,22 +222,17 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     public function forcePrependScriptLink(
         string $src,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false,
         string $position = 'header',
         array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
-            $helper->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->forcePrependFile($src, $type, $attrs);
-        if ($resetArbitraryAttributes) {
-            $helper->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $this;
     }
@@ -228,11 +240,10 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     /**
      * Prepend raw script code.
      *
-     * @param string $script              Script code
-     * @param array  $attrs               Additional attributes for the script tag
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
-     * @param string $position            Position to output script (header or footer)
-     * @param array  $options             Additional options (not yet used; for forward-compatibility)
+     * @param string $script   Script code
+     * @param array  $attrs    Additional attributes for the script tag
+     * @param string $position Position to output script (header or footer)
+     * @param array  $options  Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return static
      *
@@ -241,22 +252,17 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     public function prependScriptString(
         string $script,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false,
         string $position = 'header',
         array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$helper->arbitraryAttributesAllowed()) {
-            $helper->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($helper, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $helper->prependScript($script, $type, $attrs);
-        if ($resetArbitraryAttributes) {
-            $helper->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $helper->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $this;
     }
@@ -288,29 +294,25 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     /**
      * Output an inline script.
      *
-     * @param string $script              Script code
-     * @param array  $attrs               Additional attributes for the script tag
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $script  Script code
+     * @param array  $attrs   Additional attributes for the script tag
+     * @param array  $options Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return string
      */
     public function outputInlineScriptString(
         string $script,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false
+        array $options = []
     ): string {
         $inlineScript = $this->getView()->plugin('inlineScript');
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$inlineScript->arbitraryAttributesAllowed()) {
-            $inlineScript->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setScript($script, $type, $attrs);
         $result = ($inlineScript)();
-        if ($resetArbitraryAttributes) {
-            $inlineScript->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $result;
     }
@@ -318,29 +320,25 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
     /**
      * Output an inline script file.
      *
-     * @param string $src                 Script src
-     * @param array  $attrs               Array of script attributes
-     * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
+     * @param string $src     Script src
+     * @param array  $attrs   Additional attributes for the script tag
+     * @param array  $options Additional options (supported option: allow_arbitrary_attributes)
      *
      * @return string
      */
     public function outputInlineScriptLink(
         string $src,
         array $attrs = [],
-        bool $allowArbitraryAttrs = false
+        array $options = []
     ): string {
         $inlineScript = $this->getView()->plugin('inlineScript');
-        $resetArbitraryAttributes = false;
-        if ($allowArbitraryAttrs && !$inlineScript->arbitraryAttributesAllowed()) {
-            $inlineScript->setAllowArbitraryAttributes(true);
-            $resetArbitraryAttributes = true;
-        }
+        $resetArbitraryAttributes = $this->applyArbitraryScriptAttributesOption($inlineScript, $options);
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setFile($src, $type, $attrs);
         $result = ($inlineScript)();
-        if ($resetArbitraryAttributes) {
-            $inlineScript->setAllowArbitraryAttributes(false);
+        if ($resetArbitraryAttributes !== null) {
+            $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
         return $result;
     }

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
@@ -45,10 +45,13 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      *
      * @param string $css        Raw CSS.
      * @param array  $attributes Extra attributes for style tag
+     * @param array  $options    Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function appendStyleString(string $css, array $attributes = []): static
+    public function appendStyleString(string $css, array $attributes = [], array $options = []): static
     {
         $this->getView()->plugin('headStyle')->appendStyle($css, $attributes);
         return $this;
@@ -61,14 +64,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param string $media                 Media
      * @param string $conditionalStylesheet Any conditions
      * @param array  $extras                Array of extra attributes
+     * @param array  $options               Additional options (not yet used; for forward-compatibility)
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function appendStyleLink(
         string $href,
         string $media = 'screen',
         string $conditionalStylesheet = '',
-        array $extras = []
+        array $extras = [],
+        array $options = []
     ): static {
         $this->getView()->plugin('headLink')->appendStylesheet($href, $media, $conditionalStylesheet, $extras);
         return $this;
@@ -81,14 +88,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param string $media                 Media
      * @param string $conditionalStylesheet Any conditions
      * @param array  $extras                Array of extra attributes
+     * @param array  $options               Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function forcePrependStyleLink(
         string $href,
         string $media = 'screen',
         string $conditionalStylesheet = '',
-        array $extras = []
+        array $extras = [],
+        array $options = []
     ): static {
         $this->getView()->plugin('headLink')->forcePrependStylesheet($href, $media, $conditionalStylesheet, $extras);
         return $this;
@@ -113,14 +124,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param array  $attrs               Additional attributes for the script tag
      * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
      * @param string $position            Position to output script (header or footer)
+     * @param array  $options             Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function appendScriptString(
         string $script,
         array $attrs = [],
         bool $allowArbitraryAttrs = false,
-        string $position = 'header'
+        string $position = 'header',
+        array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
@@ -145,14 +160,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param array  $attrs               Additional attributes for the script tag
      * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
      * @param string $position            Position to output script (header or footer)
+     * @param array  $options             Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function appendScriptLink(
         string $src,
         array $attrs = [],
         bool $allowArbitraryAttrs = false,
-        string $position = 'header'
+        string $position = 'header',
+        array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
@@ -177,14 +196,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param array  $attrs               Additional attributes for the script tag
      * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
      * @param string $position            Position to output script (header or footer)
+     * @param array  $options             Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function forcePrependScriptLink(
         string $src,
         array $attrs = [],
         bool $allowArbitraryAttrs = false,
-        string $position = 'header'
+        string $position = 'header',
+        array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);
@@ -209,14 +232,18 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
      * @param array  $attrs               Additional attributes for the script tag
      * @param bool   $allowArbitraryAttrs Should we allow arbitrary attributes in $attrs?
      * @param string $position            Position to output script (header or footer)
+     * @param array  $options             Additional options (not yet used; for forward-compatibility)
      *
      * @return static
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function prependScriptString(
         string $script,
         array $attrs = [],
         bool $allowArbitraryAttrs = false,
-        string $position = 'header'
+        string $position = 'header',
+        array $options = []
     ): static {
         $helperName = $position === 'header' ? 'headScript' : 'footScript';
         $helper = $this->getView()->plugin($helperName);

--- a/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
+++ b/themes/bootstrap3/templates/Auth/MultiILS/loginfields.phtml
@@ -33,5 +33,5 @@
   $script = "setupMultiILSLoginFields($methods, 'login_{$topClass}_');";
 
   // Inline the script for lightbox compatibility
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+  echo $this->assetManager()->outputInlineScriptString($script);
 ?>

--- a/themes/bootstrap3/templates/ContentBlock/IlsStatusMonitor.phtml
+++ b/themes/bootstrap3/templates/ContentBlock/IlsStatusMonitor.phtml
@@ -12,4 +12,4 @@ $ilsStatusScript = <<<JS
       });
     });
     JS;
-echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $ilsStatusScript, 'SET');
+echo $this->assetManager()->outputInlineScriptString($ilsStatusScript);

--- a/themes/bootstrap3/templates/Helpers/cookie-consent.phtml
+++ b/themes/bootstrap3/templates/Helpers/cookie-consent.phtml
@@ -1,6 +1,6 @@
 <?php
-$this->headScript()->appendFile('vendor/cookieconsent.umd.js');
-$this->headScript()->appendFile('cookie.js');
+$this->assetManager()->appendScriptLink('vendor/cookieconsent.umd.js');
+$this->assetManager()->appendScriptLink('cookie.js');
 
 $configJson = json_encode(
     [
@@ -8,4 +8,4 @@ $configJson = json_encode(
         'controlledVuFindServices' => $this->controlledVuFindServices,
     ]
 );
-$this->headScript()->appendScript("window.addEventListener('load', function() { VuFind.cookie.setupConsent($configJson); });");
+$this->assetManager()->appendScriptString("window.addEventListener('load', function() { VuFind.cookie.setupConsent($configJson); });");

--- a/themes/bootstrap3/templates/Helpers/copy-to-clipboard-button.phtml
+++ b/themes/bootstrap3/templates/Helpers/copy-to-clipboard-button.phtml
@@ -28,5 +28,5 @@ $script = <<<JS
       });
     JS;
 // Inline the script for lightbox compatibility
-echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+echo $this->assetManager()->outputInlineScriptString($script);
 ?>

--- a/themes/bootstrap3/templates/Helpers/doi.phtml
+++ b/themes/bootstrap3/templates/Helpers/doi.phtml
@@ -1,2 +1,2 @@
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'doi.js', 'SET');?>
+<?=$this->assetManager()->outputInlineScriptLink('doi.js');?>
 <span class="doiLink" data-doi="<?=$this->escapeHtml($doi)?>"></span>

--- a/themes/bootstrap3/templates/Recommend/AbstractSearchObjectDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/AbstractSearchObjectDeferred.phtml
@@ -7,5 +7,5 @@
 ?>
 <div id="<?=$containerId?>">
     <p><?=$this->icon('spinner') ?> <?=$this->transEsc('loading_ellipsis')?></p>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadJs, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($loadJs)?>
 </div>

--- a/themes/bootstrap3/templates/Recommend/DOI.phtml
+++ b/themes/bootstrap3/templates/Recommend/DOI.phtml
@@ -6,6 +6,6 @@
   </div>
   <?php if ($this->recommend->isFullMatch() && $this->recommend->redirectFullMatch()): ?>
     <?php $redirect = 'document.location.href = "' . $this->escapeJs($url) . '";'; ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $redirect, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($redirect)?>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/MapSelection.phtml
+++ b/themes/bootstrap3/templates/Recommend/MapSelection.phtml
@@ -5,15 +5,15 @@
       'rectangle_center_message' => 'rectangle_center_message',
     ]);
 
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.js');
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.draw.js');
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.markercluster.js');
-    $this->headScript()->appendFile('map_selection_leaflet.js');
-    $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.draw.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/MarkerCluster.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/MarkerCluster.Default.css');
-    $this->headLink()->appendStylesheet('geofeatures.css');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.js');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.draw.js');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.markercluster.js');
+    $this->assetManager()->appendScriptLink('map_selection_leaflet.js');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.draw.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/MarkerCluster.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/MarkerCluster.Default.css');
+    $this->assetManager()->appendStyleLink('geofeatures.css');
 
     $basemap = $this->recommend->getBasemap();
     $geoField = $this->recommend->getGeoField();
@@ -41,7 +41,7 @@
       <span class="geo_maphelp">&nbsp;<a href="<?php echo $this->url('help', ['topic' => 'geosearch'])?>" data-lightbox class="help-link"><?php echo $this->transEsc('link_text_need_help')?></a></span>
       <div id="geo_search_map" style="height: <?php echo $height?>px;"></div>
     </div>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($jsLoad)?>
   </div>
   <?php
     // Overwrite leaflet.draw.js tooltips with international translations
@@ -49,5 +49,5 @@
       = 'L.drawLocal.draw.handlers.rectangle.tooltip.start = "' . $this->transEsc('draw_searchbox_start') . '";'
       . 'L.drawLocal.draw.handlers.simpleshape.tooltip.end = "' . $this->transEsc('draw_searchbox_end') . '";'
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadTranslations, 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString($loadTranslations)?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
@@ -1,11 +1,11 @@
 <?php if ($visFacets = $this->recommend->getVisFacets()): ?>
   <?php
     // load jQuery flot:
-    $this->headScript()->appendFile('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.min.js');
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.resize.min.js');
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.selection.min.js');
-    $this->headScript()->appendFile('pubdate_vis.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.min.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.resize.min.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.selection.min.js');
+    $this->assetManager()->appendScriptLink('pubdate_vis.js');
   ?>
   <?php foreach ($visFacets as $facetField => $facetRange): ?>
     <div class="authorbox">
@@ -22,7 +22,7 @@
     $js = "loadVis('" . $this->recommend->getFacetFields() . "', '"
         . $this->recommend->getSearchParams() . "', VuFind.path, "
         . $this->recommend->getZooming() . ');';
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $js, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($js);
   ?>
 
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets.phtml
@@ -1,6 +1,6 @@
 <?php
   $this->layout()->sideFacetsInstanceCounter = ($this->layout()->sideFacetsInstanceCounter ?? 0) + 1;
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptLink('facets.js');
 
   // Save results/options to $this so they are available to sub-templates:
   $this->results = $results = $this->recommend->getResults();
@@ -74,4 +74,4 @@
     </div>
   <?php endforeach; ?>
 <?php endif; ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'registerSideFacetTruncation();', 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString('registerSideFacetTruncation();');?>

--- a/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacets/range-slider.phtml
@@ -35,8 +35,8 @@
   </form>
 </div>
 <?php if ($this->facet['type'] == 'date'): ?>
-  <?php $this->headScript()->appendFile('vendor/bootstrap-slider.min.js'); ?>
-  <?php $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css'); ?>
+  <?php $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js'); ?>
+  <?php $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css'); ?>
   <?php
     $min = !empty($cleanValues[0]) ? min($cleanValues[0], 1400) : 1400;
     $future = date('Y', time() + 31536000); // next year
@@ -82,5 +82,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+  <?=$this->assetManager()->outputInlineScriptString($script); ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap3/templates/Recommend/SideFacetsDeferred.phtml
@@ -1,6 +1,6 @@
 <?php
   $this->layout()->sideFacetsInstanceCounter = ($this->layout()->sideFacetsInstanceCounter ?? 0) + 1;
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptLink('facets.js');
 
   $results = $this->recommend->getResults();
   $activeFacets = $this->recommend->getActiveFacets();
@@ -22,8 +22,8 @@
 
   foreach ($activeFacets as $field => $facetName) {
     if (isset($rangeFacets[$field]) && 'date' === $rangeFacets[$field]['type']) {
-      $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-      $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+      $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
       break;
     }
   }

--- a/themes/bootstrap3/templates/Recommend/TopFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/TopFacets.phtml
@@ -58,4 +58,4 @@
       VuFind.truncate.initTruncate('.top-facets-contents');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString($script);?>

--- a/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
+++ b/themes/bootstrap3/templates/Recommend/VisualFacets.phtml
@@ -1,6 +1,6 @@
 <?php
-  $this->headScript()->appendFile('vendor/d3.min.js');
-  $this->headScript()->appendFile('visual_facets.js');
+  $this->assetManager()->appendScriptLink('vendor/d3.min.js');
+  $this->assetManager()->appendScriptLink('visual_facets.js');
 
   $visualFacetSet = $this->recommend->getPivotFacetSet();
 
@@ -52,5 +52,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+  <?=$this->assetManager()->outputInlineScriptString($script);?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewdata.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/AbstractBase/previewdata.phtml
@@ -78,7 +78,7 @@
             // add the necessary identifier code:
             if (!empty($html)) {
                 $html .= '<span class="previewBibkeys ' . $idClasses . '"></span>';
-                $this->headScript()->appendFile('preview.js');
+                $this->assetManager()->appendScriptLink('preview.js');
                 echo $html;
             }
         }

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/collection-info.phtml
@@ -1,4 +1,4 @@
-<?php $this->headScript()->appendFile('collection_record.js'); ?>
+<?php $this->assetManager()->appendScriptLink('collection_record.js'); ?>
 <div class="media">
   <?php
     $QRCode = $this->record($this->driver)->getQRCode('core');

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/explain.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/explain.phtml
@@ -1,6 +1,6 @@
 <?php
-$this->headScript()->appendFile('vendor/chart.js');
-$this->headScript()->appendFile('explain.js');
+$this->assetManager()->appendScriptLink('vendor/chart.js');
+$this->assetManager()->appendScriptLink('explain.js');
 
 $explanation = $this->explanation;
 $recordId = $explanation->getRecordId();

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -256,5 +256,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+  <?=$this->assetManager()->outputInlineScriptString($script);?>
 </li>

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list-explain.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/result-list-explain.phtml
@@ -5,8 +5,8 @@
 ?>
 <?php if (!empty($this->request) && $score && $maxScore !== null && $maxScore > 0):?>
   <?php
-  $this->headScript()->appendFile('vendor/chart.js');
-  $this->headScript()->appendFile('explain.js');
+  $this->assetManager()->appendScriptLink('vendor/chart.js');
+  $this->assetManager()->appendScriptLink('explain.js');
   $link = $this->recordLinker()->getActionUrl($this->driver, 'Explain', $this->request);
   ?>
   <a class="result-list-explain" target="_blank" href="<?=$this->escapeHtmlAttr($link)?>">

--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/toolbar.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/toolbar.phtml
@@ -1,7 +1,7 @@
 <?php
   $addThis = $this->addThis();
   if (!empty($addThis)) {
-    $this->headScript()->appendFile('https://s7.addthis.com/js/250/addthis_widget.js?pub=' . urlencode($addThis));
+    $this->assetManager()->appendScriptLink('https://s7.addthis.com/js/250/addthis_widget.js?pub=' . urlencode($addThis));
   }
 ?>
 <nav class="record-nav" aria-label="<?=$this->transEscAttr('ajaxview_label_tools'); ?>">

--- a/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/core.phtml
@@ -1,4 +1,4 @@
-<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php $this->assetManager()->appendStyleLink('EDS.css'); ?>
 <?php
     $items = $this->driver->getItems('core');
     $dbLabel = $this->driver->getDbLabel();

--- a/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EDS/result-list.phtml
@@ -1,5 +1,5 @@
 <?php
-  $this->headLink()->appendStylesheet('EDS.css');
+  $this->assetManager()->appendStyleLink('EDS.css');
   $accessLevel = $this->driver->getAccessLevel();
   $restrictedView = empty($accessLevel) ? false : true;
   $recordLinker = $this->recordLinker($this->results);

--- a/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/EPF/core.phtml
@@ -1,4 +1,4 @@
-<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php $this->assetManager()->appendStyleLink('EDS.css'); ?>
 <?php
     $items = $this->driver->getItems('core');
     $accessLevel = $this->driver->getAccessLevel();

--- a/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
+++ b/themes/bootstrap3/templates/RecordTab/hierarchytree.phtml
@@ -61,9 +61,9 @@
   <?php endif; ?>
 </div>
 <?php
-  $this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'hierarchy_tree.js');
+  echo $this->assetManager()->outputInlineScriptLink('hierarchy_tree.js');
   $js = <<<JS
         document.querySelectorAll('.js-hierarchy-tree-container').forEach((el) => VuFind.hierarchyTree.initTree(el));
       JS;
-  echo $this->inlineScript()->appendScript($js);
+  echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap3/templates/RecordTab/map.phtml
+++ b/themes/bootstrap3/templates/RecordTab/map.phtml
@@ -1,8 +1,8 @@
 <?php
-  $this->headScript()->appendFile('vendor/leaflet/leaflet.js');
-  $this->headScript()->appendFile('vendor/leaflet/leaflet.latlng-graticule.js');
-  $this->headScript()->appendFile('map_tab_leaflet.js');
-  $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.css');
+  $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.js');
+  $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.latlng-graticule.js');
+  $this->assetManager()->appendScriptLink('map_tab_leaflet.js');
+  $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.css');
   $this->jsTranslations()->addStrings(
       ['Coordinates' => 'Coordinates', 'no_description' => 'no_description']
   );
@@ -17,5 +17,5 @@
 ?>
 <div id="wrap" style="width: inherit; height: 479px">
   <div id="map-canvas" style="width: 100%; height: 100%"></div>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString($jsLoad)?>
 </div>

--- a/themes/bootstrap3/templates/RecordTab/preview.phtml
+++ b/themes/bootstrap3/templates/RecordTab/preview.phtml
@@ -3,7 +3,7 @@
     $this->headTitle($this->translate('Preview') . ': ' . $this->driver->getBreadcrumb());
 
     // load the embedded preview javascript file
-    $this->headScript()->appendFile('https://www.google.com/books/jsapi.js');
-    $this->headScript()->appendFile('embedGBS.js');
+    $this->assetManager()->appendScriptLink('https://www.google.com/books/jsapi.js');
+    $this->assetManager()->appendScriptLink('embedGBS.js');
 ?>
 <div id="gbsViewer" style="height: 600px;"></div>

--- a/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap3/templates/RecordTab/similaritemscarousel.phtml
@@ -78,4 +78,4 @@
       $('#similar-items-carousel img').on('load', normalizeHeights);
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script); ?>

--- a/themes/bootstrap3/templates/RecordTab/versions.phtml
+++ b/themes/bootstrap3/templates/RecordTab/versions.phtml
@@ -55,4 +55,4 @@ $script = <<<JS
     VuFind.initResultScripts('.results');
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString($script); ?>

--- a/themes/bootstrap3/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap3/templates/admin/feedback/home.phtml
@@ -176,4 +176,4 @@ $js = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $js, 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString($js);?>

--- a/themes/bootstrap3/templates/cart/cart.phtml
+++ b/themes/bootstrap3/templates/cart/cart.phtml
@@ -121,4 +121,4 @@
         });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/cart/email.phtml
+++ b/themes/bootstrap3/templates/cart/email.phtml
@@ -40,4 +40,4 @@
       $('#itemhide').removeClass('in');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/cart/export.phtml
+++ b/themes/bootstrap3/templates/cart/export.phtml
@@ -72,4 +72,4 @@
         }).trigger('change');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/cart/save.phtml
+++ b/themes/bootstrap3/templates/cart/save.phtml
@@ -66,4 +66,4 @@
       $('#itemhide').removeClass('in');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/channels/channelList.phtml
+++ b/themes/bootstrap3/templates/channels/channelList.phtml
@@ -1,8 +1,8 @@
 <?php
-  $this->headLink()->appendStylesheet('vendor/slick.css');
-  $this->headLink()->appendStylesheet('vendor/slick-theme.css');
-  $this->headScript()->appendFile('vendor/slick.min.js');
-  $this->headScript()->appendFile('channels.js');
+  $this->assetManager()->appendStyleLink('vendor/slick.css');
+  $this->assetManager()->appendStyleLink('vendor/slick-theme.css');
+  $this->assetManager()->appendScriptLink('vendor/slick.min.js');
+  $this->assetManager()->appendScriptLink('channels.js');
   $this->jsTranslations()->addStrings([
     'channel_browse' => 'channel_browse',
     'channel_expand' => 'channel_expand',

--- a/themes/bootstrap3/templates/checkouts/history.phtml
+++ b/themes/bootstrap3/templates/checkouts/history.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Loan History') . '</li>';
 
-  $this->headScript()->appendFile('checkouts.js');
+  $this->assetManager()->appendScriptLink('checkouts.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap3/templates/collection/view.phtml
+++ b/themes/bootstrap3/templates/collection/view.phtml
@@ -1,14 +1,14 @@
 <?php
   // Set up standard record scripts:
-  $this->headScript()->appendFile('record.js');
-  $this->headScript()->appendFile('check_save_statuses.js');
+  $this->assetManager()->appendScriptLink('record.js');
+  $this->assetManager()->appendScriptLink('check_save_statuses.js');
   // Activate Syndetics Plus if necessary:
   if ($this->syndeticsPlus()->isActive()) {
-    $this->headScript()->appendFile($this->syndeticsPlus()->getScript());
+    $this->assetManager()->appendScriptLink($this->syndeticsPlus()->getScript());
   }
   // Add any extra scripts the tabs require:
   foreach ($this->tabsExtraScripts as $script) {
-    $this->headScript()->appendFile($script);
+    $this->assetManager()->appendScriptLink($script);
   }
 
   // Add RDF header link if applicable:
@@ -98,4 +98,4 @@
     <?=$this->driver->supportsCoinsOpenURL() ? '<span class="Z3988" aria-hidden="true" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>' : ''?>
   </div>
 </div>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString('$(document).ready(recordDocReady);'); ?>

--- a/themes/bootstrap3/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap3/templates/combined/results-ajax.phtml
@@ -30,5 +30,5 @@
 <?php endif; ?>
 
 <p><?=$this->icon('spinner') ?> <?=$this->transEsc('loading_ellipsis')?></p>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadJs, 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString($loadJs)?>
 <noscript><?=$this->transEsc('Please enable JavaScript.')?></noscript>

--- a/themes/bootstrap3/templates/combined/results-list.phtml
+++ b/themes/bootstrap3/templates/combined/results-list.phtml
@@ -71,7 +71,7 @@
       }
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $countsJs, 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString($countsJs)?>
 
 <?php if ($currentSearch['more_link'] ?? false): ?>
   <div class="pull-right flip">
@@ -106,7 +106,7 @@
         $recommendationClass = str_replace('\\', '_', $current::class);
         $recommendationJs = $generateMoveRecommendationToSidebarJavascript($recommendationClass);
         ?>
-        <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $recommendationJs, 'SET')?>
+        <?=$this->assetManager()->outputInlineScriptString($recommendationJs)?>
         <div id="recommendation__<?=$recommendationClass?>" style="display: none;">
           <?=$this->recommend($current)?>
         </div>
@@ -148,7 +148,7 @@
       $recommendationClass = str_replace('\\', '_', $current::class);
       $recommendationJs = $generateMoveRecommendationToSidebarJavascript($recommendationClass);
       ?>
-      <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $recommendationJs, 'SET')?>
+      <?=$this->assetManager()->outputInlineScriptString($recommendationJs)?>
       <div id="recommendation__<?=$recommendationClass?>" style="display: none;">
         <?=$this->recommend($current)?>
       </div>

--- a/themes/bootstrap3/templates/combined/results.phtml
+++ b/themes/bootstrap3/templates/combined/results.phtml
@@ -39,9 +39,9 @@
 
   // Load Javascript dependencies into header:
   $this->render('search/results-scripts.phtml', compact('displayVersions'));
-  $this->headScript()->appendFile('combined-search.js');
+  $this->assetManager()->appendScriptLink('combined-search.js');
   // Style
-  $this->headLink()->appendStylesheet('combined-search.css');
+  $this->assetManager()->appendStyleLink('combined-search.css');
 ?>
 <?=$this->flashmessages()?>
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>

--- a/themes/bootstrap3/templates/devtools/language.phtml
+++ b/themes/bootstrap3/templates/devtools/language.phtml
@@ -175,4 +175,4 @@ Current filter mode: <?=$includeOptional ? 'Unfiltered' : 'Mandatory strings onl
       });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/holds/edit.phtml
+++ b/themes/bootstrap3/templates/holds/edit.phtml
@@ -86,7 +86,7 @@
 
 <?php
     // Set up hold script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('hold.js');
+    echo $this->assetManager()->outputInlineScriptLink('hold.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -97,5 +97,5 @@
             });
         }
         JS;
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap3/templates/holds/list.phtml
+++ b/themes/bootstrap3/templates/holds/list.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('My Holds') . '</li>';
 
-  $this->headScript()->appendFile('requests.js');
+  $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap3/templates/install/showsql.phtml
+++ b/themes/bootstrap3/templates/install/showsql.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li class="active">' . $this->transEsc('Install VuFind') . '</li>';
 
     // Set up styles:
-    $this->headstyle()->appendStyle(
+    $this->assetManager()->appendStyleString(
         ".pre {\n"
         . "  white-space:pre-wrap; width:90%; overflow-y:visible; padding:8px; margin:1em 2em; background:#EEE; border:1px dashed #CCC;\n"
         . "}\n"
@@ -29,4 +29,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -53,24 +53,22 @@
     ?>
     <?php if ($this->layout()->rtl) {
       // RTL styling
-      $this->headLink()->appendStylesheet('vendor/bootstrap-rtl.min.css');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-rtl.min.css');
     } ?>
-    <?=$this->headLink()?>
-    <?=$this->headStyle()?>
     <?php
       // Collect small scripts together and append as one block:
       $appendScripts = [];
 
       if (!empty($this->themeConfig()['stickyElements'])) {
-        $this->headScript()->appendFile('sticky_elements.js');
+        $this->assetManager()->appendScriptLink('sticky_elements.js');
       }
 
       if (!isset($this->renderingError)) {
         // Deal with cart stuff:
         $cart = $this->cart();
         if ($cart->isActive()) {
-          $this->headScript()->appendFile('vendor/js.cookie.js');
-          $this->headScript()->appendFile('cart.js');
+          $this->assetManager()->appendScriptLink('vendor/js.cookie.js');
+          $this->assetManager()->appendScriptLink('cart.js');
           if ($domain = $cart->getCookieDomain()) {
             $appendScripts[] = 'VuFind.cart.setDomain("' . $domain . '");';
           }
@@ -81,7 +79,7 @@
             $appendScripts[] = 'VuFind.cart.setCookieSameSite("' . $cookieSameSite . '");';
           }
         }
-        $this->headScript()->prependScript(
+        $this->assetManager()->prependScriptString(
             'var userIsLoggedIn = ' . ($this->auth()->getIdentity() ? 'true' : 'false') . ';'
         );
       }
@@ -89,16 +87,19 @@
       // Session keep-alive
       if ($this->keepAlive()) {
           $appendScripts[] = 'var keepAliveInterval = ' . $this->keepAlive() . ';';
-          $this->headScript()->appendFile('keep_alive.js');
+          $this->assetManager()->appendScriptLink('keep_alive.js');
       }
 
       // If account ajax is active, load script and add language strings
       $account = $this->auth()->getManager();
       if ($account->ajaxEnabled()) {
-        $this->headScript()->appendFile('account_ajax.js');
+        $this->assetManager()->appendScriptLink('account_ajax.js');
         if ($this->session()->put('reset_account_status', null)) {
-          $this->headScript()->setAllowArbitraryAttributes(true);
-          $this->headScript()->appendScript('VuFind.account.clearAllCaches();', 'text/javascript', ['data-lightbox-run' => 'always']);
+          $this->assetManager()->appendScriptString(
+              'VuFind.account.clearAllCaches();',
+              ['data-lightbox-run' => 'always'],
+              true
+          );
         }
       }
 
@@ -128,14 +129,14 @@
         $appendScripts[] = 'VuFind.lightbox.child = ' . $lightboxChild . ';';
       }
 
-      $this->headScript()->appendScript(implode("\n", $appendScripts));
+      $this->assetManager()->appendScriptString(implode("\n", $appendScripts));
 
       if ($this->config()->ajaxCoversEnabled()) {
-          $this->headScript()->appendFile('covers.js');
+        $this->assetManager()->appendScriptFile('covers.js');
       }
     ?>
     <?=$this->cookieConsent()->render()?>
-    <?=$this->headScript() ?>
+    <?=$this->assetManager()->outputHeaderAssets()?>
   </head>
   <body class="template-dir-<?=$this->templateDir?> template-name-<?=$this->templateName?> <?=$this->layoutClass('offcanvas-row')?><?php if ($this->layout()->rtl): ?> rtl<?php endif; ?>">
     <header class="hidden-print">
@@ -172,9 +173,9 @@
     <div class="vufind-offcanvas-overlay" data-toggle="vufind-offcanvas"></div>
     <?=$this->render('Helpers/analytics.phtml')?>
     <?php foreach ($this->captcha()->js() as $jsInclude):?>
-      <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, $jsInclude, 'SET')?>
+      <?=$this->assetManager()->outputInlineScriptLink($jsInclude)?>
     <?php endforeach; ?>
 
-    <?=$this->footScript() ?>
+    <?=$this->assetManager()->outputFooterAssets() ?>
   </body>
 </html>

--- a/themes/bootstrap3/templates/layout/layout.phtml
+++ b/themes/bootstrap3/templates/layout/layout.phtml
@@ -96,9 +96,9 @@
         $this->assetManager()->appendScriptLink('account_ajax.js');
         if ($this->session()->put('reset_account_status', null)) {
           $this->assetManager()->appendScriptString(
-              'VuFind.account.clearAllCaches();',
-              ['data-lightbox-run' => 'always'],
-              true
+              script: 'VuFind.account.clearAllCaches();',
+              attrs: ['data-lightbox-run' => 'always'],
+              options: ['allow_arbitrary_attributes' => true]
           );
         }
       }

--- a/themes/bootstrap3/templates/layout/lightbox.phtml
+++ b/themes/bootstrap3/templates/layout/lightbox.phtml
@@ -3,6 +3,9 @@
 <?=$this->matomo(['context' => $this->layoutContext ?? 'lightbox'])?>
 <?=$this->googleanalytics($this->serverUrl(true))?>
 <?php if ($this->session()->put('reset_account_status', null) && $this->auth()->getManager()->ajaxEnabled()) {
-  $this->inlineScript()->setAllowArbitraryAttributes(true);
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.account.clearAllCaches();', 'SET', ['data-lightbox-run' => 'always']);
+  echo $this->assetManager()->outputInlineScriptString(
+      script: 'VuFind.account.clearAllCaches();',
+      attrs: ['data-lightbox-run' => 'always'],
+      allowArbitraryAttrs: true
+  );
 }

--- a/themes/bootstrap3/templates/layout/lightbox.phtml
+++ b/themes/bootstrap3/templates/layout/lightbox.phtml
@@ -6,6 +6,6 @@
   echo $this->assetManager()->outputInlineScriptString(
       script: 'VuFind.account.clearAllCaches();',
       attrs: ['data-lightbox-run' => 'always'],
-      allowArbitraryAttrs: true
+      options: ['allow_arbitrary_attributes' => true]
   );
 }

--- a/themes/bootstrap3/templates/librarycards/editcard.phtml
+++ b/themes/bootstrap3/templates/librarycards/editcard.phtml
@@ -55,6 +55,6 @@
     $script = "setupMultiILSLoginFields($methods, 'login_');";
 
     // Inline the script for lightbox compatibility
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($script);
   }
 ?>

--- a/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap3/templates/myresearch/cataloglogin.phtml
@@ -69,7 +69,7 @@
       $script = "setupMultiILSLoginFields($methods, 'profile_cat_');";
 
       // Inline the script for lightbox compatibility
-      echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+      echo $this->assetManager()->outputInlineScriptString($script);
     }
   ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap3/templates/myresearch/checkedout.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Checked Out Items') . '</li>';
 
-  $this->headScript()->appendFile('checkouts.js');
+  $this->assetManager()->appendScriptLink('checkouts.js');
 
   // Check if "Renew All" button can be displayed:
   $renewAll = !$this->ilsPaging || !$paginator;

--- a/themes/bootstrap3/templates/myresearch/deleteaccount.phtml
+++ b/themes/bootstrap3/templates/myresearch/deleteaccount.phtml
@@ -7,7 +7,7 @@
       // Logout redirect with inline script to make it lightbox compatible
       $script = "setTimeout(function() { window.location = '{$this->redirectUrl}'; }, 3000);";
     ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString($script); ?>
   </div>
 <?php else: ?>
   <form id="delete-account" method="post" action="<?=$this->url('myresearch-deleteaccount') ?>" name="deleteAccount">

--- a/themes/bootstrap3/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/illrequests.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
         . '<li class="active">' . $this->transEsc('Interlibrary Loan Requests') . '</li>';
 
-    $this->headScript()->appendFile('requests.js');
+    $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap3/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap3/templates/myresearch/mylist.phtml
@@ -10,12 +10,12 @@
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc($currPage) . '</li>';
 
   // Load Javascript dependencies into header:
-  $this->headScript()->appendFile('check_item_statuses.js');
+  $this->assetManager()->appendScriptLink('check_item_statuses.js');
 
   // Load Javascript only if list view parameter is NOT full:
   if ($this->params->getOptions()->getListViewOption() != 'full') {
-    $this->headScript()->appendFile('record.js');
-    $this->headScript()->appendFile('embedded_record.js');
+    $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('embedded_record.js');
   }
 
   $recordTotal = $this->results->getResultTotal();

--- a/themes/bootstrap3/templates/myresearch/notify-account-status.phtml
+++ b/themes/bootstrap3/templates/myresearch/notify-account-status.phtml
@@ -1,5 +1,5 @@
 <?php
 if (null !== $this->accountStatus) {
   $notifyScript = 'VuFind.account.notify("' . $this->method . '", ' . json_encode($this->accountStatus) . ');';
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $notifyScript, 'SET');
+  echo $this->assetManager()->outputInlineScriptString($notifyScript);
 }

--- a/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap3/templates/myresearch/storageretrievalrequests.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Storage Retrieval Requests') . '</li>';
 
-  $this->headScript()->appendFile('requests.js');
+  $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap3/templates/record/hold.phtml
+++ b/themes/bootstrap3/templates/record/hold.phtml
@@ -143,7 +143,7 @@
 
 <?php
     // Set up hold script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('hold.js');
+    echo $this->assetManager()->outputInlineScriptLink('hold.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -155,5 +155,5 @@
         }
         JS;
 
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap3/templates/record/illrequest.phtml
+++ b/themes/bootstrap3/templates/record/illrequest.phtml
@@ -112,7 +112,7 @@
 
 <?php
     // Set up ill script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('ill.js');
+    echo $this->assetManager()->outputInlineScriptLink('ill.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -124,5 +124,5 @@
         }
         JS;
 
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap3/templates/record/sms.phtml
+++ b/themes/bootstrap3/templates/record/sms.phtml
@@ -1,7 +1,7 @@
 <?php
   // Set page title.
   $this->headTitle($this->translate('Text this'));
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'vendor/libphonenumber.js', 'SET');
+  echo $this->assetManager()->outputInlineScriptLink('vendor/libphonenumber.js');
 
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = $this->searchMemory()->getLastSearchLink($this->transEsc('Search'), '<li>', '</li> ')

--- a/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap3/templates/record/storageretrievalrequest.phtml
@@ -113,4 +113,4 @@
       });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $changeHandler, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($changeHandler);

--- a/themes/bootstrap3/templates/record/taglist.phtml
+++ b/themes/bootstrap3/templates/record/taglist.phtml
@@ -32,4 +32,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/record/view.phtml
+++ b/themes/bootstrap3/templates/record/view.phtml
@@ -5,15 +5,15 @@
   $this->headTitle($this->driver->getBreadcrumb());
 
   // Set up standard record scripts:
-  $this->headScript()->appendFile('record.js');
-  $this->headScript()->appendFile('check_save_statuses.js');
+  $this->assetManager()->appendScriptLink('record.js');
+  $this->assetManager()->appendScriptLink('check_save_statuses.js');
   // Activate Syndetics Plus if necessary:
   if ($this->syndeticsPlus()->isActive()) {
-    $this->headScript()->appendFile($this->syndeticsPlus()->getScript());
+    $this->assetManager()->appendScriptLink($this->syndeticsPlus()->getScript());
   }
   // Add any extra scripts the tabs require:
   foreach ($this->tabsExtraScripts as $script) {
-    $this->headScript()->appendFile($script);
+    $this->assetManager()->appendScriptLink($script);
   }
 
   // Add RDF header link if applicable:
@@ -98,4 +98,4 @@
     </div>
   <?php endif; ?>
 </div>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString('$(document).ready(recordDocReady);'); ?>

--- a/themes/bootstrap3/templates/relais/button.phtml
+++ b/themes/bootstrap3/templates/relais/button.phtml
@@ -21,11 +21,11 @@
           'relais_success_message' => 'relais_success_message',
         ]
     );
-    $this->headScript()->appendFile('relais.js');
+    $this->assetManager()->appendScriptLink('relais.js');
     $addLink = $this->escapeJs($this->url('relais-request'));
     $oclc = $this->escapeJs($driver->tryMethod('getCleanOCLCNum'));
     $failLink = $this->escapeJs($this->relais()->getSearchLink($driver));
     $activateRelais = "$(document).ready(function() { VuFind.relais.checkAvailability('$addLink', '$oclc', '$failLink') });";
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $activateRelais, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($activateRelais);
   }
 ?>

--- a/themes/bootstrap3/templates/relais/request.phtml
+++ b/themes/bootstrap3/templates/relais/request.phtml
@@ -8,7 +8,7 @@
 <div id="requestButton"></div>
 
 <?php
-  $this->headScript()->appendFile('relais.js');
+  $this->assetManager()->appendScriptLink('relais.js');
   $activateRelais = "$(document).ready(function () { VuFind.relais.addItem('$oclc', '$failLink'); });\n";
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $activateRelais, 'SET')
+  echo $this->assetManager()->outputInlineScriptString($activateRelais);
 ?>

--- a/themes/bootstrap3/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap3/templates/search/advanced/eds.phtml
@@ -109,8 +109,8 @@
       <input type="text" id="PublicationDateSlider">
     </div>
     <?php
-      $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-      $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+      $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
       $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
       $future = date('Y', time() + 31536000);
       $max = !empty($current['values'][1]) ? max($future, $current['values'][1]) : $future;
@@ -142,6 +142,6 @@
           });
           JS;
     ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString($script); ?>
   </fieldset>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap3/templates/search/advanced/layout.phtml
@@ -34,11 +34,11 @@
   }
 
   // Step 1: Load the javascript
-  $this->headScript()->appendFile(
+  $this->assetManager()->appendScriptLink(
       $this->advancedSearchJsOverride ?? 'advanced_search.js'
   );
   // Step 2: Build the page
-  $this->headScript()->appendScript(
+  $this->assetManager()->appendScriptString(
       $this->partial(
           $this->buildPageOverride ?? 'search/advanced/build_page.phtml',
           ['options' => $this->options, 'searchDetails' => $searchDetails]
@@ -236,4 +236,4 @@ $script = <<<JS
     })
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap3/templates/search/advanced/ranges.phtml
@@ -20,8 +20,8 @@
           <input type="text" id="<?=$escField?><?=$this->escapeHtmlAttr($current['type'])?>Slider"  aria-label="<?=$this->transEsc('slider_label', ['%%title%%' => $this->translate($params->getFacetLabel($current['field']))])?>">
         </div>
         <?php
-          $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-          $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+          $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+          $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
           $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
           $future = date('Y', time() + 31536000);
           $max = !empty($current['values'][1]) ? max($future, $current['values'][1]) : $future;
@@ -70,7 +70,7 @@
               });
               JS;
         ?>
-        <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+        <?=$this->assetManager()->outputInlineScriptString($script); ?>
       <?php endif; ?>
     </fieldset>
   <?php endforeach; ?>

--- a/themes/bootstrap3/templates/search/facet-list.phtml
+++ b/themes/bootstrap3/templates/search/facet-list.phtml
@@ -20,8 +20,8 @@
   }
   $this->headTitle($this->translate('facet_list_for', ['%%field%%' => $this->facetLabel]));
   $multiFacetsSelection = $this->multiFacetsSelection ? 'true' : 'false';
-  $this->headScript()->appendScript('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptString('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
+  $this->assetManager()->appendScriptLink('facets.js');
 ?>
 <h2><?=$this->transEsc($this->facetLabel) ?></h2>
 
@@ -67,7 +67,7 @@
   <button class="btn btn-default lightbox-only" data-dismiss="modal"><?=$this->translate('close') ?></button>
 </div>
 
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.facetList.setup();', 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString('VuFind.facetList.setup();')?>
 <?php if ($this->inLightbox): ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.lightbox_facets.setup();', 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString('VuFind.lightbox_facets.setup();')?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/history.phtml
+++ b/themes/bootstrap3/templates/search/history.phtml
@@ -76,4 +76,4 @@
         })
         JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap3/templates/search/home.phtml
+++ b/themes/bootstrap3/templates/search/home.phtml
@@ -17,7 +17,7 @@
 <div class="searchHomeContent">
   <?php $this->slot('search-home-hero')->start() ?>
     <?=$this->render('search/searchbox.phtml')?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$("#searchForm_lookfor").focus();', 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString('$("#searchForm_lookfor").focus();'); ?>
   <?=$this->slot('search-home-hero')->end() ?>
 </div>
 

--- a/themes/bootstrap3/templates/search/reservessearch.phtml
+++ b/themes/bootstrap3/templates/search/reservessearch.phtml
@@ -48,7 +48,7 @@
         ]
     );
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, "$('#reservesSearchForm_lookfor').focus()", 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString("$('#reservesSearchForm_lookfor').focus()")?>
 
   <div class="resulthead">
     <div class="pull-left flip">

--- a/themes/bootstrap3/templates/search/results-scripts.phtml
+++ b/themes/bootstrap3/templates/search/results-scripts.phtml
@@ -1,16 +1,16 @@
 <?php
 // Load Javascript dependencies into header:
-$this->headScript()->appendFile('check_item_statuses.js');
-$this->headScript()->appendFile('check_save_statuses.js');
+$this->assetManager()->appendScriptLink('check_item_statuses.js');
+$this->assetManager()->appendScriptLink('check_save_statuses.js');
 if ($this->displayVersions) {
-    $this->headScript()->appendFile('record_versions.js');
-    $this->headScript()->appendFile('combined-search.js');
+    $this->assetManager()->appendScriptLink('record_versions.js');
+    $this->assetManager()->appendScriptLink('combined-search.js');
 }
 // Load only if list view parameter is NOT full:
 if (($this->listViewOption ?? 'full') !== 'full') {
-    $this->headScript()->appendFile('record.js');
-    $this->headScript()->appendFile('embedded_record.js');
+    $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('embedded_record.js');
 }
 if ($this->jsResults ?? false) {
-    $this->headScript()->appendFile('search.js');
+    $this->assetManager()->appendScriptLink('search.js');
 }

--- a/themes/bootstrap3/templates/search/results.phtml
+++ b/themes/bootstrap3/templates/search/results.phtml
@@ -48,7 +48,7 @@
   );
   $recommendations = $this->results->getRecommendations('side');
   $multiFacetsSelection = $this->multiFacetsSelection ? 'true' : 'false';
-  $this->headScript()->appendScript('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
+  $this->assetManager()->appendScriptString('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
 ?>
 
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>

--- a/themes/bootstrap3/templates/search/searchTabs.phtml
+++ b/themes/bootstrap3/templates/search/searchTabs.phtml
@@ -35,6 +35,6 @@
     <?php endif; ?>
   </ul>
   <?php if ($this->showCounts): ?>
-    <?php $this->headScript()->appendFile('resultcount.js'); ?>
+    <?php $this->assetManager()->appendScriptLink('resultcount.js'); ?>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap3/templates/search/searchbox.phtml
+++ b/themes/bootstrap3/templates/search/searchbox.phtml
@@ -118,10 +118,10 @@
           <button id="searchForm-reset" class="searchForm-reset hidden" type="reset" tabindex="-1" aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"><?=$this->icon('ui-reset-search');?></button>
           <?php if (!empty($keyboardLayouts)): ?>
             <?php
-            $this->headScript()->appendFile('vendor/js.cookie.js');
-            $this->headScript()->appendFile('vendor/simple-keyboard/index.js');
-            $this->headScript()->appendFile('vendor/simple-keyboard-layouts/index.js');
-            $this->headLink()->appendStylesheet('vendor/simple-keyboard/index.css');
+            $this->assetManager()->appendScriptLink('vendor/js.cookie.js');
+            $this->assetManager()->appendScriptLink('vendor/simple-keyboard/index.js');
+            $this->assetManager()->appendScriptLink('vendor/simple-keyboard-layouts/index.js');
+            $this->assetManager()->appendStyleLink('vendor/simple-keyboard/index.css');
             ?>
             <div class="keyboard-selection dropdown">
               <button class="btn btn-primary dropdown-toggle" type="button" id="keyboard-selection-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixanonymoustags.phtml
@@ -32,4 +32,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixduplicatetags.phtml
@@ -31,4 +31,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
+++ b/themes/bootstrap3/templates/upgrade/fixmetadata.phtml
@@ -25,4 +25,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap3/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap3/templates/upgrade/showsql.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('upgrade-home') . '">' . $this->transEsc('Upgrade') . '</a></li> <li class="active">' . $this->transEsc('Upgrade VuFind') . '</li>';
 
     // Set up styles:
-    $this->headstyle()->appendStyle(
+    $this->assetManager()->appendStyleString(
         ".pre {\n"
         . "  white-space:pre-wrap; width:90%; overflow-y:visible; padding:8px; margin:1em 2em; background:#EEE; border:1px dashed #CCC;\n"
         . "}\n"

--- a/themes/bootstrap5/templates/Auth/MultiILS/loginfields.phtml
+++ b/themes/bootstrap5/templates/Auth/MultiILS/loginfields.phtml
@@ -33,5 +33,5 @@
   $script = "setupMultiILSLoginFields($methods, 'login_{$topClass}_');";
 
   // Inline the script for lightbox compatibility
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+  echo $this->assetManager()->outputInlineScriptString($script);
 ?>

--- a/themes/bootstrap5/templates/ContentBlock/IlsStatusMonitor.phtml
+++ b/themes/bootstrap5/templates/ContentBlock/IlsStatusMonitor.phtml
@@ -12,4 +12,4 @@ $ilsStatusScript = <<<JS
       });
     });
     JS;
-echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $ilsStatusScript, 'SET');
+echo $this->assetManager()->outputInlineScriptString($ilsStatusScript);

--- a/themes/bootstrap5/templates/Helpers/cookie-consent.phtml
+++ b/themes/bootstrap5/templates/Helpers/cookie-consent.phtml
@@ -1,6 +1,6 @@
 <?php
-$this->headScript()->appendFile('vendor/cookieconsent.umd.js');
-$this->headScript()->appendFile('cookie.js');
+$this->assetManager()->appendScriptLink('vendor/cookieconsent.umd.js');
+$this->assetManager()->appendScriptLink('cookie.js');
 
 $configJson = json_encode(
     [
@@ -8,4 +8,4 @@ $configJson = json_encode(
         'controlledVuFindServices' => $this->controlledVuFindServices,
     ]
 );
-$this->headScript()->appendScript("window.addEventListener('load', function() { VuFind.cookie.setupConsent($configJson); });");
+$this->assetManager()->appendScriptString("window.addEventListener('load', function() { VuFind.cookie.setupConsent($configJson); });");

--- a/themes/bootstrap5/templates/Helpers/copy-to-clipboard-button.phtml
+++ b/themes/bootstrap5/templates/Helpers/copy-to-clipboard-button.phtml
@@ -28,5 +28,5 @@ $script = <<<JS
       });
     JS;
 // Inline the script for lightbox compatibility
-echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+echo $this->assetManager()->outputInlineScriptString($script);
 ?>

--- a/themes/bootstrap5/templates/Helpers/doi.phtml
+++ b/themes/bootstrap5/templates/Helpers/doi.phtml
@@ -1,2 +1,2 @@
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'doi.js', 'SET');?>
+<?=$this->assetManager()->outputInlineScriptLink('doi.js');?>
 <span class="doiLink" data-doi="<?=$this->escapeHtml($doi)?>"></span>

--- a/themes/bootstrap5/templates/Recommend/AbstractSearchObjectDeferred.phtml
+++ b/themes/bootstrap5/templates/Recommend/AbstractSearchObjectDeferred.phtml
@@ -7,5 +7,5 @@
 ?>
 <div id="<?=$containerId?>">
     <p><?=$this->icon('spinner') ?> <?=$this->transEsc('loading_ellipsis')?></p>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadJs, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($loadJs)?>
 </div>

--- a/themes/bootstrap5/templates/Recommend/DOI.phtml
+++ b/themes/bootstrap5/templates/Recommend/DOI.phtml
@@ -6,6 +6,6 @@
   </div>
   <?php if ($this->recommend->isFullMatch() && $this->recommend->redirectFullMatch()): ?>
     <?php $redirect = 'document.location.href = "' . $this->escapeJs($url) . '";'; ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $redirect, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($redirect)?>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/Recommend/MapSelection.phtml
+++ b/themes/bootstrap5/templates/Recommend/MapSelection.phtml
@@ -5,15 +5,15 @@
       'rectangle_center_message' => 'rectangle_center_message',
     ]);
 
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.js');
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.draw.js');
-    $this->headScript()->appendFile('vendor/leaflet/leaflet.markercluster.js');
-    $this->headScript()->appendFile('map_selection_leaflet.js');
-    $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.draw.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/MarkerCluster.css');
-    $this->headLink()->appendStylesheet('vendor/leaflet/MarkerCluster.Default.css');
-    $this->headLink()->appendStylesheet('geofeatures.css');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.js');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.draw.js');
+    $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.markercluster.js');
+    $this->assetManager()->appendScriptLink('map_selection_leaflet.js');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.draw.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/MarkerCluster.css');
+    $this->assetManager()->appendStyleLink('vendor/leaflet/MarkerCluster.Default.css');
+    $this->assetManager()->appendStyleLink('geofeatures.css');
 
     $basemap = $this->recommend->getBasemap();
     $geoField = $this->recommend->getGeoField();
@@ -41,7 +41,7 @@
       <span class="geo_maphelp">&nbsp;<a href="<?php echo $this->url('help', ['topic' => 'geosearch'])?>" data-lightbox class="help-link"><?php echo $this->transEsc('link_text_need_help')?></a></span>
       <div id="geo_search_map" style="height: <?php echo $height?>px;"></div>
     </div>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET')?>
+    <?=$this->assetManager()->outputInlineScriptString($jsLoad)?>
   </div>
   <?php
     // Overwrite leaflet.draw.js tooltips with international translations
@@ -49,5 +49,5 @@
       = 'L.drawLocal.draw.handlers.rectangle.tooltip.start = "' . $this->transEsc('draw_searchbox_start') . '";'
       . 'L.drawLocal.draw.handlers.simpleshape.tooltip.end = "' . $this->transEsc('draw_searchbox_end') . '";'
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadTranslations, 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString($loadTranslations)?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
@@ -1,11 +1,11 @@
 <?php if ($visFacets = $this->recommend->getVisFacets()): ?>
   <?php
     // load jQuery flot:
-    $this->headScript()->appendFile('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.min.js');
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.resize.min.js');
-    $this->headScript()->appendFile('vendor/flot/jquery.flot.selection.min.js');
-    $this->headScript()->appendFile('pubdate_vis.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.min.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.resize.min.js');
+    $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.selection.min.js');
+    $this->assetManager()->appendScriptLink('pubdate_vis.js');
   ?>
   <?php foreach ($visFacets as $facetField => $facetRange): ?>
     <div class="authorbox">
@@ -22,7 +22,7 @@
     $js = "loadVis('" . $this->recommend->getFacetFields() . "', '"
         . $this->recommend->getSearchParams() . "', VuFind.path, "
         . $this->recommend->getZooming() . ');';
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $js, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($js);
   ?>
 
 <?php endif; ?>

--- a/themes/bootstrap5/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets.phtml
@@ -1,6 +1,6 @@
 <?php
   $this->layout()->sideFacetsInstanceCounter = ($this->layout()->sideFacetsInstanceCounter ?? 0) + 1;
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptLink('facets.js');
 
   // Save results/options to $this so they are available to sub-templates:
   $this->results = $results = $this->recommend->getResults();
@@ -74,4 +74,4 @@
     </div>
   <?php endforeach; ?>
 <?php endif; ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'registerSideFacetTruncation();', 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString('registerSideFacetTruncation();');?>

--- a/themes/bootstrap5/templates/Recommend/SideFacets/range-slider.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets/range-slider.phtml
@@ -35,8 +35,8 @@
   </form>
 </div>
 <?php if ($this->facet['type'] == 'date'): ?>
-  <?php $this->headScript()->appendFile('vendor/bootstrap-slider.min.js'); ?>
-  <?php $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css'); ?>
+  <?php $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js'); ?>
+  <?php $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css'); ?>
   <?php
     $min = !empty($cleanValues[0]) ? min($cleanValues[0], 1400) : 1400;
     $future = date('Y', time() + 31536000); // next year
@@ -82,5 +82,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+  <?=$this->assetManager()->outputInlineScriptString($script); ?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/Recommend/SideFacetsDeferred.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacetsDeferred.phtml
@@ -1,6 +1,6 @@
 <?php
   $this->layout()->sideFacetsInstanceCounter = ($this->layout()->sideFacetsInstanceCounter ?? 0) + 1;
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptLink('facets.js');
 
   $results = $this->recommend->getResults();
   $activeFacets = $this->recommend->getActiveFacets();
@@ -22,8 +22,8 @@
 
   foreach ($activeFacets as $field => $facetName) {
     if (isset($rangeFacets[$field]) && 'date' === $rangeFacets[$field]['type']) {
-      $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-      $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+      $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
       break;
     }
   }

--- a/themes/bootstrap5/templates/Recommend/TopFacets.phtml
+++ b/themes/bootstrap5/templates/Recommend/TopFacets.phtml
@@ -58,4 +58,4 @@
       VuFind.truncate.initTruncate('.top-facets-contents');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString($script);?>

--- a/themes/bootstrap5/templates/Recommend/VisualFacets.phtml
+++ b/themes/bootstrap5/templates/Recommend/VisualFacets.phtml
@@ -1,6 +1,6 @@
 <?php
-  $this->headScript()->appendFile('vendor/d3.min.js');
-  $this->headScript()->appendFile('visual_facets.js');
+  $this->assetManager()->appendScriptLink('vendor/d3.min.js');
+  $this->assetManager()->appendScriptLink('visual_facets.js');
 
   $visualFacetSet = $this->recommend->getPivotFacetSet();
 
@@ -52,5 +52,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+  <?=$this->assetManager()->outputInlineScriptString($script);?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/RecordDriver/AbstractBase/previewdata.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/AbstractBase/previewdata.phtml
@@ -78,7 +78,7 @@
             // add the necessary identifier code:
             if (!empty($html)) {
                 $html .= '<span class="previewBibkeys ' . $idClasses . '"></span>';
-                $this->headScript()->appendFile('preview.js');
+                $this->assetManager()->appendScriptLink('preview.js');
                 echo $html;
             }
         }

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/collection-info.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/collection-info.phtml
@@ -1,4 +1,4 @@
-<?php $this->headScript()->appendFile('collection_record.js'); ?>
+<?php $this->assetManager()->appendScriptLink('collection_record.js'); ?>
 <div class="media">
   <?php
     $QRCode = $this->record($this->driver)->getQRCode('core');

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/explain.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/explain.phtml
@@ -1,6 +1,6 @@
 <?php
-$this->headScript()->appendFile('vendor/chart.js');
-$this->headScript()->appendFile('explain.js');
+$this->assetManager()->appendScriptLink('vendor/chart.js');
+$this->assetManager()->appendScriptLink('explain.js');
 
 $explanation = $this->explanation;
 $recordId = $explanation->getRecordId();

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -256,5 +256,5 @@
         });
         JS;
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+  <?=$this->assetManager()->outputInlineScriptString($script);?>
 </li>

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/result-list-explain.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/result-list-explain.phtml
@@ -5,8 +5,8 @@
 ?>
 <?php if (!empty($this->request) && $score && $maxScore !== null && $maxScore > 0):?>
   <?php
-  $this->headScript()->appendFile('vendor/chart.js');
-  $this->headScript()->appendFile('explain.js');
+  $this->assetManager()->appendScriptLink('vendor/chart.js');
+  $this->assetManager()->appendScriptLink('explain.js');
   $link = $this->recordLinker()->getActionUrl($this->driver, 'Explain', $this->request);
   ?>
   <a class="result-list-explain" target="_blank" href="<?=$this->escapeHtmlAttr($link)?>">

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/toolbar.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/toolbar.phtml
@@ -1,7 +1,7 @@
 <?php
   $addThis = $this->addThis();
   if (!empty($addThis)) {
-    $this->headScript()->appendFile('https://s7.addthis.com/js/250/addthis_widget.js?pub=' . urlencode($addThis));
+    $this->assetManager()->appendScriptLink('https://s7.addthis.com/js/250/addthis_widget.js?pub=' . urlencode($addThis));
   }
 ?>
 <nav class="record-nav" aria-label="<?=$this->transEscAttr('ajaxview_label_tools'); ?>">

--- a/themes/bootstrap5/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/core.phtml
@@ -1,4 +1,4 @@
-<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php $this->assetManager()->appendStyleLink('EDS.css'); ?>
 <?php
     $items = $this->driver->getItems('core');
     $dbLabel = $this->driver->getDbLabel();

--- a/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
@@ -1,5 +1,5 @@
 <?php
-  $this->headLink()->appendStylesheet('EDS.css');
+  $this->assetManager()->appendStyleLink('EDS.css');
   $accessLevel = $this->driver->getAccessLevel();
   $restrictedView = empty($accessLevel) ? false : true;
   $recordLinker = $this->recordLinker($this->results);

--- a/themes/bootstrap5/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EPF/core.phtml
@@ -1,4 +1,4 @@
-<?php $this->headLink()->appendStylesheet('EDS.css'); ?>
+<?php $this->assetManager()->appendStyleLink('EDS.css'); ?>
 <?php
     $items = $this->driver->getItems('core');
     $accessLevel = $this->driver->getAccessLevel();

--- a/themes/bootstrap5/templates/RecordTab/hierarchytree.phtml
+++ b/themes/bootstrap5/templates/RecordTab/hierarchytree.phtml
@@ -61,9 +61,9 @@
   <?php endif; ?>
 </div>
 <?php
-  $this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'hierarchy_tree.js');
+  echo $this->assetManager()->outputInlineScriptLink('hierarchy_tree.js');
   $js = <<<JS
         document.querySelectorAll('.js-hierarchy-tree-container').forEach((el) => VuFind.hierarchyTree.initTree(el));
       JS;
-  echo $this->inlineScript()->appendScript($js);
+  echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap5/templates/RecordTab/map.phtml
+++ b/themes/bootstrap5/templates/RecordTab/map.phtml
@@ -1,8 +1,8 @@
 <?php
-  $this->headScript()->appendFile('vendor/leaflet/leaflet.js');
-  $this->headScript()->appendFile('vendor/leaflet/leaflet.latlng-graticule.js');
-  $this->headScript()->appendFile('map_tab_leaflet.js');
-  $this->headLink()->appendStylesheet('vendor/leaflet/leaflet.css');
+  $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.js');
+  $this->assetManager()->appendScriptLink('vendor/leaflet/leaflet.latlng-graticule.js');
+  $this->assetManager()->appendScriptLink('map_tab_leaflet.js');
+  $this->assetManager()->appendStyleLink('vendor/leaflet/leaflet.css');
   $this->jsTranslations()->addStrings(
       ['Coordinates' => 'Coordinates', 'no_description' => 'no_description']
   );
@@ -17,5 +17,5 @@
 ?>
 <div id="wrap" style="width: inherit; height: 479px">
   <div id="map-canvas" style="width: 100%; height: 100%"></div>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $jsLoad, 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString($jsLoad)?>
 </div>

--- a/themes/bootstrap5/templates/RecordTab/preview.phtml
+++ b/themes/bootstrap5/templates/RecordTab/preview.phtml
@@ -3,7 +3,7 @@
     $this->headTitle($this->translate('Preview') . ': ' . $this->driver->getBreadcrumb());
 
     // load the embedded preview javascript file
-    $this->headScript()->appendFile('https://www.google.com/books/jsapi.js');
-    $this->headScript()->appendFile('embedGBS.js');
+    $this->assetManager()->appendScriptLink('https://www.google.com/books/jsapi.js');
+    $this->assetManager()->appendScriptLink('embedGBS.js');
 ?>
 <div id="gbsViewer" style="height: 600px;"></div>

--- a/themes/bootstrap5/templates/RecordTab/similaritemscarousel.phtml
+++ b/themes/bootstrap5/templates/RecordTab/similaritemscarousel.phtml
@@ -75,4 +75,4 @@
       $('#similar-items-carousel img').on('load', normalizeHeights);
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/RecordTab/versions.phtml
+++ b/themes/bootstrap5/templates/RecordTab/versions.phtml
@@ -55,4 +55,4 @@ $script = <<<JS
     VuFind.initResultScripts('.results');
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString($script); ?>

--- a/themes/bootstrap5/templates/admin/feedback/home.phtml
+++ b/themes/bootstrap5/templates/admin/feedback/home.phtml
@@ -176,4 +176,4 @@ $js = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $js, 'SET');?>
+<?=$this->assetManager()->outputInlineScriptString($js);?>

--- a/themes/bootstrap5/templates/cart/cart.phtml
+++ b/themes/bootstrap5/templates/cart/cart.phtml
@@ -121,4 +121,4 @@
         });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/cart/email.phtml
+++ b/themes/bootstrap5/templates/cart/email.phtml
@@ -40,4 +40,4 @@
       $('#itemhide').removeClass('in');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/cart/export.phtml
+++ b/themes/bootstrap5/templates/cart/export.phtml
@@ -72,4 +72,4 @@
         }).trigger('change');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/cart/save.phtml
+++ b/themes/bootstrap5/templates/cart/save.phtml
@@ -66,4 +66,4 @@
       $('#itemhide').removeClass('in');
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/channels/channelList.phtml
+++ b/themes/bootstrap5/templates/channels/channelList.phtml
@@ -1,8 +1,8 @@
 <?php
-  $this->headLink()->appendStylesheet('vendor/slick.css');
-  $this->headLink()->appendStylesheet('vendor/slick-theme.css');
-  $this->headScript()->appendFile('vendor/slick.min.js');
-  $this->headScript()->appendFile('channels.js');
+  $this->assetManager()->appendStyleLink('vendor/slick.css');
+  $this->assetManager()->appendStyleLink('vendor/slick-theme.css');
+  $this->assetManager()->appendScriptLink('vendor/slick.min.js');
+  $this->assetManager()->appendScriptLink('channels.js');
   $this->jsTranslations()->addStrings([
     'channel_browse' => 'channel_browse',
     'channel_expand' => 'channel_expand',

--- a/themes/bootstrap5/templates/checkouts/history.phtml
+++ b/themes/bootstrap5/templates/checkouts/history.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Loan History') . '</li>';
 
-  $this->headScript()->appendFile('checkouts.js');
+  $this->assetManager()->appendScriptLink('checkouts.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap5/templates/collection/view.phtml
+++ b/themes/bootstrap5/templates/collection/view.phtml
@@ -1,14 +1,14 @@
 <?php
   // Set up standard record scripts:
-  $this->headScript()->appendFile('record.js');
-  $this->headScript()->appendFile('check_save_statuses.js');
+  $this->assetManager()->appendScriptLink('record.js');
+  $this->assetManager()->appendScriptLink('check_save_statuses.js');
   // Activate Syndetics Plus if necessary:
   if ($this->syndeticsPlus()->isActive()) {
-    $this->headScript()->appendFile($this->syndeticsPlus()->getScript());
+    $this->assetManager()->appendScriptLink($this->syndeticsPlus()->getScript());
   }
   // Add any extra scripts the tabs require:
   foreach ($this->tabsExtraScripts as $script) {
-    $this->headScript()->appendFile($script);
+    $this->assetManager()->appendScriptLink($script);
   }
 
   // Add RDF header link if applicable:
@@ -98,4 +98,4 @@
     <?=$this->driver->supportsCoinsOpenURL() ? '<span class="Z3988" aria-hidden="true" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenURL()) . '"></span>' : ''?>
   </div>
 </div>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString('$(document).ready(recordDocReady);'); ?>

--- a/themes/bootstrap5/templates/combined/results-ajax.phtml
+++ b/themes/bootstrap5/templates/combined/results-ajax.phtml
@@ -30,5 +30,5 @@
 <?php endif; ?>
 
 <p><?=$this->icon('spinner') ?> <?=$this->transEsc('loading_ellipsis')?></p>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $loadJs, 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString($loadJs)?>
 <noscript><?=$this->transEsc('Please enable JavaScript.')?></noscript>

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -71,7 +71,7 @@
       }
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $countsJs, 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString($countsJs)?>
 
 <?php if ($currentSearch['more_link'] ?? false): ?>
   <div class="pull-right flip">
@@ -106,7 +106,7 @@
         $recommendationClass = str_replace('\\', '_', $current::class);
         $recommendationJs = $generateMoveRecommendationToSidebarJavascript($recommendationClass);
         ?>
-        <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $recommendationJs, 'SET')?>
+        <?=$this->assetManager()->outputInlineScriptString($recommendationJs)?>
         <div id="recommendation__<?=$recommendationClass?>" style="display: none;">
           <?=$this->recommend($current)?>
         </div>
@@ -148,7 +148,7 @@
       $recommendationClass = str_replace('\\', '_', $current::class);
       $recommendationJs = $generateMoveRecommendationToSidebarJavascript($recommendationClass);
       ?>
-      <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $recommendationJs, 'SET')?>
+      <?=$this->assetManager()->outputInlineScriptString($recommendationJs)?>
       <div id="recommendation__<?=$recommendationClass?>" style="display: none;">
         <?=$this->recommend($current)?>
       </div>

--- a/themes/bootstrap5/templates/combined/results.phtml
+++ b/themes/bootstrap5/templates/combined/results.phtml
@@ -39,9 +39,9 @@
 
   // Load Javascript dependencies into header:
   $this->render('search/results-scripts.phtml', compact('displayVersions'));
-  $this->headScript()->appendFile('combined-search.js');
+  $this->assetManager()->appendScriptLink('combined-search.js');
   // Style
-  $this->headLink()->appendStylesheet('combined-search.css');
+  $this->assetManager()->appendStyleLink('combined-search.css');
 ?>
 <?=$this->flashmessages()?>
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>

--- a/themes/bootstrap5/templates/devtools/language.phtml
+++ b/themes/bootstrap5/templates/devtools/language.phtml
@@ -175,4 +175,4 @@ Current filter mode: <?=$includeOptional ? 'Unfiltered' : 'Mandatory strings onl
       });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/holds/edit.phtml
+++ b/themes/bootstrap5/templates/holds/edit.phtml
@@ -86,7 +86,7 @@
 
 <?php
     // Set up hold script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('hold.js');
+    echo $this->assetManager()->outputInlineScriptLink('hold.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -97,5 +97,5 @@
             });
         }
         JS;
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap5/templates/holds/list.phtml
+++ b/themes/bootstrap5/templates/holds/list.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('My Holds') . '</li>';
 
-  $this->headScript()->appendFile('requests.js');
+  $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap5/templates/install/showsql.phtml
+++ b/themes/bootstrap5/templates/install/showsql.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li class="active">' . $this->transEsc('Install VuFind') . '</li>';
 
     // Set up styles:
-    $this->headstyle()->appendStyle(
+    $this->assetManager()->appendStyleString(
         ".pre {\n"
         . "  white-space:pre-wrap; width:90%; overflow-y:visible; padding:8px; margin:1em 2em; background:#EEE; border:1px dashed #CCC;\n"
         . "}\n"
@@ -29,4 +29,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/layout/layout.phtml
+++ b/themes/bootstrap5/templates/layout/layout.phtml
@@ -53,24 +53,22 @@
     ?>
     <?php if ($this->layout()->rtl) {
       // RTL styling
-      $this->headLink()->appendStylesheet('vendor/bootstrap-rtl.min.css');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-rtl.min.css');
     } ?>
-    <?=$this->headLink()?>
-    <?=$this->headStyle()?>
     <?php
       // Collect small scripts together and append as one block:
       $appendScripts = [];
 
       if (!empty($this->themeConfig()['stickyElements'])) {
-        $this->headScript()->appendFile('sticky_elements.js');
+        $this->assetManager()->appendScriptLink('sticky_elements.js');
       }
 
       if (!isset($this->renderingError)) {
         // Deal with cart stuff:
         $cart = $this->cart();
         if ($cart->isActive()) {
-          $this->headScript()->appendFile('vendor/js.cookie.js');
-          $this->headScript()->appendFile('cart.js');
+          $this->assetManager()->appendScriptLink('vendor/js.cookie.js');
+          $this->assetManager()->appendScriptLink('cart.js');
           if ($domain = $cart->getCookieDomain()) {
             $appendScripts[] = 'VuFind.cart.setDomain("' . $domain . '");';
           }
@@ -81,7 +79,7 @@
             $appendScripts[] = 'VuFind.cart.setCookieSameSite("' . $cookieSameSite . '");';
           }
         }
-        $this->headScript()->prependScript(
+        $this->assetManager()->prependScriptString(
             'var userIsLoggedIn = ' . ($this->auth()->getIdentity() ? 'true' : 'false') . ';'
         );
       }
@@ -89,16 +87,19 @@
       // Session keep-alive
       if ($this->keepAlive()) {
           $appendScripts[] = 'var keepAliveInterval = ' . $this->keepAlive() . ';';
-          $this->headScript()->appendFile('keep_alive.js');
+          $this->assetManager()->appendScriptLink('keep_alive.js');
       }
 
       // If account ajax is active, load script and add language strings
       $account = $this->auth()->getManager();
       if ($account->ajaxEnabled()) {
-        $this->headScript()->appendFile('account_ajax.js');
+        $this->assetManager()->appendScriptLink('account_ajax.js');
         if ($this->session()->put('reset_account_status', null)) {
-          $this->headScript()->setAllowArbitraryAttributes(true);
-          $this->headScript()->appendScript('VuFind.account.clearAllCaches();', 'text/javascript', ['data-lightbox-run' => 'always']);
+          $this->assetManager()->appendScriptString(
+              'VuFind.account.clearAllCaches();',
+              ['data-lightbox-run' => 'always'],
+              true
+          );
         }
       }
 
@@ -128,14 +129,14 @@
         $appendScripts[] = 'VuFind.lightbox.child = ' . $lightboxChild . ';';
       }
 
-      $this->headScript()->appendScript(implode("\n", $appendScripts));
+      $this->assetManager()->appendScriptString(implode("\n", $appendScripts));
 
       if ($this->config()->ajaxCoversEnabled()) {
-          $this->headScript()->appendFile('covers.js');
+        $this->assetManager()->appendScriptFile('covers.js');
       }
     ?>
     <?=$this->cookieConsent()->render()?>
-    <?=$this->headScript() ?>
+    <?=$this->assetManager()->outputHeaderAssets()?>
   </head>
   <body class="template-dir-<?=$this->templateDir?> template-name-<?=$this->templateName?> <?=$this->layoutClass('offcanvas-row')?><?php if ($this->layout()->rtl): ?> rtl<?php endif; ?>">
     <header class="hidden-print">
@@ -172,9 +173,9 @@
     <div class="vufind-offcanvas-overlay" data-toggle="vufind-offcanvas"></div>
     <?=$this->render('Helpers/analytics.phtml')?>
     <?php foreach ($this->captcha()->js() as $jsInclude):?>
-      <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, $jsInclude, 'SET')?>
+      <?=$this->assetManager()->outputInlineScriptLink($jsInclude)?>
     <?php endforeach; ?>
 
-    <?=$this->footScript() ?>
+    <?=$this->assetManager()->outputFooterAssets() ?>
   </body>
 </html>

--- a/themes/bootstrap5/templates/layout/layout.phtml
+++ b/themes/bootstrap5/templates/layout/layout.phtml
@@ -96,9 +96,9 @@
         $this->assetManager()->appendScriptLink('account_ajax.js');
         if ($this->session()->put('reset_account_status', null)) {
           $this->assetManager()->appendScriptString(
-              'VuFind.account.clearAllCaches();',
-              ['data-lightbox-run' => 'always'],
-              true
+              script: 'VuFind.account.clearAllCaches();',
+              attrs: ['data-lightbox-run' => 'always'],
+              options: ['allow_arbitrary_attributes' => true]
           );
         }
       }

--- a/themes/bootstrap5/templates/layout/lightbox.phtml
+++ b/themes/bootstrap5/templates/layout/lightbox.phtml
@@ -3,6 +3,9 @@
 <?=$this->matomo(['context' => $this->layoutContext ?? 'lightbox'])?>
 <?=$this->googleanalytics($this->serverUrl(true))?>
 <?php if ($this->session()->put('reset_account_status', null) && $this->auth()->getManager()->ajaxEnabled()) {
-  $this->inlineScript()->setAllowArbitraryAttributes(true);
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.account.clearAllCaches();', 'SET', ['data-lightbox-run' => 'always']);
+  echo $this->assetManager()->outputInlineScriptString(
+      script: 'VuFind.account.clearAllCaches();',
+      attrs: ['data-lightbox-run' => 'always'],
+      allowArbitraryAttrs: true
+  );
 }

--- a/themes/bootstrap5/templates/layout/lightbox.phtml
+++ b/themes/bootstrap5/templates/layout/lightbox.phtml
@@ -6,6 +6,6 @@
   echo $this->assetManager()->outputInlineScriptString(
       script: 'VuFind.account.clearAllCaches();',
       attrs: ['data-lightbox-run' => 'always'],
-      allowArbitraryAttrs: true
+      options: ['allow_arbitrary_attributes' => true]
   );
 }

--- a/themes/bootstrap5/templates/librarycards/editcard.phtml
+++ b/themes/bootstrap5/templates/librarycards/editcard.phtml
@@ -55,6 +55,6 @@
     $script = "setupMultiILSLoginFields($methods, 'login_');";
 
     // Inline the script for lightbox compatibility
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($script);
   }
 ?>

--- a/themes/bootstrap5/templates/myresearch/cataloglogin.phtml
+++ b/themes/bootstrap5/templates/myresearch/cataloglogin.phtml
@@ -69,7 +69,7 @@
       $script = "setupMultiILSLoginFields($methods, 'profile_cat_');";
 
       // Inline the script for lightbox compatibility
-      echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+      echo $this->assetManager()->outputInlineScriptString($script);
     }
   ?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap5/templates/myresearch/checkedout.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Checked Out Items') . '</li>';
 
-  $this->headScript()->appendFile('checkouts.js');
+  $this->assetManager()->appendScriptLink('checkouts.js');
 
   // Check if "Renew All" button can be displayed:
   $renewAll = !$this->ilsPaging || !$paginator;

--- a/themes/bootstrap5/templates/myresearch/deleteaccount.phtml
+++ b/themes/bootstrap5/templates/myresearch/deleteaccount.phtml
@@ -7,7 +7,7 @@
       // Logout redirect with inline script to make it lightbox compatible
       $script = "setTimeout(function() { window.location = '{$this->redirectUrl}'; }, 3000);";
     ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString($script); ?>
   </div>
 <?php else: ?>
   <form id="delete-account" method="post" action="<?=$this->url('myresearch-deleteaccount') ?>" name="deleteAccount">

--- a/themes/bootstrap5/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap5/templates/myresearch/illrequests.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li>'
         . '<li class="active">' . $this->transEsc('Interlibrary Loan Requests') . '</li>';
 
-    $this->headScript()->appendFile('requests.js');
+    $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap5/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap5/templates/myresearch/mylist.phtml
@@ -10,12 +10,12 @@
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc($currPage) . '</li>';
 
   // Load Javascript dependencies into header:
-  $this->headScript()->appendFile('check_item_statuses.js');
+  $this->assetManager()->appendScriptLink('check_item_statuses.js');
 
   // Load Javascript only if list view parameter is NOT full:
   if ($this->params->getOptions()->getListViewOption() != 'full') {
-    $this->headScript()->appendFile('record.js');
-    $this->headScript()->appendFile('embedded_record.js');
+    $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('embedded_record.js');
   }
 
   $recordTotal = $this->results->getResultTotal();

--- a/themes/bootstrap5/templates/myresearch/notify-account-status.phtml
+++ b/themes/bootstrap5/templates/myresearch/notify-account-status.phtml
@@ -1,5 +1,5 @@
 <?php
 if (null !== $this->accountStatus) {
   $notifyScript = 'VuFind.account.notify("' . $this->method . '", ' . json_encode($this->accountStatus) . ');';
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $notifyScript, 'SET');
+  echo $this->assetManager()->outputInlineScriptString($notifyScript);
 }

--- a/themes/bootstrap5/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap5/templates/myresearch/storageretrievalrequests.phtml
@@ -5,7 +5,7 @@
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = '<li><a href="' . $this->url('myresearch-home') . '">' . $this->transEsc('Your Account') . '</a></li> <li class="active">' . $this->transEsc('Storage Retrieval Requests') . '</li>';
 
-  $this->headScript()->appendFile('requests.js');
+  $this->assetManager()->appendScriptLink('requests.js');
 ?>
 
 <?=$this->component('show-account-menu-button')?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -143,7 +143,7 @@
 
 <?php
     // Set up hold script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('hold.js');
+    echo $this->assetManager()->outputInlineScriptLink('hold.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -155,5 +155,5 @@
         }
         JS;
 
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap5/templates/record/illrequest.phtml
+++ b/themes/bootstrap5/templates/record/illrequest.phtml
@@ -112,7 +112,7 @@
 
 <?php
     // Set up ill script; we do this inline instead of in the header for lightbox compatibility:
-    $this->inlineScript()->appendFile('ill.js');
+    echo $this->assetManager()->outputInlineScriptLink('ill.js');
 
     $js = <<<JS
         if ($.isReady) {
@@ -124,5 +124,5 @@
         }
         JS;
 
-    echo $this->inlineScript()->appendScript($js);
+    echo $this->assetManager()->outputInlineScriptString($js);
 ?>

--- a/themes/bootstrap5/templates/record/sms.phtml
+++ b/themes/bootstrap5/templates/record/sms.phtml
@@ -1,7 +1,7 @@
 <?php
   // Set page title.
   $this->headTitle($this->translate('Text this'));
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::FILE, 'vendor/libphonenumber.js', 'SET');
+  echo $this->assetManager()->outputInlineScriptLink('vendor/libphonenumber.js');
 
   // Set up breadcrumbs:
   $this->layout()->breadcrumbs = $this->searchMemory()->getLastSearchLink($this->transEsc('Search'), '<li>', '</li> ')

--- a/themes/bootstrap5/templates/record/storageretrievalrequest.phtml
+++ b/themes/bootstrap5/templates/record/storageretrievalrequest.phtml
@@ -113,4 +113,4 @@
       });
       JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $changeHandler, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($changeHandler);

--- a/themes/bootstrap5/templates/record/taglist.phtml
+++ b/themes/bootstrap5/templates/record/taglist.phtml
@@ -32,4 +32,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/record/view.phtml
+++ b/themes/bootstrap5/templates/record/view.phtml
@@ -5,15 +5,15 @@
   $this->headTitle($this->driver->getBreadcrumb());
 
   // Set up standard record scripts:
-  $this->headScript()->appendFile('record.js');
-  $this->headScript()->appendFile('check_save_statuses.js');
+  $this->assetManager()->appendScriptLink('record.js');
+  $this->assetManager()->appendScriptLink('check_save_statuses.js');
   // Activate Syndetics Plus if necessary:
   if ($this->syndeticsPlus()->isActive()) {
-    $this->headScript()->appendFile($this->syndeticsPlus()->getScript());
+    $this->assetManager()->appendScriptLink($this->syndeticsPlus()->getScript());
   }
   // Add any extra scripts the tabs require:
   foreach ($this->tabsExtraScripts as $script) {
-    $this->headScript()->appendFile($script);
+    $this->assetManager()->appendScriptLink($script);
   }
 
   // Add RDF header link if applicable:
@@ -98,4 +98,4 @@
     </div>
   <?php endif; ?>
 </div>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$(document).ready(recordDocReady);', 'SET'); ?>
+<?=$this->assetManager()->outputInlineScriptString('$(document).ready(recordDocReady);'); ?>

--- a/themes/bootstrap5/templates/relais/button.phtml
+++ b/themes/bootstrap5/templates/relais/button.phtml
@@ -21,11 +21,11 @@
           'relais_success_message' => 'relais_success_message',
         ]
     );
-    $this->headScript()->appendFile('relais.js');
+    $this->assetManager()->appendScriptLink('relais.js');
     $addLink = $this->escapeJs($this->url('relais-request'));
     $oclc = $this->escapeJs($driver->tryMethod('getCleanOCLCNum'));
     $failLink = $this->escapeJs($this->relais()->getSearchLink($driver));
     $activateRelais = "$(document).ready(function() { VuFind.relais.checkAvailability('$addLink', '$oclc', '$failLink') });";
-    echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $activateRelais, 'SET');
+    echo $this->assetManager()->outputInlineScriptString($activateRelais);
   }
 ?>

--- a/themes/bootstrap5/templates/relais/request.phtml
+++ b/themes/bootstrap5/templates/relais/request.phtml
@@ -8,7 +8,7 @@
 <div id="requestButton"></div>
 
 <?php
-  $this->headScript()->appendFile('relais.js');
+  $this->assetManager()->appendScriptLink('relais.js');
   $activateRelais = "$(document).ready(function () { VuFind.relais.addItem('$oclc', '$failLink'); });\n";
-  echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $activateRelais, 'SET')
+  echo $this->assetManager()->outputInlineScriptString($activateRelais);
 ?>

--- a/themes/bootstrap5/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap5/templates/search/advanced/eds.phtml
@@ -109,8 +109,8 @@
       <input type="text" id="PublicationDateSlider">
     </div>
     <?php
-      $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-      $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+      $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+      $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
       $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
       $future = date('Y', time() + 31536000);
       $max = !empty($current['values'][1]) ? max($future, $current['values'][1]) : $future;
@@ -142,6 +142,6 @@
           });
           JS;
     ?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString($script); ?>
   </fieldset>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/search/advanced/layout.phtml
+++ b/themes/bootstrap5/templates/search/advanced/layout.phtml
@@ -34,11 +34,11 @@
   }
 
   // Step 1: Load the javascript
-  $this->headScript()->appendFile(
+  $this->assetManager()->appendScriptLink(
       $this->advancedSearchJsOverride ?? 'advanced_search.js'
   );
   // Step 2: Build the page
-  $this->headScript()->appendScript(
+  $this->assetManager()->appendScriptString(
       $this->partial(
           $this->buildPageOverride ?? 'search/advanced/build_page.phtml',
           ['options' => $this->options, 'searchDetails' => $searchDetails]
@@ -236,4 +236,4 @@ $script = <<<JS
     })
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/search/advanced/ranges.phtml
+++ b/themes/bootstrap5/templates/search/advanced/ranges.phtml
@@ -20,8 +20,8 @@
           <input type="text" id="<?=$escField?><?=$this->escapeHtmlAttr($current['type'])?>Slider"  aria-label="<?=$this->transEsc('slider_label', ['%%title%%' => $this->translate($params->getFacetLabel($current['field']))])?>">
         </div>
         <?php
-          $this->headScript()->appendFile('vendor/bootstrap-slider.min.js');
-          $this->headLink()->appendStylesheet('vendor/bootstrap-slider.min.css');
+          $this->assetManager()->appendScriptLink('vendor/bootstrap-slider.min.js');
+          $this->assetManager()->appendStyleLink('vendor/bootstrap-slider.min.css');
           $min = !empty($current['values'][0]) ? min($current['values'][0], 1400) : 1400;
           $future = date('Y', time() + 31536000);
           $max = !empty($current['values'][1]) ? max($future, $current['values'][1]) : $future;
@@ -70,7 +70,7 @@
               });
               JS;
         ?>
-        <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET'); ?>
+        <?=$this->assetManager()->outputInlineScriptString($script); ?>
       <?php endif; ?>
     </fieldset>
   <?php endforeach; ?>

--- a/themes/bootstrap5/templates/search/facet-list.phtml
+++ b/themes/bootstrap5/templates/search/facet-list.phtml
@@ -20,8 +20,8 @@
   }
   $this->headTitle($this->translate('facet_list_for', ['%%field%%' => $this->facetLabel]));
   $multiFacetsSelection = $this->multiFacetsSelection ? 'true' : 'false';
-  $this->headScript()->appendScript('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
-  $this->headScript()->appendFile('facets.js');
+  $this->assetManager()->appendScriptString('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
+  $this->assetManager()->appendScriptLink('facets.js');
 ?>
 <h2><?=$this->transEsc($this->facetLabel) ?></h2>
 
@@ -67,7 +67,7 @@
   <button class="btn btn-default lightbox-only" data-bs-dismiss="modal"><?=$this->translate('close') ?></button>
 </div>
 
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.facetList.setup();', 'SET')?>
+<?=$this->assetManager()->outputInlineScriptString('VuFind.facetList.setup();')?>
 <?php if ($this->inLightbox): ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, 'VuFind.lightbox_facets.setup();', 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString('VuFind.lightbox_facets.setup();')?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/search/history.phtml
+++ b/themes/bootstrap5/templates/search/history.phtml
@@ -76,4 +76,4 @@
         })
         JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET') ?>
+<?=$this->assetManager()->outputInlineScriptString($script) ?>

--- a/themes/bootstrap5/templates/search/home.phtml
+++ b/themes/bootstrap5/templates/search/home.phtml
@@ -17,7 +17,7 @@
 <div class="searchHomeContent">
   <?php $this->slot('search-home-hero')->start() ?>
     <?=$this->render('search/searchbox.phtml')?>
-    <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, '$("#searchForm_lookfor").focus();', 'SET'); ?>
+    <?=$this->assetManager()->outputInlineScriptString('$("#searchForm_lookfor").focus();'); ?>
   <?=$this->slot('search-home-hero')->end() ?>
 </div>
 

--- a/themes/bootstrap5/templates/search/reservessearch.phtml
+++ b/themes/bootstrap5/templates/search/reservessearch.phtml
@@ -48,7 +48,7 @@
         ]
     );
   ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, "$('#reservesSearchForm_lookfor').focus()", 'SET')?>
+  <?=$this->assetManager()->outputInlineScriptString("$('#reservesSearchForm_lookfor').focus()")?>
 
   <div class="resulthead">
     <div class="pull-left flip">

--- a/themes/bootstrap5/templates/search/results-scripts.phtml
+++ b/themes/bootstrap5/templates/search/results-scripts.phtml
@@ -1,16 +1,16 @@
 <?php
 // Load Javascript dependencies into header:
-$this->headScript()->appendFile('check_item_statuses.js');
-$this->headScript()->appendFile('check_save_statuses.js');
+$this->assetManager()->appendScriptLink('check_item_statuses.js');
+$this->assetManager()->appendScriptLink('check_save_statuses.js');
 if ($this->displayVersions) {
-    $this->headScript()->appendFile('record_versions.js');
-    $this->headScript()->appendFile('combined-search.js');
+    $this->assetManager()->appendScriptLink('record_versions.js');
+    $this->assetManager()->appendScriptLink('combined-search.js');
 }
 // Load only if list view parameter is NOT full:
 if (($this->listViewOption ?? 'full') !== 'full') {
-    $this->headScript()->appendFile('record.js');
-    $this->headScript()->appendFile('embedded_record.js');
+    $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('embedded_record.js');
 }
 if ($this->jsResults ?? false) {
-    $this->headScript()->appendFile('search.js');
+    $this->assetManager()->appendScriptLink('search.js');
 }

--- a/themes/bootstrap5/templates/search/results.phtml
+++ b/themes/bootstrap5/templates/search/results.phtml
@@ -48,7 +48,7 @@
   );
   $recommendations = $this->results->getRecommendations('side');
   $multiFacetsSelection = $this->multiFacetsSelection ? 'true' : 'false';
-  $this->headScript()->appendScript('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
+  $this->assetManager()->appendScriptString('var multiFacetsSelectionEnabled = ' . $multiFacetsSelection . ';');
 ?>
 
 <h1 class="sr-only"><?=$this->escapeHtml($headTitle)?></h1>

--- a/themes/bootstrap5/templates/search/searchTabs.phtml
+++ b/themes/bootstrap5/templates/search/searchTabs.phtml
@@ -35,6 +35,6 @@
     <?php endif; ?>
   </ul>
   <?php if ($this->showCounts): ?>
-    <?php $this->headScript()->appendFile('resultcount.js'); ?>
+    <?php $this->assetManager()->appendScriptLink('resultcount.js'); ?>
   <?php endif; ?>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -118,10 +118,10 @@
           <button id="searchForm-reset" class="searchForm-reset hidden" type="reset" tabindex="-1" aria-label="<?=$this->transEscAttr('searchform_reset_button')?>"><?=$this->icon('ui-reset-search');?></button>
           <?php if (!empty($keyboardLayouts)): ?>
             <?php
-            $this->headScript()->appendFile('vendor/js.cookie.js');
-            $this->headScript()->appendFile('vendor/simple-keyboard/index.js');
-            $this->headScript()->appendFile('vendor/simple-keyboard-layouts/index.js');
-            $this->headLink()->appendStylesheet('vendor/simple-keyboard/index.css');
+            $this->assetManager()->appendScriptLink('vendor/js.cookie.js');
+            $this->assetManager()->appendScriptLink('vendor/simple-keyboard/index.js');
+            $this->assetManager()->appendScriptLink('vendor/simple-keyboard-layouts/index.js');
+            $this->assetManager()->appendStyleLink('vendor/simple-keyboard/index.css');
             ?>
             <div class="keyboard-selection dropdown">
               <button class="btn btn-primary dropdown-toggle" type="button" id="keyboard-selection-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/themes/bootstrap5/templates/upgrade/fixanonymoustags.phtml
+++ b/themes/bootstrap5/templates/upgrade/fixanonymoustags.phtml
@@ -32,4 +32,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/upgrade/fixduplicatetags.phtml
+++ b/themes/bootstrap5/templates/upgrade/fixduplicatetags.phtml
@@ -31,4 +31,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/upgrade/fixmetadata.phtml
+++ b/themes/bootstrap5/templates/upgrade/fixmetadata.phtml
@@ -25,4 +25,4 @@ $script = <<<JS
     });
     JS;
 ?>
-<?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');
+<?=$this->assetManager()->outputInlineScriptString($script);

--- a/themes/bootstrap5/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap5/templates/upgrade/showsql.phtml
@@ -6,7 +6,7 @@
     $this->layout()->breadcrumbs = '<li><a href="' . $this->url('upgrade-home') . '">' . $this->transEsc('Upgrade') . '</a></li> <li class="active">' . $this->transEsc('Upgrade VuFind') . '</li>';
 
     // Set up styles:
-    $this->headstyle()->appendStyle(
+    $this->assetManager()->appendStyleString(
         ".pre {\n"
         . "  white-space:pre-wrap; width:90%; overflow-y:visible; padding:8px; margin:1em 2em; background:#EEE; border:1px dashed #CCC;\n"
         . "}\n"

--- a/themes/root/templates/Helpers/icons/font.phtml
+++ b/themes/root/templates/Helpers/icons/font.phtml
@@ -1,5 +1,7 @@
 <?php
-    $this->headLink()->appendStylesheet($this->src);
+    if ($this->src) {
+        $this->assetManager()->appendStyleLink($this->src);
+    }
     $className = trim('icon icon--font ' . $this->icon . ' ' . ($this->extra['class'] ?? ''));
 ?>
 <span class="<?=$this->escapeHtmlAttr($className) ?>"<?=$this->attrs ?> role="img" aria-hidden="true"></span>

--- a/themes/root/templates/layout/help.phtml
+++ b/themes/root/templates/layout/help.phtml
@@ -1,11 +1,13 @@
 <?=$this->doctype()?>
-
 <html lang="<?=$this->layout()->userLang?>"<?php if ($this->layout()->rtl): ?> dir="rtl"<?php endif; ?>>
   <head>
-    <?php $this->setupThemeResources(); ?>
+    <?php
+      $this->setupThemeResources();
+      $this->assetManager()->clearScriptList()->clearStyleList()->appendStyleLink('help.css');
+    ?>
     <?=$this->headMeta()?>
-    <?=$this->headTitle() ?>
-    <?=$this->headLink()->setStylesheet('help.css')  ?>
+    <?=$this->headTitle()?>
+    <?=$this->assetManager()->outputHeaderAssets()?>
   </head>
   <body>
     <?=$this->layout()->content?>


### PR DESCRIPTION
This introduces the AssetManager view helper to the release-10.2 branch to pave the way for #4213. This version is a simple wrapper around our existing customized Laminas view helpers instead of a more significant replacement, but it introduces a public interface that will work the same in 10.2 and 11.0. This will make it possible for users to prepare for the backward-breaking changes in 11.0 without having to immediately modify all of their templates.

Note that some of the logic in the AssetManager helper here is somewhat redundant; however, I opted not to refactor it into a more "clever" pattern, since it's all going to be short-lived, with a more elegant version coming in the next release.

TODO
- [x] Run full test suite
- [x] Update changelog when merging