### PR TITLE
Add trailing slash to OpenAPI url in Swagger UI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -523,7 +523,7 @@
       </fileset>
       <filterchain>
         <replaceregexp>
-          <regexp pattern="url: &quot;.*&quot;" replace="url: &quot;../api/v1?openapi&quot;" />
+          <regexp pattern="url: &quot;.*&quot;" replace="url: &quot;../api/v1/?openapi&quot;" />
         </replaceregexp>
       </filterchain>
     </reflexive>


### PR DESCRIPTION
It seems that the validator doesn't handle HTTP redirects and reports the API spec as invalid (right bottom corner of the Swagger UI page) if it gets a HTTP 301 response. This would happen for /api/v1?openapi that redirects to /api/v1/?openapi.