### PR TITLE
PHPUnit: turn on displayDetailsOnPhpunitDeprecations setting.

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -6,6 +6,7 @@
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
   displayDetailsOnTestsThatTriggerWarnings="true"
   displayDetailsOnTestsThatTriggerDeprecations="true"
+  displayDetailsOnPhpunitDeprecations="true"
   cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="AllUnitTests">


### PR DESCRIPTION
PHPUnit has added a new setting for reporting deprecations specific to the testing framework. Without this setting, tests may show a "D" status without a visible explanation. Turning it on will make future troubleshooting/updating easier. (I ran into this while collaborating on a test in #4429, and turning it on was very helpful).