### PR TITLE
Fix target version values in migration table.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Migration/MigrationManager.php
+++ b/module/VuFind/src/VuFind/Db/Migration/MigrationManager.php
@@ -198,7 +198,7 @@ class MigrationManager
         // Try to extract the target version from the migration path, but use the overall target version
         // as a fallback if we get something unexpected:
         $targetVersion = dirname($name);
-        if (!preg_match('/\d(\.\d)+/', $targetVersion)) {
+        if (!preg_match('/^\d+(\.\d+)+$/', $targetVersion)) {
             $targetVersion = $this->targetVersion;
         }
         $writeToDatabase = $connection !== null;

--- a/module/VuFind/src/VuFind/Db/Migration/MigrationManager.php
+++ b/module/VuFind/src/VuFind/Db/Migration/MigrationManager.php
@@ -34,6 +34,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use RuntimeException;
 use VuFind\Db\Connection;
 
+use function dirname;
 use function get_class;
 
 /**
@@ -194,6 +195,12 @@ class MigrationManager
         if ($name === '11.0/000-add-migrations-table.sql' && $status !== 'success') {
             return '';
         }
+        // Try to extract the target version from the migration path, but use the overall target version
+        // as a fallback if we get something unexpected:
+        $targetVersion = dirname($name);
+        if (!preg_match('/\d(\.\d)+/', $targetVersion)) {
+            $targetVersion = $this->targetVersion;
+        }
         $writeToDatabase = $connection !== null;
         $connection ??= $this->connection;
         $queryBuilder = $connection->createQueryBuilder();
@@ -202,7 +209,7 @@ class MigrationManager
                 [
                     'name' => $connection->quote($name),
                     'status' => $connection->quote($status),
-                    'target_version' => $connection->quote($this->targetVersion),
+                    'target_version' => $connection->quote($targetVersion),
                 ]
             );
         $sql = (string)$queryBuilder;


### PR DESCRIPTION
While beginning to upgrade my local instances to release 11.0.2, I ran into the same problem that @alexklbuckley recently reported: a migration failed, and then when I tried to resume the migration process, it simply reported that it was successful even though not all migrations were applied.

The issue is that the target_version column of the migrations table in the database should always be the version TARGETED BY THE SPECIFIC MIGRATION FILE, _not_ the target version of the overall upgrade. The problem is that if you're upgrading to 11.0.2, and a migration aimed for 11.0 fails, if the target_version gets set to 11.0.2, then the next attempt to migrate will pick that up as the new starting version, and will then skip over all of the 11.0 and 11.0.1 migrations.

This PR fixes the problem by setting the target version based on the version number in the migration file path instead of the version from build.xml -- now broken migrations resume correctly instead of getting skipped.

Steps to reproduce:

1.) Create a database using the release-10.2 branch's mysql.sql file
2.) Drop the login_token table
3.) Use the release-11.0 branch to run the upgrade/database tool -- a migration will fail due to the missing table
4.) Add the missing table back from the 10.2 version of the mysql.sql file
5.) Re-run the migration tool: with the fix here, it will resume and work; without the fix, it will report that there is nothing to do