### PR TITLE
Databases: Strip punctuation before matching on query term

### DIFF
--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -419,7 +419,7 @@ AU = None
 ;useQueryMinLength = 3
 
 ; When using the query string as a match point, the query string and
-; database names will first be normalize by removing the characters
+; database names will first be normalized by removing the characters
 ; in this regular expression. Default is below, use false to disable.
 ;useQueryReplacePattern = '/[-\/\.,:]/'
 

--- a/config/vufind/EDS.ini
+++ b/config/vufind/EDS.ini
@@ -418,6 +418,11 @@ AU = None
 ; useQuery above.
 ;useQueryMinLength = 3
 
+; When using the query string as a match point, the query string and
+; database names will first be normalize by removing the characters
+; in this regular expression. Default is below, use false to disable.
+;useQueryReplacePattern = '/[-\/\.,:]/'
+
 ; Display a link to an external list of all databases, below the
 ; results. Default (false) omits the link.
 ;linkToAllDatabases = https://some.url

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -108,7 +108,7 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
     /**
      * When using the query string as a match point, the query string and
      * database names will first be normalized by removing the characters
-     * in this regular expression.
+     * in this regular expression. If empty, no normalization will occur.
      *
      * @var string
      */

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -274,17 +274,11 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
         if ($this->useQuery) {
             $queryObject = $this->results->getParams()->getQuery();
             $query = is_callable([$queryObject, 'getString'])
-                ? strtolower($queryObject->getString())
+                ? $this->normalizeQueryString($queryObject->getString())
                 : '';
-            if ($this->useQueryReplacePattern) {
-                $query = preg_replace($this->useQueryReplacePattern, '', $query);
-            }
             if (strlen($query) >= $this->useQueryMinLength) {
                 foreach ($nameToDatabase as $name => $databaseInfo) {
-                    $name = strtolower($name);
-                    if ($this->useQueryReplacePattern) {
-                        $name = preg_replace($this->useQueryReplacePattern, '', $name);
-                    }
+                    $name = $this->normalizeQueryString($name);
                     if (str_contains($name, $query)) {
                         $databases[$databaseInfo['url']] = $databaseInfo;
                     }
@@ -313,6 +307,23 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
         }
 
         return $databases;
+    }
+
+    /**
+     * Normalize a query string or database name for comparison with each other.
+     * Force to lower case, and remove any characters specified by a regex.
+     *
+     * @param string $str The query string or database name
+     *
+     * @return string The normalized string
+     */
+    protected function normalizeQueryString(string $str): string
+    {
+        $str = strtolower($str);
+        if ($this->useQueryReplacePattern) {
+            $str = preg_replace($this->useQueryReplacePattern, '', $str);
+        }
+        return $str;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -189,8 +189,8 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
             ?? $this->useQuery;
         $this->useQueryMinLength = $databasesConfig['useQueryMinLength']
             ?? $this->useQueryMinLength;
-        $this->useQueryReplacePattern = $databasesConfig['useQueryReplacePattern']
-            ?? $this->useQueryReplacePattern;
+        $queryReplaceConfig = $databasesConfig['useQueryReplacePattern'] ?? $this->useQueryReplacePattern;
+        $this->useQueryReplacePattern = $queryReplaceConfig ?: '';
 
         $this->useLibGuides = $databasesConfig['useLibGuides']
             ?? $this->useLibGuides;

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -107,7 +107,7 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
 
     /**
      * When using the query string as a match point, the query string and
-     * database names will first be normalize by removing the characters
+     * database names will first be normalized by removing the characters
      * in this regular expression.
      *
      * @var string

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -278,8 +278,7 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
                 : '';
             if (strlen($query) >= $this->useQueryMinLength) {
                 foreach ($nameToDatabase as $name => $databaseInfo) {
-                    $name = $this->normalizeQueryString($name);
-                    if (str_contains($name, $query)) {
+                    if (str_contains($this->normalizeQueryString($name), $query)) {
                         $databases[$databaseInfo['url']] = $databaseInfo;
                     }
                     if (count($databases) >= $this->limit) {

--- a/module/VuFind/src/VuFind/Recommend/Databases.php
+++ b/module/VuFind/src/VuFind/Recommend/Databases.php
@@ -106,6 +106,15 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
     protected $useQueryMinLength = 3;
 
     /**
+     * When using the query string as a match point, the query string and
+     * database names will first be normalize by removing the characters
+     * in this regular expression.
+     *
+     * @var string
+     */
+    protected $useQueryReplacePattern = '/[-\/\.,:]/';
+
+    /**
      * Configuration of whether to use LibGuides as a data source
      *
      * @var bool
@@ -180,6 +189,8 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
             ?? $this->useQuery;
         $this->useQueryMinLength = $databasesConfig['useQueryMinLength']
             ?? $this->useQueryMinLength;
+        $this->useQueryReplacePattern = $databasesConfig['useQueryReplacePattern']
+            ?? $this->useQueryReplacePattern;
 
         $this->useLibGuides = $databasesConfig['useLibGuides']
             ?? $this->useLibGuides;
@@ -265,9 +276,16 @@ class Databases implements RecommendInterface, \Psr\Log\LoggerAwareInterface
             $query = is_callable([$queryObject, 'getString'])
                 ? strtolower($queryObject->getString())
                 : '';
+            if ($this->useQueryReplacePattern) {
+                $query = preg_replace($this->useQueryReplacePattern, '', $query);
+            }
             if (strlen($query) >= $this->useQueryMinLength) {
                 foreach ($nameToDatabase as $name => $databaseInfo) {
-                    if (str_contains(strtolower($name), $query)) {
+                    $name = strtolower($name);
+                    if ($this->useQueryReplacePattern) {
+                        $name = preg_replace($this->useQueryReplacePattern, '', $name);
+                    }
+                    if (str_contains($name, $query)) {
                         $databases[$databaseInfo['url']] = $databaseInfo;
                     }
                     if (count($databases) >= $this->limit) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/DatabasesTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/DatabasesTest.php
@@ -92,6 +92,52 @@ class DatabasesTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test a query with punctuation.
+     *
+     * @return void
+     */
+    public function testQueryWithPunctuation(): void
+    {
+        $configData = $this->mockConfigData();
+        $module = $this->buildModuleAndProcessResults($configData, 'His-tory.');
+
+        $databases = $module->getResults();
+        $this->assertCount(3, $databases);
+        $this->assertArrayHasKey('http://thepast.com', $databases);
+    }
+
+    /**
+     * Test a database name with punctuation.
+     *
+     * @return void
+     */
+    public function testDatabaseNameWithPunctuation(): void
+    {
+        $configData = $this->mockConfigData();
+        $module = $this->buildModuleAndProcessResults($configData, 'ABC DB');
+
+        $databases = $module->getResults();
+        $this->assertCount(3, $databases);
+        $this->assertArrayHasKey('http://spelling.com', $databases);
+    }
+
+    /**
+     * Test a database name with punctuation but regex disabled.
+     *
+     * @return void
+     */
+    public function testQueryRegexDisabled(): void
+    {
+        $configData = $this->mockConfigData();
+        $configData['Databases']['useQueryReplacePattern'] = false;
+        $module = $this->buildModuleAndProcessResults($configData, 'ABC DB');
+
+        $databases = $module->getResults();
+        $this->assertCount(2, $databases);
+        $this->assertArrayNotHasKey('http://spelling.com', $databases);
+    }
+
+    /**
      * Test setting useLibGuides to true.
      *
      * @return void
@@ -245,6 +291,7 @@ class DatabasesTest extends \PHPUnit\Framework\TestCase
                     'Sociology DB' => 'http://people.com',
                     'Biology DB' => 'http://cells.com',
                     'History DB' => 'http://thepast.com',
+                    'A.B.C. DB' => 'http://spelling.com',
                 ],
             ],
         ];


### PR DESCRIPTION
Database names like these may be searched without the punctuation, but should still match:
- ABI/Inform
- ACLS Humanities E-Book
- A.M. Explorer