### PR TITLE
Check for record tabs before trying to handle tab hash.

### DIFF
--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -448,16 +448,16 @@ function applyRecordTabHash(scrollToTabs) {
   const activeLi = recordTabs.querySelector('li.active');
   const activeTab = activeLi ? activeLi.dataset.tab : undefined;
   const initiallyActiveTab = recordTabs.querySelector('li.initiallyActive a');
-  const newTab = typeof window.location.hash !== 'undefined' ? window.location.hash.toLowerCase() : '';
+  const newTab = typeof window.location.hash !== 'undefined' ? window.location.hash.toLowerCase().substring(1) : '';
 
   // Open tab in url hash
-  if (initiallyActiveTab && (newTab.length <= 1 || newTab === '#tabnav')) {
+  if (initiallyActiveTab && (newTab === '' || newTab === 'tabnav')) {
     initiallyActiveTab.click();
-    if (newTab === '#tabnav') {
+    if (newTab === 'tabnav') {
       initiallyActiveTab.focus();
     }
-  } else if ('#' + activeTab !== newTab && /^#[a-zA-Z_][a-zA-Z0-9_-]*$/.test(newTab)) {
-    const tabLink = recordTabs.querySelector('.' + newTab.substring(1) + ' a');
+  } else if (activeTab !== newTab && /^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(newTab)) {
+    const tabLink = recordTabs.querySelector('.' + newTab + ' a');
     if (tabLink) {
       tabLink.click();
       if (typeof scrollToTabs === 'undefined' || false !== scrollToTabs) {

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -456,7 +456,7 @@ function applyRecordTabHash(scrollToTabs) {
     if (newTab === '#tabnav') {
       initiallyActiveTab.focus();
     }
-  } else if (newTab.length > 1 && '#' + activeTab !== newTab) {
+  } else if ('#' + activeTab !== newTab && /^#[a-zA-Z_][a-zA-Z0-9_-]*$/.test(newTab)) {
     const tabLink = recordTabs.querySelector('.' + newTab.substring(1) + ' a');
     if (tabLink) {
       tabLink.click();

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -441,9 +441,13 @@ function backgroundLoadTab(tabId) {
  * @param {boolean} scrollToTabs Whether to scroll to the tabs section.
  */
 function applyRecordTabHash(scrollToTabs) {
-  const activeLi = document.querySelector('.record-tabs li.active');
+  const recordTabs = document.querySelector('.record-tabs');
+  if (!recordTabs) {
+    return;
+  }
+  const activeLi = recordTabs.querySelector('li.active');
   const activeTab = activeLi ? activeLi.dataset.tab : undefined;
-  const initiallyActiveTab = document.querySelector('.record-tabs li.initiallyActive a');
+  const initiallyActiveTab = recordTabs.querySelector('li.initiallyActive a');
   const newTab = typeof window.location.hash !== 'undefined' ? window.location.hash.toLowerCase() : '';
 
   // Open tab in url hash
@@ -453,7 +457,7 @@ function applyRecordTabHash(scrollToTabs) {
       initiallyActiveTab.focus();
     }
   } else if (newTab.length > 1 && '#' + activeTab !== newTab) {
-    const tabLink = document.querySelector('.record-tabs .' + newTab.substring(1) + ' a');
+    const tabLink = recordTabs.querySelector('.' + newTab.substring(1) + ' a');
     if (tabLink) {
       tabLink.click();
       if (typeof scrollToTabs === 'undefined' || false !== scrollToTabs) {


### PR DESCRIPTION
Fixes a problem when JS pipeline is used and record.js is included to avoid the JS from trying to handle hash change outside of record page.