### PR TITLE
[VUFIND-1811] Improved format detection for video games and datasets

### DIFF
--- a/import/index_java/src/org/vufind/index/FormatCalculator.java
+++ b/import/index_java/src/org/vufind/index/FormatCalculator.java
@@ -608,7 +608,7 @@ public class FormatCalculator
             if (desc.equals("computer program")) {
                 return List.of(); // rely on getFormatFromRecordType(), 008/26 is more precise
             }
-            if ((desc.equals("two-dimensional moving image") || code.equals("tdi")) && source.equals("rdacontent")) {
+            if (desc.equals("two-dimensional moving image") || (source.equals("rdacontent") && code.equals("tdi"))) {
                 formats.add("Video");
                 if (isOnline) {
                     formats.add("VideoOnline");
@@ -616,7 +616,7 @@ public class FormatCalculator
             }
             boolean computerOrCartographicDS = desc.equals("computer dataset") || desc.equals("cartographic dataset");
             boolean crdOrCod = code.equals("crd") || code.equals("cod");
-            if (source.equals("rdacontent") && (computerOrCartographicDS || crdOrCod)) {
+            if (computerOrCartographicDS || (source.equals("rdacontent") && crdOrCod)) {
                 formats.add("DataSet");
             }
         }

--- a/import/index_java/src/org/vufind/index/FormatCalculator.java
+++ b/import/index_java/src/org/vufind/index/FormatCalculator.java
@@ -605,11 +605,19 @@ public class FormatCalculator
             String desc = getSubfieldOrDefault(typeField, 'a', "");
             String code = getSubfieldOrDefault(typeField, 'b', "");
             String source = getSubfieldOrDefault(typeField, '2', "");
+            if (desc.equals("computer program")) {
+                return List.of(); // rely on getFormatFromRecordType(), 008/26 is more precise
+            }
             if ((desc.equals("two-dimensional moving image") || code.equals("tdi")) && source.equals("rdacontent")) {
                 formats.add("Video");
                 if (isOnline) {
                     formats.add("VideoOnline");
                 }
+            }
+            boolean computerOrCartographicDS = desc.equals("computer dataset") || desc.equals("cartographic dataset");
+            boolean crdOrCod = code.equals("crd") || code.equals("cod");
+            if (source.equals("rdacontent") && (computerOrCartographicDS || crdOrCod)) {
+                formats.add("DataSet");
             }
         }
         return formats;


### PR DESCRIPTION
See [VUFIND-1811](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1811).

This PR improves the format detection for video games and datasets.
- When `336a = "computer program"`, rely on `008/26` instead of the `33X` fields to detect the format
- Added detection of computer and cartographic datasets using `33X` fields with `rdacontent` source

A reindex is needed to take advantage of the change for existing records.
