### PR TITLE
Replace Url controller plugin with RouteHelper.

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatuses.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatuses.php
@@ -30,10 +30,10 @@
 namespace VuFind\AjaxHandler;
 
 use Laminas\Mvc\Controller\Plugin\Params;
-use Laminas\Mvc\Controller\Plugin\Url;
 use VuFind\Db\Entity\UserEntityInterface;
 use VuFind\Db\Entity\UserResourceEntityInterface;
 use VuFind\Db\Service\UserResourceServiceInterface;
+use VuFind\Http\RouteHelper;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\Session\Settings as SessionSettings;
 
@@ -59,13 +59,13 @@ class GetSaveStatuses extends AbstractBase implements TranslatorAwareInterface
      *
      * @param SessionSettings              $ss                  Session settings
      * @param ?UserEntityInterface         $user                Logged in user (or null)
-     * @param Url                          $urlHelper           URL helper
+     * @param RouteHelper                  $routeHelper         Route helper
      * @param UserResourceServiceInterface $userResourceService User resource database service
      */
     public function __construct(
         SessionSettings $ss,
         protected ?UserEntityInterface $user,
-        protected Url $urlHelper,
+        protected RouteHelper $routeHelper,
         protected UserResourceServiceInterface $userResourceService
     ) {
         $this->sessionSettings = $ss;
@@ -82,8 +82,7 @@ class GetSaveStatuses extends AbstractBase implements TranslatorAwareInterface
     {
         $list = $data->getUserList();
         return !$list ? [] : [
-            'list_url' =>
-                $this->urlHelper->fromRoute('userList', ['id' => $list->getId()]),
+            'list_url' => $this->routeHelper->getUrlFromRoute('userList', ['id' => $list->getId()]),
             'list_title' => $list->getTitle(),
         ];
     }

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSaveStatusesFactory.php
@@ -35,6 +35,7 @@ use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use VuFind\Db\Service\PluginManager as DbServiceManager;
 use VuFind\Db\Service\UserResourceServiceInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Factory for GetSaveStatuses AJAX handler.
@@ -74,7 +75,7 @@ class GetSaveStatusesFactory implements \Laminas\ServiceManager\Factory\FactoryI
         return new $requestedName(
             $container->get(\VuFind\Session\Settings::class),
             $container->get(\VuFind\Auth\Manager::class)->getUserObject(),
-            $container->get('ControllerPluginManager')->get('url'),
+            $container->get(RouteHelper::class),
             $container->get(DbServiceManager::class)->get(UserResourceServiceInterface::class)
         );
     }

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowse.php
@@ -29,9 +29,8 @@
 
 namespace VuFind\ChannelProvider;
 
-use Laminas\Mvc\Controller\Plugin\Url;
+use VuFind\Http\RouteHelper;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
-use VuFind\Record\Router as RecordRouter;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\Search\Base\Results;
 use VuFindSearch\Command\AlphabeticBrowseCommand;
@@ -64,27 +63,6 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
     protected $maxRecordsToExamine;
 
     /**
-     * Search service
-     *
-     * @var \VuFindSearch\Service
-     */
-    protected $searchService;
-
-    /**
-     * URL helper
-     *
-     * @var Url
-     */
-    protected $url;
-
-    /**
-     * Record router
-     *
-     * @var RecordRouter
-     */
-    protected $recordRouter;
-
-    /**
      * Browse index to search
      *
      * @var string
@@ -115,20 +93,15 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
     /**
      * Constructor
      *
-     * @param \VuFindSearch\Service $search  Search service
-     * @param Url                   $url     URL helper
-     * @param RecordRouter          $router  Record router
-     * @param array                 $options Settings (optional)
+     * @param \VuFindSearch\Service $searchService Search service
+     * @param RouteHelper           $routeHelper   Route helper
+     * @param array                 $options       Settings (optional)
      */
     public function __construct(
-        \VuFindSearch\Service $search,
-        Url $url,
-        RecordRouter $router,
+        protected \VuFindSearch\Service $searchService,
+        protected RouteHelper $routeHelper,
         array $options = []
     ) {
-        $this->searchService = $search;
-        $this->url = $url;
-        $this->recordRouter = $router;
         $this->setOptions($options);
     }
 
