### PR TITLE
Clone any DateTime to return in entities' getters.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/AccessToken.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AccessToken.php
@@ -187,7 +187,8 @@ class AccessToken implements AccessTokenEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/ApiKey.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ApiKey.php
@@ -194,7 +194,8 @@ class ApiKey implements ApiKeyEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**
@@ -217,7 +218,8 @@ class ApiKey implements ApiKeyEntityInterface
      */
     public function getLastUsed(): DateTime
     {
-        return $this->lastUsed;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->lastUsed);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/AuditEvent.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AuditEvent.php
@@ -178,7 +178,8 @@ class AuditEvent implements AuditEventEntityInterface
      */
     public function getDate(): DateTime
     {
-        return $this->date;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->date);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/AuthHash.php
+++ b/module/VuFind/src/VuFind/Db/Entity/AuthHash.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for auth_hash table
@@ -48,6 +49,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class AuthHash implements AuthHashEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Unique ID.
      *
@@ -216,7 +219,8 @@ class AuthHash implements AuthHashEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/ChangeTracker.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ChangeTracker.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for change_tracker table
@@ -46,6 +47,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class ChangeTracker implements ChangeTrackerEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Solr core containing record.
      *
@@ -162,7 +165,8 @@ class ChangeTracker implements ChangeTrackerEntityInterface
      */
     public function getFirstIndexed(): ?DateTime
     {
-        return $this->firstIndexed;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->firstIndexed);
     }
 
     /**
@@ -185,7 +189,8 @@ class ChangeTracker implements ChangeTrackerEntityInterface
      */
     public function getLastIndexed(): ?DateTime
     {
-        return $this->lastIndexed;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->lastIndexed);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Comments.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Comments.php
@@ -149,7 +149,8 @@ class Comments implements CommentsEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/ExternalSession.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ExternalSession.php
@@ -156,7 +156,8 @@ class ExternalSession implements ExternalSessionEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Feedback.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Feedback.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for feedback table
@@ -50,6 +51,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class Feedback implements FeedbackEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Unique ID.
      *
@@ -243,7 +246,8 @@ class Feedback implements FeedbackEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/LoginToken.php
+++ b/module/VuFind/src/VuFind/Db/Entity/LoginToken.php
@@ -233,7 +233,8 @@ class LoginToken implements LoginTokenEntityInterface
      */
     public function getLastLogin(): DateTime
     {
-        return $this->lastLogin;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->lastLogin);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/OaiResumption.php
+++ b/module/VuFind/src/VuFind/Db/Entity/OaiResumption.php
@@ -171,6 +171,7 @@ class OaiResumption implements OaiResumptionEntityInterface
      */
     public function getExpiry(): DateTime
     {
-        return $this->expires;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->expires);
     }
 }

--- a/module/VuFind/src/VuFind/Db/Entity/Payment.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Payment.php
@@ -391,7 +391,8 @@ class Payment implements PaymentEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Ratings.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Ratings.php
@@ -195,7 +195,8 @@ class Ratings implements RatingsEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Record.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Record.php
@@ -221,7 +221,8 @@ class Record implements RecordEntityInterface
      */
     public function getUpdated(): DateTime
     {
-        return $this->updated;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->updated);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/ResourceTags.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ResourceTags.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for resource_tags table
@@ -49,6 +50,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class ResourceTags implements ResourceTagsEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Unique ID.
      *
@@ -227,7 +230,8 @@ class ResourceTags implements ResourceTagsEntityInterface
      */
     public function getPosted(): DateTime
     {
-        return $this->posted;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->posted);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Search.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Search.php
@@ -244,7 +244,8 @@ class Search implements SearchEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**
@@ -408,7 +409,8 @@ class Search implements SearchEntityInterface
      */
     public function getLastNotificationSent(): DateTime
     {
-        return $this->lastNotificationSent;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->lastNotificationSent);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/Shortlinks.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Shortlinks.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for shortlinks table
@@ -46,6 +47,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class Shortlinks implements ShortlinksEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Unique ID.
      *
@@ -153,7 +156,8 @@ class Shortlinks implements ShortlinksEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/User.php
+++ b/module/VuFind/src/VuFind/Db/Entity/User.php
@@ -708,7 +708,8 @@ class User implements UserEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/UserCard.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserCard.php
@@ -280,7 +280,8 @@ class UserCard implements UserCardEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**
@@ -303,7 +304,8 @@ class UserCard implements UserCardEntityInterface
      */
     public function getSaved(): DateTime
     {
-        return $this->saved;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->saved);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/UserList.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserList.php
@@ -222,7 +222,8 @@ class UserList implements UserListEntityInterface
      */
     public function getCreated(): DateTime
     {
-        return $this->created;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->created);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/UserResource.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserResource.php
@@ -31,6 +31,7 @@ namespace VuFind\Db\Entity;
 
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use VuFind\Db\Feature\DateTimeTrait;
 
 /**
  * Entity model for user_resource table
@@ -48,6 +49,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class UserResource implements UserResourceEntityInterface
 {
+    use DateTimeTrait;
+
     /**
      * Unique ID.
      *
@@ -219,7 +222,8 @@ class UserResource implements UserResourceEntityInterface
      */
     public function getSaved(): DateTime
     {
-        return $this->saved;
+        // Return to a clone to avoid indirect modification of the entity:
+        return $this->getDateTimeClone($this->saved);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Feature/DateTimeTrait.php
+++ b/module/VuFind/src/VuFind/Db/Feature/DateTimeTrait.php
@@ -44,7 +44,7 @@ use DateTimeZone;
 trait DateTimeTrait
 {
     /**
-     * Get a date or null from non-nullable date with a default value.
+     * Get a (clone) date or null from non-nullable date with a default value.
      *
      * @param DateTime $date Date
      *
@@ -55,7 +55,7 @@ trait DateTimeTrait
         // Compare strings to avoid trouble with time zones:
         return $date->format(VUFIND_DATABASE_DATETIME_FORMAT)
             !== $this->getUnassignedDefaultDateTime()->format(VUFIND_DATABASE_DATETIME_FORMAT)
-            ? $date
+            ? $this->getDateTimeClone($date)
             : null;
     }
 
@@ -68,7 +68,7 @@ trait DateTimeTrait
      */
     protected function getNonNullableDateTimeFromNullable(?DateTime $date): DateTime
     {
-        return $date ?? $this->getUnassignedDefaultDateTime();
+        return $this->getDateTimeClone($date) ?? $this->getUnassignedDefaultDateTime();
     }
 
     /**
@@ -79,5 +79,17 @@ trait DateTimeTrait
     protected function getUnassignedDefaultDateTime(): DateTime
     {
         return DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-01 00:00:00', new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Return a clone for DateTime, or null if provided null.
+     *
+     * @param ?DateTime $dateTime DateTime or null
+     *
+     * @return ?DateTime
+     */
+    protected function getDateTimeClone(?DateTime $dateTime): ?DateTime
+    {
+        return $dateTime ? clone $dateTime : null;
     }
 }


### PR DESCRIPTION
This avoids indirect/accidental updates to entities if the returned dates are manipulated.