### PR TITLE
Fix setting of option `cache_dir` for test mode

### DIFF
--- a/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
+++ b/module/VuFind/src/VuFindTest/Feature/LiveDatabaseTrait.php
@@ -125,8 +125,7 @@ trait LiveDatabaseTrait
         );
         $config = $container->get('config');
         $options = $config['caches']['doctrinemodule.cache.filesystem']['options'];
-        $options['cache_dir']
-            = LOCAL_CACHE_DIR . '/' . $options['cache_dir'] . '_testmode';
+        $options['cache_dir'] .= '_testmode';
         if (!is_dir($options['cache_dir'])) {
             mkdir($options['cache_dir'], 0o777, true);
         }


### PR DESCRIPTION
`LOCAL_CACHE_DIR` is already part of the original `$options['cache_dir']`, so it was prepended twice. This resulted in a lengthy directory name like /usr/local/vufind/local/cache/usr/local/vufind/local/cache/cli/objects_testmode.