### PR TITLE
Further improve excludeFromSiteMapPage functionality

### DIFF
--- a/config/vufind/FooterMenu.yaml
+++ b/config/vufind/FooterMenu.yaml
@@ -9,6 +9,7 @@
 #   - MenuItems: items shown in the menu - required
 #   - checkMethod: the name of a FooterMenu section plugin method to perform
 #     a check whether to show the group. If omitted, group will always display.
+#   - excludeFromSiteMapPage: set true to exclude group from the site map page
 #
 # Array keys for every menu item could be:
 #   - label: the text shown as link, will be translated - required

--- a/config/vufind/HeaderBar.yaml
+++ b/config/vufind/HeaderBar.yaml
@@ -10,6 +10,7 @@
 #   - MenuItems: items shown in the menu - required
 #   - checkMethod: the name of a HeaderBar section plugin method to perform
 #     a check whether to show the group. If omitted, group will always display.
+#   - excludeFromSiteMapPage: set true to exclude group from the site map page
 #
 # Array keys for every menu item could be:
 #   - checkMethod: the name of a HeaderBar section plugin method to perform

--- a/module/VuFind/src/VuFind/Navigation/SiteMap.php
+++ b/module/VuFind/src/VuFind/Navigation/SiteMap.php
@@ -121,6 +121,55 @@ class SiteMap extends AbstractMenu
     }
 
     /**
+     * Get processed and filtered menu configuration with groups and items to
+     * display.
+     *
+     * @return array
+     */
+    public function getMenu(): array
+    {
+        if (!isset($this->menu)) {
+            $menu = [];
+            foreach (parent::getMenu() as $key => $group) {
+                if (!empty($filtered = $this->filterAvailableForSiteMap($group))) {
+                    $menu[$key] = $filtered;
+                }
+            }
+            $this->menu = $menu;
+        }
+        return $this->menu;
+    }
+
+    /**
+     * Get available items for the site map page.
+     *
+     * @param array $menuArray Items or item to filter
+     *
+     * @return array
+     */
+    protected function filterAvailableForSiteMap(array $menuArray): array
+    {
+        if ($menuArray['excludeFromSiteMapPage'] ?? false) {
+            return [];
+        }
+        foreach (['MenuItems', 'submenuItems'] as $itemsKey) {
+            if (isset($menuArray[$itemsKey])) {
+                foreach ($menuArray[$itemsKey] as $i => $item) {
+                    $menuArray[$itemsKey][$i] = $this->filterAvailableForSiteMap($item);
+                    if (empty($menuArray[$itemsKey][$i])) {
+                        unset($menuArray[$itemsKey][$i]);
+                    }
+                }
+                if (empty($menuArray[$itemsKey])) {
+                    // Filter items without menu or submenu items to display.
+                    return [];
+                }
+            }
+        }
+        return $menuArray;
+    }
+
+    /**
      * Process and filter groups.
      *
      * @param array $groups Groups to process and filter

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/SiteMapPageTest.php
@@ -160,6 +160,50 @@ class SiteMapPageTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Apply a non-default HeaderBar.yaml configuration with excluded groups and items.
+     *
+     * @return void
+     */
+    protected function applyHeaderBarConfigWithExcludedGroupsAndItems(): void
+    {
+        $yaml = <<<YAML
+            "@parent_yaml": false
+            
+            ExcludedGroup:
+              label: 'Group 1 excluded from site map page'
+              MenuItems:
+                - label: 'Group 1 Item 1'
+                  url: '#'
+              excludeFromSiteMapPage: true
+            
+            GroupWithOneExcludedItem:
+              label: 'Group 2 with one item excluded from site map page'
+              MenuItems:
+                - label: 'Group 2 Item 1'
+                  url: '#'
+                - label: 'Group 2 Item 2 excluded from site map page'
+                  url: '#'
+                  excludeFromSiteMapPage: true
+                - label: 'Group 2 Item 3'
+                  url: '#'
+            
+            GroupWithAllItemsExcluded:
+              label: 'Group 3 with all items excluded from site map page'
+              MenuItems:
+                - label: 'Group 3 Item 1 excluded from site map page'
+                  url: '#'
+                  excludeFromSiteMapPage: true
+                - label: 'Group 3 Item 2 excluded from site map page'
+                  url: '#'
+                  excludeFromSiteMapPage: true
+                - label: 'Group 3 Item 3 excluded from site map page'
+                  url: '#'
+                  excludeFromSiteMapPage: true
+            YAML;
+        $this->changeYamlConfigs(['HeaderBar' => Yaml::parse($yaml)], ['HeaderBar']);
+    }
+
+    /**
      * Load Site Map page.
      *
      * @param ?Session $session Mink session (will be automatically established if not provided).
@@ -359,6 +403,37 @@ class SiteMapPageTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertStringContainsString(
             'Regular Item 3',
             $this->findCssAndGetText($page, '#content > ul:nth-child(13) > li:nth-child(3) > a:nth-child(1)')
+        );
+    }
+
+    /**
+     * Test groups and items excluded from site map page.
+     *
+     * @return void
+     */
+    public function testExcludedGroupsAndItems(): void
+    {
+        $this->applyHeaderBarConfigWithExcludedGroupsAndItems();
+        $page = $this->getSiteMapPage();
+        $this->assertStringNotContainsString(
+            'Group 1 excluded from site map page',
+            $this->findCssAndGetText($page, '#content')
+        );
+        $this->assertStringContainsString(
+            'Group 2 Item 1',
+            $this->findCssAndGetText($page, '#content')
+        );
+        $this->assertStringNotContainsString(
+            'Group 2 Item 2',
+            $this->findCssAndGetText($page, '#content')
+        );
+        $this->assertStringContainsString(
+            'Group 2 Item 3',
+            $this->findCssAndGetText($page, '#content')
+        );
+        $this->assertStringNotContainsString(
+            'Group 3 with all items excluded from site map page',
+            $this->findCssAndGetText($page, '#content')
         );
     }
 }

--- a/themes/bootstrap5/templates/Section/SiteMap.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap.phtml
@@ -5,11 +5,6 @@
     <ul>
   <?php endif; ?>
   <?php foreach ($group['MenuItems'] as $item): ?>
-    <?php
-      if ($item['excludeFromSiteMapPage'] ?? false) {
-        continue;
-      }
-    ?>
     <?php if (isset($item['__html'])): ?>
       <?= $this->makeTag($groupHasLabel ? 'li' : 'h2', $item['__html'], options: ['escapeContent' => false]) ?>
     <?php else: ?>

--- a/themes/bootstrap5/templates/Section/SiteMap/SiteMap-submenuItems.phtml
+++ b/themes/bootstrap5/templates/Section/SiteMap/SiteMap-submenuItems.phtml
@@ -1,10 +1,5 @@
 <ul>
 <?php foreach ($submenuItems as $item): ?>
-  <?php
-    if ($item['excludeFromSiteMapPage'] ?? false) {
-      continue;
-    }
-  ?>
   <?php $href = isset($item['route']) ? $this->url($item['route'], $item['routeParams'] ?? []) : ($item['url'] ?? null) ?>
   <?php if (isset($item['label']) && ($href || isset($item['submenuItems']))): ?>
     <li>


### PR DESCRIPTION
- Moves the filtering logic from the templates to the plugin class.
- Groups with no menu items and menu items with no submenu items are filtered, similar to checkMethod.
- Adds option to exclude groups as well.