### PR TITLE
Add ServerUrl helper

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -498,6 +498,7 @@ $config = [
             'VuFind\Hierarchy\TreeRenderer\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'VuFind\Http\CachingDownloader' => 'VuFind\Http\CachingDownloaderFactory',
             'VuFind\Http\GuzzleService' => 'VuFind\Http\GuzzleServiceFactory',
+            'VuFind\Http\ServerUrlHelper' => 'VuFind\Http\ServerUrlHelperFactory',
             'VuFind\Http\PhpEnvironment\Request' => 'Laminas\ServiceManager\Factory\InvokableFactory',
             'VuFind\I18n\Locale\LocaleSettings' => 'VuFind\Service\ServiceWithConfigIniFactory',
             'VuFind\I18n\Sorter' => 'VuFind\I18n\SorterFactory',

--- a/module/VuFind/src/VuFind/Http/ServerUrlHelper.php
+++ b/module/VuFind/src/VuFind/Http/ServerUrlHelper.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Server URL Helper class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFind\Http;
+
+use Closure;
+
+/**
+ * Server URL Helper class.  Wrapper around Laminas ServerUrlHelper.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class ServerUrlHelper
+{
+    /**
+     * Constructor.
+     *
+     * @param Closure $serverUrlHelper Server URL helper function
+     *
+     * @return void
+     */
+    public function __construct(protected Closure $serverUrlHelper)
+    {
+    }
+
+    /**
+     * Return the base URL of the current host.
+     *
+     * @return string
+     */
+    public function getBaseUrl(): string
+    {
+        return ($this->serverUrlHelper)(null);
+    }
+
+    /**
+     * Return the fully qualified request URL.
+     *
+     * @return string
+     */
+    public function getCurrentUrl(): string
+    {
+        return ($this->serverUrlHelper)(true);
+    }
+
+    /**
+     * Return the fully qualified URL for the given path on the current host.
+     *
+     * @param string $path A path beginning at the root, with starting slash.
+     *
+     * @return string
+     */
+    public function getUrlForPath(string $path): string
+    {
+        return ($this->serverUrlHelper)($path);
+    }
+}

