### PR TITLE
EDS and EPF: Respect thumbnail size config on record display

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/EDS/core.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/core.phtml
@@ -6,7 +6,7 @@
     $coverDetails = $this->record($this->driver)->getCoverDetails('core', 'medium');
     $cover = $coverDetails['html'];
   ?>
-  <div class="media-left medium img-col">
+  <div class="media-left <?=$this->escapeHtmlAttr($coverDetails['size'])?> img-col">
     <?php if ($cover): ?>
       <?=$cover?>
     <?php endif; ?>

--- a/themes/bootstrap5/templates/RecordDriver/EPF/core.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EPF/core.phtml
@@ -6,7 +6,7 @@
     $coverDetails = $this->record($this->driver)->getCoverDetails('core', 'medium');
     $cover = $coverDetails['html'];
   ?>
-  <div class="media-left medium img-col">
+  <div class="media-left <?=$this->escapeHtmlAttr($coverDetails['size'])?> img-col">
     <?php if ($cover): ?>
       <?=$cover?>
     <?php endif; ?>


### PR DESCRIPTION
EDS (and EPF) retrieves the `$coverDetails` but then ignores the configured size.  This respects the config.