### PR TITLE
Add more CSP directives to contentsecuritypolicy.ini

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1500,7 +1500,7 @@ window_settings = "toolbar=no,location=no,directories=no,buttons=no,status=no,me
 ; If you want to display a graphical link to your link resolver, uncomment the
 ; settings below.  graphic should be a URL; graphic_width and graphic_height
 ; should be sizes in pixels.
-; Note: You will probably will need to add URL of image to img-src setting
+; Note: You will probably need to add URL of image to img-src setting
 ; in contentsecuritypolicy.ini file
 ;graphic = "http://myuniversity.edu/images/findIt.gif"
 ;graphic_width = 50
@@ -2441,9 +2441,10 @@ validateHierarchySequences = true
 ; Matomo analytics version 4 and later (for version 3 and earlier, use Piwik section
 ; below):
 ; Uncomment this section and provide your Matomo server address and site id to enable
-; Matomo analytics.
+; Matomo analytics. Note: The Matomo URL should also be provided in the related
+; connect-src setting of contentsecuritypolicy.ini.
 [Matomo]
-;url = "http://server.address/matomo/"
+;url = "https://server.address/matomo/"
 ;site_id = 1
 ; Uncomment and modify the following settings to track additional information about
 ; searches and displayed records with Matomo's custom dimensions. Each entry maps an

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1212,6 +1212,7 @@ authors         = Wikipedia
 
 ; You can select from Google, OpenLibrary, HathiTrust.  You should consult
 ; https://developers.google.com/books/branding before using Google Book Search.
+; If using a CSP, you may also need to add settings to contentsecuritypolicy.ini.
 ;previews       = Google,OpenLibrary,HathiTrust
 
 ; This setting controls whether or not cover images are linked to previews when

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -49,6 +49,9 @@ worker-src[] = "blob:"
 style-src[] = "'self'"
 style-src[] = "'unsafe-inline'"
 img-src[] = "'self'"
+; If you are using Google Books previews, uncomment the line below for
+; https://www.google.com/intl/*/googlebooks/images/gbs_preview_button1.png
+;img-src[] = "https://www.google.com/intl/"
 ; If you are using LibGuidesProfile recommendation module, uncomment the line below
 ;img-src[] = libapps.s3.amazonaws.com
 ; If you are using MapSelection recommendation module, uncomment a line below

--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -44,6 +44,8 @@ script-src[] = "https:"
 connect-src[] = "'self'"
 ; If you are using Google Analytics, uncomment the line below
 ;connect-src[] = "https://*.google-analytics.com"
+; If you are using Matomo, fix the URL for your installation and uncomment the line below
+;connect-src[] = "https://server.address/matomo/matomo.php"
 ; worker-src required for jsTree with browsers that don't support 'strict-dynamic' (e.g. Safari):
 worker-src[] = "blob:"
 style-src[] = "'self'"


### PR DESCRIPTION
These directives add CSP settings for Matomo and Google Books previews.