### PR TITLE
Add RouteHelper, wrapping Laminas URL helper

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -502,6 +502,7 @@ $config = [
             'VuFind\Http\CachingDownloader' => 'VuFind\Http\CachingDownloaderFactory',
             'VuFind\Http\GuzzleService' => 'VuFind\Http\GuzzleServiceFactory',
             'VuFind\Http\PhpEnvironment\Request' => 'Laminas\ServiceManager\Factory\InvokableFactory',
+            'VuFind\Http\RouteHelper' => 'VuFind\Http\RouteHelperFactory',
             'VuFind\Http\ServerUrlHelper' => 'VuFind\Http\ServerUrlHelperFactory',
             'VuFind\I18n\Locale\LocaleSettings' => 'VuFind\Service\ServiceWithConfigIniFactory',
             'VuFind\I18n\Sorter' => 'VuFind\I18n\SorterFactory',

--- a/module/VuFind/src/VuFind/Http/RouteHelper.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelper.php
@@ -76,8 +76,9 @@ class RouteHelper
     public function getUrlFromRoute(
         $name = null,
         $linkParams = [],
-        $routeOptions = []
+        $queryParams = []
     ): string {
+        $routeOptions = $queryParams ? ['query' => $queryParams] : [];
         return ($this->urlHelper)($name, $linkParams, $routeOptions);
     }
 }

--- a/module/VuFind/src/VuFind/Http/RouteHelper.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelper.php
@@ -58,9 +58,9 @@ class RouteHelper
     /**
      * Generates a url given the name of a route.
      *
-     * @param string             $name        Name of the route
-     * @param array              $linkParams  Parameters for the link
-     * @param array|\Traversable $queryParams Query parameters
+     * @param string $name        Name of the route
+     * @param array  $routeParams Path parameters
+     * @param array  $queryParams Query parameters
      *
      * @see \Laminas\Router\RouteInterface::assemble()
      *
@@ -74,11 +74,11 @@ class RouteHelper
      * @return self|string Url For the link href attribute
      */
     public function getUrlFromRoute(
-        $name = null,
-        $linkParams = [],
-        $queryParams = []
+        string $name,
+        array $routeParams = [],
+        array $queryParams = []
     ): string {
         $routeOptions = $queryParams ? ['query' => $queryParams] : [];
-        return ($this->urlHelper)($name, $linkParams, $routeOptions);
+        return ($this->urlHelper)($name, $routeParams, $routeOptions);
     }
 }

--- a/module/VuFind/src/VuFind/Http/RouteHelper.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelper.php
@@ -58,9 +58,9 @@ class RouteHelper
     /**
      * Generates a url given the name of a route.
      *
-     * @param string             $name         Name of the route
-     * @param array              $linkParams   Parameters for the link
-     * @param array|\Traversable $routeOptions Options for the route
+     * @param string             $name        Name of the route
+     * @param array              $linkParams  Parameters for the link
+     * @param array|\Traversable $queryParams Query parameters
      *
      * @see \Laminas\Router\RouteInterface::assemble()
      *

--- a/module/VuFind/src/VuFind/Http/RouteHelper.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelper.php
@@ -78,7 +78,8 @@ class RouteHelper
         array $routeParams = [],
         array $queryParams = []
     ): string {
-        $routeOptions = $queryParams ? ['query' => $queryParams] : [];
+        // Path normalization can cause problems with IDs containing escaped slashes, so let's always disable it:
+        $routeOptions = ['normalize_path' => false] + ($queryParams ? ['query' => $queryParams] : []);
         return ($this->urlHelper)($name, $routeParams, $routeOptions);
     }
 }

--- a/module/VuFind/src/VuFind/Http/RouteHelper.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelper.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Route Helper class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFind\Http;
+
+use Closure;
+
+/**
+ * Route Helper class.  Wrapper around Laminas UrlHelper.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class RouteHelper
+{
+    /**
+     * Constructor.
+     *
+     * @param Closure $urlHelper URL helper function
+     *
+     * @return void
+     */
+    public function __construct(protected Closure $urlHelper)
+    {
+    }
+
+    /**
+     * Generates a url given the name of a route.
+     *
+     * @param string             $name         Name of the route
+     * @param array              $linkParams   Parameters for the link
+     * @param array|\Traversable $routeOptions Options for the route
+     *
+     * @see \Laminas\Router\RouteInterface::assemble()
+     *
+     * @throws \Laminas\View\Exception\RuntimeException If no RouteStackInterface was provided
+     * @throws \Laminas\View\Exception\RuntimeException If no RouteMatch was provided
+     * @throws \Laminas\View\Exception\RuntimeException If RouteMatch didn't contain a matched
+     * route name
+     * @throws \Laminas\View\Exception\InvalidArgumentException If the params object was not an
+     * array or Traversable object.
+     *
+     * @return self|string Url For the link href attribute
+     */
+    public function getUrlFromRoute(
+        $name = null,
+        $linkParams = [],
+        $routeOptions = []
+    ): string {
+        return ($this->urlHelper)($name, $linkParams, $routeOptions);
+    }
+}

