### PR TITLE
RecordDriver/EDS: preg_quote startPage in getContainerEndPage

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -870,6 +870,7 @@ class EDS extends DefaultRecord
         // cases we can abstract it from an OpenURL.
         $startPage = $this->getContainerStartPage();
         if (!empty($startPage)) {
+            $startPage = preg_quote($startPage, '/');
             $regex = "/&pages={$startPage}-(\d+)/";
             foreach ($this->getFTCustomLinks() as $link) {
                 if (preg_match($regex, $link['Url'] ?? '', $matches)) {


### PR DESCRIPTION
In cases where there is unexpected data in `startPage`, we can quote those characters to prevent a compilation error on the `preg_match`.

Sample error in our environment:  

`preg_match(): Compilation failed: missing closing parenthesis at offset 20 in /usr/local/vufind/module/VuFind/src/VuFind/RecordDriver/EDS.php on line 875, referer https://catalog.lib.msu.edu/EdsRecord/edsswe,edsswe.oai.DiVA.org.nrm.3267/Export?style=RefWorks`
