### PR TITLE
Use defaultCurrency as default for payment service, improve docs.

### DIFF
--- a/config/vufind/Demo.ini
+++ b/config/vufind/Demo.ini
@@ -278,8 +278,10 @@ minimumFee = 500
 ; Maximum duration (in minutes) for a payment session. Sessions older than this
 ; are not considered active (but may still complete later).
 paymentMaxDuration = 15
-; Currency
-currency = "EUR"
+; Currency code for the payment service. The code should indicate the same currency
+; as the defaultCurrency setting in config.ini, which is also used here as the
+; default.
+;currency = "USD"
 ; Whether to allow selection of fines to pay
 selectFines = true
 

--- a/config/vufind/KohaRest.ini
+++ b/config/vufind/KohaRest.ini
@@ -263,8 +263,10 @@ minimumFee = 500
 ; Maximum duration (in minutes) for a payment session. Sessions older than this
 ; are not considered active (but may still complete later).
 paymentMaxDuration = 15
-; Currency
-currency = "EUR"
+; Currency code for the payment service. The code should indicate the same currency
+; as the defaultCurrency setting in config.ini, which is also used here as the
+; default.
+;currency = "USD"
 ; Whether to allow selection of fines to pay
 selectFines = true
 

--- a/config/vufind/SierraRest.ini
+++ b/config/vufind/SierraRest.ini
@@ -241,8 +241,10 @@ minimumFee = 500
 ; Maximum duration (in minutes) for a payment session. Sessions older than this
 ; are not considered active (but may still complete later).
 paymentMaxDuration = 15
-; Currency
-currency = "EUR"
+; Currency code for the payment service. The code should indicate the same currency
+; as the defaultCurrency setting in config.ini, which is also used here as the
+; default.
+;currency = "USD"
 
 ; ** Product code mappings **
 

--- a/module/VuFind/src/VuFind/OnlinePayment/Handler/AbstractBase.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/Handler/AbstractBase.php
@@ -330,7 +330,7 @@ abstract class AbstractBase implements
      */
     protected function getCurrencyCode(): string
     {
-        return $this->paymentConfig['currency'] ?? 'USD';
+        return $this->paymentConfig['currency'] ?? $this->config['Site']['defaultCurrency'] ?? 'USD';
     }
 
     /**

--- a/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentManager.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentManager.php
@@ -570,13 +570,10 @@ class OnlinePaymentManager implements LoggerAwareInterface
             return [];
         }
 
-        // Check that mandatory settings exist
-        $mandatory = ['currency', 'handler'];
-        foreach ($mandatory as $current) {
-            if (empty($paymentConfig[$current])) {
-                $this->logError("Mandatory setting '$current' missing from ILS driver for $sourceIls");
-                return [];
-            }
+        // Check that mandatory handler setting exists
+        if (empty($paymentConfig['handler'])) {
+            $this->logError("Mandatory setting 'handler' missing from ILS driver for $sourceIls");
+            return [];
         }
 
         return $paymentConfig;


### PR DESCRIPTION
These changes make it more obvious that the currency codes should match. Otherwise what's displayed would not match the actual amount.