### PR TITLE
Fix audit event data JSON handling and caller method determination.

### DIFF
--- a/module/VuFind/sql/migrations/mysql/11.0.1/001-fix-auditevent-data.sql
+++ b/module/VuFind/sql/migrations/mysql/11.0.1/001-fix-auditevent-data.sql
@@ -1,0 +1,1 @@
+UPDATE audit_event SET data = JSON_UNQUOTE(data);

--- a/module/VuFind/sql/migrations/pgsql/11.0.1/001-fix-auditevent-data.sql
+++ b/module/VuFind/sql/migrations/pgsql/11.0.1/001-fix-auditevent-data.sql
@@ -1,0 +1,1 @@
+UPDATE audit_event SET data = (data #>> '{}')::json;

--- a/module/VuFind/src/VuFind/Db/Entity/AuditEvent.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AuditEvent.php
@@ -157,10 +157,10 @@ class AuditEvent implements AuditEventEntityInterface
     /**
      * Additional data (JSON).
      *
-     * @var ?string
+     * @var ?array
      */
     #[ORM\Column(name: 'data', type: 'json', nullable: true)]
-    protected ?string $data = null;
+    protected ?array $data = null;
 
     /**
      * Constructor
@@ -417,9 +417,9 @@ class AuditEvent implements AuditEventEntityInterface
     /**
      * Get additional data.
      *
-     * @return ?string
+     * @return ?array
      */
-    public function getData(): ?string
+    public function getData(): ?array
     {
         return $this->data;
     }
@@ -427,11 +427,11 @@ class AuditEvent implements AuditEventEntityInterface
     /**
      * Set additional data.
      *
-     * @param ?string $data Data
+     * @param ?array $data Data
      *
      * @return static
      */
-    public function setData(?string $data): static
+    public function setData(?array $data): static
     {
         $this->data = $data;
         return $this;

--- a/module/VuFind/src/VuFind/Db/Entity/AuditEventEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AuditEventEntityInterface.php
@@ -214,16 +214,16 @@ interface AuditEventEntityInterface extends EntityInterface
     /**
      * Get additional data.
      *
-     * @return ?string
+     * @return ?array
      */
-    public function getData(): ?string;
+    public function getData(): ?array;
 
     /**
      * Set additional data.
      *
-     * @param ?string $data Data
+     * @param ?array $data Data
      *
      * @return static
      */
-    public function setData(?string $data): static;
+    public function setData(?array $data): static;
 }

--- a/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
+++ b/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
@@ -320,8 +320,8 @@ class AuditEventService extends AbstractDbService implements
     protected function getCallerOfParentMethod(int $intermediateMethods = 0): string
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3 + $intermediateMethods);
-        $parentPos = 2 + $intermediateMethods;
-        $methodParts = [$backtrace[$parentPos]['class'] ?? '', $backtrace[$parentPos]['function'] ?? ''];
+        $caller = $backtrace[2 + $intermediateMethods];
+        $methodParts = [$caller['class'] ?? '', $caller['function'] ?? ''];
         return implode('::', array_filter($methodParts));
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
+++ b/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
@@ -126,7 +126,7 @@ class AuditEventService extends AbstractDbService implements
             ->setServerIp($this->serverIp)
             ->setServerName($this->serverName)
             ->setMessage($message)
-            ->setData(json_encode($data));
+            ->setData($data);
         // Persist and forget about this entity (this ensures that the user could be deleted without it causing issues
         // with tracked event entities):
         $this->persistEntity($event);
@@ -136,10 +136,12 @@ class AuditEventService extends AbstractDbService implements
     /**
      * Add a payment event.
      *
-     * @param PaymentEntityInterface   $payment Payment
-     * @param AuditEventSubtype|string $subtype Event subtype
-     * @param string                   $message Status message
-     * @param array                    $data    Additional data
+     * @param PaymentEntityInterface   $payment             Payment
+     * @param AuditEventSubtype|string $subtype             Event subtype
+     * @param string                   $message             Status message
+     * @param array                    $data                Additional data
+     * @param int                      $intermediateMethods Number of intermediate methods between the actual method
+     * adding the event and this method
      *
      * @return void
      */
@@ -147,14 +149,15 @@ class AuditEventService extends AbstractDbService implements
         PaymentEntityInterface $payment,
         AuditEventSubtype|string $subtype,
         string $message = '',
-        array $data = []
+        array $data = [],
+        int $intermediateMethods = 0
     ): void {
         $type = AuditEventType::Payment->value;
         if (!in_array($type, $this->enabledEventTypes)) {
             return;
         }
         $data = $this->scrubSecrets($data);
-        $data['__method'] = $this->getCallerOfParentMethod();
+        $data['__method'] = $this->getCallerOfParentMethod($intermediateMethods);
         $data['__request_uri'] = $this->requestUri;
         $event = $this->createEntity();
         $event
@@ -167,7 +170,7 @@ class AuditEventService extends AbstractDbService implements
             ->setServerIp($this->serverIp)
             ->setServerName($this->serverName)
             ->setMessage($message)
-            ->setData(json_encode($data));
+            ->setData($data);
         $this->persistEntity($event);
     }
 
@@ -309,12 +312,16 @@ class AuditEventService extends AbstractDbService implements
     /**
      * Get the method that called the parent method here.
      *
+     * @param int $intermediateMethods Number of intermediate methods between the actual method adding the event and the
+     * parent method (used for determining the caller name)
+     *
      * @return string
      */
