### PR TITLE
EDS and EPF: Remove unused getView() methods

### DIFF
--- a/module/VuFind/src/VuFind/Search/EDS/Options.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Options.php
@@ -276,16 +276,6 @@ class Options extends \VuFind\Search\Base\Options
     }
 
     /**
-     * Return the view associated with this configuration
-     *
-     * @return string
-     */
-    public function getView()
-    {
-        return $this->getApiProperty('defaultView');
-    }
-
-    /**
      * Get an array of search mode options
      *
      * @return array

--- a/module/VuFind/src/VuFind/Search/EPF/Options.php
+++ b/module/VuFind/src/VuFind/Search/EPF/Options.php
@@ -92,16 +92,6 @@ class Options extends \VuFind\Search\Base\Options
      *
      * @return string
      */
-    public function getView()
-    {
-        return $this->defaultView;
-    }
-
-    /**
-     * Return the view associated with this configuration
-     *
-     * @return string
-     */
     public function getEpfView()
     {
         $viewArr = explode('_', $this->defaultView);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EPF/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EPF/OptionsTest.php
@@ -59,7 +59,6 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
                         'default_view' => 'brief',
                     ],
                 ],
-                'list_brief',
                 'brief',
             ],
             [
@@ -68,7 +67,6 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
                         'default_view' => 'full',
                     ],
                 ],
-                'list_full',
                 'full',
             ],
         ];
@@ -78,14 +76,13 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
      * Test that the Options object returns correct data .
      *
      * @param array  $config  Blender configuration
-     * @param string $view    Expected view
      * @param string $epfView Expected epfView
      *
      * @return void
      *
      * @dataProvider optionsProvider
      */
-    public function testOptions(array $config, $view, $epfView): void
+    public function testOptions(array $config, $epfView): void
     {
         $configMgr = $this->getMockConfigPluginManager(
             [
@@ -93,7 +90,6 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
             ]
         );
         $options = new Options($configMgr);
-        $this->assertEquals($view, $options->getView());
         $this->assertEquals($epfView, $options->getEpfView());
     }
 }


### PR DESCRIPTION
Discovered during #4328 that this EDS method was not used even in the initial implementation:

https://github.com/vufind-org/vufind/pull/4328#discussion_r2035259414

It was then adapted in EPF but also unused there.