### PR TITLE
Add cache to ConfigManager

### DIFF
--- a/module/VuFind/src/VuFind/Config/ConfigManager.php
+++ b/module/VuFind/src/VuFind/Config/ConfigManager.php
@@ -53,6 +53,11 @@ class ConfigManager
 {
     use MergeRecursiveTrait;
 
+    /**
+     * Configuration cache
+     *
+     * @var array[]
+     */
     protected array $cache = [];
 
     /**

--- a/module/VuFind/src/VuFind/Config/ConfigManager.php
+++ b/module/VuFind/src/VuFind/Config/ConfigManager.php
@@ -53,6 +53,8 @@ class ConfigManager
 {
     use MergeRecursiveTrait;
 
+    protected array $cache = [];
+
     /**
      * Constructor
      *
@@ -70,32 +72,44 @@ class ConfigManager
      *
      * The path consists of a base configuration name and a path to a subsection of that configuration.
      *
-     * @param string $configPath Config path
+     * @param string  $configPath     Config path
+     * @param boolean $forceReload    If cache should be ignored
+     * @param boolean $useLocalConfig Use local configuration if available
      *
      * @return mixed
      */
-    public function getConfig(string $configPath): mixed
+    public function getConfig(string $configPath, bool $forceReload = false, bool $useLocalConfig = true): mixed
     {
+        $cacheKey =  ($useLocalConfig ? 'local_' : 'base_') . $configPath;
+        if (!$forceReload && isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
         $subsection = explode('/', $configPath);
         $configName = array_shift($subsection);
-        $configLocation = $this->pathResolver->getConfigLocation($configName);
+        $configLocation = $useLocalConfig
+            ? $this->pathResolver->getConfigLocation($configName)
+            : $this->pathResolver->getBaseConfigLocation($configName);
         if (!$configLocation) {
             return [];
         }
         $configLocation->setSubsection($subsection);
-        return $this->loadConfigFromLocation($configLocation);
+        $config = $this->loadConfigFromLocation($configLocation);
+        $this->cache[$cacheKey] = $config;
+        return $config;
     }
 
     /**
      * Get config as array by path.
      *
-     * @param string $configPath Config path
+     * @param string  $configPath     Config path
+     * @param boolean $forceReload    If cache should be ignored
+     * @param boolean $useLocalConfig Use local configuration if available
      *
      * @return array
      */
-    public function getConfigArray(string $configPath): array
+    public function getConfigArray(string $configPath, bool $forceReload = false, bool $useLocalConfig = true): array
     {
-        $config = $this->getConfig($configPath);
+        $config = $this->getConfig($configPath, $forceReload, $useLocalConfig);
         if (!is_array($config)) {
             throw new ConfigException('Configuration on path ' . $configPath . ' is not an array.');
         }
@@ -105,13 +119,15 @@ class ConfigManager
     /**
      * Get config as object by path.
      *
-     * @param string $configPath Config path
+     * @param string  $configPath     Config path
+     * @param boolean $forceReload    If cache should be ignored
+     * @param boolean $useLocalConfig Use local configuration if available
      *
      * @return Config
      */
-    public function getConfigObject(string $configPath): Config
+    public function getConfigObject(string $configPath, bool $forceReload = false, bool $useLocalConfig = true): Config
     {
-        return new Config($this->getConfigArray($configPath));
+        return new Config($this->getConfigArray($configPath, $forceReload, $useLocalConfig));
     }
 
     /**

--- a/module/VuFind/src/VuFind/Config/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginFactory.php
@@ -75,7 +75,9 @@ class PluginFactory implements AbstractFactoryInterface
         $requestedName,
         ?array $options = null
     ) {
-        $configManager = $container->get(ConfigManager::class);
-        return $configManager->getConfigObject($requestedName);
+        return $container->get(ConfigManager::class)->getConfigObject(
+            $requestedName,
+            forceReload: $options['forceReload'] ?? false
+        );
     }
 }

--- a/module/VuFind/src/VuFind/Config/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginFactory.php
@@ -64,11 +64,9 @@ class PluginFactory implements AbstractFactoryInterface
      *
      * @param ContainerInterface $container     Service container
      * @param string             $requestedName Name of service
-     * @param array              $options       Options (unused)
+     * @param array              $options       Options
      *
      * @return object
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __invoke(
         ContainerInterface $container,

--- a/module/VuFind/src/VuFind/Config/PluginManager.php
+++ b/module/VuFind/src/VuFind/Config/PluginManager.php
@@ -82,12 +82,14 @@ class PluginManager extends Base
      * @param string $id Service identifier
      *
      * @return \VuFind\Config\Config
+     *
+     * @deprecated Use \VuFind\Config\ConfigManager::getConfig with forceReload=true directly
      */
     public function reload($id)
     {
         $oldOverrideSetting = $this->getAllowOverride();
         $this->setAllowOverride(true);
-        $this->setService($id, $this->build($id));
+        $this->setService($id, $this->build($id, ['forceReload' => true]));
         $this->setAllowOverride($oldOverrideSetting);
         return $this->get($id);
     }

--- a/module/VuFind/src/VuFind/Config/PluginManager.php
+++ b/module/VuFind/src/VuFind/Config/PluginManager.php
@@ -56,6 +56,10 @@ class PluginManager extends Base
         array $v3config = []
     ) {
         $this->addAbstractFactory(PluginFactory::class);
+        // Disable caching in the plugin manager. This is handled by the \VuFind\Config\ConfigManager.
+        if (!isset($v3config['shared_by_default'])) {
+            $v3config['shared_by_default'] = false;
+        }
         parent::__construct($configOrContainerInstance, $v3config);
     }
 

--- a/module/VuFind/src/VuFindTest/Integration/ConfigTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/ConfigTestCase.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Abstract base class for config integration test cases.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Hebis Verbundzentrale 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Integration;
+
+use VuFind\Exception\FileAccess;
+use VuFind\Feature\DirUtilityTrait;
+use VuFindTest\Feature\ConfigRelatedServicesTrait;
+use VuFindTest\Feature\FixtureTrait;
+use VuFindTest\Feature\LiveDetectionTrait;
+
+/**
+ * Abstract base class for config integration test cases.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+abstract class ConfigTestCase extends \PHPUnit\Framework\TestCase
+{
+    use LiveDetectionTrait;
+    use FixtureTrait;
+    use DirUtilityTrait;
+    use ConfigRelatedServicesTrait;
+
+    /**
+     * Path to base configurations
+     *
+     * @var string
+     */
+    protected string $baseDirPath;
+
+    /**
+     * Path to local dir configurations
+     *
+     * @var string
+     */
+    protected string $localDirPath;
+
+    /**
+     * Setup local dir with fixture.
+     *
+     * @param string $fixture Fixture to use
+     *
+     * @return void
+     */
+    protected function setUpLocalConfigDir(string $fixture): void
+    {
+        $fixtureDir = realpath($this->getFixtureDir() . 'configs/' . $fixture);
+        $localDirPath = $this->localDirPath;
+        if (is_dir($localDirPath)) {
+            self::rmDir($localDirPath);
+        }
+        self::cpDir($fixtureDir, $localDirPath);
+    }
+
+    /**
+     * Read the current config.
+     *
+     * @param string  $config Config name
+     * @param ?string $path   Optional alternative path to config directory
+     *
+     * @return array
+     */
+    protected function readConfig(string $config, ?string $path = null): array
+    {
+        $configFile = ($path ?? $this->localDirPath) . '/' . $config . '.ini';
+        $result = parse_ini_file($configFile, true);
+        if ($result === false) {
+            throw new FileAccess('Could not read config file: ' . $configFile);
+        }
+        return $result;
+    }
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        // Give up if we're not running in CI:
+        if (!$this->continuousIntegrationRunning()) {
+            $this->markTestSkipped('Continuous integration not running.');
+            return;
+        }
+
+        $pathResolver = $this->getPathResolver();
+        $this->baseDirPath = $pathResolver->getBaseConfigDirPath();
+        $this->localDirPath = $pathResolver->getLocalConfigDirPath();
+        if ($this->localDirPath === null) {
+            $this->markTestSkipped('No local config dir configured.');
+        }
+
+        // create backup of local config dir
+        if (is_dir($this->localDirPath)) {
+            $backUpDir = $this->localDirPath . '.bak';
+            rename($this->localDirPath, $backUpDir);
+            mkdir($this->localDirPath);
+        }
+    }
+
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        // restore backup of local config dir
+        $localDirPath = $this->localDirPath;
+        $backUpDir = $localDirPath . '.bak';
+        if (is_dir($localDirPath)) {
+            self::rmDir($localDirPath);
+        }
+        if (is_dir($backUpDir)) {
+            rename($backUpDir, $localDirPath);
+        }
+    }
+}

