### PR TITLE
Fix AuthHashService::getLatestBySessionId.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/AuthHashService.php
+++ b/module/VuFind/src/VuFind/Db/Service/AuthHashService.php
@@ -117,8 +117,8 @@ class AuthHashService extends AbstractDbService implements
             . 'ORDER BY ah.created DESC';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameter('sessionId', $sessionId);
-        $result = $query->getOneOrNullResult();
-        return $result;
+        $query->setMaxResults(1);
+        return $query->getOneOrNullResult();
     }
 
     /**


### PR DESCRIPTION
The method failed when there were multiple rows for the session in the database.