### PR TITLE
Fix update_resource_metadata util to clear entities after each iteration.

### DIFF
--- a/module/VuFind/src/VuFind/Db/PersistenceManager.php
+++ b/module/VuFind/src/VuFind/Db/PersistenceManager.php
@@ -115,6 +115,18 @@ class PersistenceManager implements DbServiceAwareInterface
     }
 
     /**
+     * Clear all entities from EntityManager.
+     *
+     * Allows all managed entities to be detached so that they don't pile up during batch processing.
+     *
+     * @return void
+     */
+    public function clearAllEntities(): void
+    {
+        $this->entityManager->clear();
+    }
+
+    /**
      * Detach an entity from being managed.
      *
      * Allows entities to become unmanaged so that they don't pile up in the EntityManager during batch processing.

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
@@ -170,7 +170,7 @@ class UpdateResourceMetadataCommand extends Command
                 }
             }
             $this->persistenceManager->flushEntities();
-            array_walk($resources, [$this->persistenceManager, 'detachEntity']);
+            $this->persistenceManager->clearAllEntities();
             $output->writeln(
                 "<info>$updated records updated ($redirected redirects), $missing records missing</info>"
             );

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
@@ -161,7 +161,7 @@ class UpdateResourceMetadataCommand extends Command
                 } else {
                     $this->resourcePopulator->assignMetadata($resource, $driver);
                     $resource->setUpdated(new DateTime());
-                    $driverRecordId = $driver->getUniqueId();
+                    $driverRecordId = $driver->getUniqueID();
                     if ($recordId != $driverRecordId) {
                         $resource->setRecordId($driverRecordId);
                         ++$redirected;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
@@ -143,7 +143,8 @@ class UpdateResourceMetadataCommand extends Command
                 $lastId = $resource->getId();
                 $recordId = $resource->getRecordId();
                 $source = $resource->getSource();
-                assert($recordId == $driver->getUniqueID());
+                $driverRecordId = $driver->getUniqueID();
+                assert($recordId == $driverRecordId);
                 if ($output->isVerbose()) {
                     $output->writeln("Checking record {$source}:{$recordId}");
                 }
@@ -161,7 +162,6 @@ class UpdateResourceMetadataCommand extends Command
                 } else {
                     $this->resourcePopulator->assignMetadata($resource, $driver);
                     $resource->setUpdated(new DateTime());
-                    $driverRecordId = $driver->getUniqueID();
                     if ($recordId != $driverRecordId) {
                         $resource->setRecordId($driverRecordId);
                         ++$redirected;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
@@ -43,8 +43,6 @@ use VuFind\Record\Loader;
 use VuFind\Record\ResourcePopulator;
 use VuFind\RecordDriver\Missing as MissingRecord;
 
-use function assert;
-
 /**
  * Command for updating metadata in the resource table.
  *

--- a/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Util/UpdateResourceMetadataCommand.php
@@ -143,8 +143,6 @@ class UpdateResourceMetadataCommand extends Command
                 $lastId = $resource->getId();
                 $recordId = $resource->getRecordId();
                 $source = $resource->getSource();
-                $driverRecordId = $driver->getUniqueID();
-                assert($recordId == $driverRecordId);
                 if ($output->isVerbose()) {
                     $output->writeln("Checking record {$source}:{$recordId}");
                 }
@@ -162,6 +160,7 @@ class UpdateResourceMetadataCommand extends Command
                 } else {
                     $this->resourcePopulator->assignMetadata($resource, $driver);
                     $resource->setUpdated(new DateTime());
+                    $driverRecordId = $driver->getUniqueID();
                     if ($recordId != $driverRecordId) {
                         $resource->setRecordId($driverRecordId);
                         ++$redirected;

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
@@ -110,7 +110,7 @@ class UpdateResourceMetadataCommandTest extends \PHPUnit\Framework\TestCase
         );
 
         $driver = $this->createMock(DefaultRecord::class);
-        $driver->expects($this->any())
+        $driver->expects($this->once())
             ->method('getUniqueID')
             ->willReturn('foo');
         $loader = $this->createMock(Loader::class);

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
@@ -121,6 +121,8 @@ class UpdateResourceMetadataCommandTest extends \PHPUnit\Framework\TestCase
 
         $persistenceManager = $this->createMock(PersistenceManager::class);
         $persistenceManager->expects($this->once())
+            ->method('flushEntities');
+        $persistenceManager->expects($this->once())
             ->method('clearAllEntities');
 
         $command = new UpdateResourceMetadataCommand(

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
@@ -110,7 +110,7 @@ class UpdateResourceMetadataCommandTest extends \PHPUnit\Framework\TestCase
         );
 
         $driver = $this->createMock(DefaultRecord::class);
-        $driver->expects($this->exactly(2))
+        $driver->expects($this->any())
             ->method('getUniqueID')
             ->willReturn('foo');
         $loader = $this->createMock(Loader::class);

--- a/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
+++ b/module/VuFindConsole/tests/unit-tests/src/VuFindTest/Command/Util/UpdateResourceMetadataCommandTest.php
@@ -30,11 +30,14 @@
 namespace VuFindTest\Command\Util;
 
 use Symfony\Component\Console\Tester\CommandTester;
+use VuFind\Db\Entity\ResourceEntityInterface;
 use VuFind\Db\PersistenceManager;
 use VuFind\Db\Service\ResourceServiceInterface;
 use VuFind\Record\Loader;
 use VuFind\Record\ResourcePopulator;
+use VuFind\RecordDriver\DefaultRecord;
 use VuFindConsole\Command\Util\UpdateResourceMetadataCommand;
+use VuFindTest\Feature\WithConsecutiveTrait;
 
 /**
  * UpdateResourceMetadataCommand test.
@@ -47,6 +50,8 @@ use VuFindConsole\Command\Util\UpdateResourceMetadataCommand;
  */
 class UpdateResourceMetadataCommandTest extends \PHPUnit\Framework\TestCase
 {
+    use WithConsecutiveTrait;
+
     /**
      * Data provider for testUpdate
      *
@@ -77,22 +82,59 @@ class UpdateResourceMetadataCommandTest extends \PHPUnit\Framework\TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('updateProvider')]
     public function testUpdate(array $commandParams, array $expectedFindParams)
     {
+        $resource = $this->createMock(ResourceEntityInterface::class);
+        $resource->expects($this->once())
+            ->method('getId')
+            ->willReturn(123);
+        $resource->expects($this->exactly(2))
+            ->method('getRecordId')
+            ->willReturn('foo');
+        $resource->expects($this->exactly(2))
+            ->method('getSource')
+            ->willReturn('src');
         $resourceService = $this->createMock(ResourceServiceInterface::class);
-        $resourceService->expects($this->once())
-            ->method('findMetadataToUpdate')
-            ->with(...$expectedFindParams)
-            ->willReturn([]);
+
+        $secondFindParams = $expectedFindParams;
+        $secondFindParams[0] = 123;
+        $this->expectConsecutiveCalls(
+            $resourceService,
+            'findMetadataToUpdate',
+            [
+                $expectedFindParams,
+                $secondFindParams,
+            ],
+            [
+                [$resource],
+                [],
+            ]
+        );
+
+        $driver = $this->createMock(DefaultRecord::class);
+        $driver->expects($this->exactly(2))
+            ->method('getUniqueID')
+            ->willReturn('foo');
+        $loader = $this->createMock(Loader::class);
+        $loader->expects($this->once())
+            ->method('loadBatch')
+            ->with([['id' => 'foo', 'source' => 'src']])
+            ->willReturn([$driver]);
+
+        $persistenceManager = $this->createMock(PersistenceManager::class);
+        $persistenceManager->expects($this->once())
+            ->method('clearAllEntities');
+
         $command = new UpdateResourceMetadataCommand(
             $resourceService,
-            $this->createMock(Loader::class),
+            $loader,
             $this->createMock(ResourcePopulator::class),
-            $this->createMock(PersistenceManager::class)
+            $persistenceManager
         );
         $commandTester = new CommandTester($command);
         $commandTester->execute($commandParams);
         $this->assertEquals(0, $commandTester->getStatusCode());
         $this->assertEquals(
-            "Updating resource metadata\nResource metadata update completed\n",
+            "Updating resource metadata\n1 records updated (0 redirects), 0 records missing\n"
+            . "Resource metadata update completed\n",
             $commandTester->getDisplay()
         );
     }


### PR DESCRIPTION
This ensures more thoroughly than the previous mechanism that tracked entities do not accumulate and cause excessive memory usage.