### PR TITLE
Fix duplicate 'rows' param from SimilarBuilder

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php
@@ -324,8 +324,8 @@ class Backend extends AbstractBackend implements
         $params = $params ?: new ParamBag();
         $this->injectResponseWriter($params);
 
-        $params->mergeWith($this->getSimilarBuilder()->build($id));
-        $response   = $this->connector->similar($id, $params);
+        $params = $this->getSimilarBuilder()->build($id, $params);
+        $response = $this->connector->similar($id, $params);
         $collection = $this->createRecordCollection($response);
         $this->injectSourceIdentifier($collection);
         return $collection;

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilder.php
@@ -113,13 +113,14 @@ class SimilarBuilder implements SimilarBuilderInterface
     /**
      * Return SOLR search parameters based on a record Id and params.
      *
-     * @param string $id Record Id
+     * @param string    $id     Record Id
+     * @param ?ParamBag $params Existing params
      *
      * @return ParamBag
      */
-    public function build($id)
+    public function build(string $id, ?ParamBag $params = null): ParamBag
     {
-        $params = new ParamBag();
+        $params = $params ?: new ParamBag();
         if ($this->useHandler) {
             $mltParams = $this->handlerParams
                 ? $this->handlerParams

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilderInterface.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilderInterface.php
@@ -52,9 +52,10 @@ interface SimilarBuilderInterface
     /**
      * Build SOLR query based on VuFind query object.
      *
-     * @param string $id Record id
+     * @param string    $id     Record id
+     * @param ?ParamBag $params Existing params
      *
      * @return ParamBag
      */
-    public function build($id);
+    public function build(string $id, ?ParamBag $params = null): ParamBag;
 }

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
@@ -32,6 +32,7 @@
 namespace VuFindTest\Backend\Solr;
 
 use VuFindSearch\Backend\Solr\SimilarBuilder;
+use VuFindSearch\ParamBag;
 
 /**
  * Unit tests for SOLR similar records query builder
@@ -60,6 +61,19 @@ class SimilarBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('id:"testrecord"', $q[0]);
         $qt = $response->get('qt');
         $this->assertEquals('morelikethis', $qt[0]);
+    }
+
+    /**
+     * Test builder with an existing limit
+     *
+     * @return void
+     */
+    public function testExistingLimit()
+    {
+        $sb = new SimilarBuilder();
+        $response = $sb->build('testrecord', new ParamBag(['rows' => 42]));
+        $rows = $response->get('rows');
+        $this->assertEquals(42, $rows[0]);
     }
 
     /**


### PR DESCRIPTION
SimilarBuilder->build [intends ](https://github.com/vufind-org/vufind/blob/v11.0.1/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilder.php#L136C1-L138C10) to avoid setting a `rows` param if it already exists

```
        if (null === $params->get('rows')) {
            $params->set('rows', $this->count);
        }
```

But $params is constructed fresh in the same method, so the condition is always true and `rows` is always set.  Then in [Backend->similar](https://github.com/vufind-org/vufind/blob/v11.0.1/module/VuFindSearch/src/VuFindSearch/Backend/Solr/Backend.php#L327), these new params from SimilarBuilder are merged with any that were passed into `similar`, which sometimes already contains `rows`.  This leads to two `rows` params, and ultimate query params like:

/select?fl=%2A&rows=24&rows=5&wt=json&json.nl=arrarr&q=id%3A%22topcollection2%22&qt=morelikethis

(see the duplicate `rows`)

This fixes the original logic by passing in any existing `$params`, so that `rows` is actually not set if it shouldn't be.