### PR TITLE
Remove non-in-place config upgrading and make upgrader a service

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -433,6 +433,7 @@ $config = [
             'VuFind\ChannelProvider\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Config\AccountCapabilities' => 'VuFind\Config\AccountCapabilitiesFactory',
             'VuFind\Config\ConfigManager' => 'VuFind\Config\ConfigManagerFactory',
+            'VuFind\Config\Upgrade' => 'VuFind\Config\UpgradeFactory',
             'VuFind\Config\Handler\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Config\PathResolver' => 'VuFind\Config\PathResolverFactory',
             'VuFind\Config\PluginManager' => 'VuFind\Config\PluginManagerFactory',

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -85,11 +85,11 @@ class Upgrade
     protected bool $permissionsModified = false;
 
     /**
-     * If writing of new configuration should be disabled (used in tests).
+     * If writing of configuration is enabled (disabled in tests).
      *
      * @var bool
      */
-    protected bool $dryRun = false;
+    protected bool $writeMode = true;
 
     /**
      * Constructor
@@ -104,16 +104,27 @@ class Upgrade
     }
 
     /**
-     * Run through all of the necessary upgrading.
+     * Set write mode
      *
-     * @param string $newVersion Version to upgrade to
-     * @param bool   $dryRun     If writing of new configuration should be disabled (used in tests)
+     * @param bool $writeMode Write mode (true for enabling and false for disabling writing)
      *
      * @return void
      */
-    public function run(string $newVersion, bool $dryRun = false): void
+    public function setWriteMode(bool $writeMode): void
     {
-        $this->dryRun = $dryRun;
+        $this->writeMode = $writeMode;
+    }
+
+    /**
+     * Run through all of the necessary upgrading.
+     *
+     * @param string $newVersion Version to upgrade to
+     *
+     * @return void
+     */
+    public function run(string $newVersion): void
+    {
+        $this->permissionsModified = false;
 
         // Load all old configurations:
         $this->loadConfigs();
@@ -254,8 +265,8 @@ class Upgrade
      */
     protected function saveModifiedConfig(string $filename, bool $forceCreation = false): void
     {
-        // don't write to files in dry run mode
-        if ($this->dryRun) {
+        // don't write to files when write mode is disabled.
+        if (!$this->writeMode) {
             return;
         }
 

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -23,6 +23,7 @@
  * @category VuFind
  * @package  Config
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
@@ -42,6 +43,7 @@ use function is_array;
  * @category VuFind
  * @package  Config
  * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
  */
@@ -52,83 +54,78 @@ class Upgrade
      *
      * @var array
      */
-    protected $oldConfigs = [];
+    protected array $oldConfigs = [];
 
     /**
      * Processed new configurations
      *
      * @var array
      */
-    protected $newConfigs = [];
+    protected array $newConfigs = [];
 
     /**
      * Comments parsed from configuration files
      *
      * @var array
      */
-    protected $comments = [];
+    protected array $comments = [];
 
     /**
      * Warnings generated during upgrade process
      *
      * @var array
      */
-    protected $warnings = [];
-
-    /**
-     * Are we upgrading files in place rather than creating them?
-     *
-     * @var bool
-     */
-    protected $inPlaceUpgrade;
+    protected array $warnings = [];
 
     /**
      * Have we modified permissions.ini?
      *
      * @var bool
      */
-    protected $permissionsModified = false;
+    protected bool $permissionsModified = false;
+
+    /**
+     * If writing of new configuration should be disabled (used in tests).
+     *
+     * @var bool
+     */
+    protected bool $dryRun = false;
 
     /**
      * Constructor
      *
-     * @param string  $from   Version we're upgrading from.
-     * @param string  $to     Version we're upgrading to.
-     * @param string  $oldDir Directory containing old configurations.
-     * @param string  $rawDir Directory containing raw new configurations.
-     * @param ?string $newDir Directory to write updated new configurations into
-     * (leave null to disable writes -- used in test mode).
+     * @param PathResolver  $pathResolver  Path Resolver
+     * @param ConfigManager $configManager Config Manager
      */
     public function __construct(
-        protected string $from,
-        protected string $to,
-        protected string $oldDir,
-        protected string $rawDir,
-        protected ?string $newDir = null
+        protected PathResolver $pathResolver,
+        protected ConfigManager $configManager,
     ) {
-        $this->inPlaceUpgrade = ($this->oldDir == $this->newDir);
     }
 
     /**
      * Run through all of the necessary upgrading.
      *
+     * @param string $newVersion Version to upgrade to
+     * @param bool   $dryRun     If writing of new configuration should be disabled (used in tests)
+     *
      * @return void
      */
-    public function run()
+    public function run(string $newVersion, bool $dryRun = false): void
     {
+        $this->dryRun = $dryRun;
+
         // Load all old configurations:
         $this->loadConfigs();
 
         // Upgrade them one by one and write the results to disk; order is
         // important since in some cases, settings may migrate out of config.ini
         // and into other files.
-        $this->upgradeConfig();
+        $this->upgradeConfig($newVersion);
         $this->upgradeAuthority();
         $this->upgradeFacetsAndCollection();
-        $this->upgradeFulltext();
         $this->upgradeReserves();
         $this->upgradeSearches();
-        $this->upgradeSitemap();
         $this->upgradeSms();
         $this->upgradeEDS();
         $this->upgradeEPF();
@@ -138,9 +135,7 @@ class Upgrade
 
         // The previous upgrade routines may have added values to permissions.ini,
         // so we should save it last. It doesn't have its own upgrade routine.
-        $this->saveModifiedConfig('permissions.ini');
-
-        $this->upgradeILS();
+        $this->saveModifiedConfig('permissions', $this->permissionsModified);
     }
 
     /**
@@ -148,7 +143,7 @@ class Upgrade
      *
      * @return array
      */
-    public function getNewConfigs()
+    public function getNewConfigs(): array
     {
         return $this->newConfigs;
     }
@@ -158,7 +153,7 @@ class Upgrade
      *
      * @return array
      */
-    public function getWarnings()
+    public function getWarnings(): array
     {
         return $this->warnings;
     }
@@ -170,7 +165,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function addWarning($msg)
+    protected function addWarning(string $msg): void
     {
         $this->warnings[] = $msg;
     }
@@ -200,34 +195,25 @@ class Upgrade
     }
 
     /**
-     * Find the path to the old configuration file.
-     *
-     * @param string $filename Filename of configuration file.
-     *
-     * @return string
-     */
-    protected function getOldConfigPath($filename)
-    {
-        return $this->oldDir . '/' . $filename;
-    }
-
-    /**
      * Load all of the user's existing configurations.
      *
      * @return void
      */
-    protected function loadConfigs()
+    protected function loadConfigs(): void
     {
-        foreach (glob($this->rawDir . '/*.ini') as $ini) {
-            $parts = explode('/', str_replace('\\', '/', $ini));
-            $config = array_pop($parts);
-            $path = $this->getOldConfigPath($config);
-            $this->oldConfigs[$config]
-                = file_exists($path) ? parse_ini_file($path, true) : [];
-            $this->newConfigs[$config]
-                = parse_ini_file($this->rawDir . '/' . $config, true);
-            $this->comments[$config]
-                = $this->extractComments($this->rawDir . '/' . $config);
+        $baseConfigLocations = $this->pathResolver->getConfigLocationsInPath(
+            $this->pathResolver->getBaseConfigDirPath()
+        );
+        foreach ($baseConfigLocations as $configLocation) {
+            $fileName = $configLocation->getFileName();
+            $path = $this->pathResolver->getLocalConfigPath($fileName);
+            $this->oldConfigs[$fileName] =
+                ($path != null && file_exists($path)) ? parse_ini_file($path, true) : [];
+
+            $this->newConfigs[$fileName] =
+                parse_ini_file($configLocation->getPath(), true);
+            $this->comments[$fileName]
+                = $this->extractComments($configLocation->getPath());
         }
     }
 
@@ -240,7 +226,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function applyOldSettings($filename, $fullSections = [])
+    protected function applyOldSettings(string $filename, array $fullSections = []): void
     {
         // First override all individual settings:
         foreach ($this->oldConfigs[$filename] as $section => $subsection) {
@@ -259,30 +245,30 @@ class Upgrade
     /**
      * Save a modified configuration file.
      *
-     * @param string $filename Name of config file to write (contents will be
+     * @param string $filename      Name of config file to write (contents will be
      * pulled from current state of object properties).
+     * @param bool   $forceCreation Force the creation of the file even if the file does not exist.
      *
      * @throws FileAccessException
      * @return void
      */
-    protected function saveModifiedConfig($filename)
+    protected function saveModifiedConfig(string $filename, bool $forceCreation = false): void
     {
-        if (null === $this->newDir) {   // skip write if no destination
+        // don't write to files in dry run mode
+        if ($this->dryRun) {
             return;
         }
 
-        // If we're doing an in-place upgrade, and the source file is empty,
-        // there is no point in upgrading anything (the file doesn't exist).
-        if (empty($this->oldConfigs[$filename]) && $this->inPlaceUpgrade) {
-            // Special case: if we set up custom permissions, we need to
-            // write the file even if it didn't previously exist.
-            if (!$this->permissionsModified || $filename !== 'permissions.ini') {
-                return;
-            }
+        // If the source file is empty, there is usually no point in upgrading anything (the file doesn't exist).
+        if (
+            empty($this->oldConfigs[$filename])
+            && !$forceCreation
+        ) {
+            return;
         }
 
         // If target file already exists, back it up:
-        $outfile = $this->newDir . '/' . $filename;
+        $outfile = $this->pathResolver->getLocalConfigPath($filename);
         $bakfile = $outfile . '.bak.' . time();
         if (file_exists($outfile) && !copy($outfile, $bakfile)) {
             throw new FileAccessException(
@@ -303,55 +289,14 @@ class Upgrade
     }
 
     /**
-     * Save an unmodified configuration file -- copy the old version, unless it is
-     * the same as the new version!
-     *
-     * @param string $filename Path to the old config file
-     *
-     * @throws FileAccessException
-     * @return void
-     */
-    protected function saveUnmodifiedConfig($filename)
-    {
-        if (null === $this->newDir) {   // skip write if no destination
-            return;
-        }
-
-        if ($this->inPlaceUpgrade) {    // skip write if doing in-place upgrade
-            return;
-        }
-
-        // Figure out directories for all versions of this config file:
-        $src = $this->getOldConfigPath($filename);
-        $raw = $this->rawDir . '/' . $filename;
-        $dest = $this->newDir . '/' . $filename;
-
-        // Compare the source file against the raw file; if they happen to be the
-        // same, we don't need to copy anything!
-        if (
-            file_exists($src) && file_exists($raw)
-            && md5(file_get_contents($src)) === md5(file_get_contents($raw))
-        ) {
-            return;
-        }
-
-        // If we got this far, we need to copy the user's file into place:
-        if (file_exists($src) && !copy($src, $dest)) {
-            throw new FileAccessException(
-                "Error: Could not copy {$src} to {$dest}."
-            );
-        }
-    }
-
-    /**
      * Check for invalid theme setting.
      *
-     * @param string $setting Name of setting in [Site] section to check.
-     * @param string $default Default value to use if invalid option was found.
+     * @param string  $setting Name of setting in [Site] section to check.
+     * @param ?string $default Default value to use if invalid option was found.
      *
      * @return void
      */
-    protected function checkTheme($setting, $default = null)
+    protected function checkTheme(string $setting, ?string $default = null): void
     {
         // If a setting is not set, there is nothing to check:
         $theme = $this->newConfigs['config.ini']['Site'][$setting] ?? null;
@@ -391,7 +336,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function checkAmazonConfig($config)
+    protected function checkAmazonConfig(array $config): void
     {
         // Warn the user if they have Amazon enabled but do not have the appropriate
         // credentials set up.
@@ -408,10 +353,12 @@ class Upgrade
     /**
      * Upgrade config.ini.
      *
+     * @param string $newVersion Version to upgrade to
+     *
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeConfig()
+    protected function upgradeConfig(string $newVersion): void
     {
         // override new version's defaults with matching settings from old version:
         $this->applyOldSettings('config.ini');
@@ -557,7 +504,7 @@ class Upgrade
             isset($newConfig['Site']['generator'])
             && preg_match('/^VuFind (\d+\.?)+$/', $newConfig['Site']['generator'])
         ) {
-            $newConfig['Site']['generator'] = 'VuFind ' . $this->to;
+            $newConfig['Site']['generator'] = 'VuFind ' . $newVersion;
         }
 
         // Update Syndetics config:
@@ -602,7 +549,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function upgradeAdminPermissions()
+    protected function upgradeAdminPermissions(): void
     {
         $config = & $this->newConfigs['config.ini'];
         $permissions = & $this->newConfigs['permissions.ini'];
@@ -639,7 +586,7 @@ class Upgrade
      *
      * @return array
      */
-    protected function changeArrayKey($array, $old, $new)
+    protected function changeArrayKey(array $array, string $old, string $new): array
     {
         $newArr = [];
         foreach ($array as $k => $v) {
@@ -660,7 +607,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function renameFacet($old, $new)
+    protected function renameFacet(string $old, string $new): void
     {
         $didWork = false;
         if (isset($this->newConfigs['facets.ini']['Results'][$old])) {
@@ -690,7 +637,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeFacetsAndCollection()
+    protected function upgradeFacetsAndCollection(): void
     {
         // we want to retain the old installation's various facet groups
         // exactly as-is
@@ -721,7 +668,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeSearches()
+    protected function upgradeSearches(): void
     {
         // we want to retain the old installation's Basic/Advanced search settings
         // and sort settings exactly as-is
@@ -750,34 +697,12 @@ class Upgrade
     }
 
     /**
-     * Upgrade fulltext.ini.
-     *
-     * @throws FileAccessException
-     * @return void
-     */
-    protected function upgradeFulltext()
-    {
-        $this->saveUnmodifiedConfig('fulltext.ini');
-    }
-
-    /**
-     * Upgrade sitemap.ini.
-     *
-     * @throws FileAccessException
-     * @return void
-     */
-    protected function upgradeSitemap()
-    {
-        $this->saveUnmodifiedConfig('sitemap.ini');
-    }
-
-    /**
      * Upgrade sms.ini.
      *
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeSms()
+    protected function upgradeSms(): void
     {
         $this->applyOldSettings('sms.ini', ['Carriers']);
         $this->saveModifiedConfig('sms.ini');
@@ -789,7 +714,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeAuthority()
+    protected function upgradeAuthority(): void
     {
         // we want to retain the old installation's search and facet settings
         // exactly as-is
@@ -808,7 +733,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeReserves()
+    protected function upgradeReserves(): void
     {
         // If Reserves module is disabled, don't bother updating config:
         if (
@@ -835,7 +760,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeEDS()
+    protected function upgradeEDS(): void
     {
         $this->upgradeEbsco('EDS.ini');
     }
@@ -846,7 +771,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeEPF()
+    protected function upgradeEPF(): void
     {
         $this->upgradeEbsco('EPF.ini');
     }
@@ -859,7 +784,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeEbsco(string $filename)
+    protected function upgradeEbsco(string $filename): void
     {
         // we want to retain the old installation's search and facet settings
         // exactly as-is
@@ -885,7 +810,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradeSummon()
+    protected function upgradeSummon(): void
     {
         // If Summon is disabled in our current configuration, we don't need to
         // load any Summon-specific settings:
@@ -912,7 +837,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function upgradeSummonPermissions()
+    protected function upgradeSummonPermissions(): void
     {
         $config = & $this->newConfigs['Summon.ini'];
         $permissions = & $this->newConfigs['permissions.ini'];
@@ -948,7 +873,7 @@ class Upgrade
      * @throws FileAccessException
      * @return void
      */
-    protected function upgradePrimo()
+    protected function upgradePrimo(): void
     {
         // we want to retain the old installation's search and facet settings
         // exactly as-is
@@ -984,7 +909,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function upgradePrimoPermissions()
+    protected function upgradePrimoPermissions(): void
     {
         $config = & $this->newConfigs['Primo.ini'];
         $permissions = & $this->newConfigs['permissions.ini'];
@@ -1037,7 +962,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function upgradePrimoServerSettings()
+    protected function upgradePrimoServerSettings(): void
     {
         $config = & $this->newConfigs['Primo.ini'];
         // Convert apiId to url
@@ -1059,59 +984,6 @@ class Upgrade
     }
 
     /**
-     * Does the specified properties file contain any meaningful
-     * (non-empty/non-comment) lines?
-     *
-     * @param string $src File to check
-     *
-     * @return bool
-     */
-    protected function fileContainsMeaningfulLines($src)
-    {
-        // Does the file contain any meaningful lines?
-        foreach (file($src) as $line) {
-            $line = trim($line);
-            if ('' !== $line && !str_starts_with($line, '#')) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Upgrade ILS driver configuration.
-     *
-     * @throws FileAccessException
-     * @return void
-     */
-    protected function upgradeILS()
-    {
-        $driver = $this->newConfigs['config.ini']['Catalog']['driver'] ?? '';
-        if (empty($driver)) {
-            $this->addWarning('WARNING: Could not find ILS driver setting.');
-        } elseif ('Sample' == $driver) {
-            // No configuration file for Sample driver
-        } elseif ('AdminScripts' == $driver) {
-            // Prevent abuse if upgrade process is hijacked
-        } elseif (!file_exists($this->oldDir . '/' . $driver . '.ini')) {
-            $this->addWarning(
-                "WARNING: Could not find {$driver}.ini file; "
-                . 'check your ILS driver configuration.'
-            );
-        } else {
-            $this->saveUnmodifiedConfig($driver . '.ini');
-        }
-
-        // If we're set to load NoILS.ini on failure, copy that over as well:
-        if ($this->newConfigs['config.ini']['Catalog']['loadNoILSOnFailure'] ?? false) {
-            // If NoILS is also the main driver, we don't need to copy it twice:
-            if ($driver != 'NoILS') {
-                $this->saveUnmodifiedConfig('NoILS.ini');
-            }
-        }
-    }
-
-    /**
      * Upgrade shard settings (they have moved to a different config file, so
      * this is handled as a separate method so that all affected settings are
      * addressed in one place.
@@ -1125,7 +997,7 @@ class Upgrade
      *
      * @return void
      */
-    protected function upgradeShardSettings()
+    protected function upgradeShardSettings(): void
     {
         // move settings from config.ini to searches.ini:
         if (isset($this->newConfigs['config.ini']['IndexShards'])) {
@@ -1185,7 +1057,7 @@ class Upgrade
      *
      * @return array           Associative array as described above.
      */
-    protected function extractComments($filename)
+    protected function extractComments(string $filename): array
     {
         $lines = file($filename);
 

--- a/module/VuFind/src/VuFind/Config/UpgradeFactory.php
+++ b/module/VuFind/src/VuFind/Config/UpgradeFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Upgrade controller factory.
+ * Factory for Upgrade.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2018.
+ * Copyright (C) Hebis Verbundzentrale 2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,30 +21,30 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  Controller
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @package  Config
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
 
-namespace VuFind\Controller;
+namespace VuFind\Config;
 
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
-use VuFind\Config\Upgrade;
 
 /**
- * Upgrade controller factory.
+ * Factory for Upgrade.
  *
  * @category VuFind
- * @package  Controller
- * @author   Demian Katz <demian.katz@villanova.edu>
+ * @package  Config
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class UpgradeControllerFactory extends AbstractBaseFactory
+class UpgradeFactory implements FactoryInterface
 {
     /**
      * Create an object
@@ -68,15 +68,9 @@ class UpgradeControllerFactory extends AbstractBaseFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory.');
         }
-        $cookieManager = $container->get(\VuFind\Cookie\CookieManager::class);
-        $session = new \Laminas\Session\Container(
-            'upgrade',
-            $container->get(\Laminas\Session\SessionManager::class)
-        );
-        $configUpgrader = $container->get(Upgrade::class);
-        return $this->applyPermissions(
-            $container,
-            new $requestedName($container, $cookieManager, $session, $configUpgrader)
+        return new $requestedName(
+            $container->get(PathResolver::class),
+            $container->get(ConfigManager::class),
         );
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -81,7 +81,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     /**
      * Run config upgrader with fixture.
      *
-     * @param string $fixture Version
+     * @param string $fixture Fixture
      *
      * @return Upgrade
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -29,7 +29,10 @@
 
 namespace VuFindTest\Config;
 
+use VuFind\Config\ConfigManager;
+use VuFind\Config\PathResolver;
 use VuFind\Config\Upgrade;
+use VuFindTest\Feature\ConfigRelatedServicesTrait;
 
 use function in_array;
 
@@ -47,26 +50,46 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
     use \VuFindTest\Feature\ReflectionTrait;
+    use ConfigRelatedServicesTrait;
 
     /**
      * Target upgrade version
      *
      * @var string
      */
-    protected $targetVersion = '11.0';
+    protected string $targetVersion = '11.0';
 
     /**
      * Get an upgrade object for the specified source version:
      *
-     * @param string $version Version
+     * @param string $fixture Fixture
      *
      * @return Upgrade
      */
-    protected function getUpgrader(string $version): Upgrade
+    protected function getUpgrader(string $fixture): Upgrade
     {
-        $oldDir = realpath($this->getFixtureDir() . 'configs/' . $version);
-        $rawDir = realpath(__DIR__ . '/../../../../../../../config/vufind');
-        return new Upgrade($version, $this->targetVersion, $oldDir, $rawDir);
+        $container = $this->getContainerWithConfigRelatedServices(
+            localDir: $this->getFixtureDir() . 'configs/' . $fixture,
+            localSubDir: ''
+        );
+        return new Upgrade(
+            $container->get(PathResolver::class),
+            $container->get(ConfigManager::class),
+        );
+    }
+
+    /**
+     * Run config upgrader with fixture.
+     *
+     * @param string $fixture Version
+     *
+     * @return Upgrade
+     */
+    protected function runAndGetConfigUpgrader(string $fixture): Upgrade
+    {
+        $upgrader = $this->getUpgrader($fixture);
+        $upgrader->run($this->targetVersion, true);
+        return $upgrader;
     }
 
     /**
@@ -140,8 +163,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testDatabaseUpgrade(string $fixture, array $expected): void
     {
-        $upgrader = $this->getUpgrader($fixture);
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader($fixture);
         $results = $upgrader->getNewConfigs();
         $this->assertEquals($expected, $results['config.ini']['Database']);
     }
@@ -154,8 +176,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     public function testDefaultGenerator(): void
     {
         // We expect the upgrader to switch default values:
-        $upgrader = $this->getUpgrader('defaultgenerator');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('defaultgenerator');
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
             'VuFind ' . $this->targetVersion,
@@ -163,8 +184,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         );
 
         // We expect the upgrader not to change custom values:
-        $upgrader = $this->getUpgrader('customgenerator');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('customgenerator');
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
             'Custom Generator',
@@ -179,8 +199,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testSpelling(): void
     {
-        $upgrader = $this->getUpgrader('spelling');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('spelling');
         $results = $upgrader->getNewConfigs();
 
         // Make sure spellcheck 'simple' is replaced by 'dictionaries'
@@ -196,8 +215,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     public function testSyndetics(): void
     {
         // Test upgrading an SSL URL
-        $upgrader = $this->getUpgrader('syndeticsurlssl');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('syndeticsurlssl');
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
             1,
@@ -205,8 +223,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         );
 
         // Test upgrading a non-SSL URL
-        $upgrader = $this->getUpgrader('syndeticsurlnossl');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('syndeticsurlnossl');
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
             '',
@@ -221,8 +238,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testGooglePreviewUpgrade(): void
     {
-        $upgrader = $this->getUpgrader('googlepreview');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('googlepreview');
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
             'noview,full',
@@ -237,8 +253,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testPermissionUpgrade(): void
     {
-        $upgrader = $this->getUpgrader('permissions');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('permissions');
         $results = $upgrader->getNewConfigs();
 
         // Admin assertions:
@@ -305,8 +320,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testGoogleWarnings(): void
     {
-        $upgrader = $this->getUpgrader('googlewarnings');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('googlewarnings');
         $warnings = $upgrader->getWarnings();
         $this->assertTrue(
             in_array(
@@ -343,44 +357,13 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testWorldCatWarnings(): void
     {
-        $upgrader = $this->getUpgrader('worldcatwarnings');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('worldcatwarnings');
         $warnings = $upgrader->getWarnings();
         $this->assertTrue(
             in_array(
                 'The [WorldCat] section of config.ini has been removed following'
                 . ' the shutdown of the v1 WorldCat search API; use WorldCat2.ini instead.',
                 $warnings
-            )
-        );
-    }
-
-    /**
-     * Test "meaningful line" detection in SolrMarc properties files.
-     *
-     * @return void
-     */
-    public function testMeaningfulLineDetection(): void
-    {
-        $upgrader = $this->getUpgrader('1.4');
-        $meaningless = realpath(
-            $this->getFixtureDir() . 'configs/solrmarc/empty.properties'
-        );
-        $this->assertFalse(
-            $this->callMethod(
-                $upgrader,
-                'fileContainsMeaningfulLines',
-                [$meaningless]
-            )
-        );
-        $meaningful = realpath(
-            $this->getFixtureDir() . 'configs/solrmarc/meaningful.properties'
-        );
-        $this->assertTrue(
-            $this->callMethod(
-                $upgrader,
-                'fileContainsMeaningfulLines',
-                [$meaningful]
             )
         );
     }
@@ -454,8 +437,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testEbscoUpgrade(string $backend, string $configFilename): void
     {
-        $upgrader = $this->getUpgrader($backend);
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader($backend);
         $this->assertEquals([], $upgrader->getWarnings());
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
@@ -475,8 +457,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testPrimoUpgrade(): void
     {
-        $upgrader = $this->getUpgrader('primo');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('primo');
         $this->assertEquals([], $upgrader->getWarnings());
         $results = $upgrader->getNewConfigs();
         $this->assertEquals(
@@ -492,8 +473,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testAmazonCoverWarning(): void
     {
-        $upgrader = $this->getUpgrader('amazoncover');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('amazoncover');
         $warnings = $upgrader->getWarnings();
         $this->assertTrue(
             in_array(
@@ -511,8 +491,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testAmazonReviewWarning(): void
     {
-        $upgrader = $this->getUpgrader('amazonreview');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('amazonreview');
         $warnings = $upgrader->getWarnings();
         $this->assertTrue(
             in_array(
@@ -530,8 +509,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testReCaptcha(): void
     {
-        $upgrader = $this->getUpgrader('recaptcha');
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader('recaptcha');
         $results = $upgrader->getNewConfigs();
         $captcha = $results['config.ini']['Captcha'];
         $this->assertEquals('public', $captcha['recaptcha_siteKey']);
@@ -565,8 +543,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
      */
     public function testMailRequireLoginMigration(string $fixture, string $expected): void
     {
-        $upgrader = $this->getUpgrader($fixture);
-        $upgrader->run();
+        $upgrader = $this->runAndGetConfigUpgrader($fixture);
         $results = $upgrader->getNewConfigs();
         $this->assertFalse(isset($results['config.ini']['Mail']['require_login']));
         $this->assertEquals($expected, $results['config.ini']['Mail']['email_action']);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -88,7 +88,8 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     protected function runAndGetConfigUpgrader(string $fixture): Upgrade
     {
         $upgrader = $this->getUpgrader($fixture);
-        $upgrader->run($this->targetVersion, true);
+        $upgrader->setWriteMode(false);
+        $upgrader->run($this->targetVersion);
         return $upgrader;
     }
 


### PR DESCRIPTION
This PR removes the non-in-place config upgrading as discussed before. It also makes Upgrade a service, because that way it is easier to add the ConfigManager and PathResolver to it.