### PR TITLE
Remove umask from cache settings

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2297,8 +2297,6 @@ legacyPbkdf2 = true
 ;disabled = true
 ; Set time to live value for caches (in seconds), 0 means maximum possible.
 ;ttl = 0
-; Override umask for cache directories and files.
-;umask = 022
 ; Permissions for framework-created cache directories and files, subject to umask
 ; Default dir_permission seems to be 0700.
 ;dir_permission = 0700

--- a/module/VuFind/src/VuFind/Cache/Manager.php
+++ b/module/VuFind/src/VuFind/Cache/Manager.php
@@ -366,18 +366,6 @@ class Manager implements LoggerAwareInterface
         $opts = array_merge($this->defaults, $overrideOpts);
 
         if (!is_dir($dirName)) {
-            if (isset($opts['umask'])) {
-                // convert umask from string
-                $umask = octdec($opts['umask']);
-                // validate
-                if ($umask & 0o700) {
-                    throw new \Exception(
-                        'Invalid umask: ' . $opts['umask']
-                        . '; need permission to execute, read and write by owner'
-                    );
-                }
-                umask($umask);
-            }
             if (isset($opts['dir_permission'])) {
                 $dir_perm = octdec($opts['dir_permission']);
             } else {

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -550,8 +550,15 @@ class Upgrade implements LoggerAwareInterface
                 = ['link' => $newConfig['Content']['GoogleOptions']];
         }
 
-        // Disable unused, obsolete setting:
+        // Disable unused, obsolete settings:
         unset($newConfig['Index']['local']);
+        if (isset($newConfig['Cache']['umask'])) {
+            unset($newConfig['Cache']['umask']);
+            $this->addWarning(
+                'The Cache umask setting never worked as intended and is no longer supported; '
+                . 'if you need a custom umask, please configure it at the operating system level.'
+            );
+        }
 
         // Warn the user if they are using an unsupported theme:
         $this->checkTheme('theme', 'sandal5');

--- a/module/VuFind/tests/fixtures/configs/umaskwarning/config.ini
+++ b/module/VuFind/tests/fixtures/configs/umaskwarning/config.ini
@@ -1,0 +1,2 @@
+[Cache]
+umask = 022

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -340,20 +340,43 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test Booksite section warning.
+     * Data provider for testSimpleWarnings().
+     *
+     * @return array[]
+     */
+    public static function simpleWarningsProvider(): array
+    {
+        return [
+            'booksite' => [
+                'booksite',
+                'The [Booksite] section of config.ini is no longer supported.',
+            ],
+            'umask' => [
+                'umaskwarning',
+                'The Cache umask setting never worked as intended and is no longer supported; '
+                . 'if you need a custom umask, please configure it at the operating system level.',
+            ],
+            'worldcat' => [
+                'worldcatwarnings',
+                'The [WorldCat] section of config.ini has been removed following'
+                . ' the shutdown of the v1 WorldCat search API; use WorldCat2.ini instead.',
+            ],
+        ];
+    }
+
+    /**
+     * Test upgrades that are expected to trigger a single warning
+     *
+     * @param string $fixture         Fixture to load
+     * @param string $expectedWarning Expected warning
      *
      * @return void
      */
-    public function testBooksiteWarning(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('simpleWarningsProvider')]
+    public function testSimpleWarnings(string $fixture, string $expectedWarning): void
     {
-        $upgrader = $this->runAndGetConfigUpgrader('booksite');
-        $warnings = $upgrader->getWarnings();
-        $this->assertTrue(
-            in_array(
-                'The [Booksite] section of config.ini is no longer supported.',
-                $warnings
-            )
-        );
+        $upgrader = $this->runAndGetConfigUpgrader($fixture);
+        $this->assertEquals([$expectedWarning], $upgrader->getWarnings());
     }
 
     /**
@@ -383,24 +406,6 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(isset($results['config']['Content']['recordMap']));
         $this->assertFalse(
             isset($results['config']['Content']['googleMapApiKey'])
-        );
-    }
-
-    /**
-     * Test WorldCat-related warnings.
-     *
-     * @return void
-     */
-    public function testWorldCatWarnings(): void
-    {
-        $upgrader = $this->runAndGetConfigUpgrader('worldcatwarnings');
-        $warnings = $upgrader->getWarnings();
-        $this->assertTrue(
-            in_array(
-                'The [WorldCat] section of config.ini has been removed following'
-                . ' the shutdown of the v1 WorldCat search API; use WorldCat2.ini instead.',
-                $warnings
-            )
         );
     }
 


### PR DESCRIPTION
The umask is a global setting which does not only affect cache related files and directories, but any other files and directories, too.

Setting umask outside of VuFind or fixing directory permissions after the directories were created are alternatives which are easy to implement for installations which want a special umask.

TODO:
- [x] Update VuFind\Config\Upgrade
- [x] Update changelog when merging