### PR TITLE
Use UserEntityInterface in list template.

### DIFF
--- a/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap3/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -7,7 +7,7 @@
     $user_id = $this->list->getUser()->getId();
   } else {
     $list_id = null;
-    $user_id = $this->user ? $this->user->id : null;
+    $user_id = $this->user ? $this->user->getId() : null;
   }
   // Thumbnail
   $coverDetails = $this->record($this->driver)->getCoverDetails('list-entry', 'medium', $this->recordLinker()->getUrl($this->driver));

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -7,7 +7,7 @@
     $user_id = $this->list->getUser()->getId();
   } else {
     $list_id = null;
-    $user_id = $this->user ? $this->user->id : null;
+    $user_id = $this->user ? $this->user->getId() : null;
   }
   // Thumbnail
   $coverDetails = $this->record($this->driver)->getCoverDetails('list-entry', 'medium', $this->recordLinker()->getUrl($this->driver));


### PR DESCRIPTION
This PR adds a missing call to UserEntityInterface (instead of deprecated direct property access) that was overlooked in earlier refactoring.