### PR TITLE
Include all source directories in PHPUnit configuration.

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -18,13 +18,7 @@
   </testsuites>
   <source>
     <include>
-      <directory suffix=".php">../src/VuFind</directory>
-      <directory suffix=".php">../../VuFindAdmin/src</directory>
-      <directory suffix=".php">../../VuFindApi/src</directory>
-      <directory suffix=".php">../../VuFindConsole/src</directory>
-      <directory suffix=".php">../../VuFindDevTools/src</directory>
-      <directory suffix=".php">../../VuFindSearch/src</directory>
-      <directory suffix=".php">../../VuFindTheme/src</directory>
+      <directory suffix=".php">../../*/src</directory>
     </include>
   </source>
 </phpunit>


### PR DESCRIPTION
This allows the coverage report to include all the modules that would be included in tests as well.