### PR TITLE
Disable loading of results with JS for reserves search.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -1313,6 +1313,18 @@ abstract class Options implements TranslatorAwareInterface
     }
 
     /**
+     * Override the setting for loading results with JavaScript.
+     *
+     * @param bool $enable Enable JS?
+     *
+     * @return void
+     */
+    public function setLoadResultsWithJs(bool $enable): void
+    {
+        $this->loadResultsWithJs = $enable;
+    }
+
+    /**
      * Get top paginator style
      *
      * @return string

--- a/themes/bootstrap5/templates/search/reservesresults.phtml
+++ b/themes/bootstrap5/templates/search/reservesresults.phtml
@@ -14,4 +14,6 @@
     }
     $this->slot('empty-message')->set($this->transEsc('course_reserves_empty_list'));
     $this->breadcrumbs()->set($this->translate('Search For Items on Reserve'), $this->url('search-reserves'));
+    // Disable loading of results with JS for now since it doesn't handle the special parameters:
+    $this->results->getOptions()->setLoadResultsWithJs(false);
     echo $this->render('search/results.phtml');


### PR DESCRIPTION
The custom search mechanism doesn't work with JS results at the moment.