### PR TITLE
Fix FooterMenu default configuration backward compatibility

### DIFF
--- a/config/vufind/FooterMenu.yaml
+++ b/config/vufind/FooterMenu.yaml
@@ -24,7 +24,7 @@
 # configuration you can disable configuration inheritance by adding a
 # "@parent_yaml": false entry at the very top of your local configuration file.
 
-FooterFirst:
+footer-left:
   label: footer_header_search_options
   MenuItems:
     - label: 'Search History'
@@ -33,7 +33,7 @@ FooterFirst:
     - label: 'Advanced Search'
       route: search-advanced
 
-FooterSecond:
+footer-center:
   label: footer_header_find_more
   MenuItems:
     - label: 'Browse the Catalog'
@@ -51,7 +51,7 @@ FooterSecond:
     - label: 'New Items'
       route: search-newitem
 
-FooterThird:
+footer-right:
   label: footer_header_need_help
   MenuItems:
     - label: 'Search Tips'

--- a/module/VuFind/src/VuFind/Navigation/FooterMenu.php
+++ b/module/VuFind/src/VuFind/Navigation/FooterMenu.php
@@ -114,7 +114,7 @@ class FooterMenu extends AbstractMenu
     public static function getDefaultMenuConfig(): array
     {
         return [
-            'FooterFirst' => [
+            'footer-left' => [
                 'label' => 'footer_header_search_options',
                 'MenuItems' => [
                     [
@@ -127,7 +127,7 @@ class FooterMenu extends AbstractMenu
                     ],
                 ],
             ],
-            'FooterSecond' => [
+            'footer-center' => [
                 'label' => 'footer_header_find_more',
                 'MenuItems' => [
                     [
@@ -152,7 +152,7 @@ class FooterMenu extends AbstractMenu
                     ],
                 ],
             ],
-            'FooterThird' => [
+            'footer-right' => [
                 'label' => 'footer_header_need_help',
                 'MenuItems' => [
                     [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/FooterMenuTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/FooterMenuTest.php
@@ -75,7 +75,7 @@ class FooterMenuTest extends AbstractSectionTestCase
             $this->assertEquals(false, $plugin->{$method}());
         }
         $menu = $plugin->getMenu();
-        $this->assertCount(3, $menu['FooterThird']['MenuItems']);
+        $this->assertCount(3, $menu['footer-right']['MenuItems']);
     }
 
     /**


### PR DESCRIPTION
This should fix a potential backwards compatibility issue if someone has used the slots feature to customize footer menus.