### PR TITLE
Fix bug: multi-select facets broke course reserves sort.

### DIFF
--- a/themes/bootstrap5/js/facets.js
+++ b/themes/bootstrap5/js/facets.js
@@ -1,7 +1,7 @@
 /*global VuFind, multiFacetsSelection, unwrapJQuery */
 
 /**
- * Get the globally-configured multi-facets selection string (or default to 'false').
+ * Get the globally-configured multi-facets selection setting (or default to 'false').
  *
  * @returns string
  */
@@ -18,6 +18,11 @@ const isMultiFacetsSelectionEnabled = () => {
   return getMultiFacetsSelectionSetting() !== 'false';
 };
 
+/**
+ * Get the default checkbox selection state to apply if overriding user state is not found.
+ *
+ * @returns boolean
+ */
 const getMultiFacetsSelectionPageLoadValue = () => {
   const setting = getMultiFacetsSelectionSetting();
   return setting === 'always' || setting === 'checked';

--- a/themes/bootstrap5/js/facets.js
+++ b/themes/bootstrap5/js/facets.js
@@ -1,20 +1,21 @@
 /*global VuFind, multiFacetsSelection, unwrapJQuery */
 
+const getMultiFacetsSelectionSetting = () => {
+  return typeof multiFacetsSelection === 'undefined' ? 'false' : multiFacetsSelection;
+};
+
 /**
  * Returns if multiFacetsSelectionEnabled is set. Fallback if the value is missing for false
  *
  * @type {Function} Function to check for multiFacetsSelectionEnabled
  */
 const isMultiFacetsSelectionEnabled = () => {
-  return multiFacetsSelection !== 'false';
+  return getMultiFacetsSelectionSetting() !== 'false';
 };
 
 const getMultiFacetsSelectionPageLoadValue = () => {
-  return multiFacetsSelection === 'always' || multiFacetsSelection === 'checked';
-};
-
-const getMultiFacetsSelectionSetting = () => {
-  return multiFacetsSelection;
+  const setting = getMultiFacetsSelectionSetting();
+  return setting === 'always' || setting === 'checked';
 };
 
 /* --- Facet List --- */

--- a/themes/bootstrap5/js/facets.js
+++ b/themes/bootstrap5/js/facets.js
@@ -1,13 +1,18 @@
 /*global VuFind, multiFacetsSelection, unwrapJQuery */
 
+/**
+ * Get the globally-configured multi-facets selection string (or default to 'false').
+ *
+ * @returns string
+ */
 const getMultiFacetsSelectionSetting = () => {
   return typeof multiFacetsSelection === 'undefined' ? 'false' : multiFacetsSelection;
 };
 
 /**
- * Returns if multiFacetsSelectionEnabled is set. Fallback if the value is missing for false
+ * Returns whether multi-facets selection is enabled.
  *
- * @type {Function} Function to check for multiFacetsSelectionEnabled
+ * @returns boolean
  */
 const isMultiFacetsSelectionEnabled = () => {
   return getMultiFacetsSelectionSetting() !== 'false';

--- a/themes/bootstrap5/templates/Recommend/SideFacets.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets.phtml
@@ -35,7 +35,7 @@
 ?>
 <?php if ($results->getResultTotal() > 0 || $hasVisibleCheckboxes): ?>
   <h2><?=$this->transEsc($this->slot('side-facet-caption')->get('Refine Results')) ?></h2>
-  <?php if ($this->multiFacetsSelection !== 'false' && $this->layout()->sideFacetsInstanceCounter === 1): ?>
+  <?php if (($this->multiFacetsSelection ?? 'false') !== 'false' && $this->layout()->sideFacetsInstanceCounter === 1): ?>
     <?= $this->render('Recommend/SideFacets/multiFacetsSelection.phtml'); ?>
   <?php endif; ?>
   <span class="visually-hidden"><?=$this->transEsc('page_reload_on_select_hint') ?></span>


### PR DESCRIPTION
I discovered today that #4305 broke the sort functionality on course reserves. An undefined variable caused a fatal Javascript error, which stopped execution and prevented the sort control from operating. This PR just adds minimal logic to prevent the error; I'm not sure if it's worth the additional effort of allowing multi-facet selection to be enabled in this context. (At present, if I switch the setting to a non-false value, the multi-select control appears but is non-functional).

This is also a sign that we need to add some integration testing for course reserves search, since if we had that, we would have caught this regression; unfortunately, I'm presently too short on time to build a new test.

@rominail / @meganschanz, any thoughts/preferences?