### PR TITLE
Allow URL helper to be created even if Application does not have MvcEvent

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UrlFactory.php
@@ -79,7 +79,7 @@ class UrlFactory implements FactoryInterface
 
         $match = $container->get('Application')
             ->getMvcEvent()
-            ->getRouteMatch();
+            ?->getRouteMatch();
 
         if ($match instanceof RouteMatch) {
             $helper->setRouteMatch($match);


### PR DESCRIPTION
Anything (such as an event listener) that tries to create the plugin before MvcEvent is created for Application would cause an error. 

Related to #5062.