### PR TITLE
Fix bug: focus was not restored after closing lightbox.

### DIFF
--- a/themes/bootstrap5/js/lightbox.js
+++ b/themes/bootstrap5/js/lightbox.js
@@ -14,7 +14,7 @@ VuFind.register('lightbox', function Lightbox() {
   var _modal, _modalBody, _clickedButton = null;
   // Boostrap modal
   var _bsModal = null;
-  
+
   /**
    * Store the currently clicked button element to be used later in form submission.
    */
@@ -602,16 +602,16 @@ VuFind.register('lightbox', function Lightbox() {
       if (VuFind.lightbox.refreshOnClose) {
         VuFind.refreshPage();
       } else {
-        if (_beforeOpenElement) {
-          _beforeOpenElement.focus();
-          _beforeOpenElement = null;
-        }
         unbindFocus();
         this.setAttribute('aria-hidden', true);
         VuFind.emit('lightbox.closing');
       }
     });
     _modal.addEventListener('hidden.bs.modal', function lightboxHidden() {
+      if (_beforeOpenElement) {
+        _beforeOpenElement.focus();
+        _beforeOpenElement = null;
+      }
       VuFind.lightbox.reset();
       VuFind.emit('lightbox.closed');
     });


### PR DESCRIPTION
It was reported on vufind-tech that keyboard focus did not restore correctly after closing the lightbox. It appears to be related to bootstrap event behavior; moving the focus restoration to a later stage of the process seems to have solved the issue. Thanks to @crhallberg for help figuring this out!