### PR TITLE
Fix some Doctrine runtime exceptions

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/ExternalSessionService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ExternalSessionService.php
@@ -103,7 +103,7 @@ class ExternalSessionService extends AbstractDbService implements
      */
     public function destroySession(string $sid): void
     {
-        $dql = 'DELETE FROM ' . ExternalSessionEntityInterface::class . ' es'
+        $dql = 'DELETE FROM ' . \VuFind\Db\Entity\ExternalSession::class . ' es'
             . ' WHERE es.sessionId = :sid';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameter('sid', $sid);

--- a/module/VuFind/src/VuFind/Db/Service/ResourceService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceService.php
@@ -38,7 +38,6 @@ use VuFind\Db\Entity\ResourceEntityInterface;
 use VuFind\Db\Entity\ResourceTagsEntityInterface;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Entity\UserListEntityInterface;
-use VuFind\Db\Entity\UserResourceEntityInterface;
 use VuFind\Db\PersistenceManager;
 use VuFind\Log\LoggerAwareTrait;
 
@@ -213,15 +212,15 @@ class ResourceService extends AbstractDbService implements
         ?int $limit = null,
         bool $caseSensitiveTags = false
     ): array {
-        $user = $this->getDoctrineReference(UserEntityInterface::class, $userOrId);
+        $user = $this->getDoctrineReference(\VuFind\Db\Entity\User::class, $userOrId);
         $list = $listOrId ? $this->getDoctrineReference(UserListEntityInterface::class, $listOrId) : null;
         $orderByDetails = empty($sort) ? [] : $this->getResourceOrderByClause($sort);
         $dql = 'SELECT DISTINCT r';
         if (!empty($orderByDetails['extraSelect'])) {
             $dql .= ', ' . $orderByDetails['extraSelect'];
         }
-        $dql .= ' FROM ' . ResourceEntityInterface::class . ' r '
-            . 'JOIN ' . UserResourceEntityInterface::class . ' ur WITH r.id = ur.resource ';
+        $dql .= ' FROM ' . \VuFind\Db\Entity\Resource::class . ' r '
+            . 'JOIN ' . \VuFind\Db\Entity\UserResource::class . ' ur WITH r.id = ur.resource ';
         $dqlWhere = [];
         $dqlWhere[] = 'ur.user = :user';
         $parameters = compact('user');

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -104,7 +104,7 @@ class UserService extends AbstractDbService implements
     public function deleteUser(UserEntityInterface|int $userOrId): void
     {
         $userId = $userOrId instanceof UserEntityInterface ? $userOrId->getId() : $userOrId;
-        $dql = 'DELETE FROM ' . UserEntityInterface::class . ' u'
+        $dql = 'DELETE FROM ' . \VuFind\Db\Entity\User::class . ' u'
             . ' WHERE u.id = :id';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameter('id', $userId);
@@ -121,7 +121,7 @@ class UserService extends AbstractDbService implements
     public function getUserById(int $id): ?UserEntityInterface
     {
         $dql = 'SELECT u '
-                . 'FROM ' . UserEntityInterface::class . ' u '
+                . 'FROM ' . \VuFind\Db\Entity\User::class . ' u '
                 . 'WHERE u.id = :id';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameter('id', $id);
@@ -158,7 +158,7 @@ class UserService extends AbstractDbService implements
             $where = $caseInsensitive
                 ? 'LOWER(U.' . $legalFieldMap[$fieldName] . ') = LOWER(:fieldValue)'
                 : 'U.' . $legalFieldMap[$fieldName] . ' = :fieldValue';
-            $dql = 'SELECT U FROM ' . UserEntityInterface::class . ' U '
+            $dql = 'SELECT U FROM ' . \VuFind\Db\Entity\User::class . ' U '
                 . 'WHERE ' . $where;
             $parameters = compact('fieldValue');
             $query = $this->entityManager->createQuery($dql);
@@ -318,7 +318,7 @@ class UserService extends AbstractDbService implements
     public function getAllUsersWithCatUsernames(): array
     {
         $dql = 'SELECT u '
-                . 'FROM ' . UserEntityInterface::class . ' u '
+                . 'FROM ' . \VuFind\Db\Entity\User::class . ' u '
                 . 'WHERE u.catUsername IS NOT NULL';
         $query = $this->entityManager->createQuery($dql);
         $result = $query->getResult();
@@ -333,7 +333,7 @@ class UserService extends AbstractDbService implements
     public function getInsecureRows(): array
     {
         $dql = 'SELECT u '
-                . 'FROM ' . UserEntityInterface::class . ' u '
+                . 'FROM ' . \VuFind\Db\Entity\User::class . ' u '
                 . "WHERE u.password != '' "
                 . 'AND u.catPassword IS NOT NULL';
         $query = $this->entityManager->createQuery($dql);


### PR DESCRIPTION
Doctrine ORM expects an entity class, not an interface. Doctrine cannot instantiate or query interfaces—only concrete classes.

The mapping in PluginManager.php only applies to dependency injection and factory-based object creation, not to Doctrine ORM DQL queries.