### PR TITLE
RateLimiter: Add RejectAll policy

### DIFF
--- a/config/vufind/RateLimiter.yaml
+++ b/config/vufind/RateLimiter.yaml
@@ -111,8 +111,8 @@ Storage:
 #                              reached, a Turnstile challenge is used instead of simply
 #                              returning a 429. The challenge result is cached. 
 #                              Failing the challenge results in standard 429 behavior.
-#                              Passing the challenge bypasses this check, but note the
-#                              rateLimiterSettings quota is still separately applied.
+#                              Passing the challenge bypasses this Turnstile check, but
+#                              note the rateLimiterSettings quota is still separately applied.
 #                              To show the challenge immediately, use policy reject_all.
 #                              Default (not defined) means don't use Turnstile.
 #

--- a/config/vufind/RateLimiter.yaml
+++ b/config/vufind/RateLimiter.yaml
@@ -110,10 +110,10 @@ Storage:
 # turnstileRateLimiterSettings Defined like rateLimiterSettings, but when the limit is
 #                              reached, a Turnstile challenge is used instead of simply
 #                              returning a 429. The challenge result is cached. 
+#                              To show the challenge immediately, use policy reject_all.
 #                              Failing the challenge results in standard 429 behavior.
 #                              Passing the challenge bypasses this Turnstile check, but
 #                              note the rateLimiterSettings quota is still separately applied.
-#                              To show the challenge immediately, use policy reject_all.
 #                              Default (not defined) means don't use Turnstile.
 #
 # addHeaders            Whether to add X-RateLimit-* headers (default is false)

--- a/config/vufind/RateLimiter.yaml
+++ b/config/vufind/RateLimiter.yaml
@@ -97,7 +97,8 @@ Storage:
 #
 # rateLimiterSettings   Rate Limiter settings.
 #                       See https://symfony.com/doc/current/rate_limiter.html#rate-limiting-policies
-#                       for more information and policy settings.
+#                       for more information and policy settings.  In addition to those
+#                       policies, a "reject_all" policy is available to block all requests.
 #                       For a limiter using the token bucket algorithm, the following
 #                       settings could be used to e.g. allow 500 requests initially,
 #                       and add 100 more to the bucket every 10 minutes:
@@ -112,6 +113,7 @@ Storage:
 #                              Failing the challenge results in standard 429 behavior.
 #                              Passing the challenge bypasses this check, but note the
 #                              rateLimiterSettings quota is still separately applied.
+#                              To show the challenge immediately, use policy reject_all.
 #                              Default (not defined) means don't use Turnstile.
 #
 # addHeaders            Whether to add X-RateLimit-* headers (default is false)

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
@@ -41,6 +41,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use VuFind\RateLimiter\Storage\CredisStorage;
+use VuFind\RateLimiter\Turnstile\RejectAll;
 use VuFind\Service\GetServiceTrait;
 
 /**
@@ -135,6 +136,9 @@ class RateLimiterManagerFactory implements FactoryInterface
         }
 
         $rateLimiterConfig = $policy[$configSection] ?? [];
+        if ('reject_all' == $rateLimiterConfig['policy'] ?? null) {
+            return new RejectAll();
+        }
         $rateLimiterConfig['id'] = $policyId;
         if (null !== $userId && !($policy['preferIPAddress'] ?? false)) {
             $clientId = "u:$userId";

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
@@ -135,7 +135,7 @@ class RateLimiterManagerFactory implements FactoryInterface
         }
 
         $rateLimiterConfig = $policy[$configSection] ?? [];
-        if ('reject_all' == $rateLimiterConfig['policy'] ?? null) {
+        if ('reject_all' === ($rateLimiterConfig['policy'] ?? null)) {
             return new RejectAll();
         }
         $rateLimiterConfig['id'] = $policyId;

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManagerFactory.php
@@ -41,7 +41,6 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use VuFind\RateLimiter\Storage\CredisStorage;
-use VuFind\RateLimiter\Turnstile\RejectAll;
 use VuFind\Service\GetServiceTrait;
 
 /**

--- a/module/VuFind/src/VuFind/RateLimiter/RejectAll.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RejectAll.php
@@ -27,7 +27,7 @@
  * @link     https://vufind.org/wiki/development Wiki
  */
 
