### PR TITLE
Add --ignore-scripts to relevant NPM commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
         "qa": "phing qa-console -Ddefaultconfigs=true",
         "show-outdated": "composer show -oD --ignore-platform-req=ext-oci8",
         "update-npm-deps": [
-            "npm update",
+            "npm update --ignore-scripts",
             "cd themes/bootstrap5 && npm run updateDeps"
         ],
         "install-build-deps": [

--- a/themes/bootstrap5/package.json
+++ b/themes/bootstrap5/package.json
@@ -2,8 +2,8 @@
   "name": "vufind-bootstrap5",
   "description": "Dependencies for the bootstrap5 theme",
   "scripts": {
-    "installBuildDeps": "npm install --no-audit && node tools/copyDependencies.mjs --only-build-deps",
-    "updateDeps": "npm update && node tools/copyDependencies.mjs"
+    "installBuildDeps": "npm install --ignore-scripts --no-audit && node tools/copyDependencies.mjs --only-build-deps",
+    "updateDeps": "npm update --ignore-scripts && node tools/copyDependencies.mjs"
   },
   "dependencies": {
     "@popperjs/core": "2.11.8",


### PR DESCRIPTION
Our dependencies don't require scripts, and it's safer not to allow them to run in case of upstream package compromise.