### PR TITLE
Fix EDS default search mode

### DIFF
--- a/module/VuFind/src/VuFind/Search/EDS/Options.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Options.php
@@ -72,11 +72,11 @@ class Options extends AbstractEDSOptions
     protected $defaultMode = 'all';
 
     /**
-     * The set search mode
+     * The search mode (null to use default mode)
      *
-     * @var string
+     * @var ?string
      */
-    protected $searchMode;
+    protected $searchMode = null;
 
     /**
      * Default expanders to apply

--- a/module/VuFind/src/VuFind/Search/EDS/Options.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Options.php
@@ -227,7 +227,7 @@ class Options extends AbstractEDSOptions
      */
     public function getSearchMode()
     {
-        return $this->searchMode;
+        return $this->searchMode ?? $this->getDefaultMode();
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/EDS/Params.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Params.php
@@ -165,9 +165,7 @@ class Params extends AbstractEDSParams
         $backendParams->set('view', $view);
 
         $mode = $options->getSearchMode();
-        if (isset($mode)) {
-            $backendParams->set('searchMode', $mode);
-        }
+        $backendParams->set('searchMode', $mode);
 
         $this->createBackendFilterParameters($backendParams);
 

--- a/module/VuFind/src/VuFind/Search/EDS/Params.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Params.php
@@ -137,10 +137,6 @@ class Params extends AbstractEDSParams
         $searchmode = $request->get('searchmode');
         if (isset($searchmode)) {
             $this->getOptions()->setSearchMode($searchmode);
-        } else {
-            //get default search mode and set as a hidden filter
-            $defaultSearchMode = $this->getOptions()->getDefaultMode();
-            $this->getOptions()->setSearchMode($defaultSearchMode);
         }
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/Blender/ParamsTest.php
@@ -884,6 +884,9 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                 'filters' => [
                     'building:OR:main',
                 ],
+                'searchMode' => [
+                    'all',
+                ],
             ],
             $edsParams->getArrayCopy()
         );


### PR DESCRIPTION
Search requests to the EDS-API fail if no search mode is set. This is problem appears when next_prev_navigation is activated in records and you want to load a record that the first or last search result.