### PR TITLE
Add Mink test coverage for ILS-driven New Items.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
@@ -85,8 +85,8 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
             [
                 'config' => [
                     'Catalog' => [
-                        'driver' => 'Demo'
-                    ]
+                        'driver' => 'Demo',
+                    ],
                 ],
                 'Demo' => $this->getDemoIniOverrides(...$expectedIds),
                 'searches' => [

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
+use VuFindTest\Feature\DemoDriverTestTrait;
 
 /**
  * Test new item search functionality.
@@ -42,6 +43,8 @@ use Behat\Mink\Element\Element;
  */
 class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
 {
+    use DemoDriverTestTrait;
+
     /**
      * Submit a new item search and return the resulting page object.
      *
@@ -67,6 +70,46 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.form-search-newitem input[type="submit"]');
         $this->waitForPageLoad($page);
         return $page;
+    }
+
+    /**
+     * Test that new items can be retrieved from the ILS.
+     *
+     * @return void
+     */
+    public function testILSDrivenNewItems(): void
+    {
+        // This only works for exactly 2 IDs due to the way getDemoIniOverrides works:
+        $expectedIds = ['testsample1', 'testsample2'];
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Catalog' => [
+                        'driver' => 'Demo'
+                    ]
+                ],
+                'Demo' => $this->getDemoIniOverrides(...$expectedIds),
+                'searches' => [
+                    'NewItem' => [
+                        'method' => 'ils',
+                    ],
+                ],
+            ]
+        );
+        $page = $this->submitNewItemSearch();
+        // Confirm that we've reached the custom results page:
+        $this->assertStringStartsWith(
+            'Showing 1 - 2 results of 2 New Items',
+            $this->findCssAndGetText($page, '.search-stats')
+        );
+        // Confirm that the listed records are the ones found in getDemoIniOverrides() config
+        $results = $page->findAll('css', 'h2 a.title');
+        $extractId = function ($result) {
+            $href = $result->getAttribute('href');
+            preg_match('|/Record/([^?]+)|', $href, $matches);
+            return $matches[1];
+        };
+        $this->assertSame($expectedIds, array_map($extractId, $results));
     }
 
     /**


### PR DESCRIPTION
While testing #4922, I noticed that there was a gap in the Mink test suite -- this PR adds missing test coverage for ILS-driven new items searching.