### PR TITLE
RateLimiter: Limit bots ignoring a Turnstile challenge

### DIFF
--- a/config/vufind/RateLimiter.yaml
+++ b/config/vufind/RateLimiter.yaml
@@ -114,6 +114,15 @@ Storage:
 #                              rateLimiterSettings quota is still separately applied.
 #                              Default (not defined) means don't use Turnstile.
 #
+# turnstileIgnoredRateLimiterSettings 
+#                              Bots may ignore all Javascript, and thus never actually
+#                              submit a generated Turnstile challenge, so that it is
+#                              issued again on every request. This limits the number
+#                              of times the challenge will be presented and not
+#                              completed, before it will be recorded as failed.
+#                              Defined like rateLimiterSettings, but it decrements each
+#                              time the challenge is presented.
+#
 # addHeaders            Whether to add X-RateLimit-* headers (default is false)
 #
 # reportOnly            If set to true, will not enforce the policy even if the main

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -224,7 +224,7 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                         );
                         $turnstileIgnoredLimit = $turnstileIgnoredLimiter->consume(1);
                         if (!$turnstileIgnoredLimit->isAccepted()) {
-                            $this->verboseDebug('No more ignoring the challenge.');
+                            $this->verboseDebug('Turnstile ignored limit exceeded.');
                             $this->turnstile->setResult($policyId, $this->clientIp, false);
                             $result['presentTurnstileChallenge'] = false;
                         } else {

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -228,7 +228,9 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                             $this->turnstile->setResult($policyId, $this->clientIp, false);
                             $result['presentTurnstileChallenge'] = false;
                         } else {
-                            $this->verboseDebug('Turnstile ignored limit down to ' . $turnstileIgnoredLimit->getRemainingTokens());
+                            $this->verboseDebug(
+                                'Turnstile ignored limit down to ' . $turnstileIgnoredLimit->getRemainingTokens()
+                            );
                         }
                     }
                     return $result;

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -212,7 +212,7 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                     $result['message'] = $this->getTooManyRequestsResponseMessage($event, $result);
                     $result['presentTurnstileChallenge'] = ($priorTurnstileResult === null);
                     if (
-                        $result['presentTurnstileChallenge'] && 
+                        $result['presentTurnstileChallenge'] &&
                         ($this->config['Policies'][$policyId]['turnstileIgnoredRateLimiterSettings'] ?? false)
                     ) {
                         $turnstileIgnoredLimiter = ($this->rateLimiterFactoryCallback)(

--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -211,6 +211,26 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                     $result['allow'] = false;
                     $result['message'] = $this->getTooManyRequestsResponseMessage($event, $result);
                     $result['presentTurnstileChallenge'] = ($priorTurnstileResult === null);
+                    if (
+                        $result['presentTurnstileChallenge'] && 
+                        ($this->config['Policies'][$policyId]['turnstileIgnoredRateLimiterSettings'] ?? false)
+                    ) {
+                        $turnstileIgnoredLimiter = ($this->rateLimiterFactoryCallback)(
+                            $this->config,
+                            $policyId,
+                            $this->clientIp,
+                            $this->userId,
+                            'turnstileIgnoredRateLimiterSettings'
+                        );
+                        $turnstileIgnoredLimit = $turnstileIgnoredLimiter->consume(1);
+                        if (!$turnstileIgnoredLimit->isAccepted()) {
+                            $this->verboseDebug('No more ignoring the challenge.');
+                            $this->turnstile->setResult($policyId, $this->clientIp, false);
+                            $result['presentTurnstileChallenge'] = false;
+                        } else {
+                            $this->verboseDebug('Turnstile ignored limit down to ' . $turnstileIgnoredLimit->getRemainingTokens());
+                        }
+                    }
                     return $result;
                 }
             }

--- a/module/VuFind/src/VuFind/RateLimiter/Turnstile/Turnstile.php
+++ b/module/VuFind/src/VuFind/RateLimiter/Turnstile/Turnstile.php
@@ -157,7 +157,7 @@ class Turnstile implements HttpServiceAwareInterface, LoggerAwareInterface
      *
      * @return void
      */
-    protected function setResult($policyId, $clientIp, $success)
+    public function setResult($policyId, $clientIp, $success)
     {
         $cacheKey = $this->getCacheKey($policyId, $clientIp);
         $this->turnstileCache->setItem($cacheKey, $success);


### PR DESCRIPTION
As explained in the config:

> Bots may ignore all Javascript, and thus never actually submit a generated Turnstile challenge, so that it is issued again on every request. This limits the number of times the challenge will be presented and not completed, before it will be recorded as failed.

I'm seeing this bot behavior almost all of the time.  Showing the challenge infinitely (until the base rateLimiterSettings limit is reached) is a waste of resources, and defeats the purpose of the challenge.  That said, it may be appropriate to allow one or two ignores for simple user error.