### PR TITLE
Fix some typos in bootstrap5 JavaScript comments

### DIFF
--- a/themes/bootstrap5/js/checkouts.js
+++ b/themes/bootstrap5/js/checkouts.js
@@ -1,5 +1,5 @@
 /**
- * Submit a form to processe a renewal request
+ * Submit a form to process a renewal request
  * @param {jQuery|HTMLElement} link   The button or link that was clicked
  * @param {string}             action The action to perform 
  */

--- a/themes/bootstrap5/js/common.js
+++ b/themes/bootstrap5/js/common.js
@@ -390,7 +390,7 @@ var VuFind = (function VuFindModule() {
     const tmpDiv = document.createElement('div');
     tmpDiv.innerHTML = html;
     const scripts = [];
-    // Cloning scripts wont work as they pass internal executed state so save them for later
+    // Cloning scripts won't work as they pass internal executed state so save them for later
     tmpDiv.querySelectorAll('script').forEach(script => {
       const type = script.getAttribute('type');
       if (!type || 'text/javascript' === type) {

--- a/themes/bootstrap5/js/visual_facets.js
+++ b/themes/bootstrap5/js/visual_facets.js
@@ -34,7 +34,7 @@ function settext() {
       return VuFind.translate('more_topics_unescaped', { '%%count%%': d.count});
     }
 
-    // Csae 4 (default): Standard second-level field
+    // Case 4 (default): Standard second-level field
     return d.name + " (" + d.count + ")";
   });
 }


### PR DESCRIPTION
The typos were found using
`codespell -s -S vendor -S node_modules -S HelpTranslations themes`