### PR TITLE
GetResolverLinksTest: fully mock the resolver plugin manager.

### DIFF
--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
@@ -55,7 +55,7 @@ class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTestCase
      *
      * @return void
      */
-    protected function setupConfig($config = [])
+    protected function setupConfig($config = []): void
     {
         $this->container->set(
             \VuFind\Config\ConfigManagerInterface::class,
@@ -68,7 +68,7 @@ class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTestCase
      *
      * @return void
      */
-    public function testResponse()
+    public function testResponse(): void
     {
         // Set up session settings:
         $ss = $this->container->createMock(Settings::class, ['disableWrite']);
@@ -96,10 +96,8 @@ class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTestCase
             ->method('supportsMoreOptionsLink')
             ->willReturn(false);
         $rm = $this->container->createMock(PluginManager::class);
-        $rm->expects($this->once())->method('has')->with('generic')
-            ->willReturn(true);
-        $rm->expects($this->once())->method('get')->with('generic')
-            ->willReturn($mockPlugin);
+        $rm->expects($this->once())->method('has')->with('generic')->willReturn(true);
+        $rm->expects($this->once())->method('get')->with('generic')->willReturn($mockPlugin);
         $this->container->set(PluginManager::class, $rm);
 
         // Set up view helper and renderer:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/AjaxHandler/GetResolverLinksTest.php
@@ -95,7 +95,9 @@ class GetResolverLinksTest extends \VuFindTest\Unit\AjaxHandlerTestCase
         $mockPlugin->expects($this->once())
             ->method('supportsMoreOptionsLink')
             ->willReturn(false);
-        $rm = $this->container->createMock(PluginManager::class, ['get']);
+        $rm = $this->container->createMock(PluginManager::class);
+        $rm->expects($this->once())->method('has')->with('generic')
+            ->willReturn(true);
         $rm->expects($this->once())->method('get')->with('generic')
             ->willReturn($mockPlugin);
         $this->container->set(PluginManager::class, $rm);


### PR DESCRIPTION
This test was using a partial mock of a plugin manager, but it makes more sense to fully mock the class to keep the test self-contained.

I also added return types to methods while I was in the area anyway.