### PR TITLE
Add support for extracting subject from email body in Mailer.

### DIFF
--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -196,7 +196,8 @@ class Email implements HandlerInterface, LoggerAwareInterface
                 $emailMessage,
                 null,
                 !empty($replyToEmail)
-                    ? new Address($replyToEmail, $replyToName) : null
+                    ? new Address($replyToEmail, $replyToName) : null,
+                false
             );
             return true;
         } catch (MailException $e) {

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -207,8 +207,8 @@ class Mailer implements
      * @param string|string[]|Address|Address[]|null $cc            CC recipient(s) (null for none)
      * @param string|string[]|Address|Address[]|null $replyTo       Reply-To address(es) (or delimited list, null for
      * none)
-     * @param bool                                   $subjectInBody Allow subject to be extracted from body (string
-     * only)?
+     * @param bool                                   $subjectInBody Allow subject to be extracted from body when
+     * body text begins with "Subject: " (string only)?
      *
      * @throws MailException
      * @return void

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -200,12 +200,15 @@ class Mailer implements
     /**
      * Send an email message.
      *
-     * @param string|string[]|Address|Address[]      $to      Recipient email address(es) (or delimited list)
-     * @param string|Address                         $from    Sender name and email address
-     * @param string                                 $subject Subject line for message
-     * @param string|Email                           $body    Message body
-     * @param string|string[]|Address|Address[]|null $cc      CC recipient(s) (null for none)
-     * @param string|string[]|Address|Address[]|null $replyTo Reply-To address(es) (or delimited list, null for none)
+     * @param string|string[]|Address|Address[]      $to            Recipient email address(es) (or delimited list)
+     * @param string|Address                         $from          Sender name and email address
+     * @param string                                 $subject       Subject line for message
+     * @param string|Email                           $body          Message body
+     * @param string|string[]|Address|Address[]|null $cc            CC recipient(s) (null for none)
+     * @param string|string[]|Address|Address[]|null $replyTo       Reply-To address(es) (or delimited list, null for
+     * none)
+     * @param bool                                   $subjectInBody Allow subject to be extracted from body (string
+     * only)?
      *
      * @throws MailException
      * @return void
@@ -216,7 +219,8 @@ class Mailer implements
         string $subject,
         string|Email $body,
         string|Address|array|null $cc = null,
-        string|Address|array|null $replyTo = null
+        string|Address|array|null $replyTo = null,
+        bool $subjectInBody = true
     ) {
         try {
             if (!($from instanceof Address)) {
@@ -280,6 +284,17 @@ class Mailer implements
                     $email->subject($subject);
                 }
             } else {
+                if ($subjectInBody) {
+                    // Extract any subject line at the beginning of the message body:
+                    $body = preg_replace_callback(
+                        '/^Subject: (.+)\n+/',
+                        function ($matches) use (&$subject) {
+                            $subject = $matches[1];
+                            return '';
+                        },
+                        $body
+                    );
+                }
                 $email = $this->getNewMessage();
                 $email->text($body);
                 $email->subject($subject);

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -208,7 +208,7 @@ class Mailer implements
      * @param string|string[]|Address|Address[]|null $replyTo       Reply-To address(es) (or delimited list, null for
      * none)
      * @param bool                                   $subjectInBody Allow subject to be extracted from body when
-     * body text begins with "Subject: " (string only)?
+     * body text begins with "Subject: " and $body is a string (ignored when $body is an Email object)
      *
      * @throws MailException
      * @return void

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -224,6 +224,64 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test sending an email with subject in the body
+     *
+     * @return void
+     */
+    public function testSendWithSubjectInBody()
+    {
+        $callback = function ($message): bool {
+            return 'to@example.com' == $message->getTo()[0]->toString()
+                && 'from@example.com' == $message->getFrom()[0]->toString()
+                && 'body' == $message->getBody()->getBody()
+                && 'overridden subject' == $message->getSubject();
+        };
+        $mailer = $this->getMailer($callback);
+        $mailer->send(
+            'to@example.com',
+            'from@example.com',
+            'subject',
+            <<<EOT
+                Subject: overridden subject
+
+                body
+                EOT
+        );
+    }
+
+    /**
+     * Test sending an email with subject not allowed in the body
+     *
+     * @return void
+     */
+    public function testSendWithSubjectNotAllowedInBody()
+    {
+        $body = <<<EOT
+            Subject: overridden subject
+
+            body
+            EOT;
+        $callback = function ($message) use ($body): bool {
+            return 'to@example.com' == $message->getTo()[0]->toString()
+                && 'from@example.com' == $message->getFrom()[0]->toString()
+                && $body == $message->getBody()->getBody()
+                && 'subject' == $message->getSubject();
+        };
+        $mailer = $this->getMailer($callback);
+        $mailer->send(
+            'to@example.com',
+            'from@example.com',
+            'subject',
+            <<<EOT
+                Subject: overridden subject
+
+                body
+                EOT,
+            subjectInBody: false
+        );
+    }
+
+    /**
      * Test bad to address.
      *
      * @return void


### PR DESCRIPTION
This makes it possible for a single template to return both the email subject and body, which makes translation or customization of message subjects easier.

Subject must be the first line in the body and must start with 'Subject: '.