### PR TITLE
Pass key and configuration as options to section manager

### DIFF
--- a/module/VuFind/src/VuFind/Section/SectionService.php
+++ b/module/VuFind/src/VuFind/Section/SectionService.php
@@ -33,7 +33,6 @@ use VuFind\Config\Feature\ConfigSettingPropertiesInterface;
 use VuFind\Config\YamlReader;
 use VuFind\Exception\BadConfig;
 use VuFind\Exception\ConfigException;
-use VuFind\Navigation\NavigationInterface;
 use VuFind\Section\Plugin\PluginManager as SectionManager;
 use VuFind\Section\Plugin\SectionInterface;
 
@@ -114,15 +113,7 @@ class SectionService implements SectionServiceInterface
             throw new BadConfig('Missing required setting: plugin');
         }
 
-        // Get plugin and initialize with key and optionally configuration,
-        // depending on plugin type.
-        $plugin = $this->sectionManager->get($classOrAlias);
-        $plugin->setSectionKey($key);
-        if (!$plugin instanceof NavigationInterface) {
-            $plugin->setSectionConfig($config);
-        }
-
-        return $plugin;
+        return $this->sectionManager->get($classOrAlias, [$key, $config]);
     }
 
     /**


### PR DESCRIPTION
Passing these is actually essential to how the section service and non-navigation sections are meant to work. It somehow got changed during PR refactoring and concentrating on navigation sections, which use their own separate configuration files.