### PR TITLE
Ensure consistent string type on IDs in GetItemStatuses.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetItemStatuses.php
@@ -567,7 +567,7 @@ class GetItemStatuses extends AbstractBase implements
         foreach ($missingIds as $missingId => $recordNumber) {
             $availabilityStatus = $this->availabilityStatusManager->createAvailabilityStatus(false);
             $statuses[] = [
-                'id'                   => $missingId,
+                'id'                   => (string)$missingId, // array_flip may have converted to int
                 'availability'         => 'false',
                 'availability_message' => $this->getAvailabilityMessage($availabilityStatus),
                 'location'             => $this->translate('Unknown'),


### PR DESCRIPTION
This bug fix has been extracted from #4809. Thanks again, @betullam!