### PR TITLE
EDS: Treat 'News', 'Conference' format as also an 'Article' for OpenURL

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1071,6 +1071,7 @@ class EDS extends DefaultRecord
             case 'academic journal':
             case 'periodical':
             case 'report':
+            case 'news':
                 // Add "article" format for better OpenURL generation
                 $formats[] = $pubType;
                 $formats[] = 'Article';

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1069,10 +1069,10 @@ class EDS extends DefaultRecord
         $pubType = $this->getPubType();
         switch (strtolower($pubType)) {
             case 'academic journal':
+            case 'conference':
+            case 'news':
             case 'periodical':
             case 'report':
-            case 'news':
-            case 'conference':
                 // Add "article" format for better OpenURL generation
                 $formats[] = $pubType;
                 $formats[] = 'Article';

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1072,6 +1072,7 @@ class EDS extends DefaultRecord
             case 'periodical':
             case 'report':
             case 'news':
+            case 'conference':
                 // Add "article" format for better OpenURL generation
                 $formats[] = $pubType;
                 $formats[] = 'Article';


### PR DESCRIPTION
If OpenURL links are displayed for EDS records, the format "News" should generate OpenURL links that include the name of the publication.  So for OpenURL purposes it should be treated as an "Article".  

From the limited source I can still find on the OpenURL standard and these specific ["KEV" format guidelines](https://oclc-research.github.io/OpenURL-Frozen/docs/implementation_guidelines/KEV_Guidelines-20041209.pdf), newspaper articles (like journal articles) should get the OpenURL format journal (`$params['rft_val_fmt'] = 'info:ofi/fmt:kev:mtx:journal';`) 

> The journal Metadata Format is a general purpose Format to describe all levels within a journal **or serial** publication. 

with genre `article`, which is what `DefaultRecord->getArticleOpenUrlParams()` does.