### PR TITLE
Update Syndetics URL to use CDN URL instead

### DIFF
--- a/module/VuFind/src/VuFind/Content/AbstractSyndetics.php
+++ b/module/VuFind/src/VuFind/Content/AbstractSyndetics.php
@@ -78,7 +78,7 @@ abstract class AbstractSyndetics extends AbstractBase
      */
     protected function getIsbnUrl($isbn, $id, $file = 'index.xml', $type = 'rw12,h7')
     {
-        $url = 'https://secure.syndetics.com/index.aspx?isbn=' . $isbn
+        $url = 'https://www.syndetics.com/index.aspx?isbn=' . $isbn
             . '/' . $file . '&client=' . $id . '&type=' . $type;
         $this->debug('Syndetics request: ' . $url);
         return $url;

--- a/module/VuFind/src/VuFind/Content/Covers/Syndetics.php
+++ b/module/VuFind/src/VuFind/Content/Covers/Syndetics.php
@@ -108,7 +108,7 @@ class Syndetics extends \VuFind\Content\AbstractCover implements \VuFind\Http\Ca
      */
     protected function getBaseUrl($key, $ids)
     {
-        $url = "https://secure.syndetics.com/index.aspx?client={$key}";
+        $url = "https://www.syndetics.com/index.aspx?client={$key}";
         $ident = '';
         if (isset($ids['isbn']) && $ids['isbn']->isValid()) {
             $isbn = $ids['isbn']->get13();

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/SyndeticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/SyndeticsTest.php
@@ -68,7 +68,7 @@ class SyndeticsTest extends \PHPUnit\Framework\TestCase
             $mockDownloader = $this->createMock(CachingDownloader::class);
             $fixture = $this->getFixture($fixtureFile);
             $mockDownloader->expects($this->once())->method('download')
-                ->with("https://secure.syndetics.com/index.aspx?client=test&isbn=$isbn/index.xml")
+                ->with("https://www.syndetics.com/index.aspx?client=test&isbn=$isbn/index.xml")
                 ->willReturn($fixture);
             $loader->setCachingDownloader($mockDownloader);
         }
@@ -84,7 +84,7 @@ class SyndeticsTest extends \PHPUnit\Framework\TestCase
     {
         $loader = $this->getLoader('content/covers/syndetics-metadata_with_images.xml', '9780520080607', false);
         $this->assertEquals(
-            'https://secure.syndetics.com/index.aspx?client=test&isbn=9780520080607/SC.GIF',
+            'https://www.syndetics.com/index.aspx?client=test&isbn=9780520080607/SC.GIF',
             $loader->getUrl(
                 'test',
                 'small',
@@ -102,7 +102,7 @@ class SyndeticsTest extends \PHPUnit\Framework\TestCase
     {
         $loader = $this->getLoader(null, '9780709933847', true);
         $this->assertEquals(
-            'https://secure.syndetics.com/index.aspx?client=test&isbn=9780709933847/SC.GIF',
+            'https://www.syndetics.com/index.aspx?client=test&isbn=9780709933847/SC.GIF',
             $loader->getUrl(
                 'test',
                 'small',


### PR DESCRIPTION
Related to the work from https://github.com/vufind-org/vufind/pull/4791, this updates the Syndetics URL to use the CDN URL instead. This was at the advice of Syndetics support:

> Here is what I would suggest the customer do going forward to ensure they get the best performance and reliability with Syndetics.  They should switch their configured cover image url to use our CDN.  My guess is they have a cover image url configured that either starts with https://syndetics.com or https://secure.syndetics.com.  They can switch it to https://www.syndetics.com, which routes traffic through our CDN which has a very large cache, and is geographically distributed. This means that the cover images, on average, will be returned much quicker than they are now, even if there are issues with our origin infrastructure.