### PR TITLE
Update laminas-validator to 2.64.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "laminas/laminas-session": "2.24.0",
         "laminas/laminas-stdlib": "3.20.0",
         "laminas/laminas-translator": "^1",
-        "laminas/laminas-validator": "2.64.2",
+        "laminas/laminas-validator": "2.64.4",
         "laminas/laminas-view": "2.36.0",
         "league/commonmark": "2.7.1",
         "league/oauth2-client": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74f1f6b98e684a65fea4bfa2b259fa7c",
+    "content-hash": "62b780b6357be4c023fcd5bf8a135d1c",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -5571,16 +5571,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.64.2",
+            "version": "2.64.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
                 "shasum": ""
             },
             "require": {
@@ -5651,7 +5651,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-26T21:29:17+00:00"
+            "time": "2025-06-16T14:38:00+00:00"
         },
         {
             "name": "laminas/laminas-view",


### PR DESCRIPTION
@sturkel89, while investigating whether I could fix the problem blocking us on updates to laminas-escaper (sadly, it's not yet possible), I discovered that there was a small update available to laminas-validator, so I went ahead and applied it here. I didn't have time to run the test suite, though.

Do you mind running the test suite on this branch, and if it passes, approving and merging the PR? (I strongly suspect that it will pass).

Thanks!