@@ -303,22 +276,29 @@ class AlphaBrowse extends AbstractChannelProvider implements TranslatorAwareInte
             $retVal['links'][] = [
                 'label' => 'View Record',
                 'icon' => 'format-default',
-                'url' => $this->url
-                    ->fromRoute($route['route'], $route['params']),
+                'url' => $this->routeHelper->getUrlFromRoute($route['route'], $route['params']),
             ];
             $retVal['links'][] = [
                 'label' => 'channel_expand',
                 'icon' => 'ui-add',
-                'url' => $this->url->fromRoute('channels-record')
-                    . '?id=' . urlencode($driver->getUniqueID())
-                    . '&source=' . urlencode($driver->getSourceIdentifier()),
+                'url' => $this->routeHelper->getUrlFromRoute(
+                    'channels-record',
+                    queryParams: [
+                        'id' => $driver->getUniqueID(),
+                        'source' => $driver->getSourceIdentifier(),
+                    ]
+                ),
             ];
             $retVal['links'][] = [
                 'label' => 'channel_browse',
                 'icon' => 'list',
-                'url' => $this->url->fromRoute('alphabrowse-home')
-                    . '?source=' . urlencode($this->browseIndex)
-                    . '&from=' . $from[0],
+                'url' => $this->routeHelper->getUrlFromRoute(
+                    'alphabrowse-home',
+                    queryParams: [
+                        'source' => $this->browseIndex,
+                        'from' => $from[0],
+                    ]
+                ),
             ];
         }
         return $retVal;

--- a/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/AlphaBrowseFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Factory for AlphaBrowse channel provider.
@@ -70,8 +71,7 @@ class AlphaBrowseFactory implements FactoryInterface
         }
         return new $requestedName(
             $container->get(\VuFindSearch\Service::class),
-            $container->get('ControllerPluginManager')->get('url'),
-            $container->get(\VuFind\Record\Router::class)
+            $container->get(RouteHelper::class),
         );
     }
 }

--- a/module/VuFind/src/VuFind/ChannelProvider/Facets.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/Facets.php
@@ -29,8 +29,8 @@
 
 namespace VuFind\ChannelProvider;
 
-use Laminas\Mvc\Controller\Plugin\Url;
 use VuFind\Http\PhpEnvironment\Request as HttpRequest;
+use VuFind\Http\RouteHelper;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\Search\Base\Params;
@@ -93,12 +93,12 @@ class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
      * Constructor
      *
      * @param ResultsManager $resultsManager Results manager
-     * @param Url            $url            URL helper
+     * @param RouteHelper    $routeHelper    Route helper
      * @param array          $options        Settings (optional)
      */
     public function __construct(
         protected ResultsManager $resultsManager,
-        protected Url $url,
+        protected RouteHelper $routeHelper,
         array $options = []
     ) {
         $this->setOptions($options);
@@ -280,18 +280,17 @@ class Facets extends AbstractChannelProvider implements TranslatorAwareInterface
         // Determine the filter for the current channel, and add it:
         $params->addFilter($filter);
 
-        $query = $newResults->getUrlQuery()->getParams(false);
+        $query = $newResults->getUrlQuery()->getParamArray();
         $retVal['links'][] = [
             'label' => 'channel_search',
             'icon' => 'search',
-            'url' => $this->url->fromRoute($params->getOptions()->getSearchAction())
-                . $query,
+            'url' => $this->routeHelper->getUrlFromRoute($params->getOptions()->getSearchAction(), queryParams: $query),
         ];
+        $query['source'] = $params->getSearchClassId();
         $retVal['links'][] = [
             'label' => 'channel_expand',
             'icon' => 'ui-add',
-            'url' => $this->url->fromRoute('channels-search')
-                . $query . '&source=' . urlencode($params->getSearchClassId()),
+            'url' => $this->routeHelper->getUrlFromRoute('channels-search', queryParams: $query),
         ];
 
         // Add pagination

--- a/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/FacetsFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Factory for Facets channel provider.
@@ -70,7 +71,7 @@ class FacetsFactory implements FactoryInterface
         }
         return new $requestedName(
             $container->get(\VuFind\Search\Results\PluginManager::class),
-            $container->get('ControllerPluginManager')->get('url')
+            $container->get(RouteHelper::class)
         );
     }
 }

