### PR TITLE
Fix off-by-one counting bug in ajax/status-full

### DIFF
--- a/themes/bootstrap5/templates/ajax/status-full.phtml
+++ b/themes/bootstrap5/templates/ajax/status-full.phtml
@@ -8,7 +8,7 @@
   <?php foreach (array_slice($this->statusItems, 0, $maxItems) as $item): ?>
     <?php
       $callNumPrefix = !empty($item['callnumber_prefix']) ? $item['callnumber_prefix'] . ' ' : '';
- 
+
       $itemHasAdditionalHoldingsFields = false;
       foreach ($this->holdingsTextFieldNames as $holdingsTextField) {
         if (!empty($item[$holdingsTextField])) {

--- a/themes/bootstrap5/templates/ajax/status-full.phtml
+++ b/themes/bootstrap5/templates/ajax/status-full.phtml
@@ -4,15 +4,11 @@
     <th><?=$this->transEsc('Call Number')?></th>
     <th><?=$this->transEsc('Status')?></th>
   </tr>
-  <?php $i = 0; ?>
-  <?php foreach ($this->statusItems as $item): ?>
+  <?php $maxItems = 5; ?>
+  <?php foreach (array_slice($this->statusItems, 0, $maxItems) as $item): ?>
     <?php
-      if (++$i == 5) {
-        // Show no more than 5 items
-        break;
-      }
       $callNumPrefix = !empty($item['callnumber_prefix']) ? $item['callnumber_prefix'] . ' ' : '';
-
+ 
       $itemHasAdditionalHoldingsFields = false;
       foreach ($this->holdingsTextFieldNames as $holdingsTextField) {
         if (!empty($item[$holdingsTextField])) {
@@ -62,7 +58,7 @@
       <?php endif; ?>
     <?php endforeach; ?>
   <?php endforeach; ?>
-<?php if (count($this->statusItems) > 5): ?>
-  <tr><td colspan="3"><a href="<?=$this->url('record', ['id' => $this->statusItems[0]['id']], ['query' => ['sid' => $this->searchId]])?>"><?=count($this->statusItems) - 5?> <?=$this->transEsc('more_ellipsis')?></a></td></tr>
+<?php if (count($this->statusItems) > $maxItems): ?>
+  <tr><td colspan="3"><a href="<?=$this->url('record', ['id' => $this->statusItems[0]['id']], ['query' => ['sid' => $this->searchId]])?>"><?=count($this->statusItems) - $maxItems?> <?=$this->transEsc('more_ellipsis')?></a></td></tr>
 <?php endif; ?>
 </table>


### PR DESCRIPTION
The issue is that `++$i == 5` checks if `$i` equals 5, and if true, breaks **before** displaying that item. This means:

*   Items 1-4 are displayed (when `$i` increments from 0→1, 1→2, 2→3, 3→4)
*   On the 5th item, `$i` increments to 5, the condition is true, and the loop breaks **without displaying the 5th item**

So only 4 items are displayed, not 5. This suggested fix also puts the number of items to display in a variable because the value is used in a number of places.