### PR TITLE
CI action: Base NPM caching on package.json instead of package-lock.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
+          key: npm-${{ hashFiles('package.json') }}
           restore-keys: npm-
 
       - name: Install node dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ hashFiles('package.json') }}
+          key: npm-${{ hashFiles('**/package.json') }}
           restore-keys: npm-
 
       - name: Install node dependencies


### PR DESCRIPTION
NPM caching hasn't been working effectively. This is likely because the cache key is based on package-lock.json, but we do not commit the lockfile to the repository, so the key will be different on every run due to variations in lockfile generation. This PR changes the key to use the multiple package.json files that actually exist in the repo instead.