### PR TITLE
Improve types in GoogleAnalytics view helper.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -43,37 +43,20 @@ use function is_array;
 class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
 {
     /**
-     * API key (false if disabled)
-     *
-     * @var string|bool
-     */
-    protected $key;
-
-    /**
      * Options to pass to the ga() create command.
      *
      * @var string
      */
-    protected $createOptions;
+    protected string $createOptions;
 
     /**
      * Constructor
      *
-     * @param string|bool $key     API key (false if disabled)
-     * @param bool|array  $options Configuration options (supported option:
-     * 'create_options_js'). If a Boolean is provided instead of an array,
-     * no options will be set (for backward compatibility).
+     * @param ?string $key     API key (null if disabled)
+     * @param array   $options Configuration options (supported option: 'create_options_js').
      */
-    public function __construct($key, $options = [])
+    public function __construct(protected ?string $key, array $options = [])
     {
-        // The second constructor parameter used to be a Boolean representing
-        // an obsolete setting, but that is no longer meaningful, so treat it as
-        // an empty array for legacy compatibility. We should remove Boolean
-        // support entirely in a future release.
-        if (!is_array($options)) {
-            $options = [];
-        }
-        $this->key = $key;
         $this->createOptions = $options['create_options_js'] ?? "'auto'";
     }
 

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -29,8 +29,6 @@
 
 namespace VuFind\View\Helper\Root;
 
-use function is_array;
-
 /**
  * GoogleAnalytics view helper
  *

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalyticsFactory.php
@@ -69,7 +69,7 @@ class GoogleAnalyticsFactory implements FactoryInterface
             throw new \Exception('Unexpected options passed to factory.');
         }
         $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config');
-        $key = $config->GoogleAnalytics->apiKey ?? false;
+        $key = $config->GoogleAnalytics->apiKey ?? null;
         $options = [
             'create_options_js' =>
                 $config->GoogleAnalytics->create_options_js ?? null,

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -99,18 +99,18 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
      */
     public function testDisabled(): void
     {
-        $this->assertEquals('', $this->renderGA(false));
+        $this->assertEquals('', $this->renderGA(null));
     }
 
     /**
      * Render the GA code
      *
-     * @param string $key     GA key (false for disabled)
-     * @param array  $options Options for GA helper
+     * @param ?string $key     GA key (null for disabled)
+     * @param array   $options Options for GA helper
      *
      * @return string
      */
-    protected function renderGA(string $key, $options = []): string
+    protected function renderGA(?string $key, array $options = []): string
     {
         $helper = new GoogleAnalytics($key, $options);
         $helper->setView($this->getPhpRenderer());


### PR DESCRIPTION
This is a follow-up to #4916, improving typing and removing obsolete functionality.

TODO
- [x] Update changelog when merging (removed Boolean support from view helper constructor and added types to signature)