### PR TITLE
Remove deprecated Auth::isLoggedIn() method.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Auth.php
@@ -109,19 +109,6 @@ class Auth extends \Laminas\View\Helper\AbstractHelper implements DbServiceAware
     /**
      * Checks whether the user is logged in.
      *
-     * @return UserEntityInterface|bool Object if user is logged in, false
-     * otherwise.
-     *
-     * @deprecated Use getIdentity() or getUserObject() instead.
-     */
-    public function isLoggedIn()
-    {
-        return $this->getManager()->isLoggedIn();
-    }
-
-    /**
-     * Checks whether the user is logged in.
-     *
      * @return ?UserEntityInterface Object if user is logged in, null otherwise.
      */
     public function getUserObject(): ?UserEntityInterface


### PR DESCRIPTION
This PR removes the deprecated isLoggedIn method from the Auth view helper. This method was already non-functional, as the corresponding VuFind\Auth\Manager method was already removed in #4325.

TODO:
- [x] Update changelog and [VUFIND-1655](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1655) when merging