### PR TITLE
Fix default locale handling in CurrencyFormatter.

### DIFF
--- a/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
+++ b/module/VuFind/src/VuFind/Service/CurrencyFormatter.php
@@ -66,9 +66,8 @@ class CurrencyFormatter
      */
     public function __construct($defaultCurrency = null, $locale = null)
     {
-        // Initialize number formatter:
-        $locale ??= setlocale(LC_MONETARY, '');
-        $this->formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        // Initialize number formatter (an empty string makes NumberFormatter use the default locale):
+        $this->formatter = new NumberFormatter($locale ?? '', NumberFormatter::CURRENCY);
 
         // Initialize default currency:
         if (null === $defaultCurrency) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Service/CurrencyFormatterTest.php
@@ -53,8 +53,7 @@ class CurrencyFormatterTest extends \PHPUnit\Framework\TestCase
     public function testFormatting()
     {
         // test default settings
-        $locale = setlocale(LC_MONETARY, '');
-        $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
+        $formatter = new NumberFormatter('', NumberFormatter::CURRENCY);
         $defaultCurrencyCode = trim($formatter->getTextAttribute(NumberFormatter::CURRENCY_CODE) ?: '') ?: 'USD';
         $cc = new \VuFind\Service\CurrencyFormatter();
         $this->assertEquals(


### PR DESCRIPTION
Fixes an exception with PHP 8.4 when a locale is not passed or is null.