--- a/module/VuFind/src/VuFind/Http/RouteHelperFactory.php
+++ b/module/VuFind/src/VuFind/Http/RouteHelperFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Route Helper factory.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Http;
+
+use Closure;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Route Helper factory.
+ *
+ * @category VuFind
+ * @package  Http
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class RouteHelperFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options passed to factory.');
+        }
+
+        $viewRenderer = $container->get('ViewRenderer');
+        return new $requestedName(
+            Closure::fromCallable($viewRenderer->plugin('url'))
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
@@ -51,15 +51,18 @@ class RouteHelperTest extends \PHPUnit\Framework\TestCase
      */
     public function testShallowGetUrlFromRoute(): void
     {
-        $routeName = 'some_route';
+        $routeName = 'some-route';
+        $routeParams = ['record' => 1];
+        $queryParams = ['foo' => 'bar'];
+        $routeResult = '/some/route/1?foo=bar';
 
         $urlHelper = $this->createMock(UrlHelper::class);
-        $urlHelper->expects($this->once())->method('__invoke')->willReturn($routeName);
+        $urlHelper->expects($this->once())->method('__invoke')->with($routeName, $routeParams, ['query' => $queryParams])->willReturn($routeResult);
         $routeHelper = new RouteHelper(
             Closure::fromCallable($urlHelper)
         );
 
-        $url = $routeHelper->getUrlFromRoute('', [], []);
-        $this->assertSame($routeName, $url);
+        $url = $routeHelper->getUrlFromRoute($routeName, $routeParams, $queryParams);
+        $this->assertSame($routeResult, $url);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
@@ -57,7 +57,10 @@ class RouteHelperTest extends \PHPUnit\Framework\TestCase
         $routeResult = '/some/route/1?foo=bar';
 
         $urlHelper = $this->createMock(UrlHelper::class);
-        $urlHelper->expects($this->once())->method('__invoke')->with($routeName, $routeParams, ['query' => $queryParams])->willReturn($routeResult);
+        $urlHelper->expects($this->once())
+            ->method('__invoke')
+            ->with($routeName, $routeParams, ['query' => $queryParams])
+            ->willReturn($routeResult);
         $routeHelper = new RouteHelper(
             Closure::fromCallable($urlHelper)
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * RouteHelper Test Class
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Http;
+
+use Closure;
+use Laminas\View\Helper\Url as UrlHelper;
+use VuFind\Http\RouteHelper;
+
+/**
+ * RouteHelper Test Class
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Maccabee Levine <msl321@lehigh.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class RouteHelperTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Shallowly test helper's getUrlFromRoute method
+     *
+     * @return void
+     */
+    public function testShallowGetUrlFromRoute(): void
+    {
+        $routeName = 'some_route';
+
+        $urlHelper = $this->createMock(UrlHelper::class);
+        $urlHelper->expects($this->once())->method('__invoke')->willReturn($routeName);
+        $routeHelper = new RouteHelper(
+            Closure::fromCallable($urlHelper)
+        );
+
+        $url = $routeHelper->getUrlFromRoute('', [], []);
+        $this->assertSame($routeName, $url);
+    }
+
+    // /**
+    //  * Data provider for testGetUrlFromRoute tests.
+    //  *
+    //  * @return \Iterator<string, array>
+    //  */
+    // public static function getUrlFromRouteProvider(): \Iterator
+    // {
+    //     yield 'Solr results' => [ 'search-results', [], ['query' => ['lookfor' => 'foo']], 'vufind/search/results' ];
+    // }
+
+    // /**
+    //  * Test helper's getUrlFromRoute method
+    //  *
+    //  * @param string             $name         Name of the route
+    //  * @param array              $linkParams   Parameters for the link
+    //  * @param array|\Traversable $routeOptions Options for the route
+    //  * @param string             $expected     Expected route URL
+    //  *
+    //  * @return void
+    //  */
+    // #[\PHPUnit\Framework\Attributes\DataProvider('getUrlFromRouteProvider')]
+    // public function testGetUrlFromRoute(
+    //     string $name,
+    //     array $linkParams,
+    //     array | \Traversable $routeOptions,
+    //     string $expected
+    // ): void {
+    //     $routeHelper = new RouteHelper(
+    //         Closure::fromCallable(new UrlHelper())
+    //     );
+
+    //     $url = $routeHelper->getUrlFromRoute($name, $linkParams, $routeOptions);
+    //     $this->assertSame($expected, $url);
+    // }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
@@ -62,39 +62,4 @@ class RouteHelperTest extends \PHPUnit\Framework\TestCase
         $url = $routeHelper->getUrlFromRoute('', [], []);
         $this->assertSame($routeName, $url);
     }
-
-    // /**
-    //  * Data provider for testGetUrlFromRoute tests.
-    //  *
-    //  * @return \Iterator<string, array>
-    //  */
-    // public static function getUrlFromRouteProvider(): \Iterator
-    // {
-    //     yield 'Solr results' => [ 'search-results', [], ['query' => ['lookfor' => 'foo']], 'vufind/search/results' ];
-    // }
-
-    // /**
-    //  * Test helper's getUrlFromRoute method
-    //  *
-    //  * @param string             $name         Name of the route
-    //  * @param array              $linkParams   Parameters for the link
-    //  * @param array|\Traversable $routeOptions Options for the route
-    //  * @param string             $expected     Expected route URL
-    //  *
-    //  * @return void
-    //  */
-    // #[\PHPUnit\Framework\Attributes\DataProvider('getUrlFromRouteProvider')]
-    // public function testGetUrlFromRoute(
-    //     string $name,
-    //     array $linkParams,
-    //     array | \Traversable $routeOptions,
-    //     string $expected
-    // ): void {
-    //     $routeHelper = new RouteHelper(
-    //         Closure::fromCallable(new UrlHelper())
-    //     );
-
-    //     $url = $routeHelper->getUrlFromRoute($name, $linkParams, $routeOptions);
-    //     $this->assertSame($expected, $url);
-    // }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Http/RouteHelperTest.php
@@ -59,7 +59,7 @@ class RouteHelperTest extends \PHPUnit\Framework\TestCase
         $urlHelper = $this->createMock(UrlHelper::class);
         $urlHelper->expects($this->once())
             ->method('__invoke')
-            ->with($routeName, $routeParams, ['query' => $queryParams])
+            ->with($routeName, $routeParams, ['query' => $queryParams, 'normalize_path' => false])
             ->willReturn($routeResult);
         $routeHelper = new RouteHelper(
             Closure::fromCallable($urlHelper)


### PR DESCRIPTION
For #4939, discussed here: https://github.com/vufind-org/vufind/pull/4939/changes#r2736633817 

Wrap Laminas URL helper so it can be used outside of the view rendering context, specifically as part of an API implementation.  Similar to #4983.