### PR TITLE
Folio.ini: Add note about potential account collisions

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -61,10 +61,10 @@ type = instance
 ; that cannot be easily guessed, and you will want to modify the myresearch/
 ; cataloglogin.phtml template in your theme to properly label the form fields.
 ;
-; Note that if no matching user account is found in VuFind, a new account will be
-; created using the value configured for username_field below. Be sure to choose
+; Note that if no matching account is found in VuFind's user table, a new one will
+; be created using the value configured for username_field below. Be sure to choose
 ; a username_field that maps to a unique attribute, as using a non-unique value
-; may result in account collisions within the VuFind user database.
+; may result in account collisions within the user database.
 ;
 ; If you want to do an Okapi login, but you do not want to use the Okapi username
 ; as the user's primary login credential, you can set username_field to the

--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -61,6 +61,11 @@ type = instance
 ; that cannot be easily guessed, and you will want to modify the myresearch/
 ; cataloglogin.phtml template in your theme to properly label the form fields.
 ;
+; Note that if no matching user account is found in VuFind, a new account will be
+; created using the value configured for username_field below. Be sure to choose
+; a username_field that maps to a unique attribute, as using a non-unique value
+; may result in account collisions within the VuFind user database.
+;
 ; If you want to do an Okapi login, but you do not want to use the Okapi username
 ; as the user's primary login credential, you can set username_field to the
 ; desired primary value and set okapi_login to true. The code will use the


### PR DESCRIPTION
Adding a note to warn about potential account collisions when a non unique username_field such as personal.lastName is configured. This will create clarity to avoid unintended outcomes