### PR TITLE
Fix minor issues with GetRecordVersions.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersions.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordVersions.php
@@ -101,7 +101,7 @@ class GetRecordVersions extends \VuFind\AjaxHandler\AbstractBase
      */
     protected function getVersionsLinkForRecord($id, $source, $searchId)
     {
-        $driver = $this->recordLoader->load($id, $source, $searchId);
+        $driver = $this->recordLoader->load($id, $source);
         $tabs = $this->tabManager->getTabsForRecord($driver);
         $full = true;
 
@@ -128,17 +128,18 @@ class GetRecordVersions extends \VuFind\AjaxHandler\AbstractBase
 
         if (!is_array($id)) {
             return $this->formatResponse(
-                $this->getVersionsLinkForRecord($id, $source, $searchId)
+                $this->getVersionsLinkForRecord($id, $source ?? DEFAULT_SEARCH_BACKEND, $searchId)
             );
         }
 
         $htmlByRecord = [];
         for ($i = 0; $i < count($id); $i++) {
-            $key = $source[$i] . '|' . $id[$i];
+            $currentSource = $source[$i] ?? DEFAULT_SEARCH_BACKEND;
+            $key = $currentSource . '|' . $id[$i];
 
             $htmlByRecord[$key] = $this->getVersionsLinkForRecord(
                 $id[$i],
-                $source[$i],
+                $currentSource,
                 $searchId
             );
         }


### PR DESCRIPTION
This PR addresses two different issues with GetRecordVersions:

1.) It passes the $searchId to the record loader, but this makes no sense -- there is no argument that expects a search ID in that context. The inappropriate argument is removed.

2.) If the source parameter is missing, it triggers illegal index checks; I set it to use DEFAULT_SEARCH_BACKEND as a fallback. I encountered this problem because a vulnerability scanning tool manipulated AJAX queries and triggered PHP notices as a consequence. I'm open to a different solution (like failing entirely if source is missing), but since we have a default, it seemed sensible to use it.

TODO
- [x] Run Mink tests.