### PR TITLE
Fix direct access to username in DB entity

### DIFF
--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -311,7 +311,7 @@ class LoggerFactory implements FactoryInterface
                 $authManager = $container->get(\VuFind\Auth\Manager::class);
                 if ($user = $authManager->getUserObject()) {
                     $processor = new \Laminas\Log\Processor\ReferenceId();
-                    $processor->setReferenceId($user->username);
+                    $processor->setReferenceId($user->getUsername());
                     $logger->addProcessor($processor);
                 }
             }


### PR DESCRIPTION
I'm getting an error

> Cannot access protected property VuFind\Db\Entity\User::$username

And it certainly looks like the Doctrine pattern is to use accessor methods instead.