### PR TITLE
Fix hold pickup location label handling and title label.

### DIFF
--- a/themes/bootstrap5/js/hold.js
+++ b/themes/bootstrap5/js/hold.js
@@ -55,7 +55,7 @@ function setUpHoldRequestForm(recordId) {
             $emptyOption.removeAttr('hidden');
           }
           $select.show();
-          $('#pickUpLocationLabel').text($self.find(':selected').data('locations-label'));
+          $('#pickUpLocationLabel .pick-up-location-label-text').text($self.find(':selected').data('locations-label'));
         } else {
           $select.hide();
           $noResults.show();

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -89,7 +89,9 @@
     ?>
     <?php if ($this->requestGroupNeeded): ?>
       <div class="form-group hold-pickup-location">
-        <label id="pickUpLocationLabel" class="form-label"><?=$this->icon('spinner', 'loading-icon hidden')?> <?=$this->transEsc('pick_up_location')?>:
+        <label id="pickUpLocationLabel" class="form-label">
+          <span class="pick-up-location-label-text"><?=$this->transEsc('pick_up_location')?></span>:
+          <?=$this->icon('spinner', 'loading-icon hidden')?>
           <?php if (in_array('requestGroup', $this->extraHoldFields)): ?>
             <noscript> (<?=$this->transEsc('Please enable JavaScript.')?>)</noscript>
           <?php endif; ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -17,7 +17,7 @@
 
 <form class="form-record-hold" method="post" name="placeHold" data-clear-account-cache="holds">
   <?=$this->flashmessages()?>
-  <label class="form-label"><?=$this->transEsc('Title')?></label>
+  <label class="form-label"><?=$this->transEsc('Title')?>:</label>
   <p class="form-control-static"><?=$this->escapeHtml($this->driver->getBreadcrumb() . $enumchron) ?></p>
   <?php if (in_array('comments', $this->extraHoldFields)): ?>
     <div class="form-group hold-comment">


### PR DESCRIPTION
The piece of JS updating the label in hold form destroyed the spinner and removed the colon after the label. While at it, I moved the spinner after the label to avoid the label jumping around when the spinner is displayed, and added colon to the title label.