### PR TITLE
Raise Rector level to 23.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountActionsTest.php
@@ -100,7 +100,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Change the password (but get the old password wrong)
         $this->fillInChangePasswordForm($page, 'bad', 'good');
         $this->clickCss($page, '#newpassword .btn.btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid login -- please try again.',
             $this->findCssAndGetText($page, '.alert-danger')
         );
@@ -108,7 +108,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Change the password successfully:
         $this->fillInChangePasswordForm($page, 'test', 'good');
         $this->clickCss($page, '#newpassword .btn.btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'Your password has successfully been changed',
             $this->findCssAndGetText($page, '.alert-success')
         );
@@ -267,14 +267,14 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '[name="email"]', 'new@email.com');
         $this->clickCss($page, '[name="submitButton"]');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Your email address has been changed successfully',
             $this->findCssAndGetText($page, '.alert-success')
         );
 
         // Now go to profile page and confirm that email has changed:
         $session->visit($this->getVuFindUrl('/MyResearch/Profile'));
-        $this->assertEquals(
+        $this->assertSame(
             'First Name: Tester Last Name: McTestenson Email: new@email.com',
             $this->findCssAndGetText($page, '.table-striped')
         );
@@ -325,7 +325,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Check the default library and possible values:
         $userService = $this->getDbService(UserService::class);
         $this->assertSame('', $userService->getUserByUsername('username2')->getHomeLibrary());
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->findCssAndGetValue($page, '#home_library')
         );
@@ -348,7 +348,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#home_library', 'B');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
-        $this->assertEquals('B', $this->findCssAndGetValue($page, '#home_library'));
+        $this->assertSame('B', $this->findCssAndGetValue($page, '#home_library'));
         $entityManager = $this->getLiveDatabaseContainer()->get(EntityManager::class);
         $entityManager->clear();
         $this->assertSame(
@@ -360,7 +360,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#home_library', ' ** ');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             ' ** ',
             $this->findCssAndGetValue($page, '#home_library')
         );
@@ -371,7 +371,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#home_library', '');
         $this->clickCss($page, '#profile_form .btn');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->findCssAndGetValue($page, '#home_library')
         );
@@ -449,7 +449,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLoginForm($page, 'username2', 'test', false);
         $this->submitLoginForm($page, false);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Invalid login -- please try again.', $this->findCssAndGetText($page, '.alert-danger'));
