### PR TITLE
Disable Wikipedia by default.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1221,14 +1221,14 @@ noCoverAvailableImage = images/noCover2.gif
 ; You can only select Syndetics
 ;authorNotes = Syndetics:MySyndeticsId
 
-; You can select from Wikipedia
+; You can select from Wikipedia or disabled
 ; See also the AuthorInfo recommendation module setting in searches.ini; this
 ; includes notes on improving the accuracy of Wikipedia retrievals.
 ; Note: The Wikipedia Commons URL should also be enabled in the related
 ; img-src setting of contentsecuritypolicy.ini to support author images.
 ; Note for Windows users: If using Wikipedia, you may need to increase your Apache
 ; heap size settings.  For details, see: https://vufind.org/jira/browse/VUFIND-630
-authors         = Wikipedia
+authors         = disabled
 
 ; You can select from Google, OpenLibrary, HathiTrust.  You should consult
 ; https://developers.google.com/books/branding before using Google Book Search.


### PR DESCRIPTION
The Wikipedia integration is not very robust and has historically caused problems (e.g. by breaking results when Wikipedia's API is unreachable). This should really be an "opt-in" feature rather than an "opt-out." This PR simply changes the default behavior.

TODO:
- [x] Update changelog when merging