### PR TITLE
Add audit event for password reset.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -793,10 +793,7 @@ class Manager implements IdentityProviderInterface, LoggerAwareInterface
         $this->auditEventService->addEvent(
             AuditEventType::User,
             AuditEventSubType::PasswordReset,
-            data: [
-                'recoveryData' => $recoveryData,
-                'params' => $params,
-            ]
+            data: compact('recoveryData', 'params')
         );
     }
 

--- a/module/VuFind/src/VuFind/Auth/Manager.php
+++ b/module/VuFind/src/VuFind/Auth/Manager.php
@@ -790,6 +790,14 @@ class Manager implements IdentityProviderInterface, LoggerAwareInterface
     public function resetPassword(array $recoveryData, array $params)
     {
         $this->getAuth()->resetPassword($recoveryData, $params);
+        $this->auditEventService->addEvent(
+            AuditEventType::User,
+            AuditEventSubType::PasswordReset,
+            data: [
+                'recoveryData' => $recoveryData,
+                'params' => $params,
+            ]
+        );
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Type/AuditEventSubtype.php
+++ b/module/VuFind/src/VuFind/Db/Type/AuditEventSubtype.php
@@ -72,6 +72,7 @@ enum AuditEventSubtype: string
     case LoginFailure = 'login_fail';
     case Logout = 'logout';
     case PasswordChanged = 'password_changed';
+    case PasswordReset = 'password_reset';
     case RememberLogin = 'remember_login';
     case SaveSearch = 'save_search';
     case ScheduleSearch = 'schedule_search';


### PR DESCRIPTION
Password reset was missing audit event logging that other functions, such as password update, had.