### PR TITLE
Add password hasher to AlmaDatabase

### DIFF
--- a/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
@@ -65,8 +65,7 @@ class AlmaDatabase extends Database
      *
      * @param \VuFind\ILS\Connection        $catalog       The ILS connection
      * @param \VuFind\Auth\ILSAuthenticator $authenticator The ILS authenticator
-     * @param ?PasswordHasher               $hasher        Password hash service
-     * (null to create one)
+     * @param ?PasswordHasher               $hasher        Password hash service (null to create one)
      */
     public function __construct(
         protected \VuFind\ILS\Connection $catalog,

--- a/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) AK Bibliothek Wien für Sozialwissenschaften 2018.
+ * Copyright (C) AK Bibliothek Wien für Sozialwissenschaften 2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,7 @@
  *
  * @category VuFind
  * @package  Authentication
- * @author   Michael Birkner <michael.birkner@akwien.at>
+ * @author   Michael Birkner-Tröger <michael.birkner@akwien.at>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:authentication_handlers Wiki
  */
@@ -30,6 +30,7 @@
 namespace VuFind\Auth;
 
 use Laminas\Http\PhpEnvironment\Request;
+use VuFind\Crypt\PasswordHasher;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Exception\Auth as AuthException;
 
@@ -39,7 +40,7 @@ use VuFind\Exception\Auth as AuthException;
  *
  * @category VuFind
  * @package  Authentication
- * @author   Michael Birkner <michael.birkner@akwien.at>
+ * @author   Michael Birkner-Tröger <michael.birkner@akwien.at>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:plugins:authentication_handlers Wiki
  */
@@ -64,13 +65,17 @@ class AlmaDatabase extends Database
      *
      * @param \VuFind\ILS\Connection        $catalog       The ILS connection
      * @param \VuFind\Auth\ILSAuthenticator $authenticator The ILS authenticator
+     * @param ?PasswordHasher               $hasher        Password hash service
+     * (null to create one)
      */
     public function __construct(
         protected \VuFind\ILS\Connection $catalog,
-        protected \VuFind\Auth\ILSAuthenticator $authenticator
+        protected \VuFind\Auth\ILSAuthenticator $authenticator,
+        ?PasswordHasher $hasher = null
     ) {
         $this->almaDriver = $catalog->getDriver();
         $this->almaConfig = $catalog->getDriverConfig();
+        $this->hasher = $hasher ?? new PasswordHasher();
     }
 
     /**
@@ -117,9 +122,15 @@ class AlmaDatabase extends Database
 
             // Save the credentials to cat_username and cat_password to bypass
             // the ILS login screen from VuFind
-            $this->authenticator->saveUserCatalogCredentials($user, $params['username'], $params['password']);
+            $this->authenticator->saveUserCatalogCredentials(
+                $user,
+                $params['username'],
+                $params['password']
+            );
         } else {
-            throw new AuthException($this->translate('ils_account_create_error'));
+            throw new AuthException(
+                $this->translate('ils_account_create_error')
+            );
         }
 
         return $user;

--- a/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) AK Bibliothek Wien für Sozialwissenschaften 2025.
+ * Copyright (C) AK Bibliothek Wien für Sozialwissenschaften 2018-2025.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabase.php
@@ -75,7 +75,7 @@ class AlmaDatabase extends Database
     ) {
         $this->almaDriver = $catalog->getDriver();
         $this->almaConfig = $catalog->getDriverConfig();
-        $this->hasher = $hasher ?? new PasswordHasher();
+        parent::__construct($hasher);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Auth/AlmaDatabaseFactory.php
+++ b/module/VuFind/src/VuFind/Auth/AlmaDatabaseFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Factory for AlmaDatabase authentication module.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) AK Bibliothek Wien für Sozialwissenschaften 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Authentication
+ * @author   Michael Birkner-Tröger <michael.birkner@akwien.at>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Auth;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+use VuFind\Crypt\PasswordHasher;
+
+/**
+ * Factory for AlmaDatabase authentication module.
+ *
+ * @category VuFind
+ * @package  Authentication
+ * @author   Michael Birkner-Tröger <michael.birkner@akwien.at>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class AlmaDatabaseFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options passed to factory.');
+        }
+        return new $requestedName(
+            $container->get(\VuFind\ILS\Connection::class),
+            $container->get(ILSAuthenticator::class),
+            $container->get(PasswordHasher::class)
+        );
+    }
+}

--- a/module/VuFind/src/VuFind/Auth/PluginManager.php
+++ b/module/VuFind/src/VuFind/Auth/PluginManager.php
@@ -71,7 +71,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        AlmaDatabase::class => ILSFactory::class,
+        AlmaDatabase::class => AlmaDatabaseFactory::class,
         CAS::class => CASFactory::class,
         ChoiceAuth::class => ChoiceAuthFactory::class,
         Database::class => DatabaseFactory::class,


### PR DESCRIPTION
The auth method `AlmaDatabase` extends `Database` which has a constructor that sets a password hasher. I added the password hasher to `AlmaDatabase`. Without that, login is not possible when using `AlmaDatabase`.