### PR TITLE
Use standard text for Primo search in all fields

### DIFF
--- a/config/vufind/Primo.ini
+++ b/config/vufind/Primo.ini
@@ -261,7 +261,7 @@ translated_facets[] = tlevel
 ; be sure to update language files if necessary.  The order of these settings
 ; will be maintained in the drop-down list in the UI.
 [Basic_Searches]
-AllFields           = Keyword
+AllFields           = "All Fields"
 Title               = Title
 Author              = Author
 Subject             = Subject
@@ -271,7 +271,7 @@ Subject             = Subject
 ; This section defines which search options will be included on the advanced
 ; search screen.  All the notes above [Basic_Searches] also apply here.
 [Advanced_Searches]
-AllFields           = Keyword
+AllFields           = adv_search_all
 Title               = Title
 Author              = Author
 Subject             = Subject


### PR DESCRIPTION
One of our test users found the text 'Keyword' confusing, and I agree. Note that "All Fields" and `adv_search_all` resolve to the same English text and translations. I used the pattern from Search2.ini.

It would also be possible to use `adv_search_title` ... for the remaining strings in the advanced search. Should this be done?

Should module/VuFind/tests/fixtures/configs/permissions/Primo.ini and module/VuFind/tests/fixtures/configs/primo/Primo.ini also be updated? It looks like the translation for "Keyword" is then unused and could be removed.
