### PR TITLE
Fix HTML error in query parameters for geo search URL

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/GeoCoords.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GeoCoords.php
@@ -113,8 +113,9 @@ class GeoCoords extends \Laminas\View\Helper\AbstractHelper
             return false;
         }
         $urlHelper = $this->getView()->plugin('url');
-        return $urlHelper('search-results')
-            . '?filter[]=' . urlencode($this->geoField)
-            . ':Intersects(ENVELOPE(' . urlencode($this->coords) . '))';
+        $query = http_build_query([
+            'filter' => [$this->geoField . ':Intersects(ENVELOPE(' . $this->coords . '))'],
+        ]);
+        return $urlHelper('search-results') . '?' . $query;
     }
 }

--- a/themes/bootstrap5/js/map_selection_leaflet.js
+++ b/themes/bootstrap5/js/map_selection_leaflet.js
@@ -73,7 +73,7 @@ function loadMapSelection(geoField, boundingBox, baseURL, homeURL, searchParams,
     }
   });
 
-  /** 
+  /**
    * Handle user interaction with markers and rectangles
    */
   function onClick() {
@@ -312,9 +312,9 @@ function loadMapSelection(geoField, boundingBox, baseURL, homeURL, searchParams,
     var di_south = di_sw.lat;
     var di_west = di_sw.lng;
 
-    //Create search query
+    // Create search query
     var rawFilter = geoField + ':Intersects(ENVELOPE(' + di_west + ', ' + di_east + ', ' + di_north + ', ' + di_south + '))';
-    location.href = baseURL + searchParams + "&filter[]=" + rawFilter;
+    location.href = baseURL + searchParams + "&filter%5B%5D=" + rawFilter;
   }, this);
 
   document.getElementById("draw_box").onclick = function drawSearchBox() {


### PR DESCRIPTION
Error message from W3C validator:

    **Error**: Bad value
    /vufind/Search/Results?filter[]=long_lat:Intersects(ENVELOPE(-95%2C+30%2C+72%2C+15))
    for attribute href on element a: Illegal character in query: [ is not allowed.