### PR TITLE
Fix OpenIDConnect::getJwks to return only signature keys

### DIFF
--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -552,7 +552,10 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
             }
             $jwks = json_decode($response->getBody(), true);
             foreach ($jwks['keys'] as $i => $jwk) {
-                $this->jwks[$jwk['kid'] ?? $i] = $jwk;
+                // Filter for signature keys only.
+                if (isset($jwk['use']) && $jwk['use'] === 'sig') {
+                    $this->jwks[$jwk['kid'] ?? $i] = $jwk;
+                }
             }
         }
         return $this->jwks;

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -537,7 +537,12 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
      * @return array
      * @throws AuthException
      */
-    protected function getJwks(): array
+    * Get signature JWKs from provider
+    *
+    * @return array
+    * @throws AuthException
+    */
+protected function getSignatureJwks(): array
     {
         if (empty($this->jwks)) {
             try {

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -473,7 +473,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     {
         [$headerEncoded] = explode('.', $jwt);
         $header = json_decode(base64_decode(strtr($headerEncoded, '-_', '+/')));
-        $key = JWK::parseKey($this->getJwk($header->kid ?? null), $header->alg);
+        $key = JWK::parseKey($this->getSignatureJwk($header->kid ?? null), $header->alg);
         return JWT::decode($jwt, $key);
     }
 
@@ -562,14 +562,14 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     }
 
     /**
-     * Get JWK data
+     * Get signature JWK data
      *
      * @param ?string $kid Key id or null for first (default)
      *
      * @return array
      * @throws AuthException
      */
-    protected function getJwk(?string $kid): array
+    protected function getSignatureJwk(?string $kid): array
     {
         $jwks = $this->getSignatureJwks();
         if (null !== $kid) {

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -576,7 +576,7 @@ protected function getSignatureJwks(): array
      */
     protected function getJwk(?string $kid): array
     {
-        $jwks = $this->getJwks();
+        $jwks = $this->getSignatureJwks();
         if (null !== $kid) {
             if (!isset($jwks[$kid])) {
                 $this->logError("JWK '$kid' not found");

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -542,7 +542,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     * @return array
     * @throws AuthException
     */
-protected function getSignatureJwks(): array
+    protected function getSignatureJwks(): array
     {
         if (empty($this->jwks)) {
             try {

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -553,7 +553,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
             $jwks = json_decode($response->getBody(), true);
             foreach ($jwks['keys'] as $i => $jwk) {
                 // Filter for signature keys only.
-                if (isset($jwk['use']) && $jwk['use'] === 'sig') {
+                if (($jwk['use'] ?? '') === 'sig') {
                     $this->jwks[$jwk['kid'] ?? $i] = $jwk;
                 }
             }

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -532,16 +532,11 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     }
 
     /**
-     * Get JWKs from provider
+     * Get signature JWKs from provider
      *
      * @return array
      * @throws AuthException
      */
-    * Get signature JWKs from provider
-    *
-    * @return array
-    * @throws AuthException
-    */
     protected function getSignatureJwks(): array
     {
         if (empty($this->jwks)) {


### PR DESCRIPTION
Without a filter it could return an encryption key, causing a runtime exception and preventing a successful login.