### PR TITLE
PropertyString: decode HTML entities appropriately.

### DIFF
--- a/module/VuFind/src/VuFind/String/PropertyString.php
+++ b/module/VuFind/src/VuFind/String/PropertyString.php
@@ -66,7 +66,8 @@ class PropertyString implements PropertyStringInterface
      */
     public static function fromHtml(string $html, array $properties = []): PropertyString
     {
-        return (new PropertyString(strip_tags($html), $properties))->setHtml($html);
+        $decodedHtml = html_entity_decode(strip_tags($html));
+        return (new PropertyString($decodedHtml, $properties))->setHtml($html);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/String/PropertyStringTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/String/PropertyStringTest.php
@@ -114,6 +114,13 @@ class PropertyStringTest extends \PHPUnit\Framework\TestCase
                 '<strong>HTML</strong> string',
                 ['__html' => '<strong>HTML</strong> string'],
             ],
+            'HTML string containing entities' => [
+                '<i>Dungeons &amp; Dragons</i>',
+                [],
+                'Dungeons & Dragons',
+                '<i>Dungeons &amp; Dragons</i>',
+                ['__html' => '<i>Dungeons &amp; Dragons</i>'],
+            ],
         ];
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/EscapeOrCleanHtmlTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/EscapeOrCleanHtmlTest.php
@@ -56,6 +56,7 @@ class EscapeOrCleanHtmlTest extends \PHPUnit\Framework\TestCase
     {
         $link = '<a href="https://vufind.org/">VuFind</a>';
         $div = '<div>Div</div>';
+        $dnd = '<i>Dungeons &amp; Dragons</i>';
         return [
             'plain string' => ['plain string', null, null, 'default', [], 'plain string'],
             'link' => [$link, null, null, 'default', [], htmlentities($link)],
@@ -74,6 +75,9 @@ class EscapeOrCleanHtmlTest extends \PHPUnit\Framework\TestCase
             ],
             'div as PropertyString, allow HTML, rendered in heading' => [
                 PropertyString::fromHtml($div), null, true, 'heading', [], 'Div',
+            ],
+            'HTML containing entity, disallow HTML' => [
+                PropertyString::fromHtml($dnd), null, false, 'heading', [], 'Dungeons &amp; Dragons',
             ],
         ];
     }


### PR DESCRIPTION
As discussed on #4319, this addresses a shortcoming of PropertyString HTML handling.