### PR TITLE
KohaRest: Fix hold expiration date conversion when placing a hold.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1280,7 +1280,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
             'pickup_library_id' => $pickUpLocation,
             'notes' => $comment,
             'expiration_date' => !empty($holdDetails['requiredByTS'])
-                        ? date('Y-m-d', $holdDetails['requiredByTS'])
+                        ? gmdate('Y-m-d', $holdDetails['requiredByTS'])
                         : null,
         ];
         if ($level == 'copy') {


### PR DESCRIPTION
Timestamp is in UTC, so the conversion should use gmdate like other ILS drivers do.