### PR TITLE
Add limit parameter to search handler SolrPrefix in [Autocomplete_Types]

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -682,10 +682,11 @@ prioritizeRecordDriverLinks = false
 ;       call numbers using the custom CallNumber search handler.
 ; Tag
 ;       Provide suggestions from the local database of tags.
-; SolrPrefix:[Autocomplete field]:[Display field]
+; SolrPrefix:[Autocomplete field]:[Display field]:[Limit]
 ;       Perform a search against [Autocomplete field] using the edge n-gram
 ;       tokenizer. Each word in the user's query is handled as a prefix. Values
-;       from [Display field] will be displayed for matching records. It is
+;       from [Display field] will be displayed for matching records. The
+;       maximum number of records is set by [Limit] which defaults to 10. It is
 ;       recommended that you index values for this handler into fields of type
 ;       "text_autocomplete" (which are available using the dynamic field suffix
 ;       *_autocomplete). These values should also be copied into a separate

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -172,7 +172,10 @@ class SolrPrefix implements AutocompleteInterface
      */
     public function setConfig($params)
     {
-        [$this->autocompleteField, $this->facetField] = explode(':', $params, 2);
+        [$this->autocompleteField, $this->facetField, $limit] = explode(':', $params, 3);
+        if (ctype_digit($limit)) {
+            $this->limit = $limit;
+        }
         $this->initSearchObject();
     }
 

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -172,8 +172,8 @@ class SolrPrefix implements AutocompleteInterface
      */
     public function setConfig($params)
     {
-        [$this->autocompleteField, $this->facetField, $limit] = explode(':', $params, 3);
-        if (ctype_digit($limit)) {
+        [$this->autocompleteField, $this->facetField, $limit] = explode(':', $params . '::');
+        if ($limit && ctype_digit($limit)) {
             $this->limit = $limit;
         }
         $this->initSearchObject();


### PR DESCRIPTION
Just like in #4647 add a limit parameter to SolrPrefix. The default is still at 10 which used to be the default for search handler Solr as well, but it's now 20. We could consider to increase the default limit of SolrPrefix to 20, too.