### PR TITLE
PHPUnit: make sure error handlers are always restored.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/TabManagerTest.php
@@ -132,7 +132,6 @@ class TabManagerTest extends \PHPUnit\Framework\TestCase
         $errorCallback = function (int $code, string $msg) {
             throw new \Exception($msg, $code);
         };
-        set_error_handler($errorCallback, E_USER_WARNING);
         $legacyConfig = [
             'vufind' => [
                 'recorddriver_tabs' => [
@@ -145,8 +144,14 @@ class TabManagerTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
         ];
-        $this->getTabManager(legacyConfig: $legacyConfig);
-        restore_error_handler();
+        set_error_handler($errorCallback, E_USER_WARNING);
+        try {
+            $this->getTabManager(legacyConfig: $legacyConfig);
+        } catch (\Throwable $e) {
+            throw $e;
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/MakeTagTest.php
@@ -279,7 +279,12 @@ class MakeTagTest extends \VuFindTest\Unit\AbstractMakeTagTestCase
             throw new \Exception($msg, $code);
         };
         set_error_handler($errorCallback, E_USER_WARNING);
-        $helper('marquee', 'Now Playing: A Simpler Time!');
-        restore_error_handler();
+        try {
+            $helper('marquee', 'Now Playing: A Simpler Time!');
+        } catch (\Throwable $e) {
+            throw $e;
+        } finally {
+            restore_error_handler();
+        }
     }
 }


### PR DESCRIPTION
These changes prevent "Risky test" warnings in PHPUnit 11.