### PR TITLE
Hide edit actions on public favorite list entries

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -207,29 +207,50 @@
       </div>
 
       <div class="result-links hidden-print">
-        <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool icon-link">
-          <?=$this->icon('user-list-entry-edit', 'icon-link__icon') ?>
-          <span class="icon-link__label"><?=$this->transEsc('Edit')?></span>
-        </a><br>
-        <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
-          $deleteUrl = null === $list_id
-              ? $this->url('myresearch-favorites')
-              : $this->url('userList', ['id' => $list_id]);
-          $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
-          $md5Id = md5($id);
-        ?>
-        <?=
-          $this->component(
-              'confirm-button',
-              [
-                  'buttonClass' => 'btn-link',
-                  'buttonLink' => $deleteUrlGet,
-                  'buttonIcon' => 'user-list-remove',
-                  'buttonLabel' => 'Delete',
-                  'confirmId' => 'confirm_delete_item_' . $md5Id,
-              ]
-          )
-        ?>
+        <?php if ($this->list === null || $this->userlist()->userCanEditList($this->auth()->getManager()->getUserObject(), $this->list)): ?>
+          <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool icon-link">
+            <?=$this->icon('user-list-entry-edit', 'icon-link__icon') ?>
+            <span class="icon-link__label"><?=$this->transEsc('Edit')?></span>
+          </a><br>
+          <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
+            $deleteUrl = null === $list_id
+                ? $this->url('myresearch-favorites')
+                : $this->url('userList', ['id' => $list_id]);
+            $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
+            $md5Id = md5($id);
+          ?>
+          <?=
+            $this->component(
+                'confirm-button',
+                [
+                    'buttonClass' => 'btn-link',
+                    'buttonLink' => $deleteUrlGet,
+                    'buttonIcon' => 'user-list-remove',
+                    'buttonLabel' => 'Delete',
+                    'confirmId' => 'confirm_delete_item_' . $md5Id,
+                ]
+            )
+          ?>
+          <?php
+            $escId = $this->escapeJs($id);
+            $escSource = $this->escapeJs($source);
+            $script = <<<JS
+                $('#confirm_delete_item_{$md5Id}').click(function(e) {
+                    e.preventDefault();
+                    $.post('{$deleteUrl}', {
+                                'delete':'{$escId}',
+                                'source':'{$escSource}',
+                                'confirm':true
+                            },
+                            function() {
+                                location.reload()
+                            }
+                        );
+                });
+                JS;
+          ?>
+          <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
+        <?php endif; ?>
         <?=$this->driver->supportsCoinsOpenUrl() ? '<span class="Z3988" aria-hidden="true" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
       </div>
     </div>
@@ -237,23 +258,4 @@
       <?=$thumbnail ?>
     <?php endif; ?>
   </div>
-  <?php
-    $escId = $this->escapeJs($id);
-    $escSource = $this->escapeJs($source);
-    $script = <<<JS
-        $('#confirm_delete_item_{$md5Id}').click(function(e) {
-            e.preventDefault();
-            $.post('{$deleteUrl}', {
-                        'delete':'{$escId}',
-                        'source':'{$escSource}',
-                        'confirm':true
-                    },
-                    function() {
-                        location.reload()
-                    }
-                );
-        });
-        JS;
-  ?>
-  <?=$this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $script, 'SET');?>
 </li>


### PR DESCRIPTION
Besides the list editing actions and the bulk deletion button, the editing actions on single list entries of public lists should also be hidden for unauthorized users.