### PR TITLE
Update Solr schemas to version 1.7.

### DIFF
--- a/solr/vufind/authority/conf/schema.xml
+++ b/solr/vufind/authority/conf/schema.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" ?>
-<schema name="VuFind Authority Index" version="1.2">
+<schema name="VuFind Authority Index" version="1.7">
   <types>
     <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0"/>
-    <fieldtype name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-    <fieldtype name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
-    <fieldtype name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="string" class="solr.StrField" sortMissingLast="true"/>
+    <fieldtype name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldtype name="date" class="solr.DatePointField" sortMissingLast="true"/>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
   </types>
   <fields>
-    <!-- Required by Solr 4.x -->
-    <field name="_version_" type="long" indexed="true" stored="true"/>
+    <!-- Required by Solr -->
+   <field name="_version_" type="long" indexed="false" stored="false"/>
     <!-- Core Fields  -->
     <field name="id" type="string" indexed="true" stored="true"/>
-    <field name="fullrecord" type="string" indexed="false" stored="true"/>
+    <field name="fullrecord" type="string" indexed="false" stored="true" docValues="false"/>
     <field name="marc_error" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="allfields" type="text" indexed="true" stored="false" multiValued="true"/>
     <field name="record_format" type="string" indexed="true" stored="true"/>

--- a/solr/vufind/biblio/conf/schema.xml
+++ b/solr/vufind/biblio/conf/schema.xml
@@ -194,7 +194,7 @@
     <field name="topic_browse" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="author_browse" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="genre" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="genre_facet" type="textFacet" indexed="true" stored="true" useDocValuesAsStored="false" multiValued="true"/>
+    <field name="genre_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="geographic" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="geographic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="era" type="text" indexed="true" stored="true" multiValued="true"/>

--- a/solr/vufind/biblio/conf/schema.xml
+++ b/solr/vufind/biblio/conf/schema.xml
@@ -1,79 +1,78 @@
 <?xml version="1.0" ?>
-<schema name="VuFind Bibliographic Index" version="1.2">
+<schema name="VuFind Bibliographic Index" version="1.7">
   <types>
-    <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0"/>
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
+    <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true" uninvertible="true">
       <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <tokenizer name="keyword"/>
         <!-- strip trailing punctuation from facets: -->
-        <filter class="solr.PatternReplaceFilterFactory" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
+        <filter name="patternReplace" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
       </analyzer>
     </fieldType>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <tokenizer name="icu"/>
+        <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field without Stemming and Synonyms -->
     <fieldType name="textProper" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Basic Text Field for use with Spell Correction -->
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- More advanced spell checking field. -->
     <fieldType name="textSpellShingle" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field for Normalized ISBN/ISSN Numbers - take first chunk of text
@@ -81,201 +80,201 @@
          omit results that are empty after stripping. -->
     <fieldType name="isn" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.PatternTokenizerFactory" pattern="^(\S*)\s*.*$" group="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="[^0-9x]" replacement="" replace="all"/>
-        <filter class="solr.LengthFilterFactory" min="4" max="100" />
+        <tokenizer name="pattern" pattern="^(\S*)\s*.*$" group="1"/>
+        <filter name="lowercase"/>
+        <filter name="patternReplace" pattern="[^0-9x]" replacement="" replace="all"/>
+        <filter name="length" min="4" max="100" />
       </analyzer>
     </fieldType>
     <!-- case-insensitive/whitespace-agnostic field type for callnumber searching -->
     <fieldType name="callnumberSearch" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\s)" replacement=""/>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <charFilter name="patternReplace" pattern="(\s)" replacement=""/>
+        <tokenizer name="keyword"/>
+        <filter name="icuFolding"/>
       </analyzer>
     </fieldType>
     <!-- Field for SolrPrefix autocomplete -->
     <fieldType name="text_autocomplete" class="solr.TextField" positionIncrementGap="100" omitNorms="true">
       <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="25" />
