### PR TITLE
Eliminate top-level container injection in listeners.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -638,7 +638,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
     {
         return new DeduplicationListener(
             $backend,
-            $this->serviceLocator,
+            $this->serviceLocator->get(ConfigManagerInterface::class),
             $this->searchConfig,
             'datasources',
             $enabled
@@ -682,8 +682,8 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
     {
         return new HierarchicalFacetListener(
             $backend,
-            $this->serviceLocator,
-            $this->facetConfig
+            $this->serviceLocator->get(\VuFind\Search\Solr\HierarchicalFacetHelper::class),
+            $this->serviceLocator->get(ConfigManagerInterface::class)->getConfigArray($this->facetConfig)
         );
     }
 

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -636,11 +636,11 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
      */
     protected function getDeduplicationListener(Backend $backend, bool $enabled): DeduplicationListener
     {
+        $configManager = $this->serviceLocator->get(ConfigManagerInterface::class);
         return new DeduplicationListener(
             $backend,
-            $this->serviceLocator->get(ConfigManagerInterface::class),
-            $this->searchConfig,
-            'datasources',
+            $configManager->getConfigArray($this->searchConfig),
+            $configManager->getConfigArray('datasources'),
             $enabled
         );
     }

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -36,8 +36,7 @@ namespace VuFind\Search\Solr;
 
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
-use Psr\Container\ContainerInterface;
-use VuFind\Service\GetServiceTrait;
+use VuFind\Config\ConfigManager;
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Service;
@@ -56,27 +55,24 @@ use function in_array;
  */
 class DeduplicationListener
 {
-    use GetServiceTrait;
-
     /**
      * Constructor.
      *
-     * @param Backend            $backend          Search backend
-     * @param ContainerInterface $serviceLocator   Service locator
-     * @param string             $searchConfig     Search configuration file identifier
-     * @param string             $dataSourceConfig Data source configuration file identifier
-     * @param bool               $enabled          Whether deduplication is enabled
+     * @param Backend       $backend          Search backend
+     * @param ConfigManager $configManager    Config manager
+     * @param string        $searchConfig     Search configuration file identifier
+     * @param string        $dataSourceConfig Data source configuration file identifier
+     * @param bool          $enabled          Whether deduplication is enabled
      *
      * @return void
      */
     public function __construct(
         protected Backend $backend,
-        ContainerInterface $serviceLocator,
+        protected ConfigManager $configManager,
         protected string $searchConfig,
         protected string $dataSourceConfig = 'datasources',
         protected bool $enabled = true
     ) {
-        $this->serviceLocator = $serviceLocator;
     }
 
     /**
@@ -181,8 +177,7 @@ class DeduplicationListener
      */
     protected function fetchLocalRecords(EventInterface $event): void
     {
-        $dataSourceConfig = $this->getService(\VuFind\Config\ConfigManagerInterface::class)
-            ->getConfigArray($this->dataSourceConfig);
+        $dataSourceConfig = $this->configManager->getConfigArray($this->dataSourceConfig);
         $recordSources = $this->getActiveRecordSources($event);
         $sourcePriority = $this->determineSourcePriority($recordSources);
         $command = $event->getParam('command');
@@ -303,10 +298,9 @@ class DeduplicationListener
      */
     protected function getActiveRecordSources(EventInterface $event): array
     {
-        $searchConfig = $this->getService(\VuFind\Config\ConfigManagerInterface::class)
-            ->getConfigObject($this->searchConfig);
-        return !empty($searchConfig->Records->sources)
-            ? explode(',', $searchConfig->Records->sources)
+        $searchConfig = $this->configManager->getConfigArray($this->searchConfig);
+        return !empty($searchConfig['Records']['sources'])
+            ? explode(',', $searchConfig['Records']['sources'])
             : [];
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -36,6 +36,7 @@ namespace VuFind\Search\Solr;
 
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
+use VuFind\Config\Feature\ExplodeSettingTrait;
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Service;
@@ -54,6 +55,8 @@ use function in_array;
  */
 class DeduplicationListener
 {
+    use ExplodeSettingTrait;
+
     /**
      * Constructor.
      *
@@ -294,9 +297,7 @@ class DeduplicationListener
      */
     protected function getActiveRecordSources(EventInterface $event): array
     {
-        return !empty($this->searchConfig['Records']['sources'])
-            ? explode(',', $this->searchConfig['Records']['sources'])
-            : [];
+        return $this->explodeListSetting($this->searchConfig['Records']['sources'] ?? '');
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/DeduplicationListener.php
@@ -36,7 +36,6 @@ namespace VuFind\Search\Solr;
 
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
-use VuFind\Config\ConfigManager;
 use VuFindSearch\Backend\Solr\Backend;
 use VuFindSearch\ParamBag;
 use VuFindSearch\Service;
@@ -58,19 +57,17 @@ class DeduplicationListener
     /**
      * Constructor.
      *
-     * @param Backend       $backend          Search backend
-     * @param ConfigManager $configManager    Config manager
-     * @param string        $searchConfig     Search configuration file identifier
-     * @param string        $dataSourceConfig Data source configuration file identifier
-     * @param bool          $enabled          Whether deduplication is enabled
+     * @param Backend $backend          Search backend
+     * @param array   $searchConfig     Search configuration
+     * @param array   $dataSourceConfig Data source configuration
+     * @param bool    $enabled          Whether deduplication is enabled
      *
      * @return void
      */
     public function __construct(
         protected Backend $backend,
-        protected ConfigManager $configManager,
-        protected string $searchConfig,
-        protected string $dataSourceConfig = 'datasources',
+        protected array $searchConfig,
+        protected array $dataSourceConfig,
         protected bool $enabled = true
     ) {
     }
@@ -177,7 +174,6 @@ class DeduplicationListener
      */
     protected function fetchLocalRecords(EventInterface $event): void
     {
-        $dataSourceConfig = $this->configManager->getConfigArray($this->dataSourceConfig);
         $recordSources = $this->getActiveRecordSources($event);
         $sourcePriority = $this->determineSourcePriority($recordSources);
         $command = $event->getParam('command');
@@ -209,8 +205,8 @@ class DeduplicationListener
                 if (!empty($buildingPriority)) {
                     if (isset($buildingPriority[$source])) {
                         $localPriority = -$buildingPriority[$source];
-                    } elseif (isset($dataSourceConfig[$source]['institution'])) {
-                        $institution = $dataSourceConfig[$source]['institution'];
+                    } elseif (isset($this->dataSourceConfig[$source]['institution'])) {
+                        $institution = $this->dataSourceConfig[$source]['institution'];
                         if (isset($buildingPriority[$institution])) {
                             $localPriority = -$buildingPriority[$institution];
                         }
@@ -298,9 +294,8 @@ class DeduplicationListener
      */
     protected function getActiveRecordSources(EventInterface $event): array
     {
-        $searchConfig = $this->configManager->getConfigArray($this->searchConfig);
-        return !empty($searchConfig['Records']['sources'])
-            ? explode(',', $searchConfig['Records']['sources'])
+        return !empty($this->searchConfig['Records']['sources'])
+            ? explode(',', $this->searchConfig['Records']['sources'])
             : [];
     }
 

--- a/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
+++ b/module/VuFind/src/VuFind/Search/Solr/HierarchicalFacetListener.php
@@ -33,10 +33,7 @@ namespace VuFind\Search\Solr;
 
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
-use VuFind\Config\Config;
 use VuFind\I18n\TranslatableString;
-use VuFind\Service\GetServiceTrait;
 use VuFindSearch\Backend\BackendInterface;
 use VuFindSearch\Service;
 
@@ -55,22 +52,6 @@ use function is_array;
  */
 class HierarchicalFacetListener
 {
-    use GetServiceTrait;
-
-    /**
-     * Facet configuration.
-     *
-     * @var Config
-     */
-    protected Config $facetConfig;
-
-    /**
-     * Facet helper.
-     *
-     * @var HierarchicalFacetHelper
-     */
-    protected HierarchicalFacetHelper $facetHelper;
-
     /**
      * Facet display styles.
      *
@@ -102,35 +83,22 @@ class HierarchicalFacetListener
     /**
      * Constructor.
      *
-     * @param BackendInterface        $backend         Search backend
-     * @param ServiceLocatorInterface $serviceLocator  Service locator
-     * @param string                  $facetConfigName Facet config name
+     * @param BackendInterface        $backend     Search backend
+     * @param HierarchicalFacetHelper $facetHelper Hierarchical facet helper
+     * @param array                   $facetConfig Facet configuration
      *
      * @return void
      */
     public function __construct(
         protected BackendInterface $backend,
-        ServiceLocatorInterface $serviceLocator,
-        string $facetConfigName
+        protected HierarchicalFacetHelper $facetHelper,
+        protected array $facetConfig
     ) {
-        $this->serviceLocator = $serviceLocator;
+        $specialFacets = $this->facetConfig['SpecialFacets'] ?? [];
+        $this->displayStyles = $specialFacets['hierarchicalFacetDisplayStyles'] ?? [];
+        $this->separators = $specialFacets['hierarchicalFacetSeparators'] ?? [];
 
-        $this->facetConfig = $this->getService(\VuFind\Config\ConfigManagerInterface::class)
-            ->getConfigObject($facetConfigName);
-        $this->facetHelper = $this->getService(\VuFind\Search\Solr\HierarchicalFacetHelper::class);
-
-        $specialFacets = $this->facetConfig->SpecialFacets;
-        $this->displayStyles
-            = isset($specialFacets->hierarchicalFacetDisplayStyles)
-            ? $specialFacets->hierarchicalFacetDisplayStyles->toArray()
-            : [];
-        $this->separators
-            = isset($specialFacets->hierarchicalFacetSeparators)
-            ? $specialFacets->hierarchicalFacetSeparators->toArray()
-            : [];
-
-        $translatedFacets = $this->facetConfig->Advanced_Settings->translated_facets
-            ?? [];
+        $translatedFacets = $this->facetConfig['Advanced_Settings']['translated_facets'] ?? [];
         foreach ($translatedFacets as $current) {
             $parts = explode(':', $current);
             $this->translatedFacets[] = $parts[0];
@@ -187,13 +155,13 @@ class HierarchicalFacetListener
      */
     protected function processHierarchicalFacets(EventInterface $event): void
     {
-        if (empty($this->facetConfig->SpecialFacets->hierarchical)) {
+        if (empty($this->facetConfig['SpecialFacets']['hierarchical'])) {
             return;
         }
         $result = $event->getParam('command')->getResult();
         foreach ($result->getRecords() as $record) {
             $fields = $record->getRawData();
-            foreach ($this->facetConfig->SpecialFacets->hierarchical as $facetName) {
+            foreach ($this->facetConfig['SpecialFacets']['hierarchical'] as $facetName) {
                 if (!isset($fields[$facetName])) {
                     continue;
                 }


### PR DESCRIPTION
As discussed on #5036, this refactors search listeners to eliminate the need to inject top-level containers. It also factors out VuFind\Config\Config objects at the same time.