### PR TITLE
Add missing data-title attribute facet-group in a lightbox

### DIFF
--- a/themes/bootstrap5/templates/search/facet-list-content.phtml
+++ b/themes/bootstrap5/templates/search/facet-list-content.phtml
@@ -17,7 +17,8 @@
     $nextHrefParams['facetpage'] = $this->page + 1;
     $nextParams['href'] = $urlBase . '&' . http_build_query($nextHrefParams);
 ?>
-<ul class="full-facet-list facet__list facet-group" id="facet-list-<?=$this->escapeHtmlAttr($key) ?>">
+<?php // Data-title attribute is for analytics use.  Do not remove. ?>
+<ul class="full-facet-list facet__list facet-group" id="facet-list-<?=$this->escapeHtmlAttr($key) ?>" data-title="<?=$this->escapeHtmlAttr($this->facetLabel) ?>">
   <?php if ($this->page > 1 && !$this->inLightbox): ?>
     <a<?=$this->htmlAttributes($prevParams)?>><?=$this->transEsc('prev_ellipsis') ?></a>
   <?php endif; ?>


### PR DESCRIPTION
In #2686 we added the data-title attribute to `facet-group` elements, for analytics use.  This fixes a gap with that attribute missed when facets appear in a lightbox popup.