### PR TITLE
Explain: Remove unused params

### DIFF
--- a/module/VuFind/src/VuFind/Search/Solr/Explanation.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Explanation.php
@@ -252,10 +252,8 @@ class Explanation extends \VuFind\Search\Base\Explanation
         $params->set('spellcheck', 'false');
         $explainParams = new ParamBag([
             'fl' => 'id,score',
-            'facet' => 'true',
             'debug' => 'true',
             'indent' => 'true',
-            'param' => 'q',
             'echoParams' => 'all',
             'explainOther' => 'id:"' . addcslashes($recordId, '"') . '"',
         ]);


### PR DESCRIPTION
For #4991 I am migrating all Solr parameters to use the Solr [JSON Request API](https://solr.apache.org/guide/solr/latest/query-guide/json-request-api.html).  I am not sure how to migrate these parameters used in the Explain feature, and they don't seem to have any effect on the output anyway, so hoping we can just remove them.