### PR TITLE
Use handleParentConfig in Dir config handler

### DIFF
--- a/module/VuFind/src/VuFind/Config/Handler/Dir.php
+++ b/module/VuFind/src/VuFind/Config/Handler/Dir.php
@@ -90,10 +90,11 @@ class Dir extends AbstractBase
             if ($subsection !== null) {
                 $location->setSubsection($subsection);
             }
-            $config[$configName] = $this->configManager->loadConfigFromLocation($location);
+            $config[$configName] = $this->configManager->loadConfigFromLocation($location, $handleParentConfig);
         } else {
             foreach ($this->pathResolver->getConfigLocationsInPath($path) as $location) {
-                $config[$location->getConfigName()] = $this->configManager->loadConfigFromLocation($location);
+                $config[$location->getConfigName()] = $this->configManager
+                    ->loadConfigFromLocation($location, $handleParentConfig);
             }
         }
 

--- a/module/VuFind/src/VuFind/Config/Handler/Dir.php
+++ b/module/VuFind/src/VuFind/Config/Handler/Dir.php
@@ -68,8 +68,6 @@ class Dir extends AbstractBase
      * @param bool                    $handleParentConfig If parent configuration should be handled
      *
      * @return array
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function parseConfig(ConfigLocationInterface $configLocation, bool $handleParentConfig = true): array
     {

--- a/module/VuFind/tests/fixtures/configs/inheritance/dir-config/subdir-child.ini
+++ b/module/VuFind/tests/fixtures/configs/inheritance/dir-config/subdir-child.ini
@@ -1,0 +1,6 @@
+[Section1]
+j=10
+
+[Parent_Config]
+relative_path = "../unit-test-parent.ini"
+override_full_sections = Section1


### PR DESCRIPTION
The `handleParentConfig` should be passed down in the `parseConfig` method of the Dir config handler.