### PR TITLE
Fix bug: AJAX covers broken in grid view.

### DIFF
--- a/themes/bootstrap5/js/covers.js
+++ b/themes/bootstrap5/js/covers.js
@@ -21,7 +21,7 @@ VuFind.register('covers', function covers() {
       if (typeof response.data.url !== 'undefined' && response.data.url !== false) {
         img.src = response.data.url;
         var inlink = element.parentElement.matches('a.record-cover-link');
-        var medium = img.closest('.media-left, .media-right, .carousel-item');
+        var medium = img.closest('.media-left, .media-right, .carousel-item, .grid-body');
         if (typeof response.data.backlink_text !== 'undefined') {
           if (typeof response.data.backlink_url !== 'undefined') {
             var link = document.createElement('a');


### PR DESCRIPTION
AJAX covers did not load correctly in grid view. This PR fixes the problem.

Steps to reproduce:

1.) In searches.ini, enable grid view in the `[Views]` section.
2.) In config.ini, turn on `ajaxcovers` and set `coverimages` to `Demo`.
3.) Perform a search and switch to grid view.
4.) Without this fix, the covers will never load (spinners forever). With the fix, the covers will populate as expected.

Thanks to Ján Krištof for reporting the problem and providing the solution.