### PR TITLE
Remove obsolete node-sass reference from CI workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,13 +58,6 @@ jobs:
         # (a security precaution).
         run: npm install --ignore-scripts
 
-      - name: Rebuild node-sass dependency
-        if: ${{ matrix.phing_tasks == 'qa-console' }}
-        # The --ignore-scripts parameter to npm install prevents node-sass from
-        # fully building. We need to force it to build so the SCSS check in the
-        # qa-console task runs successfully.
-        run: npm rebuild node-sass
-
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We no longer use node-sass, so there is no reason to rebuild it during CI.