### PR TITLE
Simplify handling of subdirs in config upgrade

### DIFF
--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -31,6 +31,7 @@
 namespace VuFind\Config;
 
 use VuFind\Config\Location\ConfigDirectory;
+use VuFind\Config\Location\ConfigLocationInterface;
 use VuFind\Exception\FileAccess as FileAccessException;
 
 use function count;
@@ -244,28 +245,38 @@ class Upgrade
                         $localConfigDir . '/' . $configName,
                         $subDirLocation->getConfigName()
                     );
-                    $this->oldConfigs[$subConfigName] = ($oldConfigLocation !== null)
-                        ? $this->configManager->loadConfigFromLocation(
-                            $oldConfigLocation,
-                            handleParentConfig: false
-                        ) : [];
-                    $this->newConfigs[$subConfigName] = $this->configManager->loadConfigFromLocation(
-                        $subDirLocation,
-                        handleParentConfig: false
-                    );
+                    $this->registerConfigToUpgrade($subConfigName, $subDirLocation, $oldConfigLocation);
                 }
             } else {
                 $oldConfigLocation = $this->pathResolver->getMatchingConfigLocation($localConfigDir, $configName);
-                $this->oldConfigs[$configName] = ($oldConfigLocation !== null)
-                    ? $this->configManager->loadConfigFromLocation($oldConfigLocation, handleParentConfig: false)
-                    : [];
-
-                $this->newConfigs[$configName] = $this->configManager->loadConfigFromLocation(
-                    $configLocation,
-                    handleParentConfig: false
-                );
+                $this->registerConfigToUpgrade($configName, $configLocation, $oldConfigLocation);
             }
         }
+    }
+
+    /**
+     * Load configuration used during upgrade.
+     *
+     * @param string                   $name        Identifier for the configuration
+     * @param ConfigLocationInterface  $newLocation Location of new configuration
+     * @param ?ConfigLocationInterface $oldLocation Optional location of old configuration
+     *
+     * @return void
+     */
+    protected function registerConfigToUpgrade(
+        string $name,
+        ConfigLocationInterface $newLocation,
+        ?ConfigLocationInterface $oldLocation
+    ): void {
+        $this->oldConfigs[$name] = ($oldLocation !== null)
+            ? $this->configManager->loadConfigFromLocation(
+                $oldLocation,
+                handleParentConfig: false
+            ) : [];
+        $this->newConfigs[$name] = $this->configManager->loadConfigFromLocation(
+            $newLocation,
+            handleParentConfig: false
+        );
     }
 
     /**
@@ -317,7 +328,7 @@ class Upgrade
             return;
         }
 
-        $configNameParts = explode('/', $configName);
+        $configNameParts = explode('/', $configName, 2);
         $subDir = (count($configNameParts) > 1) ? '/' . $configNameParts[0] : '';
         $baseConfigLocation = $this->pathResolver->getMatchingConfigLocation(
             $this->pathResolver->getBaseConfigDirPath() . $subDir,

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -30,6 +30,7 @@
 
 namespace VuFind\Config;
 
+use VuFind\Config\Location\ConfigDirectory;
 use VuFind\Exception\FileAccess as FileAccessException;
 
 use function count;
@@ -230,18 +231,40 @@ class Upgrade
         $baseConfigLocations = $this->pathResolver->getConfigLocationsInPath(
             $this->pathResolver->getBaseConfigDirPath()
         );
+        $localConfigDir = $this->pathResolver->getLocalConfigDirPath();
         foreach ($baseConfigLocations as $configLocation) {
             $configName = $configLocation->getConfigName();
-            $localConfigDir = $this->pathResolver->getLocalConfigDirPath();
-            $oldConfigLocation = $this->pathResolver->getMatchingConfigLocation($localConfigDir, $configName);
-            $this->oldConfigs[$configName] = ($oldConfigLocation !== null)
-                ? $this->configManager->loadConfigFromLocation($oldConfigLocation, handleParentConfig: false)
-                : [];
+            if ($configLocation instanceof ConfigDirectory) {
+                $subDirLocations = $this->pathResolver->getConfigLocationsInPath(
+                    $configLocation->getPath()
+                );
+                foreach ($subDirLocations as $subDirLocation) {
+                    $subConfigName = $configName . '/' . $subDirLocation->getConfigName();
+                    $oldConfigLocation = $this->pathResolver->getMatchingConfigLocation(
+                        $localConfigDir . '/' . $configName,
+                        $subDirLocation->getConfigName()
+                    );
+                    $this->oldConfigs[$subConfigName] = ($oldConfigLocation !== null)
+                        ? $this->configManager->loadConfigFromLocation(
+                            $oldConfigLocation,
+                            handleParentConfig: false
+                        ) : [];
+                    $this->newConfigs[$subConfigName] = $this->configManager->loadConfigFromLocation(
+                        $subDirLocation,
+                        handleParentConfig: false
+                    );
+                }
+            } else {
+                $oldConfigLocation = $this->pathResolver->getMatchingConfigLocation($localConfigDir, $configName);
+                $this->oldConfigs[$configName] = ($oldConfigLocation !== null)
+                    ? $this->configManager->loadConfigFromLocation($oldConfigLocation, handleParentConfig: false)
+                    : [];
 
-            $this->newConfigs[$configName] = $this->configManager->loadConfigFromLocation(
-                $configLocation,
-                handleParentConfig: false
-            );
+                $this->newConfigs[$configName] = $this->configManager->loadConfigFromLocation(
+                    $configLocation,
+                    handleParentConfig: false
+                );
+            }
         }
     }
 
@@ -294,14 +317,15 @@ class Upgrade
             return;
         }
 
+        $configNameParts = explode('/', $configName);
+        $subDir = (count($configNameParts) > 1) ? '/' . $configNameParts[0] : '';
         $baseConfigLocation = $this->pathResolver->getMatchingConfigLocation(
-            $this->pathResolver->getBaseConfigDirPath(),
-            $configName
+            $this->pathResolver->getBaseConfigDirPath() . $subDir,
+            $configNameParts[1] ?? $configName
         );
 
         $destinationLocation = clone $baseConfigLocation;
-        $destinationLocation->setBasePath($this->pathResolver->getLocalConfigDirPath());
-
+        $destinationLocation->setBasePath($this->pathResolver->getLocalConfigDirPath() . $subDir);
         $this->configManager->writeConfig($destinationLocation, $this->newConfigs[$configName], $baseConfigLocation);
     }
 


### PR DESCRIPTION
This PR simplifies handling of subdirectories in the config upgrading. 

This will not yet be used, since we do not have any subdirectories yet. But I wanted to keep this change separated from #4240 and #4497, after which it will be used.