+        $this->assertSame('Invalid login -- please try again.', $this->findCssAndGetText($page, '.alert-danger'));
     }
 
     /**
@@ -502,9 +502,9 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#recovery_username', 'bad');
         $this->clickCss($page, '.modal-body input[type="submit"]');
         if ($beHonest) {
-            $this->assertEquals('We could not find your account', $this->findCssAndGetText($page, '.alert-danger'));
+            $this->assertSame('We could not find your account', $this->findCssAndGetText($page, '.alert-danger'));
         } else {
-            $this->assertEquals(
+            $this->assertSame(
                 'Password recovery instructions have been sent to the email address registered with this account.',
                 $this->findCssAndGetText($page, '.alert-success')
             );
@@ -548,7 +548,7 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.modal-body .recover-account-link');
         $this->findCssAndSetValue($page, '#recovery_username', 'username1');
         $this->clickCss($page, '.modal-body input[type="submit"]');
-        $this->assertEquals(
+        $this->assertSame(
             'Password recovery instructions have been sent to the email address registered with this account.',
             $this->findCssAndGetText($page, '.alert-success')
         );
@@ -560,11 +560,11 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Reset the password:
         $session->visit($link);
-        $this->assertEquals('username1', $this->findCssAndGetText($page, '.form-control-static'));
+        $this->assertSame('username1', $this->findCssAndGetText($page, '.form-control-static'));
         $this->findCssAndSetValue($page, '#password', 'recovered');
         $this->findCssAndSetValue($page, '#password2', 'recovered');
         $this->clickCss($page, '.form-new-password .btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'Your password has successfully been changed',
             $this->findCssAndGetText($page, '.alert-success')
         );
@@ -736,11 +736,11 @@ final class AccountActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Reset the password:
         $session->visit($link);
-        $this->assertEquals('catuser', $this->findCssAndGetText($page, '.form-control-static'));
+        $this->assertSame('catuser', $this->findCssAndGetText($page, '.form-control-static'));
         $this->findCssAndSetValue($page, '#password', 'recovered');
         $this->findCssAndSetValue($page, '#password2', 'recovered');
         $this->clickCss($page, '.form-new-password .btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'Your password has successfully been changed',
             $this->findCssAndGetText($page, '.alert-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AccountMenuTest.php
@@ -376,7 +376,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '1',
             $this->findCssAndGetText($checkoutsStatus, '.badge.account-info')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Items due later: 1 ,',
             $this->findCssAndGetText($checkoutsStatus, '.visually-hidden')
         );
@@ -385,7 +385,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '2',
             $this->findCssAndGetText($checkoutsStatus, ' .badge.account-warning')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Items due soon: 2 ,',
             $this->findCssAndGetText($checkoutsStatus, '.visually-hidden', null, 1)
         );
@@ -394,7 +394,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '3',
             $this->findCssAndGetText($checkoutsStatus, '.badge.account-alert')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Items overdue: 3 ,',
             $this->findCssAndGetText($checkoutsStatus, '.visually-hidden', null, 2)
         );
@@ -405,7 +405,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '1',
             $this->findCssAndGetText($holdsStatus, '.badge.account-info')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Available for Pickup: 1 ,',
             $this->findCssAndGetText($holdsStatus, '.visually-hidden')
         );
@@ -414,7 +414,7 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '2',
             $this->findCssAndGetText($holdsStatus, '.badge.account-warning')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'In Transit: 2 ,',
             $this->findCssAndGetText($holdsStatus, '.visually-hidden', null, 1)
         );
@@ -423,13 +423,13 @@ final class AccountMenuTest extends \VuFindTest\Integration\MinkTestCase
             '3',
             $this->findCssAndGetText($holdsStatus, '.badge.account-none')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Other Status: 3 ,',
             $this->findCssAndGetText($holdsStatus, '.visually-hidden', null, 2)
         );
 
         // Fines
-        $this->assertEquals(
+        $this->assertSame(
             '$1.23',
             $this->findCssAndGetText($page, '.myresearch-menu .fines-status .badge.account-alert')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdminTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdminTest.php
@@ -52,7 +52,7 @@ class AdminTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl() . '/Admin');
         $page = $session->getPage();
-        $this->assertEquals('The Admin module is currently disabled.', $this->findCssAndGetText($page, 'p.error b'));
+        $this->assertSame('The Admin module is currently disabled.', $this->findCssAndGetText($page, 'p.error b'));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AdvancedSearchTest.php
@@ -152,7 +152,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '[type=submit]')->press();
 
         // Check for proper search
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:bride AND Title:tomb AND All Fields:garbage AND Year of Publication:1883) AND '
             . '(All Fields:miller)',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
@@ -160,20 +160,20 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test edit search
         $this->editAdvancedSearch($page);
-        $this->assertEquals('bride', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
-        $this->assertEquals('tomb', $this->findCssAndGetValue($page, '#search_lookfor0_1'));
-        $this->assertEquals('Title', $this->findCssAndGetValue($page, '#search_type0_1'));
-        $this->assertEquals('garbage', $this->findCssAndGetValue($page, '#search_lookfor0_2'));
+        $this->assertSame('bride', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
+        $this->assertSame('tomb', $this->findCssAndGetValue($page, '#search_lookfor0_1'));
+        $this->assertSame('Title', $this->findCssAndGetValue($page, '#search_type0_1'));
+        $this->assertSame('garbage', $this->findCssAndGetValue($page, '#search_lookfor0_2'));
         $this->assertEquals('1883', $this->findCssAndGetValue($page, '#search_lookfor0_3'));
-        $this->assertEquals('year', $this->findCssAndGetValue($page, '#search_type0_3'));
-        $this->assertEquals('miller', $this->findCssAndGetValue($page, '#search_lookfor1_0'));
+        $this->assertSame('year', $this->findCssAndGetValue($page, '#search_type0_3'));
+        $this->assertSame('miller', $this->findCssAndGetValue($page, '#search_lookfor1_0'));
 
         // Term removal
         $session->executeScript('deleteSearch(0, 2)'); // search0_2 x click
         $this->assertNull($page->findById('search0_3'));
         // Terms collapsing up
         $this->assertEquals('1883', $this->findCssAndGetValue($page, '#search_lookfor0_2'));
-        $this->assertEquals('year', $this->findCssAndGetValue($page, '#search_type0_2'));
+        $this->assertSame('year', $this->findCssAndGetValue($page, '#search_type0_2'));
 
         // Group removal
         $session->executeScript('deleteGroup(0)');
@@ -182,14 +182,14 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '[type=submit]')->press();
 
         // Check for proper search (second group only)
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:miller)',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
         );
 
         // Test edit search (modified search is restored properly)
         $this->editAdvancedSearch($page);
-        $this->assertEquals('miller', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
+        $this->assertSame('miller', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
 
         // Clear test
         $multiSel = $this->findCss($page, '#limit_callnumber-first');
@@ -198,7 +198,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertCount(2, $multiSel->getValue());
 
         $this->findCss($page, '.adv-submit .clear-btn')->press();
-        $this->assertEquals('', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
+        $this->assertSame('', $this->findCssAndGetValue($page, '#search_lookfor0_0'));
         $this->assertCount(0, $multiSel->getValue());
     }
 
@@ -213,14 +213,14 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->goToAdvancedSearch($session);
 
         // Check breadcrumb without link
-        $this->assertEquals('Search', $this->findCssAndGetHtml($page, '.breadcrumb-item'));
+        $this->assertSame('Search', $this->findCssAndGetHtml($page, '.breadcrumb-item'));
 
         // Enter and submit search
         $this->findCssAndSetValue($page, '#search_lookfor0_0', 'miller');
         $this->findCss($page, '[type=submit]')->press();
 
         // Check for proper search
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:miller)',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
         );
@@ -228,7 +228,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         // Test breadcrumb link
         $this->editAdvancedSearch($page);
         $this->clickCss($page, '.breadcrumb-item a');
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:miller)',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
         );
@@ -259,7 +259,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '[type=submit]')->press();
 
         // Check for proper search and result count
-        $this->assertEquals(
+        $this->assertSame(
             '(All Fields:building:"journals.mrc") NOT ((Title:rational))',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
         );
@@ -288,7 +288,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '[type=submit]')->press();
 
         // Check for proper search and result count
-        $this->assertEquals(
+        $this->assertSame(
             '() NOT ((Title:rational))',
             $this->findCssAndGetHtml($page, '.adv_search_terms strong')
         );
@@ -310,7 +310,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $page = $this->goToAdvancedSearch($session);
         // By default, everything is sorted alphabetically:
-        $this->assertEquals(
+        $this->assertSame(
             'Article Book Book Chapter Conference Proceeding eBook Electronic Journal Manuscript Microfilm',
             $this->findCssAndGetText($page, '#limit_format')
         );
@@ -319,7 +319,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.language.dropdown li a:not(.active)');
         $this->waitForPageLoad($page);
         // Still sorted alphabetically, even though in a different language:
-        $this->assertEquals(
+        $this->assertSame(
             'Artikel Buch Buchkapitel E-Book Elektronisch Manuskript Mikrofilm Tagungsbericht Zeitschrift',
             $this->findCssAndGetText($page, '#limit_format')
         );
@@ -346,7 +346,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $page = $this->goToAdvancedSearch($session);
         // By default, everything is sorted alphabetically:
-        $this->assertEquals(
+        $this->assertSame(
             'Book eBook Article Book Chapter Conference Proceeding Electronic Journal Manuscript Microfilm',
             $this->findCssAndGetText($page, '#limit_format')
         );
@@ -355,7 +355,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.language.dropdown li a:not(.active)');
         $this->waitForPageLoad($page);
         // Still sorted alphabetically, even though in a different language:
-        $this->assertEquals(
+        $this->assertSame(
             'Buch E-Book Artikel Buchkapitel Elektronisch Manuskript Mikrofilm Tagungsbericht Zeitschrift',
             $this->findCssAndGetText($page, '#limit_format')
         );
@@ -496,7 +496,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm expected label text:
         $checkboxSelector = '.checkbox-filters .checkbox label';
-        $this->assertEquals('The Test Record', $this->findCssAndGetText($page, $checkboxSelector));
+        $this->assertSame('The Test Record', $this->findCssAndGetText($page, $checkboxSelector));
 
         // Select checkbox and submit search:
         $this->clickCss($page, $checkboxSelector);
@@ -504,7 +504,7 @@ class AdvancedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
 
         // Confirm expected result -- just the record specified by the checkbox filter:
-        $this->assertEquals('Showing 1 - 1 results of 1', $this->findCssAndGetText($page, '.js-search-stats'));
+        $this->assertSame('Showing 1 - 1 results of 1', $this->findCssAndGetText($page, '.js-search-stats'));
         $this->assertStringStartsWith(
             'La congiura dei Principi Napoletani 1701',
             $this->findCssAndGetText($page, '.result-body .title')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ApiTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ApiTest.php
@@ -235,7 +235,7 @@ final class ApiTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.btn-default[data-bs-dismiss="modal"]');
 
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'test title',
             $this->findCssAndGetText($page, '.table.table-striped th', index: 0)
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AutocompleteTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/AutocompleteTest.php
@@ -201,7 +201,7 @@ class AutocompleteTest extends \VuFindTest\Integration\MinkTestCase
         );
         $acItem->click();
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             '"Fake DOI test 1"',
             $this->findCssAndGetValue($page, '#searchForm_lookfor')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicTest.php
@@ -69,11 +69,11 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
         // only appear after AJAX returns):
         $this->unFindCss($page, '.callnumber.ajax-availability');
         $this->unFindCss($page, '.location.ajax-availability');
-        $this->assertEquals(
+        $this->assertSame(
             'A1234.567',
             $this->findCssAndGetText($page, '.callnumber')
         );
-        $this->assertEquals(
+        $this->assertSame(
             '3rd Floor Main Library',
             $this->findCssAndGetText($page, '.location')
         );
@@ -88,7 +88,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
     {
         $page = $this->getSearchHomePage();
         // Check footer help-link
-        $this->assertEquals(
+        $this->assertSame(
             'Search Tips',
             $this->findCssAndGetHtml($page, 'footer .help-link')
         );
@@ -97,7 +97,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.language.dropdown li a:not(.active)');
         $this->waitForPageLoad($page);
         // Check footer help-link
-        $this->assertNotEquals(
+        $this->assertNotSame(
             'Search Tips',
             $this->findCssAndGetHtml($page, 'footer .help-link')
         );
@@ -136,7 +136,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
 
         // Check h1 again -- it should exist now
-        $this->assertEquals(
+        $this->assertSame(
             'Welcome to your custom theme!',
             $this->findCssAndGetHtml($page, 'h1')
         );
@@ -192,7 +192,7 @@ class BasicTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertEquals('200', $this->getMinkSession()->getStatusCode());
         $this->assertStringNotContainsString('Other Search', (string)$page->getContent());
         $this->assertStringNotContainsString('ServiceNotFoundException', (string)$page->getContent());
-        $this->assertEquals(
+        $this->assertSame(
             'Catalog',
             $this->findCssAndGetHtml($page, '#searchForm .nav-link')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BlendedSearchTest.php
@@ -112,7 +112,7 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $session->setWhoopsDisabled(true);
         $session->visit($this->getVuFindUrl() . '/Blender/Results');
         $page = $session->getPage();
-        $this->assertEquals(
+        $this->assertSame(
             'An error has occurred',
             $this->findCssAndGetText($page, '.alert-danger p')
         );
@@ -204,7 +204,7 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
         // Go to record screen and check active tab:
         $this->clickCss($page, '#result0 .title');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             $searchBoxLabel,
             $this->findCssAndGetText($page, '.searchbox li a.active')
         );
@@ -344,7 +344,7 @@ class BlendedSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#search_type0_1', 'Author');
         $this->clickCss($page, '.adv-submit .btn-primary');
 
-        $this->assertEquals(
+        $this->assertSame(
             'Your search - (All Fields:Dublin AND Author:Award) - did not match any resources.',
             $this->findCssAndGetText($page, '.mainbody p')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BrowseTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BrowseTest.php
@@ -198,7 +198,7 @@ class BrowseTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertSame(['HG - Finance 1'], $values2);
         $page->clickLink($values2[0]);
         // We should now be on search results with a filter applied:
-        $this->assertEquals('HG - Finance', $this->findCssAndGetText($page, '.filter-value .text'));
+        $this->assertSame('HG - Finance', $this->findCssAndGetText($page, '.filter-value .text'));
     }
 
     /**
@@ -293,7 +293,7 @@ class BrowseTest extends \VuFindTest\Integration\MinkTestCase
         $page->clickLink('Tag');
         $page->clickLink('By Alphabetical');
         $page->clickLink('A');
-        $this->assertEquals('No Results!', $this->findCssAndGetText($page, '#list4 .browse-item'));
+        $this->assertSame('No Results!', $this->findCssAndGetText($page, '#list4 .browse-item'));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BulkTest.php
@@ -103,7 +103,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function checkForNonSelectedMessage(Element $page): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'No items were selected. '
             . 'Please click on a checkbox next to an item and try again.',
             $this->findCssAndGetText($page, '.modal-body .alert-danger')
@@ -122,7 +122,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function checkForLimitExceededMessage(Element $page, $count, $limit): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'Selection of ' . $count . ' items exceeds the limit of '
             . $limit . ' for this action. Please select fewer items.',
             $this->findCssAndGetText($page, '.modal-body .alert-danger')
@@ -181,7 +181,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         );
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were emailed',
             $this->findCssAndGetText($page, '.modal-body .alert-success')
         );
@@ -215,7 +215,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         // Save the favorites.
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.modal-body input[name=submitButton]');
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were saved successfully. Go to List.',
             $this->findCssAndGetText($page, '.modal-body .alert-success')
         );
@@ -261,7 +261,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
 
         // Confirm contents of confirmation box:
-        $this->assertEquals(
+        $this->assertSame(
             'Title: Journal of rational emotive therapy : Title: Rational living.',
             $this->findCssAndGetText($page, '#modal ul.record-list')
         );
@@ -271,7 +271,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         // If all records were deleted, success message should be visible, and delete button should be gone after
         // lightbox is closed.
         $this->waitForLightboxHidden();
-        $this->assertEquals(
+        $this->assertSame(
             'Your saved item(s) were deleted.',
             $this->findCssAndGetText($page, '.alert-success')
         );
@@ -329,7 +329,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         // Do the export:
         $this->clickCss($page, '.form-cart-export input[name=submitButton]');
         $buttonText = $this->findCssAndGetText($page, '.alert .text-center .btn');
-        $this->assertEquals('Download File', $buttonText);
+        $this->assertSame('Download File', $buttonText);
     }
 
     /**
@@ -429,7 +429,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         // Save the favorites.
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.modal-body input[name=submitButton]');
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were saved successfully. Go to List.',
             $this->findCssAndGetText($page, '.modal-body .alert-success')
         );
@@ -452,7 +452,7 @@ final class BulkTest extends \VuFindTest\Integration\MinkTestCase
         $select->selectOption('MARC');
         $submit = $this->findCss($page, '.modal-body input[name=submitButton]');
         $submit->click();
-        $this->assertEquals(
+        $this->assertSame(
             'Download File',
             $this->findCssAndGetText($page, '.modal-body .alert .text-center .btn')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CartTest.php
@@ -613,7 +613,7 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
         );
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were emailed',
             $this->findCssAndGetText($page, '.modal .alert-success')
         );
@@ -646,7 +646,7 @@ final class CartTest extends \VuFindTest\Integration\MinkTestCase
 
         // Save the favorites.
         $this->clickCss($page, '.modal-body input[name=submitButton]');
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were saved successfully. Go to List.',
             $this->findCssAndGetText($page, '.modal-body .alert-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -111,7 +111,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         $channels = $page->findAll('css', $this->channelSelector);
         $this->assertCount(4, $channels);
         // Make sure appropriate similar records are displayed:
-        $this->assertEquals(
+        $this->assertSame(
             'Similar Items: Journal of rational emotive therapy :',
             $this->findCssAndGetText($page, 'h2.channel-title')
         );
@@ -135,7 +135,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         $channels = $page->findAll('css', $this->channelSelector);
         $this->assertCount(6, $channels);
         // Make sure search input matches url
-        $this->assertEquals(
+        $this->assertSame(
             'building:"weird_ids.mrc"',
             $this->findCssAndGetValue($page, '[action*="Channels/Search"] .form-control')
         );
@@ -183,16 +183,16 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         // Click link to go to search results
         $this->clickCss($channel, '.channel-options .fa-search');
         // Make sure the search translated
-        $this->assertEquals(
+        $this->assertSame(
             'building:"weird_ids.mrc"',
             $this->findCssAndGetValue($page, '#searchForm_lookfor')
         );
         // Check facet
-        $this->assertEquals(
+        $this->assertSame(
             'Suggested Topics:',
             $this->findCssAndGetText($page, '.filters .filters-title')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Remove Filter Adult children of aging parents',
             $this->findCssAndGetText($page, '.filters .filter-value')
         );
@@ -281,13 +281,13 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         // Now click back to the original record; the popover should contain the same contents.
         $this->clickCss($page, '.channel-item[data-record-id="' . $record1 . '"] .channel-quick-look-btn');
         $popoverContents3 = $this->findCssAndGetText($page, '.channels-quick-look');
-        $this->assertEquals($popoverContents, $popoverContents3);
+        $this->assertSame($popoverContents, $popoverContents3);
         // Finally, click through to the record page.
         $link = $this->findCss($page, '.ql-view-record-btn');
         $this->assertEquals('View Record', $link->getText());
         $link->click();
         $this->waitForPageLoad($page);
-        $this->assertEquals($title1, $this->findCssAndGetText($page, 'h1'));
+        $this->assertSame($title1, $this->findCssAndGetText($page, 'h1'));
     }
 
     /**
@@ -336,7 +336,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
             ],
         );
         $page = $this->getChannelsHomePage();
-        $this->assertEquals($expectedTitle, $this->findCssAndGetText($page, 'h2.channel-title'));
+        $this->assertSame($expectedTitle, $this->findCssAndGetText($page, 'h2.channel-title'));
         $this->assertCount(2, $page->findAll('css', 'li.channel-item'));
         $this->assertCount(1, $page->findAll('css', 'li.channel-item[data-record-id="' . $bibId1 . '"]'));
         $this->assertCount(1, $page->findAll('css', 'li.channel-item[data-record-id="' . $bibId2 . '"]'));
@@ -362,7 +362,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
             ],
         );
         $page = $this->getChannelsHomePage();
-        $this->assertEquals('New Items', $this->findCssAndGetText($page, 'h2.channel-title'));
+        $this->assertSame('New Items', $this->findCssAndGetText($page, 'h2.channel-title'));
         // In case test data changes, we won't make specific assertions about specific records,
         // but we can assume that we'll get at least two pages worth of them!
         $this->assertCount(6, $page->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
@@ -390,7 +390,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
             ],
         );
         $page = $this->getChannelsHomePage();
-        $this->assertEquals('Random items from your results', $this->findCssAndGetText($page, 'h2.channel-title'));
+        $this->assertSame('Random items from your results', $this->findCssAndGetText($page, 'h2.channel-title'));
         // Since selected records are random, we can't make specific assertions about specific records,
         // but we can assume that we'll get at least four pages worth of them!
         $this->assertCount(6, $page->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
@@ -429,7 +429,7 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         );
         $page = $this->getChannelsHomePage();
         $channel = $this->findCss($page, 'div.channel', index: 1);
-        $this->assertEquals('Format: Book Chapter', $this->findCssAndGetText($channel, 'h2.channel-title'));
+        $this->assertSame('Format: Book Chapter', $this->findCssAndGetText($channel, 'h2.channel-title'));
         // Let's get more than 48 items on the page to ensure that we call back to the server for more results:
         $this->assertCount(6, $channel->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
         for ($i = 0; $i < 8; $i++) {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChoiceAuthTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChoiceAuthTest.php
@@ -244,7 +244,7 @@ final class ChoiceAuthTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#loginOptions a');
 
         // Login with SSO
-        $this->assertEquals(
+        $this->assertSame(
             'Institutional Login',
             $this->findCssAndGetText($page, '.modal-body .authmethod1 .btn.btn-link')
         );
@@ -280,7 +280,7 @@ final class ChoiceAuthTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#loginOptions a');
         $this->findCssAndSetValue($page, '#login_Email_username', 'username1@ignore.com');
         $this->clickCss($page, '.authmethod1 input[type="submit"]');
-        $this->assertEquals(
+        $this->assertSame(
             'We have sent a login link to your email address. It may take a few moments for the link to arrive. '
             . "If you don't receive the link shortly, please check also your spam filter.",
             $this->findCssAndGetText($page, '.modal .alert-success')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CombinedSearchTest.php
@@ -104,11 +104,11 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
             // only appear after AJAX returns):
             $this->unFindCss($page, '.callnumber.ajax-availability');
             $this->unFindCss($page, '.location.ajax-availability');
-            $this->assertEquals(
+            $this->assertSame(
                 'A1234.567',
                 $this->findCssAndGetText($page, "$container .callnumber")
             );
-            $this->assertEquals(
+            $this->assertSame(
                 '3rd Floor Main Library',
                 $this->findCssAndGetText($page, "$container .location")
             );
@@ -307,7 +307,7 @@ class CombinedSearchTest extends \VuFindTest\Integration\MinkTestCase
         // The AJAX count may not load right away, so wait to be sure we assert on the final value:
         $getText = "document.getElementsByClassName('combined-jump-links')[0].textContent.replace(/\s+/g, ' ').trim()";
         $this->waitStatement("$getText === '$expectedContent'");
-        $this->assertEquals(
+        $this->assertSame(
             $expectedContent,
             $this->findCssAndGetText($page, '.combined-jump-links')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ContentControllerTest.php
@@ -79,11 +79,11 @@ class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
         $session->visit($this->getVuFindUrl() . $basePath . '/example');
         $page = $session->getPage();
         // Confirm that the Markdown was converted into appropriate h1/a tags:
-        $this->assertEquals(
+        $this->assertSame(
             'Static Content Example',
             $this->findCssAndGetText($page, 'h1')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'Static Pages documentation',
             $this->findCssAndGetText($page, '#content a')
         );
@@ -181,7 +181,7 @@ class ContentControllerTest extends \VuFindTest\Integration\MinkTestCase
         $session->visit($this->getVuFindUrl() . "/Content/$path");
         $page = $session->getPage();
         // Confirm that the correct page was retrieved:
-        $this->assertEquals($expected, $this->findCssAndGetText($page, 'h1'));
+        $this->assertSame($expected, $this->findCssAndGetText($page, 'h1'));
         // Confirm that we have the correct footer:
         if ('html' === $pageType) {
             $this->findCss($page, 'body.template-dir-content.template-name-content');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/DirLocationsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/DirLocationsTest.php
@@ -220,7 +220,7 @@ class DirLocationsTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function checkTranslation(DocumentElement $page, string $expected, string $field): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->findCssAndGetText($page, '#searchForm_type option[value="' . $field . '"]')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/EmailAuthenticationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/EmailAuthenticationTest.php
@@ -83,7 +83,7 @@ final class EmailAuthenticationTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#loginOptions a');
         $this->findCssAndSetValue($page, '.modal-body #login_Email_username', 'username1@ignore.com');
         $this->clickCss($page, '.modal-body .btn.btn-primary', null, 1);
-        $this->assertEquals(
+        $this->assertSame(
             'We have sent a login link to your email address. It may take a few moments for the link to arrive.'
             . " If you don't receive the link shortly, please check also your spam filter.",
             $this->findCssAndGetText($page, '.alert-success')
@@ -127,7 +127,7 @@ final class EmailAuthenticationTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#loginOptions a');
         $this->findCssAndSetValue($page, '.modal-body #login_Email_username', 'username1@foo.bar');
         $this->clickCss($page, '.modal-body .btn.btn-primary', null, 1);
-        $this->assertEquals(
+        $this->assertSame(
             'We have sent a login link to your email address. It may take a few moments for the link to arrive.'
             . " If you don't receive the link shortly, please check also your spam filter.",
             $this->findCssAndGetText($page, '.alert-success')
@@ -180,7 +180,7 @@ final class EmailAuthenticationTest extends \VuFindTest\Integration\MinkTestCase
             $this->clickCss($page, '#loginOptions a');
             $this->findCssAndSetValue($page, '.modal-body [name="username"]', 'catuser@vufind.org');
             $this->clickCss($page, '.modal-body .btn.btn-primary');
-            $this->assertEquals(
+            $this->assertSame(
                 'We have sent a login link to your email address. It may take a few moments for the link to arrive.'
                 . " If you don't receive the link shortly, please check also your spam filter.",
                 $this->findCssAndGetText($page, '.alert-success')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/EmailVerificationTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/EmailVerificationTest.php
@@ -89,7 +89,7 @@ final class EmailVerificationTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.modal-body .createAccountLink');
         $this->fillInAccountForm($page);
         $this->clickCss($page, '.modal-body .btn.btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'Email address verification instructions have been sent to the email address registered with this account.',
             $this->findCssAndGetText($page, '.alert-info')
         );
@@ -105,7 +105,7 @@ final class EmailVerificationTest extends \VuFindTest\Integration\MinkTestCase
 
         // Follow the verification link:
         $session->visit($verifyLink);
-        $this->assertEquals(
+        $this->assertSame(
             'Your email address has been verified successfully.',
             $this->findCssAndGetText($page, '.alert-info')
         );
@@ -159,7 +159,7 @@ final class EmailVerificationTest extends \VuFindTest\Integration\MinkTestCase
 
         // Request the email change:
         $this->clickCss($page, '.fa-envelope');
-        $this->assertEquals(
+        $this->assertSame(
             'Submitting this form will send an email to the new address; '
             . 'you will have to click on a link in the email before the change will take effect.',
             $this->findCssAndGetText($page, '.alert-info')
@@ -193,7 +193,7 @@ final class EmailVerificationTest extends \VuFindTest\Integration\MinkTestCase
 
         // Follow the verification link:
         $session->visit($verifyLink);
-        $this->assertEquals(
+        $this->assertSame(
             'Your email address has been verified successfully.',
             $this->findCssAndGetText($page, '.alert-info')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ErrorHandlingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ErrorHandlingTest.php
@@ -50,7 +50,7 @@ class ErrorHandlingTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl('/Record/does_not_exist'));
         $page = $session->getPage();
-        $this->assertEquals(
+        $this->assertSame(
             'An error has occurred An error occurred during execution; please try again later. Please contact the'
             . ' Library Reference Department for assistance support@myuniversity.edu',
             $this->findCssAndGetText($page, '.alert-danger')
@@ -77,7 +77,7 @@ class ErrorHandlingTest extends \VuFindTest\Integration\MinkTestCase
         $session = $this->getMinkSession();
         $session->visit($this->getVuFindUrl('/Record/does_not_exist'));
         $page = $session->getPage();
-        $this->assertEquals(
+        $this->assertSame(
             'An error has occurred An error occurred during execution; please try again later. Please contact the'
             . ' Library Reference Department for assistance',
             $this->findCssAndGetText($page, '.alert-danger')

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FallbackLoaderTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FallbackLoaderTest.php
@@ -141,7 +141,7 @@ final class FallbackLoaderTest extends \VuFindTest\Integration\MinkTestCase
         } catch (\Exception $e) {
             $this->retryClickWithResizedWindow($this->getMinkSession(), $page, $buttonSelector);
         }
-        $this->assertEquals($comment, $this->findCssAndGetText($page, $commentSelector));
+        $this->assertSame($comment, $this->findCssAndGetText($page, $commentSelector));
     }
 
     /**
@@ -155,11 +155,11 @@ final class FallbackLoaderTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function assertMergedResults(Element $page): void
     {
-        $this->assertEquals('new_tag 1 old_tag 1', $this->findCssAndGetText($page, '.tagList'));
-        $this->assertEquals('old_list new_list', $this->findCssAndGetText($page, '.savedLists.loaded ul'));
+        $this->assertSame('new_tag 1 old_tag 1', $this->findCssAndGetText($page, '.tagList'));
+        $this->assertSame('old_list new_list', $this->findCssAndGetText($page, '.savedLists.loaded ul'));
         $this->clickCss($page, '.record-tabs .usercomments a');
-        $this->assertEquals('old comment', $this->findCssAndGetText($page, '.comment-text', index: 0));
-        $this->assertEquals('new comment', $this->findCssAndGetText($page, '.comment-text', index: 1));
+        $this->assertSame('old comment', $this->findCssAndGetText($page, '.comment-text', index: 0));
+        $this->assertSame('new comment', $this->findCssAndGetText($page, '.comment-text', index: 1));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FavoritesTest.php
@@ -265,7 +265,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.save-record');
         $this->waitForPageLoad($page);
         $this->assertLightboxTitle($page, 'Login');
-        $this->assertEquals('Login', $this->findCssAndGetText($page, '#lightbox-title'));
+        $this->assertSame('Login', $this->findCssAndGetText($page, '#lightbox-title'));
         $this->clickCss($page, '.modal-body .createAccountLink');
         // Empty
         $this->waitForPageLoad($page);
@@ -602,7 +602,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
      */
     protected function checkForNonSelectedMessage(Element $page): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             'No items were selected. Please click on a checkbox next to an item and try again.',
             $this->findCssAndGetText($page, '.modal-body .alert')
         );
