### PR TITLE
Separate title parts for escapeOrCleanHtml

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/core.phtml
@@ -45,7 +45,7 @@
   <?php endif; ?>
   <div class="media-body">
 
-    <h1<?=$this->schemaOrg()->getAttributes(['property' => 'name'])?>><?=$this->escapeOrCleanHtml($this->driver->getShortTitle() . ' ' . $this->driver->getSubtitle() . ' ' . $this->driver->getTitleSection(), 'title', renderingContext: 'heading')?></h1>
+    <h1<?=$this->schemaOrg()->getAttributes(['property' => 'name'])?>><?=$this->escapeOrCleanHtml($this->driver->getShortTitle(), 'title', renderingContext: 'heading') . ' ' . $this->escapeOrCleanHtml($this->driver->getSubtitle(), 'title', renderingContext: 'heading') . ' ' . $this->escapeOrCleanHtml($this->driver->getTitleSection(), 'title', renderingContext: 'heading')?></h1>
 
     <?php if ($this->driver->getExtraDetail('cached_record') && !$this->translationEmpty('cached_record_warning')): ?>
       <div class="alert alert-warning">


### PR DESCRIPTION
Using the string contact operator on the output of `getShortTitle()`, `getSubtitle()`, and `getTitleSection()` converts them all into strings, regardless if any (or all?) were PropertyStrings.  So this does the `escapeOrCleanHtml` separately for each value.

Would be nice if PHP let you overload the `.` operator in an object, i.e. what PHP apparently calls [magic methods](https://www.php.net/manual/en/language.oop5.magic.php), but that doesn't seem to be supported.  Still there may be a better way.