### PR TITLE
Fix method timed blocks near midnight

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1356,8 +1356,13 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                 $startTime = $start ? new \DateTime($start) : null;
                 $endTime = $end ? new \DateTime($end) : null;
                 if ($startTime && $endTime) {
+                    $now = new \DateTime();
                     if ($endTime <= $startTime) {
-                        $endTime->modify('+1 day');
+                        if ($now < $endTime) {
+                            $startTime->modify('-1 day');
+                        } else {
+                            $endTime->modify('+1 day');
+                        }
                     }
                     $blocks[] = [
                         'start' => $startTime,

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -1356,8 +1356,8 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                 $startTime = $start ? new \DateTime($start) : null;
                 $endTime = $end ? new \DateTime($end) : null;
                 if ($startTime && $endTime) {
-                    $now = new \DateTime();
                     if ($endTime <= $startTime) {
+                        $now = new \DateTime();
                         if ($now < $endTime) {
                             $startTime->modify('-1 day');
                         } else {


### PR DESCRIPTION
This should fix method blocks near midnight. I believe this is the problem: If we have for example this configuration
`Renewals[] = "23:00/01:00"` in `getMethodTimedBlocks` that is parsed differently depending on the current time because it creates DateTime objects for today and then modifies the end time by +1 day if end ≤ start. So tonight:

- at 23:30 the datetimes would be 2025-11-17 23:00 - 2025-11-18 01:00 - blocked
- at 00:30 the datetimes would be 2025-11-18 23:00 - 2025-11-19 01:00 - not blocked