### PR TITLE
Add RecordDriver\Feature\IiifAwareTrait

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/Feature/IiifAwareTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/IiifAwareTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Functionality related to IIIF manifests in records
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2025-2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  RecordDrivers
+ * @author   Ronja Koistinen <ronja.koistinen@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
+ */
+
+namespace Finna\RecordDriver\Feature;
+
+/**
+ * Additional functionality for IIIF in Finna
+ *
+ * @category VuFind
+ * @package  RecordDrivers
+ * @author   Ronja Koistinen <ronja.koistinen@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
+ */
+trait IiifAwareTrait
+{
+    /**
+     * Get all IIIF manifests.
+     *
+     * @return array
+     */
+    public function getIiifManifests(): array
+    {
+        return [];
+    }
+
+    /**
+     * Checks that the content type corresponds to a IIIF Presentation manifest
+     *
+     * @param string $contentType Content type to check
+     *
+     * @return bool
+     */
+    public function isIiifPresentationManifest(string $contentType): bool
+    {
+        $iiifManifestContentTypeRegex =
+            '/application\/ld(\+json)?;profile="http:\/\/iiif\.io\/api\/presentation\/.+\.json"/';
+        return preg_match($iiifManifestContentTypeRegex, $contentType) === 1;
+    }
+}

--- a/module/VuFind/src/VuFind/RecordDriver/Feature/IiifAwareTrait.php
+++ b/module/VuFind/src/VuFind/RecordDriver/Feature/IiifAwareTrait.php
@@ -27,7 +27,7 @@
  * @link     https://vufind.org/wiki/development:plugins:record_drivers Wiki
  */
 
-namespace Finna\RecordDriver\Feature;
+namespace VuFind\RecordDriver\Feature;
 
 /**
  * Additional functionality for IIIF in Finna


### PR DESCRIPTION
This trait provides common functionality through which to query a record driver for IIIF Presentation API manifests.

The implementation of the `isIiifPresentationManifest()` method is not a fool-proof way to identify which URLs in metadata refer to IIIF resources, because the wording in [the spec](https://iiif.io/api/presentation/3.0/#63-responses) is (note the SHOULD):

> If the request does not include an Accept header, the HTTP Content-Type header of the response SHOULD have the value `application/ld+json` (JSON-LD) with the profile parameter given as the context document: `http://iiif.io/api/presentation/3/context.json`.

At least the regex in my implementation tries to be Presentation API version-agnostic.

For an example of a record driver using this trait, see what Finna does in the [SolrMarc driver](https://github.com/NatLibFi/NDL-VuFind2/blob/167b7caa4527973f45a8819ce860fad8602183a4/module/Finna/src/Finna/RecordDriver/SolrMarc.php#L187).

In my first implementation, `getIiifManifests()` was a generator, and maybe it still should be. I don't remember why I changed it...