### PR TITLE
Specify all environments in CspTest

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CspTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CspTest.php
@@ -52,6 +52,8 @@ class CspTest extends \PHPUnit\Framework\TestCase
                 'CSP' => [
                     'use_nonce' => true,
                     'enabled' => [
+                        'development' => true,
+                        'production' => true,
                         'testing' => true,
                     ],
                 ],
@@ -136,6 +138,8 @@ class CspTest extends \PHPUnit\Framework\TestCase
                 'CSP' => [
                     'use_nonce' => true,
                     'enabled' => [
+                        'development' => false,
+                        'production' => false,
                         'testing' => false,
                     ],
                 ],


### PR DESCRIPTION
These tests were failing in my local development Docker environment where I set VUFIND_ENV=development.  This change enables these tests to pass no matter what value is set in VUFIND_ENV.

For example, `$cspHeaderGenerator->getCspHeader()` returned a `Laminas\Http\Header\ContentSecurityPolicyReportOnly` which then didn't match the `$headers->get('Content-Security-Policy')`.