### PR TITLE
Site map page related improvements to navigation sections

### DIFF
--- a/config/vufind/FooterMenu.yaml
+++ b/config/vufind/FooterMenu.yaml
@@ -18,6 +18,7 @@
 #   - checkMethod: the name of a FooterMenu section plugin method to perform
 #     a check whether to show the item. If omitted, item will always display.
 #   - attributes: additional attributes for the menu item's <a> tag
+#   - excludeFromSiteMapPage: set true to exclude item from the site map page
 #
 # You can use checkMethod: alwaysFail to disable specific inherited groups or items
 # in local configuration. If you wish to completely override the default

--- a/config/vufind/HeaderBar.yaml
+++ b/config/vufind/HeaderBar.yaml
@@ -5,6 +5,8 @@
 # The format of this configuration is as follows:
 #
 # Array keys for every group are:
+#   - label: text shown as group header, will be translated. Only shown on the
+#     site map page.
 #   - MenuItems: items shown in the menu - required
 #   - checkMethod: the name of a HeaderBar section plugin method to perform
 #     a check whether to show the group. If omitted, group will always display.
@@ -25,6 +27,9 @@
 #   - routeParams: parameters for dynamic routes
 #   - url: target url, alternative to route - required unless route, template or
 #     submenuItems is set
+#   - siteMapPageTemplate: template to render the item with on the site map page if
+#     the regular item is not suitable for use in the site map
+#   - excludeFromSiteMapPage: set true to exclude item from the site map page
 #
 # You can use checkMethod: alwaysFail to disable specific inherited groups or items
 # in local configuration. If you wish to completely override the default
@@ -40,15 +45,20 @@ Header:
       attributes:
         id: feedbackLink
         data-lightbox: data-lightbox
+      siteMapPageTemplate: Section/SiteMap/SiteMap-feedback.phtml
 
     - template: Section/HeaderBar/HeaderBar-cart.phtml
       checkMethod: checkCart
+      siteMapPageTemplate: Section/SiteMap/SiteMap-cart.phtml
 
     - template: Section/HeaderBar/HeaderBar-account.phtml
       checkMethod: checkAccount
+      siteMapPageTemplate: Section/SiteMap/SiteMap-account.phtml
 
     - template: Section/HeaderBar/HeaderBar-themeOptions.phtml
       checkMethod: checkThemeOptions
+      excludeFromSiteMapPage: true
 
     - template: Section/HeaderBar/HeaderBar-allLangs.phtml
       checkMethod: checkAllLangs
+      excludeFromSiteMapPage: true

--- a/config/vufind/SiteMap.yaml
+++ b/config/vufind/SiteMap.yaml
@@ -7,10 +7,10 @@
 # The format of this configuration is as follows:
 #
 # Array keys for every group are:
+#   - section: renders menuItems with a route, url, template or siteMapPageTemplate
+#     key from the specified section. Specifying SiteMap plugin sections is not
+#     possible. Keys documented below are not supported if set.
 #   - label: text shown as group header, will be translated
-#   - section: renders menuItems with a route or url key from the specified section.
-#     Specifying SiteMap plugin sections is not possible. Keys documented below are
-#     not supported if set.
 #   - MenuItems: items shown in the menu - required unless section is set
 #   - checkMethod: the name of a SiteMap section plugin method to perform
 #     a check whether to show the group. If omitted, group will always display.

--- a/module/VuFind/src/VuFind/Navigation/HeaderBar.php
+++ b/module/VuFind/src/VuFind/Navigation/HeaderBar.php
@@ -159,18 +159,23 @@ class HeaderBar extends AbstractMenu
                   attributes:
                     id: feedbackLink
                     data-lightbox: data-lightbox
+                  siteMapPageTemplate: Section/SiteMap/SiteMap-feedback.phtml
             
                 - template: Section/HeaderBar/HeaderBar-cart.phtml
                   checkMethod: checkCart
+                  siteMapPageTemplate: Section/SiteMap/SiteMap-cart.phtml
             
                 - template: Section/HeaderBar/HeaderBar-account.phtml
                   checkMethod: checkAccount
+                  siteMapPageTemplate: Section/SiteMap/SiteMap-account.phtml
             
                 - template: Section/HeaderBar/HeaderBar-themeOptions.phtml
                   checkMethod: checkThemeOptions
+                  excludeFromSiteMapPage: true
             
                 - template: Section/HeaderBar/HeaderBar-allLangs.phtml
                   checkMethod: checkAllLangs
+                  excludeFromSiteMapPage: true
             YAML;
         return Yaml::parse($yaml);
     }

