### PR TITLE
Fix AbstractExpireCommand handling of float age

### DIFF
--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
@@ -209,8 +209,7 @@ class AbstractExpireCommand extends Command
     {
         if ($daysOld == (int)$daysOld) {
             return new DateTime("now - $daysOld days");
-        }
-        else {
+        } else {
             $hoursOld = round($daysOld * 24);
             return new DateTime("now - $hoursOld hours");
         }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
@@ -207,6 +207,12 @@ class AbstractExpireCommand extends Command
      */
     protected function getDateThreshold(float $daysOld): DateTime
     {
-        return new DateTime("now - $daysOld days");
+        if ($daysOld == (int)$daysOld) {
+            return new DateTime("now - $daysOld days");
+        }
+        else {
+            $hoursOld = round($daysOld * 24);
+            return new DateTime("now - $hoursOld hours");
+        }
     }
 }

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/AbstractExpireCommand.php
@@ -207,6 +207,7 @@ class AbstractExpireCommand extends Command
      */
     protected function getDateThreshold(float $daysOld): DateTime
     {
+        // DateTime doesn't support floating point relative values, so convert days to hours as needed:
         if ($daysOld == (int)$daysOld) {
             return new DateTime("now - $daysOld days");
         } else {


### PR DESCRIPTION
AbstractExpireCommand defines both $minAge and $defaultAge as `@var int|float|null`, and says that `$minAge is used if $defaultAge is null`.  Float values are fine for comparing the given value to $minAge, but they can't actually be used to construct a DateTime object as 

```
return new DateTime("now - $daysOld days");
```

as that syntax can't be used with float values.  From https://www.php.net/manual/en/datetime.formats.php under Relative Formats

> Note:
number is an integer number; if a decimal number is given, the dot (or comma) is likely interpreted as delimiter. For instance, '+1.5 hours' is parsed like '+1 5 hours', not as '+1 hour +30 minutes'.

This attempts to convert the float days to an equivalent int hours.