### PR TITLE
Simplify ILS logic code; add minimal test coverage.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/HoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/HoldsTest.php
@@ -50,7 +50,7 @@ class HoldsTest extends \PHPUnit\Framework\TestCase
      * Get a Holds object for testing.
      *
      * @param ?\VuFind\Auth\ILSAuthenticator $ilsAuth ILS authenticator (null for mock)
-     * @param ?ILSConnection                 $ils     A catalog connection (null for mock)
+     * @param ?ILSConnection                 $catalog A catalog connection (null for mock)
      * @param ?\VuFind\Crypt\HMAC            $hmac    HMAC generator (null for mock)
      * @param ?array                         $config  Configuration array (empty by default)
      *
@@ -58,13 +58,13 @@ class HoldsTest extends \PHPUnit\Framework\TestCase
      */
     protected function getHoldsLogic(
         ?ILSAuthenticator $ilsAuth = null,
-        ?Connection $ils = null,
+        ?Connection $catalog = null,
         ?HMAC $hmac = null,
         array $config = []
     ): Holds {
         return new Holds(
             $ilsAuth ?? $this->createMock(ILSAuthenticator::class),
-            $ils ?? $this->createMock(Connection::class),
+            $catalog ?? $this->createMock(Connection::class),
             $hmac ?? $this->createMock(HMAC::class),
             new Config($config)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/HoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/HoldsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Holds logic test
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\ILS\Driver;
+
+use VuFind\Auth\ILSAuthenticator;
+use VuFind\Config\Config;
+use VuFind\Crypt\HMAC;
+use VuFind\ILS\Connection;
+use VuFind\ILS\Logic\Holds;
+
+/**
+ * Holds logic test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class HoldsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Get a Holds object for testing.
+     *
+     * @param ?\VuFind\Auth\ILSAuthenticator $ilsAuth ILS authenticator (null for mock)
+     * @param ?ILSConnection                 $ils     A catalog connection (null for mock)
+     * @param ?\VuFind\Crypt\HMAC            $hmac    HMAC generator (null for mock)
+     * @param ?array                         $config  Configuration array (empty by default)
+     *
+     * @return Holds
+     */
+    protected function getHoldsLogic(
+        ?ILSAuthenticator $ilsAuth = null,
+        ?Connection $ils = null,
+        ?HMAC $hmac = null,
+        array $config = []
+    ): Holds {
+        return new Holds(
+            $ilsAuth ?? $this->createMock(ILSAuthenticator::class),
+            $ils ?? $this->createMock(Connection::class),
+            $hmac ?? $this->createMock(HMAC::class),
+            new Config($config)
+        );
+    }
+
+    /**
+     * Data provider for testGetSuppressedLocations().
+     *
+     * @return array
+     */
+    public static function suppressedLocationsProvider(): array
+    {
+        return [
+            'default' => [[], []],
+            'non-empty list' => [['Record' => ['hide_holdings' => ['a', 'b', 'c']]], ['a', 'b', 'c']],
+        ];
+    }
+
+    /**
+     * Test getSuppressedLocations().
+     *
+     * @param array $configArray  Configuration array
+     * @param array $expectedList Expected suppressed locations list
+     *
+     * @return void
+     *
+     * @dataProvider suppressedLocationsProvider
+     */
+    public function testGetSuppressedLocations(array $configArray, array $expectedList): void
+    {
+        $logic = $this->getHoldsLogic(config: $configArray);
+        $this->assertEquals($expectedList, $logic->getSuppressedLocations());
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
@@ -53,7 +53,7 @@ class TitleHoldsTest extends \PHPUnit\Framework\TestCase
      * Get a TitleHolds object for testing.
      *
      * @param ?\VuFind\Auth\ILSAuthenticator $ilsAuth ILS authenticator (null for mock)
-     * @param ?ILSConnection                 $ils     A catalog connection (null for mock)
+     * @param ?ILSConnection                 $catalog A catalog connection (null for mock)
      * @param ?\VuFind\Crypt\HMAC            $hmac    HMAC generator (null for mock)
      * @param ?array                         $config  Configuration array (empty by default)
      *
@@ -61,13 +61,13 @@ class TitleHoldsTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTitleHoldsLogic(
         ?ILSAuthenticator $ilsAuth = null,
-        ?Connection $ils = null,
+        ?Connection $catalog = null,
         ?HMAC $hmac = null,
         array $config = []
     ): TitleHolds {
         return new TitleHolds(
             $ilsAuth ?? $this->createMock(ILSAuthenticator::class),
-            $ils ?? $this->createMock(Connection::class),
+            $catalog ?? $this->createMock(Connection::class),
             $hmac ?? $this->createMock(HMAC::class),
             new Config($config)
         );
@@ -111,7 +111,7 @@ class TitleHoldsTest extends \PHPUnit\Framework\TestCase
     {
         $catalog = $this->createMock(Connection::class);
         $catalog->expects($this->once())->method('getTitleHoldsMode')->willReturn('disabled');
-        $logic = $this->getTitleHoldsLogic(ils: $catalog);
+        $logic = $this->getTitleHoldsLogic(catalog: $catalog);
         $this->assertFalse($logic->getHold('foo'));
     }
 
@@ -126,7 +126,7 @@ class TitleHoldsTest extends \PHPUnit\Framework\TestCase
         $catalog->expects($this->once())->method('getTitleHoldsMode')->willReturn('driver');
         $ilsAuth = $this->createMock(ILSAuthenticator::class);
         $ilsAuth->expects($this->once())->method('storedCatalogLogin')->willReturn(false);
-        $logic = $this->getTitleHoldsLogic(ils: $catalog, ilsAuth: $ilsAuth);
+        $logic = $this->getTitleHoldsLogic(catalog: $catalog, ilsAuth: $ilsAuth);
         $this->assertFalse($logic->getHold('foo'));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
@@ -101,4 +101,32 @@ class TitleHoldsTest extends \PHPUnit\Framework\TestCase
         $logic = $this->getTitleHoldsLogic(config: $configArray);
         $this->assertEquals($expectedList, $this->getProperty($logic, 'hideHoldings'));
     }
+
+    /**
+     * Test that title holds can be disabled.
+     *
+     * @return void
+     */
+    public function testDisabledMode(): void
+    {
+        $catalog = $this->createMock(Connection::class);
+        $catalog->expects($this->once())->method('getTitleHoldsMode')->willReturn('disabled');
+        $logic = $this->getTitleHoldsLogic(ils: $catalog);
+        $this->assertFalse($logic->getHold('foo'));
+    }
+
+    /**
+     * Test a failed catalog login
+     *
+     * @return void
+     */
+    public function testFailedCatalogLogin(): void
+    {
+        $catalog = $this->createMock(Connection::class);
+        $catalog->expects($this->once())->method('getTitleHoldsMode')->willReturn('driver');
+        $ilsAuth = $this->createMock(ILSAuthenticator::class);
+        $ilsAuth->expects($this->once())->method('storedCatalogLogin')->willReturn(false);
+        $logic = $this->getTitleHoldsLogic(ils: $catalog, ilsAuth: $ilsAuth);
+        $this->assertFalse($logic->getHold('foo'));
+    }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Logic/TitleHoldsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Title holds logic test
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\ILS\Driver;
+
+use VuFind\Auth\ILSAuthenticator;
+use VuFind\Config\Config;
+use VuFind\Crypt\HMAC;
+use VuFind\ILS\Connection;
+use VuFind\ILS\Logic\TitleHolds;
+use VuFindTest\Feature\ReflectionTrait;
+
+/**
+ * Title holds logic test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class TitleHoldsTest extends \PHPUnit\Framework\TestCase
+{
+    use ReflectionTrait;
+
+    /**
+     * Get a TitleHolds object for testing.
+     *
+     * @param ?\VuFind\Auth\ILSAuthenticator $ilsAuth ILS authenticator (null for mock)
+     * @param ?ILSConnection                 $ils     A catalog connection (null for mock)
+     * @param ?\VuFind\Crypt\HMAC            $hmac    HMAC generator (null for mock)
+     * @param ?array                         $config  Configuration array (empty by default)
+     *
+     * @return Holds
+     */
+    protected function getTitleHoldsLogic(
+        ?ILSAuthenticator $ilsAuth = null,
+        ?Connection $ils = null,
+        ?HMAC $hmac = null,
+        array $config = []
+    ): TitleHolds {
+        return new TitleHolds(
+            $ilsAuth ?? $this->createMock(ILSAuthenticator::class),
+            $ils ?? $this->createMock(Connection::class),
+            $hmac ?? $this->createMock(HMAC::class),
+            new Config($config)
+        );
+    }
+
+    /**
+     * Data provider for testGetSuppressedLocations().
+     *
+     * @return array
+     */
+    public static function suppressedLocationsProvider(): array
+    {
+        return [
+            'default' => [[], []],
+            'non-empty list' => [['Record' => ['hide_holdings' => ['a', 'b', 'c']]], ['a', 'b', 'c']],
+        ];
+    }
+
+    /**
+     * Test that the hide_holdings setting is processed correctly.
+     *
+     * @param array $configArray  Configuration array
+     * @param array $expectedList Expected suppressed locations list
+     *
+     * @return void
+     *
+     * @dataProvider suppressedLocationsProvider
+     */
+    public function testHideHoldingsBehavior(array $configArray, array $expectedList): void
+    {
+        $logic = $this->getTitleHoldsLogic(config: $configArray);
+        $this->assertEquals($expectedList, $this->getProperty($logic, 'hideHoldings'));
+    }
+}


### PR DESCRIPTION
It was pointed out in discussion on #4385 that there is no unit test coverage for the ILS logic classes. This PR makes two significant improvements to the classes and begins to build tests (though coverage remains low for now):

1.) Constructors have been simplified and modernized.
2.) Code checking for "falsy" values of `$this->catalog` has been removed, since constructor typing makes this scenario impossible.