--- a/module/VuFind/src/VuFind/Navigation/SiteMap.php
+++ b/module/VuFind/src/VuFind/Navigation/SiteMap.php
@@ -183,7 +183,7 @@ class SiteMap extends AbstractMenu
                     throw new BadConfig('Group key clash in configuration: ' . $pluginGroupName);
                 }
                 foreach ($pluginGroup['MenuItems'] ?? [] as $key => $item) {
-                    if (isset($item['siteMapPageTemplate']) || isset($item['template'])) {
+                    if ($templateToUse = $item['siteMapPageTemplate'] ?? $item['template'] ?? null) {
                         // Templates from included sections require a plugin
                         // specific context so they are rendered at this stage.
                         $context = [
@@ -192,10 +192,7 @@ class SiteMap extends AbstractMenu
                             ...$item,
                         ];
                         $pluginGroup['MenuItems'][$key]['__html']
-                            = $this->renderer->render(
-                                $item['siteMapPageTemplate'] ?? $item['template'],
-                                $context
-                            );
+                            = $this->renderer->render($templateToUse, $context);
                     }
                 }
                 $processedGroups[$pluginGroupName] = $pluginGroup;

--- a/module/VuFind/src/VuFind/Navigation/SiteMap.php
+++ b/module/VuFind/src/VuFind/Navigation/SiteMap.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Navigation;
 
+use Laminas\View\Renderer\RendererInterface;
 use Symfony\Component\Yaml\Yaml;
 use VuFind\Exception\BadConfig;
 
@@ -51,10 +52,12 @@ class SiteMap extends AbstractMenu
     /**
      * Constructor
      *
-     * @param array $sectionConfig Site map configuration
+     * @param array             $sectionConfig Site map configuration
+     * @param RendererInterface $renderer      View renderer
      */
     public function __construct(
-        array $sectionConfig
+        array $sectionConfig,
+        protected RendererInterface $renderer,
     ) {
         $this->addRequiredSettings(
             [
@@ -178,6 +181,22 @@ class SiteMap extends AbstractMenu
                 }
                 if (isset($processedGroups[$pluginGroupName])) {
                     throw new BadConfig('Group key clash in configuration: ' . $pluginGroupName);
+                }
+                foreach ($pluginGroup['MenuItems'] ?? [] as $key => $item) {
+                    if (isset($item['siteMapPageTemplate']) || isset($item['template'])) {
+                        // Templates from included sections require a plugin
+                        // specific context so they are rendered at this stage.
+                        $context = [
+                            'sectionPlugin' => $plugin,
+                            ...$plugin->getSectionContext(),
+                            ...$item,
+                        ];
+                        $pluginGroup['MenuItems'][$key]['__html']
+                            = $this->renderer->render(
+                                $item['siteMapPageTemplate'] ?? $item['template'],
+                                $context
+                            );
+                    }
                 }
                 $processedGroups[$pluginGroupName] = $pluginGroup;
             }

--- a/module/VuFind/src/VuFind/Navigation/SiteMapFactory.php
+++ b/module/VuFind/src/VuFind/Navigation/SiteMapFactory.php
@@ -69,6 +69,7 @@ class SiteMapFactory extends AbstractMenuFactory
             $requestedName,
             [
                 'SiteMap.yaml',
+                $container->get('ViewRenderer'),
                 ...$options ?? [],
             ]
         );

--- a/module/VuFind/src/VuFindTest/Unit/AbstractSectionTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractSectionTestCase.php
@@ -29,9 +29,10 @@
 
 namespace VuFindTest\Unit;
 
-use Laminas\Http\Request;
+use Laminas\Http\PhpEnvironment\Request;
 use Laminas\Mvc\View\Http\ViewManager;
 use Laminas\View\Model\ViewModel;
+use Laminas\View\Renderer\PhpRenderer;
 use VuFind\Auth\Manager;
 use VuFind\Cart;
 use VuFind\Config\AccountCapabilities;
@@ -467,6 +468,12 @@ abstract class AbstractSectionTestCase extends \PHPUnit\Framework\TestCase
     ): SiteMap {
         $config ??= $this->getDefaultYamlConfig('SiteMap.yaml');
         $this->mockYamlReaderFiles['SiteMap.yaml'] = $config;
+
+        $mockViewRenderer = $this->createMock(PhpRenderer::class);
+        // We are only testing that the templates are getting rendered, not the
+        // actual templates themselves.
+        $mockViewRenderer->method('render')->willReturn('<li></li>');
+        $container->set('ViewRenderer', $mockViewRenderer);
 
         $siteMap = (new SiteMapFactory())($container, SiteMap::class);
         $this->setSectionPlugin($container, $siteMap, 'siteMap');

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
@@ -58,6 +58,9 @@ class SiteMapPageTest extends \VuFindTest\Integration\MinkTestCase
                     'Site' => [
                         'siteMapPageEnabled' => true,
                     ],
+                    'Feedback' => [
+                        'tab_enabled' => true,
+                    ],
                 ],
             ]
         );
