### PR TITLE
Added refresh of holdable items after reserve lightbox close.

### DIFF
--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -15,7 +15,7 @@
   <p class="helptext"><?=$this->helpTextHtml?></p>
 <?php endif; ?>
 
-<form class="form-record-hold" method="post" name="placeHold" data-clear-account-cache="holds">
+<form class="form-record-hold" method="post" name="placeHold" data-clear-account-cache="holds" data-lightbox-onclose="VuFind.refreshPage">
   <?=$this->flashmessages()?>
   <label class="form-label"><?=$this->transEsc('Title')?></label>
   <p class="form-control-static"><?=$this->escapeHtml($this->driver->getBreadcrumb() . $enumchron) ?></p>


### PR DESCRIPTION
When you reserve an item in the holdings view, for a detailed record, the list of holdings was not refreshed after closing the reserve lightbox, which gave the possibility to click on reserve for the same item again. The change adds a refresh (code from Demian Katz).