### PR TITLE
Avoid overriding stored Results object by null in RecordLinker.

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordLinker.php
@@ -6,7 +6,7 @@
  * PHP version 8
  *
  * Copyright (C) Villanova University 2010.
- * Copyright (C) The National Library of Finland 2023.
+ * Copyright (C) The National Library of Finland 2023-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -89,8 +89,21 @@ class RecordLinker extends \Laminas\View\Helper\AbstractHelper
      */
     public function __invoke($results = null)
     {
-        $this->results = $results;
+        // Avoid setting any existing results null:
+        if (null !== $results) {
+            $this->results = $results;
+        }
         return $this;
+    }
+
+    /**
+     * Reset any stored Results object.
+     *
+     * @return void
+     */
+    public function resetStoredResults(): void
+    {
+        $this->results = null;
     }
 
     /**
@@ -216,9 +229,9 @@ class RecordLinker extends \Laminas\View\Helper\AbstractHelper
         $driverId = is_string($driver)
             ? $driver
             : ($driver->getSourceIdentifier() . '|' . $driver->getUniqueID());
+        $recordUrlParams = $this->getRecordUrlParams($options);
         $cacheKey = md5(
-            $driverId . '|' . ($tab ?? '-') . '|' . var_export($query, true)
-            . var_export($options, true)
+            $driverId . '|' . ($tab ?? '-') . '|' . var_export($query, true) . var_export($recordUrlParams, true)
         );
         if (!isset($this->cachedDriverUrls[$cacheKey])) {
             // Build the URL:
@@ -229,7 +242,7 @@ class RecordLinker extends \Laminas\View\Helper\AbstractHelper
                 $details['params'],
                 array_merge_recursive(
                     $details['options'] ?? [],
-                    ['query' => $this->getRecordUrlParams($options)]
+                    ['query' => $recordUrlParams]
                 )
             );
         }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkerTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2019.
+ * Copyright (C) The National Library of Finland 2019-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -31,6 +31,7 @@ namespace VuFindTest\View\Helper\Root;
 
 use VuFind\Config\Config;
 use VuFind\Record\Router;
+use VuFind\Search\Base\Results;
 use VuFind\View\Helper\Root\RecordLinker;
 use VuFind\View\Helper\Root\Translate;
 use VuFind\View\Helper\Root\Truncate;
@@ -158,6 +159,43 @@ class RecordLinkerTest extends \PHPUnit\Framework\TestCase
         $driver = new TestHarness();
         $driver->setRawData(['Breadcrumb' => $breadcrumb]);
         $this->assertEquals([$expected, '/Record/?sid=-123'], $recordLinker->getBreadcrumbParams($driver));
+    }
+
+    /**
+     * Test handling of Results in __invoke.
+     *
+     * @return void
+     */
+    public function testInvoke(): void
+    {
+        $recordLinker = $this->getRecordLinker();
+        $results = $this->createMock(Results::class);
+        $results->expects($this->exactly(2))
+            ->method('getSearchId')
+            ->willReturn(234);
+        $this->assertEquals(
+            '/Record/foo?sid=234',
+            $recordLinker($results)->getUrl('Solr|foo')
+        );
+        $recordLinker(null);
+        $this->assertEquals(
+            '/Record/foo?sid=234',
+            $recordLinker->getUrl('Solr|foo')
+        );
+        $recordLinker->resetStoredResults();
+        $this->assertEquals(
+            '/Record/foo?sid=-123',
+            $recordLinker->getUrl('Solr|foo')
+        );
+
+        $results2 = $this->createMock(Results::class);
+        $results2->expects($this->once())
+            ->method('getSearchId')
+            ->willReturn(345);
+        $this->assertEquals(
+            '/Record/foo?sid=345',
+            $recordLinker($results2)->getUrl('Solr|foo')
+        );
     }
 
     /**


### PR DESCRIPTION
The new resetStoredResults method can be used to reset results if necessary.

This also fixes caching for when query params might have changed.