### PR TITLE
Improve default BrowZine sort configuration.

### DIFF
--- a/module/VuFind/src/VuFind/Search/BrowZine/Options.php
+++ b/module/VuFind/src/VuFind/Search/BrowZine/Options.php
@@ -43,6 +43,13 @@ class Options extends \VuFind\Search\Base\Options
     use \VuFind\Search\Options\ViewOptionsTrait;
 
     /**
+     * Available sort options (BrowZine only supports relevance sorting)
+     *
+     * @var array
+     */
+    protected $sortOptions = ['relevance' => 'Relevance'];
+
+    /**
      * Constructor
      *
      * @param \VuFind\Config\PluginManager $configLoader Config loader

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/BrowZine/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/BrowZine/OptionsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * BrowZine Options Test
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Search\Blender;
+
+use VuFind\Search\BrowZine\Options;
+use VuFindTest\Feature\ConfigPluginManagerTrait;
+
+/**
+ * BrowZine Options Test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class OptionsTest extends \PHPUnit\Framework\TestCase
+{
+    use ConfigPluginManagerTrait;
+
+    /**
+     * Test that the Options object returns correct data .
+     *
+     * @return void
+     */
+    public function testOptions(): void
+    {
+        $configMgr = $this->getMockConfigPluginManager(
+            [
+                'BrowZine' => [],
+            ]
+        );
+        $options = new Options($configMgr);
+        $this->assertEquals('browzine-search', $options->getSearchAction());
+        $this->assertEquals(['relevance' => 'Relevance'], $options->getSortOptions());
+        $this->assertFalse($options->getFacetListAction());
+        $this->assertFalse($options->getAdvancedSearchAction());
+        $this->assertFalse($options->getAdvancedSearchAction());
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/BrowZine/OptionsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/BrowZine/OptionsTest.php
@@ -27,7 +27,7 @@
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
 
-namespace VuFindTest\Search\Blender;
+namespace VuFindTest\Search\BrowZine;
 
 use VuFind\Search\BrowZine\Options;
 use VuFindTest\Feature\ConfigPluginManagerTrait;


### PR DESCRIPTION
BrowZine only supports relevance sorting, but since this was not previously defined in the Options class, the sort value would display as "other" instead of "relevance" in the UI. This PR sets a more appropriate default to provide more correct information to the user.