+        <tokenizer name="whitespace"/>
+        <filter name="icuFolding"/>
+        <filter name="edgeNGram" minGramSize="1" maxGramSize="25" />
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
+        <tokenizer name="whitespace"/>
+        <filter name="icuFolding"/>
       </analyzer>
     </fieldType>
     <fieldType name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="dateRange" class="solr.DateRangeField" sortMissingLast="true" uninvertible="false"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <!-- add geo field to handle geographic search and display capabilities -->
     <fieldType name="geo" class="solr.SpatialRecursivePrefixTreeFieldType" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
   </types>
- <fields>
-   <!-- Required by Solr 4.x -->
-   <field name="_version_" type="long" indexed="true" stored="true"/>
-   <!-- Core Fields  -->
-   <field name="id" type="string" indexed="true" stored="true"/>
-   <field name="fullrecord" type="string" indexed="false" stored="true"/>
-   <field name="marc_error" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="allfields" type="text" indexed="true" stored="false" multiValued="true"/>
-   <field name="allfields_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
-   <field name="fulltext" type="text" indexed="true" stored="false"/>
-   <field name="fulltext_unstemmed" type="textProper" indexed="true" stored="false"/>
-   <field name="spelling" type="textSpell" indexed="true" stored="true" multiValued="true"/>
-   <field name="spellingShingle" type="textSpellShingle" indexed="true" stored="true" multiValued="true"/>
-   <!-- Institutional Fields -->
-   <field name="institution" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="collection" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="building" type="string" indexed="true" stored="true" multiValued="true"/>
-   <!-- Generic Fields -->
-   <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true" storeOffsetsWithPositions="true"/>
-   <field name="author_variant" type="text" indexed="true" stored="true" multiValued="true" termVectors="true" storeOffsetsWithPositions="true"/>
-   <field name="author_role" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="author_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="author_sort" type="string" indexed="true" stored="true"/>
-   <field name="title" type="text" indexed="true" stored="true"/>
-   <field name="title_sort" type="string" indexed="true" stored="true"/>
-   <field name="title_sub" type="text" indexed="true" stored="true"/>
-   <field name="title_short" type="text" indexed="true" stored="true"/>
-   <field name="title_full" type="text" indexed="true" stored="true"/>
-   <field name="title_full_unstemmed" type="textProper" indexed="true" stored="true"/>
-   <field name="title_fullStr" type="string" indexed="true" stored="true"/>
-   <field name="title_auth" type="text" indexed="true" stored="true"/>
-   <field name="physical" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="publisher" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <field name="publisherStr" type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="publishDate" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="publishDateRange" type="dateRange" indexed="true" stored="true" multiValued="true"/>
-   <field name="publishDateSort" type="string" indexed="true" stored="false"/>
-   <field name="edition" type="string" indexed="true" stored="true"/>
-   <field name="description" type="text" indexed="true" stored="true"/>
-   <field name="contents" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="url" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="thumbnail" type="string" indexed="false" stored="true"/>
-   <!-- Catalog Specific Fields -->
-   <field name="lccn" type="string" indexed="true" stored="true"/>
-   <field name="ctrlnum" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="isbn" type="isn" indexed="true" stored="true" multiValued="true"/>
-   <field name="issn" type="isn" indexed="true" stored="true" multiValued="true"/>
-   <field name="oclc_num" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="callnumber-first" type="string" indexed="true" stored="true"/>
-   <field name="callnumber-subject" type="string" indexed="true" stored="true"/>
-   <field name="callnumber-label" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="callnumber-sort" type="string" indexed="true" stored="true"/>
-   <field name="callnumber-raw" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="callnumber-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
-   <field name="dewey-hundreds" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="dewey-tens" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="dewey-ones" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="dewey-full" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="dewey-sort" type="string" indexed="true" stored="true" />
-   <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
-   <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <field name="author2_variant" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="author_corporate" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <field name="author_corporate_role" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_old" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_new" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="series" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="series2" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="topic" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="topic_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
-   <field name="topic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="topic_browse" type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="author_browse" type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="genre" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="genre_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="geographic" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="geographic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="era" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="era_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="illustrated" type="string" indexed="true" stored="true" multiValued="false"/>
-   <!-- Used for geographic search and display fields -->
-   <field name="long_lat" type="geo" indexed="true" stored="true" multiValued="true" />
-   <field name="long_lat_display" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="long_lat_label" type="string" indexed="false" stored="true" multiValued="true"/>
-   <!-- Container fields (i.e. for describing journal containing an article) -->
-   <field name="container_title" type="text" indexed="true" stored="true"/>
-   <field name="container_volume" type="text" indexed="true" stored="true"/>
-   <field name="container_issue" type="text" indexed="true" stored="true"/>
-   <field name="container_start_page" type="text" indexed="true" stored="true"/>
-   <field name="container_reference" type="text" indexed="true" stored="true"/>
-   <!-- Hierarchy Fields -->
-   <field name="hierarchytype" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="hierarchy_top_id" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="hierarchy_top_title" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="hierarchy_parent_id" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="hierarchy_parent_title" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="hierarchy_sequence" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="is_hierarchy_id" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true"/>
-   <!-- Used for loading correct record driver -->
-   <field name="record_format" type="string" indexed="true" stored="true"/>
-   <!-- Tracking fields to keep track of oldest and most recent index times -->
-   <field name="first_indexed" type="date" indexed="true" stored="true" docValues="true"/>
-   <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true"/>
-   <!-- Dynamic fields for customization without schema modification -->
-   <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>
-   <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true" docValues="true"/>
-   <dynamicField name="*_dateRange" type="dateRange" indexed="true" stored="true" multiValued="false"/>
-   <dynamicField name="*_dateRange_mv" type="dateRange" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_isn" type="isn" indexed="true" stored="true"/>
-   <dynamicField name="*_isn_mv" type="isn" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_str" type="string" indexed="true" stored="true"/>
-   <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txt" type="text" indexed="true" stored="true"/>
-   <dynamicField name="*_txt_mv" type="text" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txtF" type="textFacet" indexed="true" stored="true"/>
-   <dynamicField name="*_txtF_mv" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txtP" type="textProper" indexed="true" stored="true"/>
-   <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_random" type="random" />
-   <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
-   <dynamicField name="*_geo" type="geo" indexed="true" stored="true" multiValued="false" />
-   <dynamicField name="*_geo_mv" type="geo" indexed="true" stored="true" multiValued="true" />
-   <dynamicField name="*_autocomplete" type="text_autocomplete" indexed="true" stored="true" multiValued="false"/>
- </fields>
- <uniqueKey>id</uniqueKey>
- <!-- CopyFields for Spelling -->
- <!-- ** Basic, single word spelling -->
- <copyField source="allfields" dest="spelling"/>
- <!-- ** Complex, Shingle spelling -->
- <copyField source="author"   dest="spellingShingle"/>
- <copyField source="title"    dest="spellingShingle"/>
- <copyField source="contents" dest="spellingShingle"/>
- <copyField source="series"   dest="spellingShingle"/>
- <copyField source="topic"    dest="spellingShingle"/>
- <!-- CopyFields for Faceting on Text -->
- <copyField source="title_full" dest="title_fullStr"/>
- <copyField source="title_full" dest="title_full_unstemmed"/>
- <copyField source="author" dest="author_facet"/>
- <copyField source="author2" dest="author_facet"/>
- <copyField source="author_corporate" dest="author_facet"/>
- <copyField source="publisher" dest="publisherStr"/>
- <copyField source="topic" dest="topic_unstemmed"/>
- <copyField source="allfields" dest="allfields_unstemmed"/>
- <copyField source="fulltext" dest="fulltext_unstemmed"/>
- <!-- CopyFields for Alphabetic Browse -->
- <copyField source="author" dest="author_browse"/>
- <copyField source="author2" dest="author_browse"/>
- <copyField source="author_corporate" dest="author_browse"/>
- <!-- CopyFields for All Fields -->
- <copyField source="format"    dest="allfields"/>
- <copyField source="format"    dest="allfields_unstemmed"/>
- <!-- CopyFields for call numbers -->
- <copyField source="dewey-raw" dest="dewey-search"/>
- <copyField source="callnumber-raw" dest="callnumber-search"/>
+  <fields>
+    <!-- Required by Solr -->
+    <field name="_version_" type="long" indexed="false" stored="false"/>
+    <!-- Core Fields  -->
+    <field name="id" type="string" indexed="true" stored="true"/>
+    <field name="fullrecord" type="string" indexed="false" stored="true" docValues="false"/>
+    <field name="marc_error" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="allfields" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="allfields_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
+    <field name="fulltext" type="text" indexed="true" stored="false"/>
+    <field name="fulltext_unstemmed" type="textProper" indexed="true" stored="false"/>
+    <field name="spelling" type="textSpell" indexed="true" stored="true" multiValued="true"/>
+    <field name="spellingShingle" type="textSpellShingle" indexed="true" stored="true" multiValued="true"/>
+    <!-- Institutional Fields -->
+    <field name="institution" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="collection" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="building" type="string" indexed="true" stored="true" multiValued="true"/>
+    <!-- Generic Fields -->
+    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true" storeOffsetsWithPositions="true"/>
+    <field name="author_variant" type="text" indexed="true" stored="true" multiValued="true" termVectors="true" storeOffsetsWithPositions="true"/>
+    <field name="author_role" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_sort" type="string" indexed="true" stored="true"/>
+    <field name="title" type="text" indexed="true" stored="true"/>
+    <field name="title_sort" type="string" indexed="true" stored="true"/>
+    <field name="title_sub" type="text" indexed="true" stored="true"/>
+    <field name="title_short" type="text" indexed="true" stored="true"/>
+    <field name="title_full" type="text" indexed="true" stored="true"/>
+    <field name="title_full_unstemmed" type="textProper" indexed="true" stored="true"/>
+    <field name="title_fullStr" type="string" indexed="true" stored="true"/>
+    <field name="title_auth" type="text" indexed="true" stored="true"/>
+    <field name="physical" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="publisher" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="publisherStr" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="publishDate" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="publishDateRange" type="dateRange" indexed="true" stored="true" multiValued="true"/>
+    <field name="publishDateSort" type="string" indexed="true" stored="false"/>
+    <field name="edition" type="string" indexed="true" stored="true"/>
+    <field name="description" type="text" indexed="true" stored="true"/>
+    <field name="contents" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="thumbnail" type="string" indexed="false" stored="true"/>
+    <!-- Catalog Specific Fields -->
+    <field name="lccn" type="string" indexed="true" stored="true"/>
+    <field name="ctrlnum" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="isbn" type="isn" indexed="true" stored="true" multiValued="true"/>
+    <field name="issn" type="isn" indexed="true" stored="true" multiValued="true"/>
+    <field name="oclc_num" type="string" indexed="true" stored="true" multiValued="true" />
+    <field name="callnumber-first" type="string" indexed="true" stored="true"/>
+    <field name="callnumber-subject" type="string" indexed="true" stored="true"/>
+    <field name="callnumber-label" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="callnumber-sort" type="string" indexed="true" stored="true"/>
+    <field name="callnumber-raw" type="string" indexed="true" stored="true" multiValued="true" />
+    <field name="callnumber-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
+    <field name="dewey-hundreds" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="dewey-tens" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="dewey-ones" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="dewey-full" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="dewey-sort" type="string" indexed="true" stored="true" />
+    <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true" />
+    <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true" />
+    <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author2_variant" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate_role" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_old" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_new" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="series" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="series2" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="topic" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="topic_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
+    <field name="topic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="topic_browse" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="author_browse" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="genre" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="genre_facet" type="textFacet" indexed="true" stored="true" useDocValuesAsStored="false" multiValued="true"/>
+    <field name="geographic" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="geographic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="era" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="era_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="illustrated" type="string" indexed="true" stored="true" multiValued="false"/>
+    <!-- Used for geographic search and display fields -->
+    <field name="long_lat" type="geo" indexed="true" stored="true" multiValued="true" />
+    <field name="long_lat_display" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="long_lat_label" type="string" indexed="false" stored="true" multiValued="true"/>
+    <!-- Container fields (i.e. for describing journal containing an article) -->
+    <field name="container_title" type="text" indexed="true" stored="true"/>
+    <field name="container_volume" type="text" indexed="true" stored="true"/>
+    <field name="container_issue" type="text" indexed="true" stored="true"/>
+    <field name="container_start_page" type="text" indexed="true" stored="true"/>
+    <field name="container_reference" type="text" indexed="true" stored="true"/>
+    <!-- Hierarchy Fields -->
+    <field name="hierarchytype" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="hierarchy_top_id" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="hierarchy_top_title" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="hierarchy_parent_id" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="hierarchy_parent_title" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="hierarchy_sequence" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="is_hierarchy_id" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true" />
+    <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true"/>
+    <!-- Used for loading correct record driver -->
+    <field name="record_format" type="string" indexed="true" stored="true"/>
+    <!-- Tracking fields to keep track of oldest and most recent index times -->
+    <field name="first_indexed" type="date" indexed="true" stored="true" docValues="true"/>
+    <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true"/>
+    <!-- Dynamic fields for customization without schema modification -->
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <dynamicField name="*_dateRange" type="dateRange" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_dateRange_mv" type="dateRange" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_isn" type="isn" indexed="true" stored="true"/>
+    <dynamicField name="*_isn_mv" type="isn" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_str" type="string" indexed="true" stored="true"/>
+    <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txt" type="text" indexed="true" stored="true"/>
+    <dynamicField name="*_txt_mv" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtF" type="textFacet" indexed="true" stored="true"/>
+    <dynamicField name="*_txtF_mv" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtP" type="textProper" indexed="true" stored="true"/>
+    <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_random" type="random" />
+    <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
+    <dynamicField name="*_geo" type="geo" indexed="true" stored="true" multiValued="false" />
+    <dynamicField name="*_geo_mv" type="geo" indexed="true" stored="true" multiValued="true" />
+    <dynamicField name="*_autocomplete" type="text_autocomplete" indexed="true" stored="true" multiValued="false"/>
+  </fields>
+  <uniqueKey>id</uniqueKey>
+  <!-- CopyFields for Spelling -->
+  <!-- ** Basic, single word spelling -->
+  <copyField source="allfields" dest="spelling"/>
+  <!-- ** Complex, Shingle spelling -->
+  <copyField source="author"   dest="spellingShingle"/>
+  <copyField source="title"    dest="spellingShingle"/>
+  <copyField source="contents" dest="spellingShingle"/>
+  <copyField source="series"   dest="spellingShingle"/>
+  <copyField source="topic"    dest="spellingShingle"/>
+  <!-- CopyFields for Faceting on Text -->
+  <copyField source="title_full" dest="title_fullStr"/>
+  <copyField source="title_full" dest="title_full_unstemmed"/>
+  <copyField source="author" dest="author_facet"/>
+  <copyField source="author2" dest="author_facet"/>
+  <copyField source="author_corporate" dest="author_facet"/>
+  <copyField source="publisher" dest="publisherStr"/>
+  <copyField source="topic" dest="topic_unstemmed"/>
+  <copyField source="allfields" dest="allfields_unstemmed"/>
+  <copyField source="fulltext" dest="fulltext_unstemmed"/>
+  <!-- CopyFields for Alphabetic Browse -->
+  <copyField source="author" dest="author_browse"/>
+  <copyField source="author2" dest="author_browse"/>
+  <copyField source="author_corporate" dest="author_browse"/>
+  <!-- CopyFields for All Fields -->
+  <copyField source="format"    dest="allfields"/>
+  <copyField source="format"    dest="allfields_unstemmed"/>
+  <!-- CopyFields for call numbers -->
+  <copyField source="dewey-raw" dest="dewey-search"/>
+  <copyField source="callnumber-raw" dest="callnumber-search"/>
 </schema>

