### PR TITLE
[VUFIND-1808] No fancy quote normalization

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -366,33 +366,6 @@ class LuceneSyntaxHelper
     /// Internal API
 
     /**
-     * Normalize fancy quotes in a query.
-     *
-     * @param string $input String to normalize
-     *
-     * @return string
-     */
-    protected function normalizeFancyQuotes($input)
-    {
-        // Normalize fancy quotes:
-        $quotes = [
-            "\xC2\xAB"     => '"', // « (U+00AB) in UTF-8
-            "\xC2\xBB"     => '"', // » (U+00BB) in UTF-8
-            "\xE2\x80\x98" => "'", // ‘ (U+2018) in UTF-8
-            "\xE2\x80\x99" => "'", // ’ (U+2019) in UTF-8
-            "\xE2\x80\x9A" => "'", // ‚ (U+201A) in UTF-8
-            "\xE2\x80\x9B" => "'", // ? (U+201B) in UTF-8
-            "\xE2\x80\x9C" => '"', // “ (U+201C) in UTF-8
-            "\xE2\x80\x9D" => '"', // ” (U+201D) in UTF-8
-            "\xE2\x80\x9E" => '"', // „ (U+201E) in UTF-8
-            "\xE2\x80\x9F" => '"', // ? (U+201F) in UTF-8
-            "\xE2\x80\xB9" => "'", // ‹ (U+2039) in UTF-8
-            "\xE2\x80\xBA" => "'", // › (U+203A) in UTF-8
-        ];
-        return strtr($input, $quotes);
-    }
-
-    /**
      * Normalize wildcards in a query.
      *
      * @param string $input String to normalize
@@ -553,8 +526,6 @@ class LuceneSyntaxHelper
      */
     protected function prepareForLuceneSyntax($input)
     {
-        $input = $this->normalizeFancyQuotes($input);
-
         // If the user has entered a lone BOOLEAN operator, convert it to lowercase
         // so it is treated as a word (otherwise it will trigger a fatal error):
         switch (trim($input)) {

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -86,7 +86,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
             ['NOT', 'not'],                      // freestanding operator
             ['*bad', 'bad'],                     // leading wildcard
             ['?bad', 'bad'],                     // leading wildcard
-            ["\xE2\x80\x9Ca\xE2\x80\x9D", '"a"'],// fancy quotes
+            ["\xE2\x80\x9Ca\xE2\x80\x9D", "\xE2\x80\x9Ca\xE2\x80\x9D"],// no fancy quotes normalization, see VUFIND-1808
             // improperly escaped floating braces/brackets:
             ['a:{a TO b} [ }', 'a:{a TO b} \[ \}'],
             // properly escaped floating braces/brackets:


### PR DESCRIPTION
See [VUFIND-1808](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1808) - Do not strip fancy quotes

This change fixes issues with fancy quotes when they are part of the title and are included in a phrase (exact) query. Also, normalizing quotes does not seem useful in any way with the current Solr implementation.

TODO
- [x] Add changelog note about changed behavior when merging