### PR TITLE
[VUFIND-1789] Use EDS default setting for searchmode in advanced search

### DIFF
--- a/module/VuFind/src/VuFind/Controller/EdsController.php
+++ b/module/VuFind/src/VuFind/Controller/EdsController.php
@@ -32,6 +32,7 @@ namespace VuFind\Controller;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFind\Solr\Utils as SolrUtils;
 
+use function array_key_exists;
 use function in_array;
 
 /**
@@ -229,9 +230,10 @@ class EdsController extends AbstractSearch
         $params = $results->getParams();
         $options = $params->getOptions();
         $searchModes = $options->getModeOptions();
+        $useDefault = true;
         // Process the facets, assuming they came back
-        foreach ($searchModes as $key => $mode) {
-            if ($searchObject) {
+        if ($searchObject) {
+            foreach ($searchModes as $key => $mode) {
                 $modeFilter = 'SEARCHMODE:' . $mode['Value'];
                 if ($searchObject->getParams()->hasFilter($modeFilter)) {
                     $searchModes[$key]['selected'] = true;
@@ -240,11 +242,14 @@ class EdsController extends AbstractSearch
                     // will already be accounted for by being selected in the
                     // filter select list!
                     $searchObject->getParams()->removeFilter($modeFilter);
+                    $useDefault = false;
                 }
-            } else {
-                if ($key == $options->getDefaultMode()) {
-                    $searchModes[$key]['selected'] = true;
-                }
+            }
+        }
+        if ($useDefault) {
+            $key = $options->getDefaultMode();
+            if (array_key_exists($key, $searchModes)) {
+                $searchModes[$key]['selected'] = true;
             }
         }
 


### PR DESCRIPTION
When making a new advanced search with EDS, the default search mode is not selected because it assumes that if there is a search object that it will specify the search mode, but the search object can be created with other defaults that don't include the search mode.

This changes the function to check the search object for a search mode and select the default if none were found.

TODO:
- [x] Resolve [VUFIND-1789](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1789) when merging