### PR TITLE
Add support for index-specific HTTP settings.

### DIFF
--- a/config/vufind/Search2.ini
+++ b/config/vufind/Search2.ini
@@ -22,6 +22,8 @@ maxBooleanClauses = 1024
 timeout = 30
 default_dismax_handler = dismax
 
+[IndexHttp]
+
 [Spelling]
 enabled = true
 limit   = 3

--- a/config/vufind/authority.ini
+++ b/config/vufind/authority.ini
@@ -76,3 +76,5 @@ Heading = "SolrAuth:Heading"
 ;[Index]
 ;url = http://localhost:8983/solr
 ;default_authority_core = authority
+
+[IndexHttp]

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -712,6 +712,13 @@ default_dismax_handler = dismax
 ; memory problems.
 ;record_batch_size = 100
 
+; HTTP settings used when making a request to the search index. These can be used
+; to add new settings or override the defaults from [Http] section.
+; See [Http] section for more information about the settings.
+[IndexHttp]
+;sslcapath = "/etc/ssl/certs" ; e.g. for Debian systems
+;sslcafile = "/etc/pki/tls/cert.pem" ; e.g. for CentOS systems
+
 ; Enable/Disable searching reserves using the "reserves" Solr index.  When enabling
 ; this feature, you need to run the util/index_reserves.php script to populate the
 ; new index.

--- a/config/vufind/reserves.ini
+++ b/config/vufind/reserves.ini
@@ -62,3 +62,5 @@ translated_facets[] = instructor_str:Reserves
 ;maxBooleanClauses = 1024
 ;timeout = 30
 ;default_dismax_handler = dismax
+
+[IndexHttp]

--- a/config/vufind/website.ini
+++ b/config/vufind/website.ini
@@ -52,6 +52,8 @@ facet_limit = 30
 ;url             = http://localhost:8983/solr
 ;default_core    = website
 
+[IndexHttp]
+
 ; Enable JS feature to select multiple facets without reloading the result page
 ; Possible values :
 ; false (default) => behaviour disabled


### PR DESCRIPTION
This makes it easy to e.g. set up SSL connection to Solr using self-signed certificates without affecting other HTTP requests.