--- a/module/VuFind/src/VuFind/ChannelProvider/ListItems.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ListItems.php
@@ -29,10 +29,10 @@
 
 namespace VuFind\ChannelProvider;
 
-use Laminas\Mvc\Controller\Plugin\Url;
 use Laminas\Stdlib\Parameters;
 use VuFind\Db\Entity\UserListEntityInterface;
 use VuFind\Db\Service\UserListServiceInterface;
+use VuFind\Http\RouteHelper;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\Search\Base\Results;
 use VuFind\Tags\TagsService;
@@ -93,14 +93,14 @@ class ListItems extends AbstractChannelProvider
      * Constructor
      *
      * @param UserListServiceInterface             $userListService UserList database service
-     * @param Url                                  $url             URL helper
+     * @param RouteHelper                          $routeHelper     Route helper
      * @param \VuFind\Search\Results\PluginManager $resultsManager  Results manager
      * @param TagsService                          $tagsService     Tags service
      * @param array                                $options         Settings (optional)
      */
     public function __construct(
         protected UserListServiceInterface $userListService,
-        protected Url $url,
+        protected RouteHelper $routeHelper,
         protected \VuFind\Search\Results\PluginManager $resultsManager,
         protected TagsService $tagsService,
         array $options = []
@@ -279,7 +279,7 @@ class ListItems extends AbstractChannelProvider
         $retVal['links'][] = [
             'label' => 'channel_search',
             'icon' => 'search',
-            'url' => $this->url->fromRoute('userList', ['id' => $list->getId()]),
+            'url' => $this->routeHelper->getUrlFromRoute('userList', ['id' => $list->getId()]),
         ];
         return $retVal;
     }

--- a/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/ListItemsFactory.php
@@ -35,6 +35,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use VuFind\Db\Service\UserListServiceInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Factory for ListItems channel provider.
@@ -71,7 +72,7 @@ class ListItemsFactory implements FactoryInterface
         }
         return new $requestedName(
             $container->get(\VuFind\Db\Service\PluginManager::class)->get(UserListServiceInterface::class),
-            $container->get('ControllerPluginManager')->get('url'),
+            $container->get(RouteHelper::class),
             $container->get(\VuFind\Search\Results\PluginManager::class),
             $container->get(\VuFind\Tags\TagsService::class)
         );

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItems.php
@@ -29,9 +29,8 @@
 
 namespace VuFind\ChannelProvider;
 
-use Laminas\Mvc\Controller\Plugin\Url;
+use VuFind\Http\RouteHelper;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
-use VuFind\Record\Router as RecordRouter;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 use VuFind\Search\Base\Results;
 use VuFindSearch\Command\RetrieveCommand;
@@ -62,43 +61,17 @@ class SimilarItems extends AbstractChannelProvider implements TranslatorAwareInt
     protected $maxRecordsToExamine;
 
     /**
-     * Search service
-     *
-     * @var \VuFindSearch\Service
-     */
-    protected $searchService;
-
-    /**
-     * URL helper
-     *
-     * @var Url
-     */
-    protected $url;
-
-    /**
-     * Record router
-     *
-     * @var RecordRouter
-     */
-    protected $recordRouter;
-
-    /**
      * Constructor
      *
-     * @param \VuFindSearch\Service $search  Search service
-     * @param Url                   $url     URL helper
-     * @param RecordRouter          $router  Record router
-     * @param array                 $options Settings (optional)
+     * @param \VuFindSearch\Service $searchService Search service
+     * @param RouteHelper           $routeHelper   Route helper
+     * @param array                 $options       Settings (optional)
      */
     public function __construct(
-        \VuFindSearch\Service $search,
-        Url $url,
-        RecordRouter $router,
+        protected \VuFindSearch\Service $searchService,
+        protected RouteHelper $routeHelper,
         array $options = []
     ) {
-        $this->searchService = $search;
-        $this->url = $url;
-        $this->recordRouter = $router;
         $this->setOptions($options);
     }
 
