### PR TITLE
Folio: Avoid duplicate bound-with items

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -603,61 +603,79 @@ class Folio extends AbstractAPI implements
     /**
      * Support method for getHoldings() -- retrieve items by holding ids (including bound-with items)
      *
-     * @param string[] $holdingIds the FOLIO holdings ids
+     * @param string[] $holdingsIds the FOLIO holdings ids
      *
      * @return object[] The items, with an additional queryHoldingsRecordId property with the matching holdings id
      * @throws ILSException if there is an issue with the FOLIO response
      */
-    protected function getItemsByHoldingIds(array $holdingIds)
+    protected function getItemsByHoldingIds(array $holdingsIds)
     {
-        if (count($holdingIds) == 0) {
+        if (count($holdingsIds) == 0) {
             return [];
         }
         $items = [];
         $folioItemSort = $this->config['Holdings']['folio_sort'] ?? '';
-        $querySuffix = !empty($folioItemSort) ? ' sortby ' . $folioItemSort : '';
-        if (count($holdingIds) == 1) {
+        if (!empty($folioItemSort)) {
+            $querySuffix = ' sortby ' . $folioItemSort;
+        } else {
+            $querySuffix = '';
+        }
+        if (count($holdingsIds) == 1) {
             // /inventory/items-by-holdings-id returns bound-with items too (but it only takes one holdingsRecordId)
             foreach (
                 $this->getByBatch(
-                    $holdingIds,
+                    $holdingsIds,
                     'holdingsRecordId',
                     'items',
                     '/inventory/items-by-holdings-id',
                     $querySuffix
                 ) as $item
             ) {
-                $item->queryHoldingsRecordId = $holdingIds[0];
+                $item->queryHoldingsRecordId = $holdingsIds[0];
                 $items[] = $item;
             }
             return $items;
         }
-        // /inventory/items does not return bound-with items, we have to retrieve them afterwards
+        // Retrieve the item records
+        $holdingsItemIds = [];
+        foreach ($holdingsIds as $holdingsId) {
+            $holdingsItemIds[$holdingsId] = [];
+        }
         foreach (
             $this->getByBatch(
-                $holdingIds,
+                $holdingsIds,
                 'holdingsRecordId',
                 'items',
                 '/inventory/items',
                 $querySuffix
             ) as $item
         ) {
-            $item->queryHoldingsRecordId = $item->holdingsRecordId;
+            $holdingsId = $item->holdingsRecordId;
+            $item->queryHoldingsRecordId = $holdingsId;
+            $holdingsItemIds[$holdingsId][] = $item->id;
             $items[] = $item;
         }
+        // Retrieve the related bound-with items
+        // Duplicate items are avoided for each holdings
         $boundWithItemIds = [];
         $itemIdToHoldingsRecordId = [];
         foreach (
             $this->getByBatch(
-                $holdingIds,
+                $holdingsIds,
                 'holdingsRecordId',
                 'boundWithParts',
                 '/inventory-storage/bound-with-parts',
                 $querySuffix
             ) as $boundWithPart
         ) {
-            $boundWithItemIds[] = $boundWithPart->itemId;
-            $itemIdToHoldingsRecordId[$boundWithPart->itemId] = $boundWithPart->holdingsRecordId;
+            $itemId = $boundWithPart->itemId;
+            $holdingsId = $boundWithPart->holdingsRecordId;
+            if (in_array($itemId, $holdingsItemIds[$holdingsId])) {
+                continue;
+            }
+            $holdingsItemIds[$holdingsId][] = $itemId;
+            $boundWithItemIds[] = $itemId;
+            $itemIdToHoldingsRecordId[$itemId] = $holdingsId;
         }
         foreach (
             $this->getByBatch(

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -615,11 +615,7 @@ class Folio extends AbstractAPI implements
         }
         $items = [];
         $folioItemSort = $this->config['Holdings']['folio_sort'] ?? '';
-        if (!empty($folioItemSort)) {
-            $querySuffix = ' sortby ' . $folioItemSort;
-        } else {
-            $querySuffix = '';
-        }
+        $querySuffix = empty($folioItemSort) ? '' : ' sortby ' . $folioItemSort;
         if (count($holdingsIds) == 1) {
             // /inventory/items-by-holdings-id returns bound-with items too (but it only takes one holdingsRecordId)
             foreach (


### PR DESCRIPTION
When items in FOLIO are linked to their holdings (as bound-with records), they appear twice in the VuFind holdings page.
I am not sure why anyone would do that, but the fact is that it did occur in our library.

This PR avoids duplicates for each holdings. Some items might still be returned twice by `getItemsByHoldingIds()` if they are bound-with items for separate holdings. This can for instance be useful when loading the statuses for several instances at the same time, for the search results page.