### PR TITLE
WCAG fix: proper label for modal's close button

### DIFF
--- a/themes/bootstrap5/templates/layout/layout.phtml
+++ b/themes/bootstrap5/templates/layout/layout.phtml
@@ -158,8 +158,8 @@
     <div id="modal" class="modal fade hidden-print" tabindex="-1" role="dialog" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
-          <button type="button" class="close" data-bs-dismiss="modal">
-            <?=$this->icon('lightbox-close', ['aria-label' => $this->transEscAttr('Close')]) ?>
+          <button type="button" class="close" data-bs-dismiss="modal" aria-label="<?=$this->transEscAttr('Close')?>">
+            <?=$this->icon('lightbox-close')?>
           </button>
           <div class="modal-body"></div>
         </div>


### PR DESCRIPTION
The problem is that icons have `aria-hidden="true"`. When a label is added to such an icon, it isn't visible to assistive technology. As a result, WebAIM WAVE detected the close button as empty. Adding the label directly to the button works correctly.

The old rendering:
<img width="995" height="128" alt="aria-label on aria-hidden span" src="https://github.com/user-attachments/assets/5a9197c6-7c7f-4673-bb03-94b5c640b8da" />

The new rendering:
<img width="536" height="52" alt="aria-label on the button" src="https://github.com/user-attachments/assets/0b955596-8fbe-42f8-a512-28e4fecb92dc" />
