### PR TITLE
Clear local storage between tests to prevent side effects.

### DIFF
--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -442,11 +442,17 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     /**
      * Shut down the Mink session.
      *
+     * @param bool $clearLocalStorage Should we clear out local storage as part of shutdown?
+     *
      * @return void
      */
-    protected function stopMinkSession(): void
+    protected function stopMinkSession(bool $clearLocalStorage = true): void
     {
         if (!empty($this->session)) {
+            // If requested, make sure we don't carry local storage forward to the next test:
+            if ($clearLocalStorage) {
+                $this->clearBrowserLocalStorage();
+            }
             $this->session->stop();
             $this->session = null;
         }
@@ -1473,10 +1479,6 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             }
         }
 
-        // If a session is active, make sure we don't carry local storage forward to the next test:
-        if ($this->session) {
-            $this->clearBrowserLocalStorage();
-        }
         $this->stopMinkSession();
         $this->restoreConfigs();
 

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -1473,8 +1473,9 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             }
         }
 
-        if ($this->continuousIntegrationRunning()) {
-            $this->clearBrowserLocalStorage();  // don't carry data from one test to another!
+        // If a session is active, make sure we don't carry local storage forward to the next test:
+        if ($this->session) {
+            $this->clearBrowserLocalStorage();
         }
         $this->stopMinkSession();
         $this->restoreConfigs();

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -1473,7 +1473,9 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             }
         }
 
-        $this->clearBrowserLocalStorage();  // don't carry data from one test to another!
+        if ($this->continuousIntegrationRunning()) {
+            $this->clearBrowserLocalStorage();  // don't carry data from one test to another!
+        }
         $this->stopMinkSession();
         $this->restoreConfigs();
 

--- a/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
+++ b/module/VuFind/src/VuFindTest/Integration/MinkTestCase.php
@@ -1385,6 +1385,16 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Clear the browser's local storage.
+     *
+     * @return void
+     */
+    protected function clearBrowserLocalStorage(): void
+    {
+        $this->getMinkSession()->evaluateScript('window.localStorage.clear();');
+    }
+
+    /**
      * Standard setup method.
      *
      * @return void
@@ -1463,6 +1473,7 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
             }
         }
 
+        $this->clearBrowserLocalStorage();  // don't carry data from one test to another!
         $this->stopMinkSession();
         $this->restoreConfigs();
 


### PR DESCRIPTION
Some tests were failing when using a non-headless browser because local storage was persisting between test cases and leading to unexpected behavior. This PR explicitly clears local storage as part of Mink test teardown to prevent cross-test contamination. (This was not noticed sooner because the ChromeDriver clears storage ONLY for headless browsers, so things worked fine in headless mode).

TODO
- [x] Run full test suite in non-headless mode to confirm that there are no side effects.