### PR TITLE
Base64-encode serialized email.

### DIFF
--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -312,7 +312,7 @@ class Mailer implements
             if ($logFile = $this->options['message_log'] ?? null) {
                 $format = $this->options['message_log_format'] ?? 'plain';
                 $data = 'serialized' === $format
-                    ? serialize($email) . "\x1E\x00" // use Record Separator + null to separate messages
+                    ? base64_encode(serialize($email)) . "\x1E" // Record Separator
                     : $email->toString() . "\n\n";
                 file_put_contents($logFile, $data, FILE_APPEND);
             }

--- a/module/VuFind/src/VuFindTest/Feature/EmailTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/EmailTrait.php
@@ -85,10 +85,10 @@ trait EmailTrait
         if (!$data) {
             throw new \Exception('No serialized email message data found');
         }
-        $records = explode("\x1E\x00", $data);
+        $records = explode("\x1E", $data);
         if (null === ($record = $records[$index] ?? null)) {
             throw new \Exception("Message with index $index not found");
         }
-        return unserialize($record);
+        return unserialize(base64_decode($record));
     }
 }


### PR DESCRIPTION
This ensures that the serialized email never contains the record separator, which would otherwise be possible with PDF attachments.