### PR TITLE
Allow local sort definitions in the "Sort By" menu

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -237,7 +237,7 @@ callnumber-sort = sort_callnumber
 author = sort_author
 title = sort_title
 
-; This section allows you to override existing special shortcut aliases like 
+; This section allows you to override existing special sort type aliases like 
 ; "year", "author", "title", etc. or to define your own. It is necessary 
 ; to specify xxx[field] - option either with index field name or user sort function. 
 ; Default sort direction is 'desc', but it could be overridden by xxx[order].

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -242,7 +242,7 @@ title = sort_title
 ; to specify xxx[field] - option either with index field name or user sort function. 
 ; Default sort direction is 'desc', but it could be overridden by xxx[order].
 [LocalSortDefinitions]
-;title[field] = title_short
+;title[field] = title_sort
 ;title[order] = desc
 ;ebook[field] = "max(1,product(termfreq('format','ebook'),20.0))"
 ;ebook[order] = desc

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -242,10 +242,10 @@ title = sort_title
 ; to specify xxx[field] - option either with index field name or user sort function. 
 ; Default sort direction is 'desc', but it could be overridden by xxx[order].
 [LocalSortDefinitions]
-; title[field] = title_short
-; title[order] = desc
-; ebook[field] = "max(1,product(termfreq('format','ebook'),20.0))"
-; ebook[order] = desc
+;title[field] = title_short
+;title[order] = desc
+;ebook[field] = "max(1,product(termfreq('format','ebook'),20.0))"
+;ebook[order] = desc
 
 ; This section allows you to specify the default sort order for specific types of
 ; searches.  Each key in this section should correspond with a key in the

--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -237,6 +237,16 @@ callnumber-sort = sort_callnumber
 author = sort_author
 title = sort_title
 
+; This section allows you to override existing special shortcut aliases like 
+; "year", "author", "title", etc. or to define your own. It is necessary 
+; to specify xxx[field] - option either with index field name or user sort function. 
+; Default sort direction is 'desc', but it could be overridden by xxx[order].
+[LocalSortDefinitions]
+; title[field] = title_short
+; title[order] = desc
+; ebook[field] = "max(1,product(termfreq('format','ebook'),20.0))"
+; ebook[order] = desc
+
 ; This section allows you to specify the default sort order for specific types of
 ; searches.  Each key in this section should correspond with a key in the
 ; [Basic_Searches] section above.  Each value should correspond with a key in the

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -144,6 +144,21 @@ class Params extends \VuFind\Search\Base\Params
     protected $customFilterFieldName;
 
     /**
+     * Default sort aliases
+     *
+     * @var array
+     */
+    protected array $sortDefinitions =  [
+        'year' => ['field' => 'publishDateSort', 'order' => 'desc'],
+        'publishDateSort' => ['field' => 'publishDateSort', 'order' => 'desc'],
+        'author' => ['field' => 'author_sort', 'order' => 'asc'],
+        'authorStr' => ['field' => 'author_sort', 'order' => 'asc'],
+        'title' => ['field' => 'title_sort', 'order' => 'asc'],
+        'relevance' => ['field' => 'score', 'order' => 'desc'],
+        'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc']];
+
+
+    /**
      * Constructor
      *
      * @param \VuFind\Search\Base\Options $options       Options to use
@@ -177,6 +192,11 @@ class Params extends \VuFind\Search\Base\Params
             );
         }
         $this->customFilterFieldName = $config->CustomFilters->custom_filter_field ?? 'vufind';
+        $searchConfig = $this->configManager->getConfigArray($this->getOptions()->getSearchIni());
+        $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? array();
+        foreach ($localSortDefinitions as $alias => $localSortDefinition) {
+            $this->sortDefinitions[$alias] = $localSortDefinition;
+        }
     }
 
     /**
@@ -523,19 +543,6 @@ class Params extends \VuFind\Search\Base\Params
      */
     protected function normalizeSort($sort)
     {
-        $table = [
-            'year' => ['field' => 'publishDateSort', 'order' => 'desc'],
-            'publishDateSort' => ['field' => 'publishDateSort', 'order' => 'desc'],
-            'author' => ['field' => 'author_sort', 'order' => 'asc'],
-            'authorStr' => ['field' => 'author_sort', 'order' => 'asc'],
-            'title' => ['field' => 'title_sort', 'order' => 'asc'],
-            'relevance' => ['field' => 'score', 'order' => 'desc'],
-            'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc'],
-        ];
-        //add/overwrite default sort aliases
-        foreach ($this->getLocalSortDefinitions() as $alias => $localSortDefinition) {
-            $table[$alias] = $localSortDefinition;
-        }
         $tieBreaker = $this->getOptions()->getSortTieBreaker();
         if ($tieBreaker) {
             $sort .= ',' . $tieBreaker;
@@ -547,11 +554,11 @@ class Params extends \VuFind\Search\Base\Params
             $parts = explode(' ', trim($component));
             $field = reset($parts);
             $order = next($parts);
-            if (isset($table[$field])) {
+            if (isset($this->sortDefinitions[$field])) {
                 $normalized[] = sprintf(
                     '%s %s',
-                    $table[$field]['field'],
-                    $order ?: $table[$field]['order']
+                    $this->sortDefinitions[$field]['field'],
+                    $order ?: $this->sortDefinitions[$field]['order']
                 );
                 $fields[] = $field;
             } else {
@@ -781,16 +788,5 @@ class Params extends \VuFind\Search\Base\Params
 
         // Return modified list:
         return $facets;
-    }
-
-    /**
-     * Get local sort definitions for additional user-defined entries in the "Sort By" menu.
-     *
-     * @return array
-     */
-    public function getLocalSortDefinitions()
-    {
-        $config = $this->configManager->getConfigArray($this->getOptions()->getMainIni());
-        return $config['LocalSortDefinitions'] ?? array();
     }
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -156,24 +156,22 @@ class Params extends \VuFind\Search\Base\Params
         'authorStr' => ['field' => 'author_sort', 'order' => 'asc'],
         'title' => ['field' => 'title_sort', 'order' => 'asc'],
         'relevance' => ['field' => 'score', 'order' => 'desc'],
-        'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc']
+        'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc'],
     ];