--- a/module/VuFind/src/VuFindTest/Integration/ConfigTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/ConfigTestCase.php
@@ -66,6 +66,26 @@ abstract class ConfigTestCase extends \PHPUnit\Framework\TestCase
     protected string $localDirPath;
 
     /**
+     * Path to local dir backup
+     *
+     * @var string
+     */
+    protected string $localDirBackupPath;
+
+    /**
+     * Set local dir path.
+     *
+     * @param string $localDirPath Local dir path
+     *
+     * @return void
+     */
+    protected function setLocalDirPath(string $localDirPath): void
+    {
+        $this->localDirPath = $localDirPath;
+        $this->localDirBackupPath = $localDirPath . '.bak';
+    }
+
+    /**
      * Setup local dir with fixture.
      *
      * @param string $fixture Fixture to use
@@ -75,11 +95,10 @@ abstract class ConfigTestCase extends \PHPUnit\Framework\TestCase
     protected function setUpLocalConfigDir(string $fixture): void
     {
         $fixtureDir = realpath($this->getFixtureDir() . 'configs/' . $fixture);
-        $localDirPath = $this->localDirPath;
-        if (is_dir($localDirPath)) {
-            self::rmDir($localDirPath);
+        if (is_dir($this->localDirPath)) {
+            self::rmDir($this->localDirPath);
         }
-        self::cpDir($fixtureDir, $localDirPath);
+        self::cpDir($fixtureDir, $this->localDirPath);
     }
 
     /**
@@ -115,15 +134,14 @@ abstract class ConfigTestCase extends \PHPUnit\Framework\TestCase
 
         $pathResolver = $this->getPathResolver();
         $this->baseDirPath = $pathResolver->getBaseConfigDirPath();
-        $this->localDirPath = $pathResolver->getLocalConfigDirPath();
+        $this->setLocalDirPath($pathResolver->getLocalConfigDirPath());
         if ($this->localDirPath === null) {
             $this->markTestSkipped('No local config dir configured.');
         }
 
         // create backup of local config dir
         if (is_dir($this->localDirPath)) {
-            $backUpDir = $this->localDirPath . '.bak';
-            rename($this->localDirPath, $backUpDir);
+            rename($this->localDirPath, $this->localDirBackupPath);
             mkdir($this->localDirPath);
         }
     }
@@ -136,13 +154,11 @@ abstract class ConfigTestCase extends \PHPUnit\Framework\TestCase
     public function tearDown(): void
     {
         // restore backup of local config dir
-        $localDirPath = $this->localDirPath;
-        $backUpDir = $localDirPath . '.bak';
-        if (is_dir($localDirPath)) {
-            self::rmDir($localDirPath);
+        if (is_dir($this->localDirPath)) {
+            self::rmDir($this->localDirPath);
         }
-        if (is_dir($backUpDir)) {
-            rename($backUpDir, $localDirPath);
+        if (is_dir($this->localDirBackupPath)) {
+            rename($this->localDirBackupPath, $this->localDirPath);
         }
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigManagerIntegrationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigManagerIntegrationTest.php
@@ -29,7 +29,6 @@
 
 namespace VuFindTest\Config;
 
-use VuFind\Config\ConfigManager;
 use VuFindTest\Integration\ConfigTestCase;
 
 /**
@@ -51,7 +50,7 @@ class ConfigManagerIntegrationTest extends ConfigTestCase
     public function testCaching(): void
     {
         $container = $this->getContainerWithConfigRelatedServices();
-        $configManager = $container->get(ConfigManager::class);
+        $configManager = $container->get(\VuFind\Config\ConfigManager::class);
         $this->setUpLocalConfigDir('defaultgenerator');
         $config = $configManager->getConfig('config');
         $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
@@ -61,6 +60,29 @@ class ConfigManagerIntegrationTest extends ConfigTestCase
         $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
         // check that the cache is ignored
         $config = $configManager->getConfig('config', forceReload: true);
+        $this->assertEquals('Custom Generator', $config['Site']['generator']);
+    }
+
+    /**
+     * Test that the config PluginManager caching is disabled.
+     *
+     * @return void
+     */
+    public function testDisabledPluginManagerCaching(): void
+    {
+        $container = $this->getContainerWithConfigRelatedServices();
+        $configManager = $container->get(\VuFind\Config\ConfigManager::class);
+        $pluginManager = $container->get(\VuFind\Config\PluginManager::class);
+        $this->setUpLocalConfigDir('defaultgenerator');
+        $config = $pluginManager->get('config')->toArray();
+        $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
+        // check that the cache is used and the change in the config files is ignored
+        $this->setUpLocalConfigDir('customgenerator');
+        $config = $pluginManager->get('config')->toArray();
+        $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
+        // check that the plugin manager cache is ignored
+        $configManager->getConfig('config', forceReload: true);
+        $config = $pluginManager->get('config')->toArray();
         $this->assertEquals('Custom Generator', $config['Site']['generator']);
     }
 
