### PR TITLE
EDS: Remove URL prefix from DOI

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -713,7 +713,7 @@ class EDS extends DefaultRecord
         $doi = $this->getItem('Name', 'DOI');
         if (isset($doi[0]['Data'])) {
             $cleanDoi = strip_tags($doi[0]['Data']);
-            $cleanDoi = preg_replace('/http:\/\/.*doi.org\//', '', $cleanDoi);
+            $cleanDoi = preg_replace('/https?:\/\/.*doi.org\//', '', $cleanDoi);
             return $cleanDoi;
         }
         $dois = $this->getFilteredIdentifiers(['doi']);

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -713,7 +713,7 @@ class EDS extends DefaultRecord
         $doi = $this->getItem('Name', 'DOI');
         if (isset($doi[0]['Data'])) {
             $cleanDoi = strip_tags($doi[0]['Data']);
-            $cleanDoi = preg_replace('/http:\/\/.*.doi.org\//', '', $cleanDoi);
+            $cleanDoi = preg_replace('/http:\/\/.*doi.org\//', '', $cleanDoi);
             return $cleanDoi;
         }
         $dois = $this->getFilteredIdentifiers(['doi']);

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -712,7 +712,10 @@ class EDS extends DefaultRecord
     {
         $doi = $this->getItem('Name', 'DOI');
         if (isset($doi[0]['Data'])) {
-            return strip_tags($doi[0]['Data']);
+            $cleanDoi = strip_tags($doi[0]['Data']);
+            $cleanDoi = str_replace('http://dx.doi.org/', '', $cleanDoi);
+            $cleanDoi = str_replace('http://doi.org/', '', $cleanDoi);
+            return $cleanDoi;
         }
         $dois = $this->getFilteredIdentifiers(['doi']);
         return $dois[0] ?? false;

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -713,8 +713,7 @@ class EDS extends DefaultRecord
         $doi = $this->getItem('Name', 'DOI');
         if (isset($doi[0]['Data'])) {
             $cleanDoi = strip_tags($doi[0]['Data']);
-            $cleanDoi = str_replace('http://dx.doi.org/', '', $cleanDoi);
-            $cleanDoi = str_replace('http://doi.org/', '', $cleanDoi);
+            $cleanDoi = preg_replace('/http:\/\/.*.doi.org\//', '', $cleanDoi);
             return $cleanDoi;
         }
         $dois = $this->getFilteredIdentifiers(['doi']);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -666,15 +666,15 @@ class EDSTest extends \PHPUnit\Framework\TestCase
 
         $cleanDoi = '10.1016/j.jveb.2025.02.006';
         $fields = $driver->getRawData();
-
-        foreach ([
+        $doiVariations = [
             $cleanDoi,
             'http://doi.org/' . $cleanDoi,     // http, and no subdomain
             'https://dx.doi.org/' . $cleanDoi, // https, and subdomain
             '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/'
                 . $cleanDoi
                 . '"&gt;http://dx.doi.org/' . $cleanDoi . '&lt;/link&gt;',  // link wrapper
-        ] as $testDoi) {
+        ];
+        foreach ($doiVariations as $testDoi) {
             $fields['Items'][10]['Data'] = $testDoi;
             $driver->setRawData($fields);
             $this->assertEquals($cleanDoi, $driver->getCleanDOI());

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -655,30 +655,45 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testGetCleanDOIFromUrl().
+     *
+     * @return array[]
+     */
+    public static function getCleanDOIFromUrlProvider(): array
+    {
+        $cleanDoi = '10.1016/j.jveb.2025.02.006';
+        return [
+            'plain DOI' => [$cleanDoi, $cleanDoi],
+            'URL: http, and no subdomain' => ['http://doi.org/' . $cleanDoi, $cleanDoi],
+            'URL: https, and subdomain' => ['https://dx.doi.org/' . $cleanDoi, $cleanDoi],
+            'link wrapper' => [
+                '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/'
+                . $cleanDoi
+                . '"&gt;http://dx.doi.org/' . $cleanDoi . '&lt;/link&gt;',
+                $cleanDoi,
+            ],
+        ];
+    }
+
+    /**
      * Test getCleanDOI for a record when it's in the [Items] block but
      * is formatted as a URL.
      *
+     * @param string $testDoi  DOI value to test with
+     * @param string $cleanDoi Expected value
+     *
      * @return void
+     *
+     * @dataProvider getCleanDOIFromUrlProvider
      */
-    public function testGetCleanDOIFromUrl(): void
+    public function testGetCleanDOIFromUrl(string $testDoi, string $cleanDoi): void
     {
         $driver = $this->getDriver('valid-eds-record-2');
 
-        $cleanDoi = '10.1016/j.jveb.2025.02.006';
         $fields = $driver->getRawData();
-        $doiVariations = [
-            $cleanDoi,
-            'http://doi.org/' . $cleanDoi,     // http, and no subdomain
-            'https://dx.doi.org/' . $cleanDoi, // https, and subdomain
-            '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/'
-                . $cleanDoi
-                . '"&gt;http://dx.doi.org/' . $cleanDoi . '&lt;/link&gt;',  // link wrapper
-        ];
-        foreach ($doiVariations as $testDoi) {
-            $fields['Items'][10]['Data'] = $testDoi;
-            $driver->setRawData($fields);
-            $this->assertEquals($cleanDoi, $driver->getCleanDOI());
-        }
+        $fields['Items'][10]['Data'] = $testDoi;
+        $driver->setRawData($fields);
+        $this->assertEquals($cleanDoi, $driver->getCleanDOI());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -667,13 +667,13 @@ class EDSTest extends \PHPUnit\Framework\TestCase
         $cleanDoi = '10.1016/j.jveb.2025.02.006';
         $fields = $driver->getRawData();
 
-        foreach([
+        foreach ([
             $cleanDoi,
-            'http://doi.org/' . $cleanDoi,      # http, and no subdomain
-            'https://dx.doi.org/' . $cleanDoi,  # https, and subdomain
-            '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/' 
-                . $cleanDoi 
-                . '"&gt;http://dx.doi.org/'.$cleanDoi.'&lt;/link&gt;',  # link wrapper
+            'http://doi.org/' . $cleanDoi,     // http, and no subdomain
+            'https://dx.doi.org/' . $cleanDoi, // https, and subdomain
+            '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/'
+                . $cleanDoi
+                . '"&gt;http://dx.doi.org/' . $cleanDoi . '&lt;/link&gt;',  // link wrapper
         ] as $testDoi) {
             $fields['Items'][10]['Data'] = $testDoi;
             $driver->setRawData($fields);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -655,6 +655,33 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getCleanDOI for a record when it's in the [Items] block but
+     * is formatted as a URL.
+     *
+     * @return void
+     */
+    public function testGetCleanDOIFromUrl(): void
+    {
+        $driver = $this->getDriver('valid-eds-record-2');
+
+        $cleanDoi = '10.1016/j.jveb.2025.02.006';
+        $fields = $driver->getRawData();
+
+        foreach([
+            $cleanDoi,
+            'http://doi.org/' . $cleanDoi,      # http, and no subdomain
+            'https://dx.doi.org/' . $cleanDoi,  # https, and subdomain
+            '&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/' 
+                . $cleanDoi 
+                . '"&gt;http://dx.doi.org/'.$cleanDoi.'&lt;/link&gt;',  # link wrapper
+        ] as $testDoi) {
+            $fields['Items'][10]['Data'] = $testDoi;
+            $driver->setRawData($fields);
+            $this->assertEquals($cleanDoi, $driver->getCleanDOI());
+        }
+    }
+
+    /**
      * Test getCleanDOI for a record when DOI is in bib data.
      *
      * @return void


### PR DESCRIPTION
The DOI returned by the EDS /retrieve API in the Items > DOI block is usually just a raw (clean) DOI, like 

`            <Item>
                <Name>DOI</Name>
                <Label>DOI</Label>
                <Group>ID</Group>
                <Data>10.1007/s00500-020-05451-0</Data>
            </Item>
`

However sometimes it is wrapped in a link

`            <Item>
                <Name>DOI</Name>
                <Label>Digital Object Identifier</Label>
                <Group>ID</Group>
                <Data>&lt;link linkTarget="URL" linkWindow="_blank" linkTerm="http://dx.doi.org/10.1016/j.jveb.2025.02.006"&gt;http://dx.doi.org/10.1016/j.jveb.2025.02.006&lt;/link&gt;</Data>
            </Item>
`

Presumably EDS's `getCleanDoi` implementation should return the same "clean" format of DOI either way.  Its current call to `strip_tags` removes the `<a>` wrapper, but still returns the URL.  This removes the URL prefix.