### PR TITLE
Add a space between exception message and server details.

### DIFF
--- a/module/VuFind/src/VuFind/Log/Logger.php
+++ b/module/VuFind/src/VuFind/Log/Logger.php
@@ -316,7 +316,7 @@ class Logger implements LoggerInterface, ExtendedLoggerInterface
         $referer = $server->get('HTTP_REFERER', 'none');
         $ipAddr = $this->userIpReader->getUserIp();
         $basicServer
-            = '(Server: IP = ' . $ipAddr . ', '
+            = ' (Server: IP = ' . $ipAddr . ', '
             . 'Referer = ' . $referer . ', '
             . 'User Agent = '
             . $server->get('HTTP_USER_AGENT') . ', '


### PR DESCRIPTION
It's just a space, but it was bugging me with lower logging levels that the server details didn't have a space before them.