### PR TITLE
Fix identifier link lookup for multiple items.

### DIFF
--- a/themes/bootstrap5/js/identifierLinks.js
+++ b/themes/bootstrap5/js/identifierLinks.js
@@ -28,14 +28,13 @@ VuFind.register('identifierLinks', function identifierLinks() {
     queryParams.set("method", "identifierLinksLookup");
     var url = VuFind.path + '/AJAX/JSON?' + queryParams.toString();
     fetch(url, { method: "POST", body: JSON.stringify(postBody) })
-      .then(function embedIdentifierLinksDone(rawResponse) {
-        elements.forEach(function populateIdentifierLinks(identifierEl) {
+      .then((rawResponse) => rawResponse.json())
+      .then((response) => {
+        elements.forEach((identifierEl) => {
           var currentInstance = identifierEl.dataset.instance;
-          rawResponse.json().then(response => {
-            if ("undefined" !== typeof response.data[currentInstance]) {
-              VuFind.setInnerHtml(identifierEl, response.data[currentInstance]);
-            }
-          });
+          if ("undefined" !== typeof response.data[currentInstance]) {
+            VuFind.setInnerHtml(identifierEl, response.data[currentInstance]);
+          }
         });
       });
   }


### PR DESCRIPTION
The code was trying to consume the response multiple times when the lookup was done for multiple items. This caused an error since the response can only be consumed once.