### PR TITLE
Add database log table and logging integration tests

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1803,10 +1803,7 @@ skip_numeric = true
 ; file system full) may then be reported to another.
 ;
 ; If database is uncommented, messages will be logged to the named MySQL table.
-; The table can be created with this SQL statement:
-; CREATE TABLE log_table ( id INT NOT NULL AUTO_INCREMENT,
-;     logtime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, ident CHAR(16) NOT NULL DEFAULT '',
-;     priority INT NOT NULL DEFAULT '0', message TEXT, PRIMARY KEY (id) );
+; A table called log_table is part of the schema by default.
 ;
 ; If file is uncommented, messages will be logged to the named file.  Be sure
 ; that Apache has permission to write to the specified file!

--- a/module/VuFind/sql/migrations/mysql/11.0/008-add-log-table.sql
+++ b/module/VuFind/sql/migrations/mysql/11.0/008-add-log-table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `log_table` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `logtime` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `ident` CHAR(16) NOT NULL DEFAULT '',
+  `priority` INT NOT NULL DEFAULT '0',
+  `message` TEXT,
+  PRIMARY KEY (id)
+);

--- a/module/VuFind/sql/migrations/pgsql/11.0/008-add-log-table.sql
+++ b/module/VuFind/sql/migrations/pgsql/11.0/008-add-log-table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE log_table (
+  id SERIAL,
+  logtime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ident char(16) NOT NULL DEFAULT '',
+  priority int NOT NULL DEFAULT '0',
+  message text,
+  PRIMARY KEY (id)
+);

--- a/module/VuFind/sql/mysql.sql
+++ b/module/VuFind/sql/mysql.sql
@@ -535,3 +535,19 @@ CREATE TABLE `migrations` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `log_table`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `log_table` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `logtime` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `ident` CHAR(16) NOT NULL DEFAULT '',
+  `priority` INT NOT NULL DEFAULT '0',
+  `message` TEXT,
+  PRIMARY KEY (id)
+);
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/module/VuFind/sql/pgsql.sql
+++ b/module/VuFind/sql/pgsql.sql
@@ -496,6 +496,18 @@ CREATE TABLE migrations (
   PRIMARY KEY (id)
 );
 
+--
+-- Table structure for table `log_table`
+
+CREATE TABLE log_table (
+  id SERIAL,
+  logtime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ident char(16) NOT NULL DEFAULT '',
+  priority int NOT NULL DEFAULT '0',
+  message text,
+  PRIMARY KEY (id)
+);
+
 -- --------------------------------------------------------
 
 --

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Mink;
 
+use VuFind\Db\Connection;
 use VuFindTest\Integration\MinkTestCase;
 
 use function count;
@@ -45,6 +46,7 @@ use function count;
 class LoggingTest extends MinkTestCase
 {
     use \VuFindTest\Feature\EmailTrait;
+    use \VuFindTest\Feature\LiveDatabaseTrait;
     use \VuFindTest\Feature\LiveSolrTrait;
 
     protected const CRITICAL_LEVEL_REGEX = '/CRIT/';
@@ -347,11 +349,6 @@ class LoggingTest extends MinkTestCase
                 'Index'   => [
                     'url' => "http://localhost:$port/not-solr",
                 ],
-                'Mail'    => [
-                    'testOnly'           => true,
-                    'message_log'        => $this->getEmailLogPath(),
-                    'message_log_format' => $this->getEmailLogFormat(),
-                ],
                 'Logging' => [
                     'file' => $loggingConfig,
                 ],
@@ -436,5 +433,106 @@ class LoggingTest extends MinkTestCase
         } else {
             $this->assertTrue(true, 'Email log file does not exist, which is expected when logging is disabled');
         }
