### PR TITLE
parameter to limit number of autocomplete items is called 'limit' now

### DIFF
--- a/themes/bootstrap5/js/searchbox_controls.js
+++ b/themes/bootstrap5/js/searchbox_controls.js
@@ -244,7 +244,7 @@ VuFind.register('searchbox_controls', function SearchboxControls() {
       };
       const typeahead = new Autocomplete({
         rtl: $(document.body).hasClass("rtl"),
-        maxResults: 10,
+        limit: 20,
         loadingString: VuFind.translate('loading_ellipsis'),
       });
 


### PR DESCRIPTION
Currently the parameter `maxResult` is set, but that is not used in the autocomplete library anymore. It's now called `limit` and set to 20 by default. So, renaming `maxResult` to `limit` would set a limit of 10. Because nobody complained about the limit of 20, it's been changed as well.