-    protected function getCallerOfParentMethod(): string
+    protected function getCallerOfParentMethod(int $intermediateMethods = 0): string
     {
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
-        $methodParts = [$backtrace[2]['class'] ?? '', $backtrace[2]['function'] ?? ''];
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3 + $intermediateMethods);
+        $parentPos = 2 + $intermediateMethods;
+        $methodParts = [$backtrace[$parentPos]['class'] ?? '', $backtrace[$parentPos]['function'] ?? ''];
         return implode('::', array_filter($methodParts));
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/AuditEventServiceInterface.php
+++ b/module/VuFind/src/VuFind/Db/Service/AuditEventServiceInterface.php
@@ -76,10 +76,12 @@ interface AuditEventServiceInterface extends DbServiceInterface
     /**
      * Add a payment event.
      *
-     * @param PaymentEntityInterface   $payment Payment
-     * @param AuditEventSubtype|string $subtype Event subtype
-     * @param string                   $message Status message
-     * @param array                    $data    Additional data
+     * @param PaymentEntityInterface   $payment             Payment
+     * @param AuditEventSubtype|string $subtype             Event subtype
+     * @param string                   $message             Status message
+     * @param array                    $data                Additional data
+     * @param int                      $intermediateMethods Number of intermediate methods between the actual method
+     * adding the event and this method (used for determining the caller name)
      *
      * @return void
      */
@@ -87,7 +89,8 @@ interface AuditEventServiceInterface extends DbServiceInterface
         PaymentEntityInterface $payment,
         AuditEventSubtype|string $subtype,
         string $message = '',
-        array $data = []
+        array $data = [],
+        int $intermediateMethods = 0
     ): void;
 
     /**

--- a/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentEventTrait.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentEventTrait.php
@@ -77,6 +77,6 @@ trait OnlinePaymentEventTrait
                 throw new \Exception('Event log service not set');
             }
         }
-        $this->auditEventService->addPaymentEvent($payment, $subtype, $message, $data);
+        $this->auditEventService->addPaymentEvent($payment, $subtype, $message, $data, 1);
     }
 }

--- a/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentManager.php
+++ b/module/VuFind/src/VuFind/OnlinePayment/OnlinePaymentManager.php
@@ -714,7 +714,7 @@ class OnlinePaymentManager implements LoggerAwareInterface
         $this->paymentService->beginTransaction();
         try {
             $this->paymentService->persistEntity($payment);
-            $this->auditEventService->addPaymentEvent($payment, $eventSubtype, $auditMessage, $eventData);
+            $this->auditEventService->addPaymentEvent($payment, $eventSubtype, $auditMessage, $eventData, 1);
         } catch (\Exception $e) {
             $this->paymentService->rollbackTransaction();
             throw $e;

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuditEventsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AuditEventsTest.php
@@ -261,7 +261,11 @@ final class AuditEventsTest extends \VuFindTest\Integration\MinkTestCase
 
         $eventData = array_map(
             function ($event) {
-                $data = preg_replace('/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', '<datetime>', $event->getData());
+                $data = preg_replace(
+                    '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/',
+                    '<datetime>',
+                    json_encode($event->getData())
+                );
                 $data = preg_replace('/"user_id":\d+/', '"user_id":<userid>', $data);
                 return [
                     $event->getType(),

--- a/themes/bootstrap5/templates/admin/payment/details-events.phtml
+++ b/themes/bootstrap5/templates/admin/payment/details-events.phtml
@@ -25,15 +25,14 @@
           <?=$this->escapeHtml($event->getServerName())?>
         </td>
         <td>
-          <?=$this->escapeHtml(json_decode($event->getData(), true)['__request_uri'] ?? '')?>
+          <?=$this->escapeHtml($event->getData()['__request_uri'] ?? '')?>
         </td>
         <td>
           <?=$this->transEsc('Payment::' . $event->getMessage())?>
         </td>
         <td>
           <?php
-            if ($data = $event->getData()) {
-              $details = json_decode($data, true);
+            if ($details = $event->getData()) {
               if ($error = $details['error'] ?? null) {
                 echo $this->transEsc("Payment::$error");
               }

--- a/themes/bootstrap5/templates/admin/payment/details-events.phtml
+++ b/themes/bootstrap5/templates/admin/payment/details-events.phtml
@@ -12,6 +12,7 @@
   </thead>
   <tbody>
     <?php foreach ($this->paymentEvents as $event): ?>
+      <?php $eventData = $event->getData(); ?>
       <tr>
         <td>
           <time datetime="<?=$this->escapeHtmlAttr($event->getDate()->format('Y-m-d\TH:i:s'))?>">
@@ -25,17 +26,15 @@
           <?=$this->escapeHtml($event->getServerName())?>
         </td>
         <td>
-          <?=$this->escapeHtml($event->getData()['__request_uri'] ?? '')?>
+          <?=$this->escapeHtml($eventData['__request_uri'] ?? '')?>
         </td>
         <td>
           <?=$this->transEsc('Payment::' . $event->getMessage())?>
         </td>
         <td>
           <?php
-            if ($details = $event->getData()) {
-              if ($error = $details['error'] ?? null) {
-                echo $this->transEsc("Payment::$error");
-              }
+            if ($error = $eventData['error'] ?? null) {
+              echo $this->transEsc("Payment::$error");
             }
           ?>
         </td>


### PR DESCRIPTION
TODO
- [x] Update changelog when merging: `:!: As part of a bug fix, some minor changes were made to the audit logging feature added in 11.0.0: the type of the data property (and related signatures in getData/setData) of AuditEventEntityInterface was changed from string to array, and a new $intermediateMethods parameter was added to the addPaymentEvent and getCallerOfParentMethod methods of AuditEventService. See [[https://github.com/vufind-org/vufind/pull/4912|pull request #4912]] for details.`