### PR TITLE
Update sort settings on Folio.ini for checkout items page

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -237,10 +237,17 @@ in_transit[] = "Open - Awaiting delivery"
 ; available options defined here.
 page_size[] = 50
 ; Sort options
-;sort[dueDate/sort.ascending] = sort_due_date_asc
-;sort[dueDate/sort.descending] = sort_due_date_desc
+; Note: When choosing a sort, ensure that you select
+; field(s) that will return the records in a consistent order so that
+; when paginating, will get all of the records in the same order for
+; every page of results without possibly having duplicates appear or missing items.
+; For example, using just dueDate will cause problems if there are more than
+; your page_size of items due on the same day since the order is not guaranteed to be
+; the same for non-unique values.
+;sort[dueDate/sort.ascending itemId/sort.ascending] = sort_due_date_asc
+;sort[dueDate/sort.descending itemId/sort.ascending] = sort_due_date_desc
 ; Default sort (note: this must be defined in the sort[] options above to be applied!)
-;default_sort=dueDate/sort.ascending
+;default_sort="dueDate/sort.ascending itemId/sort.ascending"
 
 [CourseReserves]
 ; If set to true, the course number will be prefixed on the course name; if false,


### PR DESCRIPTION
This is a smaller change spun off from https://github.com/vufind-org/vufind/pull/5109 with only the update to the sort option values that are provided in the `Folio.ini` to have a value that would ensure a consistent result order from the FOLIO API and prevent any items from appearing on multiple pages of results if they had the same `dueDate` value.