### PR TITLE
Fix incorrect hierarchy field names in comments.

### DIFF
--- a/config/vufind/HierarchyDefault.ini
+++ b/config/vufind/HierarchyDefault.ini
@@ -1,8 +1,8 @@
 [Collections]
 ; What determines which records get linked to the Collection module instead of the
 ; Record module?  Legal values:
-;     All  - any record with is_hierarchy set
-;     Top  - any record where is_hierarchy = hierarchy_top
+;     All  - any record with is_hierarchy_id set
+;     Top  - any record where is_hierarchy_id = hierarchy_top_id
 ;     None - never link to the collection module
 link_type = "Top"
 ; When a user searches within a collection, which Solr field should be used to filter

--- a/config/vufind/HierarchyFlat.ini
+++ b/config/vufind/HierarchyFlat.ini
@@ -1,8 +1,8 @@
 [Collections]
 ; What determines which records get linked to the Collection module instead of the
 ; Record module?  Legal values:
-;     All  - any record with is_hierarchy set
-;     Top  - any record where is_hierarchy = hierarchy_top
+;     All  - any record with is_hierarchy_id set
+;     Top  - any record where is_hierarchy_id = hierarchy_top_id
 ;     None - never link to the collection module
 link_type = "Top"
 ; When a user searches within a collection, which Solr field should be used to filter


### PR DESCRIPTION
Incomplete field names were used in comments in the hierarchy .ini files -- this PR corrects them to the full versions.