### PR TITLE
Fix HTML error in preview links for bootstrap5

### DIFF
--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -59,6 +59,7 @@ function getHTPreviews(keys) {
 function applyPreviewUrl($link, url) {
   // Update the preview button:
   $link.attr('href', url).removeClass('hidden')
+    .attr('target', '_blank')
     .attr('rel', 'noopener'); // Performance improvement
 
   // Update associated record thumbnail, if any:

--- a/themes/bootstrap5/templates/RecordDriver/AbstractBase/previewlink.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/AbstractBase/previewlink.phtml
@@ -37,7 +37,7 @@
                 if ($name) {
                     $title = $this->transEsc('Preview from') . ' ' . $name;
                     $html .= '<div class="' . $divClass . '">'
-                        . '<a title="' . $title . '" class="hidden ' . $linkClass . ' ' . $idClasses . '" target="_blank">'
+                        . '<a title="' . $title . '" class="hidden ' . $linkClass . ' ' . $idClasses . '">'
                         . '<img src="' . $icon . '" alt="' . $this->transEsc('Preview') . '">'
                         . '</a>'
                         . '</div>';


### PR DESCRIPTION
The target attribute must be omitted if the href attribute is not present.