### PR TITLE
Replace short Solr start parameters by long ones

### DIFF
--- a/solr.bat
+++ b/solr.bat
@@ -92,7 +92,7 @@ if not "!%SOLR_SECURITY_MANAGER_ENABLED%!"=="!!" goto solrsecmanset
 set SOLR_SECURITY_MANAGER_ENABLED=false
 :solrsecmanset
 
-call %SOLR_BIN%\solr.cmd %1 %SOLR_ADDITIONAL_START_OPTIONS% -p %SOLR_PORT% -s %SOLR_HOME% -m %SOLR_HEAP% --user-managed -a "-Ddisable.configEdit=true -Dsolr.log=%SOLR_LOGS_DIR% -Dsolr.config.lib.enabled=true %SOLR_ADDITIONAL_JVM_OPTIONS%"
+call %SOLR_BIN%\solr.cmd %1 %SOLR_ADDITIONAL_START_OPTIONS% --port %SOLR_PORT% --solr-home %SOLR_HOME% -m %SOLR_HEAP% --user-managed --jvm-opts "-Ddisable.configEdit=true -Dsolr.log=%SOLR_LOGS_DIR% -Dsolr.config.lib.enabled=true %SOLR_ADDITIONAL_JVM_OPTIONS%"
 goto end
 
 :usage

--- a/solr.sh
+++ b/solr.sh
@@ -97,4 +97,4 @@ then
 fi
 
 export SOLR_LOGS_DIR=$SOLR_LOGS_DIR
-"$SOLR_BIN/solr" "$1" ${SOLR_ADDITIONAL_START_OPTIONS} -p "$SOLR_PORT" -s "$SOLR_HOME" -m "$SOLR_HEAP" --user-managed -a "-Ddisable.configEdit=true -Dsolr.log=$SOLR_LOGS_DIR -Dsolr.config.lib.enabled=true $SOLR_ADDITIONAL_JVM_OPTIONS"
+"$SOLR_BIN/solr" "$1" ${SOLR_ADDITIONAL_START_OPTIONS} --port "$SOLR_PORT" --solr-home "$SOLR_HOME" -m "$SOLR_HEAP" --user-managed --jvm-opts "-Ddisable.configEdit=true -Dsolr.log=$SOLR_LOGS_DIR -Dsolr.config.lib.enabled=true $SOLR_ADDITIONAL_JVM_OPTIONS"


### PR DESCRIPTION
The short parameters are no longer supported by Solr 10.0.0, and the long ones already work with Solr 9.8.0:

https://solr.apache.org/guide/solr/9_8/deployment-guide/solr-control-script-reference.html