### PR TITLE
Fix monolog error when logged in

### DIFF
--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -325,7 +325,9 @@ class LoggerFactory implements FactoryInterface
                     $authManager = $container->get(AuthManager::class);
                     if ($user = $authManager->getUserObject()) {
                         $monologLogger->pushProcessor(function (LogRecord $record) use ($user) {
-                            $record['extra']['username'] = $user->getUsername();
+                            $record['extra'] = array_merge($record['extra'], [
+                                'username' => $user->getUsername(),
+                            ]);
                             return $record;
                         });
                     }

--- a/module/VuFind/src/VuFind/Log/LoggerFactory.php
+++ b/module/VuFind/src/VuFind/Log/LoggerFactory.php
@@ -37,6 +37,7 @@ use Monolog\Handler\BufferHandler;
 use Monolog\Handler\FilterHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger as MonologLogger;
+use Monolog\LogRecord;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
@@ -323,7 +324,7 @@ class LoggerFactory implements FactoryInterface
                 try {
                     $authManager = $container->get(AuthManager::class);
                     if ($user = $authManager->getUserObject()) {
-                        $monologLogger->pushProcessor(function (array $record) use ($user) {
+                        $monologLogger->pushProcessor(function (LogRecord $record) use ($user) {
                             $record['extra']['username'] = $user->getUsername();
                             return $record;
                         });


### PR DESCRIPTION
monolog's ProcessorInterface's anonymous function takes a monolog Record object as a param, not array, since monolog v3.

https://github.com/Seldaek/monolog/releases/tag/3.0.0

This was causing an error when I was logged in.