### PR TITLE
Eliminate title_sort copyField from Solr web schema.

### DIFF
--- a/module/VuFind/src/VuFind/XSLT/Import/VuFindSitemap.php
+++ b/module/VuFind/src/VuFind/XSLT/Import/VuFindSitemap.php
@@ -286,6 +286,9 @@ class VuFindSitemap extends VuFind
         $fields['url'] = $url;
         $fields['last_indexed'] = date('Y-m-d\TH:i:s\Z');
 
+        // Format the sortable title:
+        $fields['title_sort'] = static::stripArticles($fields['title'] ?? '');
+
         return $fields;
     }
 }

--- a/module/VuFind/tests/fixtures/web/test.html
+++ b/module/VuFind/tests/fixtures/web/test.html
@@ -1,0 +1,11 @@
+<html>
+    <head>
+        <title>Test page</title>
+        <meta name="subject" content="fake subject">
+        <meta name="useCount" content="123">
+        <meta name="category" content="fake category">
+    </head>
+    <body>
+        <p>This is a test.</p>
+    </body>
+</html>

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/WebSearchTest.php
@@ -30,6 +30,7 @@
 
 namespace VuFindTest\Mink;
 
+use function count;
 use function intval;
 
 /**
@@ -51,27 +52,41 @@ class WebSearchTest extends \VuFindTest\Integration\MinkTestCase
      */
     public static function webSearchProvider(): \Iterator
     {
-        yield 'blank search' => ['', 3, '', ['Fact', 'Fantasy', 'Fiction']];
-        yield 'search in full text' => ['"second record"', 1, 'second record', ['Fact']];
-        yield 'search in description' => ['three', 1, 'three', ['Fantasy']];
+        yield 'blank search' => [
+            '',
+            ['First Web Page', 'Second Web Page', 'Third Web Page', 'The Fourth Web Page'],
+            '',
+            ['Fantasy', 'Fact', 'Fiction'],
+        ];
+        yield 'blank search with title sort' => [
+            '',
+            ['First Web Page', 'The Fourth Web Page', 'Second Web Page', 'Third Web Page'],
+            '',
+            ['Fantasy', 'Fact', 'Fiction'],
+            'title',
+        ];
+        yield 'search in full text' => ['"second record"', ['Second Web Page'], 'second record', ['Fact']];
+        yield 'search in description' => ['three', ['Third Web Page'], 'three', ['Fantasy']];
     }
 
     /**
      * Test performing a Web search.
      *
      * @param string   $query                  Search query
-     * @param int      $expectedCount          Expected search result count
+     * @param string[] $expectedTitles         Expected titles in search results
      * @param string   $expectedFirstHighlight Expected first highlighted text on page
      * @param string[] $expectedSubjectFacets  Expected subject facet values
+     * @param ?string  $sort                   Sort to apply (null for default)
      *
      * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('webSearchProvider')]
     public function testWebSearch(
         string $query,
-        int $expectedCount,
+        array $expectedTitles,
         string $expectedFirstHighlight,
-        array $expectedSubjectFacets
+        array $expectedSubjectFacets,
+        ?string $sort = null
     ): void {
         // Perform the search:
         $session = $this->getMinkSession();
@@ -81,11 +96,24 @@ class WebSearchTest extends \VuFindTest\Integration\MinkTestCase
         $this->findCss($page, '.btn-primary')->click();
         $this->waitForPageLoad($page);
 
-        // Confirm the result count:
+        // Apply sort if applicable:
+        if ($sort) {
+            $this->findCssAndSetValue($page, '#sort_options_1', $sort, verifyValue: false);
+            $this->waitForPageLoad($page);
+        }
+
+        // Confirm the result count is displayed:
         $this->assertSame(
-            $expectedCount,
+            count($expectedTitles),
             intval($this->findCssAndGetText($page, '.js-search-stats strong', index: 1))
         );
+
+        // Confirm that we got the titles we wanted:
+        $foundTitles = [];
+        foreach ($page->findAll('css', '.record-list a.title') as $title) {
+            $foundTitles[] = $title->getText();
+        }
+        $this->assertSame($expectedTitles, $foundTitles);
 
         // Confirm highlighting:
         if ($expectedFirstHighlight) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindSitemapTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindSitemapTest.php
@@ -79,14 +79,15 @@ class VuFindSitemapTest extends \PHPUnit\Framework\TestCase
                     'title' => 'The Fake Title',
                     'keywords' => 'fake keywords',
                     'description' => 'fake description',
-                    'fulltext' => 'fake full text',
+                    'fulltext' => 'fake full text ' . md5(file_get_contents($htmlFile)),
                 ];
             }
         };
         $url = $this->getFixturePath('web/test.html');
         $xml = $class::getDocument($url);
         $xmlRegEx = '|<field name="title">The Fake Title</field><field name="keywords">fake keywords</field>'
-            . '<field name="description">fake description</field><field name="fulltext">fake full text</field>'
+            . '<field name="description">fake description</field>'
+            . '<field name="fulltext">fake full text ' . md5(file_get_contents($url)) . '</field>'
             . '<field name="category">fake category</field><field name="subject">fake subject</field>'
             . '<field name="use_count">123</field><field name="id">' . md5($url) . '</field>'
             . '<field name="url">' . $url . '</field>'

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindSitemapTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/XSLT/Import/VuFindSitemapTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Sitemap XSLT helper tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\XSLT\Import;
+
+use VuFind\XSLT\Import\VuFindSitemap;
+use VuFindTest\Feature\FixtureTrait;
+
+/**
+ * Sitemap XSLT helper tests.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class VuFindSitemapTest extends \PHPUnit\Framework\TestCase
+{
+    use FixtureTrait;
+
+    /**
+     * Test indexing a web page.
+     *
+     * @return void
+     */
+    public function testWebIndexing(): void
+    {
+        /**
+         * Extend the class so we can mock some details:
+         */
+        $class = new class () extends VuFindSitemap {
+            /**
+             * Simulate reading parser method from fulltext.ini.
+             *
+             * @return string Name of parser to use (i.e. Aperture or Tika)
+             */
+            public static function getParser()
+            {
+                return 'Tika';
+            }
+
+            /**
+             * Simulate loading metadata about an HTML document using Tika.
+             *
+             * @param string $htmlFile File on disk containing HTML.
+             *
+             * @return array
+             */
+            protected static function getTikaFields($htmlFile)
+            {
+                return [
+                    'title' => 'The Fake Title',
+                    'keywords' => 'fake keywords',
+                    'description' => 'fake description',
+                    'fulltext' => 'fake full text',
+                ];
+            }
+        };
+        $url = $this->getFixturePath('web/test.html');
+        $xml = $class::getDocument($url);
+        $xmlRegEx = '|<field name="title">The Fake Title</field><field name="keywords">fake keywords</field>'
+            . '<field name="description">fake description</field><field name="fulltext">fake full text</field>'
+            . '<field name="category">fake category</field><field name="subject">fake subject</field>'
+            . '<field name="use_count">123</field><field name="id">' . md5($url) . '</field>'
+            . '<field name="url">' . $url . '</field>'
+            . '<field name="last_indexed">\d+-\d+-\d+T\d+:\d+:\d+Z</field>'
+            . '<field name="title_sort">fake title</field>|';
+        $this->assertMatchesRegularExpression($xmlRegEx, $xml);
+    }
+}

