### PR TITLE
EPF: Add test for missing default view setting.

### DIFF
--- a/module/VuFind/src/VuFind/Search/EPF/Options.php
+++ b/module/VuFind/src/VuFind/Search/EPF/Options.php
@@ -88,9 +88,9 @@ class Options extends \VuFind\Search\Base\Options
     }
 
     /**
-     * Return the view associated with this configuration
+     * Return the view associated with this configuration (or null if none set)
      *
-     * @return string
+     * @return ?string
      */
     public function getEpfView()
     {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EPF/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/EPF/OptionsTest.php
@@ -69,6 +69,13 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
                 ],
                 'full',
             ],
+            [
+                [
+                    'General' => [
+                    ],
+                ],
+                null,
+            ],
         ];
     }
 


### PR DESCRIPTION
While reviewing #4353, I wondered what would happen if the EPF default_view setting was omitted. It turns out that this causes getEpfView to return null, which seems to violate the documented type.

In the interest of making the smallest possible change, I have added a test and adjusted the type to `?string` to reflect the current behavior. However, I am not sure if this is what is intended; it's possible that we need to change the type back to `string` and have a different default value returned.

@maccabeelevine, can you comment? I unfortunately don't have time to dig deeper into this since I'm flying to a conference in a couple of hours, but I wanted to create a PR to get the conversation started before I forgot about it!