### PR TITLE
Fix check request is valid

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
@@ -89,6 +89,8 @@ class CheckRequestIsValid extends AbstractIlsAndUserAction
     public function handleRequest(Params $params)
     {
         $this->disableSessionWrites();  // avoid session write timing bug
+
+        // process and validate input:
         $id = $params->fromQuery('id');
         $jsonData = $params->fromQuery('data');
         $requestType = $params->fromQuery('requestType');

--- a/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
@@ -32,6 +32,7 @@ namespace VuFind\AjaxHandler;
 use Laminas\Mvc\Controller\Plugin\Params;
 
 use function is_array;
+use function is_string;
 
 /**
  * "Check Request is Valid" AJAX handler
@@ -91,6 +92,9 @@ class CheckRequestIsValid extends AbstractIlsAndUserAction
         $this->disableSessionWrites();  // avoid session write timing bug
         $id = $params->fromQuery('id');
         $data = $params->fromQuery('data');
+        if (!empty($data) && is_string($data)) {
+            $data = json_decode($data, true);
+        }
         $requestType = $params->fromQuery('requestType');
         if (empty($id) || empty($data)) {
             return $this->formatResponse(

--- a/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
@@ -92,13 +92,12 @@ class CheckRequestIsValid extends AbstractIlsAndUserAction
         $id = $params->fromQuery('id');
         $jsonData = $params->fromQuery('data');
         $requestType = $params->fromQuery('requestType');
-        if (empty($id) || empty($jsonData)) {
+        if (empty($id) || empty($jsonData) || !($data = json_decode($jsonData, true))) {
             return $this->formatResponse(
                 $this->translate('bulk_error_missing'),
                 self::STATUS_HTTP_BAD_REQUEST
             );
         }
-        $data = json_decode($jsonData, true);
 
         // check if user is logged in
         if (!$this->user) {

--- a/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/CheckRequestIsValid.php
@@ -32,7 +32,6 @@ namespace VuFind\AjaxHandler;
 use Laminas\Mvc\Controller\Plugin\Params;
 
 use function is_array;
-use function is_string;
 
 /**
  * "Check Request is Valid" AJAX handler
@@ -91,17 +90,16 @@ class CheckRequestIsValid extends AbstractIlsAndUserAction
     {
         $this->disableSessionWrites();  // avoid session write timing bug
         $id = $params->fromQuery('id');
-        $data = $params->fromQuery('data');
-        if (!empty($data) && is_string($data)) {
-            $data = json_decode($data, true);
-        }
+        $jsonData = $params->fromQuery('data');
         $requestType = $params->fromQuery('requestType');
-        if (empty($id) || empty($data)) {
+        if (empty($id) || empty($jsonData)) {
             return $this->formatResponse(
                 $this->translate('bulk_error_missing'),
                 self::STATUS_HTTP_BAD_REQUEST
             );
         }
+        $data = json_decode($jsonData, true);
+
         // check if user is logged in
         if (!$this->user) {
             return $this->formatResponse(

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -51,6 +51,7 @@ use function array_key_exists;
 use function array_slice;
 use function count;
 use function in_array;
+use function is_array;
 use function is_callable;
 use function sprintf;
 use function strlen;
@@ -2256,9 +2257,13 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     ? 'hold_error_blocked' : 'Demonstrating a custom failure',
             ];
         }
-        return [
+        // Validate that we received data in the appropriate format (see PR #4985):
+        return is_array($data) ? [
             'valid' => true,
             'status' => 'request_place_text',
+        ] : [
+            'valid' => false,
+            'status' => 'invalid data provided',
         ];
     }
 
@@ -2381,9 +2386,13 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     : 'Demonstrating a custom failure',
             ];
         }
-        return [
+        // Validate that we received data in the appropriate format (see PR #4985):
+        return is_array($data) ? [
             'valid' => true,
             'status' => 'storage_retrieval_request_place_text',
+        ] : [
+            'valid' => false,
+            'status' => 'invalid data provided',
         ];
     }
 
@@ -2511,9 +2520,13 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
                     ? 'ill_request_error_blocked' : 'Demonstrating a custom failure',
             ];
         }
-        return [
+        // Validate that we received data in the appropriate format (see PR #4985):
+        return is_array($data) ? [
             'valid' => true,
             'status' => 'ill_request_place_text',
+        ] : [
+            'valid' => false,
+            'status' => 'invalid data provided',
         ];
     }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -51,7 +51,6 @@ use function array_key_exists;
 use function array_slice;
 use function count;
 use function in_array;
-use function is_array;
 use function is_callable;
 use function sprintf;
 use function strlen;

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -2258,7 +2258,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             ];
         }
         // Validate that we received data in the appropriate format (see PR #4985):
-        return is_array($data) ? [
+        return isset($data['id']) ? [
             'valid' => true,
             'status' => 'request_place_text',
         ] : [
@@ -2387,7 +2387,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             ];
         }
         // Validate that we received data in the appropriate format (see PR #4985):
-        return is_array($data) ? [
+        return isset($data['id']) ? [
             'valid' => true,
             'status' => 'storage_retrieval_request_place_text',
         ] : [
@@ -2521,7 +2521,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
             ];
         }
         // Validate that we received data in the appropriate format (see PR #4985):
-        return is_array($data) ? [
+        return isset($data['id']) ? [
             'valid' => true,
             'status' => 'ill_request_place_text',
         ] : [

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -16,7 +16,7 @@ function checkRequestIsValid(element, requestType, icon = 'place-hold') {
     method: 'checkRequestIsValid',
     id: recordId,
     requestType: requestType,
-    data: vars
+    data: JSON.stringify(vars)
   });
   fetch(url, {
     headers: {


### PR DESCRIPTION
This pull request improves the handling of the "vars" parameter in the request validation workflow. It was getting passed from JS to PHP as string `"[object Object]"`. The PHP code couldn't use the data in the `vars` variable. The result was that the request validation check couldn't be executed.

**Changes:**

- In `record.js]`, the "vars" object is now stringified before being sent, preventing it from being passed as `"[object Object]"` to PHP.
- In `CheckRequestIsValid.php`, the values in "vars" are now decoded, ensuring proper processing on the server side.

Some screenshots of the problem:
- `vars` is added as `data=[object Object]` to the URL:<img width="923" height="314" alt="01-record js" src="https://github.com/user-attachments/assets/42113b07-f734-4e01-8d9a-7fc338f562ca" />
- AjaxHandler is getting `"[object Object]"` in `$data`:<img width="480" height="270" alt="02-ajax-handler" src="https://github.com/user-attachments/assets/2b5674ae-f876-461b-aa76-6e12f474fee7" />
- Function `checkRequestIsValid` (here in the Alma driver as an example) can't use it - `$data` is not an array:<img width="480" height="270" alt="03-alma-driver" src="https://github.com/user-attachments/assets/41a98bdd-0ede-4e26-9a2f-72a1bfd4286f" />
