### PR TITLE
Remove obsolete references to Google Analytics universal setting.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -494,17 +494,6 @@ class Upgrade implements LoggerAwareInterface
                 . ' please review your config.ini.'
             );
         }
-        if (isset($newConfig['GoogleAnalytics']['apiKey'])) {
-            if (
-                !isset($newConfig['GoogleAnalytics']['universal'])
-                || !$newConfig['GoogleAnalytics']['universal']
-            ) {
-                $this->addWarning(
-                    'The [GoogleAnalytics] universal setting is off. See config.ini '
-                    . 'for important information on how to upgrade your Analytics.'
-                );
-            }
-        }
 
         // Upgrade CAPTCHA Options
         $legacySettingsMap = [

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -60,17 +60,18 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
      * Constructor
      *
      * @param string|bool $key     API key (false if disabled)
-     * @param bool|array  $options Configuration options (supported options:
-     * 'universal' and 'create_options_js'). If a boolean is provided instead of
-     * an array, that value is used as the 'universal' setting and no other options
-     * are set (for backward compatibility).
+     * @param bool|array  $options Configuration options (supported option:
+     * 'create_options_js'). If a Boolean is provided instead of an array,
+     * no options will be set (for backward compatibility).
      */
     public function __construct($key, $options = [])
     {
-        // The second constructor parameter used to be a boolean representing
-        // the "universal" setting, so convert to an array for legacy compatibility:
+        // The second constructor parameter used to be a Boolean representing
+        // an obsolete setting, but that is no longer meaningful, so treat it as
+        // an empty array for legacy compatibility. We should remove Boolean
+        // support entirely in a future release.
         if (!is_array($options)) {
-            $options = ['universal' => (bool)$options];
+            $options = [];
         }
         $this->key = $key;
         $this->createOptions = $options['create_options_js'] ?? "'auto'";

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -374,13 +374,6 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertTrue(
             in_array(
-                'The [GoogleAnalytics] universal setting is off. See config.ini '
-                . 'for important information on how to upgrade your Analytics.',
-                $warnings
-            )
-        );
-        $this->assertTrue(
-            in_array(
                 'Google Maps is no longer a supported Content/recordMap option;'
                 . ' please review your config.ini.',
                 $warnings

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -75,7 +75,6 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
     {
         $createJs = "{cookie_flags: 'max-age=7200;secure;samesite=none'}";
         $options = [
-            'universal' => true,
             'create_options_js' => $createJs,
         ];
         $expectedUrl = 'https&#x3A;&#x2F;&#x2F;www.googletagmanager.com&#x2F;gtag&#x2F;js&#x3F;id&#x3D;myfakekey';


### PR DESCRIPTION
The GoogleAnalytics "universal" setting was removed some time ago (see #2402, included in release 9.0), but it was still referenced in several places. This PR cleans that up.

TODO
- [x] After merging, open follow-up 12.0 PR to remove the boolean options support from the helper.