### PR TITLE
Disable default file logging in logging tests.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LoggingTest.php
@@ -298,6 +298,7 @@ final class LoggingTest extends MinkTestCase
                 ],
                 'Logging' => [
                     'email' => $emailConfig,
+                    'file' => null,
                 ],
             ],
         ]);
@@ -449,6 +450,7 @@ final class LoggingTest extends MinkTestCase
                 ],
                 'Logging' => [
                     'email' => '',
+                    'file' => null,
                 ],
             ],
         ]);
@@ -523,6 +525,7 @@ final class LoggingTest extends MinkTestCase
                 ],
                 'Logging' => [
                     'database' => $loggingConfig,
+                    'file' => null,
                 ],
             ],
         ]);


### PR DESCRIPTION
This ensures that the expected exceptions are not logged to vufind-exception.log during Mink tests.