### PR TITLE
Checkbox HTML Validation

### DIFF
--- a/themes/bootstrap5/templates/RecordTab/collectionlist.phtml
+++ b/themes/bootstrap5/templates/RecordTab/collectionlist.phtml
@@ -80,7 +80,7 @@
           <?php endif; ?>
         </div>
       </div>
-      <form class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>">
+      <form class="form-inline" method="post" name="bulkActionForm" action="<?=$this->url('cart-searchresultsbulk')?>" id="search-cart-form">
         <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', $searchDetails + ['idPrefix' => ''])?>
         <?=$this->render('search/list-' . $results->getParams()->getView() . '.phtml', $searchDetails)?>
         <?=$this->paginationControl($results->getPaginator(), 'Sliding', 'Helpers/pagination.phtml', ['params' => ['results' => $results]])?>

--- a/themes/bootstrap5/templates/checkouts/history.phtml
+++ b/themes/bootstrap5/templates/checkouts/history.phtml
@@ -102,7 +102,7 @@
                 <input class="checkbox-select-item" type="checkbox" name="purgeSelectedIDs[]" value="<?=$this->escapeHtmlAttr($ilsDetails['row_id'])?>" id="checkbox_<?=$safeId?>" aria-label="<?=$this->transEscAttr('select_item_purge')?>">
               <?php endif; ?>
             <?php endif; ?>
-            <div class="checkbox-select-number"><?=$this->escapeHtml($startRecord + $i) ?></div>
+            <span class="checkbox-select-number"><?=$this->escapeHtml($startRecord + $i) ?></span>
           </label>
           <?php
             $coverDetails = $this->record($resource)->getCoverDetails('checkedout', 'small', $this->recordLinker()->getUrl($resource));

--- a/themes/bootstrap5/templates/holds/list.phtml
+++ b/themes/bootstrap5/templates/holds/list.phtml
@@ -84,7 +84,7 @@
               <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['cancel_details'] ?? $ilsDetails['updateDetails']); ?>
               <input type="checkbox" name="selectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details'] ?? $ilsDetails['updateDetails']) ?>" id="checkbox_<?=$safeId?>" class="checkbox-select-item" aria-label="<?=$this->transEscAttr('select_item_hold_cancel')?>">
             <?php endif; ?>
-            <div class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></div>
+            <span class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></span>
           </label>
 
           <?php

--- a/themes/bootstrap5/templates/myresearch/checkedout.phtml
+++ b/themes/bootstrap5/templates/myresearch/checkedout.phtml
@@ -111,7 +111,7 @@
               <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $ilsDetails['renew_details']); ?>
               <input class="checkbox-select-item" type="checkbox" name="renewSelectedIDS[]" value="<?=$this->escapeHtmlAttr($ilsDetails['renew_details'])?>" id="checkbox_<?=$safeId?>" aria-label="<?=$this->transEscAttr('select_item_checked_out_renew')?>">
             <?php endif; ?>
-            <div class="checkbox-select-number"><?=$this->escapeHtml($startRecord + $i) ?></div>
+            <span class="checkbox-select-number"><?=$this->escapeHtml($startRecord + $i) ?></span>
           </label>
           <?php
             $coverDetails = $this->record($resource)->getCoverDetails('checkedout', 'small', $this->recordLinker()->getUrl($resource));

--- a/themes/bootstrap5/templates/myresearch/illrequests.phtml
+++ b/themes/bootstrap5/templates/myresearch/illrequests.phtml
@@ -63,7 +63,7 @@
               <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
               <input type="checkbox" name="cancelSelectedIDS[]" class="checkbox-select-item" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>">
             <?php endif; ?>
-            <div class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></div>
+            <span class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></span>
           </label>
           <?php
             $coverDetails = $this->record($resource)->getCoverDetails('illrequests', 'small', $this->recordLinker()->getUrl($resource));

--- a/themes/bootstrap5/templates/myresearch/storageretrievalrequests.phtml
+++ b/themes/bootstrap5/templates/myresearch/storageretrievalrequests.phtml
@@ -63,7 +63,7 @@
               <?php $safeId = preg_replace('/[^a-zA-Z0-9]/', '', $resource->getUniqueId()); ?>
               <input type="checkbox" name="cancelSelectedIDS[]" class="checkbox-select-item" value="<?=$this->escapeHtmlAttr($ilsDetails['cancel_details']) ?>" id="checkbox_<?=$safeId?>" aria-label="<?=$this->transEscAttr('select_item_storage_retrieval_request_cancel')?>">
             <?php endif; ?>
-            <div class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></div>
+            <span class="checkbox-select-number"><?=$this->escapeHtml($iteration) ?></span>
           </label>
           <?php
             $coverDetails = $this->record($resource)->getCoverDetails('storageretrievalrequests', 'small', $this->recordLinker()->getUrl($resource));

--- a/themes/bootstrap5/templates/record/checkbox.phtml
+++ b/themes/bootstrap5/templates/record/checkbox.phtml
@@ -2,6 +2,6 @@
 <label class="checkbox-select" aria-label="<?=$this->transEscAttr('result_checkbox_label', ['%%number%%' => $this->number]) ?>">
   <input class="checkbox-select-item" type="checkbox" name="ids[]" value="<?=$this->escapeHtmlAttr($this->id) ?>"<?php if (isset($this->formAttr)): ?> form="<?=$this->formAttr ?>"<?php endif; ?>>
   <?php if (strlen($this->number ?? '') > 0): ?>
-    <div class="checkbox-select-number"><?=$this->number ?></div>
+    <span class="checkbox-select-number"><?=$this->number ?></span>
   <?php endif; ?>
 </label>


### PR DESCRIPTION
HTML validation fixes for checkboxes.

- add ID to collections form to validate form="search-cart-form"
- switch from div to span (allowed inside of labels)