### PR TITLE
Disable hidden sort for new searches

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -728,6 +728,24 @@ class Params
     }
 
     /**
+     * Check if sort is valid.
+     *
+     * @param ?string $sort            Sort value
+     * @param bool    $allowHiddenSort If hidden sort is allowed
+     *
+     * @return bool
+     */
+    public function isValidSort(?string $sort, bool $allowHiddenSort = true): bool
+    {
+        $valid = array_keys($this->getOptions()->getSortOptions());
+        return !empty($sort)
+            && (
+                in_array($sort, $valid)
+                || $allowHiddenSort && $this->getMatchingHiddenSortingPatterns($sort)
+            );
+    }
+
+    /**
      * Set the sorting value (note: sort will be set to default if an illegal
      * or empty value is passed in).
      *
@@ -745,12 +763,7 @@ class Params
         }
 
         // Validate and assign the sort value:
-        $valid = array_keys($this->getOptions()->getSortOptions());
-
-        if (
-            !empty($sort)
-            && (in_array($sort, $valid) || $this->getMatchingHiddenSortingPatterns($sort))
-        ) {
+        if ($this->isValidSort($sort)) {
             $this->sort = $sort;
         } else {
             $this->sort = $this->getDefaultSort();

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -224,7 +224,11 @@
         if (!empty($lastLimit)) {
           echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '">';
         }
-        if (!empty($lastSort) && $lastSort !== $params?->getDefaultSort()) {
+        if (
+          !empty($lastSort)
+          && $lastSort !== $params?->getDefaultSort()
+          && $params?->isValidSort($lastSort, allowHiddenSort: false)
+        ) {
           echo '<input type="hidden" name="sort" value="' . $this->escapeHtmlAttr($lastSort) . '">';
         }
       ?>


### PR DESCRIPTION
For the context in which we use the hidden sort option, it does not make sense to apply it to new searches. That's why I want to deactivate for those.