### PR TITLE
Catch token errors in FOLIO init

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -395,10 +395,16 @@ class Folio extends AbstractAPI implements
                 'Token taken from ' . $cacheType . ' cache: ' . substr($this->token, 0, 30) . '...'
             );
         }
-        if ($this->token == null) {
-            $this->renewTenantToken();
-        } else {
-            $this->checkTenantToken();
+        try {
+            if ($this->token == null) {
+                $this->renewTenantToken();
+            } else {
+                $this->checkTenantToken();
+            }
+        } catch (\Exception $e) {
+            // Errors in init() should not be fatal, it could prevent using EDS when FOLIO fails
+            $this->token = $this->tokenExpiration = null;
+            $this->logError("Failed to get a token to initialize the FOLIO driver: " . $e->getMessage());
         }
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -402,7 +402,8 @@ class Folio extends AbstractAPI implements
                 $this->checkTenantToken();
             }
         } catch (\Exception $e) {
-            // Errors in init() should not be fatal, it could prevent using EDS when FOLIO fails
+            // Errors in init() should not be fatal,
+            // it could prevent using other configured search handlers when FOLIO fails
             $this->token = $this->tokenExpiration = null;
             $this->logError('Failed to get a token to initialize the FOLIO driver: ' . $e->getMessage());
         }

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -404,7 +404,7 @@ class Folio extends AbstractAPI implements
         } catch (\Exception $e) {
             // Errors in init() should not be fatal, it could prevent using EDS when FOLIO fails
             $this->token = $this->tokenExpiration = null;
-            $this->logError("Failed to get a token to initialize the FOLIO driver: " . $e->getMessage());
+            $this->logError('Failed to get a token to initialize the FOLIO driver: ' . $e->getMessage());
         }
     }
 


### PR DESCRIPTION
Errors when obtaining a FOLIO token can break initialization, which can prevent users from using other services such as EDS when FOLIO is failing. Errors in FOLIO requests in `init()` should not be fatal.
This PR adds a simple try/catch when obtaining a token.