### PR TITLE
Aleph driver: ensure XML is properly converted to string.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1229,7 +1229,7 @@ class Aleph extends AbstractBase implements
         return $this->createProfileArray(
             firstname: $firstname,
             lastname: $lastname,
-            group: $xml->xpath('//institution/z305-bor-status')[0],
+            group: (string)$xml->xpath('//institution/z305-bor-status')[0],
             city: $mappedValues['city'] ?? null,
             country: $mappedValues['country'] ?? null,
             phone: $mappedValues['phone'] ?? null,
@@ -1238,7 +1238,7 @@ class Aleph extends AbstractBase implements
             address2: $mappedValues['address2'] ?? null,
             zip: $mappedValues['zip'] ?? null,
             birthdate: $mappedValues['birthdate'] ?? '',
-            expiration_date: $this->parseDate($expiry[0]),
+            expiration_date: $this->parseDate((string)$expiry[0]),
             // Merge all mapped values here even if all the default values are checked
             // independently. This ensures that all the possible values are being set correctly
             // and clarification what is being output remains.


### PR DESCRIPTION
This PR addresses a couple of instances where simple XML objects are not explicitly converted to strings. In the first case, typing on function parameters probably handles the conversion anyway, but it doesn't hurt to be explicit, especially in case we increase type strictness in the future.

(This was discovered due to a report that placing a hold with Aleph in release 10.2.1 leads to an error about serializing XML into the session).