### PR TITLE
Ensure Doctrine cache exists even when caching was disabled in configs

### DIFF
--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -415,7 +415,7 @@ class Manager implements LoggerAwareInterface
             unset($opts['disabled']);
         }
 
-        $this->ensureCacheDirectoyExists($dirName, $opts);
+        $this->ensureCacheDirectoryExists($dirName, $opts);
 
         if (empty($opts)) {
             $opts = ['cache_dir' => $dirName];

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -354,24 +354,16 @@ class Manager implements LoggerAwareInterface
     }
 
     /**
-     * Add a file cache to the manager and ensure that necessary directory exists.
+     * Ensure that a cache directory exists.
      *
-     * @param string $cacheName    Name of new cache to create
      * @param string $dirName      Directory to use for storage
      * @param array  $overrideOpts Options to override default values.
      *
      * @return void
      */
-    protected function createFileCache($cacheName, $dirName, $overrideOpts = [])
+    public function ensureCacheDirectoyExists($dirName, $overrideOpts = [])
     {
         $opts = array_merge($this->defaults, $overrideOpts);
-        if ($opts['disabled'] ?? false) {
-            $this->createNoCache($cacheName);
-            return;
-        } else {
-            // Laminas does not support "disabled = false"; unset to avoid error.
-            unset($opts['disabled']);
-        }
 
         if (!is_dir($dirName)) {
             if (isset($opts['umask'])) {
@@ -401,6 +393,30 @@ class Manager implements LoggerAwareInterface
                 $this->directoryCreationError = true;
             }
         }
+    }
+
+    /**
+     * Add a file cache to the manager and ensure that necessary directory exists.
+     *
+     * @param string $cacheName    Name of new cache to create
+     * @param string $dirName      Directory to use for storage
+     * @param array  $overrideOpts Options to override default values.
+     *
+     * @return void
+     */
+    protected function createFileCache($cacheName, $dirName, $overrideOpts = [])
+    {
+        $opts = array_merge($this->defaults, $overrideOpts);
+        if ($opts['disabled'] ?? false) {
+            $this->createNoCache($cacheName);
+            return;
+        } else {
+            // Laminas does not support "disabled = false"; unset to avoid error.
+            unset($opts['disabled']);
+        }
+
+        $this->ensureCacheDirectoyExists($dirName, $opts);
+
         if (empty($opts)) {
             $opts = ['cache_dir' => $dirName];
         } elseif (is_array($opts)) {

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -361,7 +361,7 @@ class Manager implements LoggerAwareInterface
      *
      * @return void
      */
-    public function ensureCacheDirectoyExists($dirName, $overrideOpts = [])
+    public function ensureCacheDirectoryExists($dirName, $overrideOpts = [])
     {
         $opts = array_merge($this->defaults, $overrideOpts);
 

--- a/module/VuFind/src/VuFind/Db/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/Db/ConnectionFactory.php
@@ -117,7 +117,7 @@ class ConnectionFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
         $doctrineCacheDir = $container
             ->get('config')['caches']['doctrinemodule.cache.filesystem']['options']['cache_dir'];
         $cacheManager = $container->get(\VuFind\Cache\Manager::class);
-        $cacheManager->ensureCacheDirectoyExists($doctrineCacheDir);
+        $cacheManager->ensureCacheDirectoryExists($doctrineCacheDir);
 
         $this->config = $container->get(\VuFind\Config\ConfigManagerInterface::class)
             ->getConfigObject($this->configName);

--- a/module/VuFind/src/VuFind/Db/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/Db/ConnectionFactory.php
@@ -114,6 +114,11 @@ class ConnectionFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
         if (!empty($options)) {
             throw new \Exception('Unexpected options sent to factory!');
         }
+        $doctrineCacheDir = $container
+            ->get('config')['caches']['doctrinemodule.cache.filesystem']['options']['cache_dir'];
+        $cacheManager = $container->get(\VuFind\Cache\Manager::class);
+        $cacheManager->ensureCacheDirectoyExists($doctrineCacheDir);
+
         $this->config = $container->get(\VuFind\Config\ConfigManagerInterface::class)
             ->getConfigObject($this->configName);
         $this->container = $container;


### PR DESCRIPTION
This PR fixes a bug when caching is disabled in the config.ini but the cache directory is still required for Doctrine.