### PR TITLE
Catch runtime exception for EDS search with a query string of one or more spaces

### DIFF
--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -80,7 +80,7 @@ class Results extends \VuFind\Search\Base\Results
     protected function performSearch()
     {
         $query  = $this->getParams()->getQuery();
-        $allTerms = $query->getAllTerms();
+        $allTerms = trim($query->getAllTerms());
         if ($allTerms === '') {
             $this->storeErrorResponse('empty_search_disallowed');
             return;


### PR DESCRIPTION
Runtime error:

    vufind.ERROR: VuFindSearch\Backend\EDS\Backend: Unhandled EDS API error 106 : Unknown Error
    vufind.CRITICAL: VuFindSearch\Backend\Exception\BackendException : Unhandled EDS API error 106 :
      Unknown Error at /usr/local/vufind/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php line 295 ;
      VuFindSearch\Backend\EDS\ApiException : Unknown Error