--- a/solr/vufind/website/conf/schema.xml
+++ b/solr/vufind/website/conf/schema.xml
@@ -133,8 +133,6 @@
   <uniqueKey>id</uniqueKey>
   <!-- CopyFields for Spelling -->
   <copyField source="title"    dest="spellingShingle"/>
-  <!-- Copy title information to special field for sorting -->
-  <copyField source="title"    dest="title_sort"/>
   <!-- CopyFields to allow keyword searching within URL -->
   <copyField source="url" dest="url_keywords"/>
   <!-- CopyFields for unstemmed searching -->

--- a/tests/data/website/solr.xml
+++ b/tests/data/website/solr.xml
@@ -5,6 +5,7 @@
     <field name="description">This is the description of record number one.</field>
     <field name="keywords">one first</field>
     <field name="title">First Web Page</field>
+    <field name="title_sort">first web page</field>
     <field name="url">http://localhost/1</field>
     <field name="category">Test Pages</field>
     <field name="linktype">Fake Link</field>
@@ -16,6 +17,7 @@
     <field name="description">This is the description of record number two.</field>
     <field name="keywords">two second</field>
     <field name="title">Second Web Page</field>
+    <field name="title_sort">second web page</field>
     <field name="url">http://localhost/2</field>
     <field name="category">Test Pages</field>
     <field name="linktype">Fake Link</field>
@@ -27,7 +29,20 @@
     <field name="description">This is the description of record number three.</field>
     <field name="keywords">three third</field>
     <field name="title">Third Web Page</field>
+    <field name="title_sort">third web page</field>
     <field name="url">http://localhost/3</field>
+    <field name="category">Test Pages</field>
+    <field name="linktype">Fake Link</field>
+    <field name="subject">Fantasy</field>
+  </doc>
+  <doc>
+    <field name="id">004</field>
+    <field name="fulltext">This is the content of the fourth record.</field>
+    <field name="description">This is the description of record number four.</field>
+    <field name="keywords">four fourth</field>
+    <field name="title">The Fourth Web Page</field>
+    <field name="title_sort">fourth web page</field>
+    <field name="url">http://localhost/4</field>
     <field name="category">Test Pages</field>
     <field name="linktype">Fake Link</field>
     <field name="subject">Fantasy</field>


### PR DESCRIPTION
The Solr web schema had a hard-coded copyField to populate title_sort with a copy of title. This is suboptimal, as it did not allow for normalization and article stripping, and it caused a conflict if local custom indexers tried to pass in custom sort values.

This PR eliminates the copyField, replaces it with a default normalization behavior, and improves test coverage.

I'm targeting this to dev-12.0 since it is technically a breaking change; it could be pretty easily backported if needed, though.

TODO:
- [x] Run full test suite
- [ ] Update changelog and schema changelog when merging (note potential need to adjust custom indexers)