### PR TITLE
Fix PathResolver tests when the local directory contains a symlink.

### DIFF
--- a/module/VuFind/src/VuFind/Config/PathResolver.php
+++ b/module/VuFind/src/VuFind/Config/PathResolver.php
@@ -157,6 +157,7 @@ class PathResolver
     public static function getLocalDirStack(?string $localConfigDir, ?string $localConfigSubDir = null): array
     {
         $localDirs = [];
+        $localDirsCanonical = [];
         $currentDir = $localConfigDir;
         while (!empty($currentDir)) {
             // check if the directory exists
@@ -164,13 +165,13 @@ class PathResolver
                 trigger_error('Configured local directory does not exist: ' . $currentDir, E_USER_WARNING);
                 break;
             }
-            $currentDir = $canonicalizedCurrentDir;
 
             // check if the current directory was already included in the stack to avoid infinite loops
-            if (in_array($currentDir, array_column($localDirs, 'directory'))) {
+            if (in_array($canonicalizedCurrentDir, $localDirsCanonical)) {
                 trigger_error('Current directory was already included in the stack: ' . $currentDir, E_USER_WARNING);
                 break;
             }
+            $localDirsCanonical[] = $canonicalizedCurrentDir;
 
             // loading DirLocations.ini of currentDir
             $systemConfigFile = $currentDir . '/DirLocations.ini';

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/PathResolverTest.php
@@ -117,7 +117,7 @@ class PathResolverTest extends \PHPUnit\Framework\TestCase
             [
                 // A file that exists in the secondary path as well as base path:
                 'facets.ini',
-                'secondary/config/custom/facets.ini',
+                'primary/../secondary/config/custom/facets.ini',
             ],
             [
                 // A file that exists only in the base path:


### PR DESCRIPTION
#4415 broke PathResolverTest when LOCAL_OVERRIDE_DIR contains a symlink. This is the case e.g. when running `composer qa` on macOS where /tmp is actually a symlink.