### PR TITLE
More robust OIDC attribute retrieval.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -577,7 +577,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     protected function getAttributeValue(object $userInfo, string $attribute): string
     {
         $attributeName = $this->oidcConfig->attributes[$attribute] ?? $attribute;
-        return $userInfo->$attributeName ?? '';
+        return (string)($userInfo->attributes->$attributeName ?? $userInfo->$attributeName ?? '');
     }
 
     /**


### PR DESCRIPTION
Ján Krištof reported that in his environment, OIDC user objects store attributes inside a separate `attributes` key rather than at the root of the object. This PR adjusts attribute retrieval to tolerate both situations.

I do not have an OIDC instance to test with, so this fix is currently untested. This should not be merged until Ján and/or others report that it is working as expected.