### PR TITLE
FOLIO: Fix displaying fine type

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2599,7 +2599,7 @@ class Folio extends AbstractAPI implements
                 'amount' => $fine->amount * 100,
                 'balance' => $fine->remaining * 100,
                 'status' => $fine->paymentStatus->name,
-                'type' => $fine->feeFineType,
+                'description' => $fine->feeFineType,
                 'title' => $title,
                 'createdate' => date_format($date, 'j M Y'),
             ];

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2599,7 +2599,7 @@ class Folio extends AbstractAPI implements
                 'amount' => $fine->amount * 100,
                 'balance' => $fine->remaining * 100,
                 'status' => $fine->paymentStatus->name,
-                'description' => $fine->feeFineType,
+                'fine' => $fine->feeFineType,
                 'title' => $title,
                 'createdate' => date_format($date, 'j M Y'),
             ];


### PR DESCRIPTION
Display the FOLIO `feeFineType` on the Fines table.

<img width="835" height="203" alt="image" src="https://github.com/user-attachments/assets/392cf635-3294-492e-8bac-3fc41aaeebf9" />
