### PR TITLE
Force APPLICATION_ENV = 'testing' for tests

### DIFF
--- a/module/VuFind/tests/bootstrap_constants.php
+++ b/module/VuFind/tests/bootstrap_constants.php
@@ -31,5 +31,5 @@
 defined('APPLICATION_ENV')
     || define(
         'APPLICATION_ENV',
-        (getenv('VUFIND_ENV') ? getenv('VUFIND_ENV') : 'testing')
+        'testing'
     );


### PR DESCRIPTION
This fixes some more tests that were failing in my environment when `VUFIND_ENV == 'development'`:

    1) VuFindTest\Mailer\MailerTest::testUnknownException
    Failed asserting that two strings are identical.
    --- Expected
    +++ Actual
    @@ @@
    -'email_failure'
    +'Technical message'

    /opt/vufind2/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php:399

    2) VuFindTest\SMS\ClickatellTest::testUnknownException
    Failed asserting that two strings are identical.
    --- Expected
    +++ Actual
    @@ @@
    -'sms_failure'
    +'Technical message'

    /opt/vufind2/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php:110

These failed because the behaviour of the `getDisplayMessage()` method of `VuFind\Exception\Mail` diverges on the value of `APPLICATION_ENV`: https://github.com/vufind-org/vufind/blob/f02e6901c6ebad720dbbd5b107baeaa7fd9af929/module/VuFind/src/VuFind/Exception/Mail.php#L91-L98

We were not able to figure out any reason why testing would want to be sensitive to this variable.