### PR TITLE
Disable logging for tests of invalid search handlers

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
@@ -174,12 +174,16 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
      */
     public function testBadSearchTabConfig(): void
     {
+        // Add a bad search tab config and disable logging of that exception
         $this->changeConfigs(
             [
                 'config' => [
                     'SearchTabs' => [
                         'Solr' => 'Catalog',
                         'INVALID' => 'Other Search',
+                    ],
+                    'Logging' => [
+                        'file' => null,
                     ],
                 ],
             ]
@@ -201,6 +205,8 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
      */
     public function testBadSearchBoxConfig(): void
     {
+        // Add a bad search handler config to the combined handlers
+        // and disable logging of that exception
         $this->changeConfigs(
             [
                 'searchbox' => [
@@ -212,6 +218,11 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
                         'target' => ['Solr', 'INVALID'],
                         'label' => ['Catalog', 'Other Search'],
                         'group' => [false, false],
+                    ],
+                ],
+                'config' => [
+                    'Logging' => [
+                        'file' => null,
                     ],
                 ],
             ]

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -49,9 +49,6 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function getCombinedIniOverrides(): array
     {
-        // Include 2 valid combined handlers, and one invalid one
-        // to ensure that the exception handling correctly filters
-        // it out from the final results.
         return [
             'Solr:one' => [
                 'label' => 'Solr One',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -61,9 +61,6 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
                 'label' => 'Solr Two',
                 'hiddenFilter' => 'building:weird_ids.mrc',
             ],
-            'INVALID:one' => [
-                'label' => 'Invalid handler',
-            ],
         ];
     }
 
@@ -135,6 +132,43 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
         $this->unFindCss($page, '.fa-spinner.icon--spin');
         $this->assertResultsForDefaultQuery($page);
+    }
+
+    /**
+     * Test that combined results work with an invalid search heandler.
+     *
+     * @return void
+     */
+    public function testCombinedSearchResultsInvalidHandler(): void
+    {
+        $combined = $this->getCombinedIniOverrides();
+        $combined['INVALID:one'] = [
+            'label' => 'Invalid handler',
+        ];
+
+        // Include an invalid combined search handler, and disable logging
+        $this->changeConfigs(
+            [
+                'combined' => $combined,
+                'config' => [
+                    'Logging' => [
+                        'file' => null,
+                    ],
+                ],
+            ],
+            ['combined']
+        );
+        $page = $this->performCombinedSearch('id:"testsample1" OR id:"theplus+andtheminus-"');
+        $this->assertEquals('200', $this->getMinkSession()->getStatusCode());
+        $this->assertResultsForDefaultQuery($page);
+        $this->assertStringContainsString(
+            'Solr One',
+            $this->findCssAndGetHtml($page, '.combined-search-container')
+        );
+        $this->assertStringNotContainsString(
+            'Invalid handler',
+            $this->findCssAndGetHtml($page, '.combined-search-container')
+        );
     }
 
     /**


### PR DESCRIPTION
The tests added in [PR 4678](https://github.com/vufind-org/vufind/pull/4678) added extra logs when running tests. To reduce the noise in the logs, this PR disables file logging for those specific tests.