### PR TITLE
Check configured extraHoldFields to skip unused API calls in HoldsTrait

### DIFF
--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -238,20 +238,25 @@ trait HoldsTrait
         $defaultStartDate = $dateConverter->convertToDisplayDate('U', time());
 
         // Find and format the default required date:
-        $defaultRequiredTS = $this->holds()->getDefaultRequiredDate(
-            $checkHolds,
-            $catalog,
-            $patron,
-            $gatheredDetails
-        );
-        $defaultRequiredDate = $defaultRequiredTS
-            ? $dateConverter->convertToDisplayDate(
-                'U',
-                $defaultRequiredTS
-            ) : '';
+        $defaultRequiredDate = '';
+        if (in_array('requiredByDate', $extraHoldFields)
+            || in_array('requiredByDateOptional', $extraHoldFields)) {
+            $defaultRequiredTS = $this->holds()->getDefaultRequiredDate(
+                $checkHolds,
+                $catalog,
+                $patron,
+                $gatheredDetails
+            );
+            $defaultRequiredDate = $defaultRequiredTS
+                ? $dateConverter->convertToDisplayDate(
+                    'U',
+                    $defaultRequiredTS
+                ) : '';
+        }
         try {
-            $defaultPickup
-                = $catalog->getDefaultPickUpLocation($patron, $gatheredDetails);
+            $defaultPickup = empty($pickup)
+                ? false
+                : $catalog->getDefaultPickUpLocation($patron, $gatheredDetails);
         } catch (\Exception $e) {
             $defaultPickup = false;
         }

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -97,15 +97,12 @@ trait HoldsTrait
 
         // Send various values to the view so we can build the form:
         $requestGroups = [];
-        if (in_array('requestGroup', $extraHoldFields)) {
-            $requestGroups = $catalog->checkCapability(
-                'getRequestGroups',
-                [$driver->getUniqueID(), $patron, $gatheredDetails]
-            ) ? $catalog->getRequestGroups(
-                $driver->getUniqueID(),
-                $patron,
-                $gatheredDetails
-            ) : [];
+        $requestGroupsArgs = [$driver->getUniqueID(), $patron, $gatheredDetails];
+        if (
+            in_array('requestGroup', $extraHoldFields)
+            && $catalog->checkCapability('getRequestGroups', $requestGroupsArgs)
+        ) {
+            $requestGroups = $catalog->getRequestGroups(...$requestGroupsArgs);
         }
 
         $requestGroupNeeded = in_array('requestGroup', $extraHoldFields)
@@ -130,8 +127,7 @@ trait HoldsTrait
         if (in_array('pickUpLocation', $extraHoldFields)) {
             $pickup = $catalog->getPickUpLocations($patron, $pickupDetails);
             if (!$pickup) {
-                $this->flashMessenger()
-                    ->addErrorMessage('No pickup locations available');
+                $this->flashMessenger()->addErrorMessage('No pickup locations available');
                 return $this->redirectToRecord('#top');
             }
         }

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -239,8 +239,10 @@ trait HoldsTrait
 
         // Find and format the default required date:
         $defaultRequiredDate = '';
-        if (in_array('requiredByDate', $extraHoldFields)
-            || in_array('requiredByDateOptional', $extraHoldFields)) {
+        if (
+            in_array('requiredByDate', $extraHoldFields)
+            || in_array('requiredByDateOptional', $extraHoldFields)
+        ) {
             $defaultRequiredTS = $this->holds()->getDefaultRequiredDate(
                 $checkHolds,
                 $catalog,

--- a/module/VuFind/src/VuFind/Controller/HoldsTrait.php
+++ b/module/VuFind/src/VuFind/Controller/HoldsTrait.php
@@ -92,17 +92,21 @@ trait HoldsTrait
             return $this->redirectToRecord('#top');
         }
 
-        // Send various values to the view so we can build the form:
-        $requestGroups = $catalog->checkCapability(
-            'getRequestGroups',
-            [$driver->getUniqueID(), $patron, $gatheredDetails]
-        ) ? $catalog->getRequestGroups(
-            $driver->getUniqueID(),
-            $patron,
-            $gatheredDetails
-        ) : [];
         $extraHoldFields = isset($checkHolds['extraHoldFields'])
             ? explode(':', $checkHolds['extraHoldFields']) : [];
+
+        // Send various values to the view so we can build the form:
+        $requestGroups = [];
+        if (in_array('requestGroup', $extraHoldFields)) {
+            $requestGroups = $catalog->checkCapability(
+                'getRequestGroups',
+                [$driver->getUniqueID(), $patron, $gatheredDetails]
+            ) ? $catalog->getRequestGroups(
+                $driver->getUniqueID(),
+                $patron,
+                $gatheredDetails
+            ) : [];
+        }
 
         $requestGroupNeeded = in_array('requestGroup', $extraHoldFields)
             && !empty($requestGroups)
@@ -119,14 +123,17 @@ trait HoldsTrait
             // group, so make sure pickup locations match with the group
             $pickupDetails['requestGroupId'] = $requestGroups[0]['id'];
         }
-        $pickup = $catalog->getPickUpLocations($patron, $pickupDetails);
 
         // Check that there are pick up locations to choose from if the field is
         // required:
-        if (in_array('pickUpLocation', $extraHoldFields) && !$pickup) {
-            $this->flashMessenger()
-                ->addErrorMessage('No pickup locations available');
-            return $this->redirectToRecord('#top');
+        $pickup = [];
+        if (in_array('pickUpLocation', $extraHoldFields)) {
+            $pickup = $catalog->getPickUpLocations($patron, $pickupDetails);
+            if (!$pickup) {
+                $this->flashMessenger()
+                    ->addErrorMessage('No pickup locations available');
+                return $this->redirectToRecord('#top');
+            }
         }
 
         $proxiedUsers = [];


### PR DESCRIPTION
In the `HoldsTrait` we are currently calling `getRequestGroups`, `getPickUpLocations`, `getDefaultRequiredDate`, and `getDefaultPickUpLocation` even if they were not configured within the `extraHoldFields`. This change is to only make those calls if configured in order to reduce unnecessary API calls.