### PR TITLE
Improve EBSCO thumbnail logic.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -481,7 +481,7 @@ class EDS extends DefaultRecord
         $desiredFit = $sizes[$size] ?? count($sizes);
         $closestMatch = false;
         foreach ($this->fields['ImageInfo'] ?? [] as $image) {
-            $currentFit = $sizes[$image['Size'] ?? ''] ?? 0;
+            $currentFit = $sizes[$image['Size'] ?? 'thumb'] ?? 0;
             $target = $image['Target'] ?? '';
             if ($target) {
                 if ($currentFit === $desiredFit) {

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -473,12 +473,29 @@ class EDS extends DefaultRecord
      */
     public function getThumbnail($size = 'small')
     {
+        // Create a ranked list of sizes so we can use "best available" when appropriate.
+        // Note that "thumb" is a value used by EBSCO, not by VuFind; it is included so
+        // it can be matched up with requests for "small."
+        $sizes = ['thumb' => 0, 'small' => 1, 'medium' => 2, 'large' => 3];
+        $bestFit = -1;
+        $desiredFit = $sizes[$size] ?? count($sizes);
+        $closestMatch = false;
         foreach ($this->fields['ImageInfo'] ?? [] as $image) {
-            if ($size == ($image['Size'] ?? '')) {
-                return $image['Target'] ?? '';
+            $currentFit = $sizes[$image['Size'] ?? ''] ?? 0;
+            $target = $image['Target'] ?? '';
+            if ($target) {
+                if ($currentFit === $desiredFit) {
+                    return $target;
+                }
+                // Aim for the best match that is smaller than the requested size; we
+                // don't want to overflow, but something small is better than nothing.
+                if ($currentFit > $bestFit && $currentFit < $desiredFit) {
+                    $bestFit = $currentFit;
+                    $closestMatch = $target;
+                }
             }
         }
-        return false;
+        return $closestMatch;
     }
 
     /**

--- a/module/VuFind/tests/fixtures/eds/valid-eds-record.json
+++ b/module/VuFind/tests/fixtures/eds/valid-eds-record.json
@@ -121,8 +121,12 @@
     ],
     "ImageInfo": [
         {
-            "Size": "small",
-            "Target": "thumbnail link"
+            "Size": "thumb",
+            "Target": "small thumbnail link"
+        },
+        {
+            "Size": "medium",
+            "Target": "medium thumbnail link"
         }
     ],
     "RecordInfo": {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -572,14 +572,33 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testGetThumbnail().
+     *
+     * @return array[]
+     */
+    public static function getThumbnailProvider(): array
+    {
+        return [
+            'thumb is upscaled to small' => ['small', 'small thumbnail link'],
+            'medium is used as-is' => ['medium', 'medium thumbnail link'],
+            'medium is upscaled to large' => ['large', 'medium thumbnail link'],
+        ];
+    }
+
+    /**
      * Test getThumbnail for a record.
      *
+     * @param string $size     Size to request
+     * @param string $expected Expected result
+     *
      * @return void
+     *
+     * @dataProvider getThumbnailProvider
      */
-    public function testGetThumbnail(): void
+    public function testGetThumbnail(string $size, string $expected): void
     {
         $driver = $this->getDriver('valid-eds-record');
-        $this->assertEquals('thumbnail link', $driver->getThumbnail());
+        $this->assertEquals($expected, $driver->getThumbnail($size));
     }
 
     /**


### PR DESCRIPTION
As mentioned on #4712, this increases the odds that we'll actually display an image when the EDS API response includes data but it's not an exact match for the size requested.