### PR TITLE
Do not lowercase class-based section template name

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/Section.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Section.php
@@ -159,7 +159,7 @@ class Section extends AbstractHelper
         } else {
             // Default to class-based template.
             $template = $this->defaultTemplateDir . '/%s.phtml';
-            $className = strtolower($this->section::class);
+            $className = $this->section::class;
             return $this->renderClassTemplate($template, $className, $mergedContext);
         }
     }


### PR DESCRIPTION
For consistency, since key-based template names are not lowercased.