--- a/module/VuFind/src/VuFind/Http/ServerUrlHelperFactory.php
+++ b/module/VuFind/src/VuFind/Http/ServerUrlHelperFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Server URL Helper factory.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Http;
+
+use Closure;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Server URL Helper factory.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class ServerUrlHelperFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options passed to factory.');
+        }
+
+        $viewRenderer = $container->get('ViewRenderer');
+        return new $requestedName(
+            Closure::fromCallable($viewRenderer->plugin('serverurl'))
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/ServerUrlHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/ServerUrlHelperTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * ServerUrlHelper Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Http;
+
+use Closure;
+use Laminas\View\Helper\ServerUrl;
+use VuFind\Http\ServerUrlHelper;
+
+/**
+ * ServerUrlHelper Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ServerUrlHelperTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\ViewTrait;
+
+    /**
+     * Specific $_SERVER fields to backup before tests and restore after
+     *
+     * @var array
+     */
+    protected array $serverBackupFields = ['HTTPS', 'HTTP_HOST', 'REQUEST_URI'];
+
+    /**
+     * Data provider to return in getBaseUrl tests.
+     *
+     * @return \Iterator<string, array>
+     */
+    public static function getBaseUrlProvider(): \Iterator
+    {
+        yield 'http, no port' => [ '', 'somehost', 'http://somehost' ];
+        yield 'http, port' => [ '', 'somehost:8080', 'http://somehost:8080'];
+        yield 'https, no port' => [ 'on', 'somehost', 'https://somehost'];
+    }
+
+    /**
+     * Test helper's getBaseUrl method
+     *
+     * @param string $https    $_SERVER['HTTPS'] value
+     * @param string $host     $_SERVER['HTTP_HOST'] value
+     * @param string $expected Expected result
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getBaseUrlProvider')]
+    public function testGetBaseUrl(string $https, string $host, string $expected): void
+    {
+        $helper = $this->getServerUrlHelper();
+        $serverBackup = $this->backupAndSetServerFields($https, $host);
+        try {
+            $results = $helper->getBaseUrl();
+            $this->assertSame($expected, $results);
+        } finally {
+            $this->restoreServerFields($serverBackup);
+        }
+    }
+
+    /**
+     * Data provider to return in getCurrentUrl and getUrlForPath tests.
+     *
+     * @return \Iterator<string, array>
+     */
+    public static function urlsWithPathsProvider(): \Iterator
+    {
+        yield 'http, no port' => [ '', 'somehost', '/vufind/Record/12345', 'http://somehost/vufind/Record/12345' ];
+        yield 'http, port' =>
+            [ '', 'somehost:8080', '/vufind/Record/12345', 'http://somehost:8080/vufind/Record/12345'];
+        yield 'https, no port' => [ 'on', 'somehost', '/vufind/Record/12345', 'https://somehost/vufind/Record/12345'];
+    }
+
+    /**
+     * Test helper's getCurrentUrl method
+     *
+     * @param string $https       $_SERVER['HTTPS'] value
+     * @param string $host        $_SERVER['HTTP_HOST'] value
+     * @param string $currentPath Current path
+     * @param string $expected    Expected result
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('urlsWithPathsProvider')]
+    public function testGetCurrentUrl(string $https, string $host, string $currentPath, string $expected): void
+    {
+        $helper = $this->getServerUrlHelper();
+        $serverBackup = $this->backupAndSetServerFields($https, $host, $currentPath);
+        try {
+            $results = $helper->getCurrentUrl();
+            $this->assertSame($expected, $results);
+        } finally {
+            $this->restoreServerFields($serverBackup);
+        }
+    }
+
+    /**
+     * Test helper's getUrlForPath method
+     *
+     * @param string $https    $_SERVER['HTTPS'] value
+     * @param string $host     $_SERVER['HTTP_HOST'] value
+     * @param string $path     Input path
+     * @param string $expected Expected result
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('urlsWithPathsProvider')]
+    public function testGetUrlForPath(string $https, string $host, string $path, string $expected): void
+    {
+        $helper = $this->getServerUrlHelper();
+        $serverBackup = $this->backupAndSetServerFields($https, $host);
+        try {
+            $results = $helper->getUrlForPath($path);
+            $this->assertSame($expected, $results);
+        } finally {
+            $this->restoreServerFields($serverBackup);
+        }
+    }
+
+    /**
+     * Backup the specified $_SERVER fields to $serverBackup and write the given
+     * temporary values.
+     *
+     * @param string $https      $_SERVER['HTTPS'] value to use during tests
+     * @param string $host       $_SERVER['HTTP_HOST'] value to use during tests
+     * @param string $requestUri $_SERVER['REQUEST_URI'] value to use during tests
+     *
+     * @return array Backup of these fields
+     */
+    protected function backupAndSetServerFields(
+        string $https,
+        string $host,
+        string $requestUri = '/vufind/current-page'
+    ): array {
+        $serverBackup = array_map(fn ($field) => $_SERVER[$field] ?? null, $this->serverBackupFields);
+
+        $_SERVER['HTTPS'] = $https;
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SERVER['REQUEST_URI'] = $requestUri;
+
+        return $serverBackup;
+    }
+
+    /**
+     * Restore the specified fields into $_SERVER.
+     *
+     * @param array $serverBackup Original values to restore
+     *
+     * @return void
+     */
+    protected function restoreServerFields(array $serverBackup): void
+    {
+        foreach ($this->serverBackupFields as $field) {
+            if ($backupValue = ($serverBackup[$field] ?? null)) {
+                $_SERVER[$field] = $backupValue;
+            } else {
+                unset($_SERVER[$field]);
+            }
+        }
+    }
+
+    /**
+     * Return an instance of ServerUrlHelper
+     *
+     * @return ServerUrlHelper
+     */
+    protected function getServerUrlHelper(): ServerUrlHelper
+    {
+        return new ServerUrlHelper(
+            Closure::fromCallable(new ServerUrl())
+        );
+    }
+}


### PR DESCRIPTION
Abstract server URL generation away from the underlying Laminas view helper, as [suggested](https://github.com/vufind-org/vufind/pull/4954#discussion_r2604184979) by @demiankatz :

> Maybe a good strategy would be to build a top-level service somewhere to get server URLs. The initial implementation could be a thin wrapper around the view helper, but that would result in a cleaner overall design, and might make it easier to swap out a different implementation in the future if we find ourselves needing to step back from the view helper approach.

And extracted from #4954 as also [suggested](https://github.com/vufind-org/vufind/pull/4954#pullrequestreview-3601096946)

