### PR TITLE
Style: Activate and apply class_reference_name_casing rule.

### DIFF
--- a/module/VuFind/functions/codecoverage.php
+++ b/module/VuFind/functions/codecoverage.php
@@ -80,7 +80,7 @@ function setupVuFindRemoteCodeCoverage(array $modules): void
                 // includeFile below will do it in any case):
                 $iterator = new \RecursiveDirectoryIterator(
                     "$moduleDir/src/",
-                    \FileSystemIterator::CURRENT_AS_PATHNAME | \FileSystemIterator::SKIP_DOTS
+                    \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS
                 );
                 $filterIterator = new \RecursiveCallbackFilterIterator(
                     $iterator,

--- a/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Alma.php
@@ -109,7 +109,7 @@ class Alma extends AbstractBase
     {
         $records = []; // array to return
         try {
-            $xml = new \SimpleXmlElement($xmlstr);
+            $xml = new \SimpleXMLElement($xmlstr);
         } catch (\Exception $e) {
             return $records;
         }

--- a/module/VuFind/src/VuFind/Resolver/Driver/Sfx.php
+++ b/module/VuFind/src/VuFind/Resolver/Driver/Sfx.php
@@ -95,7 +95,7 @@ class Sfx extends AbstractBase
     {
         $records = []; // array to return
         try {
-            $xml = new \SimpleXmlElement($xmlstr);
+            $xml = new \SimpleXMLElement($xmlstr);
         } catch (\Exception $e) {
             return $records;
         }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
@@ -621,7 +621,7 @@ class RestConnector implements ConnectorInterface, \Psr\Log\LoggerAwareInterface
      *
      * @return void
      */
-    protected function processHighlighting(array &$record, array $params, \StdClass $highlight): void
+    protected function processHighlighting(array &$record, array $params, \stdClass $highlight): void
     {
         if (empty($params['highlight'])) {
             return;

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -16,6 +16,7 @@ $rules = [
     ],
     'cast_spaces' => ['space' => 'none'],
     'class_attributes_separation' => ['elements' => ['method' => 'one', 'property' => 'one']],
+    'class_reference_name_casing' => true,
     'concat_space' => ['spacing' => 'one'],
     'ereg_to_preg' => true,
     'get_class_to_class_keyword' => true,

--- a/tests/vufind_templates.php-cs-fixer.php
+++ b/tests/vufind_templates.php-cs-fixer.php
@@ -14,6 +14,7 @@ $rules = [
     'blank_line_after_opening_tag' => false,
     'cast_spaces' => ['space' => 'none'],
     'class_attributes_separation' => ['elements' => ['method' => 'one', 'property' => 'one']],
+    'class_reference_name_casing' => true,
     'concat_space' => ['spacing' => 'one'],
     'ereg_to_preg' => true,
     'get_class_to_class_keyword' => true,


### PR DESCRIPTION
Inspired by #4750, this should help reduce inconsistencies in the code (though at present, php-cs-fixer doesn't seem to be smart enough to fix Datetime --> DateTime references, so we still need to keep our eyes out for those).