### PR TITLE
Fix remaining select fields that had the form-control class.

### DIFF
--- a/themes/bootstrap5/templates/Auth/MultiILS/loginfields.phtml
+++ b/themes/bootstrap5/templates/Auth/MultiILS/loginfields.phtml
@@ -7,7 +7,7 @@
       $currentTarget = $this->auth()->getManager()->getDefaultLoginTarget();
     }
   ?>
-  <select id="login_<?=$this->escapeHtmlAttr($topClass)?>_target" name="target" class="form-control">
+  <select id="login_<?=$this->escapeHtmlAttr($topClass)?>_target" name="target" class="form-select">
     <?php foreach ($loginTargets as $target):?>
       <option value="<?=$this->escapeHtmlAttr($target)?>"<?=($target == $currentTarget ? ' selected="selected"' : '')?>><?=$this->transEsc("source_$target", null, $target)?></option>
     <?php endforeach ?>

--- a/themes/bootstrap5/templates/blender/advanced.phtml
+++ b/themes/bootstrap5/templates/blender/advanced.phtml
@@ -16,7 +16,7 @@
       <?php endif; ?>
       <div class="adv-search">
         <input id="search_lookfor0_<?=$search ?>" name="lookfor0[]" class="adv-term-input form-control" type="text" value="" aria-label="<?=$this->transEscAttr('search_terms')?>">
-        <select id="search_type0_<?=$search ?>" name="type0[]" class="adv-term-type form-control" aria-label="<?=$this->transEscAttr('Search type')?>">
+        <select id="search_type0_<?=$search ?>" name="type0[]" class="adv-term-type form-select" aria-label="<?=$this->transEscAttr('Search type')?>">
           <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
             <option value="<?=$this->escapeHtml($searchVal)?>"><?=$this->transEsc($searchDesc)?></option>
           <?php endforeach; ?>

--- a/themes/bootstrap5/templates/eds/advanced.phtml
+++ b/themes/bootstrap5/templates/eds/advanced.phtml
@@ -17,14 +17,14 @@
       <?php endif; ?>
       <div class="adv-search">
         <?php if ($search === 0): ?><input type="hidden" value="AND" class="first-op"><?php endif; ?>
-        <select id="search_op0_<?=$search ?>" name="op0[]" class="adv-term-op form-control">
+        <select id="search_op0_<?=$search ?>" name="op0[]" class="adv-term-op form-select">
           <option value="AND"><?=$this->transEsc('AND')?></option>
           <option value="OR"><?=$this->transEsc('OR')?></option>
           <option value="NOT"><?=$this->transEsc('NOT')?></option>
         </select>
         <input id="search_lookfor0_<?=$search ?>" name="lookfor0[]" class="adv-term-input form-control" type="text" value="" aria-label="<?=$this->transEscAttr('search_terms')?>">
         <span class="help-block"><?=$this->transEsc('in')?></span>
-        <select id="search_type0_<?=$search ?>" name="type0[]" class="adv-term-type form-control" aria-label="<?=$this->transEscAttr('Search type')?>">
+        <select id="search_type0_<?=$search ?>" name="type0[]" class="adv-term-type form-select" aria-label="<?=$this->transEscAttr('Search type')?>">
           <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
             <option value="<?=$this->escapeHtml($searchVal)?>"><?=$this->transEsc($searchDesc)?></option>
           <?php endforeach; ?>

--- a/themes/bootstrap5/templates/primo/advanced.phtml
+++ b/themes/bootstrap5/templates/primo/advanced.phtml
@@ -54,12 +54,12 @@
           <?php for ($j = 0; $j < $numRows; $j++): ?>
             <?php $currRow = $currentGroup[$j] ?? false; ?>
             <div class="search">
-              <select id="search_type<?=$i?>_<?=$j?>" name="type<?=$i?>[]" class="form-control adv-term-type">
+              <select id="search_type<?=$i?>_<?=$j?>" name="type<?=$i?>[]" class="form-select adv-term-type">
                 <?php foreach ($this->options->getAdvancedHandlers() as $searchVal => $searchDesc): ?>
                   <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getHandler() == $searchVal) ? ' selected="selected"' : ''?>><?=$this->transEsc($searchDesc)?></option>
                 <?php endforeach; ?>
               </select>
-              <select name="op<?=$i?>[]" id="searchForm_op<?=$i?>_<?=$j?>" class="form-control adv-term-type">
+              <select name="op<?=$i?>[]" id="searchForm_op<?=$i?>_<?=$j?>" class="form-select adv-term-type">
                 <?php foreach ($this->options->getAdvancedOperators() as $searchVal => $searchDesc): ?>
                   <option value="<?=$this->escapeHtmlAttr($searchVal)?>"<?=($currRow && $currRow->getOperator() == $searchVal) ? ' selected="selected"' : ''?>><?=$this->transEsc($searchDesc)?></option>
                 <?php endforeach; ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -94,7 +94,7 @@
             <noscript> (<?=$this->transEsc('Please enable JavaScript.')?>)</noscript>
           <?php endif; ?>
         </label>
-        <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-control">
+        <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-select">
           <?php if ($selected === false): ?>
           <option value="" selected="selected">
             <?=$this->transEsc('select_pickup_location')?>

--- a/themes/bootstrap5/templates/search/advanced/eds.phtml
+++ b/themes/bootstrap5/templates/search/advanced/eds.phtml
@@ -12,7 +12,7 @@
     <?php endforeach; ?>
 
     <label for="searchModes"><?=$this->transEsc('Search Mode')?></label>
-    <select id="searchMode_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" class="form-control">
+    <select id="searchMode_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" class="form-select">
       <?php foreach ($this->searchModes as $field => $searchMode):
         $value = $searchMode['Value'] ?>
         <option <?=(isset($searchMode['selected']) && $searchMode['selected']) ? 'selected="selected"' : ''?> value="SEARCHMODE:<?=$this->escapeHtmlAttr($value)?>">
@@ -30,7 +30,7 @@
       <?php switch($facet['Type']) {
           case 'multiselectvalue': ?>
             <label for="limit_<?=$this->escapeHtmlAttr(str_replace(' ', '+', $field))?>"><?=$this->transEsc($facet['Label'])?></label><br>
-            <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-control">
+            <select id="limit_<?=$this->escapeHtmlAttr($field)?>" name="filter[]" multiple="multiple" size="10" class="form-select">
               <?php
               // Sort the current facet list alphabetically; we'll use this data
               // along with the foreach below to display facet options in the


### PR DESCRIPTION
These were missed in previous Bootstrap 5 cleanup.