### PR TITLE
Paytrail: Cast merchant ID to int.

### DIFF
--- a/module/VuFind/src/VuFind/OnlinePayment/Handler/Paytrail.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/Handler/Paytrail.php
@@ -327,7 +327,7 @@ class Paytrail extends AbstractBase
         }
 
         return new Client(
-            $this->paymentConfig['merchantId'],
+            (int)$this->paymentConfig['merchantId'],
             $this->paymentConfig['secret'],
             $this->config['Site']['generator'] ?? 'VuFind'
         );


### PR DESCRIPTION
Apparently I had missed this when enabling strict typing.