### PR TITLE
WorldCat2: Do not include relator info from creatorNotes in names

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
@@ -181,13 +181,10 @@ class WorldCat2 extends DefaultRecord
         return implode(
             ', ',
             array_filter(
-                array_merge(
-                    [
-                        $data['secondName']['text'] ?? null,
-                        $data['firstName']['text'] ?? null,
-                    ],
-                    $data['creatorNotes'] ?? []
-                )
+                [
+                    $data['secondName']['text'] ?? null,
+                    $data['firstName']['text'] ?? null,
+                ]
             )
         );
     }

--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
@@ -195,26 +195,45 @@ class WorldCat2 extends DefaultRecord
         $creatorNotes = array_diff(
             array_map(
                 function ($note) use ($relatorTerms) {
-                    return implode(
+                    $result = implode(
                         ', ',
                         array_filter(
                             array_map(
                                 function ($value) use ($relatorTerms) {
+                                    // Regex for capturing useful patterns at the beginning of creatorNotes
+                                    $datesRegex = '((ca\. )?\d{4}-(\d{4})?)';
+                                    $parensRegex = '(\\([^)]+\\)\\.?)';
+                                    $startRegex = "^($datesRegex|$parensRegex)";
+                                    // Regex for capturing a code or URI:
+                                    $codeRegex = '(https?:[^\s]+|\\w{3})';
+
                                     // Skip note segments that are relators:
                                     if (in_array(strtolower($value), $relatorTerms)) {
                                         return '';
                                     }
+                                    $allEscapedTerms = [];
                                     foreach ($relatorTerms as $term) {
-                                        $escapedTerm = preg_quote($term, '/');
+                                        $allEscapedTerms[] = $escapedTerm = preg_quote($term, '/');
                                         // Skip note segments that are a relator term followed by a 3-character code:
-                                        if (preg_match("/^$escapedTerm( \\w{3})?$/i", $value)) {
+                                        if (preg_match("/^$escapedTerm\\.?( $codeRegex)?$/i", $value)) {
                                             return '';
                                         }
                                         // If a note segment starts with a date range and ends in a relator term
                                         // (possibly followed by a 3-letter code), we should skip it:
-                                        if (preg_match("/^(\d{4}-\d{4}) $escapedTerm( \\w{3})?$/i", $value, $matches)) {
+                                        $singleTermRegex = "/$startRegex $escapedTerm\\.?( $codeRegex)*$/i";
+                                        if (preg_match($singleTermRegex, $value, $matches)) {
                                             return $matches[1];
                                         }
+                                    }
+                                    // If there are multiple relator terms, they may all be concatenated together;
+                                    // strip them off in that case as well:
+                                    $allEscapedTermsStr = implode(
+                                        '',
+                                        array_map(fn ($term) => "( ($codeRegex )?$term\\.?)?", $allEscapedTerms)
+                                    );
+                                    $allEscapedTermsRegex = "/$startRegex$allEscapedTermsStr( $codeRegex)*$/i";
+                                    if (preg_match($allEscapedTermsRegex, $value, $matches)) {
+                                        return $matches[1];
                                     }
                                     return $value;
                                 },
@@ -222,6 +241,8 @@ class WorldCat2 extends DefaultRecord
                             )
                         )
                     ) . (str_ends_with($note, '.') ? '.' : '');
+                    // Collapse redundant periods:
+                    return preg_replace('/\\.+$/', '.', $result);
                 },
                 $rawCreatorNotes
             ),

--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
@@ -178,13 +178,36 @@ class WorldCat2 extends DefaultRecord
         if (!empty($data['nonPersonName']['text'])) {
             return $data['nonPersonName']['text'];
         }
+        $rawCreatorNotes = $data['creatorNotes'] ?? [];
+        // The creatorNotes field may include useful information like author birth/death dates, but
+        // also useless information like redundant relator information. We need to strip out the
+        // relator terms so that author search will work correctly.
+        $relatorTerms = array_map(
+            fn ($relator) => strtolower($relator['term'] ?? ''),
+            $data['relators'] ?? []
+        );
+        $creatorNotes = array_map(
+            function ($note) use ($relatorTerms) {
+                return implode(
+                    ', ',
+                    array_diff(
+                        explode(', ', trim($note, '.')),
+                        $relatorTerms
+                    )
+                ) . (str_ends_with($note, '.') ? '.' : '');
+            },
+            $rawCreatorNotes
+        );
         return implode(
             ', ',
             array_filter(
-                [
-                    $data['secondName']['text'] ?? null,
-                    $data['firstName']['text'] ?? null,
-                ]
+                array_merge(
+                    [
+                        $data['secondName']['text'] ?? null,
+                        $data['firstName']['text'] ?? null,
+                    ],
+                    $creatorNotes
+                )
             )
         );
     }

--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
@@ -30,6 +30,7 @@
 namespace VuFind\RecordDriver;
 
 use function count;
+use function in_array;
 
 /**
  * Model for WorldCat v2 records.
@@ -182,21 +183,49 @@ class WorldCat2 extends DefaultRecord
         // The creatorNotes field may include useful information like author birth/death dates, but
         // also useless information like redundant relator information. We need to strip out the
         // relator terms so that author search will work correctly.
-        $relatorTerms = array_map(
-            fn ($relator) => strtolower($relator['term'] ?? ''),
-            $data['relators'] ?? []
-        );
-        $creatorNotes = array_map(
-            function ($note) use ($relatorTerms) {
-                return implode(
-                    ', ',
-                    array_diff(
-                        explode(', ', trim($note, '.')),
-                        $relatorTerms
-                    )
-                ) . (str_ends_with($note, '.') ? '.' : '');
-            },
-            $rawCreatorNotes
+        $relatorTerms = [];
+        foreach ($data['relators'] ?? [] as $relator) {
+            if ($term = strtolower($relator['term'] ?? '')) {
+                $relatorTerms[] = $term;
+            }
+            if ($altTerm = strtolower($relator['alternateTerm'] ?? '')) {
+                $relatorTerms[] = $altTerm;
+            }
+        }
+        $creatorNotes = array_diff(
+            array_map(
+                function ($note) use ($relatorTerms) {
+                    return implode(
+                        ', ',
+                        array_filter(
+                            array_map(
+                                function ($value) use ($relatorTerms) {
+                                    // Skip note segments that are relators:
+                                    if (in_array(strtolower($value), $relatorTerms)) {
+                                        return '';
+                                    }
+                                    foreach ($relatorTerms as $term) {
+                                        $escapedTerm = preg_quote($term, '/');
+                                        // Skip note segments that are a relator term followed by a 3-character code:
+                                        if (preg_match("/^$escapedTerm( \\w{3})?$/i", $value)) {
+                                            return '';
+                                        }
+                                        // If a note segment starts with a date range and ends in a relator term
+                                        // (possibly followed by a 3-letter code), we should skip it:
+                                        if (preg_match("/^(\d{4}-\d{4}) $escapedTerm( \\w{3})?$/i", $value, $matches)) {
+                                            return $matches[1];
+                                        }
+                                    }
+                                    return $value;
+                                },
+                                explode(', ', trim($note, '.')),
+                            )
+                        )
+                    ) . (str_ends_with($note, '.') ? '.' : '');
+                },
+                $rawCreatorNotes
+            ),
+            ['.'] // Strip out any empty values
         );
         return implode(
             ', ',

--- a/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
+++ b/module/VuFind/src/VuFind/RecordDriver/WorldCat2.php
@@ -215,7 +215,7 @@ class WorldCat2 extends DefaultRecord
                                     foreach ($relatorTerms as $term) {
                                         $allEscapedTerms[] = $escapedTerm = preg_quote($term, '/');
                                         // Skip note segments that are a relator term followed by a 3-character code:
-                                        if (preg_match("/^$escapedTerm\\.?( $codeRegex)?$/i", $value)) {
+                                        if (preg_match("/^$escapedTerm\\.?( $codeRegex)*$/i", $value)) {
                                             return '';
                                         }
                                         // If a note segment starts with a date range and ends in a relator term

--- a/module/VuFind/tests/fixtures/worldcat2/authors.json
+++ b/module/VuFind/tests/fixtures/worldcat2/authors.json
@@ -1,0 +1,5 @@
+{"identifier":{"oclcNumber":"foo"},"contributor": {"creators":[
+    {"firstName": {"text": "First"}, "secondName": {"text": "Last"}, "isPrimary": true, "type": "person", "creatorNotes": ["Title, author"], "relators": [{"term": "Author"}]},
+    {"firstName": {"text": "1st"}, "secondName": {"text": "Lst"}, "type": "person", "creatorNotes": ["1900-1960, aut aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st2"}, "secondName": {"text": "Lst2"}, "type": "person", "creatorNotes": ["1900-1960 author aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]}
+]}}

--- a/module/VuFind/tests/fixtures/worldcat2/authors.json
+++ b/module/VuFind/tests/fixtures/worldcat2/authors.json
@@ -8,5 +8,6 @@
     {"firstName": {"text": "1st6"}, "secondName": {"text": "Lst6"}, "type": "person", "creatorNotes": ["1900- author. aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
     {"firstName": {"text": "1st7"}, "secondName": {"text": "Lst7"}, "type": "person", "creatorNotes": ["(1900-...). aut author."], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
     {"firstName": {"text": "1st8"}, "secondName": {"text": "Lst8"}, "type": "person", "creatorNotes": ["1900- author. http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
-    {"firstName": {"text": "1st9"}, "secondName": {"text": "Lst9"}, "type": "person", "creatorNotes": ["(First M.), author. http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]}
+    {"firstName": {"text": "1st9"}, "secondName": {"text": "Lst9"}, "type": "person", "creatorNotes": ["(First M.), author. http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st10"}, "secondName": {"text": "Lst10"}, "type": "person", "creatorNotes": ["author. aut http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]}
 ]}}

--- a/module/VuFind/tests/fixtures/worldcat2/authors.json
+++ b/module/VuFind/tests/fixtures/worldcat2/authors.json
@@ -1,5 +1,12 @@
 {"identifier":{"oclcNumber":"foo"},"contributor": {"creators":[
     {"firstName": {"text": "First"}, "secondName": {"text": "Last"}, "isPrimary": true, "type": "person", "creatorNotes": ["Title, author"], "relators": [{"term": "Author"}]},
     {"firstName": {"text": "1st"}, "secondName": {"text": "Lst"}, "type": "person", "creatorNotes": ["1900-1960, aut aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
-    {"firstName": {"text": "1st2"}, "secondName": {"text": "Lst2"}, "type": "person", "creatorNotes": ["1900-1960 author aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]}
+    {"firstName": {"text": "1st2"}, "secondName": {"text": "Lst2"}, "type": "person", "creatorNotes": ["1900-1960 author aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st3"}, "secondName": {"text": "Lst3"}, "type": "person", "creatorNotes": ["1900- author aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st4"}, "secondName": {"text": "Lst4"}, "type": "person", "creatorNotes": ["1900- Verfasser Herausgeber aut edt"], "relators": [{"term": "Verfasser", "alternateTerm": "Verfasser"}, {"term": "Herausgeber", "alternateTerm": "Herausgeber"}]},
+    {"firstName": {"text": "1st5"}, "secondName": {"text": "Lst5"}, "type": "person", "creatorNotes": ["ca. 1900-1970 author aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st6"}, "secondName": {"text": "Lst6"}, "type": "person", "creatorNotes": ["1900- author. aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st7"}, "secondName": {"text": "Lst7"}, "type": "person", "creatorNotes": ["(1900-...). aut author."], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st8"}, "secondName": {"text": "Lst8"}, "type": "person", "creatorNotes": ["1900- author. http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]},
+    {"firstName": {"text": "1st9"}, "secondName": {"text": "Lst9"}, "type": "person", "creatorNotes": ["(First M.), author. http://id.loc.gov/vocabulary/relators/aut"], "relators": [{"term": "Author", "alternateTerm": "aut"}]}
 ]}}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
@@ -116,6 +116,7 @@ class WorldCat2Test extends \PHPUnit\Framework\TestCase
                     'Lst7, 1st7, (1900-...).',
                     'Lst8, 1st8, 1900-',
                     'Lst9, 1st9, (First M.)',
+                    'Lst10, 1st10',
                 ],
                 'worldcat2/authors.json',
             ],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
@@ -104,8 +104,21 @@ class WorldCat2Test extends \PHPUnit\Framework\TestCase
             'non-default primary author with relator code in notes' =>
                 ['getPrimaryAuthor', 'Last, First, Title', 'worldcat2/authors.json'],
             'non-default secondary authors' => ['getSecondaryAuthors', ['Kinsley, James'], 'worldcat2/pride.json'],
-            'non-default secondary authors with relator codes in notes' =>
-                ['getSecondaryAuthors', ['Lst, 1st, 1900-1960', 'Lst2, 1st2, 1900-1960'], 'worldcat2/authors.json'],
+            'non-default secondary authors with relator codes in notes' => [
+                'getSecondaryAuthors',
+                [
+                    'Lst, 1st, 1900-1960',
+                    'Lst2, 1st2, 1900-1960',
+                    'Lst3, 1st3, 1900-',
+                    'Lst4, 1st4, 1900-',
+                    'Lst5, 1st5, ca. 1900-1970',
+                    'Lst6, 1st6, 1900-',
+                    'Lst7, 1st7, (1900-...).',
+                    'Lst8, 1st8, 1900-',
+                    'Lst9, 1st9, (First M.)',
+                ],
+                'worldcat2/authors.json',
+            ],
             'non-default publication dates' => ['getPublicationDates', ['1990'], 'worldcat2/pride.json'],
             'non-default human-readable dates' =>
                 ['getHumanReadablePublicationDates', ['1990'], 'worldcat2/pride.json'],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/WorldCat2Test.php
@@ -101,7 +101,11 @@ class WorldCat2Test extends \PHPUnit\Framework\TestCase
             'non-default places of publication' => ['getPlacesOfPublication', ['Oxford :'], 'worldcat2/pride.json'],
             'non-default primary authors' =>
                 ['getPrimaryAuthors', ['Austen, Jane, 1775-1817.'], 'worldcat2/pride.json'],
+            'non-default primary author with relator code in notes' =>
+                ['getPrimaryAuthor', 'Last, First, Title', 'worldcat2/authors.json'],
             'non-default secondary authors' => ['getSecondaryAuthors', ['Kinsley, James'], 'worldcat2/pride.json'],
+            'non-default secondary authors with relator codes in notes' =>
+                ['getSecondaryAuthors', ['Lst, 1st, 1900-1960', 'Lst2, 1st2, 1900-1960'], 'worldcat2/authors.json'],
             'non-default publication dates' => ['getPublicationDates', ['1990'], 'worldcat2/pride.json'],
             'non-default human-readable dates' =>
                 ['getHumanReadablePublicationDates', ['1990'], 'worldcat2/pride.json'],


### PR DESCRIPTION
Including the relator terms found in the creatorNotes field as part of creator names causes search problems -- e.g. "author, illustrator" being part of an author's name prevents the author search link from matching all records belonging to that author. This PR strips out the unwanted redundant information.