### PR TITLE
Simplify ALMA ILS driver

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -165,7 +165,7 @@ class Alma extends AbstractBase implements
             }
 
             // Create the API URL
-            $url = !str_contains($path, '://') ? $this->baseUrl . $path : $path;
+            $url = $this->baseUrl . $path;
 
             // Create client with API URL
             $client = $this->httpService->createClient($url);
@@ -997,7 +997,6 @@ class Alma extends AbstractBase implements
             try {
                 // Delete the request in Alma
                 $apiResult = $this->makeRequest(
-                    $this->baseUrl .
                     '/users/' . rawurlencode($patronId) .
                     '/requests/' . rawurlencode($requestId),
                     ['reason' => 'CancelledAtPatronRequest'],
@@ -1056,7 +1055,7 @@ class Alma extends AbstractBase implements
         $results = [];
         $patronId = $patron['id'];
         foreach ($holdsDetails as $requestId) {
-            $requestUrl = $this->baseUrl . '/users/' . rawurlencode($patronId)
+            $requestUrl = '/users/' . rawurlencode($patronId)
                 . '/requests/' . rawurlencode($requestId);
             $requestDetails = $this->makeRequest($requestUrl);
 


### PR DESCRIPTION
It's not necessary to start the path parameter with the baseUrl when calling function makeRequest because the baseUrl is added there.