### PR TITLE
[VUFIND-1804] Fix bug: do not double-encode location text.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -325,7 +325,7 @@ class GetItemStatuses extends AbstractBase implements
             'id' => $record[0]['id'],
             'availability' => $combinedAvailability->availabilityAsString(),
             'availability_message' => $availabilityMessage,
-            'location' => htmlentities(implode(",\t", $location), ENT_COMPAT, 'UTF-8'),
+            'location' => implode(",\t", $location),
             'locationList' => false,
             'reserve' => $reserve ? 'true' : 'false',
             'reserve_message'
@@ -370,11 +370,7 @@ class GetItemStatuses extends AbstractBase implements
 
             $locationInfo = [
                 'availability' => $locationStatus['availability'],
-                'location' => htmlentities(
-                    $this->translateWithPrefix('location_', $location),
-                    ENT_COMPAT,
-                    'UTF-8'
-                ),
+                'location' => $this->translateWithPrefix('location_', $location),
                 'callnumberHtml' =>
                     $this->renderCallnumbers($callnumberSetting, $locationCallnumbers),
             ];


### PR DESCRIPTION
As @stweil reported in [VUFIND-1804](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1804), a bug was introduced by #4065. That PR changes the way location names are processed in Javascript, so they are treated as text rather than HTML; however, the values sent by the AJAX handler were being converted into HTML.

This PR removes the extra layer of escaping from the AJAX handler, as the updated client Javascript no longer needs it. Since the underlying data is not expected to contain HTML tags, etc., there is no reason to transmit it as HTML. This simplifies everything and solves the reported bug.

TODO
- [x] Run full test suite
- [x] Close [VUFIND-1804](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1804) when merging
