### PR TITLE
Add comments to help configure email on typical servers

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -736,7 +736,8 @@ search_enabled  = false
 ; This section requires no changes for most installations; if your SMTP server
 ; requires authentication, you can fill in a username and password below.
 [Mail]
-; For normal SMTP you can use the following settings:
+; For normal SMTP without advanced settings (like disabled certificate verification)
+; you can use the following settings:
 host            = localhost
 port            = 25
 ;username       = user
@@ -759,12 +760,14 @@ connection_time_limit = 60
 ; The server name to report to the upstream mail server when sending mail.
 ;name = vufind.myuniversity.edu
 
-; To use any other transport than SMTP, you can use the dsn setting to define
-; the connection string.
+; To use SMTP with special settings or any other transport than SMTP,
+; you can use the dsn setting to define the connection string.
 ; See https://symfony.com/doc/current/mailer.html#transport-setup for more
 ; information on the DSN configuration. Also note that VuFind does not include the
 ; third-party transports out of box, but you can add them to composer.local.json.
 ;dsn             = "native://default"
+; Use this setting for normal SMTP without certificate verification:
+;dsn             = "smtp://localhost:25?verify_peer=0"
 
 ; Uncomment this setting to disable outbound mail but simulate success; this
 ; is useful for interface testing but should never be used in production!


### PR DESCRIPTION
By default, Debian GNU Linux installs mail software with a self-signed
certificate. This causes a runtime exception when trying to send
feedback emails.

Improve the config.ini documentation to show how certificate
verification can be disabled to enable email sending.