### PR TITLE
Channels tab: enable AJAX compatibility.

### DIFF
--- a/config/vufind/RecordTabs.ini
+++ b/config/vufind/RecordTabs.ini
@@ -155,6 +155,7 @@ defaultTab = null
 ; by a tab. Settings are named by the tab name (X above) and may be repeated if
 ; multiple scripts are required.
 [TabScripts]
+Channels[] = channels.js
 Versions[] = combined-search.js
 Versions[] = check_item_statuses.js
 Versions[] = record_versions.js

--- a/module/VuFind/src/VuFind/RecordTab/Channels.php
+++ b/module/VuFind/src/VuFind/RecordTab/Channels.php
@@ -70,17 +70,6 @@ class Channels extends AbstractBase
     }
 
     /**
-     * Can this tab be loaded via AJAX?
-     *
-     * @return bool
-     */
-    public function supportsAjax()
-    {
-        // Due to heavy Javascript in channels, the tab cannot be AJAX-loaded:
-        return false;
-    }
-
-    /**
      * Return context variables used for rendering the block's template.
      *
      * @return array

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ChannelsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordTab/ChannelsTest.php
@@ -85,7 +85,7 @@ class ChannelsTest extends \PHPUnit\Framework\TestCase
      */
     public function testSupportsAjax(): void
     {
-        $this->assertFalse($this->getChannels()->supportsAjax());
+        $this->assertTrue($this->getChannels()->supportsAjax());
     }
 
     /**

--- a/themes/bootstrap5/templates/channels/channelList.phtml
+++ b/themes/bootstrap5/templates/channels/channelList.phtml
@@ -1,9 +1,5 @@
 <?php
   $this->assetManager()->appendScriptLink('channels.js');
-  $this->jsTranslations()->addStrings([
-    'channel_more_items' => 'channel_more_items',
-    'nohit_heading' => 'nohit_heading',
-  ]);
 ?>
 
 <?php if (empty($token) && ($displaySearchBox ?? true)): // no results ?>

--- a/themes/bootstrap5/templates/layout/js-translations.phtml
+++ b/themes/bootstrap5/templates/layout/js-translations.phtml
@@ -8,6 +8,7 @@ $this->jsTranslations()->addStrings(
       'bulk_limit_exceeded' => 'bulk_limit_exceeded',
       'bulk_noitems_advice' => 'bulk_noitems_advice',
       'bulk_save_success' => 'bulk_save_success',
+      'channel_more_items' => 'channel_more_items',
       'clear_selection' => 'clear_selection',
       'close' => 'close',
       'collection_empty' => 'collection_empty',
@@ -28,6 +29,7 @@ $this->jsTranslations()->addStrings(
       'modified_filter_count' => 'modified_filter_count',
       'more_ellipsis' => 'more_ellipsis',
       'no_description' => 'no_description',
+      'nohit_heading' => 'nohit_heading',
       'number_thousands_separator' => [
         'number_thousands_separator', [], ',',
       ],

--- a/themes/bootstrap5/templates/myresearch/mylist.phtml
+++ b/themes/bootstrap5/templates/myresearch/mylist.phtml
@@ -16,6 +16,7 @@
   // Load Javascript only if list view parameter is NOT full:
   if ($this->params->getOptions()->getListViewOption() != 'full') {
     $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('channels.js');
     $this->assetManager()->appendScriptLink('embedded_record.js');
   }
 

--- a/themes/bootstrap5/templates/search/results-scripts.phtml
+++ b/themes/bootstrap5/templates/search/results-scripts.phtml
@@ -9,6 +9,7 @@ if ($this->displayVersions) {
 // Load only if list view parameter is NOT full:
 if (($this->listViewOption ?? 'full') !== 'full') {
     $this->assetManager()->appendScriptLink('record.js');
+    $this->assetManager()->appendScriptLink('channels.js');
     $this->assetManager()->appendScriptLink('embedded_record.js');
 }
 if ($this->jsResults ?? false) {


### PR DESCRIPTION
Based on discussion in #4901, I thought it would be a good idea to investigate the feasibility of getting the Channels record tab out of "no AJAX" mode. Turns out it was simpler than I expected -- just required moving some translations into the global file instead of making them template-specific and enabling the channels.js Javascript file in a couple of extra places (one for record tabs, one for accordion/tab search result views).

I'll be interested to hear whether anyone has concerns about this. I can move the milestone to 11.1 if this is too significant a change for a patch release, but it's such a big improvement to accessibility that I'd rather not wait if it's safe.