### PR TITLE
Lock lm-commons/lmc-rbac to release 2.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
         "league/oauth1-client": "1.11.0",
         "league/oauth2-client": "^2.7",
         "league/oauth2-server": "^9.2",
+        "lm-commons/lmc-rbac": "2.1.1",
         "lm-commons/lmc-rbac-mvc": "4.1.1",
         "matthiasmullie/minify": "1.3.75",
         "monolog/monolog": "^3.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4204393385164fbd21e71a2436182e78",
+    "content-hash": "d3b9369eea23723e6f0bd6af34638e3f",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -16088,7 +16088,7 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },


### PR DESCRIPTION
Release 2.2.0 changes the interface of AssertionInterface::assert.