### PR TITLE
Improve Search2 tag search defaults/behavior.

### DIFF
--- a/config/vufind/Search2.ini
+++ b/config/vufind/Search2.ini
@@ -80,7 +80,7 @@ Subject             = Subject
 CallNumber          = "Call Number"
 ISN                 = "ISBN/ISSN"
 ;Coordinate        = Coordinates
-tag                 = Tag
+;tag                 = Tag
 
 [Advanced_Searches]
 AllFields           = adv_search_all

--- a/module/VuFind/src/VuFind/Controller/Search2Controller.php
+++ b/module/VuFind/src/VuFind/Controller/Search2Controller.php
@@ -52,4 +52,24 @@ class Search2Controller extends AbstractSolrSearch
         $this->searchClassId = 'Search2';
         parent::__construct($sm);
     }
+
+    /**
+     * Results action.
+     *
+     * @return mixed
+     */
+    public function resultsAction()
+    {
+        // Special case -- redirect tag searches.
+        if ($this->params()->fromQuery('type') == 'tag') {
+            // Because we're coming in from a search, we want to do a fuzzy
+            // tag search, not an exact search like we would when linking to a
+            // specific tag name.
+            $query = $this->getRequest()->getQuery()->set('fuzzy', 'true');
+            return $this->forwardTo('Tag', 'Home');
+        }
+
+        // Default case -- standard behavior.
+        return parent::resultsAction();
+    }
 }


### PR DESCRIPTION
I noticed during testing that Search2.ini had tag search enabled by default, but that it did not work correctly in the Search2 module.

This PR adds support to ensure that tag search is functional in Search2, but it also turns it off by default since tag search is potentially confusing and is rarely used.