### PR TITLE
Fix New Items HTML (BS5 radio button group markup / button tab order).

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NewItemsTest.php
@@ -63,7 +63,7 @@ class NewItemsTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCssAndGetText($page, '.form-search-newitem .btn-group')
         );
         // Now perform a search:
-        $this->clickCss($page, '.form-search-newitem .btn-group .btn-primary', index: $buttonIndex);
+        $this->clickCss($page, '.form-search-newitem .btn-group .btn-outline-primary', index: $buttonIndex);
         $this->clickCss($page, '.form-search-newitem input[type="submit"]');
         $this->waitForPageLoad($page);
         return $page;

--- a/themes/bootstrap5/templates/search/newitem.phtml
+++ b/themes/bootstrap5/templates/search/newitem.phtml
@@ -18,10 +18,29 @@
   <?php endif; ?>
   <div class="form-group">
     <label class="form-label"><?=$this->transEsc('Range')?>:</label>
-    <div class="btn-group" data-bs-toggle="buttons">
+    <div class="btn-group" role="group" data-bs-toggle="buttons">
       <?php foreach ($this->ranges as $key => $range): ?>
-        <label class="btn btn-primary<?php if ($key == 0): ?> active<?php endif ?>">
-          <input type="radio" name="range" id="newitem_range_<?=$this->escapeHtmlAttr($key)?>" value="<?=$this->escapeHtmlAttr($range)?>"<?=($key == 0) ? ' checked="checked" data-checked-by-default="true"' : ''?>>
+        <?php
+          $inputId = 'newitem_range_' . $key;
+          $inputAttrs = [
+            'id' => $inputId,
+            'type' => 'radio',
+            'class' => 'btn-check',
+            'name' => 'range',
+            'value' => $range,
+            'autocomplete' => 'off',
+          ];
+          if ($key == 0) {
+            $inputAttrs['checked'] = 'checked';
+            $inputAttrs['data-checked-by-default'] = 'true';
+          }
+          $labelAttrs = [
+            'for' => $inputId,
+            'class' => 'btn btn-outline-primary',
+          ]
+        ?>
+        <input<?=$this->htmlAttributes($inputAttrs)?>>
+        <label<?=$this->htmlAttributes($labelAttrs)?>>
           <?=$this->transEsc('past_days', ['range' => $this->escapeHtml($range)], null, true)?>
         </label>
       <?php endforeach; ?>

--- a/themes/bootstrap5/templates/search/newitem.phtml
+++ b/themes/bootstrap5/templates/search/newitem.phtml
@@ -58,7 +58,7 @@
     </div>
   <?php endif; ?>
   <div class="adv-submit">
-    <input class="clear-btn btn btn-default" type="button" value="<?= $this->transEscAttr('Clear')?>">
     <input class="btn btn-primary" type="submit" name="submitButton" value="<?=$this->transEscAttr('Find')?>">
+    <input class="clear-btn btn btn-default" type="button" value="<?= $this->transEscAttr('Clear')?>">
   </div>
 </form>


### PR DESCRIPTION
Looks like the Bootstrap5 theme conversion didn't fully address the new item page radio button controls. They were functional but did not render as intended. This PR adjusts the markup to match [current Bootstrap5 guidelines](https://getbootstrap.com/docs/5.0/components/button-group/).

Here's what the control looks like now:

<img width="374" height="84" alt="image" src="https://github.com/user-attachments/assets/7794890f-a3f1-4cdd-a00e-57134e05f451" />

And here's what it looked like prior to correction of the markup:

<img width="436" height="85" alt="image" src="https://github.com/user-attachments/assets/8bf43163-d88f-4494-b9c2-88554a1cbb3f" />

I think we're better off without the visible radio buttons and with the more obvious color contrast.