### PR TITLE
ILSTest: remove duplicate trait inclusion.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Auth/ILSTest.php
@@ -42,7 +42,6 @@ namespace VuFindTest\Auth;
  */
 final class ILSTest extends \PHPUnit\Framework\TestCase
 {
-    use \VuFindTest\Feature\ConfigRelatedServicesTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\LiveDetectionTrait;
 


### PR DESCRIPTION
Since ConfigRelatedServicesTrait is already included by LiveDatabaseTrait, we don't need to import it separately in this test. The redundant inclusion was causing a PDepend error, though it was not negatively impacting the test itself.