### PR TITLE
Improve OpenAPI search description.

### DIFF
--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -76,7 +76,7 @@
         "/<?=$recordRoute?>": {
             "get": {
                 "summary": "Fetch records from <?=$this->indexLabel?> index",
-                "description": "Return a single record or multiple records from <?=$this->indexLabel?> index. POST method may also be used if sending a long request.",   
+                "description": "Return a single record or multiple records from <?=$this->indexLabel?> index. POST method may also be used if sending a long request.",
 <?=$securityBlock?>
                 "parameters": [
                     {
@@ -136,7 +136,7 @@
         "/<?=$searchRoute?>": {
             "get": {
                 "summary": "Search <?=$this->indexLabel?> index",
-                "description": "Search <?=$this->indexLabel?> index with given terms and filters. POST method may also be used if sending a long request.\n\nThe URL syntax here is the as the one used in VuFind user interface. It is possible to make a search in VuFind and copy the query parameters here to make the same search via the API.",
+                "description": "Search <?=$this->indexLabel?> index with given terms and filters. POST method may also be used if sending a long request.\n\nThe URL syntax here is the same as the one used in VuFind® user interface. It is possible to make a search in VuFind® and copy the query parameters here to make the same search via the API. While this formal specification only describes basic searching, advanced searches like join=AND&lookfor0[]=apples&type0[]=Title&lookfor0[]=oranges&type0[]=Subject&bool0[]=AND are also supported by the endpoint.",
 <?=$securityBlock?>
                 "parameters": [
                     {


### PR DESCRIPTION
This PR documents advanced search support as discussed by [VUFIND-1625](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1625), fixes a missing-word error, and adds appropriate trademark symbols.

Revised description, as rendered in Swagger UI:

<img width="1437" height="175" alt="image" src="https://github.com/user-attachments/assets/14ff05e0-fd16-4aa5-bba8-7031f91f4273" />

TODO
- [x] Resolve [VUFIND-1625](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1625) when merging, and open a new ticket to capture ongoing discussions about JSON schema support in the API.