### PR TITLE
Modernize Solr code and configuration

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -500,6 +500,9 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
             'terms' => [
                 'functions' => ['terms'],
             ],
+            'morelikethis' => [
+                'functions' => ['similar'],
+            ],
         ];
 
         foreach ($this->getHiddenFilters() as $filter) {

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/QueryBuilder.php
@@ -178,7 +178,7 @@ class QueryBuilder implements QueryBuilderInterface
                 }
             } elseif ($handler->hasDismax()) {
                 $newParams->set('qf', implode(' ', $handler->getDismaxFields()));
-                $newParams->set('qt', $handler->getDismaxHandler());
+                $newParams->set('defType', $handler->getDismaxHandler());
                 foreach ($handler->getDismaxParams() as $param) {
                     $newParams->add(reset($param), next($param));
                 }

--- a/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilder.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/Solr/SimilarBuilder.php
@@ -131,7 +131,6 @@ class SimilarBuilder implements SimilarBuilderInterface
                 'q',
                 sprintf('%s:"%s"', $this->uniqueKey, addcslashes($id, '"'))
             );
-            $params->set('qt', 'morelikethis');
         }
         if (null === $params->get('rows')) {
             $params->set('rows', $this->count);

--- a/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
+++ b/module/VuFindSearch/tests/unit-tests/src/VuFindTest/Backend/Solr/SimilarBuilderTest.php
@@ -59,7 +59,7 @@ class SimilarBuilderTest extends \PHPUnit\Framework\TestCase
         $q = $response->get('q');
         $this->assertEquals('id:"testrecord"', $q[0]);
         $qt = $response->get('qt');
-        $this->assertEquals('morelikethis', $qt[0]);
+        $this->assertNull($qt);
     }
 
     /**

--- a/solr/vufind/authority/conf/solrconfig.xml
+++ b/solr/vufind/authority/conf/solrconfig.xml
@@ -264,12 +264,7 @@
 
   </query>
 
-  <!--
-    Let the dispatch filter handler /select?qt=XXX
-    handleSelect=true will use consistent error handling for /select and /update
-    handleSelect=false will use solr1.1 style error formatting
-    -->
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher>
     <requestParsers multipartUploadLimitInKB="2048"
                     formdataUploadLimitInKB="2048"/>
 
@@ -319,6 +314,16 @@
      If no qt is defined, the requestHandler that declares default="true"
      will be used.
   -->
+  <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
+       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="q.op">AND</str>
+      <str name="df">allfields</str>
+    </lst>
+  </requestHandler>
+
   <requestHandler name="standard" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters may optionally be defined here
      <lst name="defaults">

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -357,6 +357,14 @@
       <str name="spellcheck.count">20</str>
       <str name="q.op">AND</str>
       <str name="df">allfields</str>
+      <!-- Enable split on whitespace to prevent switching from term centric to field
+           centric search if different field types return different analysis (such as
+           synonyms or stopwords). Note the downside that sow=true prevents
+           multi-word synonyms from working properly.
+           See the following links for more information:
+           https://opensourceconnections.com/blog/2018/02/20/edismax-and-multiterm-synonyms-oddities/
+           https://lucene.472066.n3.nabble.com/Problem-with-eDisMax-and-multi-word-synonyms-td4471917.html
+      -->
       <str name="sow">true</str>
     </lst>
     <arr name="last-components">

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -315,10 +315,40 @@
      Names starting with a '/' are accessed with a path equal to the
      registered name.  Names without a leading '/' are accessed with:
       http://host/app/select?qt=name
+     If no qt is defined, the requestHandler that declares default="true"
+     will be used.
   -->
+  <requestHandler name="standard" class="solr.SearchHandler" default="true">
+    <!-- default values for query parameters -->
+     <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <!--
+       <int name="rows">10</int>
+       <str name="fl">*</str>
+       <str name="version">2.1</str>
+        -->
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
+      <str name="q.op">AND</str>
+      <str name="df">allfields</str>
+      <!-- Enable split on whitespace to prevent switching from term centric to field
+           centric search if different field types return different analysis (such as
+           synonyms or stopwords). Note the downside that sow=true prevents
+           multi-word synonyms from working properly.
+           See the following links for more information:
+           https://opensourceconnections.com/blog/2018/02/20/edismax-and-multiterm-synonyms-oddities/
+           https://lucene.472066.n3.nabble.com/Problem-with-eDisMax-and-multi-word-synonyms-td4471917.html
+      -->
+      <str name="sow">true</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
 
   <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
-       This mirrors the former "standard" handler so that requests to /select behave the same as before. -->
+       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
   <requestHandler name="/select" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">explicit</str>

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -271,12 +271,7 @@
 
   </query>
 
-  <!--
-    Let the dispatch filter handler /select?qt=XXX
-    handleSelect=true will use consistent error handling for /select and /update
-    handleSelect=false will use solr1.1 style error formatting
-    -->
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher>
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)
@@ -345,6 +340,23 @@
            https://opensourceconnections.com/blog/2018/02/20/edismax-and-multiterm-synonyms-oddities/
            https://lucene.472066.n3.nabble.com/Problem-with-eDisMax-and-multi-word-synonyms-td4471917.html
       -->
+      <str name="sow">true</str>
+    </lst>
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
+       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
+      <str name="q.op">AND</str>
+      <str name="df">allfields</str>
       <str name="sow">true</str>
     </lst>
     <arr name="last-components">

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -423,7 +423,7 @@
     </arr>
   </requestHandler>
 
-  <requestHandler name="morelikethis" class="solr.MoreLikeThisHandler">
+  <requestHandler name="/morelikethis" class="solr.MoreLikeThisHandler">
     <lst name="defaults">
       <str name="mlt.fl">title,title_short,callnumber-label,topic,language,author,publishDate</str>
       <str name="mlt.qf">

--- a/solr/vufind/biblio/conf/solrconfig.xml
+++ b/solr/vufind/biblio/conf/solrconfig.xml
@@ -315,40 +315,10 @@
      Names starting with a '/' are accessed with a path equal to the
      registered name.  Names without a leading '/' are accessed with:
       http://host/app/select?qt=name
-     If no qt is defined, the requestHandler that declares default="true"
-     will be used.
   -->
-  <requestHandler name="standard" class="solr.SearchHandler" default="true">
-    <!-- default values for query parameters -->
-     <lst name="defaults">
-       <str name="echoParams">explicit</str>
-       <!--
-       <int name="rows">10</int>
-       <str name="fl">*</str>
-       <str name="version">2.1</str>
-        -->
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.onlyMorePopular">true</str>
-      <str name="spellcheck.count">20</str>
-      <str name="q.op">AND</str>
-      <str name="df">allfields</str>
-      <!-- Enable split on whitespace to prevent switching from term centric to field
-           centric search if different field types return different analysis (such as
-           synonyms or stopwords). Note the downside that sow=true prevents
-           multi-word synonyms from working properly.
-           See the following links for more information:
-           https://opensourceconnections.com/blog/2018/02/20/edismax-and-multiterm-synonyms-oddities/
-           https://lucene.472066.n3.nabble.com/Problem-with-eDisMax-and-multi-word-synonyms-td4471917.html
-      -->
-      <str name="sow">true</str>
-    </lst>
-    <arr name="last-components">
-      <str>spellcheck</str>
-    </arr>
-  </requestHandler>
 
   <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
-       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
+       This mirrors the former "standard" handler so that requests to /select behave the same as before. -->
   <requestHandler name="/select" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">explicit</str>

--- a/solr/vufind/reserves/conf/solrconfig.xml
+++ b/solr/vufind/reserves/conf/solrconfig.xml
@@ -264,12 +264,7 @@
 
   </query>
 
-  <!--
-    Let the dispatch filter handler /select?qt=XXX
-    handleSelect=true will use consistent error handling for /select and /update
-    handleSelect=false will use solr1.1 style error formatting
-    -->
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher>
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)
@@ -316,6 +311,16 @@
      If no qt is defined, the requestHandler that declares default="true"
      will be used.
   -->
+  <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
+       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="echoParams">explicit</str>
+      <str name="q.op">AND</str>
+      <str name="df">course</str>
+    </lst>
+  </requestHandler>
+
   <requestHandler name="standard" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters may optionally be defined here
      <lst name="defaults">

--- a/solr/vufind/website/conf/solrconfig.xml
+++ b/solr/vufind/website/conf/solrconfig.xml
@@ -269,12 +269,7 @@
 
   </query>
 
-  <!--
-    Let the dispatch filter handler /select?qt=XXX
-    handleSelect=true will use consistent error handling for /select and /update
-    handleSelect=false will use solr1.1 style error formatting
-    -->
-  <requestDispatcher handleSelect="true" >
+  <requestDispatcher>
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)
@@ -321,6 +316,18 @@
      If no qt is defined, the requestHandler that declares default="true"
      will be used.
   -->
+  <!-- Explicit /select handler to replace deprecated requestDispatcher handleSelect handling.
+       This mirrors the "standard" handler so that requests to /select behave the same as before. -->
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <str name="spellcheck.extendedResults">true</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="spellcheck.count">20</str>
+      <str name="q.op">AND</str>
+      <str name="df">fulltext</str>
+    </lst>
+  </requestHandler>
+
   <requestHandler name="standard" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters -->
     <lst name="defaults">


### PR DESCRIPTION
This removes `handleSelect="true"` which was deprecated in Solr 9.9.x and unsupported in 10.0.x, but also no longer needed for 9.8.x.