### PR TITLE
Fix database upgrade workflow.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/UpgradeController.php
+++ b/module/VuFind/src/VuFind/Controller/UpgradeController.php
@@ -455,8 +455,10 @@ class UpgradeController extends AbstractBase
     {
         $continue = $this->params()->fromPost('continue', 'nope');
         if (str_contains($continue, 'Next')) {
-            unset($this->session->sql);
-            $this->cookie->databaseOkay = true;
+            // Clear the SQL out but leave it set; this will prevent the user from
+            // getting caught in a loop -- we won't show them the migrations another
+            // time this session.
+            $this->session->sql = '';
             return $this->redirect()->toRoute('upgrade-home');
         }
 


### PR DESCRIPTION
My fix in #4382 wasn't quite right -- when you skipped entering credentials and manually applied structural updates, the extra checks like duplicate tag fixing, etc., would get skipped as well (because the databaseOkay flag would bypass all the rest of the fixdatabase action). This PR changes the logic slightly to ensure that no steps are skipped.