### PR TITLE
Fix Primo backend for dedupmrg records

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
@@ -480,7 +480,7 @@ class RestConnector implements ConnectorInterface, \Psr\Log\LoggerAwareInterface
                 if (!$recordId) {
                     $recordId = $control->sourcerecordid[0];
                 }
-                $parts = explode('$', $recordId);
+                $parts = explode('$$', $recordId);
                 $recordId = substr(end($parts), 1);
             }
             $item['recordid'] = $this->getRecordId($recordId);

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
@@ -475,7 +475,14 @@ class RestConnector implements ConnectorInterface, \Psr\Log\LoggerAwareInterface
             $display = $pnx->display;
             $search = $pnx->search ?? null;
             $recordId = $control->recordid[0];
-            $recordId = str_starts_with($recordId, 'dedupmrg') ? $search->recordid[0] : $recordId;
+            if (str_starts_with($recordId, 'dedupmrg')) {
+                $recordId = $control->almaid[0] ?? false;
+                if (!$recordId) {
+                    $recordId = $control->sourcerecordid[0];
+                }
+                $parts = explode('$', $recordId);
+                $recordId = substr(end($parts), 1);
+            }
             $item['recordid'] = $this->getRecordId($recordId);
             $item['title'] = $display->title[0] ?? '';
             $item['format'] = $display->type ?? [];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Primo/RestConnector.php
@@ -474,7 +474,9 @@ class RestConnector implements ConnectorInterface, \Psr\Log\LoggerAwareInterface
             $control = $pnx->control;
             $display = $pnx->display;
             $search = $pnx->search ?? null;
-            $item['recordid'] = $this->getRecordId($control->recordid[0]);
+            $recordId = $control->recordid[0];
+            $recordId = str_starts_with($recordId, 'dedupmrg') ? $search->recordid[0] : $recordId;
+            $item['recordid'] = $this->getRecordId($recordId);
             $item['title'] = $display->title[0] ?? '';
             $item['format'] = $display->type ?? [];
             // creators (use the search fields instead of display (if available) to get them as an array instead of a


### PR DESCRIPTION
Such records currently throw a runtime exception which is fixed here:

    VuFind\Exception\RecordMissing : Record Primo:dedupmrg404088390 does not exist. at /usr/local/vufind/module/VuFind/src/VuFind/Record/Loader.php line 184  