@@ -76,7 +98,7 @@ class ConfigManagerIntegrationTest extends ConfigTestCase
             baseSubDir: ''
         );
         $this->setUpLocalConfigDir('customgenerator');
-        $configManager = $container->get(ConfigManager::class);
+        $configManager = $container->get(\VuFind\Config\ConfigManager::class);
         $config = $configManager->getConfig('config');
         $this->assertEquals('Custom Generator', $config['Site']['generator']);
         $config = $configManager->getConfig('config', useLocalConfig: false);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigManagerIntegrationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigManagerIntegrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * ConfigManager Integration Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Hebis Verbundzentrale 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Config;
+
+use VuFind\Config\ConfigManager;
+use VuFindTest\Integration\ConfigTestCase;
+
+/**
+ * ConfigManager Integration Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Thomas Wagener <wagener@hebis.uni-frankfurt.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ConfigManagerIntegrationTest extends ConfigTestCase
+{
+    /**
+     * Test caching.
+     *
+     * @return void
+     */
+    public function testCaching(): void
+    {
+        $container = $this->getContainerWithConfigRelatedServices();
+        $configManager = $container->get(ConfigManager::class);
+        $this->setUpLocalConfigDir('defaultgenerator');
+        $config = $configManager->getConfig('config');
+        $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
+        // check that the cache is used and the change in the config files is ignored
+        $this->setUpLocalConfigDir('customgenerator');
+        $config = $configManager->getConfig('config');
+        $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
+        // check that the cache is ignored
+        $config = $configManager->getConfig('config', forceReload: true);
+        $this->assertEquals('Custom Generator', $config['Site']['generator']);
+    }
+
+    /**
+     * Test the userLocalConfig parameter.
+     *
+     * @return void
+     */
+    public function testUseLocalConfigParameter(): void
+    {
+        $container = $this->getContainerWithConfigRelatedServices(
+            baseDir: $this->getFixtureDir() . 'configs/defaultgenerator',
+            baseSubDir: ''
+        );
+        $this->setUpLocalConfigDir('customgenerator');
+        $configManager = $container->get(ConfigManager::class);
+        $config = $configManager->getConfig('config');
+        $this->assertEquals('Custom Generator', $config['Site']['generator']);
+        $config = $configManager->getConfig('config', useLocalConfig: false);
+        $this->assertEquals('VuFind 1.0', $config['Site']['generator']);
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigWritingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigWritingTest.php
@@ -31,10 +31,7 @@ namespace VuFindTest\Config;
 
 use VuFind\Config\ConfigManager;
 use VuFind\Config\PathResolver;
-use VuFind\Feature\DirUtilityTrait;
-use VuFindTest\Feature\ConfigRelatedServicesTrait;
-use VuFindTest\Feature\FixtureTrait;
-use VuFindTest\Feature\LiveDetectionTrait;
+use VuFindTest\Integration\ConfigTestCase;
 
 /**
  * Config Writing Integration Test Class
@@ -45,65 +42,8 @@ use VuFindTest\Feature\LiveDetectionTrait;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class ConfigWritingTest extends \PHPUnit\Framework\TestCase
+class ConfigWritingTest extends ConfigTestCase
 {
-    use LiveDetectionTrait;
-    use FixtureTrait;
-    use DirUtilityTrait;
-    use ConfigRelatedServicesTrait;
-
-    /**
-     * Path to local dir configurations
-     *
-     * @var string
-     */
-    protected string $localDirPath;
-
-    /**
-     * Standard setup method.
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        // Give up if we're not running in CI:
-        if (!$this->continuousIntegrationRunning()) {
-            $this->markTestSkipped('Continuous integration not running.');
-            return;
-        }
-
-        $pathResolver = $this->getPathResolver();
-        $this->localDirPath = $pathResolver->getLocalConfigDirPath();
-        if ($this->localDirPath === null) {
-            $this->markTestSkipped('No local config dir configured.');
-        }
-
-        // create backup of local config dir
-        if (is_dir($this->localDirPath)) {
-            $backUpDir = $this->localDirPath . '.bak';
-            rename($this->localDirPath, $backUpDir);
-            mkdir($this->localDirPath);
-        }
-    }
-
-    /**
-     * Standard teardown method.
-     *
-     * @return void
-     */
-    public function tearDown(): void
-    {
-        // restore backup of local config dir
-        $localDirPath = $this->localDirPath;
-        $backUpDir = $localDirPath . '.bak';
-        if (is_dir($localDirPath)) {
-            self::rmDir($localDirPath);
-        }
-        if (is_dir($backUpDir)) {
-            rename($backUpDir, $localDirPath);
-        }
-    }
-
     /**
      * Upgrade test provider.
      *

--- a/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
+++ b/module/VuFindAdmin/src/VuFindAdmin/Controller/ConfigController.php
@@ -85,7 +85,8 @@ class ConfigController extends AbstractAdmin
 
             // Reload config now that it has been edited (otherwise, old setting
             // will persist in cache):
-            $this->getService(\VuFind\Config\PluginManager::class)->reload('config');
+            $this->getService(\VuFind\Config\ConfigManager::class)
+                ->getConfig('config', forceReload: true);
         } else {
             $this->flashMessenger()->addErrorMessage(
                 'Could not enable auto-configuration; check permissions on '


### PR DESCRIPTION
This PR adds caching to the ConfigManager and also adds the `useLocalConfig` parameter to the `getConfig` method in preparation to move loading of YAML files to it. 