### PR TITLE
Remove result-links empty line

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -216,7 +216,7 @@
           <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool icon-link">
             <?=$this->icon('user-list-entry-edit', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('Edit')?></span>
-          </a><br>
+          </a>
           <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
             $deleteUrl = null === $list_id
                 ? $this->url('myresearch-favorites')


### PR DESCRIPTION
The change in #4452 to remove an empty line accidentally created a different empty line on Saved Items. D'oh!.

<img width="801" height="175" alt="empty line between edit and delete links" src="https://github.com/user-attachments/assets/fa7adf92-9e3c-440e-9036-f64cec4e063b" />

Fixed:

<img width="762" height="180" alt="no newline" src="https://github.com/user-attachments/assets/9f620dda-05cf-4e75-afbc-15b37be5b2bd" />
