### PR TITLE
PubDateVisAjax: Remove incorrectly refactored argument.

### DIFF
--- a/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap3/templates/Recommend/PubDateVisAjax.phtml
@@ -1,7 +1,7 @@
 <?php if ($visFacets = $this->recommend->getVisFacets()): ?>
   <?php
     // load jQuery flot:
-    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
+    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', ['conditional' => 'IE']);
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.min.js');
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.resize.min.js');
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.selection.min.js');

--- a/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
@@ -1,7 +1,7 @@
 <?php if ($visFacets = $this->recommend->getVisFacets()): ?>
   <?php
     // load jQuery flot:
-    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', null, ['conditional' => 'IE']);
+    $this->assetManager()->appendScriptLink('vendor/flot/excanvas.min.js', ['conditional' => 'IE']);
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.min.js');
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.resize.min.js');
     $this->assetManager()->appendScriptLink('vendor/flot/jquery.flot.selection.min.js');


### PR DESCRIPTION
While upgrading one of my local instances, I found an error in refactoring which breaks the PubDateVisAjax recommendation module. This PR corrects the mistake. This was not caught sooner because that module has been completely rewritten on the dev branch in preparation for release 11, but this could be a significant break for users of 10.2, so we should issue a 10.2.1 release to correct it.