### PR TITLE
Fix incorrect log_table example definition.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1760,8 +1760,8 @@ skip_numeric = true
 ; If database is uncommented, messages will be logged to the named MySQL table.
 ; The table can be created with this SQL statement:
 ; CREATE TABLE log_table ( id INT NOT NULL AUTO_INCREMENT,
-;     logtime TIMESTAMP NOT NULL, ident CHAR(16) NOT NULL,
-;     priority INT NOT NULL, message TEXT, PRIMARY KEY (id) );
+;     logtime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, ident CHAR(16) NOT NULL DEFAULT '',
+;     priority INT NOT NULL DEFAULT '0', message TEXT, PRIMARY KEY (id) );
 ;
 ; If file is uncommented, messages will be logged to the named file.  Be sure
 ; that Apache has permission to write to the specified file!


### PR DESCRIPTION
While testing database logging, I discovered that the example `log_table` definition in `config.ini` was problematic due to missing default values. This corrects the example.