### PR TITLE
Adjust annotations to fix broken PHPstan build.

### DIFF
--- a/module/VuFind/src/VuFind/Db/ConnectionFactory.php
+++ b/module/VuFind/src/VuFind/Db/ConnectionFactory.php
@@ -201,17 +201,17 @@ class ConnectionFactory implements \Laminas\ServiceManager\Factory\FactoryInterf
         // Apply MySQL-specific adjustments:
         if ($driver == 'pdo_mysql') {
             if (PHP_VERSION_ID >= 80400) {
-                // @phpstan-ignore class.notFound
+                // @phpstan-ignore class.nameCase
                 $driverOptions[Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT]
                     = $this->config->Database->verify_server_certificate ?? false;
                 $sslKeyMap = [
-                    // @phpstan-ignore class.notFound
+                    // @phpstan-ignore class.nameCase
                     'client_key' => Pdo\Mysql::ATTR_SSL_KEY,
-                    // @phpstan-ignore class.notFound
+                    // @phpstan-ignore class.nameCase
                     'client_cert' => Pdo\Mysql::ATTR_SSL_CERT,
-                    // @phpstan-ignore class.notFound
+                    // @phpstan-ignore class.nameCase
                     'ca_cert' => Pdo\Mysql::ATTR_SSL_CA,
-                    // @phpstan-ignore class.notFound
+                    // @phpstan-ignore class.nameCase
                     'ca_path' => Pdo\Mysql::ATTR_SSL_CAPATH,
                 ];
             } else {


### PR DESCRIPTION
For some reason, #5171 broke the dev-12.0 branch when merged there, even though the dev branch build is passing, and there are no obvious changes to the affected ConnectionFactory class. This PR is an effort to fix the broken build.