### PR TITLE
Fix MariaDB support in Doctrine.

### DIFF
--- a/module/VuFind/src/VuFind/Db/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/Db/ConnectionFactory.php
@@ -169,6 +169,7 @@ class ConnectionFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
     public function getDriverName($type)
     {
         switch (strtolower($type)) {
+            case 'mariadb':
             case 'mysql':
                 return 'pdo_mysql';
             case 'pgsql':


### PR DESCRIPTION
The Doctrine code was not updated correctly to handle the mariadb database driver option added in #4108. This PR addresses the oversight.