### PR TITLE
Better exception if autowiring parameter resolution fails.

### DIFF
--- a/module/VuFind/src/VuFind/ServiceManager/Factory/AutowiringFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/Factory/AutowiringFactory.php
@@ -106,7 +106,7 @@ class AutowiringFactory implements FactoryInterface
             } catch (\Exception $e) {
                 $paramName = $reflectionParameter->getName();
                 throw new \Exception(
-                    "Problem resolving parameter $paramName when building $requestedName",
+                    "Problem resolving parameter $paramName when building $requestedName: " . $e->getMessage(),
                     previous: $e
                 );
             }

--- a/module/VuFind/src/VuFind/ServiceManager/Factory/AutowiringFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/Factory/AutowiringFactory.php
@@ -99,9 +99,17 @@ class AutowiringFactory implements FactoryInterface
         // Map constructor parameters:
         $params = [];
         foreach ($reflectionParameters as $reflectionParameter) {
-            $attributes = $reflectionParameter->getAttributes(Autowire::class);
-            $autowireArgs = ($attributes[0] ?? null)?->getArguments();
-            $params[] = $this->resolveParameter($container, $reflectionParameter, $autowireArgs);
+            try {
+                $attributes = $reflectionParameter->getAttributes(Autowire::class);
+                $autowireArgs = ($attributes[0] ?? null)?->getArguments();
+                $params[] = $this->resolveParameter($container, $reflectionParameter, $autowireArgs);
+            } catch (\Exception $e) {
+                $paramName = $reflectionParameter->getName();
+                throw new \Exception(
+                    "Problem resolving parameter $paramName when building $requestedName",
+                    previous: $e
+                );
+            }
         }
         return new $requestedName(...$params);
     }


### PR DESCRIPTION
During development of #5011, we discovered the hard way that a minor Autowire attribute misconfiguration can lead to opaque error messages (e.g. if you forget to specify a container, you'll get "cannot resolve to factory" errors about services, but no clear understanding of why). This PR adds a check to wrap exceptions that occur during parameter resolution so it's more clear where problems are actually coming from.