### PR TITLE
Disable autoconfigure: fix incorrect route name in template

### DIFF
--- a/themes/bootstrap5/templates/install/done.phtml
+++ b/themes/bootstrap5/templates/install/done.phtml
@@ -1,6 +1,6 @@
 <?php
     // Set up breadcrumbs:
-    $this->breadcrumbs()->set($this->translate('auto_configure_title'), $this->url('install_home'));
+    $this->breadcrumbs()->set($this->translate('auto_configure_title'), $this->url('install-home'));
 ?>
 <?=$this->component('page-title', ['title' => $this->translate('auto_configure_title')]);?>
 


### PR DESCRIPTION
This fixes a bug reported by @stweil; likely a typo introduced during breadcrumb refactoring.