### PR TITLE
Fix setting of VUFIND_HOME and VUFIND_LOCAL_DIR for GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ jobs:
     name: Tests with PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
     env:
-      VUFIND_HOME: $GITHUB_WORKSPACE
-      VUFIND_LOCAL_DIR: $GITHUB_WORKSPACE/local
+      VUFIND_HOME: ${{ github.workspace }}
+      VUFIND_LOCAL_DIR: ${{ github.workspace }}/local
     strategy:
       matrix:
         php-version: ['8.2', '8.3', '8.4']


### PR DESCRIPTION
The old setting resulted in an unusable `VUFIND="\$GITHUB_WORKSPACE"` instead of the correct `VUFIND_HOME=/home/runner/work/vufind/vufind`.