### PR TITLE
Fix config.ini default cover sizes

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1053,10 +1053,10 @@ verify_server_certificate = false
 ;coversize[core] = medium
 ;coversize[holds] = small
 ;coversize[illrequests] = small
-;coversize[list-entry] = small
+;coversize[list-entry] = medium
 ;coversize[RandomRecommend] = "small:medium"
 ;coversize[result-grid] = large
-;coversize[result-list] = small
+;coversize[result-list] = medium
 ;coversize[similar-items] = large
 ;coversize[storageretrievalrequests] = small
 


### PR DESCRIPTION
config.ini says it lists the defaults, but they don't all match.