### PR TITLE
Replace shebang for bash in shell scripts (improves portability)

### DIFF
--- a/harvest/batch-delete.sh
+++ b/harvest/batch-delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]

--- a/harvest/batch-import-marc-auth.sh
+++ b/harvest/batch-import-marc-auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]

--- a/harvest/batch-import-marc.sh
+++ b/harvest/batch-import-marc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure VUFIND_HOME is set:
 if [ -z "$VUFIND_HOME" ]

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper around import-marc.sh to allow import of authority records.
 #

--- a/import-marc.sh
+++ b/import-marc.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-# $Id: index_file.sh 17 2008-06-20 14:40:13Z wayne.graham $
+#!/usr/bin/env bash
 #
 # Bash script to start the import of a binary marc file for Solr indexing.
 #

--- a/index-alphabetic-browse.sh
+++ b/index-alphabetic-browse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #####################################################
 # Build java command


### PR DESCRIPTION
/bin/bash on macOS is too old (missing support for `mapfile`) for VuFind, but often a newer bash is provided (for example by Homebrew) which is used with the modified shebang.