### PR TITLE
Fix bug: passing non-numeric edit parameter caused fatal error.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -108,7 +108,7 @@ class AbstractSearch extends AbstractBase
         // Handle request to edit existing saved search:
         $view->saved = false;
         $searchId = $this->params()->fromQuery('edit', false);
-        if ($searchId !== false) {
+        if ($searchId !== false && intval($searchId) > 0) {
             $view->saved = $this->restoreAdvancedSearch($searchId);
         }
 


### PR DESCRIPTION
This adds some validation to ensure that unexpected values passed to the advanced search edit parameter do not cause fatal errors.