### PR TITLE
Get default range slider values from stats

### DIFF
--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -64,6 +64,10 @@ dateRange[] = publishDate
 ; Any fields listed below will be treated as free-form ranges rather than plain
 ; facets:
 ;genericRange[] = example_field_str
+; Any fields in dateRange, fullDateRange, numericRange and genericRange can be added to
+; includeStats. The minimal and maximum values will then be added as default values to
+; the range selector. Make sure that the stats component of Solr is supported by the field.
+includeStats[] = publishDate
 ; Any fields listed below will be treated as hierarchical facets
 ; (see https://wiki.apache.org/solr/HierarchicalFaceting but note that we always
 ; use a trailing slash to avoid ambiguities)

--- a/module/VuFind/src/VuFind/Recommend/SideFacets.php
+++ b/module/VuFind/src/VuFind/Recommend/SideFacets.php
@@ -81,6 +81,13 @@ class SideFacets extends AbstractFacets
     protected $numericRangeFacets = [];
 
     /**
+     * Range facets that should include values from stats as default range
+     *
+     * @var array
+     */
+    protected $statsRangeFacets = [];
+
+    /**
      * Main facet configuration
      *
      * @var array
@@ -208,6 +215,10 @@ class SideFacets extends AbstractFacets
             $this->numericRangeFacets
                 = $config->SpecialFacets->numericRange->toArray();
         }
+        if (isset($config->SpecialFacets->includeStats)) {
+            $this->statsRangeFacets
+                = $config->SpecialFacets->includeStats->toArray();
+        }
 
         // Checkbox facets:
         $flipCheckboxes = false;
@@ -284,6 +295,17 @@ class SideFacets extends AbstractFacets
         }
         foreach ($checkboxFacets as $name => $desc) {
             $params->addCheckboxFacet($name, $desc);
+        }
+        $allRangeFacets = array_merge(
+            $this->dateFacets,
+            $this->fullDateFacets,
+            $this->genericRangeFacets,
+            $this->numericRangeFacets
+        );
+        foreach ($allRangeFacets as $rangeFacet) {
+            if (in_array($rangeFacet, $this->statsRangeFacets)) {
+                $params->addRangeFacet($rangeFacet);
+            }
         }
         $params->toggleCheckboxFacetCounts($this->showCheckboxFacetCounts);
     }
@@ -472,6 +494,7 @@ class SideFacets extends AbstractFacets
     protected function getRangeFacets($property)
     {
         $filters = $this->results->getParams()->getRawFilters();
+        $rangeFacetStats = $this->results->getRangeFacetStats();
         $result = [];
         if (isset($this->$property) && is_array($this->$property)) {
             foreach ($this->$property as $current) {
@@ -484,6 +507,10 @@ class SideFacets extends AbstractFacets
                             break;
                         }
                     }
+                } elseif (isset($rangeFacetStats[$current])) {
+                    $stats = $rangeFacetStats[$current];
+                    $from = $stats['min'] ?? '';
+                    $to = $stats['max'] ?? '';
                 }
                 $result[$current] = [$from, $to];
             }

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -174,6 +174,13 @@ class Params
     protected $checkboxFacets = [];
 
     /**
+     * Range facet configuration
+     *
+     * @var array
+     */
+    protected $rangeFacets = [];
+
+    /**
      * Whether to fetch result counts for checkbox facets
      *
      * @var bool
@@ -1077,6 +1084,18 @@ class Params
     }
 
     /**
+     * Add a range facet which stats will be queried in the search.
+     *
+     * @param string $facet Facet name
+     *
+     * @return void
+     */
+    public function addRangeFacet($facet)
+    {
+        $this->rangeFacets[] = $facet;
+    }
+
+    /**
      * Enable or disable fetching of checkbox facet counts
      *
      * @param bool $enable Whether to enable counts
@@ -1358,6 +1377,16 @@ class Params
     protected function getRawCheckboxFacets(): array
     {
         return $this->checkboxFacets;
+    }
+
+    /**
+     * Get the range facets that the minimal and maximal value shall be queried of.
+     *
+     * @return array
+     */
+    public function getRangeFacets()
+    {
+        return $this->rangeFacets;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -92,6 +92,13 @@ abstract class Results
     protected $results = null;
 
     /**
+     * Array of range facet stats.
+     *
+     * @var array
+     */
+    protected array $rangeFacetStats = [];
+
+    /**
      * Any errors reported by the search backend
      *
      * @var array
@@ -437,6 +444,16 @@ abstract class Results
             $this->performAndProcessSearch();
         }
         return $this->results;
+    }
+
+    /**
+     * Get range facet stats.
+     *
+     * @return array
+     */
+    public function getRangeFacetStats()
+    {
+        return $this->rangeFacetStats;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -624,6 +624,11 @@ class Params extends \VuFind\Search\Base\Params
             $backendParams->set('facet', 'true');
         }
 
+        foreach ($this->getRangeFacets() as $rangeFacet) {
+            $backendParams->add('stats', 'true');
+            $backendParams->add('stats.field', $rangeFacet);
+        }
+
         return $backendParams;
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -243,6 +243,7 @@ class Results extends \VuFind\Search\Base\Results
         $this->filteredFacetCounts = $collection->getFilteredFacetCounts();
         $this->responseQueryFacets = $collection->getQueryFacets();
         $this->responsePivotFacets = $collection->getPivotFacets();
+        $this->rangeFacetStats = $collection->getRangeFacetStats();
         $this->resultTotal = $collection->getTotal();
         $this->maxScore = $collection->getMaxScore();
 

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Response/Json/RecordCollection.php
@@ -227,6 +227,32 @@ class RecordCollection extends AbstractRecordCollection
     }
 
     /**
+     * Get range facet stats.
+     *
+     * Returns an associative array with the facet name as key. The
+     * value is an associative array of the minimal and maximal value
+     * of the facet.
+     *
+     * @return array
+     */
+    public function getRangeFacetStats()
+    {
+        $result = [];
+        foreach (
+            $this->response['stats']['stats_fields'] ?? [] as $field => $stats
+        ) {
+            $result[$field] = [];
+            if (isset($stats['min'])) {
+                $result[$field]['min'] = $stats['min'];
+            }
+            if (isset($stats['max'])) {
+                $result[$field]['max'] = $stats['max'];
+            }
+        }
+        return $result;
+    }
+
+    /**
      * Get grouped results.
      *
      * @return array


### PR DESCRIPTION
This PR adds the option to get the maximum and minimum range facet values from the index by using the Solr stats component.