### PR TITLE
Fix SiteMapPageTest HTML validation errors

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
@@ -63,6 +63,7 @@ class SiteMapPageTest extends \VuFindTest\Integration\MinkTestCase
         $this->changeYamlConfigs(
             [
                 'SiteMap' => [
+                    '@parent_config_name' => false,
                     'HomePage' => [
                         'MenuItems' => [
                             [


### PR DESCRIPTION
This circumvents the problems of 

1. default configuration getting merged with the test configuration
2. `routeParams` from the default configuration not working in the tests.

Not ideal of course as the best solution would be to stop the default configuration from being merged and make `routeParams` work in the test environment.