@@ -646,7 +646,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '.modal #email_message', 'message');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were emailed',
             $this->findCssAndGetText($page, '.modal .alert-success')
         );
@@ -678,7 +678,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         // Do the export:
         $submit = $this->findCss($page, '.modal-body input[name=submitButton]');
         $submit->click();
-        $this->assertEquals('Download File', $this->findCssAndGetText($page, '.modal-body .alert .text-center .btn'));
+        $this->assertSame('Download File', $this->findCssAndGetText($page, '.modal-body .alert .text-center .btn'));
     }
 
     /**
@@ -693,7 +693,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
 
         // First try clicking without selecting anything:
         $this->clickCss($page, '[name=bulkActionForm] [name=print]');
-        $this->assertEquals(
+        $this->assertSame(
             'No items were selected. Please click on a checkbox next to an item and try again.',
             $this->findCssAndGetText($page, '.flash-message')
         );
@@ -748,7 +748,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page);
         // Check for confirmation message
-        $this->assertEquals(
+        $this->assertSame(
             'Your item(s) were emailed',
             $this->findCssAndGetText($page, '.modal .alert-success')
         );
@@ -883,7 +883,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $this->getMinkSession()->visit($this->getVuFindUrl() . '/Channels');
         $this->waitForPageLoad($page);
         if ($matchExpected) {
-            $this->assertEquals('Test List', $this->findCssAndGetText($page, 'h2.channel-title'));
+            $this->assertSame('Test List', $this->findCssAndGetText($page, 'h2.channel-title'));
             $this->assertCount(1, $page->findAll('css', 'li.channel-item'));
         } else {
             $this->unfindCss($page, 'h2.channel-title');
@@ -987,7 +987,7 @@ final class FavoritesTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         // Check for confirmation message
         $this->waitForLightboxHidden();
-        $this->assertEquals(
+        $this->assertSame(
             'Your saved item(s) were deleted.',
             $this->findCssAndGetText($page, '.alert-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/FeedbackTest.php
@@ -148,12 +148,12 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->setupPage();
         $this->fillInAndSubmitFeedbackForm($page, $sender);
         if ($expectSuccess) {
-            $this->assertEquals(
+            $this->assertSame(
                 'Thank you for your feedback.',
                 $this->findCssAndGetText($page, '#modal .alert-success')
             );
         } else {
-            $this->assertEquals(
+            $this->assertSame(
                 'Could not process your feedback. Please try again later.',
                 $this->findCssAndGetText($page, '#modal .alert-danger')
             );
@@ -195,7 +195,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         ];
         foreach ($feedbackEntries as $feedbackParams) {
             $this->fillInAndSubmitFeedbackForm($page, ...$feedbackParams);
-            $this->assertEquals(
+            $this->assertSame(
                 'Thank you for your feedback.',
                 $this->findCssAndGetText($page, '#modal .alert-success')
             );
@@ -289,7 +289,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         );
         $this->fillInAndSubmitFeedbackForm($page);
         // CAPTCHA should have failed...
-        $this->assertEquals(
+        $this->assertSame(
             'CAPTCHA not passed',
             $this->findCssAndGetText($page, '.modal-body .alert-danger')
         );
@@ -297,7 +297,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, 'form [name="demo_captcha"]')
             ->setValue('demo');
         $this->clickCss($page, '#modal input[type="submit"]');
-        $this->assertEquals(
+        $this->assertSame(
             'Thank you for your feedback.',
             $this->findCssAndGetText($page, '#modal .alert-success')
         );
@@ -337,7 +337,7 @@ class FeedbackTest extends \VuFindTest\Integration\MinkTestCase
             ]
         );
         $this->fillInAndSubmitFeedbackForm($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Thank you for your feedback.',
             $this->findCssAndGetText($page, '#modal .alert-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldingsTest.php
@@ -163,11 +163,11 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
             if ('group' === $multipleLocations) {
                 if (AvailabilityStatusInterface::STATUS_AVAILABLE === $availability) {
                     // For this case we have available items in both locations:
-                    $this->assertEquals(
+                    $this->assertSame(
                         'Test Location',
                         $this->findCssAndGetText($page, '.result-body .callnumAndLocation .groupLocation .text-success')
                     );
-                    $this->assertEquals(
+                    $this->assertSame(
                         'Main Library',
                         $this->findCssAndGetText(
                             $page,
@@ -177,11 +177,11 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
                         )
                     );
                 } else {
-                    $this->assertEquals(
+                    $this->assertSame(
                         'Test Location',
                         $this->findCssAndGetText($page, '.result-body .callnumAndLocation .groupLocation .text-danger')
                     );
-                    $this->assertEquals(
+                    $this->assertSame(
                         'Main Library',
                         $this->findCssAndGetText(
                             $page,
@@ -204,7 +204,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
             } else {
                 $selector = '.result-body .callnumAndLocation .location';
             }
-            $this->assertEquals('Main Library', $this->findCssAndGetText($page, $selector));
+            $this->assertSame('Main Library', $this->findCssAndGetText($page, $selector));
         }
     }
 
@@ -253,18 +253,18 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
 
         $page = $this->goToSearchResults();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->findCssAndGetText($page, ".result-body .fullAvailability .text-$expectedType")
         );
 
         if ($availability) {
             // Extra items, check both:
-            $this->assertEquals('Test Location', $this->findCssAndGetText($page, '.result-body .fullLocation'));
-            $this->assertEquals('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation', null, 1));
+            $this->assertSame('Test Location', $this->findCssAndGetText($page, '.result-body .fullLocation'));
+            $this->assertSame('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation', null, 1));
         } else {
             // No extra items to care for:
-            $this->assertEquals('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation'));
+            $this->assertSame('Main Library', $this->findCssAndGetText($page, '.result-body .fullLocation'));
         }
         // If testing with the custom template, be sure its custom script executed as expected:
         if ($customTemplate) {
@@ -288,7 +288,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         $page = $this->goToSearchResults();
-        $this->assertEquals(
+        $this->assertSame(
             'Simulated failure',
             $this->findCssAndGetText($page, '.result-body .callnumAndLocation.text-danger')
         );
@@ -321,7 +321,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         $page = $this->goToRecord();
-        $this->assertEquals($expected, $this->findCssAndGetText($page, ".holdings-tab span.text-$expectedType"));
+        $this->assertSame($expected, $this->findCssAndGetText($page, ".holdings-tab span.text-$expectedType"));
     }
 
     /**
@@ -369,7 +369,7 @@ class HoldingsTest extends \VuFindTest\Integration\MinkTestCase
         );
 
         $page = $this->goToSearchResults();
-        $this->assertEquals($expectedCallNo, $this->findCssAndGetText($page, '.callnumAndLocation .callnumber'));
+        $this->assertSame($expectedCallNo, $this->findCssAndGetText($page, '.callnumAndLocation .callnumber'));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -178,7 +178,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $link->click();
 
         // Make sure we arrived where we expected to:
-        $this->assertEquals(
+        $this->assertSame(
             'Your Holds and Recalls',
             $this->findCssAndGetText($page, 'h2')
         );
@@ -211,7 +211,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test invalid patron login
         $this->submitCatalogLoginForm($page, 'bad', 'incorrect');
-        $this->assertEquals(
+        $this->assertSame(
             'Invalid Patron Login',
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -221,7 +221,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test placing a hold with an empty "required by" date:
         $this->placeHold($page, ['#requiredByDate' => '']);
-        $this->assertEquals(
+        $this->assertSame(
             "Please enter a valid 'required by' date",
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -229,12 +229,12 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test placing a hold with an invalid "required by" date:
         $this->placeHold($page, ['#requiredByDate' => '01-01-2023']);
-        $this->assertEquals(
+        $this->assertSame(
             "Please enter a valid 'required by' date",
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
         // Verify the label for the "required by" field:
-        $this->assertEquals(
+        $this->assertSame(
             'No longer required after:',
             $this->findCssAndGetText($page, '.hold-required-by label')
         );
@@ -244,7 +244,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->placeHoldAndGoToHoldsScreen($page);
 
         // Verify the hold is correct:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -296,7 +296,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->placeHoldAndGoToHoldsScreen($page);
 
         // Verify the hold is correct:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -347,7 +347,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->placeHoldAndGoToHoldsScreen($page);
 
         // Verify the hold is correct:
-        $this->assertEquals(
+        $this->assertSame(
             'Rational living.',
             $this->findCssAndGetText($page, 'a.title')
         );
@@ -402,12 +402,12 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test placing a hold with an invalid "required by" date:
         $this->placeHold($page, ['#requiredByDate' => '01-01-2023'], 'Available');
-        $this->assertEquals(
+        $this->assertSame(
             "Please enter a valid 'required by' date",
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
         // Verify the label for the "required by" field:
-        $this->assertEquals(
+        $this->assertSame(
             'No longer required after (optional):',
             $this->findCssAndGetText($page, '.hold-required-by label')
         );
@@ -417,7 +417,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->placeHoldAndGoToHoldsScreen($page, ['#requiredByDate' => ''], 'Available');
 
         // Verify the hold is correct:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -463,7 +463,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Test "cancel all" button -- first make sure item is there before
         // cancel is pushed:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -472,7 +472,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         // Click cancel but bail out with no... item should still be there.
         $this->clickCss($page, '#cancelAll');
         $this->clickButtonGroupLink($page, 'No');
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -481,7 +481,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         // Now cancel for real:
         $this->clickCss($page, '#cancelAll');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             '1 request(s) were successfully canceled',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -734,7 +734,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.checkbox-select-all');
         $this->clickCss($page, '#cancelSelected');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             '1 request(s) were successfully canceled',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -793,7 +793,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Make sure we arrived where we expected to:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Your Holds and Recalls',
             $this->findCssAndGetText($page, 'h2')
         );
@@ -838,7 +838,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
         $this->clickCss($page, 'a.placehold');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'No pickup locations available',
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -876,7 +876,7 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
         $this->placeHoldAndGoToHoldsScreen($page, ['#proxiedUser' => 'user2']);
 
         // Make sure the item shows the appropriate proxy user:
-        $this->assertEquals(
+        $this->assertSame(
             'Proxy User 2',
             $this->findCssAndGetText($page, '.hold-proxied-for')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HomePageFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HomePageFacetsTest.php
@@ -55,7 +55,7 @@ class HomePageFacetsTest extends \VuFindTest\Integration\MinkTestCase
     {
         $page = $this->getSearchHomePage();
         $this->waitForPageLoad($page);
-        $this->assertEquals('A - General Works', $this->findCssAndGetText($page, '.home-facet.callnumber-first a'));
+        $this->assertSame('A - General Works', $this->findCssAndGetText($page, '.home-facet.callnumber-first a'));
         $this->clickCss($page, '.home-facet.callnumber-first a');
         $this->waitForPageLoad($page);
         $this->assertStringEndsWith(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IlsActionsTest.php
@@ -121,7 +121,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Make sure we arrived where we expected to:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Interlibrary Loan Requests',
             $this->findCssAndGetText($page, 'h2')
         );
@@ -156,7 +156,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Make sure we arrived where we expected to:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Storage Retrieval Requests',
             $this->findCssAndGetText($page, 'h2')
         );
@@ -188,7 +188,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     protected function cancelSelectedProcedure(Element $page, string $type): void
     {
         // First make sure item is there before cancel is pushed:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -203,7 +203,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#checkbox_testsample1');
         $this->clickCss($page, '#cancelSelected');
         $this->clickButtonGroupLink($page, 'No');
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -212,7 +212,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Now cancel for real:
         $this->clickCss($page, '#cancelSelected');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             '1 request(s) were successfully canceled',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -230,7 +230,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
     protected function cancelAllProcedure(Element $page, string $type): void
     {
         // First make sure item is there before cancel is pushed:
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -240,7 +240,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#cancelAll');
         $this->clickButtonGroupLink($page, 'No');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -249,7 +249,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Now cancel for real:
         $this->clickCss($page, '#cancelAll');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             '1 request(s) were successfully canceled',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -276,7 +276,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Verify the request is correct:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -304,7 +304,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Verify the request is correct:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Journal of rational emotive therapy :'
             . ' the journal of the Institute for Rational-Emotive Therapy.',
             $this->findCssAndGetText($page, 'a.title')
@@ -342,7 +342,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that login form is disabled:
         $this->unFindCss($page, '#profile_cat_username');
-        $this->assertEquals(
+        $this->assertSame(
             'Connection to the library management system failed. '
             . 'Information related to your library account cannot be displayed. '
             . 'If the problem persists, please contact your library.',
@@ -559,7 +559,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Test submitting with no selected checkboxes:
         $this->clickCss($page, '#renewSelected');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             'No items were selected',
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -567,7 +567,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Test "renew all":
         $this->clickCss($page, '#renewAll');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             'Successfully renewed 1 item.',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -613,7 +613,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Test submitting with no selected checkboxes:
         $this->clickCss($page, '#purgeSelected');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             'No Items were Selected',
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -622,7 +622,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.checkbox-select-item');
         $this->clickCss($page, '#purgeSelected');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             'Selected loans have been purged from your loan history',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -632,7 +632,7 @@ final class IlsActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Purge all:
         $this->clickCss($page, '#purgeAll');
         $this->clickButtonGroupLink($page, 'Yes');
-        $this->assertEquals(
+        $this->assertSame(
             'Your loan history has been purged',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ListViewsTest.php
@@ -114,7 +114,7 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
         // Save comment
         $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'one');
         $this->clickCss($page, 'form.comment-form .btn-primary');
-        $this->assertEquals('one', $this->findCssAndGetText($page, '.comment-text'));
+        $this->assertSame('one', $this->findCssAndGetText($page, '.comment-text'));
     }
 
     /**
@@ -146,8 +146,8 @@ final class ListViewsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'two');
         $this->clickCss($page, 'form.comment-form .btn-primary');
         // Confirm comments exist:
-        $this->assertEquals('one', $this->findCssAndGetText($page, '.comment-text'));
-        $this->assertEquals('two', $this->findCssAndGetText($page, '.comment-text', index: 1));
+        $this->assertSame('one', $this->findCssAndGetText($page, '.comment-text'));
+        $this->assertSame('two', $this->findCssAndGetText($page, '.comment-text', index: 1));
     }
 
     /**

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
@@ -61,7 +61,7 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
         $session->visit($this->getVuFindUrl() . '/Search/NewItem');
         $page = $session->getPage();
         // Confirm custom ranges display correctly:
-        $this->assertEquals(
+        $this->assertSame(
             $expectedRanges,
             $this->findCssAndGetText($page, '.form-search-newitem .btn-group')
         );
@@ -165,7 +165,7 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->submitNewItemSearch(expectedRanges: 'Yesterday Past 15 Days Past 60 Days');
 
         // Confirm that we've reached the custom results page:
-        $this->assertEquals(
+        $this->assertSame(
             'Showing 1 - 20 results of 20 New Items',
             $this->findCssAndGetText($page, '.search-stats')
         );
@@ -189,7 +189,7 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
         $recordLink = $this->findAndAssertLink($page, $title);
         $recordLink->click();
         $this->waitForPageLoad($page);
-        $this->assertEquals($title, $this->findCssAndGetText($page, 'h1'));
+        $this->assertSame($title, $this->findCssAndGetText($page, 'h1'));
         $recordAuthorLink = $this->findAndAssertLink($page, 'Shakespeare, William 1564 - 1616');
         $this->assertStringEndsWith(
             '/Author/Home?author=Shakespeare,%20William%201564%20-%201616',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NextPrevNavTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NextPrevNavTest.php
@@ -60,7 +60,7 @@ class NextPrevNavTest extends \VuFindTest\Integration\MinkTestCase
         $page = $session->getPage();
 
         $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=__ReturnNoResults__&type=AllField');
-        $this->assertEquals('No Results!', $this->findCssAndGetText($page, '.search-stats > h2'));
+        $this->assertSame('No Results!', $this->findCssAndGetText($page, '.search-stats > h2'));
 
         // collection should render as normal
         $session->visit($this->getVuFindUrl() . '/Record/geo20001');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OnlinePaymentTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/OnlinePaymentTest.php
@@ -173,7 +173,7 @@ final class OnlinePaymentTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#modal .btn.btn-primary', null, 1);
         $localIdentifier = $this->getLocalIdentifierFromReturnUrl($page);
         $this->clickCss($page, '.button-cancel');
-        $this->assertEquals(
+        $this->assertSame(
             'Payment canceled',
             $this->findCssAndGetText($page, '.alert.alert-success')
         );
@@ -188,7 +188,7 @@ final class OnlinePaymentTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '#modal .btn.btn-primary', null, 1);
         $localIdentifier = $this->getLocalIdentifierFromReturnUrl($page);
         $this->clickCss($page, '.button-failure');
-        $this->assertEquals(
+        $this->assertSame(
             'Payment request failed',
             $this->findCssAndGetText($page, '.alert.alert-danger')
         );
@@ -493,7 +493,7 @@ final class OnlinePaymentTest extends \VuFindTest\Integration\MinkTestCase
 
         $page = $this->goToFines(false, false);
         $this->checkForMissingDevTools($page);
-        $this->assertEquals(
+        $this->assertSame(
             $expectedMsg,
             $this->findCssAndGetText($page, '.fines-info-area__blocked')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/PermissionsTest.php
@@ -80,11 +80,11 @@ final class PermissionsTest extends \VuFindTest\Integration\MinkTestCase
         $session->visit($this->getVuFindUrl() . '/Search/Results');
         $page = $session->getPage();
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'test-error-message',
             $this->findCssAndGetText($page, '.alert-danger')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'An error has occurred',
             $this->findCssAndGetText($page, '.breadcrumb .active')
         );
@@ -99,7 +99,7 @@ final class PermissionsTest extends \VuFindTest\Integration\MinkTestCase
         // Now that we're logged in, we should see search results:
         $session->visit($this->getVuFindUrl() . '/Search/Results');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Search Results',
             $this->findCssAndGetText($page, '.breadcrumb .active')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -90,7 +90,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
     protected function openCommentsLoginModal(Element $page): void
     {
         $this->waitForPageLoad($page);
-        $this->assertEquals(// Can Comment?
+        $this->assertSame(// Can Comment?
             'You must be logged in first',
             $this->findCssAndGetText($page, 'form.comment-form .btn.btn-primary')
         );
@@ -118,7 +118,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Make sure page updated for login
         $this->clickCss($page, '.record-tabs .usercomments a');
         $this->waitForPageLoad($page);
-        $this->assertEquals(// Can Comment?
+        $this->assertSame(// Can Comment?
             'Add your comment',
             $this->findCssAndGetValue($page, 'form.comment-form .btn.btn-primary')
         );
@@ -164,7 +164,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Make sure page updated for login
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.record-tabs .usercomments a');
-        $this->assertEquals(// Can Comment?
+        $this->assertSame(// Can Comment?
             'Add your comment',
             $this->findCssAndGetValue($page, 'form.comment-form .btn.btn-primary')
         );
@@ -174,7 +174,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Add comment without CAPTCHA
         $this->findCssAndSetValue($page, 'form.comment-form [name="comment"]', 'one');
         $this->clickCss($page, 'form.comment-form .btn-primary');
-        $this->assertEquals(
+        $this->assertSame(
             'CAPTCHA not passed',
             $this->findCssAndGetText($page, '.modal-body .alert-danger')
         );
@@ -266,7 +266,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
     {
         // First try an undefined tag:
         $page = $this->performSearch('tag-not-in-system', 'tag');
-        $this->assertEquals('No Results!', $this->findCssAndGetText($page, 'h2'));
+        $this->assertSame('No Results!', $this->findCssAndGetText($page, 'h2'));
         // Now try a tag defined earlier, with a couple more instances added:
         $page = $this->goToRecord('id:"<angle>brackets&ampersands"');
         $this->addTagsToRecord($page, 'five', 'username2', 'test');
@@ -368,7 +368,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '.modal #addtag_tag', 'one ONE "new tag" ONE "THREE 4"');
         $this->clickCss($page, '.modal-body .btn.btn-primary');
         $this->waitForPageLoad($page);
-        $this->assertEquals('Tags Saved', $this->findCssAndGetText($page, '.modal-body .alert-success'));
+        $this->assertSame('Tags Saved', $this->findCssAndGetText($page, '.modal-body .alert-success'));
         $this->closeLightbox($page);
         // Count tags
         $this->waitForPageLoad($page);
@@ -752,7 +752,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         // Add rating
         $this->clickCss($page, '.modal form div.star-rating label', null, 10);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
+        $this->assertSame('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
         // Check result
         $this->waitForPageLoad($page);
         $inputs = $page->findAll('css', $checked);
@@ -763,7 +763,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.modal form div.star-rating label', null, 5);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
+        $this->assertSame('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
         // Check result
         $inputs = $page->findAll('css', $checked);
         $this->assertCount(1, $inputs);
@@ -802,7 +802,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, $ratingLink);
         $this->clickCss($page, '.modal form div.star-rating label', null, 10);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
+        $this->assertSame('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
         // Check result
         $this->waitForPageLoad($page);
         $inputs = $page->findAll('css', $checked);
@@ -886,7 +886,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
         $this->clickCss($page, '.modal form div.star-rating label', null, 5);
         $this->waitForPageLoad($page);
-        $this->assertEquals('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
+        $this->assertSame('Rating Saved', $this->findCssAndGetText($page, '.alert-success'));
 
         // Add two comments
         $this->clickCss($page, '.record-tabs .usercomments a');
@@ -915,7 +915,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, 'li#user-content-tag a.nav-link');
         $this->waitForPageLoad($page);
         $this->findCss($page, '.usercontent-table');
-        $this->assertEquals('testtag', $this->findCssAndGetText($page, '.usercontent-table .user-tag div'));
+        $this->assertSame('testtag', $this->findCssAndGetText($page, '.usercontent-table .user-tag div'));
         $this->clickCss($page, '.select-all-container input[name="selectAll"]');
         $this->clickCss($page, 'button#cancelSelected');
         $this->clickCss($page, 'a#confirm_cancel_selected_yes');
@@ -946,7 +946,7 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.export-toggle');
         $this->clickCss($page, '#export-options li a');
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Send to RefWorks',
             $this->findCssAndGetValue($page, '#export-form input.btn.btn-primary')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
@@ -94,7 +94,7 @@ class RecordTest extends \VuFindTest\Integration\MinkTestCase
         $staffViewTab = $this->findCss($page, '.record-tabs .holdings a');
         $this->assertEquals('Holdings', $staffViewTab->getText());
         $staffViewTab->click();
-        $this->assertEquals(
+        $this->assertSame(
             '3rd Floor Main Library',
             $this->findCssAndGetText($page, '.record-tabs .holdings-tab h2')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordVersionsTest.php
@@ -53,7 +53,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performSearch('id:0001732009-0', null, $path);
 
         // Confirm that "other versions" link exists:
-        $this->assertEquals(
+        $this->assertSame(
             'Show other versions (3)',
             $this->findCssAndGetText($page, 'div.record-versions a')
         );
@@ -63,7 +63,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that we've landed on an other versions tab:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'Other Versions (3)',
             $this->findCssAndGetText($page, $this->activeRecordTabSelector)
         );
@@ -73,7 +73,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm that all four versions are now visible in the versions display:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'The collected letters of Thomas and Jane Welsh Carlyle : Versions',
             $this->findCssAndGetText($page, 'ul.breadcrumb')
         );
@@ -151,7 +151,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performSearch('id:0001732009-0', null, '/Search');
 
         // Confirm that "all versions" link exists:
-        $this->assertEquals(
+        $this->assertSame(
             'Show all versions (4)',
             $this->findCssAndGetText($page, 'div.record-versions a')
         );
@@ -162,7 +162,7 @@ class RecordVersionsTest extends \VuFindTest\Integration\MinkTestCase
         // Confirm that we have jumped directly to the "show all versions" screen
         // and that all four versions are now visible in the versions display:
         $this->waitForPageLoad($page);
-        $this->assertEquals(
+        $this->assertSame(
             'The collected letters of Thomas and Jane Welsh Carlyle : Versions',
             $this->findCssAndGetText($page, 'ul.breadcrumb')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchViewsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchViewsTest.php
@@ -65,7 +65,7 @@ class SearchViewsTest extends \VuFindTest\Integration\MinkTestCase
         // Check for sample driver's available status in output (this will
         // only appear after AJAX returns):
         $this->unFindCss($page, '.ajax-availability');
-        $this->assertEquals(
+        $this->assertSame(
             'Available',
             $this->findCssAndGetText($page, '.grid-body .result-formats.status .label.label-success')
         );

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/UpgradeTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/UpgradeTest.php
@@ -139,9 +139,9 @@ final class UpgradeTest extends \VuFindTest\Integration\MinkTestCase
         $this->clickCss($page, '.main input.btn-primary');
         $this->waitForPageLoad($page);
         // Skip the security warning:
-        $this->assertEquals('Critical Issue: Insecure database settings', $this->findCssAndGetText($page, 'h2'));
+        $this->assertSame('Critical Issue: Insecure database settings', $this->findCssAndGetText($page, 'h2'));
         $ignoreSelector = '.main a.btn-default';
-        $this->assertEquals('ignore the problem', $this->findCssAndGetText($page, $ignoreSelector));
+        $this->assertSame('ignore the problem', $this->findCssAndGetText($page, $ignoreSelector));
         $this->clickCss($page, $ignoreSelector);
         $this->waitForPageLoad($page);
         // Now we should be on the duplicate tag screen; let's submit it:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/UrlShortenerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/UrlShortenerTest.php
@@ -74,13 +74,13 @@ class UrlShortenerTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCssAndSetValue($page, '#email_from', 'username1@ignore.com');
         $this->findCssAndSetValue($page, '#email_to', 'username2@ignore.com');
         $this->clickCss($page, '.modal input[type="submit"]');
-        $this->assertEquals('Message Sent', $this->findCssAndGetText($page, '.modal .alert-success'));
+        $this->assertSame('Message Sent', $this->findCssAndGetText($page, '.modal .alert-success'));
 
         // Extract the link from the provided message:
         $email = $this->getLoggedEmail();
         preg_match('/Link: <(http.*)>/', $email->getBody()->getBody(), $matches);
         $shortLink = $matches[1];
-        $this->assertNotEquals($searchUrl, $shortLink);
+        $this->assertNotSame($searchUrl, $shortLink);
         $this->assertStringContainsString('/short', $shortLink);
 
         // Now confirm that this sends us back to the correct set of search results:

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
@@ -89,7 +89,7 @@ class WebSearchTest extends \VuFindTest\Integration\MinkTestCase
 
         // Confirm highlighting:
         if ($expectedFirstHighlight) {
-            $this->assertEquals($expectedFirstHighlight, $this->findCssAndGetText($page, '#result0 mark'));
+            $this->assertSame($expectedFirstHighlight, $this->findCssAndGetText($page, '#result0 mark'));
         }
 
         // Confirm facet values:

--- a/tests/rector.php
+++ b/tests/rector.php
@@ -35,4 +35,4 @@ return RectorConfig::configure()
     ])
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(6)
-    ->withCodeQualityLevel(22);
+    ->withCodeQualityLevel(23);


### PR DESCRIPTION
The type changes in #5006 allow Rector to more confidently change many `assertEquals` calls to the more precise `assertSame`. We have to raise the code quality level from 22 to 23 to permit the changes.

TODO
- [x] Run full test suite.