### PR TITLE
ApiKey entity: Fix typo in PHPdoc.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/ApiKey.php
+++ b/module/VuFind/src/VuFind/Db/Entity/ApiKey.php
@@ -63,7 +63,7 @@ class ApiKey implements ApiKeyEntityInterface
     /**
      * User.
      *
-     * @var ?UserEntityInterface
+     * @var UserEntityInterface
      */
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     #[ORM\ManyToOne(targetEntity: UserEntityInterface::class)]


### PR DESCRIPTION
I just happened to notice that this PHPdoc comment doesn't match the actual property type definition.