### PR TITLE
Fix DefaultParametersListener and add Mink test

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/DefaultParametersListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DefaultParametersListener.php
@@ -32,6 +32,7 @@ namespace VuFind\Search\Solr;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use VuFindSearch\Backend\Solr\Backend;
+use VuFindSearch\Service;
 
 /**
  * Solr default parameters listener.
@@ -94,8 +95,12 @@ class DefaultParametersListener
      */
     public function attach(
         SharedEventManagerInterface $manager
-    ) {
-        $manager->attach(\VuFindSearch\Service::class, 'pre', [$this, 'onSearchPre']);
+    ): void {
+        $manager->attach(
+            Service::class,
+            Service::EVENT_PRE,
+            [$this, 'onSearchPre']
+        );
     }
 
     /**
@@ -105,16 +110,19 @@ class DefaultParametersListener
      *
      * @return EventInterface
      */
-    public function onSearchPre(EventInterface $event)
+    public function onSearchPre(EventInterface $event): EventInterface
     {
-        $backend = $event->getTarget();
-        if ($backend === $this->backend) {
-            $context = $event->getParam('context');
+        $command = $event->getParam('command');
+        if ($command->getTargetIdentifier() === $this->backend->getIdentifier()) {
+            $context = $command->getContext();
+            if (empty($context)) {
+                $context = null;
+            }
             $context = $this->contextMap[$context] ?? $context;
             $defaultParams = $this->defaultParams[$context]
                 ?? $this->defaultParams['*']
                 ?? '';
-            if ($defaultParams && $params = $event->getParam('params')) {
+            if ($defaultParams && $params = $command->getSearchParameters()) {
                 foreach (explode('&', $defaultParams) as $keyVal) {
                     $parts = explode('=', $keyVal, 2);
                     if (!isset($parts[1])) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SolrDefaultParameterTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SolrDefaultParameterTest.php
@@ -49,12 +49,19 @@ class SolrDefaultParameterTest extends \VuFindTest\Integration\MinkTestCase
      */
     public function testDefaultParameter(): void
     {
-        $this->changeConfigs(['searches' => ['General' => ['default_parameters[search]' => 'fq=id:0001732009-3']]]);
+        $id = '0001732009-3';
+        $this->changeConfigs(
+            ['searches' => ['General' => ['default_parameters' => ['search' => 'fq=' . urlencode("id:$id")]]]]
+        );
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Search/Results');
         $page = $session->getPage();
         $text = $this->findCssAndGetText($page, '.search-stats strong');
         [, $actualSize] = explode(' - ', $text);
         $this->assertSame(1, intval($actualSize));
+        $this->assertStringContainsString(
+            "/Record/$id?sid=",
+            $this->findCss($page, '.result a.title')->getAttribute('href')
+        );
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SolrDefaultParameterTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SolrDefaultParameterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Mink test class for Solr default parameter functionality.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+
+namespace VuFindTest\Mink;
+
+use function intval;
+
+/**
+ * Mink test class for Solr default parameter functionality.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Page
+ */
+class SolrDefaultParameterTest extends \VuFindTest\Integration\MinkTestCase
+{
+    /**
+     * Test that default parameters work.
+     *
+     * @return void
+     */
+    public function testDefaultParameter(): void
+    {
+        $this->changeConfigs(['searches' => ['General' => ['default_parameters[search]' => 'fq=id:0001732009-3']]]);
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results');
+        $page = $session->getPage();
+        $text = $this->findCssAndGetText($page, '.search-stats strong');
+        [, $actualSize] = explode(' - ', $text);
+        $this->assertSame(1, intval($actualSize));
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/DefaultParametersListenerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/DefaultParametersListenerTest.php
@@ -32,8 +32,11 @@
 namespace VuFindTest\Search\Solr;
 
 use Laminas\EventManager\Event;
+use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\Search\Solr\DefaultParametersListener;
+use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\ParamBag;
+use VuFindSearch\Service;
 
 /**
  * Unit tests for DefaultParametersListener.
@@ -46,6 +49,29 @@ use VuFindSearch\ParamBag;
  */
 class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
 {
+    use \VuFindTest\Feature\MockSearchCommandTrait;
+
+    /**
+     * Backends.
+     *
+     * @var BackendInterface[]|MockObject[]
+     */
+    protected $backends;
+
+    /**
+     * Setup.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->backends = [];
+        foreach (['primary', 'secondary'] as $name) {
+            $this->backends[$name] = $this->createMock(\VuFindSearch\Backend\Solr\Backend::class);
+            $this->backends[$name]->method('getIdentifier')->willReturn($name);
+        }
+    }
+
     /**
      * Test attaching listener.
      *
@@ -53,14 +79,13 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
      */
     public function testAttach()
     {
-        $backend = $this->getMockBuilder(\VuFindSearch\Backend\Solr\Backend::class)
-            ->disableOriginalConstructor()->getMock();
+        $backend = $this->createMock(\VuFindSearch\Backend\Solr\Backend::class);
         $listener = new DefaultParametersListener($backend, ['foo' => 'bar']);
         $mock = $this->createMock(\Laminas\EventManager\SharedEventManagerInterface::class);
         $mock->expects($this->once())->method('attach')->with(
-            $this->equalTo(\VuFindSearch\Service::class),
-            $this->equalTo('pre'),
-            $this->equalTo([$listener, 'onSearchPre'])
+            Service::class,
+            Service::EVENT_PRE,
+            [$listener, 'onSearchPre']
         );
         $listener->attach($mock);
     }
@@ -80,10 +105,13 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $backend = $this->getMockBuilder(\VuFindSearch\Backend\Solr\Backend::class)
-            ->disableOriginalConstructor()->getMock();
+        $command = $this->getMockSearchCommand(
+            $params,
+            'search',
+            $this->backends['secondary']->getIdentifier()
+        );
         $listener = new DefaultParametersListener(
-            $backend,
+            $this->backends['primary'],
             [
                 'search' => 'foo=1&foo=2',
                 '*' => 'bar=3&bar',
@@ -93,35 +121,45 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
         // Check that nothing fails if params element is missing:
         $event = new Event(
             'pre',
-            null,
-            ['context' => 'search']
+            $this->backends['secondary'],
+            compact('command')
         );
         $listener->onSearchPre($event);
 
         $event = new Event(
             'pre',
-            null,
-            ['params' => $params, 'context' => 'search']
+            $this->backends['secondary'],
+            compact('params', 'command')
         );
         $listener->onSearchPre($event);
 
         $this->assertEquals(null, $params->get('foo'));
         $this->assertEquals(null, $params->get('bar'));
 
+        $command = $this->getMockSearchCommand(
+            $params,
+            'search',
+            $this->backends['primary']->getIdentifier()
+        );
         $event = new Event(
             'pre',
-            $backend,
-            ['params' => $params, 'context' => 'search']
+            $this->backends['primary'],
+            compact('params', 'command')
         );
         $listener->onSearchPre($event);
 
         $this->assertEquals(['1', '2'], $params->get('foo'));
         $this->assertEquals(null, $params->get('bar'));
 
+        $command = $this->getMockSearchCommand(
+            $params,
+            'retrieve',
+            $this->backends['primary']->getIdentifier()
+        );
         $event = new Event(
             'pre',
-            $backend,
-            ['params' => $params, 'context' => 'retrieve']
+            $this->backends['primary'],
+            compact('params', 'command')
         );
         $listener->onSearchPre($event);
 
@@ -143,10 +181,13 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $backend = $this->getMockBuilder(\VuFindSearch\Backend\Solr\Backend::class)
-            ->disableOriginalConstructor()->getMock();
+        $command = $this->getMockSearchCommand(
+            $params,
+            'search',
+            $this->backends['primary']->getIdentifier()
+        );
         $listener = new DefaultParametersListener(
-            $backend,
+            $this->backends['primary'],
             [
                 'search' => 'foo=1&foo=2',
             ]
@@ -154,18 +195,23 @@ class DefaultParametersListenerTest extends \PHPUnit\Framework\TestCase
 
         $event = new Event(
             'pre',
-            $backend,
-            ['params' => $params, 'context' => 'search']
+            $this->backends['primary'],
+            compact('params', 'command')
         );
         $listener->onSearchPre($event);
 
         $this->assertEquals(['1', '2'], $params->get('foo'));
         $this->assertEquals(null, $params->get('bar'));
 
+        $command = $this->getMockSearchCommand(
+            $params,
+            'retrieve',
+            $this->backends['primary']->getIdentifier()
+        );
         $event = new Event(
             'pre',
-            $backend,
-            ['params' => $params, 'context' => 'retrieve']
+            $this->backends['primary'],
+            compact('params', 'command')
         );
         $listener->onSearchPre($event);
 


### PR DESCRIPTION
As far as I can tell, default parameters are not working at all.  It seems that applying the command pattern to the search listeners in #1967 missed DefaultParametersListener.

As defined in searches.ini, this should work
> ;default_parameters[*] = "echoParams=none&debugQuery=false"
;default_parameters[search] = "sow=false"