--- a/solr/vufind/reserves/conf/schema.xml
+++ b/solr/vufind/reserves/conf/schema.xml
@@ -1,44 +1,43 @@
 <?xml version="1.0" ?>
-<schema name="VuFind Course Reserves Index" version="1.2">
+<schema name="VuFind Course Reserves Index" version="1.7">
   <types>
-    <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0"/>
-    <fieldtype name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-    <fieldtype name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
-    <fieldtype name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="string" class="solr.StrField" sortMissingLast="true"/>
+    <fieldtype name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+    <fieldtype name="date" class="solr.DatePointField" sortMissingLast="true"/>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <tokenizer name="icu"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="icuFolding"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
   </types>
- <fields>
-   <!-- Required by Solr 4.x -->
-   <field name="_version_" type="long" indexed="true" stored="true"/>
-   <!-- Core Fields  -->
-   <field name="id" type="string" indexed="true" stored="true"/>
-   <field name="bib_id" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="course" type="text" indexed="true" stored="true"/>
-   <field name="course_id" type="string" indexed="true" stored="true"/>
-   <field name="course_str" type="string" indexed="true" stored="true"/>
-   <field name="instructor" type="text" indexed="true" stored="true"/>
-   <field name="instructor_id" type="string" indexed="true" stored="true"/>
-   <field name="instructor_str" type="string" indexed="true" stored="true"/>
-   <field name="department" type="text" indexed="true" stored="true"/>
-   <field name="department_id" type="string" indexed="true" stored="true"/>
-   <field name="department_str" type="string" indexed="true" stored="true"/>
- </fields>
- <uniqueKey>id</uniqueKey>
- <copyField source="course"     dest="course_str"/>
- <copyField source="instructor" dest="instructor_str"/>
- <copyField source="department" dest="department_str"/>
+  <fields>
+    <!-- Required by Solr -->
+    <field name="_version_" type="long" indexed="false" stored="false"/>
+    <!-- Core Fields  -->
+    <field name="id" type="string" indexed="true" stored="true"/>
+    <field name="bib_id" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="course" type="text" indexed="true" stored="true"/>
+    <field name="course_id" type="string" indexed="true" stored="true"/>
+    <field name="course_str" type="string" indexed="true" stored="true"/>
+    <field name="instructor" type="text" indexed="true" stored="true"/>
+    <field name="instructor_id" type="string" indexed="true" stored="true"/>
+    <field name="instructor_str" type="string" indexed="true" stored="true"/>
+    <field name="department" type="text" indexed="true" stored="true"/>
+    <field name="department_id" type="string" indexed="true" stored="true"/>
+    <field name="department_str" type="string" indexed="true" stored="true"/>
+  </fields>
+  <uniqueKey>id</uniqueKey>
+  <copyField source="course"     dest="course_str"/>
+  <copyField source="instructor" dest="instructor_str"/>
+  <copyField source="department" dest="department_str"/>
 </schema>

