### PR TITLE
Improve message surrounding Zotero Web Library error

### DIFF
--- a/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
+++ b/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
@@ -224,8 +224,9 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
 
         if ($vufindResponse->getStatusCode() !== 200) {
             $this->logError(
-                "GET request for '$callbackUrl' failed: "
-                . $vufindResponse->getStatusCode() . ': ' . $vufindResponse->getReasonPhrase()
+                "GET request for '$callbackUrl' failed (expected HTTP 200): " .
+                $vufindResponse->getStatusCode() . ': ' . $vufindResponse->getReasonPhrase() .
+                "; HTTP response headers: " . json_encode($vufindResponse->getHeaders())
             );
             throw new ZoteroException('Export request failed');
         }

--- a/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
+++ b/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
@@ -226,7 +226,7 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
             $this->logError(
                 "GET request for '$callbackUrl' failed (expected HTTP 200): " .
                 $vufindResponse->getStatusCode() . ': ' . $vufindResponse->getReasonPhrase() .
-                "; HTTP response headers: " . json_encode($vufindResponse->getHeaders())
+                '; HTTP response headers: ' . json_encode($vufindResponse->getHeaders())
             );
             throw new ZoteroException('Export request failed');
         }


### PR DESCRIPTION
When VuFind calls back to itself inside the Zotero Web Library export code, it can fail if the HTTP request is intercepted by a Web Application Firewall. What is logged is not helpful in diagnosing the issue; this pull request notes that an HTTP 200 code is expected and adds the HTTP response headers as JSON to the output.

---

Side note: I asked an LLM to provide a description of the Zotero Web Library code, and this — along with [Ere's comments in email](https://sourceforge.net/p/vufind/mailman/message/59310112/) — was useful for diagnosing the issue. Perhaps this can be added to the wiki as documentation for others?

The Zotero export flow in VuFind is a multi-step dance involving the user's browser, VuFind's backend, the Zotero OAuth endpoints, and the Zotero API. It reuses the existing callback mechanism from [`export.ini`](https://github.com/vufind-org/vufind/blob/HEAD/config/vufind/export.ini) — originally designed for services like RefWorks and EndNoteWeb — where an external service calls back to VuFind to retrieve the export data. In Zotero Web Library's case, VuFind itself plays that "external service" role, calling back to its own URL to fetch records. Here's the full sequence:

```mermaid
sequenceDiagram
    participant Browser
    participant VuFind
    participant ZoteroOAuth as Zotero OAuth<br/>(zotero.org/oauth)
    participant ZoteroAPI as Zotero API<br/>(api.zotero.org)

    Browser->>VuFind: 1. GET /Zotero/Export?callback={encodedCallback}
    Note over VuFind: Stores callback URL & referrer in session.<br/>Forces login if needed.
    alt No stored Zotero access token
        VuFind->>ZoteroOAuth: 2a. POST /oauth/request (get temp credentials)
        ZoteroOAuth-->>VuFind: temp token + secret
        VuFind-->>Browser: 3a. 302 Redirect to zotero.org/oauth/authorize
        Browser->>ZoteroOAuth: 4a. User authorizes VuFind
        ZoteroOAuth-->>Browser: 5a. 302 Redirect to /Zotero/Callback?oauth_token=…&oauth_verifier=…
        Browser->>VuFind: 6a. GET /Zotero/Callback?oauth_token=…&oauth_verifier=…
        VuFind->>ZoteroOAuth: 7a. POST /oauth/access (exchange verifier for token)
        ZoteroOAuth-->>VuFind: zoteroUserId + zoteroApiKey
        Note over VuFind: Persists token in DB
    end
    VuFind->>VuFind: 8. GET {callbackUrl} (self-call to fetch export records as JSON)
    Note over VuFind: callbackUrl points to /Cart/DoExport or<br/>/Record/.../Export with record IDs
    VuFind-->>VuFind: JSON array of records
    VuFind->>ZoteroAPI: 9. POST /users/{userId}/items (chunks of ≤50)
    Note over VuFind: Sends Zotero-API-Key header
    ZoteroAPI-->>VuFind: 200 OK with results
    VuFind-->>Browser: 10. Redirect back to referrer with success flash message

```

### Step-by-step breakdown

**Step 1 — User triggers export.** When a user clicks "Export to Zotero Web Library", VuFind's generic export system constructs a redirect URL from the [`[ZoteroWebLibrary]`](https://github.com/vufind-org/vufind/blob/HEAD/config/vufind/export.ini) config:

```ini
redirectUrl = "{route|zotero-export}?callback={encodedCallback}"

```

The `{encodedCallback}` token is replaced with a URL-encoded pointer back to VuFind's own `Cart/DoExport` action (for bulk) or a single-record export endpoint, including the record IDs and format as query parameters. This is the same callback mechanism RefWorks uses — except here VuFind itself will consume it. The browser is redirected to [`ZoteroController::exportAction()`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Controller/ZoteroController.php).

**Steps 2a–7a — OAuth (first time only).** [`ZoteroService::export()`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php) checks if the user already has a stored Zotero access token. If not, it initiates the OAuth 1.0a flow via [`ZoteroOAuth`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Export/Zotero/ZoteroOAuth.php):

1. Requests temporary credentials from `zotero.org/oauth/request`
2. Redirects the user's browser to `zotero.org/oauth/authorize` (requesting `library_access=1&write_access=1`)
3. After the user approves, Zotero redirects to `/Zotero/Callback` with `oauth_token` and `oauth_verifier`
4. [`handleAuthCallback()`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php) exchanges these for permanent token credentials (a `zoteroUserId` and `zoteroApiKey`), which are persisted in VuFind's `access_token` database table

On subsequent exports, this entire OAuth dance is skipped — the stored token is reused. If it fails (403), VuFind deletes it and retries the OAuth flow once.

**Step 8 — The self-callback**  [`exportToZotero()`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php) makes a **server-side HTTP GET** to the callback URL it stored in the session. That URL points to VuFind's own [`CartController::doexportAction()`](https://github.com/vufind-org/vufind/blob/HEAD/module/VuFind/src/VuFind/Controller/CartController.php), which loads the selected records, renders them using the record helper's `getExport('ZoteroWebLibrary')` method, and returns JSON. VuFind is essentially calling itself to generate the export payload.

**Step 9 — Push to Zotero API.** The JSON records are cleaned up against the [Zotero schema](https://api.zotero.org/schema) (field validation, creator type remapping), then POSTed in chunks of 50 to `https://api.zotero.org/users/{userId}/items` with the `Zotero-API-Key` header.

**Step 10 — Redirect back.** The user's browser is redirected to the original referrer (the search results or record page) with a flash message indicating success or failure.

### Why the "callback" pattern?
The author reused the existing `{encodedCallback}` mechanism so that the same record-serialization code path (in `doexportAction`) serves both external services (like RefWorks, which call VuFind from outside) and the Zotero flow (where VuFind calls itself from the server side). This avoided duplicating the record-loading and formatting logic.

