### PR TITLE
create_language_translations.js: use absolute path everywhere.

### DIFF
--- a/util/i18n/create_language_translations.js
+++ b/util/i18n/create_language_translations.js
@@ -61,4 +61,4 @@ args.forEach(lang => {
     fs.writeFileSync(`${home}/languages/ISO639-3/${lang}.ini`, lines + "\n" + existing);
 });
 
-childProcess.execSync(`php ${home}/public/index.php language normalize languages`);
+childProcess.execSync(`php ${home}/public/index.php language normalize ${home}/languages`);

--- a/util/i18n/create_language_translations.js
+++ b/util/i18n/create_language_translations.js
@@ -58,7 +58,7 @@ args.forEach(lang => {
 
     const outfile = `${home}/languages/ISO639-3/${lang}.ini`;
     const existing = fs.existsSync(outfile) ? fs.readFileSync(outfile) : "";
-    fs.writeFileSync(`${home}/languages/ISO639-3/${lang}.ini`, lines + "\n" + existing);
+    fs.writeFileSync(outfile, lines + "\n" + existing);
 });
 
 childProcess.execSync(`php ${home}/public/index.php language normalize ${home}/languages`);


### PR DESCRIPTION
The create_language_translations.js would fail if not run from $VUFIND_HOME; this change makes it more flexible, so you can run it from any working directory.