### PR TITLE
Blender: Refactor backend and config names

### DIFF
--- a/module/VuFind/src/VuFind/Controller/BlenderController.php
+++ b/module/VuFind/src/VuFind/Controller/BlenderController.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\Controller;
 
-use Laminas\ServiceManager\ServiceLocatorInterface;
-
 /**
  * Blended Search Controller
  *

--- a/module/VuFind/src/VuFind/Controller/BlenderController.php
+++ b/module/VuFind/src/VuFind/Controller/BlenderController.php
@@ -43,13 +43,9 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 class BlenderController extends AbstractSearch
 {
     /**
-     * Constructor
+     * Search class family to use.
      *
-     * @param ServiceLocatorInterface $sm Service locator
+     * @var string
      */
-    public function __construct(ServiceLocatorInterface $sm)
-    {
-        $this->searchClassId = 'Blender';
-        parent::__construct($sm);
-    }
+    protected $searchClassId = 'Blender';
 }

--- a/module/VuFind/src/VuFind/Search/Blender/Options.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Options.php
@@ -45,14 +45,44 @@ use VuFind\Config\ConfigManagerInterface;
 class Options extends \VuFind\Search\Solr\Options
 {
     /**
+     * Configuration file to read search settings from
+     *
+     * Note that any change to this must be made before calling the constructor of this class.
+     *
+     * @var string
+     */
+    protected $searchIni = 'Blender';
+
+    /**
+     * Configuration file to read facet settings from
+     *
+     * Note that any change to this must be made before calling the constructor of this class.
+     *
+     * @var string
+     */
+    protected $facetsIni = 'Blender';
+
+    /**
+     * The route name for the search results action.
+     *
+     * @var string
+     */
+    protected $searchAction = 'blender-results';
+
+    /**
+     * The route name for the advanced search action.
+     *
+     * @var string
+     */
+    protected $advancedSearchAction = 'blender-advanced';
+
+    /**
      * Constructor
      *
      * @param ConfigManagerInterface $configManager Config manager
      */
     public function __construct(ConfigManagerInterface $configManager)
     {
-        $this->facetsIni = $this->searchIni = 'Blender';
-
         // Override the default result limit with a value that we can always support:
         $this->defaultResultLimit = 400;
 
@@ -69,7 +99,7 @@ class Options extends \VuFind\Search\Solr\Options
      */
     public function getSearchAction()
     {
-        return 'blender-results';
+        return $this->searchAction;
     }
 
     /**
@@ -80,7 +110,7 @@ class Options extends \VuFind\Search\Solr\Options
      */
     public function getAdvancedSearchAction()
     {
-        return $this->advancedHandlers ? 'blender-advanced' : false;
+        return $this->advancedHandlers ? $this->advancedSearchAction : false;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
@@ -52,7 +52,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
      *
      * @var string
      */
-    protected $configIni = 'Blender';
+    protected $blenderIni = 'Blender';
 
     /**
      * Configuration file to read Blender mappings settings from
@@ -61,7 +61,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
      *
      * @var string
      */
-    protected $mappingsConfigYaml = 'BlenderMappings';
+    protected $blenderMappingsYaml = 'BlenderMappings';
 
     /**
      * Create an object
@@ -86,11 +86,11 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
             throw new \Exception('Unexpected options passed to factory.');
         }
         $blenderConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)
-            ->getConfigObject($this->configIni);
+            ->getConfigObject($this->blenderIni);
         $backendConfig = $blenderConfig->Backends
             ? $blenderConfig->Backends->toArray() : [];
         if (!$backendConfig) {
-            throw new \Exception('No backends enabled in ' . $this->configIni . '.ini');
+            throw new \Exception('No backends enabled in ' . $this->blenderIni . '.ini');
         }
 
         $facetHelper
@@ -103,7 +103,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
         }
 
         $yamlReader = $container->get(\VuFind\Config\YamlReader::class);
-        $blenderMappings = $yamlReader->get($this->mappingsConfigYaml . '.yaml');
+        $blenderMappings = $yamlReader->get($this->blenderMappingsYaml . '.yaml');
         return parent::__invoke(
             $container,
             $requestedName,

--- a/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
@@ -46,6 +46,24 @@ use Psr\Container\ContainerInterface;
 class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
 {
     /**
+     * Configuration file to read Blender settings from
+     *
+     * Note that any change to this must be made before calling the constructor of this class.
+     *
+     * @var string
+     */
+    protected $configIni = 'Blender';
+
+    /**
+     * Configuration file to read Blender mappings settings from
+     *
+     * Note that any change to this must be made before calling the constructor of this class.
+     *
+     * @var string
+     */
+    protected $mappingsConfigYaml = 'BlenderMappings';
+
+    /**
      * Create an object
      *
      * @param ContainerInterface $container     Service manager
@@ -67,11 +85,11 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $blenderConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('Blender');
+        $blenderConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject($this->configIni);
         $backendConfig = $blenderConfig->Backends
             ? $blenderConfig->Backends->toArray() : [];
         if (!$backendConfig) {
-            throw new \Exception('No backends enabled in Blender.ini');
+            throw new \Exception('No backends enabled in ' . $this->configIni . '.ini');
         }
 
         $facetHelper
@@ -84,7 +102,7 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
         }
 
         $yamlReader = $container->get(\VuFind\Config\YamlReader::class);
-        $blenderMappings = $yamlReader->get('BlenderMappings.yaml');
+        $blenderMappings = $yamlReader->get($this->mappingsConfigYaml . '.yaml');
         return parent::__invoke(
             $container,
             $requestedName,

--- a/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
+++ b/module/VuFind/src/VuFind/Search/Blender/ParamsFactory.php
@@ -85,7 +85,8 @@ class ParamsFactory extends \VuFind\Search\Params\ParamsFactory
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $blenderConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject($this->configIni);
+        $blenderConfig = $container->get(\VuFind\Config\ConfigManagerInterface::class)
+            ->getConfigObject($this->configIni);
         $backendConfig = $blenderConfig->Backends
             ? $blenderConfig->Backends->toArray() : [];
         if (!$backendConfig) {


### PR DESCRIPTION
This allows for easier extensibility of Blender.  I.e. to support a second instance of Blender, using separate config files.

As discussed in Slack:
https://open-libr-foundation.slack.com/archives/C08K7F6M61E/p1762371846761909