--- a/solr/vufind/website/conf/schema.xml
+++ b/solr/vufind/website/conf/schema.xml
@@ -1,80 +1,79 @@
 <?xml version="1.0" ?>
-<schema name="VuFind Website Index" version="1.2">
+<schema name="VuFind Website Index" version="1.7">
   <types>
-    <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.LongPointField" positionIncrementGap="0"/>
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
     <fieldType name="sint" class="solr.IntPointField" sortMissingLast="true" omitNorms="true"/>
-    <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <fieldType name="textFacet" class="solr.SortableTextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <!-- strip trailing punctuation from facets: -->
-        <filter class="solr.PatternReplaceFilterFactory" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
+        <filter name="patternReplace" pattern="(?&lt;!\b[A-Z])[.\s]*$" replacement="" replace="first"/>
       </analyzer>
     </fieldType>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+        <filter name="synonymGraph" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="icuFolding"/>
+        <filter name="keywordMarker" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field without Stemming and Synonyms -->
     <fieldType name="textProper" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Basic Text Field for use with Spell Correction -->
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="wordDelimiterGraph" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- More advanced spell checking field. -->
     <fieldType name="textSpellShingle" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter name="icuFolding"/>
+        <filter name="stop" ignoreCase="true" words="stopwords.txt"/>
+        <filter name="shingle" maxShingleSize="2" outputUnigrams="false"/>
+        <filter name="removeDuplicates"/>
       </analyzer>
     </fieldType>
     <!-- Text Field for Normalized ISBN/ISSN Numbers - take first chunk of text
