### PR TITLE
Fix default section configuration tests

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/AccountMenuTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/AccountMenuTest.php
@@ -45,8 +45,8 @@ use VuFindTest\Unit\AbstractSectionTestCase;
 class AccountMenuTest extends AbstractSectionTestCase
 {
     /**
-     * Test that the default configuration file matches the configuration
-     * returned by section class.
+     * Test that the default configuration file matches the default
+     * configuration returned by the section class.
      *
      * @return void
      */
@@ -54,8 +54,8 @@ class AccountMenuTest extends AbstractSectionTestCase
     {
         $container = $this->getContainerWithSectionRelatedServices();
         $this->assertEquals(
-            $this->getAccountMenu($container)->getMenu(),
-            $this->getAccountMenu($container, AccountMenu::getDefaultMenuConfig())->getMenu()
+            $this->getAccountMenu($container)->getSectionConfig(),
+            $this->getAccountMenu($container, AccountMenu::getDefaultMenuConfig())->getSectionConfig()
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/AdminMenuTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/AdminMenuTest.php
@@ -45,8 +45,8 @@ use VuFindTest\Unit\AbstractSectionTestCase;
 class AdminMenuTest extends AbstractSectionTestCase
 {
     /**
-     * Test that the default configuration file matches the configuration
-     * returned by section class.
+     * Test that the default configuration file matches the default
+     * configuration returned by the section class.
      *
      * @return void
      */
@@ -54,8 +54,8 @@ class AdminMenuTest extends AbstractSectionTestCase
     {
         $container = $this->getContainerWithSectionRelatedServices();
         $this->assertEquals(
-            $this->getAdminMenu($container)->getMenu(),
-            $this->getAdminMenu($container, AdminMenu::getDefaultMenuConfig())->getMenu()
+            $this->getAdminMenu($container)->getSectionConfig(),
+            $this->getAdminMenu($container, AdminMenu::getDefaultMenuConfig())->getSectionConfig()
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/FooterMenuTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/FooterMenuTest.php
@@ -45,8 +45,8 @@ use VuFindTest\Unit\AbstractSectionTestCase;
 class FooterMenuTest extends AbstractSectionTestCase
 {
     /**
-     * Test that the default configuration file matches the configuration
-     * returned by section class.
+     * Test that the default configuration file matches the default
+     * configuration returned by the section class.
      *
      * @return void
      */
@@ -54,8 +54,8 @@ class FooterMenuTest extends AbstractSectionTestCase
     {
         $container = $this->getContainerWithSectionRelatedServices();
         $this->assertEquals(
-            $this->getFooterMenu($container)->getMenu(),
-            $this->getFooterMenu($container, FooterMenu::getDefaultMenuConfig())->getMenu()
+            $this->getFooterMenu($container)->getSectionConfig(),
+            $this->getFooterMenu($container, FooterMenu::getDefaultMenuConfig())->getSectionConfig()
         );
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/HeaderBarTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Navigation/HeaderBarTest.php
@@ -45,8 +45,8 @@ use VuFindTest\Unit\AbstractSectionTestCase;
 class HeaderBarTest extends AbstractSectionTestCase
 {
     /**
-     * Test that the default configuration file matches the configuration
-     * returned by section class.
+     * Test that the default configuration file matches the default
+     * configuration returned by the section class.
      *
      * @return void
      */
@@ -54,8 +54,8 @@ class HeaderBarTest extends AbstractSectionTestCase
     {
         $container = $this->getContainerWithSectionRelatedServices();
         $this->assertEquals(
-            $this->getHeaderBar($container)->getMenu(),
-            $this->getHeaderBar($container, HeaderBar::getDefaultMenuConfig())->getMenu()
+            $this->getHeaderBar($container)->getSectionConfig(),
+            $this->getHeaderBar($container, HeaderBar::getDefaultMenuConfig())->getSectionConfig()
         );
     }
 


### PR DESCRIPTION
Compare the actual configuration as the menus could be the same even with different configuration depending on `checkMethod` results.