### PR TITLE
Cover loader: make mime type detection more robust.

### DIFF
--- a/module/VuFind/src/VuFind/Cover/Loader.php
+++ b/module/VuFind/src/VuFind/Cover/Loader.php
@@ -675,7 +675,7 @@ class Loader extends \VuFind\ImageLoader
             $imagePath = substr($url, 7);
 
             // Display the image:
-            $this->contentType = mime_content_type($imagePath);
+            $this->contentType = $this->getImageMimeTypeFromFile($imagePath);
             $this->image = file_get_contents($imagePath);
             return true;
         } else {

--- a/module/VuFind/src/VuFind/ImageLoader.php
+++ b/module/VuFind/src/VuFind/ImageLoader.php
@@ -31,6 +31,8 @@
 namespace VuFind;
 
 use function array_key_exists;
+use function function_exists;
+use function is_int;
 
 /**
  * Base class for loading images (shared by Cover\Loader and QRCode\Loader)
@@ -198,6 +200,30 @@ class ImageLoader implements \Psr\Log\LoggerAwareInterface
 
         // Load the image data:
         $this->image = file_get_contents($noCoverImage);
+    }
+
+    /**
+     * Given a file path, return the MIME type by analyzing the file. Returns null for
+     * unidentifiable or non-image files.
+     *
+     * @param string $filename File to analyze
+     *
+     * @return ?string
+     */
+    protected function getImageMimeTypeFromFile(string $filename): ?string
+    {
+        // First try mime_content_type... but this could falsely return text/plain if the
+        // PHP mime_magic.magicfile setting is not configured correctly.
+        $contentType = mime_content_type($filename);
+        if (str_starts_with($contentType, 'image/')) {
+            return $contentType;
+        }
+
+        // Next try exif_imagetype if it is available, or default to the slower getimagesize if it is not.
+        $type = function_exists('exif_imagetype')
+            ? exif_imagetype($filename)
+            : getimagesize($filename)[2] ?? null;
+        return is_int($type) ? image_type_to_mime_type($type) : null;
     }
 
     /**


### PR DESCRIPTION
While researching MIME type detection, I became concerned that `mime_content_type` may not work in all circumstances, so I created this helper method to fall back to some other possible methods. We may want to use it in more places in the future if we loosen the assumption currently baked into the code that everything is (or must become) a jpeg.