### PR TITLE
Improve Mink test types; remove unnecessary assertions.

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -29,8 +29,12 @@
 
 namespace VuFindTest\Integration;
 
+use Behat\Mink\Driver\CoreDriver;
 use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\Element;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Element\TraversableElement;
 use DMore\ChromeDriver\ChromeDriver;
 use ReflectionException;
 use Symfony\Component\Yaml\Yaml;
@@ -196,7 +200,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function changeConfigs($configs, $replace = [])
+    protected function changeConfigs(array $configs, array $replace = []): void
     {
         foreach ($configs as $file => $settings) {
             $this->changeConfigFile($file, $settings, in_array($file, $replace));
@@ -216,7 +220,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function changeYamlConfigs($configs, $replace = [])
+    protected function changeYamlConfigs(array $configs, array $replace = []): void
     {
         foreach ($configs as $file => $settings) {
             $this->changeYamlConfigFile($file, $settings, in_array($file, $replace));
@@ -295,7 +299,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function changeYamlConfigFile($configName, $settings, $replace = false)
+    protected function changeYamlConfigFile(string $configName, array $settings, bool $replace = false): void
     {
         $file = $configName . '.yaml';
         $local = $this->pathResolver->getLocalConfigPath($file, null, true);
@@ -326,7 +330,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    protected function getConfig($configName = 'config'): array
+    protected function getConfig(string $configName = 'config'): array
     {
         $file = $configName . '.ini';
         $configPath = $this->pathResolver->getLocalConfigPath($file, null, true);
@@ -357,7 +361,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function snooze($secs = 1)
+    protected function snooze(int $secs = 1): void
     {
         $snoozeMultiplier = $this->getSnoozeMultiplier();
         if ($snoozeMultiplier <= 0) {
@@ -391,11 +395,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Test an element for visibility.
      *
-     * @param Element $element Element to test
+     * @param NodeElement $element Element to test
      *
      * @return bool
      */
-    protected function checkVisibility(Element $element)
+    protected function checkVisibility(NodeElement $element): bool
     {
         return $element->isVisible();
     }
@@ -403,9 +407,9 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Get the Mink driver, initializing it if necessary.
      *
-     * @return Selenium2Driver
+     * @return CoreDriver
      */
-    protected function getMinkDriver()
+    protected function getMinkDriver(): CoreDriver
     {
         $driver = getenv('VUFIND_MINK_DRIVER') ?? 'selenium';
         if ($driver === 'chrome') {
@@ -420,7 +424,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return Session
      */
-    protected function getMinkSession()
+    protected function getMinkSession(): Session
     {
         if (empty($this->session)) {
             $this->session = new Session($this->getMinkDriver());
@@ -440,7 +444,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function stopMinkSession()
+    protected function stopMinkSession(): void
     {
         if (!empty($this->session)) {
             $this->session->stop();
@@ -455,7 +459,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return string
      */
-    protected function getVuFindUrl($path = '')
+    protected function getVuFindUrl(string $path = ''): string
     {
         $base = getenv('VUFIND_URL');
         if (empty($base)) {
@@ -518,7 +522,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function restoreConfigs()
+    protected function restoreConfigs(): void
     {
         $configs = [
             '.ini' => $this->modifiedConfigs,
@@ -547,17 +551,17 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout (in ms)
+     * @param ?int    $timeout  Wait timeout (in ms)
      * @param int     $index    Index of the element (0-based)
      *
-     * @return mixed
+     * @return NodeElement
      */
     protected function findCss(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0
+    ): NodeElement {
         $timeout ??= $this->getDefaultTimeout();
         $session = $this->getMinkSession();
         $session->wait(
@@ -580,11 +584,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      * Includes a check for $ to be available to make sure jQuery has been loaded.
      *
      * @param string $statement JavaScript statement to evaluate
-     * @param int    $timeout   Wait timeout (in ms)
+     * @param ?int   $timeout   Wait timeout (in ms)
      *
-     * @return mixed
+     * @return void
      */
-    protected function waitStatement($statement, $timeout = null)
+    protected function waitStatement(string $statement, ?int $timeout = null): void
     {
         $timeout ??= $this->getDefaultTimeout();
         $session = $this->getMinkSession();
@@ -602,17 +606,17 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout (in ms)
+     * @param ?int    $timeout  Wait timeout (in ms)
      * @param int     $index    Index of the element (0-based)
      *
      * @return void
      */
     protected function unFindCss(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0
+    ): void {
         $timeout ??= $this->getDefaultTimeout();
         $startTime = microtime(true);
         $exception = null;
@@ -647,17 +651,18 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout (in ms)
+     * @param ?int    $timeout  Wait timeout (in ms)
      * @param int     $index    Index of the element (0-based)
      *
-     * @return mixed
+     * @return NodeElement
+     * @throws \Exception
      */
     protected function clickCss(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0
+    ): NodeElement {
         $maxTries = 3;
         for ($tries = 1; $tries <= $maxTries; $tries++) {
             try {
@@ -683,22 +688,22 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      * @param Element $page        Page element
      * @param string  $selector    CSS selector
      * @param string  $value       Value to set
-     * @param int     $timeout     Wait timeout for CSS selection (in ms)
+     * @param ?int    $timeout     Wait timeout for CSS selection (in ms)
      * @param int     $retries     Retry count for set loop
      * @param bool    $verifyValue Whether to verify that the value was written
      * @param bool    $reFocus     Whether to focus the element when done setting the value
      *
-     * @return mixed
+     * @return void
      */
     protected function findCssAndSetValue(
         Element $page,
-        $selector,
-        $value,
-        $timeout = null,
-        $retries = 6,
-        $verifyValue = true,
-        $reFocus = false
-    ) {
+        string $selector,
+        string $value,
+        ?int $timeout = null,
+        int $retries = 6,
+        bool $verifyValue = true,
+        bool $reFocus = false
+    ): void {
         $timeout ??= $this->getDefaultTimeout();
 
         // Workaround for Chromedriver bug; sometimes setting a value
@@ -740,7 +745,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout for CSS selection (in ms)
+     * @param ?int    $timeout  Wait timeout for CSS selection (in ms)
      * @param int     $index    Index of the element (0-based)
      * @param int     $retries  Retry count for set loop
      *
@@ -748,11 +753,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function findCssAndGetText(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0,
-        $retries = 6
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0,
+        int $retries = 6
+    ): string {
         return $this->findCssAndCallMethod($page, $selector, 'getText', $timeout, $index, $retries);
     }
 
@@ -761,7 +766,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout for CSS selection (in ms)
+     * @param ?int    $timeout  Wait timeout for CSS selection (in ms)
      * @param int     $index    Index of the element (0-based)
      * @param int     $retries  Retry count for set loop
      *
@@ -769,11 +774,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function findCssAndGetValue(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0,
-        $retries = 6
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0,
+        int $retries = 6
+    ): string {
         return $this->findCssAndCallMethod($page, $selector, 'getValue', $timeout, $index, $retries);
     }
 
@@ -782,7 +787,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param Element $page     Page element
      * @param string  $selector CSS selector
-     * @param int     $timeout  Wait timeout for CSS selection (in ms)
+     * @param ?int    $timeout  Wait timeout for CSS selection (in ms)
      * @param int     $index    Index of the element (0-based)
      * @param int     $retries  Retry count for set loop
      *
@@ -790,11 +795,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      */
     protected function findCssAndGetHtml(
         Element $page,
-        $selector,
-        $timeout = null,
-        $index = 0,
-        $retries = 6
-    ) {
+        string $selector,
+        ?int $timeout = null,
+        int $index = 0,
+        int $retries = 6
+    ): string {
         return $this->findCssAndCallMethod($page, $selector, 'getHtml', $timeout, $index, $retries);
     }
 
@@ -804,19 +809,19 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      * @param Element         $page     Page element
      * @param string          $selector CSS selector
      * @param string|callable $method   Node's method to call (string) or callable that gets the node as parameter
-     * @param int             $timeout  Wait timeout for CSS selection (in ms)
+     * @param ?int            $timeout  Wait timeout for CSS selection (in ms)
      * @param int             $index    Index of the element (0-based)
      * @param int             $retries  Retry count for set loop
      *
-     * @return string
+     * @return mixed
      */
     protected function findCssAndCallMethod(
         Element $page,
-        $selector,
-        $method,
-        $timeout = null,
-        $index = 0,
-        $retries = 6,
+        string $selector,
+        string|callable $method,
+        ?int $timeout = null,
+        int $index = 0,
+        int $retries = 6,
     ) {
         $timeout ??= $this->getDefaultTimeout();
 
@@ -840,12 +845,12 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Retrieve a link and assert that it exists before returning it.
      *
-     * @param Element $page Page element
-     * @param string  $text Link text to match
+     * @param TraversableElement $page Page element
+     * @param string             $text Link text to match
      *
-     * @return mixed
+     * @return NodeElement
      */
-    protected function findAndAssertLink(Element $page, $text)
+    protected function findAndAssertLink(TraversableElement $page, string $text): NodeElement
     {
         $link = $page->findLink($text);
         $this->assertIsObject($link);
@@ -861,7 +866,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return bool
      */
-    protected function hasElementsMatchingText(Element $page, $selector, $text)
+    protected function hasElementsMatchingText(Element $page, string $selector, string $text): bool
     {
         foreach ($page->findAll('css', $selector) as $current) {
             if ($text === $current->getText()) {
@@ -926,7 +931,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         callable $compareFunc,
         callable $assertion,
         ?int $timeout = null
-    ) {
+    ): void {
         $timeout ??= $this->getDefaultTimeout();
         $result = null;
         $startTime = microtime(true);
@@ -964,7 +969,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         $expected,
         callable $callback,
         ?int $timeout = null
-    ) {
+    ): void {
         $this->assertWithTimeout(
             $expected,
             $callback,
@@ -989,7 +994,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
         string $expected,
         callable $callback,
         ?int $timeout = null
-    ) {
+    ): void {
         $this->assertWithTimeout(
             $expected,
             $callback,
@@ -1004,13 +1009,13 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Search for the specified query.
      *
-     * @param string $query   Search term(s)
-     * @param string $handler Search type (optional)
-     * @param string $path    Path to use as search starting point (optional)
+     * @param string  $query   Search term(s)
+     * @param ?string $handler Search type (optional)
+     * @param string  $path    Path to use as search starting point (optional)
      *
-     * @return Element
+     * @return DocumentElement
      */
-    protected function performSearch($query, $handler = null, $path = '/Search')
+    protected function performSearch(string $query, ?string $handler = null, string $path = '/Search'): DocumentElement
     {
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . $path);
@@ -1054,7 +1059,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     protected function waitForPageLoad(
         Element $page,
         ?int $timeout = null
-    ) {
+    ): void {
         $timeout ??= $this->getDefaultTimeout();
         $session = $this->getMinkSession();
         // Wait for page load to complete:
@@ -1104,7 +1109,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function closeLightbox(Element $page, $closeButton = false)
+    protected function closeLightbox(Element $page, bool $closeButton = false): void
     {
         if ($closeButton) {
             $button = $this->findCss($page, '#modal .modal-body .btn');
@@ -1127,7 +1132,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function waitForLightboxHidden()
+    protected function waitForLightboxHidden(): void
     {
         $this->waitStatement(
             '$("#modal:visible").length === 0'
@@ -1159,7 +1164,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function assertLightboxWarning(Element $page, $message)
+    protected function assertLightboxWarning(Element $page, string $message): void
     {
         $warning = $page->find('css', '.modal-body .alert-danger .message');
         if (!$warning || strlen(trim($warning->getText())) == 0) {

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -357,11 +357,11 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Sleep if necessary.
      *
-     * @param int $secs Seconds to sleep
+     * @param int|float $secs Seconds to sleep
      *
      * @return void
      */
-    protected function snooze(int $secs = 1): void
+    protected function snooze(int|float $secs = 1): void
     {
         $snoozeMultiplier = $this->getSnoozeMultiplier();
         if ($snoozeMultiplier <= 0) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
@@ -145,7 +145,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLibraryCardForm($page, 'card 1', 'catuser1', 'bad');
         $this->clickCss($page, '.form-edit-card .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid login -- please try again.',
             $this->findCssAndGetText($page, '.alert-danger')
         );
@@ -154,7 +154,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLibraryCardForm($page, 'card 1', 'catuser1', 'catpass1');
         $this->clickCss($page, '.form-edit-card .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'card 1',
             $this->findCssAndGetText($page, 'tr:nth-child(2) td')
         );
@@ -165,7 +165,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLibraryCardForm($page, 'card 2', 'catuser2', 'catpass2');
         $this->clickCss($page, '.form-edit-card .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'card 2',
             $this->findCssAndGetText($page, 'tr:nth-child(3) td')
         );
@@ -185,7 +185,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLoginForm($page, 'username1', 'test', false);
         $this->submitLoginForm($page, false);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Library Cards', $this->findCssAndGetText($page, 'h2'));
+        $this->assertSame('Library Cards', $this->findCssAndGetText($page, 'h2'));
         $this->unfindCss($page, '.add-card span.icon-link__label');
     }
 
@@ -213,7 +213,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('card 2', $secondCard->getText());
 
         // Check that the appropriate username is reflected in the output:
-        $this->assertEquals(
+        $this->assertSame(
             'Lib-catuser1',
             $this->findCssAndGetText($page, '.catalog-profile tr:nth-child(1) td:nth-child(2)')
         );
@@ -224,7 +224,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
 
         // Check that the appropriate username is reflected in the output:
-        $this->assertEquals(
+        $this->assertSame(
             'Lib-catuser2',
             $this->findCssAndGetText($page, '.catalog-profile tr:nth-child(1) td:nth-child(2)')
         );
@@ -246,7 +246,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->submitLoginForm($page, false);
         $this->waitForPageLoad($page);
         // Confirm that we are on the profile page with no cards showing:
-        $this->assertEquals('Your Profile', $this->findCssAndGetText($page, 'h2'));
+        $this->assertSame('Your Profile', $this->findCssAndGetText($page, 'h2'));
         $this->unFindCss($page, '#library_card');
     }
 
@@ -272,7 +272,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.form-edit-card .btn.btn-primary');
         $this->waitForPageLoad($page);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Username is already in use in another library card',
             $this->findCssAndGetText($page, '.alert-danger')
         );
@@ -299,7 +299,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '[name="card_name"]', 'Edited Card');
         $this->clickCss($page, '.form-edit-card .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Edited Card',
             $this->findCssAndGetText($page, 'tr:nth-child(2) td')
         );
@@ -329,19 +329,20 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Click the delete button
         $button = $this->findCss($page, 'tr:nth-child(3)')->findLink('Delete');
+        $this->assertInstanceOf(\Behat\Mink\Element\NodeElement::class, $button);
         $button->click();
         $this->waitForPageLoad($page);
         $this->clickCss($page, $this->firstOpenDropdownMenuItemSelector);
         $this->waitForPageLoad($page);
 
         // Check for success message
-        $this->assertEquals(
+        $this->assertSame(
             'Library Card Deleted',
             $this->findCssAndGetText($page, '.alert-success')
         );
 
         // Check that the deleted card is now gone, but the other card still exists.
-        $this->assertEquals(
+        $this->assertSame(
             'Edited Card',
             $this->findCssAndGetText($page, 'tr:nth-child(2) td')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LibraryCardsTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
+use Behat\Mink\Element\NodeElement;
 
 /**
  * Mink library card actions test class.
@@ -329,7 +330,7 @@ final class LibraryCardsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Click the delete button
         $button = $this->findCss($page, 'tr:nth-child(3)')->findLink('Delete');
-        $this->assertInstanceOf(\Behat\Mink\Element\NodeElement::class, $button);
+        $this->assertInstanceOf(NodeElement::class, $button);
         $button->click();
         $this->waitForPageLoad($page);
         $this->clickCss($page, $this->firstOpenDropdownMenuItemSelector);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OAuth2Test.php
@@ -483,7 +483,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
         );
         $page = $session->getPage();
 
-        $this->assertEquals(
+        $this->assertSame(
             'An error has occurred',
             $this->findCssAndGetText($page, '.alert-danger p')
         );
@@ -644,7 +644,7 @@ final class OAuth2Test extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    protected function restoreConfigs()
+    protected function restoreConfigs(): void
     {
         parent::restoreConfigs();
         if ($this->opensslKeyPairCreated) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PasswordAccessTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PasswordAccessTest.php
@@ -174,7 +174,7 @@ final class PasswordAccessTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.logoutOptions a.logout');
 
         // Check that login link is back
-        $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+        $this->findCss($page, '#loginOptions a');
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PasswordAccessTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PasswordAccessTest.php
@@ -109,7 +109,7 @@ final class PasswordAccessTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#login_PasswordAccess_password', 'bad');
         $this->clickCss($page, '.modal-content input[type="submit"]');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid login -- please try again.',
             $this->findCssAndGetText($page, '.modal-content .alert-danger')
         );
@@ -146,7 +146,7 @@ final class PasswordAccessTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#login_PasswordAccess_password', 'bad');
         $this->clickCss($page, '.modal-content input[type="submit"]');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid login -- please try again.',
             $this->findCssAndGetText($page, '.modal-content .alert-danger')
         );
@@ -155,7 +155,7 @@ final class PasswordAccessTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#login_PasswordAccess_password', 'password');
         $this->clickCss($page, '.modal-content input[type="submit"]');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid login -- please try again.',
             $this->findCssAndGetText($page, '.modal-content .alert-danger')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PrivateUserTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PrivateUserTest.php
@@ -150,7 +150,7 @@ final class PrivateUserTest extends \VuFindTest\Integration\MinkTestCase
         // Log out
         $this->clickCss($page, '.logoutOptions a.logout');
         // Check that login link is back
-        $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+        $this->findCss($page, '#loginOptions a');
         // Assert that nothing was added to the user database:
         static::failIfDataExists('User data should not have been created in private user mode.');
     }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -95,7 +95,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInAccountForm($page);
         $this->clickCss($page, 'input.btn.btn-primary');
 
-        $this->assertEquals(
+        $this->assertSame(
             'Search saved successfully.',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -181,7 +181,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
             $this->hasElementsMatchingText($page, 'a', 'log in')
         );
         $this->waitForPageLoad($page);
-        $this->assertNull($page->findLink('test'));
+        $this->assertNotInstanceOf(\Behat\Mink\Element\NodeElement::class, $page->findLink('test'));
 
         // Now log in and see if our saved search shows up (without making the
         // unsaved search go away):
@@ -210,7 +210,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         // but saved search is still present:
         $this->findAndAssertLink($page, 'Purge unsaved searches')->click();
         $this->waitForPageLoad($page);
-        $this->assertNull($page->findLink('foo \ bar'));
+        $this->assertNotInstanceOf(\Behat\Mink\Element\NodeElement::class, $page->findLink('foo \ bar'));
         $this->assertEquals(
             'test',
             $this->findAndAssertLink($page, 'test')->getText()
@@ -332,7 +332,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         // At this point, our journals search should be in the unsaved list; let's
         // set it up for alerts and confirm that this auto-saves it.
         $select = $this->findCss($page, '#recent-searches ' . $scheduleSelector);
-        $select->selectOption(7);
+        $select->selectOption('7');
         $this->waitForPageLoad($page);
         $this->assertCount(
             2,
@@ -378,12 +378,12 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         // We should now be on a page with a schedule selector; let's pick something:
         $scheduleSelector = 'select[name="schedule"]';
         $select = $this->findCss($page, $scheduleSelector);
-        $select->selectOption(7);
+        $select->selectOption('7');
         $this->waitForPageLoad($page);
 
         // Let's confirm that if we repeat the search, the alert will now be set:
         $page = $this->performSearch('employment');
-        $this->assertEquals('Alert schedule: Weekly', $this->findCssAndGetText($page, '.searchtools .manageSchedule'));
+        $this->assertSame('Alert schedule: Weekly', $this->findCssAndGetText($page, '.searchtools .manageSchedule'));
     }
 
     /**
@@ -449,7 +449,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
 
         // Let's set up our search for alerts and make sure it's handled correctly:
         $select = $this->findCss($page, '#recent-searches ' . $scheduleSelector);
-        $select->selectOption(1);
+        $select->selectOption('1');
         $this->waitForPageLoad($page);
 
         // We should now be prompted to log in:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
+use Behat\Mink\Element\NodeElement;
 
 /**
  * Mink saved searches test class.
@@ -181,7 +182,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
             $this->hasElementsMatchingText($page, 'a', 'log in')
         );
         $this->waitForPageLoad($page);
-        $this->assertNotInstanceOf(\Behat\Mink\Element\NodeElement::class, $page->findLink('test'));
+        $this->assertNotInstanceOf(NodeElement::class, $page->findLink('test'));
 
         // Now log in and see if our saved search shows up (without making the
         // unsaved search go away):

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SavedSearchesTest.php
@@ -211,7 +211,7 @@ final class SavedSearchesTest extends \VuFindTest\Integration\MinkTestCase
         // but saved search is still present:
         $this->findAndAssertLink($page, 'Purge unsaved searches')->click();
         $this->waitForPageLoad($page);
-        $this->assertNotInstanceOf(\Behat\Mink\Element\NodeElement::class, $page->findLink('foo \ bar'));
+        $this->assertNotInstanceOf(NodeElement::class, $page->findLink('foo \ bar'));
         $this->assertEquals(
             'test',
             $this->findAndAssertLink($page, 'test')->getText()

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -1502,11 +1502,11 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
     /**
      * Assert that the "reset filters" button is present.
      *
-     * @param \Behat\Mink\Element\Element $page Mink page object
+     * @param Element $page Mink page object
      *
      * @return void
      */
-    protected function assertResetFiltersButton($page)
+    protected function assertResetFiltersButton(Element $page): void
     {
         $reset = $page->findAll('css', '.reset-filters-btn');
         // The toggle bar has its own reset button, so we should have 2:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -189,7 +189,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertFullListFacetCount($page, 'count', $limit * 2, $exclusionActive);
 
         $excludeControl = $exclusionActive ? 'Exclude matching results ' : '';
-        $this->assertEquals(
+        $this->assertSame(
             'Weird IDs 9 results 9 ' . $excludeControl
             . 'Fiction 7 results 7 ' . $excludeControl
             . 'The Study Of P|pes 1 results 1 ' . $excludeControl
@@ -225,7 +225,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#modal #facet-list-index .js-facet-next-page');
         $this->waitForPageLoad($page);
         $this->assertFullListFacetCount($page, 'index', $limit * 2, $exclusionActive);
-        $this->assertEquals(
+        $this->assertSame(
             'Fiction 7 results 7 ' . $excludeControl
             . 'The Study Of P|pes 1 results 1 ' . $excludeControl
             . 'The Study and Scor_ng of Dots.and-Dashes:Colons 1 results 1 ' . $excludeControl
@@ -482,7 +482,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         // now clear the filter
         $this->clickCss($page, '#modal button[type="reset"]');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Weird IDs 9 results 9 '
             . 'Fiction 7 results 7 '
             . 'The Study Of P|pes 1 results 1 '
@@ -689,7 +689,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
         $items = $page->findAll('css', '#modal #facet-list-count .js-facet-item');
         $this->assertCount($limit * 2 - 1, $items);
-        $this->assertEquals(
+        $this->assertSame(
             'Weird IDs 9 results 9 '
             . 'The Study Of P|pes 1 results 1 '
             . 'The Study and Scor_ng of Dots.and-Dashes:Colons 1 results 1 '
@@ -1348,8 +1348,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
 
         // format:Book is also a normal facet, but count should still be empty unless enabled:
         $filter = $this->findCss($page, '.checkbox-filter');
-        $this->assertNotNull($filter);
-        $this->assertEquals('Books', $this->findCssAndGetText($filter->getParent(), '.icon-link__label'));
+        $this->assertSame('Books', $this->findCssAndGetText($filter->getParent(), '.icon-link__label'));
         $this->assertEqualsWithTimeout(
             $counts ? '9' : '',
             function () use ($filter) {
@@ -1359,8 +1358,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
 
         // illustrated:Illustrated is only a checkbox facet:
         $filter2 = $this->findCss($page, '.checkbox-filter', null, 1);
-        $this->assertNotNull($filter2);
-        $this->assertEquals('Illustrated', $this->findCssAndGetText($filter2->getParent(), '.icon-link__label'));
+        $this->assertSame('Illustrated', $this->findCssAndGetText($filter2->getParent(), '.icon-link__label'));
         $illustratedCount = $this->findCssAndGetText($filter2->getParent(), '.avail-count');
         $this->assertEquals($counts ? '2' : '', $illustratedCount);
 
@@ -1593,7 +1591,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
 
         // A past bug would cause search terms to get duplicated after facets
         // were applied; make sure the search remains as expected!
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:test AND All Fields:history)',
             $this->findCssAndGetText($page, '.adv_search_terms strong')
         );
@@ -1692,7 +1690,7 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performSearch('building:weird_ids.mrc OR building:journals.mrc');
         $sidebar = $this->findCss($page, '.sidebar');
         $this->assertFalse($this->findCss($sidebar, '.js-user-selection-multi-filters')->isVisible());
-        $this->assertNotNull($sidebar->find('css', '.js-apply-multi-facets-selection'));
+        $this->findCss($sidebar, '.js-apply-multi-facets-selection');
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
@@ -128,7 +128,7 @@ final class SsoTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.record-nav .save-record');
 
         // Login in lightbox
-        $this->assertEquals('Institutional Login', $this->findCssAndGetText($page, '.modal-body .btn.btn-link'));
+        $this->assertSame('Institutional Login', $this->findCssAndGetText($page, '.modal-body .btn.btn-link'));
         $this->clickCss($page, '.modal-body .btn.btn-link');
 
         // Check if save form is in lightbox
@@ -139,7 +139,7 @@ final class SsoTest extends \VuFindTest\Integration\MinkTestCase
         $this->closeLightbox($page);
 
         // Check that we are still on the record page
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy : the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, '.record .media-body h1')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SsoTest.php
@@ -191,7 +191,7 @@ final class SsoTest extends \VuFindTest\Integration\MinkTestCase
 
         // Check that login link is back:
         $session->reload();
-        $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+        $this->findCss($page, '#loginOptions a');
     }
 
     /**
@@ -208,7 +208,7 @@ final class SsoTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.logoutOptions a.logout');
 
         // Check that login link is back
-        $this->assertNotEmpty($this->findCss($page, '#loginOptions a'));
+        $this->findCss($page, '#loginOptions a');
     }
 
     /**


### PR DESCRIPTION
This PR adds better typing to the base Mink test case and applies Rector improvements resulting from those changes. It also removes some unnecessary assertions; since `findCss` always returns a `NodeElement`, there is no need to make assertions about the type or non-emptiness of return values; it will fail internal assertions if things are not found.

This should greatly reduce the scale of changes in (or possibly completely supersede) #5005; we should regenerate that PR after this is merged.

TODO
- [x] Run all tests
- [x] Revisit #5005 after merging