### PR TITLE
Fix covers with disabled browser cache if thumbnail is string

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1112,7 +1112,9 @@ verify_server_certificate = false
 ; some services will never have images cached even if caching is enabled.
 coverimagesCache = true
 
-; This setting controls if browsers will cache cover images. This is mainly intended for testing purposes.
+; This setting controls if browsers will cache dynamically generated cover images.
+; Note that this does not work if record drivers provide full thumbnail URLs directly.
+; This is mainly intended for testing purposes.
 ;coverimagesBrowserCache = true
 
 ; This setting controls which proxied image URLs will be cached to local disk (when

--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -135,6 +135,7 @@ class Router implements \Laminas\Log\LoggerAwareInterface
             $thumb['browser_cache_hash'] = md5(time());
         }
 
+        // If we got this far, $thumb is an array, meaning it contains parameters to send to the cover generator.
         if (!$resolveDynamic) {
             return null;
         }

--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -125,23 +125,16 @@ class Router implements \Laminas\Log\LoggerAwareInterface
             return false;
         }
 
-        if (!($this->config['coverimagesBrowserCache'] ?? true)) {
-            // Add timestamp hash to avoid browser cache
-            $thumb['hash'] = md5(time());
+        if (!is_array($thumb)) {
+            return $this->addBrowserCacheHash(['url' => $thumb]);
         }
 
-        // Array? It's parameters to send to the cover generator:
-        if (is_array($thumb)) {
-            if (!$resolveDynamic) {
-                return null;
-            }
-            $dynamicUrl =  $this->dynamicUrl . '?' . http_build_query($thumb);
-        } else {
-            return ['url' => $thumb];
+        $thumb = $this->addBrowserCacheHash($thumb);
+        if (!$resolveDynamic) {
+            return null;
         }
-
-        $settings = is_array($thumb) ? array_merge($thumb, ['size' => $size])
-            : ['size' => $size];
+        $dynamicUrl =  $this->dynamicUrl . '?' . http_build_query($thumb);
+        $settings = array_merge($thumb, ['size' => $size]);
         $handlers = $this->coverLoader->getHandlers();
         $ids = $this->coverLoader->getIdentifiersForSettings($settings);
         foreach ($handlers as $handler) {
@@ -186,5 +179,22 @@ class Router implements \Laminas\Log\LoggerAwareInterface
             }
         }
         return ['url' => $dynamicUrl];
+    }
+
+    /**
+     * Add a hash to the url if browser cache is disabled.
+     *
+     * @param array $thumb Thumbnail
+     *
+     * @return array
+     */
+    public function addBrowserCacheHash(
+        array $thumb
+    ): array {
+        if (!($this->config['coverimagesBrowserCache'] ?? true)) {
+            // Add timestamp hash to avoid browser cache
+            $thumb['browser_cache_hash'] = md5(time());
+        }
+        return $thumb;
     }
 }

--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -126,10 +126,14 @@ class Router implements \Laminas\Log\LoggerAwareInterface
         }
 
         if (!is_array($thumb)) {
-            return $this->addBrowserCacheHash(['url' => $thumb]);
+            return ['url' => $thumb];
         }
 
-        $thumb = $this->addBrowserCacheHash($thumb);
+        if (!($this->config['coverimagesBrowserCache'] ?? true)) {
+            // Add timestamp hash to avoid browser cache
+            $thumb['browser_cache_hash'] = md5(time());
+        }
+
         if (!$resolveDynamic) {
             return null;
         }
@@ -179,22 +183,5 @@ class Router implements \Laminas\Log\LoggerAwareInterface
             }
         }
         return ['url' => $dynamicUrl];
-    }
-
-    /**
-     * Add a hash to the url if browser cache is disabled.
-     *
-     * @param array $thumb Thumbnail
-     *
-     * @return array
-     */
-    public function addBrowserCacheHash(
-        array $thumb
-    ): array {
-        if (!($this->config['coverimagesBrowserCache'] ?? true)) {
-            // Add timestamp hash to avoid browser cache
-            $thumb['browser_cache_hash'] = md5(time());
-        }
-        return $thumb;
     }
 }

--- a/module/VuFind/src/VuFind/Cover/Router.php
+++ b/module/VuFind/src/VuFind/Cover/Router.php
@@ -125,6 +125,7 @@ class Router implements \Laminas\Log\LoggerAwareInterface
             return false;
         }
 
+        // If $thumb is not an array, it is a full URL to a thumbnail image.
         if (!is_array($thumb)) {
             return ['url' => $thumb];
         }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordCoverImageTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordCoverImageTest.php
@@ -203,7 +203,7 @@ class RecordCoverImageTest extends \VuFindTest\Integration\MinkTestCase
 
         // Verify query except timestamp hash for deactivated browser cache
         $imageSrcQuery = explode('&', explode('?', $imageSrc)[1] ?? '');
-        $imageSrcQuery = array_filter($imageSrcQuery, fn ($part) => !str_starts_with($part, 'hash'));
+        $imageSrcQuery = array_filter($imageSrcQuery, fn ($part) => !str_starts_with($part, 'browser_cache_hash'));
         $expectedQuery = explode('&', $expectedImageParts[1] ?? '');
         sort($expectedQuery);
         sort($imageSrcQuery);


### PR DESCRIPTION
If the `getThumbnail` of a record returns a string and cover images browser cache is disabled it results in an error. 

This PR fixes that and gives the query parameter a more specific name in case the URL returned by the record uses a "hash" query parameter for some reason.