### PR TITLE
Identifier links: improve error handling.

### DIFF
--- a/themes/bootstrap5/js/identifierLinks.js
+++ b/themes/bootstrap5/js/identifierLinks.js
@@ -32,7 +32,10 @@ VuFind.register('identifierLinks', function identifierLinks() {
       .then((response) => {
         elements.forEach((identifierEl) => {
           var currentInstance = identifierEl.dataset.instance;
-          if ("undefined" !== typeof response.data[currentInstance]) {
+          // response.data should be an array; if it's a string, there's an error message.
+          if ("string" === typeof response.data) {
+            console.error("Unexpected identifier data: " + response.data);
+          } else if ("undefined" !== typeof response.data[currentInstance]) {
             VuFind.setInnerHtml(identifierEl, response.data[currentInstance]);
           }
         });


### PR DESCRIPTION
While testing #4698, I discovered a related problem: when the identifier link handler encounters an error, it returns a string instead of an array as the response data. The logic was displaying letters from the string as if they were DOI data. This PR detects the error message and logs it to the console instead of misusing it as if it were an array. Successful scenarios are unaffected.