@@ -189,6 +192,21 @@ class SiteMapPageTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertStringEndsWith(
             '/Content/askLibrary',
             $this->findCss($page, '#content')->findLink('Ask a Librarian')->getAttribute('href')
+        );
+
+        // Item with siteMapPageTemplate is rendered using that template.
+        $this->assertInstanceOf(
+            Element::class,
+            $this->findCss($page, '#content')->findLink('Feedback')
+        );
+        $this->assertNull(
+            $this->findCss($page, '#content')->findLink('Feedback')->getAttribute('id')
+        );
+
+        // Item with excludeFromSiteMapPage: true not is shown.
+        $this->assertStringNotContainsString(
+            'Language',
+            $this->findCssAndGetText($page, '#content')
         );
     }
 

--- a/themes/bootstrap5/templates/Section/SiteMap.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap.phtml
@@ -6,23 +6,32 @@
   <?php endif; ?>
   <?php foreach ($group['MenuItems'] as $item): ?>
     <?php
-      $href = isset($item['route']) ? $this->url($item['route'], $item['routeParams'] ?? []) : ($item['url'] ?? null);
-      $hasSubmenuItems = isset($item['submenuItems']);
+      if ($item['excludeFromSiteMapPage'] ?? false) {
+        continue;
+      }
     ?>
-    <?php if (isset($item['label']) && ($href || $hasSubmenuItems)): ?>
-      <?php $label = $this->makeLink($this->translate($item['label']), $href); ?>
-      <?php if ($hasSubmenuItems): ?>
-        <?php if ($groupHasLabel): ?>
-          <li><?= $label ?>
+    <?php if (isset($item['__html'])): ?>
+      <?= $this->makeTag($groupHasLabel ? 'li' : 'h2', $item['__html'], options: ['escapeContent' => false]) ?>
+    <?php else: ?>
+      <?php
+        $href = isset($item['route']) ? $this->url($item['route'], $item['routeParams'] ?? []) : ($item['url'] ?? null);
+        $hasSubmenuItems = isset($item['submenuItems']);
+      ?>
+      <?php if (isset($item['label']) && ($href || $hasSubmenuItems)): ?>
+        <?php $label = $this->makeLink($this->translate($item['label']), $href, $item['attributes'] ?? []); ?>
+        <?php if ($hasSubmenuItems): ?>
+          <?php if ($groupHasLabel): ?>
+            <li><?= $label ?>
+          <?php else: ?>
+            <h2><?= $label ?></h2>
+          <?php endif; ?>
+          <?= $this->render('Section/SiteMap/SiteMap-submenuItems.phtml', ['submenuItems' => $item['submenuItems']]) ?>
+          <?php if ($groupHasLabel): ?>
+            </li>
+          <?php endif; ?>
         <?php else: ?>
-          <h2><?= $label ?></h2>
+          <?= $this->makeTag($groupHasLabel ? 'li' : 'h2', $label, options: ['escapeContent' => false]) ?>
         <?php endif; ?>
-        <?= $this->render('Section/SiteMap/SiteMap-submenuItems.phtml', ['submenuItems' => $item['submenuItems']]) ?>
-        <?php if ($groupHasLabel): ?>
-          </li>
-        <?php endif; ?>
-      <?php else: ?>
-        <?= $this->makeTag($groupHasLabel ? 'li' : 'h2', $label, options: ['escapeContent' => false]) ?>
       <?php endif; ?>
     <?php endif; ?>
   <?php endforeach; ?>

--- a/themes/bootstrap5/templates/Section/SiteMap/SiteMap-account.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap/SiteMap-account.phtml
@@ -1,0 +1,10 @@
+<?php $account = $this->auth()->getManager(); ?>
+<?php if ($account->getIdentity()): ?>
+  <a href="<?=$this->url('myresearch-home', [], ['query' => ['redirect' => 0]])?>">
+    <?=$this->transEsc('Your Account')?>
+  </a>
+<?php else: ?>
+  <a href="<?= $this->url('myresearch-userlogin') ?>">
+    <?=$this->transEsc($this->auth()->hasSessionInitiator() ? 'Institutional Login' : 'Login')?>
+  </a>
+<?php endif; ?>

--- a/themes/bootstrap5/templates/Section/SiteMap/SiteMap-cart.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap/SiteMap-cart.phtml
@@ -1,0 +1,1 @@
+<a href="<?=$this->url('cart-home')?>"><?=$this->transEscAttr('Book Bag')?></a>

--- a/themes/bootstrap5/templates/Section/SiteMap/SiteMap-feedback.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap/SiteMap-feedback.phtml
@@ -1,0 +1,1 @@
+<a href="<?=$this->url('feedback-home')?>"><?=$this->transEscAttr('Feedback')?></a>


### PR DESCRIPTION
This PR aims to address issues with 

- template-based items not rendered at all on the site map page and
- items containing ids rendered twice on the site map page, resulting in invalid HTML.

Also adds an `excludeFromSiteMapPage` option.