### PR TITLE
Create cache directories for cover images only when needed

### DIFF
--- a/module/VuFind/src/VuFind/Cover/Loader.php
+++ b/module/VuFind/src/VuFind/Cover/Loader.php
@@ -34,6 +34,7 @@ use VuFind\Content\Covers\PluginManager as ApiManager;
 use VuFindCode\ISBN;
 use VuFindCode\ISMN;
 
+use function dirname;
 use function func_get_args;
 use function in_array;
 use function is_array;
@@ -519,8 +520,7 @@ class Loader extends \VuFind\ImageLoader
     }
 
     /**
-     * Return a path to the image cache for the given size and ID; ensure that
-     * directories are created as needed.
+     * Return a path to the image cache for the given size and ID.
      *
      * @param string $size      Size category
      * @param string $id        Unique identifier (ISBN / ISSN)
@@ -530,15 +530,7 @@ class Loader extends \VuFind\ImageLoader
      */
     protected function getCachePath($size, $id, $extension = 'jpg')
     {
-        $base = $this->baseDir;
-        if (!is_dir($base)) {
-            mkdir($base);
-        }
-        $base .= '/' . $size;
-        if (!is_dir($base)) {
-            mkdir($base);
-        }
-        return $base . '/' . $id . '.' . $extension;
+        return $this->baseDir . '/' . $size . '/' . $id . '.' . $extension;
     }
 
     /**
@@ -696,6 +688,11 @@ class Loader extends \VuFind\ImageLoader
             // $cache is true or for temporary display purposes if $cache is false.
             $tempFile = str_replace('.jpg', uniqid(), $this->localFile);
             $finalFile = $cache ? $this->localFile : $tempFile . '.jpg';
+
+            // Make sure that the cache directory exists.
+            if (!is_dir($directory = dirname($tempFile))) {
+                mkdir(dirname($tempFile), 0o755, true);
+            }
 
             // Write image data to disk:
             if (!@file_put_contents($tempFile, $image)) {

--- a/module/VuFind/src/VuFind/Cover/Loader.php
+++ b/module/VuFind/src/VuFind/Cover/Loader.php
@@ -686,12 +686,13 @@ class Loader extends \VuFind\ImageLoader
             // Figure out file paths -- $tempFile will be used to store the
             // image for analysis. $finalFile will be used for long-term storage if
             // $cache is true or for temporary display purposes if $cache is false.
-            $tempFile = str_replace('.jpg', uniqid(), $this->localFile);
+            $directory = dirname($this->localFile);
+            $tempFile = $directory . DIRECTORY_SEPARATOR . uniqid();
             $finalFile = $cache ? $this->localFile : $tempFile . '.jpg';
 
             // Make sure that the cache directory exists.
-            if (!is_dir($directory = dirname($tempFile))) {
-                mkdir(dirname($tempFile), 0o755, true);
+            if (!is_dir($directory)) {
+                mkdir($directory, 0o755, true);
             }
 
             // Write image data to disk:


### PR DESCRIPTION
This fixes a potential race condition which could result in a runtime warning ("Warning: mkdir(): File exists") on a new VuFind installation.

The cache directories are only needed when caching is enabled.

It is sufficient to check whether they exist and to create them when a cover image is written to the cache.