### PR TITLE
Clean up orphans when deleting tags.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/TagController.php
+++ b/module/VuFind/src/VuFind/Controller/TagController.php
@@ -138,6 +138,7 @@ class TagController extends AbstractSearch
         if (!empty($tags = $this->params()->fromPost('deleteSelectedtag', []))) {
             $tagService = $this->getDbService(\VuFind\Db\Service\ResourceTagsServiceInterface::class);
             $tagService->deleteLinksByResourceTagsIdArray($tags);
+            $this->getDbService(\VuFind\Db\Service\TagServiceInterface::class)->deleteOrphanedTags();
         }
 
         return $this->redirect()->toRoute('tag-userlist');


### PR DESCRIPTION
I noticed when attempting to run the RecordActionsTest multiple times in a row that it was leaving orphaned tag data in the test database. This is because the recently added user-initiated delete tag action (see #4323) was not cleaning up orphans. This PR fixes that oversight. Note that this does have the potential to be a somewhat expensive operation; however, I expect it to be used infrequently enough that it is probably not a problem. If it turns out to be an issue, we could fairly easily create a config setting to control the behavior and offer a command line tool to clean orphans on demand.