### PR TITLE
Fix AbstractBackgroundLayer::createSeed for empty arguments

### DIFF
--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
@@ -46,27 +46,22 @@ abstract class AbstractBackgroundLayer extends AbstractLayer
     /**
      * Generates a dynamic cover image from elements of the book
      *
-     * @param string $title      Title of the book
-     * @param string $callnumber Callnumber of the book
+     * @param ?string $title      Title of the book
+     * @param ?string $callnumber Callnumber of the book
      *
      * @return int unique number for this record
      */
     protected function createSeed($title, $callnumber)
     {
-        // Turn callnumber into number
-        if (null == $callnumber) {
-            $callnumber = $title;
+        // Pick text for seeding the algorithm:
+        $textSeed = $callnumber ?? $title ?? '';
+        $cv = 0;
+        // Add up the values of the characters in the seed string:
+        for ($i = 0; $i < strlen($textSeed); $i++) {
+            $cv += ord($textSeed[$i]);
         }
-        if (null != $callnumber) {
-            $cv = 0;
-            for ($i = 0; $i < strlen($callnumber); $i++) {
-                $cv += ord($callnumber[$i]);
-            }
-            return $cv;
-        } else {
-            // If no callnumber, random
-            return ceil(rand(2 ** 4, 2 ** 32));
-        }
+        // If we failed to generate a non-zero seed, use a random one instead.
+        return $cv > 0 ? $cv : ceil(rand(2 ** 4, 2 ** 32));
     }
 
     /**

--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
@@ -57,7 +57,7 @@ abstract class AbstractBackgroundLayer extends AbstractLayer
         if (null == $callnumber) {
             $callnumber = $title;
         }
-        if (null !== $callnumber) {
+        if (null != $callnumber) {
             $cv = 0;
             for ($i = 0; $i < strlen($callnumber); $i++) {
                 $cv += ord($callnumber[$i]);

--- a/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
+++ b/module/VuFind/src/VuFind/Cover/Layer/AbstractBackgroundLayer.php
@@ -46,15 +46,15 @@ abstract class AbstractBackgroundLayer extends AbstractLayer
     /**
      * Generates a dynamic cover image from elements of the book
      *
-     * @param ?string $title      Title of the book
-     * @param ?string $callnumber Callnumber of the book
+     * @param string $title      Title of the book
+     * @param string $callnumber Callnumber of the book
      *
      * @return int unique number for this record
      */
     protected function createSeed($title, $callnumber)
     {
         // Pick text for seeding the algorithm:
-        $textSeed = $callnumber ?? $title ?? '';
+        $textSeed = $callnumber ?: $title ?: '';
         $cv = 0;
         // Add up the values of the characters in the seed string:
         for ($i = 0; $i < strlen($textSeed); $i++) {


### PR DESCRIPTION
The function calculated a seed 0 if both arguments were empty strings (which should not happen normally, but can happen in special cases).

The resulting pattern "0000" then triggered an exception in GridBackground::renderGrid:
Whoops\Exception\ErrorException, Undefined array key 4.

Because of this exception, no cover image was created and the text "Cover Image" (or its translation) was shown.