### PR TITLE
Fix and tweak export mechanism.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -401,7 +401,7 @@ class CartController extends AbstractBase
                 return $redirect;
             }
         } elseif ($this->formWasSubmitted()) {
-            $url = $export->getBulkUrl($this->getViewRenderer(), $format, $ids);
+            $url = $export->getBulkUrl($format, $ids);
             if ($export->needsRedirect($format)) {
                 return $this->redirect()->toUrl($url);
             }

--- a/module/VuFind/src/VuFind/Export.php
+++ b/module/VuFind/src/VuFind/Export.php
@@ -30,8 +30,7 @@
 namespace VuFind;
 
 use Laminas\View\Renderer\PhpRenderer;
-use VuFind\Config\Config;
-use VuFind\RecordDriver\AbstractBase;
+use VuFind\RecordDriver\AbstractBase as RecordDriver;
 
 use function in_array;
 use function is_callable;
@@ -196,12 +195,12 @@ class Export
     /**
      * Does the specified record support the specified export format?
      *
-     * @param AbstractBase $driver Record driver
+     * @param RecordDriver $driver Record driver
      * @param string       $format Format to check
      *
      * @return bool
      */
-    public function recordSupportsFormat(AbstractBase $driver, string $format): bool
+    public function recordSupportsFormat(RecordDriver $driver, string $format): bool
     {
         // Check if the driver explicitly disallows the format:
         if ($driver->tryMethod('exportDisabled', [$format])) {
@@ -231,11 +230,11 @@ class Export
      * data may be exported (empty if none). Legal values: "BibTeX", "EndNote",
      * "MARC", "MARCXML", "RDF", "RefWorks".
      *
-     * @param AbstractBase $driver Record driver
+     * @param RecordDriver $driver Record driver
      *
      * @return array Strings representing export formats.
      */
-    public function getFormatsForRecord(AbstractBase $driver): array
+    public function getFormatsForRecord(RecordDriver $driver): array
     {
         // Get an array of enabled export formats (from config, or use defaults
         // if nothing in config array).

--- a/module/VuFind/src/VuFind/Export.php
+++ b/module/VuFind/src/VuFind/Export.php
@@ -31,6 +31,7 @@ namespace VuFind;
 
 use Laminas\View\Renderer\PhpRenderer;
 use VuFind\Config\Config;
+use VuFind\RecordDriver\AbstractBase;
 
 use function in_array;
 use function is_callable;
@@ -47,20 +48,6 @@ use function is_callable;
 class Export
 {
     /**
-     * Main VuFind configuration
-     *
-     * @var Config
-     */
-    protected $mainConfig;
-
-    /**
-     * Export-specific configuration
-     *
-     * @var Config
-     */
-    protected $exportConfig;
-
-    /**
      * Property to cache active formats
      * (initialized to empty array , populated later)
      *
@@ -71,32 +58,33 @@ class Export
     /**
      * Constructor
      *
-     * @param Config $mainConfig   Main VuFind configuration
-     * @param Config $exportConfig Export-specific configuration
+     * @param array       $mainConfig   Main VuFind configuration
+     * @param array       $exportConfig Export-specific configuration
+     * @param PhpRenderer $viewRenderer View renderer
      */
-    public function __construct(Config $mainConfig, Config $exportConfig)
-    {
-        $this->mainConfig = $mainConfig;
-        $this->exportConfig = $exportConfig;
+    public function __construct(
+        protected array $mainConfig,
+        protected array $exportConfig,
+        protected PhpRenderer $viewRenderer
+    ) {
     }
 
     /**
      * Get the URL for bulk export.
      *
-     * @param PhpRenderer $view   View object (needed for URL generation)
-     * @param string      $format Export format being used
-     * @param array       $ids    Array of IDs to export (in source|id format)
+     * @param string $format Export format being used
+     * @param array  $ids    Array of IDs to export (in source|id format)
      *
      * @return string
      */
-    public function getBulkUrl($view, $format, $ids)
+    public function getBulkUrl(string $format, array $ids): string
     {
         $params = ['f=' . urlencode($format)];
         foreach ($ids as $id) {
             $params[] = urlencode('i[]') . '=' . urlencode($id);
         }
-        $serverUrlHelper = $view->plugin('serverurl');
-        $urlHelper = $view->plugin('url');
+        $serverUrlHelper = $this->viewRenderer->plugin('serverurl');
+        $urlHelper = $this->viewRenderer->plugin('url');
         $url = $serverUrlHelper($urlHelper('cart-doexport'))
             . '?' . implode('&', $params);
 
@@ -112,18 +100,18 @@ class Export
      *
      * @return string
      */
-    public function getRedirectUrl($format, $callback)
+    public function getRedirectUrl(string $format, string $callback): string
     {
         // Fill in special tokens in template:
-        $template = $this->exportConfig->$format->redirectUrl;
+        $template = $this->exportConfig[$format]['redirectUrl'] ?? '';
         preg_match_all('/\{([^}]+)\}/', $template, $matches);
         foreach ($matches[1] as $current) {
             $parts = explode('|', $current);
             switch ($parts[0]) {
                 case 'config':
                 case 'encodedConfig':
-                    if (isset($this->mainConfig->{$parts[1]}->{$parts[2]})) {
-                        $value = $this->mainConfig->{$parts[1]}->{$parts[2]};
+                    if (null !== ($configValue = $this->mainConfig[$parts[1]][$parts[2]] ?? null)) {
+                        $value = $configValue;
                     } else {
                         $value = $parts[3];
                     }
@@ -151,9 +139,9 @@ class Export
      *
      * @return bool
      */
-    public function needsRedirect($format)
+    public function needsRedirect(string $format): bool
     {
-        return !empty($this->exportConfig->$format->redirectUrl)
+        return !empty($this->exportConfig[$format]['redirectUrl'])
             && 'link' === $this->getBulkExportType($format);
     }
 
@@ -165,22 +153,20 @@ class Export
      *
      * @return string
      */
-    public function processGroup($format, $parts)
+    public function processGroup(string $format, array $parts): string
     {
+        if (!$parts) {
+            return '';
+        }
+
         // If we're in XML mode, we need to do some special processing:
-        if (isset($this->exportConfig->$format->combineXpath)) {
-            $ns = isset($this->exportConfig->$format->combineNamespaces)
-                ? $this->exportConfig->$format->combineNamespaces->toArray()
-                : [];
+        if ($combineXpath = $this->exportConfig[$format]['combineXpath'] ?? null) {
             $ns = array_map(
                 function ($current) {
                     return explode('|', $current, 2);
                 },
-                $ns
+                $this->exportConfig[$format]['combineNamespaces'] ?? []
             );
-            if (empty($parts)) {
-                return '';
-            }
             foreach ($parts as $part) {
                 // Convert text into XML object:
                 $current = simplexml_load_string($part);
@@ -194,9 +180,7 @@ class Export
                     foreach ($ns as $n) {
                         $current->registerXPathNamespace($n[0], $n[1]);
                     }
-                    $matches = $current->xpath(
-                        $this->exportConfig->$format->combineXpath
-                    );
+                    $matches = $current->xpath($combineXpath);
                     foreach ($matches as $match) {
                         SimpleXML::appendElement($retVal, $match);
                     }
@@ -212,35 +196,34 @@ class Export
     /**
      * Does the specified record support the specified export format?
      *
-     * @param \VuFind\RecordDriver\AbstractBase $driver Record driver
-     * @param string                            $format Format to check
+     * @param AbstractBase $driver Record driver
+     * @param string       $format Format to check
      *
      * @return bool
      */
-    public function recordSupportsFormat($driver, $format)
+    public function recordSupportsFormat(AbstractBase $driver, string $format): bool
     {
         // Check if the driver explicitly disallows the format:
         if ($driver->tryMethod('exportDisabled', [$format])) {
             return false;
         }
 
-        // Check the requirements for export in the requested format:
-        if (isset($this->exportConfig->$format)) {
-            if (isset($this->exportConfig->$format->requiredMethods)) {
-                foreach ($this->exportConfig->$format->requiredMethods as $method) {
-                    // If a required method is missing, give up now:
-                    if (!is_callable([$driver, $method])) {
-                        return false;
-                    }
-                }
-            }
-            // If we got this far, we didn't encounter a problem, and the
-            // requested export format is valid, so we can report success!
-            return true;
+        // Check if the format is configured:
+        if (empty($this->exportConfig[$format])) {
+            return false;
         }
 
-        // If we got this far, we couldn't find evidence of support:
-        return false;
+        // Check the requirements for export in the requested format:
+        foreach ($this->exportConfig[$format]['requiredMethods'] ?? [] as $method) {
+            // If a required method is missing, give up now:
+            if (!is_callable([$driver, $method])) {
+                return false;
+            }
+        }
+
+        // If we got this far, we didn't encounter a problem, and the
+        // requested export format is valid, so we can report success!
+        return true;
     }
 
     /**
@@ -248,11 +231,11 @@ class Export
      * data may be exported (empty if none). Legal values: "BibTeX", "EndNote",
      * "MARC", "MARCXML", "RDF", "RefWorks".
      *
-     * @param \VuFind\RecordDriver\AbstractBase $driver Record driver
+     * @param AbstractBase $driver Record driver
      *
      * @return array Strings representing export formats.
      */
-    public function getFormatsForRecord($driver)
+    public function getFormatsForRecord(AbstractBase $driver): array
     {
         // Get an array of enabled export formats (from config, or use defaults
         // if nothing in config array).
@@ -260,7 +243,7 @@ class Export
 
         // Loop through all possible formats:
         $formats = [];
-        foreach (array_keys($this->exportConfig->toArray()) as $format) {
+        foreach (array_keys($this->exportConfig) as $format) {
             if (
                 in_array($format, $active)
                 && $this->recordSupportsFormat($driver, $format)
@@ -281,7 +264,7 @@ class Export
      *
      * @return array
      */
-    public function getFormatsForRecords($drivers)
+    public function getFormatsForRecords(array $drivers): array
     {
         $formats = $this->getActiveFormats('bulk');
         foreach ($drivers as $driver) {
@@ -304,9 +287,9 @@ class Export
      *
      * @return array
      */
-    public function getHeaders($format)
+    public function getHeaders(string $format): array
     {
-        return $this->exportConfig->$format->headers ?? [];
+        return (array)($this->exportConfig[$format]['headers'] ?? []);
     }
 
     /**
@@ -316,9 +299,9 @@ class Export
      *
      * @return string
      */
-    public function getLabelForFormat($format)
+    public function getLabelForFormat(string $format): string
     {
-        return $this->exportConfig->$format->label ?? $format;
+        return $this->exportConfig[$format]['label'] ?? $format;
     }
 
     /**
@@ -328,12 +311,12 @@ class Export
      *
      * @return string
      */
-    public function getBulkExportType($format)
+    public function getBulkExportType(string $format): string
     {
         // if exportType is set on per-format basis in export.ini then use it
         // else check if export type is set in config.ini
-        return $this->exportConfig->$format->bulkExportType
-            ?? $this->mainConfig->BulkExport->defaultType ?? 'link';
+        return $this->exportConfig[$format]['bulkExportType']
+            ?? $this->mainConfig['BulkExport']['defaultType'] ?? 'link';
     }
 
     /**
@@ -343,12 +326,11 @@ class Export
      *
      * @return array
      */
-    public function getActiveFormats($context = 'record')
+    public function getActiveFormats(string $context = 'record'): array
     {
         if (!isset($this->activeFormats[$context])) {
-            $formatSettings = isset($this->mainConfig->Export)
-                ? $this->mainConfig->Export->toArray()
-                : ['RefWorks' => 'record,bulk', 'EndNote' => 'record,bulk'];
+            $formatSettings = $this->mainConfig['Export']
+                ?? ['RefWorks' => 'record,bulk', 'EndNote' => 'record,bulk'];
 
             $active = [];
             foreach ($formatSettings as $format => $allowedContexts) {
@@ -363,16 +345,12 @@ class Export
             // for legacy settings [BulkExport]
             if (
                 $context == 'bulk'
-                && isset($this->mainConfig->BulkExport->enabled)
-                && $this->mainConfig->BulkExport->enabled
-                && isset($this->mainConfig->BulkExport->options)
+                && ($this->mainConfig['BulkExport']['enabled'] ?? false)
+                && $bulkOptions = $this->mainConfig['BulkExport']['options'] ?? null
             ) {
-                $config = explode(':', $this->mainConfig->BulkExport->options);
+                $config = explode(':', $bulkOptions);
                 foreach ($config as $option) {
-                    if (
-                        isset($this->mainConfig->Export->$option)
-                        && $this->mainConfig->Export->$option == true
-                    ) {
+                    if ($this->mainConfig['Export'][$option] ?? false) {
                         $active[] = $option;
                     }
                 }
@@ -389,10 +367,10 @@ class Export
      *
      * @return string
      */
-    public function getPostField($format)
+    public function getPostField(string $format): string
     {
-        return !empty($this->exportConfig->$format->postField)
-            ? $this->exportConfig->$format->postField : 'ImportData';
+        $postField = $this->exportConfig[$format]['postField'] ?? null;
+        return $postField ?: 'ImportData';
     }
 
     /**
@@ -402,10 +380,9 @@ class Export
      *
      * @return string
      */
-    public function getTargetWindow($format)
+    public function getTargetWindow(string $format): string
     {
-        return !empty($this->exportConfig->$format->targetWindow)
-            ? $this->exportConfig->$format->targetWindow
-            : $format . 'Main';
+        $targetWindow = $this->exportConfig[$format]['targetWindow'] ?? null;
+        return $targetWindow ?: $format . 'Main';
     }
 }

--- a/module/VuFind/src/VuFind/ExportFactory.php
+++ b/module/VuFind/src/VuFind/ExportFactory.php
@@ -69,8 +69,9 @@ class ExportFactory implements FactoryInterface
             throw new \Exception('Unexpected options sent to factory.');
         }
         return new $requestedName(
-            $container->get(\VuFind\Config\PluginManager::class)->get('config'),
-            $container->get(\VuFind\Config\PluginManager::class)->get('export')
+            $container->get(\VuFind\Config\PluginManager::class)->get('config')->toArray(),
+            $container->get(\VuFind\Config\PluginManager::class)->get('export')->toArray(),
+            $container->get('ViewRenderer')
         );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest;
 
+use Laminas\View\Renderer\PhpRenderer;
 use VuFind\Config\Config;
 use VuFind\Export;
 
@@ -230,7 +231,7 @@ class ExportTest extends \PHPUnit\Framework\TestCase
     {
         $config = ['foo' => ['headers' => ['bar']]];
         $export = $this->getExport([], $config);
-        $this->assertEquals(['bar'], $export->getHeaders('foo')->toArray());
+        $this->assertEquals(['bar'], $export->getHeaders('foo'));
     }
 
     /**
@@ -310,13 +311,13 @@ class ExportTest extends \PHPUnit\Framework\TestCase
         $serverUrl->expects($this->once())->method('__invoke')
             ->with($this->equalTo('/cart/doExport'))
             ->will($this->returnValue('http://localhost/cart/doExport'));
-        $view = $this->getMockBuilder(\Laminas\View\Renderer\PhpRenderer::class)
+        $renderer = $this->getMockBuilder(\Laminas\View\Renderer\PhpRenderer::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->expectConsecutiveCalls($view, 'plugin', [['serverurl'], ['url']], [$serverUrl, $url]);
+        $this->expectConsecutiveCalls($renderer, 'plugin', [['serverurl'], ['url']], [$serverUrl, $url]);
         $this->assertEquals(
             'http://localhost/cart/doExport?f=foo&i%5B%5D=1&i%5B%5D=2&i%5B%5D=3',
-            $this->getExport()->getBulkUrl($view, 'foo', [1, 2, 3])
+            $this->getExport(renderer: $renderer)->getBulkUrl('foo', [1, 2, 3])
         );
     }
 
@@ -366,13 +367,14 @@ class ExportTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a configured Export object.
      *
-     * @param array $main   Main config
-     * @param array $export Export config
+     * @param array        $main     Main config
+     * @param array        $export   Export config
+     * @param ?PhpRenderer $renderer Preconfigured view renderer
      *
      * @return Export
      */
-    protected function getExport($main = [], $export = [])
+    protected function getExport($main = [], $export = [], $renderer = null)
     {
-        return new Export(new Config($main), new Config($export));
+        return new Export($main, $export, $renderer ?? $this->createMock(PhpRenderer::class));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ExportTest.php
@@ -304,16 +304,14 @@ class ExportTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $url->expects($this->once())->method('__invoke')
             ->with($this->equalTo('cart-doexport'))
-            ->will($this->returnValue('/cart/doExport'));
+            ->willReturn('/cart/doExport');
         $serverUrl = $this->getMockBuilder(\Laminas\View\Helper\ServerUrl::class)
             ->disableOriginalConstructor()
             ->getMock();
         $serverUrl->expects($this->once())->method('__invoke')
             ->with($this->equalTo('/cart/doExport'))
-            ->will($this->returnValue('http://localhost/cart/doExport'));
-        $renderer = $this->getMockBuilder(\Laminas\View\Renderer\PhpRenderer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+            ->willReturn('http://localhost/cart/doExport');
+        $renderer = $this->createMock(PhpRenderer::class);
         $this->expectConsecutiveCalls($renderer, 'plugin', [['serverurl'], ['url']], [$serverUrl, $url]);
         $this->assertEquals(
             'http://localhost/cart/doExport?f=foo&i%5B%5D=1&i%5B%5D=2&i%5B%5D=3',

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/toolbar.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/toolbar.phtml
@@ -55,7 +55,7 @@
         <ul class="dropdown-menu" id="export-options" role="menu">
           <?php foreach ($exportFormats as $exportFormat): ?>
             <li role="none">
-              <a class="dropdown-item" <?php if ($this->export()->needsRedirect($exportFormat)): ?>target="<?=$this->escapeHtmlAttr($exportFormat)?>Main" <?php endif; ?>href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export', [], '', ['excludeSearchId' => true]))?>?style=<?=$this->escapeHtmlAttr($exportFormat)?>" rel="nofollow" role="menuitem">
+              <a class="dropdown-item" <?php if ($this->export()->needsRedirect($exportFormat)): ?>target="<?=$this->escapeHtmlAttr($this->export()->getTargetWindow($exportFormat))?>" <?php endif; ?>href="<?=$this->escapeHtmlAttr($this->recordLinker()->getActionUrl($this->driver, 'Export', [], '', ['excludeSearchId' => true]))?>?style=<?=$this->escapeHtmlAttr($exportFormat)?>" rel="nofollow" role="menuitem">
                 <?=$this->transEsc('export_to', ['%%target%%' => $this->translate($this->export()->getLabelForFormat($exportFormat))])?>
               </a>
             </li>

--- a/themes/bootstrap5/templates/cart/export.phtml
+++ b/themes/bootstrap5/templates/cart/export.phtml
@@ -46,7 +46,7 @@
               $firstOption = $exportOption;
             }
           ?>
-          <option value="<?=$this->escapeHtmlAttr($exportOption)?>"<?php if ($this->export()->needsRedirect($exportOption)): ?> data-redirect<?php endif; ?>><?=$this->transEsc($this->export()->getLabelForFormat($exportOption))?></option>
+          <option value="<?=$this->escapeHtmlAttr($exportOption)?>"<?php if ($this->export()->needsRedirect($exportOption)): ?> data-redirect="<?=$this->escapeHtmlAttr($this->export()->getTargetWindow($exportOption))?>"<?php endif; ?>><?=$this->transEsc($this->export()->getLabelForFormat($exportOption))?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -70,7 +70,7 @@
             $('form[name=exportForm]').removeAttr('target');
           } else {
             $('.export.btn').attr('data-lightbox-ignore', '1');
-            $('form[name=exportForm]').attr('target', this.selectedOptions[0].value + 'Main');
+            $('form[name=exportForm]').attr('target', this.selectedOptions[0].getAttribute('data-redirect'));
           }
         }).trigger('change');
       JS;

--- a/themes/bootstrap5/templates/cart/export.phtml
+++ b/themes/bootstrap5/templates/cart/export.phtml
@@ -22,7 +22,7 @@
     <div class="form-group">
       <label class="form-label"><?=$this->transEsc('Title')?>:</label>
       <?php if (count($this->records) > 1): ?>
-        <button type="button" class="btn btn-default hidden" data-bs-toggle="collapse" data-bs-target="#itemhide">
+        <button type="button" class="btn btn-default hidden js-item-button" data-bs-toggle="collapse" data-bs-target="#itemhide">
           <?=count($this->records) . ' ' . $this->transEsc('items') ?>
         </button>
         <div id="itemhide" class="collapse show">
@@ -57,22 +57,39 @@
 <?php endif; ?>
 <?php
   $script = <<<JS
-        $('button.btn.hidden').removeClass('hidden');
-        $('#itemhide').removeClass('show');
-        $('.export.btn').click(function exportButtonClick() {
-          if (typeof $('#format option:selected').attr('data-redirect') !== 'undefined') {
-            VuFind.modal('hide');
+        (function initExport() {
+          const collapseBtn = document.querySelector('.js-item-button');
+          const itemCollapseEl = document.getElementById('itemhide');
+          if (collapseBtn && itemCollapseEl) {
+            collapseBtn.classList.remove('hidden');
+            itemCollapseEl.classList.remove('show');
           }
-        });
-        $('#format').change(function exportFormatChange(e) {
-          if (this.selectedOptions[0].getAttribute('data-redirect') === null) {
-            $('.export.btn').removeAttr('data-lightbox-ignore');
-            $('form[name=exportForm]').removeAttr('target');
-          } else {
-            $('.export.btn').attr('data-lightbox-ignore', '1');
-            $('form[name=exportForm]').attr('target', this.selectedOptions[0].getAttribute('data-redirect'));
+          const formatEl = document.getElementById('format');
+          const exportBtn = document.querySelector('.export.btn');
+          const formEl = document.querySelector('form[name=exportForm]');
+          if (!formatEl || !exportBtn || !formEl) {
+            console.warn('Export element(s) missing!');
+            return;
           }
-        }).trigger('change');
+          exportBtn.addEventListener('click', () => {
+            if (formatEl.selectedOptions[0].dataset.redirect !== undefined) {
+              VuFind.modal('hide');
+            }
+          });
+
+          const formatChangeHandler = () => {
+            const redirect = formatEl.selectedOptions[0].dataset.redirect;
+            if (redirect === undefined) {
+              delete exportBtn.dataset.lightboxIgnore;
+              formEl.removeAttribute('target');
+            } else {
+              exportBtn.dataset.lightboxIgnore = '1';
+              formEl.setAttribute('target', redirect);
+            }
+          };
+          formatEl.addEventListener('change', formatChangeHandler);
+          formatChangeHandler();
+        })();
       JS;
 ?>
 <?=$this->assetManager()->outputInlineScriptString($script) ?>


### PR DESCRIPTION
- Fixes the targetWindow setting.
- Eliminates the need to pass renderer to the Export support class.
- Cleans up config handling in the Export support class.
- Adds typing to methods and fixes return types in the Export support class.
- Tweaks the recordSupportsFormat method to not require the requiredMethods setting.

These changes were done in preparation for adding Zotero Web Library export. I think the only controversial one is the recordSupportsFormat change, but I also think that the old behavior was unintuitive and not supported by the comments in export.ini. Perhaps the requirement for getTitle could be scrubbed from the default export.ini as well?

TODO
- [x] Update changelog when merging: changes to signature of VuFind\Export methods (new constructor dependency, types added, eliminated need to pass renderer to getBulkUrl)
