### PR TITLE
Modernize MockContainerTrait and prepare for PHPUnit 11.

### DIFF
--- a/module/VuFind/src/VuFindTest/Container/MockContainerTrait.php
+++ b/module/VuFind/src/VuFindTest/Container/MockContainerTrait.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Container;
 
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase;
 
 use function in_array;
@@ -68,20 +69,12 @@ trait MockContainerTrait
     ];
 
     /**
-     * Test case (for building mock objects)
-     *
-     * @var TestCase
-     */
-    protected $test;
-
-    /**
      * Constructor
      *
-     * @param TestCase $test Test using the container
+     * @param TestCase $test Test using the container (for building mock objects)
      */
-    public function __construct(TestCase $test)
+    public function __construct(protected TestCase $test)
     {
-        $this->test = $test;
     }
 
     /**
@@ -94,8 +87,7 @@ trait MockContainerTrait
      */
     public function createMock($id, $methods = [])
     {
-        $builder = $this->test->getMockBuilder($id)
-            ->disableOriginalConstructor();
+        $builder = (new MockBuilder($this->test, $id))->disableOriginalConstructor();
         if ($methods) {
             $builder->onlyMethods($methods);
         }


### PR DESCRIPTION
The getMockBuilder method becomes protected in PHPUnit 11; this refactors code slightly to prepare for that change (and uses constructor property promotion for simplification while touching the trait anyway).