### PR TITLE
Fix next/prev navigation on record screen with Blender.

### DIFF
--- a/config/vufind/Blender.ini
+++ b/config/vufind/Blender.ini
@@ -30,6 +30,11 @@ blockSize = 7
 ;adaptiveBlockSizes[] = "0-20:3"
 ;adaptiveBlockSizes[] = "21-10000:5"
 
+; ---------- config.ini settings ----------
+
+[Record]
+next_prev_navigation = false
+
 ; ---------- searches.ini settings ----------
 
 [General]

--- a/module/VuFind/src/VuFind/Controller/AbstractRecord.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractRecord.php
@@ -950,8 +950,7 @@ class AbstractRecord extends AbstractBase
             ? (bool)$config->Site->loadInitialTabWithAjax : false;
 
         // Set up next/previous record links (if appropriate)
-        $searchOptions = $this->serviceLocator->get(\VuFind\Search\Options\PluginManager::class)->get($this->sourceId);
-        if ($searchOptions->resultScrollerActive()) {
+        if ($this->getSearchMemory()->getCurrentSearch()?->getOptions()?->resultScrollerActive()) {
             $driver = $this->loadRecord();
             $view->scrollData = $this->resultScroller()->getScrollData($driver);
         }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2022-2023.
+ * Copyright (C) The National Library of Finland 2022-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -63,6 +63,9 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
                     'SolrAuth',
                 ],
                 'blockSize' => 7,
+            ],
+            'Record' => [
+                'next_prev_navigation' => true,
             ],
             'Basic_Searches' => [
                 'AllFields' => 'adv_search_all',
@@ -196,6 +199,35 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
             'Blended',
             $this->findCssAndGetText($page, '.searchbox li a.active')
         );
+
+        if (1 === $queryParams['page']) {
+            // Test next/prev navigation:
+            // Next record:
+            $this->clickCss($page, '.pager a', index: 1);
+            $this->assertStringContainsStringWithTimeout(
+                '/Record/0000183626-1',
+                fn () => $session->getCurrentUrl()
+            );
+            // Next record:
+            $this->clickCss($page, '.pager a', index: 1);
+            $this->assertStringContainsStringWithTimeout(
+                'AuthorityRecord/vtls000001429',
+                fn () => $session->getCurrentUrl()
+            );
+            // Back to previous record (using history because author record doesn't show navigation):
+            $session->back();
+            $this->assertStringContainsStringWithTimeout(
+                '/Record/0000183626-1',
+                fn () => $session->getCurrentUrl()
+            );
+            // Then once more back with pager:
+            $this->clickCss($page, '.pager a');
+            $this->waitForPageLoad($page);
+            $this->assertStringContainsStringWithTimeout(
+                '/Record/0000183626-0',
+                fn () => $session->getCurrentUrl()
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
While it would have been nice to have this in 10.2, I'm targeting dev because 10.2 has a very different result scroller check.

TODO:
- [x] Resolve [VUFIND-1758](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1758) when merged. 