### PR TITLE
Fix embedded record tabs memory bug; add test coverage.

### DIFF
--- a/themes/bootstrap5/js/embedded_record.js
+++ b/themes/bootstrap5/js/embedded_record.js
@@ -159,6 +159,7 @@ VuFind.register('embedded', function embedded() {
             longNode.collapse('show');
             // Load first tab
             if (tabid) {
+              document.getElementById(tabid).click();
               ajaxLoadTab(tabid, true);
             } else {
               var $firstTab = $(longNode).find('.list-tab-toggle.active');


### PR DESCRIPTION
This PR adds test coverage for comments in embedded records and fixes a bug discovered during test development: when refreshing a tabbed page, the tab memory was not working correctly, so the selected tab for each record would revert to the default.

(To reproduce the bug: turn on tabs view in searches.ini, open any record, and pick any non-default tab; then refresh the page, and the record will open on the wrong tab. With this fix in place, the correct tab will be open).