### PR TITLE
Update lm-commons/lmc-rbac and signature for HasVerifiedEmailAssertion::assert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "league/oauth1-client": "1.11.0",
         "league/oauth2-client": "^2.7",
         "league/oauth2-server": "^9.2",
-        "lm-commons/lmc-rbac": "2.1.1",
+        "lm-commons/lmc-rbac": "^2.2.1",
         "lm-commons/lmc-rbac-mvc": "4.1.1",
         "matthiasmullie/minify": "1.3.75",
         "monolog/monolog": "^3.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3b9369eea23723e6f0bd6af34638e3f",
+    "content-hash": "2d0ee98e9c5489b59c99c2c840bad6b9",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -6586,34 +6586,32 @@
         },
         {
             "name": "lm-commons/lmc-rbac",
-            "version": "2.1.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/LM-Commons/LmcRbac.git",
-                "reference": "2110f500b6316e24fcf916dedd8bd64b74aeff44"
+                "reference": "e0638ff8cb78ec74512a705450f5f7b43ac7eddf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/LM-Commons/LmcRbac/zipball/2110f500b6316e24fcf916dedd8bd64b74aeff44",
-                "reference": "2110f500b6316e24fcf916dedd8bd64b74aeff44",
+                "url": "https://api.github.com/repos/LM-Commons/LmcRbac/zipball/e0638ff8cb78ec74512a705450f5f7b43ac7eddf",
+                "reference": "e0638ff8cb78ec74512a705450f5f7b43ac7eddf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/persistence": "^2.0 || ^3.0",
-                "laminas/laminas-permissions-rbac": "^3.1",
-                "laminas/laminas-servicemanager": "^3.15",
+                "laminas/laminas-permissions-rbac": "^3.4",
+                "laminas/laminas-servicemanager": "^3.18",
                 "laminas/laminas-stdlib": "^3.1",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "doctrine/orm": "^3.0",
-                "laminas/laminas-coding-standard": "^3.0",
-                "phpspec/prophecy": "^1.10",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.0 || ^11.0",
+                "doctrine/orm": "^3.5",
+                "laminas/laminas-coding-standard": "^3.1",
+                "phpunit/phpunit": "^11.5",
                 "psalm/plugin-phpunit": "^0.19.0",
-                "symfony/cache": "^6.3",
-                "vimeo/psalm": "^5.26"
+                "symfony/cache": "^6.4",
+                "vimeo/psalm": "^6.13"
             },
             "type": "library",
             "extra": {
@@ -6672,9 +6670,9 @@
             ],
             "support": {
                 "issues": "https://github.com/LM-Commons/LmcRbac/issues",
-                "source": "https://github.com/LM-Commons/LmcRbac/tree/2.1.1"
+                "source": "https://github.com/LM-Commons/LmcRbac/tree/2.2.1"
             },
-            "time": "2025-01-04T16:25:38+00:00"
+            "time": "2025-11-24T19:43:38+00:00"
         },
         {
             "name": "lm-commons/lmc-rbac-mvc",

--- a/module/VuFind/src/VuFind/Role/Assertion/HasVerifiedEmailAssertion.php
+++ b/module/VuFind/src/VuFind/Role/Assertion/HasVerifiedEmailAssertion.php
@@ -30,7 +30,6 @@
 namespace VuFind\Role\Assertion;
 
 use Lmc\Rbac\Assertion\AssertionInterface;
-use Lmc\Rbac\Identity\IdentityInterface;
 use VuFind\Db\Entity\UserEntityInterface;
 
 /**
@@ -47,15 +46,15 @@ class HasVerifiedEmailAssertion implements AssertionInterface
     /**
      * Check if user has verified email to display developer settings
      *
-     * @param string             $permission Permission
-     * @param ?IdentityInterface $identity   Identity to check
-     * @param mixed              $context    Permission context
+     * @param string  $permission Permission
+     * @param ?object $identity   Identity to check
+     * @param mixed   $context    Permission context
      *
      * @return bool
      */
     public function assert(
         string $permission,
-        ?IdentityInterface $identity = null,
+        ?object $identity = null,
         mixed $context = null
     ): bool {
         if ($identity instanceof UserEntityInterface) {


### PR DESCRIPTION
The signature was changed in the interface starting with lm-commons/lmc-rbac 2.2.0, see [related commit](https://github.com/LM-Commons/LmcRbac/pull/136/files#diff-a1d91e14bc4f91ef830a447915f8954184bf743f8b0f00b1259dd0e9b866dfdbL35).