### PR TITLE
Allow cat_password to be null in AbstractBase::createPatronArray

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
@@ -78,7 +78,7 @@ abstract class AbstractBase implements DriverInterface
      *
      * @param string                 $id               The patron's ID in the ILS
      * @param string                 $cat_username     The username used to log in
-     * @param string                 $cat_password     The password used to log in
+     * @param ?string                $cat_password     The password used to log in or null.
      * @param Stringable|string|null $email            The patron's email address (null if unavailable)
      * @param string                 $firstname        The patron's first name
      * @param string                 $lastname         The patron's last name

--- a/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/AbstractBase.php
@@ -94,7 +94,7 @@ abstract class AbstractBase implements DriverInterface
     protected function createPatronArray(
         string $id,
         string $cat_username = '',
-        string $cat_password = '',
+        ?string $cat_password = null,
         Stringable|string|null $email = null,
         string $firstname = '',
         string $lastname = '',

--- a/module/VuFind/tests/fixtures/alma/responses/get-patron-response.json
+++ b/module/VuFind/tests/fixtures/alma/responses/get-patron-response.json
@@ -68,5 +68,41 @@
             ],
             "resultFixture": "get-patron-login-password.xml"
         }
+    ],
+    "test patron login password and password is null": [
+        {
+            "expectedParams": [
+                "/users/1111",
+                {
+                    "user_id_type": "all_unique",
+                    "op": "auth",
+                    "password": null
+                },
+                [],
+                "POST",
+                null,
+                null,
+                [400],
+                true
+            ],
+            "resultFixture": "get-patron-login-password.xml"
+        },
+        {
+            "expectedParams": [
+                "/users/1111",
+                {
+                    "user_id_type": "all_unique",
+                    "view": "full",
+                    "expand": "none"
+                },
+                [],
+                "GET",
+                null,
+                null,
+                [400],
+                true
+            ],
+            "resultFixture": "get-patron-login-password.xml"
+        }
     ]
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AlmaTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/AlmaTest.php
@@ -365,6 +365,20 @@ class AlmaTest extends \VuFindTest\Unit\ILSDriverTestCase
             ],
             'fixtureKey' => 'test patron login password',
         ];
+        yield 'Test with login method password and password is null' => [
+            'config' => $localConfig,
+            'expected' => [
+                'id' => '21991',
+                'email' => null,
+                'firstname' => 'Sauna',
+                'lastname' => 'Tonttu',
+                'major' => null,
+                'college' => null,
+                'cat_username' => '1111',
+                'cat_password' => null,
+            ],
+            'fixtureKey' => 'test patron login password and password is null',
+        ];
     }
 
     /**
@@ -380,7 +394,7 @@ class AlmaTest extends \VuFindTest\Unit\ILSDriverTestCase
     public function testPatronLogin(array $config, array $expected, string $fixtureKey): void
     {
         $this->createConnector('get-patron-response', $config, $fixtureKey);
-        $result = $this->driver->patronLogin('1111', '1212');
+        $result = $this->driver->patronLogin($expected['cat_username'], $expected['cat_password']);
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
This is a fix for situations where password is set as null, seems like it might happen with shibboleth logins.