### PR TITLE
[VUFIND-1772] Fix accordion view in Bootstrap 5 themes.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1320,6 +1320,7 @@ ${git_status}
         <include pattern="**/*.phtml" />
         <exclude name="header.phtml" />
         <exclude name="RecordTab/similaritemscarousel.phtml" />
+        <exclude name="record/ajaxview-accordion.phtml" />
       </fileset>
       <filterchain>
         <replaceregexp>
@@ -1348,6 +1349,7 @@ ${git_status}
           <fileset dir="${templatesdir}">
             <exclude name="header.phtml" />
             <exclude name="RecordTab/similaritemscarousel.phtml" />
+            <exclude name="record/ajaxview-accordion.phtml" />
           </fileset>
         </delete>
       </then>
@@ -1384,6 +1386,7 @@ ${git_status}
         <type type="file" />
         <exclude name="header.phtml" />
         <exclude name="RecordTab/similaritemscarousel.phtml" />
+        <exclude name="record/ajaxview-accordion.phtml" />
         <different targetdir="${check_dir_compare}" ignoreFileTimes="true" />
       </fileset>
     </foreach>

--- a/themes/bootstrap5/templates/record/ajaxview-accordion.phtml
+++ b/themes/bootstrap5/templates/record/ajaxview-accordion.phtml
@@ -4,20 +4,21 @@
 <?php
   $this->defaultTab = strtolower($this->defaultTab);
   $idSuffixEsc = $this->escapeHtmlAttr(md5($this->driver->getUniqueId() . '|' . $this->driver->getSourceIdentifier()));
+  $parentIdEsc = 'accordion_' . $idSuffixEsc;
 ?>
 
-<div class="list-tabs panel-group" id="accordion_<?=$idSuffixEsc?>" role="tablist">
+<div class="list-tabs panel-group" id="<?=$parentIdEsc?>" role="tablist">
   <?php $coreMetadata = $this->record($this->driver)->getCoreMetadata(); ?>
   <?php if (!empty($coreMetadata)): ?>
     <div class="panel panel-default">
-      <div id="information_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-parent="#accordion_<?=$idSuffixEsc?>" data-bs-target="#information_<?=$idSuffixEsc?>-content" role="tab">
+      <div id="information_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#information_<?=$idSuffixEsc?>-content" role="tab">
         <h4 class="panel-title">
           <a class="accordion-toggle">
             <?=$this->translate('ajaxview_label_information') ?>
           </a>
         </h4>
       </div>
-      <div id="information_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'information'): ?> in<?php endif; ?>">
+      <div id="information_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'information'): ?> in<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
         <div class="list-tab-content record panel-body">
           <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>">
           <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource">
@@ -30,14 +31,14 @@
   <?php $toolbar = $this->record($this->driver)->getToolbar(); ?>
   <?php if (!empty($toolbar)): ?>
     <div class="panel panel-default">
-      <div id="tools_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-parent="#accordion_<?=$idSuffixEsc?>" data-bs-target="#tools_<?=$idSuffixEsc?>-content" role="tab">
+      <div id="tools_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#tools_<?=$idSuffixEsc?>-content" role="tab">
         <h4 class="panel-title">
           <a class="accordion-toggle">
             <?=$this->translate('ajaxview_label_tools') ?>
           </a>
         </h4>
       </div>
-      <div id="tools_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'tools'): ?> in<?php endif; ?>">
+      <div id="tools_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'tools'): ?> in<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
         <div class="list-tab-content panel-body">
           <?=$toolbar ?>
         </div>
@@ -48,14 +49,14 @@
   <?php $relatedList = $this->related()->getList($this->driver); ?>
   <?php if ($relatedList != null): ?>
     <div class="panel panel-default">
-      <div id="related_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-parent="#accordion_<?=$idSuffixEsc?>" data-bs-target="#related_<?=$idSuffixEsc?>-content" role="tab">
+      <div id="related_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#related_<?=$idSuffixEsc?>-content" role="tab">
         <h4 class="panel-title">
           <a class="accordion-toggle">
             <?=$this->transEsc('Related Items')?>
           </a>
         </h4>
       </div>
-      <div id="related_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'related'): ?> in<?php endif; ?>">
+      <div id="related_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'related'): ?> in<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
         <div class="list-tab-content panel-body">
           <?php foreach ($relatedList as $current): ?>
             <?=$this->related()->render($current)?>
@@ -80,12 +81,12 @@
         }
       ?>
       <div class="panel panel-default <?=implode(' ', $tab_classes) ?>">
-        <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading" data-bs-toggle="collapse" data-parent="#accordion_<?=$idSuffixEsc?>" data-bs-target="#<?=strtolower($tab)?>_<?=$idSuffixEsc?>-content"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>>
+        <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading" data-bs-toggle="collapse" data-bs-target="#<?=strtolower($tab)?>_<?=$idSuffixEsc?>-content"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?>>
           <h4 class="panel-title">
             <a class="accordion-toggle" data-href="<?=$this->escapeHtmlAttr($this->recordLinker()->getTabUrl($this->driver, $tab))?>#tabnav"><?=$this->transEsc($desc) ?></a>
           </h4>
         </div>
-        <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>-content" class="list-tab-content panel-collapse collapse<?php if ($this->defaultTab === strtolower($tab)): ?> in<?php endif; ?>"></div>
+        <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>-content" class="list-tab-content panel-collapse collapse<?php if ($this->defaultTab === strtolower($tab)): ?> in<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>"></div>
       </div>
     <?php endforeach; ?>
   <?php endif; ?>


### PR DESCRIPTION
We use panel styles for the accordion. That doesn’t affect the functionality, which is just a mode of collapse, so that's unchanged here. We can revisit any restyling later as necessary. The problem was really just that the data-bs-parent attribute was missing from the correct elements (and the useless data-parent was there).

TODO:
- [x] Mark [VUFIND-1772](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1772) done after merge.