-
 
     /**
      * Constructor
      *
-     * @param \VuFind\Search\Base\Options $options Options to use
-     * @param ConfigManagerInterface $configManager Config manager
-     * @param ?HierarchicalFacetHelper $facetHelper Hierarchical facet helper
+     * @param  \VuFind\Search\Base\Options $options       Options to use
+     * @param  ConfigManagerInterface      $configManager Config manager
+     * @param  ?HierarchicalFacetHelper    $facetHelper   Hierarchical facet helper
      * @throws BadConfig
      */
     public function __construct(
         $options,
         ConfigManagerInterface $configManager,
         ?HierarchicalFacetHelper $facetHelper = null
-    )
-    {
+    ) {
         parent::__construct($options, $configManager);
         $this->facetHelper = $facetHelper;
 
@@ -212,6 +210,7 @@ class Params extends \VuFind\Search\Base\Params
             }
         }
     }
+
     /**
      * Return the current filters as an array of strings ['field:filter']
      *

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -197,7 +197,7 @@ class Params extends \VuFind\Search\Base\Params
         }
         $this->customFilterFieldName = $config->CustomFilters->custom_filter_field ?? 'vufind';
         $searchConfig = $this->configManager->getConfigArray($this->getOptions()->getSearchIni());
-        $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? array();
+        $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? [];
         foreach ($localSortDefinitions as $alias => $localSortDefinition) {
             if (array_key_exists('field', $localSortDefinition) && $localSortDefinition['field'] !== '') {
                 if (!array_key_exists($alias, $this->sortDefinitions)) {

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -523,7 +523,7 @@ class Params extends \VuFind\Search\Base\Params
      */
     protected function normalizeSort($sort)
     {
-        static $table = [
+        $table = [
             'year' => ['field' => 'publishDateSort', 'order' => 'desc'],
             'publishDateSort' => ['field' => 'publishDateSort', 'order' => 'desc'],
             'author' => ['field' => 'author_sort', 'order' => 'asc'],
@@ -532,6 +532,10 @@ class Params extends \VuFind\Search\Base\Params
             'relevance' => ['field' => 'score', 'order' => 'desc'],
             'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc'],
         ];
+        //add/overwrite default sort aliases
+        foreach ($this->getLocalSortDefinitions() as $alias => $localSortDefinition) {
+            $table[$alias] = $localSortDefinition;
+        }
         $tieBreaker = $this->getOptions()->getSortTieBreaker();
         if ($tieBreaker) {
             $sort .= ',' . $tieBreaker;
@@ -777,5 +781,16 @@ class Params extends \VuFind\Search\Base\Params
 
         // Return modified list:
         return $facets;
+    }
+
+    /**
+     * Get local sort definitions for additional user-defined entries in the "Sort By" menu.
+     *
+     * @return array
+     */
+    public function getLocalSortDefinitions()
+    {
+        $config = $this->configManager->getConfigArray($this->getOptions()->getMainIni());
+        return $config['LocalSortDefinitions'] ?? array();
     }
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -199,16 +199,12 @@ class Params extends \VuFind\Search\Base\Params
         $searchConfig = $this->configManager->getConfigArray($this->getOptions()->getSearchIni());
         $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? [];
         foreach ($localSortDefinitions as $alias => $localSortDefinition) {
-            if (array_key_exists('field', $localSortDefinition) && $localSortDefinition['field'] !== '') {
-                if (!array_key_exists($alias, $this->sortDefinitions)) {
-                    $this->sortDefinitions[$alias] = array();
-                }
+            if (!empty($localSortDefinition['field'])) {
+                $this->sortDefinitions[$alias] ??= [];
                 $this->sortDefinitions[$alias]['field'] = $localSortDefinition['field'];
-                if (array_key_exists('order', $localSortDefinition) && in_array($localSortDefinition['order'], ['asc', 'desc'])) {
-                    $this->sortDefinitions[$alias]['order'] = $localSortDefinition['order'];
-                } else { //take default
-                    $this->sortDefinitions[$alias]['order'] = 'desc';
-                }
+                // Default to descending if no valid order provided:
+                $this->sortDefinitions[$alias]['order']  = in_array($localSortDefinition['order'] ?? '', ['asc', 'desc'])
+                     ? $localSortDefinition['order'] : 'desc';
             } else {
                 throw new BadConfig(
                     "Neither field name nor function has been provided for the 'field'-key in LocalSortDefinitions (searches.ini)"

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -162,9 +162,10 @@ class Params extends \VuFind\Search\Base\Params
     /**
      * Constructor
      *
-     * @param  \VuFind\Search\Base\Options $options       Options to use
-     * @param  ConfigManagerInterface      $configManager Config manager
-     * @param  ?HierarchicalFacetHelper    $facetHelper   Hierarchical facet helper
+     * @param \VuFind\Search\Base\Options $options       Options to use
+     * @param ConfigManagerInterface      $configManager Config manager
+     * @param ?HierarchicalFacetHelper    $facetHelper   Hierarchical facet helper
+     *
      * @throws BadConfig
      */
     public function __construct(
@@ -201,11 +202,12 @@ class Params extends \VuFind\Search\Base\Params
                 $this->sortDefinitions[$alias] ??= [];
                 $this->sortDefinitions[$alias]['field'] = $localSortDefinition['field'];
                 // Default to descending if no valid order provided:
-                $this->sortDefinitions[$alias]['order']  = in_array($localSortDefinition['order'] ?? '', ['asc', 'desc'])
-                     ? $localSortDefinition['order'] : 'desc';
+                $this->sortDefinitions[$alias]['order']
+                    = in_array($localSortDefinition['order'] ?? '', ['asc', 'desc'])
+                    ? $localSortDefinition['order'] : 'desc';
             } else {
                 throw new BadConfig(
-                    "Neither field name nor function has been provided for the 'field'-key in LocalSortDefinitions (searches.ini)"
+                    "LocalSortDefinitions $alias[field] setting missing in search configuration"
                 );
             }
         }

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -32,6 +32,7 @@ namespace VuFind\Search\Solr;
 
 use VuFind\Config\Config;
 use VuFind\Config\ConfigManagerInterface;
+use VuFind\Exception\BadConfig;
 use VuFindSearch\ParamBag;
 
 use function count;
@@ -155,21 +156,24 @@ class Params extends \VuFind\Search\Base\Params
         'authorStr' => ['field' => 'author_sort', 'order' => 'asc'],
         'title' => ['field' => 'title_sort', 'order' => 'asc'],
         'relevance' => ['field' => 'score', 'order' => 'desc'],
-        'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc']];
+        'callnumber' => ['field' => 'callnumber-sort', 'order' => 'asc']
+    ];
 
 
     /**
      * Constructor
      *
-     * @param \VuFind\Search\Base\Options $options       Options to use
-     * @param ConfigManagerInterface      $configManager Config manager
-     * @param ?HierarchicalFacetHelper    $facetHelper   Hierarchical facet helper
+     * @param \VuFind\Search\Base\Options $options Options to use
+     * @param ConfigManagerInterface $configManager Config manager
+     * @param ?HierarchicalFacetHelper $facetHelper Hierarchical facet helper
+     * @throws BadConfig
      */
     public function __construct(
         $options,
         ConfigManagerInterface $configManager,
         ?HierarchicalFacetHelper $facetHelper = null
-    ) {
+    )
+    {
         parent::__construct($options, $configManager);
         $this->facetHelper = $facetHelper;
 
@@ -194,11 +198,25 @@ class Params extends \VuFind\Search\Base\Params
         $this->customFilterFieldName = $config->CustomFilters->custom_filter_field ?? 'vufind';
         $searchConfig = $this->configManager->getConfigArray($this->getOptions()->getSearchIni());
         $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? array();
-        foreach ($localSortDefinitions as $alias => $localSortDefinition) {
-            $this->sortDefinitions[$alias] = $localSortDefinition;
+        foreach ($localSortDefinitions as $alias => $localSortDefinitionConf) {
+            $localSortDefinition = $localSortDefinitionConf->toArray();
+            if (array_key_exists('field', $localSortDefinition) && $localSortDefinition['field'] !== '') {
+                if (!array_key_exists($alias, $this->sortDefinitions)) {
+                    $this->sortDefinitions[$alias] = array();
+                }
+                $this->sortDefinitions[$alias]['field'] = $localSortDefinition['field'];
+                if (array_key_exists('order', $localSortDefinition) && in_array($localSortDefinition['order'], ['asc', 'desc'])) {
+                    $this->sortDefinitions[$alias]['order'] = $localSortDefinition['order'];
+                } else { //take default
+                    $this->sortDefinitions[$alias]['order'] = 'desc';
+                }
+            } else {
+                throw new BadConfig(
+                    "Neither field name nor function has been provided for the 'field'-key in LocalSortDefinitions (searches.ini)"
+                );
+            }
         }
     }
-
     /**
      * Return the current filters as an array of strings ['field:filter']
      *

--- a/module/VuFind/src/VuFind/Search/Solr/Params.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Params.php
@@ -198,8 +198,7 @@ class Params extends \VuFind\Search\Base\Params
         $this->customFilterFieldName = $config->CustomFilters->custom_filter_field ?? 'vufind';
         $searchConfig = $this->configManager->getConfigArray($this->getOptions()->getSearchIni());
         $localSortDefinitions = $searchConfig['LocalSortDefinitions'] ?? array();
-        foreach ($localSortDefinitions as $alias => $localSortDefinitionConf) {
-            $localSortDefinition = $localSortDefinitionConf->toArray();
+        foreach ($localSortDefinitions as $alias => $localSortDefinition) {
             if (array_key_exists('field', $localSortDefinition) && $localSortDefinition['field'] !== '') {
                 if (!array_key_exists($alias, $this->sortDefinitions)) {
                     $this->sortDefinitions[$alias] = array();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/SearchTabsHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/SearchTabsHelperTest.php
@@ -220,6 +220,7 @@ class SearchTabsHelperTest extends \PHPUnit\Framework\TestCase
         $configManager = $this->createMock(ConfigManagerInterface::class);
 
         $mockSolrOptions = $this->createMock(\VuFind\Search\Solr\Options::class);
+        $mockSolrOptions->method('getSearchIni')->willReturn('searches');
         $mockSolr = $this->createMock(\VuFind\Search\Solr\Results::class);
         $mockSolr->method('getParams')
             ->willReturn(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Solr/ParamsTest.php
@@ -190,6 +190,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         string $expectedResult
     ): void {
         $options = $this->createMock(\VuFind\Search\Solr\Options::class);
+        $options->method('getSearchIni')->willReturn('searches');
         $options->expects($this->once())->method('getSortTieBreaker')
                 ->willReturn($tieBreaker);
         $params = $this->getParams($options);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/SearchTabsTest.php
@@ -311,6 +311,7 @@ class SearchTabsTest extends \PHPUnit\Framework\TestCase
     protected function getSolrParams(): Params
     {
         $solrOptions = $this->createMock(\VuFind\Search\Solr\Options::class);
+        $solrOptions->method('getSearchIni')->willReturn('searches');
         $solrOptions->method('getSearchClassId')->willReturn('Solr');
         $solrOptions->method('getDefaultLimit')->willReturn(20);
         $configManager = $this->createMock(ConfigManagerInterface::class);


### PR DESCRIPTION
These aliases can be configured in the LocalSortDefinitions section of the search configuration file (searches.ini).
Ex.:
[LocalSortDefinitions]
locMunich[field] = "max(1,product(termfreq('owner','Munich'),20.0))"
locMunich[order] = desc

This is my first pull request and please let me know if i have to do something differently.
Do we need any configuration examples?  Or something else?

cf. https://sourceforge.net/p/vufind/mailman/message/59295052/

Thanks for supporting!