### PR TITLE
Deprecate CAS authentication support due to abandonment of php-cas library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "require": {
         "php": ">=8.2",
         "ahand/mobileesp": "dev-master",
-        "apereo/phpcas": "1.6.1",
         "browscap/browscap-php": "^7.2",
         "cap60552/php-sip2": "1.0.0",
         "colinmollenhour/credis": "1.17.0",
@@ -135,6 +134,9 @@
         "pietercolpaert/hardf": "0.5.0",
         "rector/rector": "2.2.6",
         "squizlabs/php_codesniffer": "4.0.0"
+    },
+    "suggest": {
+        "apereo/phpcas": "Allows CAS authentication to be used. Note that this functionality is deprecated."
     },
     "extra": {
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdaee71b8a97aa5615995963ee344bee",
+    "content-hash": "ddd858f7c33ada08e3c12c0da2bde7a7",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -64,77 +64,6 @@
                 "source": "https://github.com/ahand/mobileesp/"
             },
             "time": "2017-06-06T22:20:56+00:00"
-        },
-        {
-            "name": "apereo/phpcas",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/apereo/phpCAS.git",
-                "reference": "c129708154852656aabb13d8606cd5b12dbbabac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/apereo/phpCAS/zipball/c129708154852656aabb13d8606cd5b12dbbabac",
-                "reference": "c129708154852656aabb13d8606cd5b12dbbabac",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "ext-dom": "*",
-                "php": ">=7.1.0",
-                "psr/log": "^1.0 || ^2.0 || ^3.0"
-            },
-            "require-dev": {
-                "monolog/monolog": "^1.0.0 || ^2.0.0",
-                "phpstan/phpstan": "^1.5",
-                "phpunit/phpunit": ">=7.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "source/CAS.php"
-                ],
-                "classmap": [
-                    "source/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Joachim Fritschi",
-                    "email": "jfritschi@freenet.de",
-                    "homepage": "https://github.com/jfritschi"
-                },
-                {
-                    "name": "Adam Franco",
-                    "homepage": "https://github.com/adamfranco"
-                },
-                {
-                    "name": "Henry Pan",
-                    "homepage": "https://github.com/phy25"
-                }
-            ],
-            "description": "Provides a simple API for authenticating users against a CAS server",
-            "homepage": "https://wiki.jasig.org/display/CASC/phpCAS",
-            "keywords": [
-                "apereo",
-                "cas",
-                "jasig"
-            ],
-            "support": {
-                "issues": "https://github.com/apereo/phpCAS/issues",
-                "source": "https://github.com/apereo/phpCAS/tree/1.6.1"
-            },
-            "time": "2023-02-19T19:52:35+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -7386,25 +7315,25 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.2",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d"
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/da801d52f0354f70a638673c4a0f04e16529431d",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^4.0",
-                "php": "8.1 - 8.4"
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
                 "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^1.0",
+                "phpstan/phpstan-nette": "^2.0@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -7414,6 +7343,9 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -7442,9 +7374,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.2"
+                "source": "https://github.com/nette/schema/tree/v1.3.3"
             },
