### PR TITLE
Avoid fatal error when ILS driver does not support reserves.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -352,15 +352,25 @@ class SearchController extends AbstractSolrSearch
         }
 
         // If we got this far, we're using driver-based searching and need to
-        // send options to the view:
+        // send options to the view (but we should tolerate drivers that do not
+        // define all of the department/instructor/courses getters):
         $catalog = $this->getILS();
-        return $this->createViewModel(
-            [
-                'deptList' => $catalog->getDepartments(),
-                'instList' => $catalog->getInstructors(),
-                'courseList' =>  $catalog->getCourses(),
-            ]
-        );
+        try {
+            $deptList = $catalog->getDepartments();
+        } catch (\VuFind\Exception\ILS $e) {
+            $deptList = [];
+        }
+        try {
+            $instList = $catalog->getInstructors();
+        } catch (\VuFind\Exception\ILS $e) {
+            $instList = [];
+        }
+        try {
+            $courseList =  $catalog->getCourses();
+        } catch (\VuFind\Exception\ILS $e) {
+            $courseList = [];
+        }
+        return $this->createViewModel(compact('deptList', 'instList', 'courseList'));
     }
 
     /**

--- a/themes/bootstrap5/templates/search/reserves.phtml
+++ b/themes/bootstrap5/templates/search/reserves.phtml
@@ -13,7 +13,9 @@
 <?php else: ?>
   <h2><?=$this->transEsc('Search For Items on Reserve')?></h2>
   <form method="get" name="searchForm" class="form-search-reserves">
-    <?php if (is_array($this->courseList)): ?>
+    <?php $displayedSomething = false; ?>
+    <?php if (is_array($this->courseList) && $this->courseList): ?>
+      <?php $displayedSomething = true; ?>
       <div class="form-group">
         <label for="reserves_by_course" class="form-label"><?=$this->transEsc('By Course')?>:</label>
         <select name="course" id="reserves_by_course" class="form-select">
@@ -26,7 +28,8 @@
       </div>
     <?php endif; ?>
 
-    <?php if (is_array($this->instList)): ?>
+    <?php if (is_array($this->instList) && $this->instList): ?>
+      <?php $displayedSomething = true; ?>
       <div class="form-group">
         <label for="reserves_by_inst" class="form-label"><?=$this->transEsc('By Instructor')?>:</label>
         <select name="inst" id="reserves_by_inst" class="form-select">
@@ -39,7 +42,8 @@
       </div>
     <?php endif; ?>
 
-    <?php if (is_array($this->deptList)): ?>
+    <?php if (is_array($this->deptList) && $this->deptList): ?>
+      <?php $displayedSomething = true; ?>
       <div class="form-group">
         <label for="reserves_by_dept" class="form-label"><?=$this->transEsc('By Department')?>:</label>
         <select name="dept" id="reserves_by_dept" class="form-select">
@@ -50,6 +54,10 @@
         </select>
         <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
       </div>
+    <?php endif; ?>
+
+    <?php if (!$displayedSomething): ?>
+      <div class="alert alert-info"><?=$this->transEsc('course_reserves_empty_list')?></div>
     <?php endif; ?>
   </form>
 <?php endif; ?>


### PR DESCRIPTION
This PR is intended to complement #4686 -- it avoids a fatal error if an ILS driver lacks support for reserves-related methods, and it skips displaying useless form elements when reserves-related data is not provided.

I'm not sure if the message displayed when reserves are unsupported is ideal, but it seemed good enough in the interest of avoiding the need for new translations. I'm open to discussing this further if others have better ideas, though!