### PR TITLE
Remove determination of auth Solr core in import-marc-auth script

### DIFF
--- a/import-marc-auth.bat
+++ b/import-marc-auth.bat
@@ -56,7 +56,20 @@ for %%a in (%MAPPINGS_FILENAMES%) do (
 set MAPPINGS_FILES=%MAPPINGS_FILES:~2,99999%
 setlocal DisableDelayedExpansion
 
-set SOLRCORE="authority"
+rem Get the Solr core name from the properties file, default to "authority"
+set SOLRCORE=""
+for /f "delims=" %%a in ('findstr "^solr.core.name" %PROPERTIES_FILE%') do set SOLRCORE=%%a
+rem Removes the text solr.core.name from the string
+set SOLRCORE="%SOLRCORE:solr.core.name=%"
+rem Removes all spaces (replaces space with nothing)
+set SOLRCORE=%SOLRCORE: =%
+rem Removes all equals signs
+set SOLRCORE=%SOLRCORE:==%
+rem Removes all double quotes
+set SOLRCORE=%SOLRCORE:"=%
+rem If empty, default to 'authority'
+if "%SOLRCORE%"=="" set SOLRCORE=authority
+
 set EXTRA_SOLRMARC_SETTINGS="-Dsolr.indexer.properties=%MAPPINGS_FILES%"
 
 rem Call the standard script:

--- a/import-marc-auth.bat
+++ b/import-marc-auth.bat
@@ -56,20 +56,6 @@ for %%a in (%MAPPINGS_FILENAMES%) do (
 set MAPPINGS_FILES=%MAPPINGS_FILES:~2,99999%
 setlocal DisableDelayedExpansion
 
-rem Get the Solr core name from the properties file, default to "authority"
-set SOLRCORE=""
-for /f "delims=" %%a in ('findstr "^solr.core.name" %PROPERTIES_FILE%') do set SOLRCORE=%%a
-rem Removes the text solr.core.name from the string
-set SOLRCORE="%SOLRCORE:solr.core.name=%"
-rem Removes all spaces (replaces space with nothing)
-set SOLRCORE=%SOLRCORE: =%
-rem Removes all equals signs
-set SOLRCORE=%SOLRCORE:==%
-rem Removes all double quotes
-set SOLRCORE=%SOLRCORE:"=%
-rem If empty, default to 'authority'
-if "%SOLRCORE%"=="" set SOLRCORE=authority
-
 set EXTRA_SOLRMARC_SETTINGS="-Dsolr.indexer.properties=%MAPPINGS_FILES%"
 
 rem Call the standard script:

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper around import-marc.sh to allow import of authority records.
 #

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -56,17 +56,6 @@ for MAPPINGS_FILENAME in ${MAPPINGS_FILENAMES[@]}; do
   fi
 done
 
-# Get the Solr core name from the properties file, default to "authority"
-SOLRCORE=$(grep '^solr\.core\.name *=' $PROPERTIES_FILE | sed -n 's/^solr\.core\.name *= *\(.*\)/\1/p' | tr -d ' ')
-
-# Default to "authority" if not found
-if [ -z "$SOLRCORE" ]
-then
-  export SOLRCORE="authority"
-else
-  export SOLRCORE="$SOLRCORE"
-fi
-
 export EXTRA_SOLRMARC_SETTINGS="-Dsolr.indexer.properties=$MAPPINGS_FILES"
 
 # Call the standard script:

--- a/import-marc-auth.sh
+++ b/import-marc-auth.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Wrapper around import-marc.sh to allow import of authority records.
 #
@@ -56,7 +56,17 @@ for MAPPINGS_FILENAME in ${MAPPINGS_FILENAMES[@]}; do
   fi
 done
 
-export SOLRCORE="authority"
+# Get the Solr core name from the properties file, default to "authority"
+SOLRCORE=$(grep '^solr\.core\.name *=' $PROPERTIES_FILE | sed -n 's/^solr\.core\.name *= *\(.*\)/\1/p' | tr -d ' ')
+
+# Default to "authority" if not found
+if [ -z "$SOLRCORE" ]
+then
+  export SOLRCORE="authority"
+else
+  export SOLRCORE="$SOLRCORE"
+fi
+
 export EXTRA_SOLRMARC_SETTINGS="-Dsolr.indexer.properties=$MAPPINGS_FILES"
 
 # Call the standard script:


### PR DESCRIPTION
At the moment, the Solr core is hard-coded to `authority`. These changes get it dynamically from the properties file.