### PR TITLE
Fix Alma ILS driver to return default status with availability and location if needed

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1779,6 +1779,8 @@ class Alma extends AbstractBase implements
                     'id' => (string)$bib->mms_id,
                     'source' => 'Solr',
                     'callnumber' => '',
+                    'availability' => AvailabilityStatusInterface::STATUS_UNKNOWN,
+                    'location' => '',
                     'reserve' => 'N',
                 ];
                 // Physical
@@ -1863,6 +1865,9 @@ class Alma extends AbstractBase implements
                         );
                     }
                     $status[] = $item;
+                }
+                if (empty($status)) {
+                    $status[] = $tmpl;
                 }
                 $results[(string)$bib->mms_id] = $status;
             }


### PR DESCRIPTION
Currently the status was only set for physical, electronic and digital items.

For bibliographic records like serials which did not have any of these items, no status was set. This resulted in "Loading..." being shown for "Call Number" and "Location".

See [related discussion on Slack](https://app.slack.com/client/T1EPYQDAQ/C08K7F6M61E).