+    }
+
+    /**
+     * Data provider for database logging test scenarios
+     *
+     * @return array
+     */
+    public static function databaseLoggingScenarioProvider(): array
+    {
+        // Transform the email test cases into database test cases:
+        return array_map(
+            function ($case) {
+                $configParts = explode(':', $case['emailConfig']);
+                $logSettings = array_pop($configParts);
+                return [
+                    'loggingConfig' => "log_table:$logSettings",
+                    'expectedPatterns' => $case['expectedPatterns'],
+                    'unexpectedPatterns' => $case['unexpectedPatterns'],
+                    'description' => $case['description'],
+                ];
+            },
+            static::emailLoggingScenarioProvider()
+        );
+    }
+
+    /**
+     * Test database logging functionality with various configurations
+     *
+     * @param string $loggingConfig      Logging configuration string
+     * @param array  $expectedPatterns   Patterns that should be found in log
+     * @param array  $unexpectedPatterns Patterns that should NOT be found in log
+     * @param string $description        Test scenario description
+     *
+     * @return void
+     *
+     * @dataProvider DatabaseLoggingScenarioProvider
+     */
+    public function testDatabaseLogging(
+        string $loggingConfig,
+        array $expectedPatterns,
+        array $unexpectedPatterns,
+        string $description
+    ): void {
+        $port = $this->getSolrPort();
+        $this->changeConfigs([
+            'config' => [
+                'Index'   => [
+                    'url' => "http://localhost:$port/not-solr",
+                ],
+                'Logging' => [
+                    'database' => $loggingConfig,
+                ],
+            ],
+        ]);
+
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=test');
+        $page = $session->getPage();
+
+        // Wait for logging to complete
+        $this->findCss($page, 'body');
+
+        $connection = $this->getLiveDatabaseContainer()->get(Connection::class);
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->select('*')->from('log_table');
+        $result = $connection->executeQuery($queryBuilder);
+        $priorities = ['EMERGENCY', 'ALERT', 'CRITICAL', 'ERROR', 'WARNING', 'NOTICE', 'INFO', 'DEBUG'];
+        $logContent = implode("\n", array_map(
+            function ($row) use ($priorities) {
+                $row['priority'] = $priorities[$row['priority']] ?? 'UNKNOWN-PRIORITY';
+                return implode(' ', $row);
+            },
+            $result->fetchAllAssociative()));
+
+        // Basic assertions
+        $this->assertNotEmpty(
+            $logContent,
+            $description . ': Expected to have log messages'
+        );
+
+        foreach ($expectedPatterns as $pattern) {
+            $this->assertMatchesRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Expected pattern not found: ' . $pattern
+            );
+        }
+
+        $unexpectedPatterns[] = '/UNKNOWN-PRIORITY/';
+        foreach ($unexpectedPatterns as $pattern) {
+            $this->assertDoesNotMatchRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Unexpected pattern found: ' . $pattern
+            );
+        }
+
+        // Clear data for the next test:
+        $deleteQueryBuilder = $connection->createQueryBuilder();
+        $deleteQueryBuilder->delete('log_table');
+        $connection->executeQuery($deleteQueryBuilder);
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -39,13 +39,15 @@ use function count;
 /**
  * Logging integration test.
  *
+ * Class must be final due to use of "new static()" by LiveDatabaseTrait.
+ *
  * @category VuFind
  * @package  Tests
  * @author   Sambhav Pokharel <sambhavpokharel@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-class LoggingTest extends MinkTestCase
+final class LoggingTest extends MinkTestCase
 {
     use \VuFindTest\Feature\EmailTrait;
     use \VuFindTest\Feature\LiveDatabaseTrait;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTest\Mink;
 
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\GeneratorNotSupportedException;
 use VuFind\Db\Connection;
 use VuFindTest\Integration\MinkTestCase;
 
@@ -187,6 +189,46 @@ class LoggingTest extends MinkTestCase
     }
 
     /**
+     * Assert that the log content has all expected patterns and no unexpected patterns.
+     *
+     * @param string   $logContent         Log content
+     * @param string[] $expectedPatterns   Array of expected regular expressions
+     * @param string[] $unexpectedPatterns Array of unexpected regular expressions
+     * @param string   $description        Description of current test scenario
+     *
+     * @return void
+     * @throws ExpectationFailedException
+     * @throws GeneratorNotSupportedException
+     */
+    protected function assertPatternsInLog(
+        string $logContent,
+        array $expectedPatterns,
+        array $unexpectedPatterns,
+        string $description
+    ): void {
+        $this->assertNotEmpty(
+            $logContent,
+            $description . ': Expected to receive log email'
+        );
+
+        foreach ($expectedPatterns as $pattern) {
+            $this->assertMatchesRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Expected pattern not found: ' . $pattern
+            );
+        }
+
+        foreach ($unexpectedPatterns as $pattern) {
+            $this->assertDoesNotMatchRegularExpression(
+                $pattern,
+                $logContent,
+                $description . ': Unexpected pattern found: ' . $pattern
+            );
+        }
+    }
+
+    /**
      * Test email logging functionality with various configurations
      *
      * @param string $emailConfig        Email configuration string
@@ -243,26 +285,7 @@ class LoggingTest extends MinkTestCase
         $allEmailBodies = implode('', array_map(fn ($email) => $email->getBody()->getBody(), $loggedEmails));
 
         // Basic assertions
-        $this->assertNotEmpty(
-            $allEmailContent,
-            $description . ': Expected to receive log email'
-        );
-
-        foreach ($expectedPatterns as $pattern) {
-            $this->assertMatchesRegularExpression(
-                $pattern,
-                $allEmailContent,
-                $description . ': Expected pattern not found: ' . $pattern
-            );
-        }
-
-        foreach ($unexpectedPatterns as $pattern) {
-            $this->assertDoesNotMatchRegularExpression(
-                $pattern,
-                $allEmailContent,
-                $description . ': Unexpected pattern found: ' . $pattern
-            );
-        }
+        $this->assertPatternsInLog($allEmailContent, $expectedPatterns, $unexpectedPatterns, $description);
 
         // Email subject assertion
         $this->assertStringContainsString(
@@ -367,26 +390,7 @@ class LoggingTest extends MinkTestCase
         $logContent = file_get_contents($filename);
 
         // Basic assertions
-        $this->assertNotEmpty(
-            $logContent,
-            $description . ': Expected to have log messages'
-        );
-
-        foreach ($expectedPatterns as $pattern) {
-            $this->assertMatchesRegularExpression(
-                $pattern,
-                $logContent,
-                $description . ': Expected pattern not found: ' . $pattern
-            );
-        }
-
-        foreach ($unexpectedPatterns as $pattern) {
-            $this->assertDoesNotMatchRegularExpression(
-                $pattern,
-                $logContent,
-                $description . ': Unexpected pattern found: ' . $pattern
-            );
-        }
+        $this->assertPatternsInLog($logContent, $expectedPatterns, $unexpectedPatterns, $description);
     }
 
     /**
@@ -505,30 +509,12 @@ class LoggingTest extends MinkTestCase
                 $row['priority'] = $priorities[$row['priority']] ?? 'UNKNOWN-PRIORITY';
                 return implode(' ', $row);
             },
-            $result->fetchAllAssociative()));
+            $result->fetchAllAssociative()
+        ));
 
         // Basic assertions
-        $this->assertNotEmpty(
-            $logContent,
-            $description . ': Expected to have log messages'
-        );
-
-        foreach ($expectedPatterns as $pattern) {
-            $this->assertMatchesRegularExpression(
-                $pattern,
-                $logContent,
-                $description . ': Expected pattern not found: ' . $pattern
-            );
-        }
-
         $unexpectedPatterns[] = '/UNKNOWN-PRIORITY/';
-        foreach ($unexpectedPatterns as $pattern) {
-            $this->assertDoesNotMatchRegularExpression(
-                $pattern,
-                $logContent,
-                $description . ': Unexpected pattern found: ' . $pattern
-            );
-        }
+        $this->assertPatternsInLog($logContent, $expectedPatterns, $unexpectedPatterns, $description);
 
         // Clear data for the next test:
         $deleteQueryBuilder = $connection->createQueryBuilder();


### PR DESCRIPTION
This PR moves the `log_table` from comments in config.ini into the default database schema.

I don't love this name and would be willing to change it, but for now I'm retaining it for back-compatibility reasons. Open to discussing pros and cons, though!

Additionally, the PR adds integration test coverage for database logging.

TODO:
- [x] Update database changelog when merging