### PR TITLE
Fix DirectSolrSpellChecker thresholdTokenFrequency

### DIFF
--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -506,7 +506,7 @@
       <int name="minQueryLength">4</int>
       <int name="maxQueryLength">40</int>
       <float name="maxQueryFrequency">0.01</float>
-      <float name="thresholdTokenFrequency">.01</float>
+      <float name="thresholdTokenFrequency">0.0</float>
     </lst>
   </searchComponent>
   <queryConverter name="queryConverter" class="org.apache.solr.spelling.SpellingQueryConverter"/>


### PR DESCRIPTION
When I introduced the DirectSolrSpellChecker default config in #3547, I said that I was taking the default values from current documentation, but I must have been looking at a page for Solr 9.5 (or earlier) as I got this one wrong.  (Of course so did the Solr documentation <= 9.5 😄 ).  `thresholdTokenFrequency` of 0.01 (or 1%) means that it will not suggest any replacement words unless those words appear in at least 1% of the actual documents.  So for a 1 million document index, the suggestion would have to appear in >= 10,000 documents.  That's nuts and as I [noted at the time](https://github.com/vufind-org/vufind/pull/3547#issuecomment-2052015042) 🤯 was too high a threshold even for the VuFind demo index.

Solr now suggests 0.0 as a default.  Which may be too low, but it's a better starting point to adjust based on the actual size of your index.  The [Solr PR](https://github.com/apache/solr/pull/2356) that changed this has no discussion of the new default.

Aside from this parameter, I compared our config against the current "latest" docs (actually Solr 9.10) for DirectSolrSpellChecker to see if I missed anything else.  Although there are some parameters Solr has that we omit, for the ones we include, the numeric values match.  (Field names, defaults, etc. do not for good reason.)