### PR TITLE
Specify DismaxHandler within ExactSettings (comments)

### DIFF
--- a/config/vufind/searchspecs.yaml
+++ b/config/vufind/searchspecs.yaml
@@ -265,6 +265,7 @@ Subject:
 #  ExactSettings:
 #    DismaxFields:
 #      - topic_unstemmed^150
+#    DismaxHandler: edismax
 
 
 Coordinate:
@@ -294,6 +295,7 @@ JournalTitle:
 #  ExactSettings:
 #    DismaxFields:
 #      - title_full_unstemmed^450
+#    DismaxHandler: edismax
 #    FilterQuery: "format:Journal OR format:Article"
 
 Title:
@@ -311,6 +313,7 @@ Title:
 #  ExactSettings:
 #    DismaxFields:
 #      - title_full_unstemmed^450
+#    DismaxHandler: edismax
 
 Series:
   DismaxFields:
@@ -351,6 +354,7 @@ AllFields:
 #      - fulltext_unstemmed^10
 #      - isbn
 #      - issn
+#    DismaxHandler: edismax
 
 # These are advanced searches that never use Dismax:
 id:


### PR DESCRIPTION
Unintuitively, the `DismaxHandler` settings for `ExactSettings` are not inherited from the parent in `searchspecs.yaml`. This PR adds it every time `ExactSettings` is used. Since  `ExactSettings` is commented out, the new `DismaxHandler` is also commented out. It is set to `edismax`, which is different from the default given by `default_dismax_handler` (currently `dismax`).

What prompted this change was a situation for exact searches using boolean logic to search a specific field. For instance, searching for `"tests" AND "testing"` in titles. The `qf` Solr field was not used, so it was not specifically searching in titles as requested. This was because for advanced queries, VuFind is only using `qf` with `edismax` handlers (see [code](https://github.com/vufind-org/vufind/blob/8f9cea7a8dd0cbb3888cfc1457fa551875816ce9/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php#L161)). It was not obvious to track the source of the issue in the `DismaxHandler` setting for `ExactSettings`.