### PR TITLE
Minor update to Create a List display

### DIFF
--- a/themes/bootstrap5/templates/myresearch/editlist.phtml
+++ b/themes/bootstrap5/templates/myresearch/editlist.phtml
@@ -21,7 +21,7 @@
   <input type="hidden" name="id" value="<?=$this->newList || empty($listId = $this->list->getId()) ? 'NEW' : $this->escapeHtmlAttr($listId) ?>">
   <?=$this->context($this)->renderInContext('cart/form-record-hidden-inputs.phtml', []); ?>
   <div class="form-group">
-    <label class="form-label" for="list_title"><?=$this->transEsc('List'); ?>:</label>
+    <label class="form-label" for="list_title"><?=$this->transEsc('List'); ?></label>
     <input id="list_title" class="form-control" type="text" name="title" value="<?=$this->escapeHtmlAttr($this->list->getTitle())?>">
   </div>
   <div class="form-group">


### PR DESCRIPTION
The **Save to List** dialog box looks like this:

<img width="638" height="543" alt="image" src="https://github.com/user-attachments/assets/a1eb93b9-7dcd-4001-be83-12cd272a55e0" />
 
If you click 'or create a new list' the dialog box looks like this:

<img width="694" height="458" alt="image" src="https://github.com/user-attachments/assets/89c7e6da-6718-44ed-b460-637d705706e7" />

Every label for a text entry field is unpunctuated except for the title field in the **Create a List** dialog box. This PR removes that colon for consistency. This is also better for internationalization, as that punctuation might not be correct in every case. 

This PR supersedes https://github.com/vufind-org/vufind/pull/4278.