### PR TITLE
Url-encode username/password parts of DSN

### DIFF
--- a/module/VuFind/src/VuFind/Mailer/Factory.php
+++ b/module/VuFind/src/VuFind/Mailer/Factory.php
@@ -76,8 +76,8 @@ class Factory implements FactoryInterface
         $protocol = ($config['Mail']['secure'] ?? false) ? 'smtps' : 'smtp';
         $dsn = "$protocol://";
         if (
-            ($username = rawurlencode($config['Mail']['username']) ?? null)
-            && ($password = rawurlencode($this->getSecretFromConfig($config['Mail'], 'password')))
+            ('' !== ($username = rawurlencode($config['Mail']['username']) ?? ''))
+            && ('' !== ($password = rawurlencode($this->getSecretFromConfig($config['Mail'], 'password') ?? '')))
         ) {
             $dsn .= "$username:$password@";
         }

--- a/module/VuFind/src/VuFind/Mailer/Factory.php
+++ b/module/VuFind/src/VuFind/Mailer/Factory.php
@@ -76,8 +76,8 @@ class Factory implements FactoryInterface
         $protocol = ($config['Mail']['secure'] ?? false) ? 'smtps' : 'smtp';
         $dsn = "$protocol://";
         if (
-            ($username = $config['Mail']['username'] ?? null)
-            && ($password = $this->getSecretFromConfig($config['Mail'], 'password'))
+            ($username = rawurlencode($config['Mail']['username']) ?? null)
+            && ($password = rawurlencode($this->getSecretFromConfig($config['Mail'], 'password')))
         ) {
             $dsn .= "$username:$password@";
         }


### PR DESCRIPTION
`url_parse` will return false in vendor/symfony/mailer/Transport/Dsn::fromString() when a password (or username) containing a slash character is part of the `$dsn`. That will result in a `throw new InvalidArgumentException('The mailer DSN is invalid.');`