### PR TITLE
Avoid potential errors from getOneOrNullResult

### DIFF
--- a/module/VuFind/src/VuFind/Db/Service/ApiKeyService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ApiKeyService.php
@@ -104,6 +104,7 @@ class ApiKeyService extends AbstractDbService implements ApiKeyServiceInterface
             . 'WHERE ak.token = :token';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameters(['token' => $token]);
+        $query->setMaxResults(1); // token SHOULD be unique, but just in case....
         return $query->getOneOrNullResult();
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/PaymentService.php
+++ b/module/VuFind/src/VuFind/Db/Service/PaymentService.php
@@ -105,6 +105,7 @@ class PaymentService extends AbstractDbService implements PaymentServiceInterfac
         $parameters = compact('localIdentifier');
         $query = $this->entityManager->createQuery($dql);
         $query->setParameters($parameters);
+        $query->setMaxResults(1); // SHOULD be unique, but just in case...
         return $query->getOneOrNullResult();
     }
 

--- a/module/VuFind/src/VuFind/Db/Service/RatingsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/RatingsService.php
@@ -215,6 +215,7 @@ class RatingsService extends AbstractDbService implements
         $parameters = compact('resource', 'user');
         $query = $this->entityManager->createQuery($dql);
         $query->setParameters($parameters);
+        $query->setMaxResults(1); // SHOULD be unique, but just in case...
 
         if ($existing = $query->getOneOrNullResult()) {
             if (null === $rating) {

--- a/module/VuFind/src/VuFind/Db/Service/ResourceTagsService.php
+++ b/module/VuFind/src/VuFind/Db/Service/ResourceTagsService.php
@@ -213,6 +213,7 @@ class ResourceTagsService extends AbstractDbService implements
 
         $query = $this->entityManager->createQuery($dql);
         $query->setParameters($parameters);
+        $query->setMaxResults(1); // There should only be at most one row, but to be safe...
         $result = $query->getOneOrNullResult();
 
         // Only create row if it does not already exist:

--- a/module/VuFind/src/VuFind/Db/Service/UserService.php
+++ b/module/VuFind/src/VuFind/Db/Service/UserService.php
@@ -154,6 +154,7 @@ class UserService extends AbstractDbService implements
             $parameters = compact('fieldValue');
             $query = $this->entityManager->createQuery($dql);
             $query->setParameters($parameters);
+            $query->setMaxResults(1); // Not every field is guaranteed unique, so be sure to get just one!
             return $query->getOneOrNullResult();
         }
         throw new \InvalidArgumentException('Field name must be id, username, email or cat_id');


### PR DESCRIPTION
This follows on from #4994, preventing unlikely but theoretically possible Doctrine failures.

It might be preferable to address this with more UNIQUE keys in the database schema, but since problems are unlikely, and changing the schema for existing databases containing problems would cause breakages, this seems like a safer solution for a patch release. We can revisit in a future major release if there is sufficient interest.

TODO
- [x] Run Mink tests