### PR TITLE
Overdrive: Fix HTML and spacing for status

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/status-full.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/SolrOverdrive/status-full.phtml
@@ -31,7 +31,7 @@ foreach ($ids as $id) {
             . $this->transEsc('od_code_login_for_avail') . '</p>';
         $availabilityStatus = \VuFind\ILS\Logic\AvailabilityStatusInterface::STATUS_UNKNOWN;
     } else {
-        $current['full_status'] .= '<div class="availability"><p>';
+        $current['full_status'] .= '<div class="availability">';
         $copiesAvailable = (int)($avail->copiesAvailable ?? 0);
         if ($copiesAvailable > 0) {
             $current['full_status'] .= '<span class="text-success">';
@@ -51,6 +51,7 @@ foreach ($ids as $id) {
         if ($numHolds = ($avail->numberOfHolds ?? 0) > 0) {
             $current['full_status'] .= '; ' . $this->transEsc('od_waiting', ['holds' => $numHolds], null, true);
         }
+        $current['full_status'] .= '</div>';
     }
     $current['availability_message'] = $availabilityStatus ? $this->render(
         'ajax/status.phtml',


### PR DESCRIPTION
Remove the empty line that Overdrive items show on the result list.  It's caused by default margin on a `<p>` tag that doesn't need to be there at all since it's right inside a div.  Also, close that div.

<img width="892" height="215" alt="image" src="https://github.com/user-attachments/assets/2a613b09-0ef3-4e5a-b102-1812c85340c2" />
