### PR TITLE
Add missing en-gb language subdomain files.

### DIFF
--- a/languages/DDC23/en-gb.ini
+++ b/languages/DDC23/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "DDC23/en.ini"

--- a/languages/Developer/en-gb.ini
+++ b/languages/Developer/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "Developer/en.ini"

--- a/languages/IndexFieldDescription/en-gb.ini
+++ b/languages/IndexFieldDescription/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "IndexFieldDescription/en.ini"

--- a/languages/Payment/en-gb.ini
+++ b/languages/Payment/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "Payment/en.ini"

--- a/languages/RecordAttribute/en-gb.ini
+++ b/languages/RecordAttribute/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "RecordAttribute/en.ini"

--- a/languages/Reserves/en-gb.ini
+++ b/languages/Reserves/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "Reserves/en.ini"

--- a/languages/ServiceType/en-gb.ini
+++ b/languages/ServiceType/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "ServiceType/en.ini"

--- a/languages/WorldCatFormats/en-gb.ini
+++ b/languages/WorldCatFormats/en-gb.ini
@@ -1,0 +1,1 @@
+@parent_ini = "WorldCatFormats/en.ini"


### PR DESCRIPTION
We've added several new text domains without creating the necessary files to link up the en-gb translation to the en translation. This is harmless since the fallback will default to en anyway, but we might as well be explicit (and this ensure that the language checking tool displays correct counts for the en-gb translation).