### PR TITLE
Support queries where part of the query is using ExactSettings

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -218,13 +218,13 @@ class QueryBuilder implements QueryBuilderInterface
      * Logical operators can be used, but not parentheses or field names.
      * The original query is returned for any non-supported case.
      *
-     * @param QueryGroup|Query $query User query
+     * @param QueryInterface $query User query
      *
-     * @return QueryGroup|Query
+     * @return QueryInterface
      */
     protected function possiblyConvertMixedExactQueryIntoAdvanced($query)
     {
-        if ($query instanceof QueryGroup) {
+        if (! $query instanceof Query) {
             return $query;
         }
         $handler = $query->getHandler();

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -215,7 +215,7 @@ class QueryBuilder implements QueryBuilderInterface
     /**
      * Converts a simple query (Query) into an advanced one (QueryGroup) if part of it should be an exact query.
      * This only supports a single exact query (surrounded with quotes) combined with a non-exact query.
-     * Logical operators can be used, but not parenthesis or field names.
+     * Logical operators can be used, but not parentheses or field names.
      * The original query is returned for any non-supported case.
      *
      * @param QueryGroup|Query $query User query

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -218,13 +218,13 @@ class QueryBuilder implements QueryBuilderInterface
      * Logical operators can be used, but not parentheses or field names.
      * The original query is returned for any non-supported case.
      *
-     * @param QueryInterface $query User query
+     * @param AbstractQuery $query User query
      *
-     * @return QueryInterface
+     * @return AbstractQuery
      */
-    protected function possiblyConvertMixedExactQueryIntoAdvanced($query)
+    protected function possiblyConvertMixedExactQueryIntoAdvanced(AbstractQuery $query): AbstractQuery
     {
-        if (! $query instanceof Query) {
+        if (!($query instanceof Query)) {
             return $query;
         }
         $handler = $query->getHandler();

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -133,6 +133,8 @@ class QueryBuilder implements QueryBuilderInterface
      */
     public function build(AbstractQuery $query, ?ParamBag $params = null)
     {
+        $query = $this->possiblyConvertMixedExactQueryIntoAdvanced($query);
+
         $newParams = new ParamBag();
 
         // Add spelling query if applicable -- note that we must set this up before
@@ -208,6 +210,64 @@ class QueryBuilder implements QueryBuilderInterface
         }
 
         return $newParams;
+    }
+
+    /**
+     * Converts a simple query (Query) into an advanced one (QueryGroup) if part of it should be an exact query.
+     * This only supports a single exact query (surrounded with quotes) combined with a non-exact query.
+     * Logical operators can be used, but not parenthesis or field names.
+     * The original query is returned for any non-supported case.
+     *
+     * @param QueryGroup|Query $query User query
+     *
+     * @return QueryGroup|Query
+     */
+    protected function possiblyConvertMixedExactQueryIntoAdvanced($query)
+    {
+        if ($query instanceof QueryGroup) {
+            return $query;
+        }
+        $handler = $query->getHandler();
+        if ($handler && !isset($this->exactSpecs[strtolower($handler)])) {
+            return $query;
+        }
+        $queryString = trim($query->getString());
+        if (!preg_match('/^([^":()+]*)"([^"]+)"([^":()]*)$/u', $queryString, $parts)) {
+            return $query;
+        }
+        $groupOperator = 'AND';
+        $negateQuotedPart = false;
+        $before = trim($parts[1]);
+        if (preg_match('/^(.*)\s*(NOT|-)$/u', $before, $notParts)) {
+            $before = $notParts[1];
+            $negateQuotedPart = true;
+        }
+        if (preg_match('/^(.*)\s*(AND|OR)$/u', $before, $beforeParts)) {
+            $before = $beforeParts[1];
+            $groupOperator = $beforeParts[2];
+        }
+        $quoted = '"' . $parts[2] . '"';
+        $after = trim($parts[3]);
+        if (preg_match('/^(AND|OR)\s*(.*)$/u', $after, $afterParts)) {
+            $groupOperator = $afterParts[1];
+            $after = $afterParts[2];
+        }
+        if (($before == '' && $after == '') || ($before != '' && $after != '')) {
+            return $query;
+        }
+        $subQueries = [];
+        if ($before != '') {
+            $subQueries[] = new Query($before, $handler);
+        }
+        if ($negateQuotedPart) {
+            $subQueries[] = new QueryGroup('NOT', [ new Query($quoted, $handler) ]);
+        } else {
+            $subQueries[] = new Query($quoted, $handler);
+        }
+        if ($after != '') {
+            $subQueries[] = new Query($after, $handler);
+        }
+        return new QueryGroup($groupOperator, $subQueries);
     }
 
     /**

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -238,11 +238,11 @@ class QueryBuilder implements QueryBuilderInterface
         $groupOperator = 'AND';
         $negateQuotedPart = false;
         $before = trim($parts[1]);
-        if (preg_match('/^(.*)\s*(NOT|-)$/u', $before, $notParts)) {
-            $before = $notParts[1];
+        if (preg_match('/^(.+\s+)?(NOT|-)$/u', $before, $notParts)) {
+            $before = trim($notParts[1]);
             $negateQuotedPart = true;
         }
-        if (preg_match('/^(.*)\s*(AND|OR)$/u', $before, $beforeParts)) {
+        if (preg_match('/^(.*)\s+(AND|OR)$/u', $before, $beforeParts)) {
             $before = $beforeParts[1];
             $groupOperator = $beforeParts[2];
         }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -296,6 +296,74 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test queries with mixed exact and non-exact parts.
+     *
+     * @return void
+     */
+    public function testMixedExactQueryHandler()
+    {
+        // Check QueryBuilder without ExactSettings
+        $qb = new QueryBuilder(
+            [
+                'TestHandler' => [
+                    'DismaxFields' => ['a'],
+                    'DismaxHandler' => 'edismax',
+                ],
+            ]
+        );
+        $q = new Query('"t1" AND t2', 'TestHandler');
+        $response = $qb->build($q);
+        $queryString = $response->get('q')[0];
+        $this->assertEquals('"t1" AND t2', $queryString);
+
+        // Expected inputs and outputs with ExactSettings:
+        $tests = [
+            ['"t1"', '"t1"'], // simple exact queries are not affected
+            ['("t1" OR t2) AND t3', '("t1" OR t2) AND t3'], // queries with parenthesis are not supported
+            ['"t1" AND title:t2', '"t1" AND title:t2'], // queries with field are not supported
+            ['"t1" AND "t2"', '"t1" AND "t2"'], // queries with multiple exact parts are not supported
+            ['t1 AND "t2" AND t3', 't1 AND "t2" AND t3'], // queries with an exact part in the middle are not supported
+            ['"t1" t2', '((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\"") AND ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
+            ['"t1" AND t2', '((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\"") AND ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
+            ['"t1" OR t2', '((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\"") OR ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
+            ['t1 AND "t2"', '((_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t1") AND ' .
+                '(_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t2\""))'],
+            ['NOT "t1" AND t2', '((*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\""))) AND ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
+            ['t1 AND NOT "t2"', '((_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t1 AND") AND ' .
+                '(*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t2\""))))'],
+            ['-"t1" t2', '((*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\""))) AND ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
+            ['"t1" AND t2 AND t3', '((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\"") AND ' .
+                '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2 AND t3"))'], // would be different with dismax
+        ];
+
+        $qb = new QueryBuilder(
+            [
+                'TestHandler' => [
+                    'DismaxFields' => ['a'],
+                    'DismaxHandler' => 'edismax',
+                    'ExactSettings' => [
+                        'DismaxFields' => ['b'],
+                        'DismaxHandler' => 'edismax',
+                    ],
+                ],
+            ]
+        );
+
+        foreach ($tests as $test) {
+            [$input, $output] = $test;
+            $q = new Query($input, 'TestHandler');
+            $response = $qb->build($q);
+            $queryString = $response->get('q')[0];
+            $this->assertEquals($output, $queryString);
+        }
+    }
+
+    /**
      * Test generation with a query handler with a filter set and DisMax settings
      *
      * @return void

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/QueryBuilderTest.php
@@ -333,7 +333,7 @@ class QueryBuilderTest extends \PHPUnit\Framework\TestCase
                 '(_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t2\""))'],
             ['NOT "t1" AND t2', '((*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\""))) AND ' .
                 '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],
-            ['t1 AND NOT "t2"', '((_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t1 AND") AND ' .
+            ['t1 AND NOT "t2"', '((_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t1") AND ' .
                 '(*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t2\""))))'],
             ['-"t1" t2', '((*:* NOT ((_query_:"{!edismax qf=\"b\" mm=\\\'0%\\\'}\"t1\""))) AND ' .
                 '(_query_:"{!edismax qf=\"a\" mm=\\\'0%\\\'}t2"))'],


### PR DESCRIPTION
Exact queries (surrounded with quotes) are very useful to eliminate issues with stemming. But they don't work when combined with non-exact queries. Some examples:
- `translate AND "illustrate"` : matches records with `illustrated`
- `"robot" AND illustrate` : matches records with `robotics`
- `"covidence" AND review*`  : matches records with `COVID`

This PR proposes a solution for these cases. The implementation idea is to transform these queries into advanced queries, which use embedded Solr queries. Currently a workaround is to build equivalent queries as advanced queries in the UI.

It does not support multiple exact strings, or queries using field names (with '`:`') or with parenthesis. Logical operators are supported, including `NOT` for the exact part. The implementation could be improved in the future, but reported cases from our users did not include more complex queries.