### PR TITLE
Add option to sort hierarchical facets by field value.

### DIFF
--- a/config/vufind/Blender.ini
+++ b/config/vufind/Blender.ini
@@ -178,10 +178,12 @@ dateRange[] = publish_date
 ; Sort options for hierarchical facets:
 ; How hierarchical facets are sorted. Default is result count, but alternative ways
 ; can be specified:
-; top = Sort the top level list alphabetically, others by result count (useful e.g.
-;       for a large number of building facets where top level is organization and
-;       second level the library branch)
-; all = Sort all levels alphabetically
+; top       = Sort the top level list alphabetically, others by result count (useful e.g.
+;             for a large number of building facets where top level is organization and
+;             second level the library branch)
+; all       = Sort all levels alphabetically
+; top-value = Like top, but sorts by field value (case-sensitive ascii sort) instead of display text
+; all-value = Like all, but sorts by field value (case-sensitive ascii sort) instead of display text
 hierarchicalFacetSortOptions[building] = top
 ; How hierarchical facet values are displayed in the records:
 ; single = Display only the deepest level (default)

--- a/config/vufind/facets.ini
+++ b/config/vufind/facets.ini
@@ -77,11 +77,13 @@ dateRange[] = publishDate
 ; using field names (see example below).
 ;
 ; Available options:
-; top   = Sort the top level list alphabetically, others by result count (useful e.g.
-;         for a large number of building facets where top level is organization and
-;         second level the library branch)
-; all   = Sort all levels alphabetically
-; count = Sort all levels by count
+; top       = Sort the top level list alphabetically, others by result count (useful e.g.
+;             for a large number of building facets where top level is organization and
+;             second level the library branch)
+; all       = Sort all levels alphabetically
+; count     = Sort all levels by count
+; top-value = Like top, but sorts by field value (case-sensitive ascii sort) instead of display text
+; all-value = Like all, but sorts by field value (case-sensitive ascii sort) instead of display text
 ;
 ; Note: this section may be overridden for HomePage and Advanced search facets (see
 ; hierarchicalFacetSortOptions in HomePage_Settings and Advanced_Settings below).
@@ -181,6 +183,7 @@ top_rows = 2
 ; Please note: This sorts natively in the Solr index using untranslated values,
 ; so if you are using facet translation, your values may not always display in
 ; the expected order.
+; Use hierarchicalFacetSortOptions instead for hierarchical facets.
 ;sorted_by_index[] = building;
 ;sorted_by_index[] = institution;
 

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetHelper.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2014.
+ * Copyright (C) The National Library of Finland 2014-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -84,6 +84,20 @@ class HierarchicalFacetHelper implements
     protected const SORT_ALL = 2;
 
     /**
+     * Internal constant for sorting top level alphabetically by field value and the rest by count
+     *
+     * @var int
+     */
+    protected const SORT_TOP_VALUE = 3;
+
+    /**
+     * Internal constant for sorting all levels alphabetically by field value
+     *
+     * @var int
+     */
+    protected const SORT_ALL_VALUE = 4;
+
+    /**
      * View renderer
      *
      * @var RendererInterface
@@ -123,6 +137,8 @@ class HierarchicalFacetHelper implements
         $sort = match ($order) {
             true, 'top' => static::SORT_TOP,
             false, 'all' => static::SORT_ALL,
+            'top-value' => static::SORT_TOP_VALUE,
+            'all-value' => static::SORT_ALL_VALUE,
             default => static::SORT_COUNT,
         };
 
@@ -137,10 +153,12 @@ class HierarchicalFacetHelper implements
         // Avoid problems having the reference set further below
         unset($facetItem);
         $sortFunc = function ($a, $b) use ($sort) {
-            if (
-                $a['level'] == $b['level']
-                && ($sort === static::SORT_ALL || ($a['level'] == 0 && $sort === static::SORT_TOP))
-            ) {
+            // Different level?
+            if ($a['level'] != $b['level']) {
+                return $a['level'] <=> $b['level'];
+            }
+            // Sort by display text:
+            if (($sort === static::SORT_ALL || ($a['level'] == 0 && $sort === static::SORT_TOP))) {
                 $aText = $a['displayText'] == $a['value']
                     ? $this->formatDisplayText($a['displayText'])
                     : $a['displayText'];
@@ -149,9 +167,11 @@ class HierarchicalFacetHelper implements
                     : $b['displayText'];
                 return $this->getSorter()->compare($aText, $bText);
             }
-            return $a['level'] == $b['level']
-                ? $b['count'] - $a['count']
-                : $a['level'] - $b['level'];
+            // Sort by display index value:
+            if (($sort === static::SORT_ALL_VALUE || ($a['level'] == 0 && $sort === static::SORT_TOP_VALUE))) {
+                return $a['value'] <=> $b['value'];
+            }
+            return $b['count'] <=> $a['count'];
         };
         usort($facetList, $sortFunc);
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HierarchicalFacetHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/HierarchicalFacetHelperTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2014-2020.
+ * Copyright (C) The National Library of Finland 2014-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -248,6 +248,42 @@ class HierarchicalFacetHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('1/Book/Section/', $facetList[4]['value']);
         $this->assertEquals('1/Audio/Music/', $facetList[5]['value']);
         $this->assertEquals('1/Audio/Spoken/', $facetList[6]['value']);
+    }
+
+    /**
+     * Tests for sortFacetList (top level only by field value)
+     *
+     * @return void
+     */
+    public function testSortFacetListTopLevelByFieldValue(): void
+    {
+        $facetList = $this->facetList;
+        $this->helper->sortFacetList($facetList, 'top-value');
+        $this->assertEquals('0/AV/', $facetList[0]['value']);
+        $this->assertEquals('0/Audio/', $facetList[1]['value']);
+        $this->assertEquals('0/Book/', $facetList[2]['value']);
+        $this->assertEquals('1/Book/BookPart/', $facetList[3]['value']);
+        $this->assertEquals('1/Book/Section/', $facetList[4]['value']);
+        $this->assertEquals('1/Audio/Spoken/', $facetList[5]['value']);
+        $this->assertEquals('1/Audio/Music/', $facetList[6]['value']);
+    }
+
+    /**
+     * Tests for sortFacetList (all levels by field value)
+     *
+     * @return void
+     */
+    public function testSortFacetListAllLevelsByFieldValue(): void
+    {
+        $facetList = $this->facetList;
+        $this->helper->sortFacetList($facetList, 'all-value');
+        $this->assertEquals('0/AV/', $facetList[0]['value']);
+        $this->assertEquals('0/Audio/', $facetList[1]['value']);
+        $this->assertEquals('0/Book/', $facetList[2]['value']);
+        $this->assertEquals('1/Audio/Music/', $facetList[3]['value']);
+        $this->assertEquals('1/Audio/Spoken/', $facetList[4]['value']);
+        $this->assertEquals('1/Book/BookPart/', $facetList[5]['value']);
+        $this->assertEquals('1/Book/Section/', $facetList[6]['value']);
     }
 
     /**


### PR DESCRIPTION
This is similar to the sorted_by_index setting but for hierarchical facets. This makes possible to create a hierarchical facet in custom order by using suitable values for the field during indexing.