### PR TITLE
Fix record page filter behavior with retention disabled.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SearchFacetsTest.php
@@ -65,13 +65,18 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
      * Get filtered search
      *
      * @param string $building Building filter to use
+     * @param string $format   Optional format filter to use
      *
      * @return Element
      */
-    protected function getFilteredSearch(string $building = 'weird_ids.mrc'): Element
+    protected function getFilteredSearch(string $building = 'weird_ids.mrc', string $format = ''): Element
     {
+        $url = $this->getVuFindUrl() . '/Search/Results?filter%5B%5D=building%3A"' . $building . '"';
+        if ($format) {
+            $url .= '&filter%5B%5D=format%3A"' . $format . '"';
+        }
         $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Search/Results?filter%5B%5D=building%3A"' . $building . '"');
+        $session->visit($url);
         return $session->getPage();
     }
 
@@ -1038,6 +1043,35 @@ class SearchFacetsTest extends \VuFindTest\Integration\MinkTestCase
         // Re-click the search button and confirm that filters go away
         $this->clickCss($page, '#searchForm .btn.btn-primary');
         $this->assertNoFilters($page);
+
+        // Test with two filters:
+        $page = $this->getFilteredSearch(format: 'Book');
+        $this->assertAppliedFilters(
+            $page,
+            [
+                'Library:weird_ids.mrc',
+                'Format:Book',
+            ]
+        );
+        // Remove one filter:
+        $this->clickCss($page, '.active-filters .filter-value');
+        $this->waitForPageLoad($page);
+        $this->assertFilterCount($page, 1);
+
+        // Test with two filters and removal from record page:
+        $page = $this->getFilteredSearch(format: 'Book');
+        $this->assertAppliedFilters(
+            $page,
+            [
+                'Library:weird_ids.mrc',
+                'Format:Book',
+            ]
+        );
+        // Now click the first result:
+        $this->clickCss($page, '.result-body a.title');
+        $this->waitForPageLoad($page);
+        // In this mode, we do not expect there to be any filters on the record page:
+        $this->assertFilterCount($page, 0);
     }
 
     /**

--- a/themes/bootstrap5/templates/search/searchbox.phtml
+++ b/themes/bootstrap5/templates/search/searchbox.phtml
@@ -56,7 +56,7 @@
     }
     $filterDetails = $this->searchbox()->getFilterDetails($filterList, $checkboxFilters);
     $retainFilters = $this->retainFilters ?? $options->getRetainFilterSetting();
-    $showFilters = $filterDetails && ($results || $retainFilters);
+    $showFilters = $filterDetails && ($results && !$fromSearchMemory || $retainFilters);
 ?>
 <?php $tabConfig = $this->searchTabs()->getTabConfig($this->searchClassId, $this->lookfor, $this->searchIndex, $this->searchType, $hiddenFilters); ?>
 <?php if ($this->searchType == 'advanced'): ?>


### PR DESCRIPTION
The code inappropriately displayed filter options on the record page when retain_filters_by_default was disabled. The "remove filter" controls then worked incorrectly. This PR hides filters outside of actual search results when retention is disabled to prevent confusing and inconsistent behavior.