### PR TITLE
Remove support for deprecated host/port LDAP settings.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -888,11 +888,8 @@ verify_server_certificate = false
 ; LDAP is optional.  This section only needs to exist if the
 ; Authentication Method is set to LDAP.  When LDAP is active,
 ; uri, basedn and username are required.
-; Using host and port instead of uri is deprecated.
 ;[LDAP]
 ;uri             = ldap://ldap.myuniversity.edu:389
-;host            = ldap.myuniversity.edu
-;port            = 389       ; LDAPS usually uses port 636 instead
 ; By default, when you use regular LDAP (not LDAPS), VuFind uses TLS security.
 ; You can set disable_tls to true to bypass TLS if your server does not support
 ; it. Note that this setting is ignored if you use ldaps:// in the host setting.

--- a/module/VuFind/src/VuFind/Auth/LDAP.php
+++ b/module/VuFind/src/VuFind/Auth/LDAP.php
@@ -70,8 +70,7 @@ class LDAP extends AbstractBase
         if (
             empty($this->config->LDAP->basedn ?? '')
             || empty($this->config->LDAP->username ?? '')
-            || (empty($this->config->LDAP->uri ?? '')
-                && empty($this->config->LDAP->host ?? ''))
+            || empty($this->config->LDAP->uri ?? '')
         ) {
             throw new AuthException(
                 'One or more LDAP parameters are missing. Check your config.ini!'
@@ -159,20 +158,6 @@ class LDAP extends AbstractBase
         // is unavailable -- we need to check for bad return values again at search
         // time!
         $uri = $this->getSetting('uri');
-        if (!$uri) {
-            // Use deprecated old settings.
-            $host = $this->getSetting('host');
-            if (str_starts_with($host, 'ldap://') || str_starts_with($host, 'ldaps://')) {
-                $uri = $host;
-            } else {
-                $port = $this->getSetting('port');
-                if ($port === '') {
-                    $port = 389;
-                }
-                $uri = 'ldap://' . $host . ':' . $port;
-            }
-        }
-
         $this->debug("connecting to URI=$uri");
         $connection = @ldap_connect($uri);
         if (!$connection) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/LDAPTest.php
@@ -107,20 +107,6 @@ class LDAPTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test legacy host/port configuration.
-     *
-     * @return void
-     */
-    public function testLegacyHostAndPortConfiguration(): void
-    {
-        $config = $this->getAuthConfig();
-        unset($config['LDAP']['uri']);
-        $config['LDAP']['host'] = 'localhost';
-        $config['LDAP']['port'] = '636';
-        $this->assertIsObject($this->getAuthObject($config)->getConfig());
-    }
-
-    /**
      * Test case normalization of parameters.
      *
      * @return void


### PR DESCRIPTION
This is a follow-up to #4645, removing legacy compatibility logic for old host/port LDAP settings. (Support is retained in the VuFind\Config\Upgrade class, so legacy configurations will still be upgraded correctly -- the change here is that outdated configs will no longer work without being upgraded).

TODO
- [x] Update changelog when merging