### PR TITLE
Paytrail: Add product for service fee only if product code specified.

### DIFF
--- a/module/VuFind/src/VuFind/OnlinePayment/Handler/Paytrail.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/Handler/Paytrail.php
@@ -184,10 +184,10 @@ class Paytrail extends AbstractBase
 
             $items[] = $item;
         }
-        if ($serviceFee = $this->getServiceFee()) {
+        if (($serviceFee = $this->getServiceFee()) && ($serviceFeeProductCode = $this->getServiceFeeProductCode())) {
             $item = (new Item())
                 ->setDescription($this->translator->translate('Payment::Service Fee'))
-                ->setProductCode($this->getServiceFeeProductCode())
+                ->setProductCode($serviceFeeProductCode)
                 ->setUnitPrice($serviceFee)
                 ->setUnits(1)
                 ->setVatPercentage((float)($this->getServiceFeeTaxRate() ?? 0) / 100.0);


### PR DESCRIPTION
Like with other rows, the product for service fee should only be added if there's a product code for it in configuration.