### PR TITLE
Fix outdated licenses; add test to catch regressions.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -43,6 +43,17 @@ use PHPUnit\Framework\ExpectationFailedException;
 class BadStringsTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * List of bad strings to check for. Will be matched as plain text unless they
+     * start with a '/' character, in which case they will be treated as regex.
+     *
+     * @var array
+     */
+    protected array $badStrings = [
+        'outdated license address' => '51 Franklin',
+        'outdated PHP header comment' => '/\\* (PHP version [^8])\s*\n/',
+    ];
+
+    /**
      * Test for bad strings in our source files.
      *
      * @return void
@@ -50,15 +61,11 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
      */
     public function testForBadStrings(): void
     {
-        $badStrings = [
-            'outdated license address' => '51 Franklin',
-            'outdated PHP header comment' => '/\\* (PHP version [57])\s*\n/',
-        ];
         $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
         $problems =  [];
         foreach ($filesToCheck as $fileToCheck) {
             $fileContents = file_get_contents($fileToCheck);
-            foreach ($badStrings as $reason => $string) {
+            foreach ($this->badStrings as $reason => $string) {
                 $matches = null;
                 $problem = str_starts_with($string, '/')
                     ? preg_match($string, $fileContents, $matches)

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Check for outdated strings in code files.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Files;
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * Check for outdated strings in code files.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class BadStringsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test for bad strings in our source files.
+     *
+     * @return void
+     * @throws ExpectationFailedException
+     */
+    public function testForBadStrings(): void
+    {
+        $badStrings = ['outdated license address' => '51 Franklin'];
+        $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
+        $problems =  [];
+        foreach ($filesToCheck as $fileToCheck) {
+            foreach ($badStrings as $reason => $string) {
+                if (str_contains(file_get_contents($fileToCheck), $string)) {
+                    $problems[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reason: $string)";
+                }
+            }
+        }
+        $this->assertEquals('', implode("\n", $problems), 'Found bad strings in files.');
+    }
+
+    /**
+     * Recursively find all files matching a pattern inside a directory.
+     *
+     * @param string $path    Path to search
+     * @param string $pattern Search pattern
+     *
+     * @return string[]
+     */
+    protected function getAllFiles(string $path, string $pattern): array
+    {
+        $files = glob("$path/$pattern");
+        foreach (glob("$path/*", GLOB_ONLYDIR) as $dir) {
+            $files = array_merge($files, $this->getAllFiles($dir, $pattern));
+        }
+        return $files;
+    }
+}

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -64,25 +64,30 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
     public function testForBadStrings(): void
     {
         $filesToCheck = $this->getAllFiles(APPLICATION_PATH . '/module', '*.php');
-        $problems =  [];
+        $failures =  [];
         foreach ($filesToCheck as $fileToCheck) {
             $fileContents = file_get_contents($fileToCheck);
             // Use annotation to skip files:
             if (str_contains($fileContents, '* @VuFind.SkipBadStringTest')) {
                 continue;
             }
+            $reasons = [];
             foreach ($this->badStrings as $reason => $string) {
                 $matches = null;
                 $problem = str_starts_with($string, '/')
                     ? preg_match($string, $fileContents, $matches)
                     : str_contains($fileContents, $string);
                 if ($problem) {
-                    $reason .= ': ' . trim($matches[1] ?? $matches[0] ?? $string);
-                    $problems[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reason)";
+                    $reasons[] = "$reason: " . trim($matches[1] ?? $matches[0] ?? $string);
+                    var_dump($reason);
                 }
             }
+            if ($reasons) {
+                $reasonMsg = implode('; ', $reasons);
+                $failures[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reasonMsg)";
+            }
         }
-        $this->assertEquals('', implode("\n", $problems), 'Found bad strings in files.');
+        $this->assertEquals('', implode(PHP_EOL, $failures), 'Found bad strings in files.');
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -54,8 +54,9 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
         $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
         $problems =  [];
         foreach ($filesToCheck as $fileToCheck) {
+            $fileContents = file_get_contents($fileToCheck);
             foreach ($badStrings as $reason => $string) {
-                if (str_contains(file_get_contents($fileToCheck), $string)) {
+                if (str_contains($fileContents, $string)) {
                     $problems[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reason: $string)";
                 }
             }
@@ -73,8 +74,10 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
      */
     protected function getAllFiles(string $path, string $pattern): array
     {
-        $files = glob("$path/$pattern");
-        foreach (glob("$path/*", GLOB_ONLYDIR) as $dir) {
+        $filesMatchingPattern = glob("$path/$pattern");
+        $dirs = glob("$path/*", GLOB_ONLYDIR);
+        $files = array_diff($filesMatchingPattern, $dirs);
+        foreach ($dirs as $dir) {
             $files = array_merge($files, $this->getAllFiles($dir, $pattern));
         }
         return $files;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -25,6 +25,8 @@
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ *
+ * @VuFind.SkipBadStringCheck
  */
 
 namespace VuFindTest\Files;
@@ -61,10 +63,14 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
      */
     public function testForBadStrings(): void
     {
-        $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
+        $filesToCheck = $this->getAllFiles(APPLICATION_PATH . '/module', '*.php');
         $problems =  [];
         foreach ($filesToCheck as $fileToCheck) {
             $fileContents = file_get_contents($fileToCheck);
+            // Use annotation to skip files:
+            if (str_contains($fileContents, '* @VuFind.SkipBadStringTest')) {
+                continue;
+            }
             foreach ($this->badStrings as $reason => $string) {
                 $matches = null;
                 $problem = str_starts_with($string, '/')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -50,7 +50,11 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
      */
     public function testForBadStrings(): void
     {
-        $badStrings = ['outdated license address' => '51 Franklin'];
+        $badStrings = [
+            'outdated license address' => '51 Franklin',
+            'old PHP 5 header' => ' * PHP version 5',
+            'old PHP 7 header' => ' * PHP version 7',
+        ];
         $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
         $problems =  [];
         foreach ($filesToCheck as $fileToCheck) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -52,16 +52,20 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
     {
         $badStrings = [
             'outdated license address' => '51 Franklin',
-            'old PHP 5 header' => ' * PHP version 5',
-            'old PHP 7 header' => ' * PHP version 7',
+            'outdated PHP header comment' => '/\\* (PHP version [57])\s*\n/',
         ];
         $filesToCheck = array_diff($this->getAllFiles(APPLICATION_PATH . '/module', '*.php'), [__FILE__]);
         $problems =  [];
         foreach ($filesToCheck as $fileToCheck) {
             $fileContents = file_get_contents($fileToCheck);
             foreach ($badStrings as $reason => $string) {
-                if (str_contains($fileContents, $string)) {
-                    $problems[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reason: $string)";
+                $matches = null;
+                $problem = str_starts_with($string, '/')
+                    ? preg_match($string, $fileContents, $matches)
+                    : str_contains($fileContents, $string);
+                if ($problem) {
+                    $reason .= ': ' . trim($matches[1] ?? $matches[0] ?? $string);
+                    $problems[] = str_replace(APPLICATION_PATH . '/', '', $fileToCheck) . " ($reason)";
                 }
             }
         }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireOaiResumptionCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireOaiResumptionCommand.php
@@ -18,8 +18,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * @category VuFind
  * @package  Console

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireOaiResumptionCommandFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/ExpireOaiResumptionCommandFactory.php
@@ -18,8 +18,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * @category VuFind
  * @package  Console

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/ExpireOaiResumptionCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/ExpireOaiResumptionCommandTest.php
@@ -17,8 +17,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * @category VuFind
  * @package  Tests


### PR DESCRIPTION
As we work through in-progress pull requests, and as people contribute local code, there's always a chance that outdated license addresses will work their way back into the project. This PR fixes a few recent regressions and adds a test to prevent future ones.