### PR TITLE
Remove <bdi> tag in RecordDataFormatter combineAlt render type

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/combine-alt.phtml
@@ -10,8 +10,6 @@ if ($this->prioritizeAlt) {
 ?>
 <?php foreach ($values as $value): ?>
   <div>
-    <bdi>
-      <?=$value?>
-    </bdi>
+    <?=$value?>
   </div>
 <?php endforeach; ?>


### PR DESCRIPTION
The `<bdi>` tag was misused in this context and does not provide any advantage. In some cases (e.g. `$value` contains a `<div>` tag) it even causes the content to be aligned wrong compared to the rest of the fields.