### PR TITLE
Fix and tweak password recovery.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -244,9 +244,13 @@ class ILS extends AbstractBase
         // Validate Input
         $this->validatePasswordUpdate($params, $recoveryData['target'] ?? null);
 
-        $result = $this->getCatalog()->resetPassword($recoveryData['details'], $params);
-        if (!$result['success']) {
-            throw new AuthException($result['error']);
+        try {
+            $result = $this->getCatalog()->resetPassword($recoveryData['details'], $params);
+            if (!$result['success']) {
+                throw new AuthException($result['error']);
+            }
+        } catch (ILSException $e) {
+            throw new AuthException('ils_connection_failed', previous: $e);
         }
     }
 

--- a/module/VuFind/src/VuFind/Auth/MultiILS.php
+++ b/module/VuFind/src/VuFind/Auth/MultiILS.php
@@ -139,7 +139,7 @@ class MultiILS extends ILS
         if (!$target) {
             throw new \Exception(__METHOD__ . ' requires the target parameter!');
         }
-        // If a target is specified, use an arbitrary cat_username with the corrent target prefix:
+        // If a target is specified, use an arbitrary cat_username with the correct target prefix:
         $recoveryConfig = $this->getCatalog()->checkFunction(
             'resetPassword',
             ['cat_username' => "$target.123"]

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -2784,11 +2784,14 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
      * @param array $details Driver-specific account recovery details.
      * @param array $params  User-entered form parameters.
      *
-     * @throws AuthException
+     * @throws ILSException
      * @return array Status
      */
     public function resetPassword(array $details, array $params)
     {
+        if (!($this->config['PasswordRecovery']['enabled'] ?? false)) {
+            throw new ILSException('Recovery disabled');
+        }
         if (empty($details['cat_username']) || empty($details['email']) || empty($params['password'])) {
             return [
                 'success' => false,

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1811,7 +1811,7 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      * @param array $details Driver-specific account recovery details.
      * @param array $params  User-entered form parameters.
      *
-     * @throws AuthException
+     * @throws ILSException
      * @return array Status
      */
     public function resetPassword(array $details, array $params)

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1748,7 +1748,7 @@ class SierraRest extends AbstractBase implements
      * @param array $details Driver-specific account recovery details.
      * @param array $params  User-entered form parameters.
      *
-     * @throws AuthException
+     * @throws ILSException
      * @return array Status
      */
     public function resetPassword(array $details, array $params)

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -225,7 +225,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Support method for changeConfig; act on a single file.
      *
-     * @param string $configName Configuration to modify.
+     * @param string $configName Configuration to modify. Use 'Source:Target" to copy from Source.ini to Target.ini.
      * @param array  $settings   Settings to change.
      * @param bool   $replace    Should we replace the existing config entirely
      * (as opposed to extending it with new settings)?
@@ -234,20 +234,28 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function changeConfigFile(string $configName, array $settings, bool $replace = false): void
     {
-        $file = $configName . '.ini';
-        $local = $this->pathResolver->getLocalConfigPath($file, null, true);
-        if (!in_array($configName, $this->modifiedConfigs)) {
-            if (file_exists($local)) {
+        $parts = explode(':', $configName);
+        if (isset($parts[1])) {
+            $sourceConfig = $parts[0];
+            $destConfig = $parts[1];
+        } else {
+            $sourceConfig = $destConfig = $configName;
+        }
+        $sourceFile = $sourceConfig . '.ini';
+        $destFile = $destConfig . '.ini';
+        $localFile = $this->pathResolver->getLocalConfigPath($destFile, null, true);
+        if (!in_array($destConfig, $this->modifiedConfigs)) {
+            if (file_exists($localFile)) {
                 // File exists? Make a backup!
-                copy($local, $local . '.bak');
+                copy($localFile, $localFile . '.bak');
             } else {
                 // File doesn't exist? Make a baseline version.
-                copy($this->pathResolver->getBaseConfigPath($file), $local);
+                copy($this->pathResolver->getBaseConfigPath($sourceFile), $localFile);
             }
 
-            $this->modifiedConfigs[] = $configName;
+            $this->modifiedConfigs[] = $destConfig;
         }
-        $this->writeConfigFile($local, $settings, $replace);
+        $this->writeConfigFile($localFile, $settings, $replace);
     }
 
     /**

--- a/themes/bootstrap5/templates/myresearch/resetpassword.phtml
+++ b/themes/bootstrap5/templates/myresearch/resetpassword.phtml
@@ -13,19 +13,11 @@
 <h2><?=$this->transEsc('Create New Password') ?></h2>
 <?=$this->flashmessages() ?>
 
-<?php if (!$this->auth()->getManager()->supportsPasswordChange($this->auth_method)): ?>
-  <div class="error"><?=$this->transEsc('recovery_new_disabled') ?></div>
-<?php else: ?>
-  <form id="newpassword" class="form-new-password" action="<?=$this->url('myresearch-resetpassword') ?>" method="post">
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
-    <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth_method) ?>" name="auth_method">
-    <?php if (!empty($this->target)): ?>
-      <input type="hidden" value="<?=$this->escapeHtmlAttr($this->target) ?>" name="target">
-    <?php endif; ?>
-    <?=$this->auth()->getResetPasswordForm() ?>
-    <?=$this->captcha()->html($this->useCaptcha) ?>
-    <div class="form-group">
-      <input class="btn btn-primary" name="submitButton" type="submit" value="<?=$this->transEscAttr('Submit')?>">
-    </div>
-  </form>
-<?php endif; ?>
+<form id="newpassword" class="form-new-password" action="<?=$this->url('myresearch-resetpassword') ?>" method="post">
+  <input type="hidden" value="<?=$this->escapeHtmlAttr($this->auth()->getManager()->getCsrfHash())?>" name="csrf">
+  <?=$this->auth()->getResetPasswordForm() ?>
+  <?=$this->captcha()->html($this->useCaptcha) ?>
+  <div class="form-group">
+    <input class="btn btn-primary" name="submitButton" type="submit" value="<?=$this->transEscAttr('Submit')?>">
+  </div>
+</form>


### PR DESCRIPTION
- Fixes "reset password" form to not check for "change password" support. No check is required if we got this far. This was the main issue.
- Fixes exception handling and documentation.
- Simplifies "reset password" form to avoid passing around parameters that are not required.
- Extends the password recovery tests to cover more complicated scenarios with ChoiceAuth and MultiBackend driver as well. 
