### PR TITLE
Fix Unpaywall DOI Linker Configuration Loading

### DIFF
--- a/module/VuFind/src/VuFind/IdentifierLinker/UnpaywallFactory.php
+++ b/module/VuFind/src/VuFind/IdentifierLinker/UnpaywallFactory.php
@@ -69,7 +69,8 @@ class UnpaywallFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config')->IdentifierLinks;
+        $fullConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config');
+        $config = $fullConfig->IdentifierLinks ?? $fullConfig->DOI ?? null;
         return new $requestedName($config);
     }
 }

--- a/module/VuFind/src/VuFind/IdentifierLinker/UnpaywallFactory.php
+++ b/module/VuFind/src/VuFind/IdentifierLinker/UnpaywallFactory.php
@@ -69,7 +69,7 @@ class UnpaywallFactory implements \Laminas\ServiceManager\Factory\FactoryInterfa
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config')->DOI;
+        $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config')->IdentifierLinks;
         return new $requestedName($config);
     }
 }


### PR DESCRIPTION
DOI section in config.ini has been renamed to IdentifierLinks, thus making unpaywall_email can't be loaded correctly.