### PR TITLE
Fix/simplify database upgrade workflow.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -453,14 +453,10 @@ class UpgradeController extends AbstractBase
      */
     public function showsqlAction()
     {
-        $recheck = $this->params()->fromPost('recheck');
-        if ($recheck) {
-            unset($this->session->sql);
-            return $this->redirect()->toRoute('upgrade-fixdatabase');
-        }
         $continue = $this->params()->fromPost('continue', 'nope');
-        if ($continue == 'Next') {
+        if (str_contains($continue, 'Next')) {
             unset($this->session->sql);
+            $this->cookie->databaseOkay = true;
             return $this->redirect()->toRoute('upgrade-home');
         }
 

--- a/themes/bootstrap5/templates/upgrade/showsql.phtml
+++ b/themes/bootstrap5/templates/upgrade/showsql.phtml
@@ -19,8 +19,7 @@
 
 <textarea class="pre" rows="20"><?=trim($this->sql) ?></textarea>
 
-<p>Please re-check the database after applying the above changes above.</p>
+<p>Please apply these changes to your database before continuing to the next step.</p>
 <form method="post" action="<?=$this->url('upgrade-showsql')?>">
-  <input class="btn btn-primary" type="submit" name="recheck" value="Re-check">
-  <input class="btn btn-default" type="submit" name="continue" value="Skip to Next Step">
+  <input class="btn btn-default" type="submit" name="continue" value="Continue to Next Step">
 </form>


### PR DESCRIPTION
I noticed that our simplification of the database upgrade logic caused some problems when using the "show SQL" feature of the database upgrade. There was a re-check button that no longer served any purpose, and the "skip to next step" button didn't work. This PR fixes the workflow and related messaging.