### PR TITLE
Add a small delay to Demo driver's payment registration.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -1224,6 +1224,11 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             ];
         }
 
+        // Delay for a bit to avoid a race condition with session updates during CI. When this method is called via the
+        // OnlinePaymentRegister AJAX handler, the "main" request that initiated the AJAX request may be slower to shut
+        // down and write the session data due to code coverage analysis. Since we also update the session with the new
+        // fines, we need to ensure it happens later.
+        sleep(2);
         return [
             'success' => true,
         ];


### PR DESCRIPTION
This avoids a potential race condition with session writes during CI tests where the "main" process shutdown may be delayed due to code coverage processing causing session writes to happen in reverse order and fines list to not be updated properly. This also makes the process feel more realistic during manual testing, since it typically takes a moment for an ILS to register a payment.