### PR TITLE
Fix OIDC audience validation when aud is an array

### DIFF
--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -550,13 +550,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
     protected function verifyJwtClaims(object $claims): bool
     {
         $clientId = $this->getConfig('client_id');
-
-        $audValid = false;
-        if (is_string($claims->aud ?? null)) {
-            $audValid = $claims->aud === $clientId;
-        } elseif (is_array($claims->aud ?? null)) {
-            $audValid = in_array($clientId, $claims->aud, true);
-        }
+        $audValid = in_array($clientId, (array)($claims->aud ?? []), true);
 
         return (!isset($claims->nonce) || $claims->nonce === $this->session->oidc_nonce)
             && $audValid

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -549,8 +549,17 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
      */
     protected function verifyJwtClaims(object $claims): bool
     {
+        $clientId = $this->getConfig('client_id');
+
+        $audValid = false;
+        if (is_string($claims->aud ?? null)) {
+            $audValid = $claims->aud === $clientId;
+        } elseif (is_array($claims->aud ?? null)) {
+            $audValid = in_array($clientId, $claims->aud, true);
+        }
+
         return (!isset($claims->nonce) || $claims->nonce === $this->session->oidc_nonce)
-            && ($claims->aud === $this->getConfig('client_id'))
+            && $audValid
             && (!isset($claims->exp) || (is_int($claims->exp) && ($claims->exp > time())));
     }
 


### PR DESCRIPTION
According to OpenID Connect Core, the aud claim in an ID token may be either a string or an array. The current implementation assumes a string and compares it using strict equality against client_id, which causes valid ID tokens with multiple audiences to fail validation.

This patch updates verifyJwtClaims() to accept both forms and validate successfully when the configured client_id is included in the audience array.