### PR TITLE
Fix dropdown menu alignment

### DIFF
--- a/themes/bootstrap5/js/facets.js
+++ b/themes/bootstrap5/js/facets.js
@@ -709,13 +709,15 @@ VuFind.register('sideFacets', function SideFacets() {
     delayLoadAjaxSideFacets();
 
     // Keep filter dropdowns on screen
-    $(".search-filter-dropdown").on("shown.bs.dropdown", function checkFilterDropdownWidth(e) {
-      var $dropdown = $(e.target).find(".dropdown-menu");
-      if ($(e.target).position().left + $dropdown.width() >= window.innerWidth) {
-        $dropdown.addClass("dropdown-menu-right");
-      } else {
-        $dropdown.removeClass("dropdown-menu-right");
-      }
+    document.querySelectorAll('.search-filter-dropdown').forEach((dropdown) => {
+      dropdown.addEventListener('shown.bs.dropdown', () => {
+        let dropdownMenu = dropdown.querySelector('.dropdown-menu');
+        if (dropdown.getBoundingClientRect().left + dropdownMenu.offsetWidth >= window.innerWidth) {
+          dropdownMenu.classList.add('dropdown-menu-end');
+        } else {
+          dropdownMenu.classList.remove('dropdown-menu-end');
+        }
+      });
     });
 
     setupFacetFormListeners();

--- a/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
@@ -35,7 +35,7 @@
   }
 
   $ulAttrs = [
-    'class' => 'right' === ($this->align ?? 'default') ? 'dropdown-menu dropdown-menu-right' : 'dropdown-menu',
+    'class' => 'right' === ($this->align ?? 'default') ? 'dropdown-menu dropdown-menu-end' : 'dropdown-menu',
     'role' => 'menu',
     'aria-labelledby' => $buttonId,
   ];


### PR DESCRIPTION
The class for dropdown menu alignment `dropdown-menu-right ` was renamed to `dropdown-menu-end` in bootstrap 5.

This PR adjusts that and also fixes the logic for selected facets.