### PR TITLE
Fix and simplify noajax handling in embedded tab code.

### DIFF
--- a/themes/bootstrap5/js/embedded_record.js
+++ b/themes/bootstrap5/js/embedded_record.js
@@ -58,13 +58,9 @@ VuFind.register('embedded', function embedded() {
     var id = $result.find('.hiddenId')[0].value;
     var source = $result.find('.hiddenSource')[0].value;
     if ($tab.parent().hasClass('noajax')) {
-      if ($tab.is('a')) {
-        // tab case:
-        window.location.href = $tab.attr('href');
-      } else {
-        // accordion case:
-        window.location.href = $tab.find('a').attr('data-href');
-      }
+      window.location.href = $tab.is('a')
+        ? $tab.attr('href') // tab case
+        : $tab.find('a').attr('data-href'); // accordion case
       return false;
     }
     var urlroot;

--- a/themes/bootstrap5/templates/record/ajaxview-tabs.phtml
+++ b/themes/bootstrap5/templates/record/ajaxview-tabs.phtml
@@ -60,10 +60,10 @@
         }
       }
       if (!$obj->isVisible()) {
-        $tabAttrs->add('class', 'hidden');
+        $liAttrs->add('class', 'hidden');
       }
       if (!$obj->supportsAjax()) {
-        $tabAttrs->add('class', 'noajax');
+        $liAttrs->add('class', 'noajax');
       }
     ?>
     <li<?=$liAttrs?>>


### PR DESCRIPTION
This PR fixes a template bug (use of undefined variable) in ajaxview-tabs.phtml that was causing a fatal error when noajax tabs were loaded. It also simplifies some code in embedded_record.js; the simplification is not essential to the fix, but it was an optimization made while troubleshooting the code.