### PR TITLE
Allow end-positioning a drop-down menu

### DIFF
--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -54,7 +54,7 @@
       )
   ?>
 
-  <?php 
+  <?php
     $menuAttributes = $this->htmlAttributes(['class' => 'dropdown-menu']);
     if ('end' == $this->menuAlign) {
       $menuAttributes->add('class', 'dropdown-menu-end');

--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -13,7 +13,8 @@
    * @param string  $toggleLabel  The label for the toggle button (will be translated)
    * @param ?string $wrapperTag   Tag to use as a wrapper around the control (default = div)
    * @param ?string $wrapperClass Extra CSS class(es) to apply to the wrapper tag
-   * @param ?string $menuClass    Extra CSS class(es) to apply to the dropdown-menu element, i.e. from Bootstrap
+   * @param ?string $menuAlign    Alignment of the drop-down. Default is alignment with the start side of its parent.
+   *                              'end' aligns with the end side of its parent.
    */
   $wrapperTag = $this->wrapperTag ?? 'div';
   $wrapperClass = 'dropdown'; // Bootstrap class
@@ -53,7 +54,13 @@
       )
   ?>
 
-  <ul class="dropdown-menu <?=$this->menuClass ?? '' ?>">
+  <?php 
+    $menuAttributes = $this->htmlAttributes(['class' => 'dropdown-menu']);
+    if ('end' == $this->menuAlign) {
+      $menuAttributes->add('class', 'dropdown-menu-end');
+    }
+  ?>
+  <ul<?=$menuAttributes?>>
     <?php foreach ($this->menuItems as $current): ?>
       <li class="dropdown__item">
         <a class="dropdown-item dropdown__link<?=($current['selected'] ?? false) ? ' active' : ''?>"

--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -13,6 +13,7 @@
    * @param string  $toggleLabel  The label for the toggle button (will be translated)
    * @param ?string $wrapperTag   Tag to use as a wrapper around the control (default = div)
    * @param ?string $wrapperClass Extra CSS class(es) to apply to the wrapper tag
+   * @param ?string $menuClass    Extra CSS class(es) to apply to the dropdown-menu element, i.e. from Bootstrap
    */
   $wrapperTag = $this->wrapperTag ?? 'div';
   $wrapperClass = 'dropdown'; // Bootstrap class
@@ -52,7 +53,7 @@
       )
   ?>
 
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu <?=$this->menuClass ?? '' ?>">
     <?php foreach ($this->menuItems as $current): ?>
       <li class="dropdown__item">
         <a class="dropdown-item dropdown__link<?=($current['selected'] ?? false) ? ' active' : ''?>"

--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -56,7 +56,7 @@
 
   <?php
     $menuAttributes = $this->htmlAttributes(['class' => 'dropdown-menu']);
-    if ('end' == $this->menuAlign) {
+    if ('end' == ($this->menuAlign ?? null)) {
       $menuAttributes->add('class', 'dropdown-menu-end');
     }
   ?>


### PR DESCRIPTION
If the content of a menu item is wide, it can force the menu off the screen (creating a horizontal scroll bar):

<img width="393" height="263" alt="menu left-aligned with header, extending past the edge of the window" src="https://github.com/user-attachments/assets/eb473eb5-ea1c-4dd9-a6c2-0e7c6995016a" />

This allows setting bootstrap classes on the dropdown-menu such as [dropdown-menu-end](https://getbootstrap.com/docs/5.0/components/dropdowns/#menu-alignment), to right-align the menu.

In HeaderBar-allLangs.phtml:

` 'menuClass' => 'dropdown-menu-end',`

<img width="455" height="263" alt="menu right-aligned with header, so it stays within viewport" src="https://github.com/user-attachments/assets/76042a4a-c107-4a61-9b73-7e5789ab2339" />
