### PR TITLE
Refactor ObalkyKnihService: extract query building into separate method

### DIFF
--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -180,6 +180,37 @@ class ObalkyKnihService implements
     protected function getFromService(array $ids): ?\stdClass
     {
         $param = 'multi';
+        $query = $this->getServiceQuery($ids);
+
+        $url = $this->getBaseUrl();
+        if ($url === '') {
+            $this->logWarning('All ObalkyKnih servers are down.');
+            return null;
+        }
+        $url .= $this->endpoints['books'] . '?';
+        $url .= http_build_query([$param => json_encode([$query])]);
+        $client = $this->getHttpClient($url);
+        try {
+            $response = $client->send();
+        } catch (\Exception $e) {
+            $this->logError('Unexpected ' . $e::class . ': ' . $e->getMessage());
+            return null;
+        }
+        if ($response->isSuccess()) {
+            $json = json_decode($response->getBody());
+            return empty($json) ? null : $json[0];
+        }
+        return null;
+    }
+
+    /**
+     * Get query params for service
+     *
+     * @param array $ids
+     * @return array
+     */
+    protected function getServiceQuery(array $ids): array
+    {
         $query = [];
         $isbn = null;
         if (!empty($ids['isbns'])) {
@@ -209,25 +240,7 @@ class ObalkyKnihService implements
             }
         }
 
-        $url = $this->getBaseUrl();
-        if ($url === '') {
-            $this->logWarning('All ObalkyKnih servers are down.');
-            return null;
-        }
-        $url .= $this->endpoints['books'] . '?';
-        $url .= http_build_query([$param => json_encode([$query])]);
-        $client = $this->getHttpClient($url);
-        try {
-            $response = $client->send();
-        } catch (\Exception $e) {
-            $this->logError('Unexpected ' . $e::class . ': ' . $e->getMessage());
-            return null;
-        }
-        if ($response->isSuccess()) {
-            $json = json_decode($response->getBody());
-            return empty($json) ? null : $json[0];
-        }
-        return null;
+        return $query;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -207,6 +207,7 @@ class ObalkyKnihService implements
      * Get query params for service
      *
      * @param array $ids Record identifiers
+     *
      * @return array
      */
     protected function getServiceQuery(array $ids): array

--- a/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
+++ b/module/VuFind/src/VuFind/Content/ObalkyKnihService.php
@@ -206,7 +206,7 @@ class ObalkyKnihService implements
     /**
      * Get query params for service
      *
-     * @param array $ids
+     * @param array $ids Record identifiers
      * @return array
      */
     protected function getServiceQuery(array $ids): array


### PR DESCRIPTION
Description
This PR refactors ObalkyKnihService::getFromService by extracting the query-building logic into a separate protected method.

Why
The goal is to allow overriding only the query construction without duplicating the full getFromService implementation.

Use case
In our case, we need to extend the query with additional parameters (part_no, part_year, part_volume) so that the service can fetch covers for specific periodical/issue instances.