### PR TITLE
Minor improvements to switchtab recommendations.

### DIFF
--- a/themes/bootstrap3/templates/Recommend/SwitchTab.phtml
+++ b/themes/bootstrap3/templates/Recommend/SwitchTab.phtml
@@ -1,19 +1,20 @@
 <?php
   $tabConfig = is_object($this->params)
     ? $this->searchTabs()->getTabConfigForParams($this->params) : [];
+  $activeLabel = $this->recommend->getActiveTab($tabConfig)['label'] ?? '';
+  $inactiveTabs = count($tabConfig) > 0 ? $this->recommend->getInactiveTabs($tabConfig) : [];
 ?>
-<?php if (count($tabConfig) > 0): ?>
+<?php if ($inactiveTabs && $activeLabel): ?>
   <div class="alert alert-info">
-    <?=$this->transEsc('nohit_change_tab', ['%%activeTab%%' => $this->translate($this->recommend->getActiveTab($tabConfig)['label'])])?>
+    <?=$this->transEsc('nohit_change_tab', ['%%activeTab%%' => $this->translate($activeLabel)])?>
     <ul>
-    <?php $inactiveTabs = $this->recommend->getInactiveTabs($tabConfig); ?>
-    <?php foreach ($inactiveTabs as $tab): ?>
-      <li>
-        <?php if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><?php endif; ?>
-          <?=$this->transEsc($tab['label']); ?>
-        <?php if (!$tab['selected']): ?></a><?php endif; ?>
-      </li>
-    <?php endforeach; ?>
+      <?php foreach ($inactiveTabs as $tab): ?>
+        <li>
+          <?php if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><?php endif; ?>
+            <?=$this->transEsc($tab['label']); ?>
+          <?php if (!$tab['selected']): ?></a><?php endif; ?>
+        </li>
+      <?php endforeach; ?>
     </ul>
   </div>
 <?php endif; ?>

--- a/themes/bootstrap5/templates/Recommend/SwitchTab.phtml
+++ b/themes/bootstrap5/templates/Recommend/SwitchTab.phtml
@@ -1,19 +1,20 @@
 <?php
   $tabConfig = is_object($this->params)
     ? $this->searchTabs()->getTabConfigForParams($this->params) : [];
+  $activeLabel = $this->recommend->getActiveTab($tabConfig)['label'] ?? '';
+  $inactiveTabs = count($tabConfig) > 0 ? $this->recommend->getInactiveTabs($tabConfig) : [];
 ?>
-<?php if (count($tabConfig) > 0): ?>
+<?php if ($inactiveTabs && $activeLabel): ?>
   <div class="alert alert-info">
-    <?=$this->transEsc('nohit_change_tab', ['%%activeTab%%' => $this->translate($this->recommend->getActiveTab($tabConfig)['label'])])?>
+    <?=$this->transEsc('nohit_change_tab', ['%%activeTab%%' => $this->translate($activeLabel)])?>
     <ul>
-    <?php $inactiveTabs = $this->recommend->getInactiveTabs($tabConfig); ?>
-    <?php foreach ($inactiveTabs as $tab): ?>
-      <li>
-        <?php if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><?php endif; ?>
-          <?=$this->transEsc($tab['label']); ?>
-        <?php if (!$tab['selected']): ?></a><?php endif; ?>
-      </li>
-    <?php endforeach; ?>
+      <?php foreach ($inactiveTabs as $tab): ?>
+        <li>
+          <?php if (!$tab['selected']): ?><a href="<?=$this->escapeHtmlAttr($tab['url'])?>"><?php endif; ?>
+            <?=$this->transEsc($tab['label']); ?>
+          <?php if (!$tab['selected']): ?></a><?php endif; ?>
+        </li>
+      <?php endforeach; ?>
     </ul>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
This PR fixes a couple of edge-case problems in the SwitchTab recommendation module:

- If there is no active tab, the message makes no sense; we now suppress recommendations when no tab is active (which can happen in some edge case scenarios, like searching a backend that doesn't have a tab provided).
- If there are no available inactive tabs, the message makes no sense since it offers no actionable suggestions (this is unlikely in a real-world scenario but can happen if you only turn on a single tab; might as well prevent it from happening in any case).