### PR TITLE
Integration test for file and mail logging.

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/EmailTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/EmailTrait.php
@@ -81,14 +81,25 @@ trait EmailTrait
      */
     protected function getLoggedEmail(int $index = 0): Email
     {
+        $records = $this->getLoggedEmails();
+        if (null === ($record = $records[$index] ?? null)) {
+            throw new \Exception("Message with index $index not found");
+        }
+        return $record;
+    }
+
+    /**
+     * Get all logged emails from the log file.
+     *
+     * @return Email[]
+     */
+    protected function getLoggedEmails(): array
+    {
         $data = file_get_contents($this->getEmailLogPath());
         if (!$data) {
             throw new \Exception('No serialized email message data found');
         }
-        $records = explode("\x1E", $data);
-        if (null === ($record = $records[$index] ?? null)) {
-            throw new \Exception("Message with index $index not found");
-        }
-        return unserialize(base64_decode($record));
+        $decoder = fn ($email) => unserialize(base64_decode($email));
+        return array_filter(array_map($decoder, explode("\x1E", $data)));
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2024.
+ * Copyright (C) Villanova University 2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -48,6 +48,7 @@ class LoggingTest extends MinkTestCase
 
     protected const string CRITICAL_LEVEL_REGEX = '/CRIT/';
     protected const string DEBUG_LEVEL_REGEX = '/DEBUG/';
+    protected const string INFO_LEVEL_REGEX = '/INFO/';
 
     /**
      * Data provider for email logging test scenarios
@@ -83,7 +84,7 @@ class LoggingTest extends MinkTestCase
                 ],
                 'unexpectedPatterns' => [
                     self::DEBUG_LEVEL_REGEX,
-                    '/INFO:/',
+                    self::INFO_LEVEL_REGEX,
                 ],
                 'minEmails'          => 1,
                 'description'         => 'Should log critical errors when Solr connection fails',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -1,0 +1,433 @@
+<?php
+
+/**
+ * Logging integration test.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2024.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Sambhav Pokharel <sambhavpokharel@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+use VuFindTest\Integration\MinkTestCase;
+
+use function count;
+
+/**
+ * Logging integration test.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Sambhav Pokharel <sambhavpokharel@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class LoggingTest extends MinkTestCase
+{
+    use \VuFindTest\Feature\EmailTrait;
+
+    /**
+     * Data provider for email logging test scenarios
+     *
+     * @return array
+     */
+    public static function emailLoggingScenarioProvider(): array
+    {
+        return [
+            'debug_error_and_alert_logging' => [
+                'emailConfig'        => 'alerts@myuniversity.edu:debug-5,alert-5,error-5',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/RequestErrorException/',
+                    '/VuFindSearch\\\\Backend\\\\Exception/',
+                    '/Search\/Results.*lookfor.*test/',
+                    '/DEBUG:/',
+                ],
+                'unexpectedPatterns' => [
+                ],
+                'minEmails'          => 4,
+                'description'         => 'Should log critical errors when Solr connection fails',
+            ],
+            'error_and_alert_logging_only' => [
+                'emailConfig'        => 'alerts@myuniversity.edu:alert-5,error-5',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/RequestErrorException/',
+                    '/VuFindSearch\\\\Backend\\\\Exception/',
+                    '/Search\/Results.*lookfor.*test/',
+                ],
+                'unexpectedPatterns' => [
+                    '/DEBUG:/',
+                    '/INFO:/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should log critical errors when Solr connection fails',
+            ],
+            'debug_logging_only'      => [
+                'emailConfig'        => 'debug@myuniversity.edu:debug-5',
+                'expectedPatterns'   => [
+                    '/DEBUG:/',
+                ],
+                'unexpectedPatterns' => [
+                    '/CRITICAL:/',
+                ],
+                'minEmails'          => 3,
+                'description'         => 'Should capture debug messages when debug logging is enabled',
+            ],
+            'minimal_detail_level'    => [
+                'emailConfig'        => 'alerts@myuniversity.edu:error-1',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                ],
+                'unexpectedPatterns' => [
+                    '/Backtrace:/',
+                    '/\(Server: IP =/',
+                    '/Server Context:/',
+                    '/Array/',
+                    '/args:/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should provide minimal detail at level 1',
+            ],
+            'detail_level_2'    => [
+                'emailConfig'        => 'alerts@myuniversity.edu:error-2',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/\(Server: IP =/',
+                ],
+                'unexpectedPatterns' => [
+                    '/Backtrace:/',
+                    '/Server Context:/',
+                    '/Array/',
+                    '/args:/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should provide appropriate detail at level 2',
+            ],
+            'detail_level_3'    => [
+                'emailConfig'        => 'alerts@myuniversity.edu:error-3',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/\(Server: IP =/',
+                    '/Backtrace:/',
+                ],
+                'unexpectedPatterns' => [
+                    '/Server Context:/',
+                    '/Array/',
+                    '/args:/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should provide appropriate detail at level 3',
+            ],
+            'detail_level_4'    => [
+                'emailConfig'        => 'alerts@myuniversity.edu:error-4',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/Server Context:/',
+                    '/Backtrace:/',
+                ],
+                'unexpectedPatterns' => [
+                    '/\(Server: IP =/',
+                    '/args:/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should provide appropriate detail at level 4',
+            ],
+            'maximum_detail_level'    => [
+                'emailConfig'        => 'alerts@myuniversity.edu:error-5',
+                'expectedPatterns'   => [
+                    '/CRITICAL:/',
+                    '/404 Not Found/',
+                    '/Backtrace:/',
+                    '/Server Context:/',
+                    '/HTTP_USER_AGENT/',
+                    '/REQUEST_URI/',
+                    '/args:/',
+                ],
+                'unexpectedPatterns' => [
+                    '/\(Server: IP =/',
+                ],
+                'minEmails'          => 1,
+                'description'         => 'Should provide maximum detail at level 5',
+            ],
+        ];
+    }
+
+    /**
+     * Test email logging functionality with various configurations
+     *
+     * @param string $emailConfig        Email configuration string
+     * @param array  $expectedPatterns   Patterns that should be found in log
+     * @param array  $unexpectedPatterns Patterns that should NOT be found in log
+     * @param int    $minEmails          Minimum number of emails expected
+     * @param string $description        Test scenario description
+     *
+     * @return void
+     *
+     * @dataProvider emailLoggingScenarioProvider
+     */
+    public function testEmailLogging(
+        string $emailConfig,
+        array $expectedPatterns,
+        array $unexpectedPatterns,
+        int $minEmails,
+        string $description
+    ): void {
+        $this->changeConfigs([
+            'config' => [
+                'Index'   => [
+                    'url' => 'http://localhost:8983/not-solr',
+                ],
+                'Mail'    => [
+                    'testOnly'           => true,
+                    'message_log'        => $this->getEmailLogPath(),
+                    'message_log_format' => $this->getEmailLogFormat(),
+                ],
+                'Logging' => [
+                    'email' => $emailConfig,
+                ],
+            ],
+        ]);
+
+        $this->resetEmailLog();
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=test');
+        $page = $session->getPage();
+
+        // Wait for logging to complete
+        $this->findCss($page, 'body');
+
+        $loggedEmails = $this->getLoggedEmails();
+        $this->assertGreaterThanOrEqual($minEmails, count($loggedEmails));
+        $allEmailContent = preg_replace(
+            '/=[\r\n]+/',
+            '',
+            implode('', array_map(fn ($email) => $email->toString(), $loggedEmails))
+        );
+        $allEmailSubjects = implode('', array_map(fn ($email) => $email->getSubject(), $loggedEmails));
+        $allEmailBodies = implode('', array_map(fn ($email) => $email->getBody()->getBody(), $loggedEmails));
+
+        // Basic assertions
+        $this->assertNotEmpty(
+            $allEmailContent,
+            $description . ': Expected to receive log email'
+        );
+
+        $expectedPatterns[] = '/VuFind Log Alert/'; // every email contains this string
+        foreach ($expectedPatterns as $pattern) {
+            $this->assertMatchesRegularExpression(
+                $pattern,
+                $allEmailContent,
+                $description . ': Expected pattern not found: ' . $pattern
+            );
+        }
+
+        foreach ($unexpectedPatterns as $pattern) {
+            $this->assertDoesNotMatchRegularExpression(
+                $pattern,
+                $allEmailContent,
+                $description . ': Unexpected pattern found: ' . $pattern
+            );
+        }
+
+        // Email subject assertion
+        $this->assertStringContainsString(
+            'VuFind Log Message',
+            $allEmailSubjects,
+            'Email subject should contain "VuFind Log Message"'
+        );
+
+        // Conditional assertions based on log level/type
+        if (str_contains($emailConfig, 'debug')) {
+            $this->assertStringContainsString(
+                'DEBUG:',
+                $allEmailBodies,
+                'Email body should contain debug messages'
+            );
+
+            $this->assertStringContainsString(
+                'not-solr',
+                $allEmailBodies,
+                'Email body should contain the Solr URL that failed'
+            );
+        } else {
+            $this->assertStringContainsString(
+                'RequestErrorException',
+                $allEmailBodies,
+                'Email body should contain the specific exception type'
+            );
+        }
+
+        $this->assertStringContainsString(
+            '404 Not Found',
+            $allEmailBodies,
+            'Email body should contain the HTTP error'
+        );
+    }
+
+    /**
+     * Data provider for file logging test scenarios
+     *
+     * @return array
+     */
+    public static function fileLoggingScenarioProvider(): array
+    {
+        // Transform the email test cases into file test cases:
+        return array_map(
+            function ($case) {
+                $configParts = explode(':', $case['emailConfig']);
+                $logSettings = array_pop($configParts);
+                // Generate a random filename in the cache, to be sure the server has
+                // permission to write there, and to keep each test's log distinct.
+                $filename = LOCAL_CACHE_DIR . '/' . uniqid() . '.log';
+                return [
+                    'loggingConfig' => "$filename:$logSettings",
+                    'expectedPatterns' => $case['expectedPatterns'],
+                    'unexpectedPatterns' => $case['unexpectedPatterns'],
+                    'description' => $case['description'],
+                ];
+            },
+            static::emailLoggingScenarioProvider()
+        );
+    }
+
+    /**
+     * Test file logging functionality with various configurations
+     *
+     * @param string $loggingConfig      Logging configuration string
+     * @param array  $expectedPatterns   Patterns that should be found in log
+     * @param array  $unexpectedPatterns Patterns that should NOT be found in log
+     * @param string $description        Test scenario description
+     *
+     * @return void
+     *
+     * @dataProvider fileLoggingScenarioProvider
+     */
+    public function testFileLogging(
+        string $loggingConfig,
+        array $expectedPatterns,
+        array $unexpectedPatterns,
+        string $description
+    ): void {
+        $this->changeConfigs([
+            'config' => [
+                'Index'   => [
+                    'url' => 'http://localhost:8983/not-solr',
+                ],
+                'Mail'    => [
+                    'testOnly'           => true,
+                    'message_log'        => $this->getEmailLogPath(),
+                    'message_log_format' => $this->getEmailLogFormat(),
+                ],
+                'Logging' => [
+                    'file' => $loggingConfig,
+                ],
+            ],
+        ]);
+
+        [$filename] = explode(':', $loggingConfig);
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=test');
+        $page = $session->getPage();
+
+        // Wait for logging to complete
+        $this->findCss($page, 'body');
+
+        $logContent = file_get_contents($filename);
+
+        // Basic assertions
+        $this->assertNotEmpty(
+            $logContent,
+            $description . ': Expected to have log messages'
+        );
+
+        foreach ($expectedPatterns as $pattern) {
+            $this->assertMatchesRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Expected pattern not found: ' . $pattern
+            );
+        }
+
+        foreach ($unexpectedPatterns as $pattern) {
+            $this->assertDoesNotMatchRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Unexpected pattern found: ' . $pattern
+            );
+        }
+    }
+
+    /**
+     * Test that no emails are sent when logging is disabled
+     *
+     * @return void
+     */
+    public function testNoEmailLoggingWhenDisabled(): void
+    {
+        $this->changeConfigs([
+            'config' => [
+                'Index' => [
+                    'url' => 'http://localhost:8983/not-solr',
+                ],
+                'Mail'  => [
+                    'testOnly'           => true,
+                    'message_log'        => $this->getEmailLogPath(),
+                    'message_log_format' => $this->getEmailLogFormat(),
+                ],
+                'Logging' => [
+                    'email' => '',
+                ],
+            ],
+        ]);
+
+        $this->resetEmailLog();
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=test');
+        $page = $session->getPage();
+
+        // Wait for logging to complete
+        $this->findCss($page, 'body');
+
+        $emailLogPath = $this->getEmailLogPath();
+        if (file_exists($emailLogPath)) {
+            $loggedEmails = trim(file_get_contents($emailLogPath));
+            print_r($loggedEmails);
+            $this->assertEmpty(
+                $loggedEmails,
+                'No emails should be sent when email logging is not configured'
+            );
+        } else {
+            $this->assertTrue(true, 'Email log file does not exist, which is expected when logging is disabled');
+        }
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -46,9 +46,9 @@ class LoggingTest extends MinkTestCase
 {
     use \VuFindTest\Feature\EmailTrait;
 
-    protected const string CRITICAL_LEVEL_REGEX = '/CRIT/';
-    protected const string DEBUG_LEVEL_REGEX = '/DEBUG/';
-    protected const string INFO_LEVEL_REGEX = '/INFO/';
+    protected const CRITICAL_LEVEL_REGEX = '/CRIT/';
+    protected const DEBUG_LEVEL_REGEX = '/DEBUG/';
+    protected const INFO_LEVEL_REGEX = '/INFO/';
 
     /**
      * Data provider for email logging test scenarios

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -46,6 +46,9 @@ class LoggingTest extends MinkTestCase
 {
     use \VuFindTest\Feature\EmailTrait;
 
+    protected const string CRITICAL_LEVEL_REGEX = '/CRIT/';
+    protected const string DEBUG_LEVEL_REGEX = '/DEBUG/';
+
     /**
      * Data provider for email logging test scenarios
      *
@@ -57,29 +60,29 @@ class LoggingTest extends MinkTestCase
             'debug_error_and_alert_logging' => [
                 'emailConfig'        => 'alerts@myuniversity.edu:debug-5,alert-5,error-5',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/RequestErrorException/',
                     '/VuFindSearch\\\\Backend\\\\Exception/',
                     '/Search\/Results.*lookfor.*test/',
-                    '/DEBUG:/',
+                    self::DEBUG_LEVEL_REGEX,
                 ],
                 'unexpectedPatterns' => [
                 ],
-                'minEmails'          => 4,
+                'minEmails'          => 2,
                 'description'         => 'Should log critical errors when Solr connection fails',
             ],
             'error_and_alert_logging_only' => [
                 'emailConfig'        => 'alerts@myuniversity.edu:alert-5,error-5',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/RequestErrorException/',
                     '/VuFindSearch\\\\Backend\\\\Exception/',
                     '/Search\/Results.*lookfor.*test/',
                 ],
                 'unexpectedPatterns' => [
-                    '/DEBUG:/',
+                    self::DEBUG_LEVEL_REGEX,
                     '/INFO:/',
                 ],
                 'minEmails'          => 1,
@@ -88,18 +91,18 @@ class LoggingTest extends MinkTestCase
             'debug_logging_only'      => [
                 'emailConfig'        => 'debug@myuniversity.edu:debug-5',
                 'expectedPatterns'   => [
-                    '/DEBUG:/',
+                    self::DEBUG_LEVEL_REGEX,
                 ],
                 'unexpectedPatterns' => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                 ],
-                'minEmails'          => 3,
+                'minEmails'          => 1,
                 'description'         => 'Should capture debug messages when debug logging is enabled',
             ],
             'minimal_detail_level'    => [
                 'emailConfig'        => 'alerts@myuniversity.edu:error-1',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                 ],
                 'unexpectedPatterns' => [
@@ -115,7 +118,7 @@ class LoggingTest extends MinkTestCase
             'detail_level_2'    => [
                 'emailConfig'        => 'alerts@myuniversity.edu:error-2',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/\(Server: IP =/',
                 ],
@@ -131,7 +134,7 @@ class LoggingTest extends MinkTestCase
             'detail_level_3'    => [
                 'emailConfig'        => 'alerts@myuniversity.edu:error-3',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/\(Server: IP =/',
                     '/Backtrace:/',
@@ -147,7 +150,7 @@ class LoggingTest extends MinkTestCase
             'detail_level_4'    => [
                 'emailConfig'        => 'alerts@myuniversity.edu:error-4',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/Server Context:/',
                     '/Backtrace:/',
@@ -162,7 +165,7 @@ class LoggingTest extends MinkTestCase
             'maximum_detail_level'    => [
                 'emailConfig'        => 'alerts@myuniversity.edu:error-5',
                 'expectedPatterns'   => [
-                    '/CRITICAL:/',
+                    self::CRITICAL_LEVEL_REGEX,
                     '/404 Not Found/',
                     '/Backtrace:/',
                     '/Server Context:/',
@@ -240,7 +243,6 @@ class LoggingTest extends MinkTestCase
             $description . ': Expected to receive log email'
         );
 
-        $expectedPatterns[] = '/VuFind Log Alert/'; // every email contains this string
         foreach ($expectedPatterns as $pattern) {
             $this->assertMatchesRegularExpression(
                 $pattern,
@@ -267,7 +269,7 @@ class LoggingTest extends MinkTestCase
         // Conditional assertions based on log level/type
         if (str_contains($emailConfig, 'debug')) {
             $this->assertStringContainsString(
-                'DEBUG:',
+                trim(self::DEBUG_LEVEL_REGEX, '/'),
                 $allEmailBodies,
                 'Email body should contain debug messages'
             );


### PR DESCRIPTION
This PR extracts the new test from #4429 and slightly adjusts it to work with the existing laminas-log code so we can refine it and make sure we have a good baseline to compare against when finalizing the monolog migration.