### PR TITLE
Deduplicate facet values when building channels from records

### DIFF
--- a/module/VuFind/src/VuFind/ChannelProvider/Facets.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/Facets.php
@@ -153,7 +153,7 @@ class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
                 continue;
             }
             $currentValueCount = 0;
-            foreach ($data[$field] as $value) {
+            foreach (array_unique($data[$field]) as $value) {
                 $current = [
                     'value' => $value,
                     'displayText' => $value,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/FacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/FacetsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Facets Channel Provider Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\ChannelProvider;
+
+use Laminas\Mvc\Controller\Plugin\Url;
+use VuFind\ChannelProvider\Facets;
+use VuFind\Search\Results\PluginManager;
+use VuFindTest\Feature\SearchObjectsTrait;
+use VuFindTest\RecordDriver\TestHarness;
+
+/**
+ * Facets Channel Provider Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class FacetsTest extends \PHPUnit\Framework\TestCase
+{
+    use SearchObjectsTrait;
+
+    /**
+     * Test that getFromRecord deduplicates redundant facet values.
+     *
+     * @return void
+     */
+    public function testGetFromRecordDeduplicatesValues(): void
+    {
+        $resultsManager = $this->createMock(PluginManager::class);
+        $resultsManager->method('get')->willReturn($this->getMockResults());
+        $urlHelper = $this->createMock(Url::class);
+        $facets = new Facets($resultsManager, $urlHelper, ['maxFieldsToSuggest' => 0]);
+        $this->assertEquals(
+            [
+                [
+                    'title' => 'Author: foo',
+                    'providerId' => '',
+                    'groupId' => 'author_facet',
+                    'token' => 'Author: foo|author_facet:foo',
+                    'links' => [],
+                ],
+                [
+                    'title' => 'Author: bar',
+                    'providerId' => '',
+                    'groupId' => 'author_facet',
+                    'token' => 'Author: bar|author_facet:bar',
+                    'links' => [],
+                ],
+            ],
+            $facets->getFromRecord($this->getDriver(['author_facet' => ['foo', 'bar', 'bar']]))
+        );
+    }
+
+    /**
+     * Get a fake record driver
+     *
+     * @param array $data Custom record data
+     *
+     * @return TestHarness
+     */
+    protected function getDriver(array $data = [])
+    {
+        $driver = new TestHarness();
+        $finalData = $data + [
+            'Title' => 'foo_Title',
+            'SourceIdentifier' => 'foo_Identifier',
+            'Thumbnail' => 'foo_Thumbnail',
+            'UniqueID' => 'foo_Id',
+        ];
+        $driver->setRawData($finalData);
+        return $driver;
+    }
+}


### PR DESCRIPTION
When we build facet channels from a record, we need to account for the fact that some facet fields contain repeating values (e.g. authors who have multiple distinct roles -- like an author/illustrator). This PR applies `array_unique` to prevent duplicate channels from being created; it also adds a unit test to cover the new functionality.