### PR TITLE
Remove unnecessary functionality from escapeOrCleanHtml

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
@@ -68,7 +68,8 @@ class EscapeOrCleanHtml extends AbstractHelper
      *
      * @param string|PropertyStringInterface $value            Value to escape
      * @param ?string                        $dataContext      Data context (for fields that allow sanitized HTML)
-     * @param ?bool                          $allowHtml        Whether to allow sanitized HTML if passed a PropertyString
+     * @param ?bool                          $allowHtml        Whether to allow sanitized HTML if passed a
+     * PropertyString
      * @param string                         $renderingContext Rendering context for cleaning HTML
      *
      * @return mixed Returns an escaped or HTML-safe string

--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
@@ -79,7 +79,7 @@ class EscapeOrCleanHtml extends AbstractHelper
         ?bool $allowHtml = null,
         string $renderingContext = 'default'
     ) {
-        if (null === $value) {
+        if (null === $value && null === $dataContext && null === $allowHtml) {
             return $this;
         }
         if ($value instanceof PropertyStringInterface) {
@@ -91,7 +91,7 @@ class EscapeOrCleanHtml extends AbstractHelper
             }
             $value = (string)$value;
         }
-        return $this->escape($value);
+        return $this->escape($value ?? '');
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
@@ -66,23 +66,19 @@ class EscapeOrCleanHtml extends AbstractHelper
     /**
      * Invoke this helper: escape a value
      *
-     * @param ?string $value            Value to escape
-     * @param ?string $dataContext      Data context (for fields that allow sanitized HTML)
-     * @param ?bool   $allowHtml        Whether to allow sanitized HTML if passed a PropertyString
-     * @param string  $renderingContext Rendering context for cleaning HTML
+     * @param string|PropertyStringInterface $value            Value to escape
+     * @param ?string                        $dataContext      Data context (for fields that allow sanitized HTML)
+     * @param ?bool                          $allowHtml        Whether to allow sanitized HTML if passed a PropertyString
+     * @param string                         $renderingContext Rendering context for cleaning HTML
      *
-     * @return mixed Called with non-null arguments, returns an escaped string, otherwise returns self
+     * @return mixed Returns an escaped or HTML-safe string
      */
     public function __invoke(
-        $value = null,
+        string|PropertyStringInterface $value,
         ?string $dataContext = null,
         ?bool $allowHtml = null,
         string $renderingContext = 'default'
     ) {
-        // Return self if all arguments are default:
-        if (null === $value && null === $dataContext && null === $allowHtml && 'default' === $renderingContext) {
-            return $this;
-        }
         if ($value instanceof PropertyStringInterface) {
             if (
                 ($allowHtml ?? ($dataContext && ($this->htmlContexts[$dataContext] ?? false)))
@@ -92,7 +88,7 @@ class EscapeOrCleanHtml extends AbstractHelper
             }
             $value = (string)$value;
         }
-        return $this->escape($value ?? '');
+        return $this->escape($value);
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
@@ -71,7 +71,7 @@ class EscapeOrCleanHtml extends AbstractHelper
      * @param ?bool   $allowHtml        Whether to allow sanitized HTML if passed a PropertyString
      * @param string  $renderingContext Rendering context for cleaning HTML
      *
-     * @return mixed Given a string, returns an escaped string, otherwise returns self
+     * @return mixed Called with non-null arguments, returns an escaped string, otherwise returns self
      */
     public function __invoke(
         $value = null,

--- a/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/EscapeOrCleanHtml.php
@@ -79,7 +79,8 @@ class EscapeOrCleanHtml extends AbstractHelper
         ?bool $allowHtml = null,
         string $renderingContext = 'default'
     ) {
-        if (null === $value && null === $dataContext && null === $allowHtml) {
+        // Return self if all arguments are default:
+        if (null === $value && null === $dataContext && null === $allowHtml && 'default' === $renderingContext) {
             return $this;
         }
         if ($value instanceof PropertyStringInterface) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/EscapeOrCleanHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/EscapeOrCleanHtmlTest.php
@@ -106,17 +106,4 @@ class EscapeOrCleanHtmlTest extends \PHPUnit\Framework\TestCase
         $result = $escapeOrCleanHtml($input, $dataContext, $allowHtml, $renderingContext);
         $this->assertEquals($expected, $result);
     }
-
-    /**
-     * Test invoking without parameters
-     *
-     * @return void
-     */
-    public function testInvokeWithoutParameters(): void
-    {
-        $escaper = new Escaper(false);
-        $cleanHtml = $this->createCleanHtmlHelper();
-        $escapeOrCleanHtml = new EscapeOrCleanHtml($escaper, $cleanHtml, []);
-        $this->assertEquals($escapeOrCleanHtml, $escapeOrCleanHtml());
-    }
 }


### PR DESCRIPTION
escapeOrCleanHtml included a mechanism for obtaining the whole object through the `__invoke` method, but this was neither used nor needed and had the potential to cause weird side effects. This PR simplifies the helper by removing the unwanted logic.