### PR TITLE
Add new combined search box setting: collapseInactiveBackendOptions

### DIFF
--- a/config/vufind/searchbox.ini
+++ b/config/vufind/searchbox.ini
@@ -12,6 +12,12 @@ combinedHandlers = false
 ; autocomplete behavior.
 includeAlphaBrowse = false
 
+; Should we hide search handler options under inactive backends? When false, every
+; backend will be expanded to show every possible option in the drop-down. When true,
+; only the backend currently in use will show expanded options. Ignored unless the
+; combinedHandlers setting is true.
+collapseInactiveBackendOptions = false
+
 ; If includeAlphaBrowse is true, this label will be used to group the browse values
 ; together in the drop-down (see group[] setting below). Set to false for no label.
 alphaBrowseGroup = false

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchBox.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchBox.php
@@ -540,6 +540,7 @@ class SearchBox extends \Laminas\View\Helper\AbstractHelper implements \Psr\Log\
                 if (empty($basic)) {
                     $basic = ['' => ''];
                 }
+                $collapseInactiveBackends = $this->config['General']['collapseInactiveBackendOptions'] ?? false;
                 foreach ($basic as $searchVal => $searchDesc) {
                     $j++;
                     $selected = $target == $filteredActiveSearchClass
@@ -569,6 +570,11 @@ class SearchBox extends \Laminas\View\Helper\AbstractHelper implements \Psr\Log\
                         'selected' => $selected,
                         'group' => $settings['group'][$i],
                     ];
+                    // If collapsing inactive backends is turned on, we only want to show the
+                    // first value for non-active backends:
+                    if ($collapseInactiveBackends && $target !== $activeSearchClass) {
+                        break;
+                    }
                 }
 
                 // Should we add alphabrowse links?


### PR DESCRIPTION
This feature was requested at Villanova to make the search drop-down menu more manageable -- rather than showing every option under every backend, we can configure to show only sub-options for the active backend. This makes search a little less flexible (it takes multiple clicks to get to a narrow search in a different backend) but it makes the overall experience less intimidating.

To clarify, here's an example search box with default combined handler behavior:

<img width="541" height="656" alt="image" src="https://github.com/user-attachments/assets/a7870162-04ed-4f89-a052-84a761f5e256" />

And here's the same search box with the new setting turned on:

<img width="540" height="326" alt="image" src="https://github.com/user-attachments/assets/00bf6ff0-0508-4182-96db-d49e7f2a9572" />

TODO
- [ ] Add test coverage