### PR TITLE
Fix AJAX tabs with Safari.

### DIFF
--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -239,7 +239,6 @@ function handleAjaxTabLinkClick(event){
  * Register click handlers for AJAX tab links.
  */
 function handleAjaxTabLinks() {
-  // Form submission
   document.querySelectorAll('a').forEach((a) => {
     const href = a.href;
     if (typeof href !== 'undefined' && href.match(/\/AjaxTab[/?]/)) {
@@ -261,8 +260,6 @@ function registerTabEvents(params) {
   recaptchaOnLoad(container);
 
   setUpCheckRequest(container);
-
-  handleAjaxTabLinks();
 }
 VuFind.listen('record-tab-init', registerTabEvents);
 
@@ -454,16 +451,16 @@ function applyRecordTabHash(scrollToTabs) {
 
   // Open tab in url hash
   if (initiallyActiveTab && (newTab.length <= 1 || newTab === '#tabnav')) {
-    initiallyActiveTab.dispatchEvent(new Event('click'));
+    initiallyActiveTab.click();
   } else if (newTab.length > 1 && '#' + activeTab !== newTab) {
     const tabLink = document.querySelector('.record-tabs .' + newTab.substring(1) + ' a');
     if (tabLink) {
-      tabLink.dispatchEvent(new Event('click'));
+      tabLink.click();
       if (typeof scrollToTabs === 'undefined' || false !== scrollToTabs) {
         $('html, body').animate({
           scrollTop: $('.record-tabs').offset().top
         }, 500);
-        tabLink.dispatchEvent(new Event('focus'));
+        tabLink.focus();
       }
     }
   }
@@ -488,11 +485,14 @@ function removeCheckRouteParam() {
  */
 function recordDocReady() {
   removeCheckRouteParam();
+
+  handleAjaxTabLinks();
   document.querySelectorAll('.record-tabs .nav-tabs a')
     .forEach((tab) => tab.addEventListener('click', (event) => {
       const li = tab.parentNode;
-      // Don't change behavior of active tab.
+      // Do nothing if the tab is already active:
       if (tab.classList.contains('active')) {
+        event.preventDefault();
         return;
       }
       const tabId = li.dataset.tab;


### PR DESCRIPTION
Safari was exhibiting a problem where, when the initial tab is set to be loaded with AJAX, the initiating click on the tab would cause a page load due to a combination of issues.

Changes made:
- Calls handleAjaxTabLinks early to ensure that click handlers are activated when needed.
- Calls click() directly instead of dispatching click events. The empty base Event was not directed to the event listener in Safari and felt wrong regardless. Same with the focus call.
- Prevents clicking a tab from doing anything if the tab is already active so that the page doesn't get reloaded. This prevents an issue where click initiates a load and then the hash change also does that.