### PR TITLE
import-marc.sh: always initialize REGENERATE_SOLRJ_DIR

### DIFF
--- a/import-marc.sh
+++ b/import-marc.sh
@@ -149,6 +149,7 @@ then
   SOLRJ_DIR="$VUFIND_HOME/solr/vendor/.solrj"
 fi
 
+REGENERATE_SOLRJ_DIR=0
 if [ -d "$SOLRJ_DIR" ]
 then
   # validate the .solrj symlinks in case an upgrade has messed something up:


### PR DESCRIPTION
I noticed that import-marc.sh was sometimes emitting notices because REGENERATE_SOLRJ_DIR was not always initialized. This PR initializes the variable to prevent the problem.