### PR TITLE
Add a retry to lightbox close in Mink tests

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -1100,7 +1100,13 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             $button = $this->findCss($page, '#modal .modal-content > button.close');
         }
         $button->click();
-        $this->waitForLightboxHidden();
+        // Try twice just in case we missed the first click:
+        try {
+            $this->waitForLightboxHidden();
+        } catch (\Exception $e) {
+            $button->click();
+            $this->waitForLightboxHidden();
+        }
     }
 
     /**


### PR DESCRIPTION
Sometimes the lightbox may be in motion when the close button is clicked causing the click to be missed. This will retry once if the lightbox isn't hidden after timeout.