### PR TITLE
RateLimiter: Fix url parameters lost when passing through Turnstile

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -437,7 +437,7 @@ class Bootstrapper
         // base64_encoding the destination URL is just further obfuscation
         $context = base64_encode(json_encode([
             'policyId' => $policyId,
-            'destination' => $event->getRequest()->getUri()->getPath(),
+            'destination' => $event->getRequest()->getRequestUri(),
         ]));
         $response->getHeaders()->addHeaderLine(
             'Location',


### PR DESCRIPTION
Currently any URL query parameters are lost when passing through the Turnstile challenge.  I.e. http://localhost/vufind/Search/Results?type=AllFields&filter%5B%5D=%7Eformat%3A%22eBook%22 is truncated to http://localhost/vufind/Search/Results