### PR TITLE
FOLIO: tolerate missing request preferences.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2071,9 +2071,9 @@ class Folio extends AbstractAPI implements
             '/request-preference-storage/request-preference?query=userId==' . $patron['id']
         );
         $requestPreferencesResponse = json_decode($response->getBody());
-        $requestPreferences = $requestPreferencesResponse->requestPreferences[0];
-        $allowHoldShelf = $requestPreferences->holdShelf;
-        $allowDelivery = $requestPreferences->delivery && ($this->config['Holds']['allowDelivery'] ?? true);
+        $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
+        $allowHoldShelf = $requestPreferences->holdShelf ?? false;
+        $allowDelivery = ($requestPreferences->delivery ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
         $locationsLabels = $this->config['Holds']['locationsLabelByRequestGroup'] ?? [];
         if ($allowHoldShelf && $allowDelivery) {
             return [

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2072,7 +2072,7 @@ class Folio extends AbstractAPI implements
         );
         $requestPreferencesResponse = json_decode($response->getBody());
         $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
-        $allowHoldShelf = $requestPreferences->holdShelf ?? false;
+        $allowHoldShelf = $requestPreferences->holdShelf ?? true;
         $allowDelivery = ($requestPreferences->delivery ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
         $locationsLabels = $this->config['Holds']['locationsLabelByRequestGroup'] ?? [];
         if ($allowHoldShelf && $allowDelivery) {


### PR DESCRIPTION
@sturkel89 discovered that after upgrading our FOLIO test server to Sunflower, attempting to place requests triggered an error because request-preference-storage/request-preferences was returning an empty array instead of an array containing a single element. I'm not sure if this is an expected change, or something to do with our data migration. Whatever the root cause, this PR makes the code more tolerant of missing data so that missing preferences won't prevent requests from being placed. Since we don't use this functionality at Villanova, I'm not sure if it is broken under other circumstances. @maccabeelevine, are you in a position to test whether these changes are okay on your end?