### PR TITLE
Add in a fallback API call for the Folio driver getModuleMajorVersion function

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2279,15 +2279,30 @@ class Folio extends AbstractAPI implements
         $cacheKey = 'module_version:' . $moduleName;
         $version = $this->getCachedData($cacheKey);
         if ($version === null) {
-            // get latest version of a module enabled for a tenant
+            // Get latest version of a module enabled for a tenant.
+            // Allow 403 to not trigger an error because that means we need to try the next call
+            // that is compatible with Sunflower.
             $response = $this->makeRequest(
                 'GET',
-                '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1'
+                '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1',
+                allowedFailureCodes:[403]
             );
 
+            // If there was a failure with the first method, attempt the second
+            // endpoint to get the version.
+            $json = json_decode($response->getBody());
+            if (isset($json->errors) && !empty($json->errors)) {
+                $response = $this->makeRequest(
+                    'GET',
+                    '/modules/discovery?query=(name==' . $moduleName . ')'
+                );
+                $json = json_decode($response->getBody());
+                $latest = $json->discovery[0]->id ?? '0';
+            } else {
+                $latest = $json[0]->id ?? '0';
+            }
+
             // get version major from json result
-            $versions = json_decode($response->getBody());
-            $latest = $versions[0]->id ?? '0';
             preg_match_all('!\d+!', $latest, $matches);
             $version = (int)($matches[0][0] ?? 0);
             if ($version === 0) {

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2280,11 +2280,11 @@ class Folio extends AbstractAPI implements
         $version = $this->getCachedData($cacheKey);
         if ($version === null) {
             // Get latest version of a module enabled for a tenant.
-            // Allow failure response codes to not trigger an error because that
-            // means we need to try the next call that is compatible with Sunflower.
+            // Allow errors to not trigger an exception because that means we need to try the
+            // next call that is compatible with pre-Sunflower.
             $response = $this->makeRequest(
                 'GET',
-                '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1',
+                '/modules/discovery?query=(name==' . $moduleName . ')',
                 allowedFailureCodes:[400, 403, 404, 500]
             );
 
@@ -2294,12 +2294,12 @@ class Folio extends AbstractAPI implements
             if (empty($json) || isset($json['errors'])) {
                 $response = $this->makeRequest(
                     'GET',
-                    '/modules/discovery?query=(name==' . $moduleName . ')'
+                    '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1',
                 );
                 $json = json_decode($response->getBody(), true);
-                $latest = $json['discovery'][0]['id'] ?? '0';
-            } else {
                 $latest = $json[0]['id'] ?? '0';
+            } else {
+                $latest = $json['discovery'][0]['id'] ?? '0';
             }
 
             // get version major from json result

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2285,21 +2285,21 @@ class Folio extends AbstractAPI implements
             $response = $this->makeRequest(
                 'GET',
                 '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1',
-                allowedFailureCodes:[403]
+                allowedFailureCodes:[403, 500]
             );
 
             // If there was a failure with the first method, attempt the second
             // endpoint to get the version.
-            $json = json_decode($response->getBody());
-            if (isset($json->errors) && !empty($json->errors)) {
+            $json = json_decode($response->getBody(), true);
+            if (empty($json) || isset($json['errors'])) {
                 $response = $this->makeRequest(
                     'GET',
                     '/modules/discovery?query=(name==' . $moduleName . ')'
                 );
-                $json = json_decode($response->getBody());
-                $latest = $json->discovery[0]->id ?? '0';
+                $json = json_decode($response->getBody(), true);
+                $latest = $json['discovery'][0]['id'] ?? '0';
             } else {
-                $latest = $json[0]->id ?? '0';
+                $latest = $json[0]['id'] ?? '0';
             }
 
             // get version major from json result

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2280,12 +2280,12 @@ class Folio extends AbstractAPI implements
         $version = $this->getCachedData($cacheKey);
         if ($version === null) {
             // Get latest version of a module enabled for a tenant.
-            // Allow 403 to not trigger an error because that means we need to try the next call
-            // that is compatible with Sunflower.
+            // Allow failure response codes to not trigger an error because that
+            // means we need to try the next call that is compatible with Sunflower.
             $response = $this->makeRequest(
                 'GET',
                 '/_/proxy/tenants/' . $this->tenant . '/modules?filter=' . $moduleName . '&latest=1',
-                allowedFailureCodes:[403, 500]
+                allowedFailureCodes:[400, 403, 404, 500]
             );
 
             // If there was a failure with the first method, attempt the second

--- a/module/VuFind/tests/fixtures/folio/responses/request-type-fallback.json
+++ b/module/VuFind/tests/fixtures/folio/responses/request-type-fallback.json
@@ -66,14 +66,21 @@
         "status": 200
     },
     {
+        "comment": "Version check",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
-        "body": [
-            {
-                "id": "mod-circulation-23.5.7"
-            }
-        ],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-23.4.11",
+                    "name": "mod-circulation",
+                    "version": "23.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-fallback-module-version.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-fallback-module-version.json
@@ -1,0 +1,145 @@
+[
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/instance-storage\/instances",
+        "expectedParams": {
+            "query": "id == (\"instanceid\")",
+            "offset": 0,
+            "limit": 1000
+        },
+        "body": {
+            "instances": [
+                {
+                    "id": "instanceid",
+                    "_version": 1,
+                    "hrid": "foo",
+                    "source": "MARC",
+                    "title": "The bride of the tomb; or, Lancelot Darling's betrothed \/ By Mrs. Alex. McVeigh Miller.",
+                    "indexTitle": "Bride of the tomb; or, lancelot darling's betrothed",
+                    "editions": [],
+                    "series": [
+                        "Munro's library ; v. 1, no. 2"
+                    ],
+                    "identifiers": [],
+                    "contributors": [
+                        {
+                            "name": "Miller, Alex. McVeigh, Mrs",
+                            "contributorTypeId": "contypeID",
+                            "contributorTypeText": "Contributor",
+                            "contributorNameTypeId": "conNameTypeID",
+                            "primary": true
+                        }
+                    ],
+                    "subjects": [
+                        "Dime novels Specimens",
+                        "Genre: Popular literature Specimens",
+                        "Genre: Mystery and detective fiction"
+                    ],
+                    "classifications": [
+                        {
+                            "classificationNumber": "PS2394 .M643 1883",
+                            "classificationTypeId": "ctypeId"
+                        }
+                    ],
+                    "publication": [
+                        {
+                            "publisher": "Norman L. Munro",
+                            "place": "New York",
+                            "dateOfPublication": "1883"
+                        }
+                    ],
+                    "publicationFrequency": [],
+                    "publicationRange": [],
+                    "publicationPeriod": {
+                        "start": 1883
+                    },
+                    "electronicAccess": [],
+                    "instanceTypeId": "insttypeID",
+                    "instanceFormatIds": [],
+                    "instanceFormats": [],
+                    "physicalDescriptions": [
+                        "144 p.  ; 19 cm."
+                    ],
+                    "languages": [
+                        "eng"
+                    ],
+                    "notes": [],
+                    "modeOfIssuanceId": "moiid",
+                    "previouslyHeld": false,
+                    "staffSuppress": false,
+                    "discoverySuppress": false,
+                    "statisticalCodeIds": [],
+                    "statusUpdatedDate": "2022-12-22T23:34:26.209+0000",
+                    "holdingsRecords2": [],
+                    "natureOfContentTermIds": []
+                }
+            ],
+            "totalRecords": 1,
+            "resultInfo": {
+                "totalRecords": 1,
+                "facets": [],
+                "diagnostics": []
+            }
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "comment": "Version check with failure",
+        "expectedMethod": "GET",
+        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedParams": [],
+        "body": {
+            "errors": [
+                {
+                    "type":"SomeException",
+                    "code":"server_error",
+                    "message":"Some error"
+                }
+            ],
+            "total_records":1
+        },
+        "bodyType": "json",
+        "status": 500
+    },
+    {
+        "comment": "Version check fallback method",
+        "expectedMethod": "GET",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
+        "expectedParams": [],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-24.4.11",
+                    "name": "mod-circulation",
+                    "version": "24.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/circulation\/requests\/allowed-service-points?instanceId=instanceid&requesterId=foo&operation=create",
+        "expectedParams": [],
+        "body": {
+            "Page": [
+                {
+                    "id": "desk1",
+                    "name": "Main Service Desk"
+                }
+            ]
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "expectedMethod": "POST",
+        "expectedPath": "/circulation/requests",
+        "expectedParamsRegEx": "/{\"itemId\":\"record1\",\"requesterId\":\"foo\",\"requestDate\":\".*\",\"fulfillmentPreference\":\"Hold Shelf\",\"requestExpirationDate\":\"2022-01-01\",\"pickupServicePointId\":\"desk1\",\"requestType\":\"Page\"}/",
+        "body": "{ \"status\": \"success\" }"
+    }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-fallback-module-version.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-fallback-module-version.json
@@ -87,7 +87,7 @@
     {
         "comment": "Version check with failure",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
         "body": {
             "errors": [
@@ -105,19 +105,9 @@
     {
         "comment": "Version check fallback method",
         "expectedMethod": "GET",
-        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
+        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
         "expectedParams": [],
-        "body": {
-            "discovery": [
-                {
-                    "location": "http://mod-circulation-b:8051/mod-circulation",
-                    "id": "mod-circulation-24.4.11",
-                    "name": "mod-circulation",
-                    "version": "24.4.11"
-                }
-            ],
-            "totalRecords": 1
-        },
+        "body": [ {"id":"mod-circulation-24.0.0"} ],
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-invalid-module-version.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-invalid-module-version.json
@@ -1,0 +1,136 @@
+[
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/instance-storage\/instances",
+        "expectedParams": {
+            "query": "id == (\"instanceid\")",
+            "offset": 0,
+            "limit": 1000
+        },
+        "body": {
+            "instances": [
+                {
+                    "id": "instanceid",
+                    "_version": 1,
+                    "hrid": "foo",
+                    "source": "MARC",
+                    "title": "The bride of the tomb; or, Lancelot Darling's betrothed \/ By Mrs. Alex. McVeigh Miller.",
+                    "indexTitle": "Bride of the tomb; or, lancelot darling's betrothed",
+                    "editions": [],
+                    "series": [
+                        "Munro's library ; v. 1, no. 2"
+                    ],
+                    "identifiers": [],
+                    "contributors": [
+                        {
+                            "name": "Miller, Alex. McVeigh, Mrs",
+                            "contributorTypeId": "contypeID",
+                            "contributorTypeText": "Contributor",
+                            "contributorNameTypeId": "conNameTypeID",
+                            "primary": true
+                        }
+                    ],
+                    "subjects": [
+                        "Dime novels Specimens",
+                        "Genre: Popular literature Specimens",
+                        "Genre: Mystery and detective fiction"
+                    ],
+                    "classifications": [
+                        {
+                            "classificationNumber": "PS2394 .M643 1883",
+                            "classificationTypeId": "ctypeId"
+                        }
+                    ],
+                    "publication": [
+                        {
+                            "publisher": "Norman L. Munro",
+                            "place": "New York",
+                            "dateOfPublication": "1883"
+                        }
+                    ],
+                    "publicationFrequency": [],
+                    "publicationRange": [],
+                    "publicationPeriod": {
+                        "start": 1883
+                    },
+                    "electronicAccess": [],
+                    "instanceTypeId": "insttypeID",
+                    "instanceFormatIds": [],
+                    "instanceFormats": [],
+                    "physicalDescriptions": [
+                        "144 p.  ; 19 cm."
+                    ],
+                    "languages": [
+                        "eng"
+                    ],
+                    "notes": [],
+                    "modeOfIssuanceId": "moiid",
+                    "previouslyHeld": false,
+                    "staffSuppress": false,
+                    "discoverySuppress": false,
+                    "statisticalCodeIds": [],
+                    "statusUpdatedDate": "2022-12-22T23:34:26.209+0000",
+                    "holdingsRecords2": [],
+                    "natureOfContentTermIds": []
+                }
+            ],
+            "totalRecords": 1,
+            "resultInfo": {
+                "totalRecords": 1,
+                "facets": [],
+                "diagnostics": []
+            }
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "comment": "Version check with invalid response",
+        "expectedMethod": "GET",
+        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedParams": [],
+        "body": "not-valid-json",
+        "bodyType": "string",
+        "status": 200
+    },
+    {
+        "comment": "Version check fallback method",
+        "expectedMethod": "GET",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
+        "expectedParams": [],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-24.4.11",
+                    "name": "mod-circulation",
+                    "version": "24.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/circulation\/requests\/allowed-service-points?instanceId=instanceid&requesterId=foo&operation=create",
+        "expectedParams": [],
+        "body": {
+            "Page": [
+                {
+                    "id": "desk1",
+                    "name": "Main Service Desk"
+                }
+            ]
+        },
+        "bodyType": "json",
+        "status": 200
+    },
+    {
+        "expectedMethod": "POST",
+        "expectedPath": "/circulation/requests",
+        "expectedParamsRegEx": "/{\"itemId\":\"record1\",\"requesterId\":\"foo\",\"requestDate\":\".*\",\"fulfillmentPreference\":\"Hold Shelf\",\"requestExpirationDate\":\"2022-01-01\",\"pickupServicePointId\":\"desk1\",\"requestType\":\"Page\"}/",
+        "body": "{ \"status\": \"success\" }"
+    }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-invalid-module-version.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-invalid-module-version.json
@@ -87,7 +87,7 @@
     {
         "comment": "Version check with invalid response",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
         "body": "not-valid-json",
         "bodyType": "string",
@@ -96,19 +96,9 @@
     {
         "comment": "Version check fallback method",
         "expectedMethod": "GET",
-        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
+        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
         "expectedParams": [],
-        "body": {
-            "discovery": [
-                {
-                    "location": "http://mod-circulation-b:8051/mod-circulation",
-                    "id": "mod-circulation-24.4.11",
-                    "name": "mod-circulation",
-                    "version": "24.4.11"
-                }
-            ],
-            "totalRecords": 1
-        },
+        "body": [ {"id":"mod-circulation-24.0.0"} ],
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-legacy.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-legacy.json
@@ -87,9 +87,19 @@
     {
         "comment": "Version check",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
-        "body": [ {"id":"mod-circulation-23.5.7"} ],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-23.5.7",
+                    "name": "mod-circulation",
+                    "version": "23.5.7"
+                }
+            ],
+            "totalRecords": 1
+        },
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-no-expiration-date.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold-no-expiration-date.json
@@ -87,9 +87,19 @@
     {
         "comment": "Version check",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
-        "body": [ {"id":"mod-circulation-24.0.0"} ],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-24.4.11",
+                    "name": "mod-circulation",
+                    "version": "24.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/successful-place-hold.json
+++ b/module/VuFind/tests/fixtures/folio/responses/successful-place-hold.json
@@ -87,9 +87,19 @@
     {
         "comment": "Version check",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
-        "body": [ {"id":"mod-circulation-24.0.0"} ],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-24.4.11",
+                    "name": "mod-circulation",
+                    "version": "24.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/fixtures/folio/responses/unsuccessful-place-hold.json
+++ b/module/VuFind/tests/fixtures/folio/responses/unsuccessful-place-hold.json
@@ -87,9 +87,19 @@
     {
         "comment": "Version check",
         "expectedMethod": "GET",
-        "expectedPath": "\/_\/proxy\/tenants\/config_tenant\/modules?filter=mod-circulation&latest=1",
+        "expectedPath": "\/modules\/discovery?query=(name==mod-circulation)",
         "expectedParams": [],
-        "body": [ {"id":"mod-circulation-24.0.0"} ],
+        "body": {
+            "discovery": [
+                {
+                    "location": "http://mod-circulation-b:8051/mod-circulation",
+                    "id": "mod-circulation-24.4.11",
+                    "name": "mod-circulation",
+                    "version": "24.4.11"
+                }
+            ],
+            "totalRecords": 1
+        },
         "bodyType": "json",
         "status": 200
     },

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -523,6 +523,61 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test successful place hold when the first method
+     * of getting the mod-circulation version fails with an error
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\Depends('testTokens')]
+    public function testSuccessfulPlaceHoldFallbackModuleVersion(): void
+    {
+        $this->createConnector('successful-place-hold-fallback-module-version');
+        $details = [
+            'requiredBy' => '2022-01-01',
+            'requiredByTS' => 1641049790,
+            'patron' => ['id' => 'foo'],
+            'item_id' => 'record1',
+            'id' => 'instanceid',
+            'status' => 'Available',
+            'pickUpLocation' => 'desk1',
+        ];
+        $result = $this->driver->placeHold($details);
+        $expected = [
+            'success' => true,
+            'status' => 'success',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test successful place hold when the first method
+     * of getting the mod-circulation version returns
+     * invalid JSON
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\Depends('testTokens')]
+    public function testSuccessfulPlaceHoldInvalidModuleVersion(): void
+    {
+        $this->createConnector('successful-place-hold-invalid-module-version');
+        $details = [
+            'requiredBy' => '2022-01-01',
+            'requiredByTS' => 1641049790,
+            'patron' => ['id' => 'foo'],
+            'item_id' => 'record1',
+            'id' => 'instanceid',
+            'status' => 'Available',
+            'pickUpLocation' => 'desk1',
+        ];
+        $result = $this->driver->placeHold($details);
+        $expected = [
+            'success' => true,
+            'status' => 'success',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test successful renewal
      *
      * @return void


### PR DESCRIPTION
This is a possible work around for the issue with submitting requests (`placeHold`) as of the Sunflower release in FOLIO which fails due to permission errors in the `getModuleMajorVersion` function when calling the `/_/proxy/tenants/` API endpoint. Ideally we won't need to merge this and can discover some additional permission we just need to grant our application user (and [document it in the wiki](https://vufind.org/wiki/configuration:ils:folio)), since it isn't great that this method means we always have to try the first call to see if it fails before making the one that will work after Sunflower.