### PR TITLE
Disable loading new item results with JavaScript (resolves VUFIND-1778)

### DIFF
--- a/themes/bootstrap3/templates/search/newitemresults.phtml
+++ b/themes/bootstrap3/templates/search/newitemresults.phtml
@@ -3,4 +3,5 @@
   $this->slot('head-title')->set($this->translate('New Items'));
   $this->slot('search-heading')->set($this->transEsc('New Items'));
   $this->slot('empty-message')->set($this->transEsc('No new item information is currently available.'));
+  $this->results->getOptions()->setLoadResultsWithJs(false);
   echo $this->render('search/results.phtml');

--- a/themes/bootstrap5/templates/search/newitemresults.phtml
+++ b/themes/bootstrap5/templates/search/newitemresults.phtml
@@ -3,4 +3,5 @@
   $this->slot('head-title')->set($this->translate('New Items'));
   $this->slot('search-heading')->set($this->transEsc('New Items'));
   $this->slot('empty-message')->set($this->transEsc('No new item information is currently available.'));
+  $this->results->getOptions()->setLoadResultsWithJs(false);
   echo $this->render('search/results.phtml');


### PR DESCRIPTION
As discussed in https://openlibraryfoundation.atlassian.net/browse/VUFIND-1778

Problem: 
New Item Results, paging to the next page would lose the focus on new items and show you a massively increased result set, basically offering you to page through the entire Solr Index

Solution: 
As proposed by @demiankatz - I added  `$this->results->getOptions()->setLoadResultsWithJs(false);` to disable loading with JavaScript