@@ -225,16 +198,19 @@ class SimilarItems extends AbstractChannelProvider implements TranslatorAwareInt
         $retVal['links'][] = [
             'label' => 'View Record',
             'icon' => 'format-default',
-            'url' => $this->url
-                ->fromRoute($route['route'], $route['params']),
+            'url' => $this->routeHelper->getUrlFromRoute($route['route'], $route['params']),
         ];
 
         $retVal['links'][] = [
             'label' => 'channel_expand',
             'icon' => 'ui-add',
-            'url' => $this->url->fromRoute('channels-record')
-                . '?id=' . urlencode($driver->getUniqueID())
-                . '&source=' . urlencode($driver->getSourceIdentifier()),
+            'url' => $this->routeHelper->getUrlFromRoute(
+                'channels-record',
+                queryParams: [
+                    'id' => $driver->getUniqueID(),
+                    'source' => $driver->getSourceIdentifier(),
+                ]
+            ),
         ];
 
         return $retVal;

--- a/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
+++ b/module/VuFind/src/VuFind/ChannelProvider/SimilarItemsFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Factory for SimilarItems channel provider.
@@ -70,8 +71,7 @@ class SimilarItemsFactory implements FactoryInterface
         }
         return new $requestedName(
             $container->get(\VuFindSearch\Service::class),
-            $container->get('ControllerPluginManager')->get('url'),
-            $container->get(\VuFind\Record\Router::class)
+            $container->get(RouteHelper::class),
         );
     }
 }

--- a/module/VuFind/src/VuFind/Cover/RouterFactory.php
+++ b/module/VuFind/src/VuFind/Cover/RouterFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * Cover router factory.
@@ -68,14 +69,7 @@ class RouterFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        // Try to get the base URL from the controller plugin; fail over to
-        // the view helper if that doesn't work.
-        try {
-            $base = $container->get('ControllerPluginManager')->get('url')
-                ->fromRoute('cover-show');
-        } catch (\Exception $e) {
-            $base = ($container->get('ViewRenderer')->plugin('url'))('cover-show');
-        }
+        $base = $container->get(RouteHelper::class)->getUrlFromRoute('cover-show');
         $coverLoader = $container->get(\VuFind\Cover\Loader::class);
         $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)
             ->getConfigArray('config')['Content'] ?? [];

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/HTMLTree.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/HTMLTree.php
@@ -31,8 +31,8 @@
 
 namespace VuFind\Hierarchy\TreeRenderer;
 
-use Laminas\Mvc\Controller\Plugin\Url as UrlPlugin;
 use Laminas\View\Renderer\RendererInterface;
+use VuFind\Http\RouteHelper;
 
 use function in_array;
 
@@ -53,38 +53,17 @@ class HTMLTree extends AbstractBase implements \VuFind\I18n\Translator\Translato
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
 
     /**
-     * Router plugin
-     *
-     * @var UrlPlugin
-     */
-    protected $router = null;
-
-    /**
-     * Whether the collections functionality is enabled
-     *
-     * @var bool
-     */
-    protected $collectionsEnabled;
-
-    /**
-     * View renderer
-     *
-     * @var RendererInterface
-     */
-    protected $viewRenderer;
-
-    /**
      * Constructor
      *
-     * @param UrlPlugin         $router             Router plugin for urls
+     * @param RouteHelper       $routeHelper        Router plugin for urls
      * @param bool              $collectionsEnabled Whether the collections functionality is enabled
-     * @param RendererInterface $renderer           View renderer
+     * @param RendererInterface $viewRenderer       View renderer
      */