@@ -82,72 +81,72 @@
          omit results that are empty after stripping. -->
     <fieldType name="isn" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.PatternTokenizerFactory" pattern="^(\S*)\s*.*$" group="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.PatternReplaceFilterFactory" pattern="[^0-9x]" replacement="" replace="all"/>
-        <filter class="solr.LengthFilterFactory" min="1" max="100" />
+        <tokenizer name="pattern" pattern="^(\S*)\s*.*$" group="1"/>
+        <filter name="lowercase"/>
+        <filter name="patternReplace" pattern="[^0-9x]" replacement="" replace="all"/>
+        <filter name="length" min="1" max="100" />
       </analyzer>
     </fieldType>
-    <fieldType name="date" class="solr.DatePointField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="date" class="solr.DatePointField" sortMissingLast="true"/>
   </types>
- <fields>
-   <!-- Required by Solr 4.x -->
-   <field name="_version_" type="long" indexed="true" stored="true"/>
-   <!-- Core Fields  -->
-   <field name="id" type="string" indexed="true" stored="true"/>
-   <field name="fulltext" type="text" indexed="true" stored="true"/>
-   <field name="fulltext_unstemmed" type="textProper" indexed="true" stored="false"/>
-   <field name="description" type="text" indexed="true" stored="true"/>
-   <field name="description_unstemmed" type="textProper" indexed="true" stored="false"/>
-   <field name="keywords" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="keywords_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
-   <field name="spelling" type="textSpell" indexed="true" stored="true"/>
-   <field name="spellingShingle" type="textSpellShingle" indexed="true" stored="true" multiValued="true"/>
-   <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true"/>
-   <field name="last_modified" type="date" indexed="true" stored="true" docValues="true"/>
-   <field name="title" type="text" indexed="true" stored="true"/>
-   <field name="title_unstemmed" type="textProper" indexed="true" stored="false"/>
-   <field name="title_sort" type="string" indexed="true" stored="false"/>
-   <field name="url" type="string" indexed="false" stored="true"/>
-   <field name="url_keywords" type="text" indexed="true" stored="false"/>
-   <!-- Popularity of page - can be used in function query for weighting -->
-   <field name="use_count" type="sint" indexed="true" stored="true"/>
-   <!-- Facet Fields -->
-   <field name="category" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="linktype" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <field name="subject" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <!-- Dynamic fields for customization without schema modification -->
-   <dynamicField name="*_sint" type="sint" indexed="true" stored="true"/>
-   <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>
-   <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true" docValues="true"/>
-   <dynamicField name="*_isn" type="isn" indexed="true" stored="true"/>
-   <dynamicField name="*_isn_mv" type="isn" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_str" type="string" indexed="true" stored="true"/>
-   <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txt" type="text" indexed="true" stored="true"/>
-   <dynamicField name="*_txt_mv" type="text" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txtF" type="textFacet" indexed="true" stored="true"/>
-   <dynamicField name="*_txtF_mv" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-   <dynamicField name="*_txtP" type="textProper" indexed="true" stored="true"/>
-   <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
- </fields>
- <uniqueKey>id</uniqueKey>
- <!-- CopyFields for Spelling -->
- <copyField source="title"    dest="spellingShingle"/>
- <!-- Copy title information to special field for sorting -->
- <copyField source="title"    dest="title_sort"/>
- <!-- CopyFields to allow keyword searching within URL -->
- <copyField source="url" dest="url_keywords"/>
- <!-- CopyFields for unstemmed searching -->
- <copyField source="fulltext" dest="fulltext_unstemmed"/>
- <copyField source="description" dest="description_unstemmed"/>
- <copyField source="keywords" dest="keywords_unstemmed"/>
- <!-- CopyFields to treat category metadata as additional keywords -->
- <copyField source="category" dest="keywords" />
- <copyField source="subject" dest="keywords" />
- <copyField source="linktype" dest="keywords" />
- <copyField source="category" dest="keywords_unstemmed" />
- <copyField source="subject" dest="keywords_unstemmed" />
- <copyField source="linktype" dest="keywords_unstemmed" />
- <copyField source="title" dest="title_unstemmed"/>
+  <fields>
+    <!-- Required by Solr -->
+    <field name="_version_" type="long" indexed="false" stored="false"/>
+    <!-- Core Fields  -->
+    <field name="id" type="string" indexed="true" stored="true"/>
+    <field name="fulltext" type="text" indexed="true" stored="true"/>
+    <field name="fulltext_unstemmed" type="textProper" indexed="true" stored="false"/>
+    <field name="description" type="text" indexed="true" stored="true"/>
+    <field name="description_unstemmed" type="textProper" indexed="true" stored="false"/>
+    <field name="keywords" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="keywords_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
+    <field name="spelling" type="textSpell" indexed="true" stored="true"/>
+    <field name="spellingShingle" type="textSpellShingle" indexed="true" stored="true" multiValued="true"/>
+    <field name="last_indexed" type="date" indexed="true" stored="true"/>
+    <field name="last_modified" type="date" indexed="true" stored="true"/>
+    <field name="title" type="text" indexed="true" stored="true"/>
+    <field name="title_unstemmed" type="textProper" indexed="true" stored="false"/>
+    <field name="title_sort" type="string" indexed="true" stored="false"/>
+    <field name="url" type="string" indexed="false" stored="true"/>
+    <field name="url_keywords" type="text" indexed="true" stored="false"/>
+    <!-- Popularity of page - can be used in function query for weighting -->
+    <field name="use_count" type="sint" indexed="true" stored="true"/>
+    <!-- Facet Fields -->
+    <field name="category" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="linktype" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="subject" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <!-- Dynamic fields for customization without schema modification -->
+    <dynamicField name="*_sint" type="sint" indexed="true" stored="true"/>
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <dynamicField name="*_isn" type="isn" indexed="true" stored="true"/>
+    <dynamicField name="*_isn_mv" type="isn" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_str" type="string" indexed="true" stored="true"/>
+    <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txt" type="text" indexed="true" stored="true"/>
+    <dynamicField name="*_txt_mv" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtF" type="textFacet" indexed="true" stored="true"/>
+    <dynamicField name="*_txtF_mv" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtP" type="textProper" indexed="true" stored="true"/>
+    <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
+  </fields>
+  <uniqueKey>id</uniqueKey>
+  <!-- CopyFields for Spelling -->
+  <copyField source="title"    dest="spellingShingle"/>
+  <!-- Copy title information to special field for sorting -->
+  <copyField source="title"    dest="title_sort"/>
+  <!-- CopyFields to allow keyword searching within URL -->
+  <copyField source="url" dest="url_keywords"/>
+  <!-- CopyFields for unstemmed searching -->
+  <copyField source="fulltext" dest="fulltext_unstemmed"/>
+  <copyField source="description" dest="description_unstemmed"/>
+  <copyField source="keywords" dest="keywords_unstemmed"/>
+  <!-- CopyFields to treat category metadata as additional keywords -->
+  <copyField source="category" dest="keywords" />
+  <copyField source="subject" dest="keywords" />
+  <copyField source="linktype" dest="keywords" />
+  <copyField source="category" dest="keywords_unstemmed" />
+  <copyField source="subject" dest="keywords_unstemmed" />
+  <copyField source="linktype" dest="keywords_unstemmed" />
+  <copyField source="title" dest="title_unstemmed"/>
 </schema>


### PR DESCRIPTION
- Enables docValues by default for supporting fields.
- textFacet fields remain uninvertible text fields for the analysis chain to be effective.
- Classes replaced with names where possible.

Enabling docValues may cause the index to be slightly larger (~1% with the CI index), but they improve performance particularly with large indexes when fields don't need to be uninverted in Java heap. This reduces the Java memory pressure and garbage collection rate. Unfortunately the textFacet fields that are based on `solr.TextField` cannot use docValues, and they cannot be changed to string fields due to needing the analysis chain.

TODO:
- [x] Resolve [VUFIND-1100](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1100) when merging
- [x] Update changelog when merging (note need to reindex, possible need to adjust local schema edits, and potential need to reduce Java heap size due to different performance characteristics of docValues).