-            "time": "2024-10-06T23:10:23+00:00"
+            "time": "2025-10-30T22:57:59+00:00"
         },
         {
             "name": "nette/utils",
@@ -11841,16 +11773,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "541057574806f942c94662b817a50f63f7345360"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
-                "reference": "541057574806f942c94662b817a50f63f7345360",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
@@ -11893,9 +11825,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2025-10-20T12:43:39+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         },
         {
             "name": "webmozart/glob",
@@ -16049,7 +15981,7 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -483,7 +483,7 @@ force_first_scheduled_email = false
 [Authentication]
 ; You can authenticate using one or more of the following methods:
 ; - AlmaDatabase (combination of VuFind database and Alma account; see also Alma.ini)
-; - CAS (see also [CAS] section)
+; - CAS (see also [CAS] section -- deprecated, use OpenIDConnect instead when possible)
 ; - Database: VuFind's internal user database
 ; - Email (see notes below)
 ; - Facebook (see also [Facebook] section)
@@ -972,7 +972,7 @@ verify_server_certificate = false
 ; in Shibboleth.ini
 ;allow_configuration_override = true
 
-; CAS is optional.  This section only needs to exist if the
+; CAS is optional (and deprecated). This section only needs to exist if the
 ; Authentication Method is set to CAS.
 ;[CAS]
 
@@ -2701,7 +2701,7 @@ description = "The REST API provides access to search functions and records cont
 ; Minimum allowed length for salt is 10 characters.
 ; Example command for creating a salt in terminal:
 ; php -r "echo hash('sha256', random_bytes(16)) . PHP_EOL;"
-;token_salt = 
+;token_salt =
 ; The header field key that should be used to provide the API key. Default is X-API-KEY.
 ;header_field = 'X-API-KEY'
 ; How many API keys can a user have at maximum. Default is 5.

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -46,7 +46,7 @@ use function constant;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  *
- * @deprecated
+ * @deprecated This integration cannot be maintained due to the abandonment of https://github.com/apereo/phpCAS
  */
 class CAS extends AbstractBase
 {

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -45,6 +45,8 @@ use function constant;
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
+ *
+ * @deprecated
  */
 class CAS extends AbstractBase
 {

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -303,6 +303,9 @@ class CAS extends AbstractBase
      */
     protected function setupCAS()
     {
+        if (!class_exists(\phpCAS::class)) {
+            throw new \Exception('php-cas module not found; install apereo/phpcas to use CAS');
+        }
         $casauth = new \phpCAS();
 
         // Check to see if phpCAS has already been setup. If it has, than skip as

--- a/module/VuFind/src/VuFind/Auth/CAS.php
+++ b/module/VuFind/src/VuFind/Auth/CAS.php
@@ -46,7 +46,8 @@ use function constant;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Page
  *
- * @deprecated This integration cannot be maintained due to the abandonment of https://github.com/apereo/phpCAS
+ * @deprecated This integration cannot be maintained due to the abandonment of the apereo/phpCAS library.
+ * Use OpenIDConnect instead if possible.
  */
 class CAS extends AbstractBase
 {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
@@ -46,18 +46,6 @@ class CASTest extends \PHPUnit\Framework\TestCase
     use \VuFindTest\Feature\ReflectionTrait;
 
     /**
-     * Setup method
-     *
-     * @return void
-     */
-    public function setUp(): void
-    {
-        if (PHP_VERSION_ID >= 80400) {
-            $this->markTestSkipped('PHP-CAS is no longer supported and throws deprecation warnings in PHP 8.4+.');
-        }
-    }
-
-    /**
      * Get an authentication object.
      *
      * @param ?array $config Configuration to use (null for default)

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/CASTest.php
@@ -46,6 +46,18 @@ class CASTest extends \PHPUnit\Framework\TestCase
     use \VuFindTest\Feature\ReflectionTrait;
 
     /**
+     * Setup method
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->markTestSkipped('PHP-CAS is no longer supported and throws deprecation warnings in PHP 8.4+.');
+        }
+    }
+
+    /**
      * Get an authentication object.
      *
      * @param ?array $config Configuration to use (null for default)


### PR DESCRIPTION
As discussed on the [4 November 2025 Community Call](https://vufind.org/wiki/community_call:minutes20251104), the php-cas library is no longer supported and throws deprecation warnings in PHP 8.4+. This PR simply deprecates the CAS authentication plugin and disables the offending tests.

In the next major version, we can either remove CAS support (if no solution is found) or revert the deprecation (if a long-term solution for CAS support can be found).

TODO
- [x] Before merging this, consider whether #4761 is a better solution (or close that PR if this approach is preferred).
- [x] Update changelog when merging