-    public function __construct(UrlPlugin $router, bool $collectionsEnabled, RendererInterface $renderer)
-    {
-        $this->router = $router;
-        $this->collectionsEnabled = $collectionsEnabled;
-        $this->viewRenderer = $renderer;
+    public function __construct(
+        protected RouteHelper $routeHelper,
+        protected bool $collectionsEnabled,
+        protected RendererInterface $viewRenderer,
+    ) {
     }
 
     /**
@@ -231,15 +210,13 @@ class HTMLTree extends AbstractBase implements \VuFind\I18n\Translator\Translato
                 'id' => '__record_id__',
                 'tab' => 'HierarchyTree',
             ];
-            $options = [
-                'query' => [
-                    'recordID' => '__record_id__',
-                ],
+            $query = [
+                'recordID' => '__record_id__',
             ];
-            $cache[$route] = $this->router->fromRoute(
+            $cache[$route] = $this->routeHelper->getUrlFromRoute(
                 $this->getRouteNameFromDataSource($route),
                 $params,
-                $options
+                $query
             );
         }
         return str_replace('__record_id__', urlencode($id), $cache[$route]);

--- a/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/HTMLTreeFactory.php
+++ b/module/VuFind/src/VuFind/Hierarchy/TreeRenderer/HTMLTreeFactory.php
@@ -33,6 +33,7 @@ use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\Http\RouteHelper;
 
 /**
  * HTMLTree hierarchy tree renderer plugin factory.
@@ -69,7 +70,7 @@ class HTMLTreeFactory implements \Laminas\ServiceManager\Factory\FactoryInterfac
         }
         $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigArray('config');
         return new $requestedName(
-            $container->get('ControllerPluginManager')->get('Url'),
+            $container->get(RouteHelper::class),
             !empty($config['Collections']['collections']),
             $container->get('ViewRenderer')
         );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/AlphaBrowseTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/AlphaBrowseTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\ChannelProvider;
 
 use VuFind\ChannelProvider\AlphaBrowse;
+use VuFind\Http\RouteHelper;
 use VuFindSearch\ParamBag;
 use VuFindTest\RecordDriver\TestHarness;
 
@@ -150,7 +151,7 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
         $objects = $this->getAlphaBrowse($options);
         $alpha = $objects['alpha'];
         $search = $objects['search'];
-        $url = $objects['url'];
+        $routeHelper = $objects['routeHelper'];
         $router = $objects['router'];
         $alpha->setProviderId('foo_ProviderId');
         $driver = $this->getDriver(['solrField' => 'foo']);
@@ -231,14 +232,18 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
             ->with($driver)
             ->willReturn($routeDetails);
         $this->expectConsecutiveCalls(
-            $url,
-            'fromRoute',
+            $routeHelper,
+            'getUrlFromRoute',
             [
                 [$routeDetails['route'], $routeDetails['params']],
-                ['channels-record'],
-                ['alphabrowse-home'],
+                ['channels-record', [], ['id' => 'foo_Id', 'source' => 'foo_Identifier']],
+                ['alphabrowse-home', [], ['source' => 'lcc', 'from' => 'foo']],
             ],
-            ['url_test', 'channels-record', 'alphabrowse-home']
+            [
+                'url_test',
+                'channels-record?id=foo_Id&source=foo_Identifier',
+                'alphabrowse-home?source=lcc&from=foo',
+            ]
         );
         $expectedResult = [[
             'title' => 'nearby_items',
@@ -327,10 +332,11 @@ class AlphaBrowseTest extends \PHPUnit\Framework\TestCase
     protected function getAlphaBrowse($options = [])
     {
         $search = $this->createMock(\VuFindSearch\Service::class);
-        $url = $this->createMock(\Laminas\Mvc\Controller\Plugin\Url::class);
+        $routeHelper = $this->createMock(RouteHelper::class);
         $router = $this->createMock(\VuFind\Record\Router::class);
-        $alpha = new AlphaBrowse($search, $url, $router, $options);
+        $alpha = new AlphaBrowse($search, $routeHelper, $options);
+        $alpha->setRecordRouter($router);
 
-        return compact('search', 'url', 'router', 'alpha');
+        return compact('search', 'routeHelper', 'router', 'alpha');
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/FacetsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/FacetsTest.php
@@ -29,8 +29,8 @@
 
 namespace VuFindTest\ChannelProvider;
 
-use Laminas\Mvc\Controller\Plugin\Url;
 use VuFind\ChannelProvider\Facets;
+use VuFind\Http\RouteHelper;
 use VuFind\Search\Results\PluginManager;
 use VuFindTest\Feature\SearchObjectsTrait;
 use VuFindTest\RecordDriver\TestHarness;
@@ -57,8 +57,8 @@ class FacetsTest extends \PHPUnit\Framework\TestCase
     {
         $resultsManager = $this->createMock(PluginManager::class);
         $resultsManager->method('get')->willReturn($this->getMockResults());
-        $urlHelper = $this->createMock(Url::class);
-        $facets = new Facets($resultsManager, $urlHelper, ['maxFieldsToSuggest' => 0]);
+        $routeHelper = $this->createMock(RouteHelper::class);
+        $facets = new Facets($resultsManager, $routeHelper, ['maxFieldsToSuggest' => 0]);
         $this->assertEquals(
             [
                 [

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/SimilarItemsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ChannelProvider/SimilarItemsTest.php
@@ -30,6 +30,7 @@
 namespace VuFindTest\ChannelProvider;
 
 use VuFind\ChannelProvider\SimilarItems;
+use VuFind\Http\RouteHelper;
 use VuFindSearch\ParamBag;
 use VuFindTest\RecordDriver\TestHarness;
 
@@ -149,7 +150,7 @@ class SimilarItemsTest extends \PHPUnit\Framework\TestCase
         $mockObjects = $this->getSimilarItems($options);
         $similar = $mockObjects['similar'];
         $search = $mockObjects['search'];
-        $url = $mockObjects['url'];
+        $routeHelper = $mockObjects['routeHelper'];
         $router = $mockObjects['router'];
         $similar->setProviderId('foo_ProviderId');
         $params = new ParamBag(['rows' => $options['rows']]);
@@ -223,15 +224,15 @@ class SimilarItemsTest extends \PHPUnit\Framework\TestCase
             ->with($recordDriver)
             ->willReturn($routeDetails);
         $this->expectConsecutiveCalls(
-            $url,
-            'fromRoute',
+            $routeHelper,
+            'getUrlFromRoute',
             [
-                [$this->equalTo($routeDetails['route']), $this->equalTo($routeDetails['params'])],
-                [$this->equalTo('channels-record')],
+                [$routeDetails['route'], $routeDetails['params']],
+                ['channels-record', [], ['id' => 'foo_Id', 'source' => 'Solr']],
             ],
             [
                 'url_test',
-                'channels-record',
+                'channels-record?id=foo_Id&source=Solr',
             ]
         );
         return [
@@ -250,11 +251,12 @@ class SimilarItemsTest extends \PHPUnit\Framework\TestCase
     protected function getSimilarItems($options = [])
     {
         $search = $this->createMock(\VuFindSearch\Service::class);
-        $url = $this->createMock(\Laminas\Mvc\Controller\Plugin\Url::class);
+        $routeHelper = $this->createMock(RouteHelper::class);
         $router = $this->createMock(\VuFind\Record\Router::class);
-        $similar = new SimilarItems($search, $url, $router, $options);
+        $similar = new SimilarItems($search, $routeHelper, $options);
+        $similar->setRecordRouter($router);
 
-        return compact('search', 'url', 'router', 'similar');
+        return compact('search', 'routeHelper', 'router', 'similar');
     }
 
     /**


### PR DESCRIPTION
Also cleans up channel provider constructors that don't need to include record router (it's handled by RouterInitializer).