### PR TITLE
Index marc_error field to make error-detection possible.

### DIFF
--- a/solr/vufind/biblio/conf/schema.xml
+++ b/solr/vufind/biblio/conf/schema.xml
@@ -119,7 +119,7 @@
    <!-- Core Fields  -->
    <field name="id" type="string" indexed="true" stored="true"/>
    <field name="fullrecord" type="string" indexed="false" stored="true"/>
-   <field name="marc_error" type="string" indexed="false" stored="true" multiValued="true"/>
+   <field name="marc_error" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="allfields" type="text" indexed="true" stored="false" multiValued="true"/>
    <field name="allfields_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
    <field name="fulltext" type="text" indexed="true" stored="false"/>


### PR DESCRIPTION
The SolrMarc tool populates the marc_error field in the Solr index when something goes wrong. However, this field is not currently indexed, which makes it impossible to quickly identify problem records. This PR changes the field to be indexed so that a search of `marc_error:*` can be performed to review possible issues in the index.

TODO
- [x] Update schema changelog when merging