### PR TITLE
Prevent duplicates in alphabrowse useInstead and seeAlso headings

### DIFF
--- a/themes/bootstrap5/templates/alphabrowse/home.phtml
+++ b/themes/bootstrap5/templates/alphabrowse/home.phtml
@@ -116,7 +116,7 @@
               <div>
                 <?=$this->transEsc('Use instead') ?>:
                 <ul>
-                  <?php foreach ($item['useInstead'] as $heading): ?>
+                  <?php foreach (array_unique($item['useInstead']) as $heading): ?>
                   <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => ['from' => $heading] + $baseQuery]))?>"><?=$this->escapeHtml($heading)?></a></li>
                   <?php endforeach; ?>
                 </ul>
@@ -127,7 +127,7 @@
               <div>
                 <?=$this->transEsc('See also') ?>:
                 <ul>
-                  <?php foreach ($item['seeAlso'] as $heading): ?>
+                  <?php foreach (array_unique($item['seeAlso']) as $heading): ?>
                   <li><a href="<?=$this->escapeHtmlAttr($this->url('alphabrowse-home', [], ['query' => ['from' => $heading] + $baseQuery]))?>"><?=$this->escapeHtml($heading)?></a></li>
                   <?php endforeach; ?>
                 </ul>


### PR DESCRIPTION
This is to prevent duplicate "Use instead" or "See also" headings from displaying in the alphabrowse template. This can happen if there are unique authority records coming from different sources that have the same heading value. From VuFind's perspective, the search link is identical so we should only need to display that heading once.

Sample Solr record:

```json
[{
      "id":"bslw93007784",
      "record_type":"Topical",
      "heading":"Indigenous women",
      "use_for":["Indian women","Women, Indian","Women, Indigenous","Women, Native","Native women"],
      "see_also":["Women"]
    },{
      "id":"fst00970270",
      "record_type":"Topical",
      "heading":"Indigenous women",
      "use_for":["Aboriginal women","Native women"],
      "see_also":["Women"]
    },{
      "id":"sh 00007362",
      "lccn":["sh00007362"],
      "record_type":"Topical",
      "heading":"Indigenous women",
      "use_for":["Aboriginal women","Native women"],
      "see_also":["Women"]
}]
```
Display before this change is applied:
<img width="330" height="169" alt="image" src="https://github.com/user-attachments/assets/f5e2773e-91b6-4517-a0f9-53ac9540963f" />