### PR TITLE
Change database structure and rename indexes 

### DIFF
--- a/module/VuFind/sql/migrations/mysql/11.0/004-rename-indexes.sql
+++ b/module/VuFind/sql/migrations/mysql/11.0/004-rename-indexes.sql
@@ -1,0 +1,144 @@
+-- This script renames indexes to match the new naming convention
+
+-- change_tracker table
+ALTER TABLE `change_tracker` 
+DROP INDEX `deleted_index`,
+ADD INDEX `change_tracker_deleted_idx` (`deleted`);
+
+-- comments table
+ALTER TABLE `comments` 
+DROP INDEX `user_id`,
+DROP INDEX `resource_id`,
+ADD INDEX `comments_user_id_idx` (`user_id`),
+ADD INDEX `comments_resource_id_idx` (`resource_id`);
+
+-- ratings table
+ALTER TABLE `ratings` 
+DROP INDEX `user_id`,
+DROP INDEX `resource_id`,
+ADD INDEX `ratings_user_id_idx` (`user_id`),
+ADD INDEX `ratings_resource_id_idx` (`resource_id`);
+
+-- oai_resumption table
+ALTER TABLE `oai_resumption`
+DROP INDEX `token`,
+ADD UNIQUE INDEX `oai_resumption_token_idx` (`token`);
+
+-- resource table
+ALTER TABLE `resource`
+DROP INDEX `record_id`,
+ADD INDEX `resource_record_id_idx` (`record_id`(190));
+
+-- resource_tags table
+ALTER TABLE `resource_tags`
+DROP INDEX `user_id`,
+DROP INDEX `resource_id`,
+DROP INDEX `tag_id`,
+DROP INDEX `list_id`,
+ADD INDEX `resource_tags_user_id_idx` (`user_id`),
+ADD INDEX `resource_tags_resource_id_idx` (`resource_id`),
+ADD INDEX `resource_tags_tag_id_idx` (`tag_id`),
+ADD INDEX `resource_tags_list_id_idx` (`list_id`);
+
+-- search table
+ALTER TABLE `search`
+DROP INDEX `user_id`,
+DROP INDEX `session_id`,
+DROP INDEX `notification_frequency`,
+DROP INDEX `notification_base_url`,
+DROP INDEX `created_saved`,
+ADD INDEX `search_user_id_idx` (`user_id`),
+ADD INDEX `session_id_idx` (`session_id`),
+ADD INDEX `notification_frequency_idx` (`notification_frequency`),
+ADD INDEX `notification_base_url_idx` (`notification_base_url`(190)),
+ADD INDEX `search_created_saved_idx` (`created`, `saved`);
+
+-- session table
+ALTER TABLE `session`
+DROP INDEX `session_id`,
+DROP INDEX `last_used`,
+ADD UNIQUE INDEX `session_session_id_idx` (`session_id`),
+ADD INDEX `session_last_used_idx` (`last_used`);
+
+-- external_session table
+ALTER TABLE `external_session`
+DROP INDEX `session_id`,
+DROP INDEX `external_session_id`,
+ADD UNIQUE INDEX `external_session_session_id_idx` (`session_id`),
+ADD INDEX `external_session_id_idx` (`external_session_id`(190));
+
+-- shortlinks table
+ALTER TABLE `shortlinks`
+DROP INDEX `shortlinks_hash_IDX`,
+ADD UNIQUE INDEX `shortlinks_hash_idx` USING HASH (`hash`);
+
+-- user table
+ALTER TABLE `user`
+DROP INDEX `username`,
+DROP INDEX `cat_id`,
+DROP INDEX `email`,
+DROP INDEX `verify_hash`,
+ADD UNIQUE INDEX `user_username_idx` (`username`(190)),
+ADD UNIQUE INDEX `user_cat_id_idx` (`cat_id`(190)),
+ADD INDEX `user_email_idx` (`email`(190)),
+ADD INDEX `user_verify_hash_idx` (`verify_hash`);
+
+-- user_list table
+ALTER TABLE `user_list`
+DROP INDEX `user_id`,
+ADD INDEX `user_list_user_id_idx` (`user_id`);
+
+-- user_resource table
+ALTER TABLE `user_resource`
+DROP INDEX `resource_id`,
+DROP INDEX `user_id`,
+DROP INDEX `list_id`,
+ADD INDEX `user_resource_resource_id_idx` (`resource_id`),
+ADD INDEX `user_resource_user_id_idx` (`user_id`),
+ADD INDEX `user_resource_list_id_idx` (`list_id`);
+
+-- user_card table
+ALTER TABLE `user_card`
+DROP INDEX `user_id`,
+DROP INDEX `user_card_cat_username`,
+ADD INDEX `user_card_user_id_idx` (`user_id`),
+ADD INDEX `user_card_cat_username_idx` (`cat_username`);
+
+-- record table
+ALTER TABLE `record`
+DROP INDEX `record_id_source`,
+ADD UNIQUE INDEX `record_record_id_source_index` (`record_id`(140), `source`);
+
+-- auth_hash table
+ALTER TABLE `auth_hash`
+DROP INDEX `session_id`,
+DROP INDEX `hash_type`,
+DROP INDEX `created`,
+ADD INDEX `auth_hash_session_id_idx` (`session_id`),
+ADD UNIQUE INDEX `auth_hash_hash_type_idx` (`hash`(140), `type`),
+ADD INDEX `auth_hash_created_idx` (`created`);
+
+-- feedback table
+ALTER TABLE `feedback`
+DROP INDEX `user_id`,
+DROP INDEX `created`,
+DROP INDEX `status`,
+DROP INDEX `form_name`,
+ADD INDEX `feedback_user_id_idx` (`user_id`),
+ADD INDEX `feedback_updated_by_idx` (`updated_by`),
+ADD INDEX `feedback_created_idx` (`created`),
+ADD INDEX `feedback_status_idx` (`status`(191)),
+ADD INDEX `feedback_form_name_idx` (`form_name`(191));
+
+-- access_token table
+ALTER TABLE `access_token`
+DROP INDEX `user_id`,
+ADD INDEX `access_token_user_id_idx` (`user_id`);
+
+-- login_token table
+ALTER TABLE `login_token`
+DROP INDEX `user_id`,
+DROP INDEX `series`,
+ADD INDEX `login_token_user_id_idx` (`user_id`),
+ADD INDEX `login_token_series_idx` (`series`),
+ADD CONSTRAINT `login_token_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE;

--- a/module/VuFind/sql/migrations/pgsql/11.0/004-modify-table-structures-and-rename-indexes.sql
+++ b/module/VuFind/sql/migrations/pgsql/11.0/004-modify-table-structures-and-rename-indexes.sql
@@ -1,0 +1,131 @@
+-- Update comments table default timestamp
+ALTER TABLE comments ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update ratings table - add NOT NULL constraint and update defaults
+UPDATE ratings SET resource_id = '0' WHERE resource_id IS NULL; -- Check if null value exists before setting the column as not null
+ALTER TABLE ratings ALTER COLUMN resource_id SET DEFAULT '0';
+ALTER TABLE ratings ALTER COLUMN resource_id SET NOT NULL;
+ALTER TABLE ratings ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update shortlinks table - make path NOT NULL
+UPDATE shortlinks SET path = '' WHERE path IS NULL;
+ALTER TABLE shortlinks ALTER COLUMN path SET NOT NULL;
+
+-- Update user table defaults
+ALTER TABLE "user" ALTER COLUMN cat_pass_enc TYPE varchar(255);
+ALTER TABLE "user" ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+ALTER TABLE "user" ALTER COLUMN last_login SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update search table defaults
+ALTER TABLE search ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+ALTER TABLE search ALTER COLUMN last_notification_sent SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update user_list table default
+ALTER TABLE user_list ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update session table default
+ALTER TABLE session ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update external_session table default
+ALTER TABLE external_session ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update oai_resumption table default
+ALTER TABLE oai_resumption ALTER COLUMN expires SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update record table - add NOT NULL constraint and default
+UPDATE record SET updated = '2000-01-01 00:00:00' WHERE updated IS NULL;
+ALTER TABLE record ALTER COLUMN updated SET DEFAULT '2000-01-01 00:00:00';
+ALTER TABLE record ALTER COLUMN updated SET NOT NULL;
+
+-- Update user_card table defaults and column types
+ALTER TABLE user_card ALTER COLUMN cat_password TYPE varchar(70);
+ALTER TABLE user_card ALTER COLUMN cat_pass_enc TYPE varchar(255);
+ALTER TABLE user_card ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update auth_hash table defaults and constraints
+ALTER TABLE auth_hash ALTER COLUMN session_id DROP NOT NULL;
+UPDATE auth_hash SET hash = '' WHERE hash IS NULL;
+ALTER TABLE auth_hash ALTER COLUMN hash SET DEFAULT '';
+ALTER TABLE auth_hash ALTER COLUMN hash SET NOT NULL;
+ALTER TABLE auth_hash ALTER COLUMN created SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE auth_hash ALTER COLUMN type DROP NOT NULL;
+
+-- Update feedback table - change form_data default
+ALTER TABLE feedback ALTER COLUMN form_data SET DEFAULT NULL;
+
+-- Update access_token table default
+ALTER TABLE access_token ALTER COLUMN created SET DEFAULT '2000-01-01 00:00:00';
+
+-- Update change_tracker table columns to allow NULL
+
+ALTER TABLE change_tracker ALTER COLUMN first_indexed DROP NOT NULL;
+ALTER TABLE change_tracker ALTER COLUMN last_indexed DROP NOT NULL;
+ALTER TABLE change_tracker ALTER COLUMN last_record_change DROP NOT NULL;
+ALTER TABLE change_tracker ALTER COLUMN deleted DROP NOT NULL;
+
+-- Add unique indexes for user table
+CREATE UNIQUE INDEX IF NOT EXISTS user_username_idx ON "user" (username);
+CREATE UNIQUE INDEX IF NOT EXISTS user_cat_id_idx ON "user" (cat_id);
+
+-- Update session table indexes
+DROP INDEX IF EXISTS last_used_idx;
+CREATE INDEX IF NOT EXISTS session_last_used_idx ON session(last_used);
+CREATE UNIQUE INDEX IF NOT EXISTS session_session_id_idx ON session (session_id);
+
+-- Update external_session indexes
+DROP INDEX IF EXISTS external_session_id;
+CREATE INDEX IF NOT EXISTS external_session_id_idx ON external_session(external_session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS external_session_session_id_idx ON external_session (session_id);
+
+-- Update oai_resumption index
+CREATE UNIQUE INDEX IF NOT EXISTS oai_resumption_token_idx ON oai_resumption (token);
+
+-- Update record table index
+CREATE UNIQUE INDEX IF NOT EXISTS record_record_id_source_index ON record (record_id, source);
+
+-- Add new auth_hash indexes
+CREATE INDEX IF NOT EXISTS auth_hash_session_id_idx ON auth_hash(session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS auth_hash_hash_type_idx ON auth_hash(hash, type);
+
+-- Add new feedback indexes
+CREATE INDEX IF NOT EXISTS feedback_user_id_idx ON feedback (user_id);
+CREATE INDEX IF NOT EXISTS feedback_updated_by_idx ON feedback (updated_by);
+
+-- Add access_token index
+CREATE INDEX IF NOT EXISTS access_token_user_id_idx ON access_token (user_id);
+
+-- Remove old foreign key constraint from search table (if it exists)
+ALTER TABLE search DROP CONSTRAINT IF EXISTS search_ibfk_1;
+
+-- Remove old constraints from user_resource table
+ALTER TABLE user_resource DROP CONSTRAINT IF EXISTS user_resource_ibfk_1;
+ALTER TABLE user_resource DROP CONSTRAINT IF EXISTS user_resource_ibfk_2;
+ALTER TABLE user_resource DROP CONSTRAINT IF EXISTS user_resource_ibfk_3;
+ALTER TABLE user_resource DROP CONSTRAINT IF EXISTS user_resource_ibfk_4;
+ALTER TABLE user_resource DROP CONSTRAINT IF EXISTS user_resource_ibfk_5;
+
+-- Add new/updated foreign key constraints
+ALTER TABLE search ADD CONSTRAINT search_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+ALTER TABLE user_card DROP CONSTRAINT IF EXISTS user_card_ibfk_1;
+ALTER TABLE user_card ADD CONSTRAINT user_card_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+ALTER TABLE user_resource ADD CONSTRAINT user_resource_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+ALTER TABLE user_resource ADD CONSTRAINT user_resource_ibfk_2 FOREIGN KEY (resource_id) REFERENCES resource (id) ON DELETE CASCADE;
+ALTER TABLE user_resource ADD CONSTRAINT user_resource_ibfk_5 FOREIGN KEY (list_id) REFERENCES user_list (id) ON DELETE CASCADE;
+
+ALTER TABLE login_token ADD CONSTRAINT login_token_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+-- Clean up any duplicate or old index names
+DROP INDEX IF EXISTS last_used_idx;
+DROP INDEX IF EXISTS external_session_id;
+DROP INDEX IF EXISTS shortlinks_hash_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS shortlinks_hash_idx ON shortlinks (hash);
+
+ALTER TABLE auth_hash DROP CONSTRAINT IF EXISTS auth_hash_hash_type_key;
+ALTER TABLE session DROP CONSTRAINT IF EXISTS session_session_id_key;
+ALTER TABLE external_session DROP CONSTRAINT IF EXISTS external_session_session_key;
+ALTER TABLE "user" DROP CONSTRAINT IF EXISTS user_cat_id_key;
+ALTER TABLE "user" DROP CONSTRAINT IF EXISTS user_username_key;
+ALTER TABLE oai_resumption DROP CONSTRAINT IF EXISTS oai_resumption_token_key;
+ALTER TABLE record DROP CONSTRAINT IF EXISTS record_record_id_source_key;

--- a/module/VuFind/sql/migrations/pgsql/11.0/004-modify-table-structures-and-rename-indexes.sql
+++ b/module/VuFind/sql/migrations/pgsql/11.0/004-modify-table-structures-and-rename-indexes.sql
@@ -124,7 +124,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS shortlinks_hash_idx ON shortlinks (hash);
 
 ALTER TABLE auth_hash DROP CONSTRAINT IF EXISTS auth_hash_hash_type_key;
 ALTER TABLE session DROP CONSTRAINT IF EXISTS session_session_id_key;
-ALTER TABLE external_session DROP CONSTRAINT IF EXISTS external_session_session_key;
+ALTER TABLE external_session DROP CONSTRAINT IF EXISTS external_session_session_id_key;
 ALTER TABLE "user" DROP CONSTRAINT IF EXISTS user_cat_id_key;
 ALTER TABLE "user" DROP CONSTRAINT IF EXISTS user_username_key;
 ALTER TABLE oai_resumption DROP CONSTRAINT IF EXISTS oai_resumption_token_key;

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -23,7 +23,7 @@ CREATE TABLE `change_tracker` (
   `last_record_change` datetime DEFAULT NULL, -- last time original record was edited
   `deleted` datetime DEFAULT NULL,            -- time record was removed from index
   PRIMARY KEY (`core`,`id`),
-  KEY `deleted_index` (`deleted`)
+  KEY `change_tracker_deleted_idx` (`deleted`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -40,8 +40,8 @@ CREATE TABLE `comments` (
   `comment` text NOT NULL,
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `resource_id` (`resource_id`),
+  KEY `comments_user_id_idx` (`user_id`),
+  KEY `comments_resource_id_idx` (`resource_id`),
   CONSTRAINT `comments_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL,
   CONSTRAINT `comments_ibfk_2` FOREIGN KEY (`resource_id`) REFERENCES `resource` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -60,8 +60,8 @@ CREATE TABLE `ratings` (
   `rating` int(3) NOT NULL,
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `resource_id` (`resource_id`),
+  KEY `ratings_user_id_idx` (`user_id`),
+  KEY `ratings_resource_id_idx` (`resource_id`),
   CONSTRAINT `ratings_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL,
   CONSTRAINT `ratings_ibfk_2` FOREIGN KEY (`resource_id`) REFERENCES `resource` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -79,7 +79,7 @@ CREATE TABLE `oai_resumption` (
   `params` text,
   `expires` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY (`token`)
+  UNIQUE KEY `oai_resumption_token_idx` (`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -98,7 +98,7 @@ CREATE TABLE `resource` (
   `source` varchar(50) NOT NULL DEFAULT 'Solr',
   `extra_metadata` mediumtext DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `record_id` (`record_id`(190))
+  KEY `resource_record_id_idx` (`record_id`(190))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -116,10 +116,10 @@ CREATE TABLE `resource_tags` (
   `user_id` int(11) DEFAULT NULL,
   `posted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `resource_id` (`resource_id`),
-  KEY `tag_id` (`tag_id`),
-  KEY `list_id` (`list_id`),
+  KEY `resource_tags_user_id_idx` (`user_id`),
+  KEY `resource_tags_resource_id_idx` (`resource_id`),
+  KEY `resource_tags_tag_id_idx` (`tag_id`),
+  KEY `resource_tags_list_id_idx` (`list_id`),
   CONSTRAINT `resource_tags_ibfk_14` FOREIGN KEY (`resource_id`) REFERENCES `resource` (`id`) ON DELETE CASCADE,
   CONSTRAINT `resource_tags_ibfk_15` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`) ON DELETE CASCADE,
   CONSTRAINT `resource_tags_ibfk_16` FOREIGN KEY (`list_id`) REFERENCES `user_list` (`id`) ON DELETE SET NULL,
@@ -146,11 +146,11 @@ CREATE TABLE `search` (
   `last_notification_sent` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `notification_base_url` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `session_id` (`session_id`),
-  KEY `notification_frequency` (`notification_frequency`),
-  KEY `notification_base_url` (`notification_base_url`(190)),
-  KEY `created_saved` (`created`, `saved`),
+  KEY `search_user_id_idx` (`user_id`),
+  KEY `session_id_idx` (`session_id`),
+  KEY `notification_frequency_idx` (`notification_frequency`),
+  KEY `notification_base_url_idx` (`notification_base_url`(190)),
+  KEY `search_created_saved_idx` (`created`, `saved`),
   CONSTRAINT `search_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -168,8 +168,8 @@ CREATE TABLE `session` (
   `last_used` int(12) NOT NULL DEFAULT '0',
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `session_id` (`session_id`),
-  KEY `last_used` (`last_used`)
+  UNIQUE KEY `session_session_id_idx` (`session_id`),
+  KEY `session_last_used_idx` (`last_used`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -185,8 +185,8 @@ CREATE TABLE `external_session` (
   `external_session_id` varchar(255) NOT NULL,
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `session_id` (`session_id`),
-  KEY `external_session_id` (`external_session_id`(190))
+  UNIQUE KEY `external_session_session_id_idx` (`session_id`),
+  KEY `external_session_id_idx` (`external_session_id`(190))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -202,7 +202,7 @@ CREATE TABLE `shortlinks` (
   `hash` varchar(32),
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `shortlinks_hash_IDX` USING HASH (`hash`)
+  UNIQUE KEY `shortlinks_hash_idx` USING HASH (`hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -249,10 +249,10 @@ CREATE TABLE `user` (
   `auth_method` varchar(50) DEFAULT NULL,
   `last_language` varchar(30) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `username` (`username`(190)),
-  UNIQUE KEY `cat_id` (`cat_id`(190)),
-  KEY `email` (`email`(190)),
-  KEY `verify_hash` (`verify_hash`)
+  UNIQUE KEY `user_username_idx` (`username`(190)),
+  UNIQUE KEY `user_cat_id_idx` (`cat_id`(190)),
+  KEY `user_email_idx` (`email`(190)),
+  KEY `user_verify_hash_idx` (`verify_hash`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -270,7 +270,7 @@ CREATE TABLE `user_list` (
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `public` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
+  KEY `user_list_user_id_idx` (`user_id`),
   CONSTRAINT `user_list_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -289,9 +289,9 @@ CREATE TABLE `user_resource` (
   `notes` text,
   `saved` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `resource_id` (`resource_id`),
-  KEY `user_id` (`user_id`),
-  KEY `list_id` (`list_id`),
+  KEY `user_resource_resource_id_idx` (`resource_id`),
+  KEY `user_resource_user_id_idx` (`user_id`),
+  KEY `user_resource_list_id_idx` (`list_id`),
   CONSTRAINT `user_resource_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
   CONSTRAINT `user_resource_ibfk_2` FOREIGN KEY (`resource_id`) REFERENCES `resource` (`id`) ON DELETE CASCADE,
   CONSTRAINT `user_resource_ibfk_5` FOREIGN KEY (`list_id`) REFERENCES `user_list` (`id`) ON DELETE CASCADE
@@ -315,8 +315,8 @@ CREATE TABLE `user_card` (
   `created` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   `saved` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `user_card_cat_username` (`cat_username`),
+  KEY `user_card_user_id_idx` (`user_id`),
+  KEY `user_card_cat_username_idx` (`cat_username`),
   CONSTRAINT `user_card_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -345,7 +345,7 @@ CREATE TABLE `record` (
   `data` longtext DEFAULT NULL,
   `updated` datetime NOT NULL DEFAULT '2000-01-01 00:00:00',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `record_id_source` (`record_id`(140), `source`)
+  UNIQUE KEY `record_record_id_source_index` (`record_id`(140), `source`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -363,9 +363,9 @@ CREATE TABLE `auth_hash` (
   `data` mediumtext,
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `session_id` (`session_id`),
-  UNIQUE KEY `hash_type` (`hash`(140), `type`),
-  KEY `created` (`created`)
+  KEY `auth_hash_session_id_idx` (`session_id`),
+  UNIQUE KEY `auth_hash_hash_type_idx` (`hash`(140), `type`),
+  KEY `auth_hash_created_idx` (`created`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -387,10 +387,11 @@ CREATE TABLE `feedback` (
   `status` varchar(255) NOT NULL DEFAULT 'open',
   `site_url` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `created` (`created`),
-  KEY `status` (`status`(191)),
-  KEY `form_name` (`form_name`(191)),
+  KEY `feedback_user_id_idx` (`user_id`),
+  KEY `feedback_updated_by_idx` (`updated_by`),
+  KEY `feedback_created_idx` (`created`),
+  KEY `feedback_status_idx` (`status`(191)),
+  KEY `feedback_form_name_idx` (`form_name`(191)),
   CONSTRAINT `feedback_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL,
   CONSTRAINT `feedback_ibfk_2` FOREIGN KEY (`updated_by`) REFERENCES `user` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -410,7 +411,7 @@ CREATE TABLE `access_token` (
   `data` mediumtext DEFAULT NULL,
   `revoked` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`, `type`),
-  KEY `user_id` (`user_id`),
+  KEY `access_token_user_id_idx` (`user_id`),
   CONSTRAINT `access_token_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -432,7 +433,8 @@ CREATE TABLE `login_token` (
   `expires` int NOT NULL,
   `last_session_id` varchar(255) NULL,
   PRIMARY KEY (`id`),
-  KEY `user_id` (`user_id`),
-  KEY `series` (`series`)
+  KEY `login_token_user_id_idx` (`user_id`),
+  KEY `login_token_series_idx` (`series`),
+  CONSTRAINT `login_token_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -9,7 +9,7 @@ id SERIAL,
 user_id int DEFAULT NULL,
 resource_id int NOT NULL DEFAULT '0',
 comment text NOT NULL,
-created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 PRIMARY KEY (id)
 );
 CREATE INDEX comments_user_id_idx ON comments (user_id);
@@ -71,9 +71,9 @@ DROP TABLE IF EXISTS "ratings";
 CREATE TABLE ratings (
 id SERIAL,
 user_id int DEFAULT NULL,
-resource_id int DEFAULT NULL,
+resource_id int NOT NULL DEFAULT '0',
 rating int NOT NULL,
-created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 PRIMARY KEY (id)
 );
 CREATE INDEX ratings_user_id_idx ON ratings (user_id);
@@ -89,7 +89,7 @@ DROP TABLE IF EXISTS "shortlinks";
 
 CREATE TABLE shortlinks (
 id SERIAL,
-path text,
+path text NOT NULL,
 hash varchar(32),
 created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 PRIMARY KEY (id)
@@ -118,7 +118,7 @@ PRIMARY KEY (id)
 
 DROP TABLE IF EXISTS "user";
 
-CREATE TABLE "user"(
+CREATE TABLE "user" (
 id SERIAL,
 username varchar(255) NOT NULL DEFAULT '',
 password varchar(32) NOT NULL DEFAULT '',
@@ -132,22 +132,22 @@ user_provided_email boolean NOT NULL DEFAULT '0',
 cat_id varchar(255) DEFAULT NULL,
 cat_username varchar(50) DEFAULT NULL,
 cat_password varchar(70) DEFAULT NULL,
-cat_pass_enc varchar(170) DEFAULT NULL,
+cat_pass_enc varchar(255) DEFAULT NULL,
 college varchar(100) NOT NULL DEFAULT '',
 major varchar(100) NOT NULL DEFAULT '',
 home_library varchar(100) DEFAULT '',
-created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 verify_hash varchar(42) NOT NULL DEFAULT '',
-last_login timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+last_login timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 auth_method varchar(50) DEFAULT NULL,
 last_language varchar(30) NOT NULL DEFAULT '',
-PRIMARY KEY (id),
-UNIQUE (username),
-UNIQUE (cat_id)
+PRIMARY KEY (id)
 );
 
 CREATE INDEX user_email_idx ON "user" (email);
 CREATE INDEX user_verify_hash_idx ON "user" (verify_hash);
+CREATE UNIQUE INDEX user_username_idx on "user" (username);
+CREATE UNIQUE INDEX user_cat_id_idx on "user" (cat_id);
 
 -- --------------------------------------------------------
 
@@ -161,7 +161,7 @@ CREATE TABLE "search" (
 id BIGSERIAL,
 user_id int DEFAULT NULL,
 session_id varchar(128),
-created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 title varchar(20) DEFAULT NULL,
 saved boolean NOT NULL DEFAULT '0',
 search_object bytea,
@@ -169,8 +169,7 @@ checksum int DEFAULT NULL,
 notification_frequency int NOT NULL DEFAULT '0',
 last_notification_sent timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 notification_base_url varchar(255) NOT NULL DEFAULT '',
-PRIMARY KEY (id),
-CONSTRAINT search_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE
+PRIMARY KEY (id)
 );
 CREATE INDEX search_user_id_idx ON search (user_id);
 CREATE INDEX session_id_idx ON search (session_id);
@@ -191,7 +190,7 @@ id SERIAL,
 user_id int NOT NULL,
 title varchar(200) NOT NULL,
 description text DEFAULT NULL,
-created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 public boolean NOT NULL DEFAULT '0',
 PRIMARY KEY (id)
 );
@@ -213,9 +212,7 @@ resource_id int NOT NULL,
 list_id int DEFAULT NULL,
 notes text,
 saved timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-PRIMARY KEY (id),
-CONSTRAINT user_resource_ibfk_2 FOREIGN KEY (resource_id) REFERENCES resource (id) ON DELETE CASCADE,
-CONSTRAINT user_resource_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE
+PRIMARY KEY (id)
 );
 CREATE INDEX user_resource_resource_id_idx ON user_resource (resource_id);
 CREATE INDEX user_resource_user_id_idx ON user_resource (user_id);
@@ -233,11 +230,11 @@ id BIGSERIAL,
 session_id varchar(128),
 data text,
 last_used int NOT NULL default 0,
-created timestamp NOT NULL default '1970-01-01 00:00:00',
-PRIMARY KEY (id),
-UNIQUE (session_id)
+created timestamp NOT NULL default '2000-01-01 00:00:00',
+PRIMARY KEY (id)
 );
-CREATE INDEX last_used_idx on session(last_used);
+CREATE INDEX session_last_used_idx on session(last_used);
+CREATE UNIQUE INDEX session_session_id_idx ON session (session_id);
 
 --
 -- Table structure for table external_session
@@ -249,11 +246,11 @@ CREATE TABLE external_session (
 id BIGSERIAL,
 session_id varchar(128) NOT NULL,
 external_session_id varchar(255) NOT NULL,
-created timestamp NOT NULL default '1970-01-01 00:00:00',
-PRIMARY KEY (id),
-UNIQUE (session_id)
+created timestamp NOT NULL default '2000-01-01 00:00:00',
+PRIMARY KEY (id)
 );
-CREATE INDEX external_session_id on external_session(external_session_id);
+CREATE INDEX external_session_id_idx on external_session(external_session_id);
+CREATE UNIQUE INDEX external_session_session_id_idx ON external_session (session_id);
 
 --
 -- Table structure for table change_tracker
@@ -262,12 +259,12 @@ CREATE INDEX external_session_id on external_session(external_session_id);
 DROP TABLE IF EXISTS "change_tracker";
 
 CREATE TABLE change_tracker (
-core varchar(30) NOT NULL,              -- solr core containing record
-id varchar(120) NOT NULL,               -- ID of record within core
-first_indexed timestamp,                -- first time added to index
-last_indexed timestamp,                 -- last time changed in index
-last_record_change timestamp,           -- last time original record was edited
-deleted timestamp,                      -- time record was removed from index
+core varchar(30) NOT NULL,                           -- solr core containing record
+id varchar(120) NOT NULL,                            -- ID of record within core
+first_indexed timestamp DEFAULT NULL,                -- first time added to index
+last_indexed timestamp DEFAULT NULL,                 -- last time changed in index
+last_record_change timestamp DEFAULT NULL,           -- last time original record was edited
+deleted timestamp DEFAULT NULL,                      -- time record was removed from index
 PRIMARY KEY (core, id)
 );
 CREATE INDEX change_tracker_deleted_idx on change_tracker(deleted);
@@ -282,10 +279,10 @@ CREATE TABLE oai_resumption (
 id SERIAL,
 token varchar(255) DEFAULT NULL,
 params text,
-expires timestamp NOT NULL default '1970-01-01 00:00:00',
-PRIMARY KEY (id),
-UNIQUE(token)
+expires timestamp NOT NULL default '2000-01-01 00:00:00',
+PRIMARY KEY (id)
 );
+CREATE UNIQUE INDEX oai_resumption_token_idx ON oai_resumption (token);
 
 -- --------------------------------------------------------
 
@@ -301,10 +298,10 @@ CREATE TABLE record (
   source varchar(50),
   version varchar(20) NOT NULL,
   data text,
-  updated timestamp without time zone,
-  PRIMARY KEY (id),
-  UNIQUE(record_id, source)
+  updated timestamp without time zone NOT NULL DEFAULT '2000-01-01 00:00:00',
+  PRIMARY KEY (id)
 );
+CREATE UNIQUE INDEX record_record_id_source_index ON record (record_id, source);
 
 -- --------------------------------------------------------
 
@@ -319,13 +316,12 @@ id SERIAL,
 user_id int NOT NULL,
 card_name varchar(255) NOT NULL DEFAULT '',
 cat_username varchar(50) NOT NULL DEFAULT '',
-cat_password varchar(50) DEFAULT NULL,
-cat_pass_enc varchar(110) DEFAULT NULL,
+cat_password varchar(70) DEFAULT NULL,
+cat_pass_enc varchar(255) DEFAULT NULL,
 home_library varchar(100) DEFAULT '',
-created timestamp NOT NULL DEFAULT '1970-01-01 00:00:00',
+created timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
 saved timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-PRIMARY KEY (id),
-CONSTRAINT user_card_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE
+PRIMARY KEY (id)
 );
 CREATE INDEX user_card_cat_username_idx ON user_card (cat_username);
 CREATE INDEX user_card_user_id_idx ON user_card (user_id);
@@ -338,15 +334,16 @@ DROP TABLE IF EXISTS "auth_hash";
 
 CREATE TABLE auth_hash (
 id BIGSERIAL,
-session_id varchar(128),
-hash varchar(255),
-type varchar(50),
+session_id varchar(128) DEFAULT NULL,
+hash varchar(255) NOT NULL DEFAULT '',
+type varchar(50) DEFAULT NULL,
 data text,
-created timestamp NOT NULL default '1970-01-01 00:00:00',
-PRIMARY KEY (id),
-UNIQUE (hash, type)
+created timestamp NOT NULL default CURRENT_TIMESTAMP,
+PRIMARY KEY (id)
 );
 CREATE INDEX auth_hash_created_idx on auth_hash(created);
+CREATE INDEX auth_hash_session_id_idx on auth_hash(session_id);
+CREATE UNIQUE INDEX auth_hash_hash_type_idx on auth_hash(hash, type);
 
 --
 -- Table structure for table `feedback`
@@ -358,7 +355,7 @@ CREATE TABLE feedback (
 id SERIAL,
 user_id int DEFAULT NULL,
 message text,
-form_data json DEFAULT '{}'::jsonb,
+form_data json DEFAULT NULL,
 form_name varchar(255) NOT NULL,
 created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 updated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -367,6 +364,12 @@ status varchar(255) NOT NULL DEFAULT 'open',
 site_url varchar(255) NOT NULL,
 PRIMARY KEY (id)
 );
+
+CREATE INDEX feedback_created_idx ON feedback (created);
+CREATE INDEX feedback_status_idx ON feedback (status);
+CREATE INDEX feedback_form_name_idx ON feedback (form_name);
+CREATE INDEX feedback_user_id_idx ON feedback (user_id);
+CREATE INDEX feedback_updated_by_idx ON feedback (updated_by);
 
 --
 -- Table structure for table `access_token`
@@ -378,11 +381,12 @@ CREATE TABLE access_token (
 id varchar(255) NOT NULL,
 type varchar(128) NOT NULL,
 user_id int DEFAULT NULL,
-created timestamp NOT NULL default '1970-01-01 00:00:00',
+created timestamp NOT NULL default '2000-01-01 00:00:00',
 data text,
 revoked boolean NOT NULL DEFAULT '0',
 PRIMARY KEY (id, type)
 );
+CREATE INDEX access_token_user_id_idx ON access_token (user_id);
 
 --
 -- Table structure for table `login_token`
@@ -419,6 +423,21 @@ ADD CONSTRAINT comments_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON D
 ADD CONSTRAINT comments_ibfk_2 FOREIGN KEY (resource_id) REFERENCES resource (id) ON DELETE CASCADE;
 
 
+
+--
+-- Constraints for table search
+--
+ALTER TABLE search
+ADD CONSTRAINT search_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+
+--
+-- Constraints for table user_card
+--
+ALTER TABLE user_card
+ADD CONSTRAINT user_card_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+
 --
 -- Constraints for table resource_tags
 --
@@ -448,8 +467,8 @@ ADD CONSTRAINT user_list_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON 
 -- Constraints for table user_resource
 --
 ALTER TABLE user_resource
-ADD CONSTRAINT user_resource_ibfk_3 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE,
-ADD CONSTRAINT user_resource_ibfk_4 FOREIGN KEY (resource_id) REFERENCES resource (id) ON DELETE CASCADE,
+ADD CONSTRAINT user_resource_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE,
+ADD CONSTRAINT user_resource_ibfk_2 FOREIGN KEY (resource_id) REFERENCES resource (id) ON DELETE CASCADE,
 ADD CONSTRAINT user_resource_ibfk_5 FOREIGN KEY (list_id) REFERENCES user_list (id) ON DELETE CASCADE;
 
 
@@ -460,13 +479,16 @@ ALTER TABLE feedback
 ADD CONSTRAINT feedback_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE SET NULL,
 ADD CONSTRAINT feedback_ibfk_2 FOREIGN KEY (updated_by) REFERENCES "user" (id) ON DELETE SET NULL;
 
-CREATE INDEX feedback_created_idx ON feedback (created);
-CREATE INDEX feedback_status_idx ON feedback (status);
-CREATE INDEX feedback_form_name_idx ON feedback (form_name);
 
 -- Constraints for table access_token
 --
 ALTER TABLE access_token
 ADD CONSTRAINT access_token_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
+
+--
+-- Constraints for table login_token
+--
+ALTER TABLE login_token
+ADD CONSTRAINT login_token_ibfk_1 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
The PostgreSQL database structure has been modified to match the MySQL schema design, while indexes in both PostgreSQL and MySQL have been renamed to use uniform naming patterns to maintain cross database consistency.