### PR TITLE
Bump firebase/php-jwt from 6.11.1 to 7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "composer/package-versions-deprecated": "1.11.99.5",
         "composer/semver": "3.4.3",
         "endroid/qr-code": "5.1.0",
-        "firebase/php-jwt": "6.11.1",
+        "firebase/php-jwt": "7.0.0",
         "guzzlehttp/guzzle": "7.9.2",
         "jaybizzle/crawler-detect": "^1.2",
         "laminas/laminas-cache": "3.13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c84b117acc200335ee638d2dd8476791",
+    "content-hash": "170730c91d943d7a68577b0fee1f74b3",
     "packages": [
         {
             "name": "ahand/mobileesp",
@@ -1143,16 +1143,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "reference": "c03036fd5dbd530a95406ca3b5f6d7b24eaa3910"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/c03036fd5dbd530a95406ca3b5f6d7b24eaa3910",
+                "reference": "c03036fd5dbd530a95406ca3b5f6d7b24eaa3910",
                 "shasum": ""
             },
             "require": {
@@ -1200,9 +1200,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v7.0.0"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2025-12-15T19:26:43+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
Composer install fails on the 10.x line because of the known security issue in the JWT library. To restore the 10‑series to a buildable state, we need to apply the same upgrade that was automatically merged into the 11‑branch (see https://github.com/vufind-org/vufind/pull/5082).

That change has been applied manually here.