### PR TITLE
Defer construction of MigrationManager in upgrade/database utility.

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommand.php
@@ -60,7 +60,7 @@ class DatabaseCommand extends Command
     /**
      * Constructor
      *
-     * @param Closure           $migrationManagerFactory Database migration manager
+     * @param Closure           $migrationManagerFactory Database migration manager factory
      * @param ConnectionFactory $connectionFactory       Database connection factory
      * @param ?string           $name                    The name of the command; passing null means it
      * must be set in configure()

--- a/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommand.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Upgrade;
 
+use Closure;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -59,13 +60,13 @@ class DatabaseCommand extends Command
     /**
      * Constructor
      *
-     * @param MigrationManager  $migrationManager  Database migration manager
-     * @param ConnectionFactory $connectionFactory Database connection factory
-     * @param ?string           $name              The name of the command; passing null means it
+     * @param Closure           $migrationManagerFactory Database migration manager
+     * @param ConnectionFactory $connectionFactory       Database connection factory
+     * @param ?string           $name                    The name of the command; passing null means it
      * must be set in configure()
      */
     public function __construct(
-        protected MigrationManager $migrationManager,
+        protected Closure $migrationManagerFactory,
         protected ConnectionFactory $connectionFactory,
         $name = null
     ) {
@@ -115,21 +116,23 @@ class DatabaseCommand extends Command
     /**
      * Support method for "interactive mode."
      *
-     * @param string[]        $migrations Migrations to apply
-     * @param Connection      $connection Active database connection
-     * @param InputInterface  $input      Input object
-     * @param OutputInterface $output     Output object
+     * @param MigrationManager $migrationManager Migration manager
+     * @param string[]         $migrations       Migrations to apply
+     * @param Connection       $connection       Active database connection
+     * @param InputInterface   $input            Input object
+     * @param OutputInterface  $output           Output object
      *
      * @return void
      */
     protected function applyMigrationsInteractively(
+        MigrationManager $migrationManager,
         array $migrations,
         Connection $connection,
         InputInterface $input,
         OutputInterface $output
     ): void {
         foreach ($migrations as $migration) {
-            $output->writeln('Working on migration: ' . $this->migrationManager->getShortMigrationName($migration));
+            $output->writeln('Working on migration: ' . $migrationManager->getShortMigrationName($migration));
             $question = new ChoiceQuestion(
                 'Choose an option:',
                 [
@@ -146,12 +149,12 @@ class DatabaseCommand extends Command
                         $output->writeln(file_get_contents($migration));
                         break;
                     case 'Appl':
-                        $this->migrationManager->applyMigrations([$migration], $connection);
+                        $migrationManager->applyMigrations([$migration], $connection);
                         break 2;
                     case 'Skip':
                         break 2;
                     case 'Mark':
-                        $this->migrationManager->markMigrationApplied($migration, $connection);
+                        $migrationManager->markMigrationApplied($migration, $connection);
                         break 2;
                 }
             }
@@ -180,12 +183,12 @@ class DatabaseCommand extends Command
 
         try {
             $connection = $sqlOnly ? null : $this->connectionFactory->getConnection($rootUser, $rootPass);
-            $migrations = $this->migrationManager
-                ->getMigrations($fromVersion ?? $this->migrationManager->determineOldVersion());
+            $migrationManager = ($this->migrationManagerFactory)();
+            $migrations = $migrationManager->getMigrations($fromVersion ?? $migrationManager->determineOldVersion());
             if ($interactive) {
-                $this->applyMigrationsInteractively($migrations, $connection, $input, $output);
+                $this->applyMigrationsInteractively($migrationManager, $migrations, $connection, $input, $output);
             } else {
-                $result = $this->migrationManager->applyMigrations($migrations, $connection);
+                $result = $migrationManager->applyMigrations($migrations, $connection);
                 if ($sqlOnly) {
                     $output->writeln($result);
                 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommandFactory.php
@@ -29,6 +29,7 @@
 
 namespace VuFindConsole\Command\Upgrade;
 
+use Closure;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -68,7 +69,7 @@ class DatabaseCommandFactory implements FactoryInterface
         ?array $options = null
     ) {
         return new $requestedName(
-            $container->get(MigrationManager::class),
+            Closure::fromCallable(fn () => $container->get(MigrationManager::class)),
             $container->get(ConnectionFactory::class),
             ...($options ?? [])
         );

--- a/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Upgrade/DatabaseCommandFactory.php
@@ -69,6 +69,7 @@ class DatabaseCommandFactory implements FactoryInterface
         ?array $options = null
     ) {
         return new $requestedName(
+            // Defer MigrationManager build so database errors don't break other console utils:
             Closure::fromCallable(fn () => $container->get(MigrationManager::class)),
             $container->get(ConnectionFactory::class),
             ...($options ?? [])

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Upgrade/DatabaseCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Upgrade/DatabaseCommandTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Command\Upgrade;
 
+use Closure;
 use Symfony\Component\Console\Tester\CommandTester;
 use VuFind\Db\Connection;
 use VuFind\Db\ConnectionFactory;
@@ -82,7 +83,7 @@ class DatabaseCommandTest extends \PHPUnit\Framework\TestCase
         if (!$sqlOnly) {
             $factory->expects($this->once())->method('getConnection')->with(null, null)->willReturn($connection);
         }
-        $command = new DatabaseCommand($manager, $factory);
+        $command = new DatabaseCommand(Closure::fromCallable(fn () => $manager), $factory);
         $commandTester = new CommandTester($command);
         $commandTester->execute($sqlOnly ? ['--sql-only' => true] : []);
         $this->assertEquals(
@@ -101,7 +102,7 @@ class DatabaseCommandTest extends \PHPUnit\Framework\TestCase
     {
         $manager = $this->createMock(MigrationManager::class);
         $factory = $this->createMock(ConnectionFactory::class);
-        $command = new DatabaseCommand($manager, $factory);
+        $command = new DatabaseCommand(Closure::fromCallable(fn () => $manager), $factory);
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
         $this->assertEquals(


### PR DESCRIPTION
This prevents database connection errors from derailing other console utilities.