### PR TITLE
Skip tests depending on APPLICATION_ENV value

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -386,6 +386,11 @@ class MailerTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnknownException()
     {
+        // Behavior of getDisplayMessage() in VuFind\Exception\Mail depends on
+        // environment
+        if (APPLICATION_ENV !== 'testing') {
+            $this->markTestSkipped('Unexpected APPLICATION_ENV: ' . APPLICATION_ENV);
+        }
         $mailer = $this->createMock(Mailer::class);
         $mailer->expects($this->once())->method('send')->willThrowException(
             new \VuFind\Exception\Mail(

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -85,6 +85,11 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnknownException()
     {
+        // Behavior of getDisplayMessage() in VuFind\Exception\Mail depends on
+        // environment
+        if (APPLICATION_ENV !== 'testing') {
+            $this->markTestSkipped('Unexpected APPLICATION_ENV: ' . APPLICATION_ENV);
+        }
         $client = $this->getMockClient();
         $expectedUri = $this->expectedBaseUri . '&to=1234567890&text=hello';
         $client->expects($this->once())


### PR DESCRIPTION
These tests call the `getDisplayMessage()` method of `VuFind\Exception\Mail` which produces different behavior based on the value of the `APPLICATION_ENV` constant.  This change resolves the issue by skipping the tests when `APPLICATION_ENV !== 'testing'`.