### PR TITLE
Use updated PHP_CodeSniffer annotations (prepare for 4.0).

### DIFF
--- a/module/VuFind/src/VuFind/Feed/Writer/Extension/OpenSearch/Renderer/Feed.php
+++ b/module/VuFind/src/VuFind/Feed/Writer/Extension/OpenSearch/Renderer/Feed.php
@@ -75,10 +75,10 @@ class Feed extends AbstractRenderer
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:disable
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
         // (We have to ignore coding standards here because the method name has
         // to have an underscore for compatibility w/ parent class)
         $this->getRootElement()->setAttribute(

--- a/module/VuFind/src/VuFind/Search/minSO.php
+++ b/module/VuFind/src/VuFind/Search/minSO.php
@@ -38,8 +38,8 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  */
-// @codingStandardsIgnoreStart - lowercase class name
+// phpcs:disable
 class minSO extends \VuFind\Search\Minified
 {
 }
-// @codingStandardsIgnoreEnd
+// phpcs:enable

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CitationTest.php
@@ -51,7 +51,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
      * @var array
      */
     protected $citations = [
-        // @codingStandardsIgnoreStart
+        // phpcs:disable
         [
             'raw' => [
                 'SecondaryAuthors' => ['Shafer, Kathleen Newton'],
@@ -358,7 +358,7 @@ class CitationTest extends \PHPUnit\Framework\TestCase
             'mla' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i>, vol. 1, no. 7, 1999, pp. 19-21, https://doi.org/testDOI.',
             'chicago' => 'One, Person. &quot;Test Article.&quot; <i>Test Journal</i> 1, no. 7 (1999): 19-21. https://doi.org/testDOI.',
         ],
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable
     ];
 
     /**


### PR DESCRIPTION
PHP_CodeSniffer is discontinuing deprecated ignore annotations in version 4; this brings us up to date with forward-compatible annotations.