-namespace VuFind\RateLimiter\Turnstile;
+namespace VuFind\RateLimiter;
 
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\LimiterInterface;

--- a/module/VuFind/src/VuFind/RateLimiter/Turnstile/RejectAll.php
+++ b/module/VuFind/src/VuFind/RateLimiter/Turnstile/RejectAll.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * RejectAll policy for RateLimiter.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Service
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\RateLimiter\Turnstile;
+
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
+
+/**
+ * RejectAll policy for RateLimiter.
+ *
+ * @category VuFind
+ * @package  RateLimiter
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class RejectAll implements LimiterInterface
+{
+    /**
+     * Waits until the required number of tokens is available.
+     *
+     * In this implementation, just throws an exception since reserving is not supported.
+     *
+     * @param int        $tokens  the number of tokens required
+     * @param float|null $maxTime maximum accepted waiting time in seconds
+     *
+     * @return Reservation The reservation
+     *
+     * @throws MaxWaitDurationExceededException if $maxTime is set and the process needs to wait longer than its value
+     *                                          (in seconds)
+     * @throws ReserveNotSupportedException     if this limiter implementation doesn't support reserving tokens
+     * @throws \InvalidArgumentException        if $tokens is larger than the maximum burst size
+     */
+    public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
+    {
+        throw new ReserveNotSupportedException(__CLASS__);
+    }
+
+    /**
+     * Use this method if you intend to drop if the required number
+     * of tokens is unavailable.
+     *
+     * @param int $tokens the number of tokens required
+     *
+     * @return RateLimit The limit counter
+     */
+    public function consume(int $tokens = 1): RateLimit
+    {
+        return new RateLimit(0, new \DateTimeImmutable(), false, 0);
+    }
+
+    /**
+     * Resets the limit.
+     *
+     * No-op in this implementation.
+     *
+     * @return void
+     */
+    public function reset(): void
+    {
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RateLimiter/RejectAllTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RateLimiter/RejectAllTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * RejectAll Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\RateLimiter;
+
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+use VuFind\RateLimiter\RejectAll;
+
+/**
+ * RejectAll Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RejectAllTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test that using reserve() throws an exception.
+     *
+     * @return void
+     */
+    public function testReserve()
+    {
+        $policy = new RejectAll();
+
+        $this->expectException(ReserveNotSupportedException::class);
+        $policy->reserve(42);
+    }
+
+    /**
+     * Test that using consume() returns an empty limit.
+     *
+     * @return void
+     */
+    public function testConsume()
+    {
+        $policy = new RejectAll();
+        $limit = $policy->consume();
+        $this->assertFalse($limit->isAccepted());
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RateLimiter/RejectAllTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RateLimiter/RejectAllTest.php
@@ -51,7 +51,6 @@ class RejectAllTest extends \PHPUnit\Framework\TestCase
     public function testReserve()
     {
         $policy = new RejectAll();
-
         $this->expectException(ReserveNotSupportedException::class);
         $policy->reserve(42);
     }


### PR DESCRIPTION
This adds a RateLimiter policy that simply always returns a fully consumed RateLimit.  Symfony builds in the opposite policy https://github.com/symfony/rate-limiter/blob/7.3/Policy/NoLimiter.php but not this one.

This is intended for Turnstile, i.e. to show the Turnstile challenge immediately on the first request.  The botnets have gotten so large that they appear to use a unique IP every single time, so it can be helpful to challenge immediately.

This can also be used for testing purposes on either of the rate limiters.

```
turnstileRateLimiterSettings:
  policy: reject_all
```

