### PR TITLE
Use empty arrays instead of false in ILS drivers getConfig method

### DIFF
--- a/module/VuFind/src/VuFind/Auth/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Auth/AbstractBase.php
@@ -337,7 +337,7 @@ abstract class AbstractBase implements
      *
      * @return bool
      */
-    public function supportsPasswordChange()
+    public function supportsPasswordChange(): bool
     {
         // By default, password changing is not supported.
         return false;
@@ -350,7 +350,7 @@ abstract class AbstractBase implements
      *
      * @return bool
      */
-    public function supportsPasswordRecovery(?string $target = null)
+    public function supportsPasswordRecovery(?string $target = null): bool
     {
         // By default, password recovery is not supported.
         return false;

--- a/module/VuFind/src/VuFind/Auth/AuthInterface.php
+++ b/module/VuFind/src/VuFind/Auth/AuthInterface.php
@@ -183,7 +183,7 @@ interface AuthInterface
      *
      * @return bool
      */
-    public function supportsPasswordChange();
+    public function supportsPasswordChange(): bool;
 
     /**
      * Does this authentication method support password recovery.
@@ -192,7 +192,7 @@ interface AuthInterface
      *
      * @return bool
      */
-    public function supportsPasswordRecovery(?string $target = null);
+    public function supportsPasswordRecovery(?string $target = null): bool;
 
     /**
      * Does this authentication method support connecting library card of

--- a/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
+++ b/module/VuFind/src/VuFind/Auth/ChoiceAuth.php
@@ -289,7 +289,7 @@ class ChoiceAuth extends AbstractBase
      *
      * @return bool
      */
-    public function supportsPasswordChange()
+    public function supportsPasswordChange(): bool
     {
         return $this->proxyAuthMethod('supportsPasswordChange', func_get_args());
     }
@@ -301,7 +301,7 @@ class ChoiceAuth extends AbstractBase
      *
      * @return bool
      */
-    public function supportsPasswordRecovery(?string $target = null)
+    public function supportsPasswordRecovery(?string $target = null): bool
     {
         return $this->proxyAuthMethod('supportsPasswordRecovery', func_get_args());
     }

--- a/module/VuFind/src/VuFind/Auth/Database.php
+++ b/module/VuFind/src/VuFind/Auth/Database.php
@@ -360,7 +360,7 @@ class Database extends AbstractBase
      *
      * @return bool
      */
-    public function supportsPasswordChange()
+    public function supportsPasswordChange(): bool
     {
         return true;
     }
@@ -374,7 +374,7 @@ class Database extends AbstractBase
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function supportsPasswordRecovery(?string $target = null)
+    public function supportsPasswordRecovery(?string $target = null): bool
     {
         return true;
     }

--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -122,10 +122,9 @@ class ILS extends AbstractBase
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function supportsPasswordRecovery(?string $target = null)
+    public function supportsPasswordRecovery(?string $target = null): bool
     {
-        $recoveryConfig = $this->getCatalog()->checkFunction('resetPassword');
-        return (bool)$recoveryConfig;
+        return !empty($this->getCatalog()->checkFunction('resetPassword'));
     }
 
     /**
@@ -133,13 +132,13 @@ class ILS extends AbstractBase
      *
      * @return bool
      */
-    public function supportsPasswordChange()
+    public function supportsPasswordChange(): bool
     {
         try {
-            return false !== $this->getCatalog()->checkFunction(
+            return !empty($this->getCatalog()->checkFunction(
                 'changePassword',
                 ['patron' => $this->authenticator->getStoredCatalogCredentials()]
-            );
+            ));
         } catch (ILSException $e) {
             return false;
         }
@@ -156,8 +155,8 @@ class ILS extends AbstractBase
     {
         // If a target is specified, use an arbitrary cat_username with the current target prefix:
         $patron = $target ? ['cat_username' => "$target.123"] : $this->getLoggedInPatron();
-        $policy = $this->getCatalog()->getPasswordPolicy($patron);
-        if ($policy === false) {
+        $policy = $this->getCatalog()->getPasswordPolicy($patron ?? []);
+        if (!$policy) {
             return parent::getPasswordPolicy();
         }
         if (isset($policy['pattern']) && empty($policy['hint'])) {

--- a/module/VuFind/src/VuFind/Auth/MultiILS.php
+++ b/module/VuFind/src/VuFind/Auth/MultiILS.php
@@ -134,17 +134,16 @@ class MultiILS extends ILS
      *
      * @throws \Exception
      */
-    public function supportsPasswordRecovery(?string $target = null)
+    public function supportsPasswordRecovery(?string $target = null): bool
     {
         if (!$target) {
             throw new \Exception(__METHOD__ . ' requires the target parameter!');
         }
         // If a target is specified, use an arbitrary cat_username with the correct target prefix:
-        $recoveryConfig = $this->getCatalog()->checkFunction(
+        return !empty($this->getCatalog()->checkFunction(
             'resetPassword',
             ['cat_username' => "$target.123"]
-        );
-        return (bool)$recoveryConfig;
+        ));
     }
 
     /**

--- a/module/VuFind/src/VuFind/Controller/CheckoutsController.php
+++ b/module/VuFind/src/VuFind/Controller/CheckoutsController.php
@@ -121,7 +121,7 @@ class CheckoutsController extends AbstractBase
             'getMyTransactionHistory',
             $patron
         );
-        if (false === $functionConfig) {
+        if (!$functionConfig) {
             $this->getFlashMessenger()->addErrorMessage('ils_action_unavailable');
             return $this->createViewModel();
         }

--- a/module/VuFind/src/VuFind/ILS/Connection.php
+++ b/module/VuFind/src/VuFind/ILS/Connection.php
@@ -341,29 +341,27 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * if the system supports a particular function.
      *
      * @param string $function The name of the function to check.
-     * @param ?array $params   (optional) An array of function-specific parameters
+     * @param array  $params   (optional) An array of function-specific parameters
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values; on failure, false.
+     * @return array
      */
-    public function checkFunction($function, $params = null)
+    public function checkFunction(string $function, array $params = []): array
     {
         try {
             // Extract the configuration from the driver if available:
-            $paramsArray = $params ?? [];
             $functionConfig = $this->checkCapability(
                 'getConfig',
-                [$function, $paramsArray],
+                [$function, $params],
                 true
-            ) ? $this->getDriver()->getConfig($function, $paramsArray) : false;
+            ) ? $this->getDriver()->getConfig($function, $params) : [];
 
             // See if we have a corresponding check method to analyze the response:
             $checkMethod = 'checkMethod' . $function;
             if (!method_exists($this, $checkMethod)) {
-                return false;
+                return [];
             }
-            if (!empty($this->getMethodBlock($function, $paramsArray))) {
-                return false;
+            if (!empty($this->getMethodBlock($function, $params))) {
+                return [];
             }
 
             // Send back the settings:
@@ -373,7 +371,7 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
                 "checkFunction($function) with params: " . $this->varDump($params)
                 . ' failed: ' . $e->getMessage()
             );
-            return false;
+            return [];
         }
     }
 
@@ -383,15 +381,14 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * A support method for checkFunction(). This is responsible for checking
      * the driver configuration to determine if the system supports Holds.
      *
-     * @param array  $functionConfig The Hold configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The Hold configuration values
+     * @param array $params         An array of function-specific params
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for placing holds via a form or a URL; on failure, false.
+     * @return array
      */
-    protected function checkMethodHolds($functionConfig, $params)
+    protected function checkMethodHolds(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         // We pass an array containing $params to checkCapability since $params
         // should contain 'id' and 'patron' keys; this isn't exactly the same as
@@ -441,18 +438,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * A support method for checkFunction(). This is responsible for checking
      * the driver configuration to determine if the system supports Cancelling Holds.
      *
-     * @param array  $functionConfig The Cancel Hold configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The Cancel Hold configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for cancelling holds via a form or a URL;
-     * on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodcancelHolds($functionConfig, $params)
+    protected function checkMethodcancelHolds(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         // We can't pass exactly accurate parameters to checkCapability in this
         // context, so we'll just pass along $params as the best available
@@ -479,17 +474,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * A support method for checkFunction(). This is responsible for checking
      * the driver configuration to determine if the system supports Renewing Items.
      *
-     * @param array  $functionConfig The Renewal configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The Renewal configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for renewing items via a form or a URL; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodRenewals($functionConfig, $params)
+    protected function checkMethodRenewals(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         // We can't pass exactly accurate parameters to checkCapability in this
         // context, so we'll just pass along $params as the best available
@@ -517,15 +511,14 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * the driver configuration to determine if the system supports storage
      * retrieval requests.
      *
-     * @param array  $functionConfig The storage retrieval request configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The storage retrieval request configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for placing requests via a form; on failure, false.
+     * @return array
      */
-    protected function checkMethodStorageRetrievalRequests($functionConfig, $params)
+    protected function checkMethodStorageRetrievalRequests(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         // $params doesn't include all of the keys used by
         // placeStorageRetrievalRequest, but it is the best we can do in the context.
@@ -552,20 +545,18 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * the driver configuration to determine if the system supports Cancelling
      * Storage Retrieval Requests.
      *
-     * @param array  $functionConfig The Cancel function configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The Cancel function configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for cancelling requests via a form or a URL;
-     * on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function checkMethodcancelStorageRetrievalRequests(
-        $functionConfig,
-        $params
-    ) {
-        $response = false;
+        array $functionConfig,
+        array $params
+    ): array {
+        $response = [];
 
         if (
             isset($this->config->cancel_storage_retrieval_requests_enabled)
@@ -603,15 +594,14 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * the driver configuration to determine if the system supports storage
      * retrieval requests.
      *
-     * @param array  $functionConfig The ILL request configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The ILL request configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for placing requests via a form; on failure, false.
+     * @return array
      */
-    protected function checkMethodILLRequests($functionConfig, $params)
+    protected function checkMethodILLRequests(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         // $params doesn't include all of the keys used by
         // placeILLRequest, but it is the best we can do in the context.
@@ -641,18 +631,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * the driver configuration to determine if the system supports Cancelling
      * ILL Requests.
      *
-     * @param array  $functionConfig The Cancel function configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The Cancel function configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for cancelling requests via a form or a URL;
-     * on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodcancelILLRequests($functionConfig, $params)
+    protected function checkMethodcancelILLRequests(array $functionConfig, array $params): array
     {
-        $response = false;
+        $response = [];
 
         if (
             isset($this->config->cancel_ill_requests_enabled)
@@ -693,50 +681,48 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * @param array $functionConfig The password change configuration values
      * @param array $params         Patron data
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values either for cancelling requests via a form or a URL;
-     * on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodchangePassword($functionConfig, $params)
+    protected function checkMethodchangePassword(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('changePassword', [$params ?: []])) {
             return ['function' => 'changePassword'];
         }
-        return false;
+        return [];
     }
 
     /**
      * Check if initiating of password recovery is supported.
      *
-     * @param array  $functionConfig Function configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig Function configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return array|false
+     * @return array
      */
-    protected function checkMethodgetPasswordRecoveryData($functionConfig, $params)
+    protected function checkMethodgetPasswordRecoveryData(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('getPasswordRecoveryData', [$params ?: []])) {
             return $functionConfig;
         }
-        return false;
+        return [];
     }
 
     /**
      * Check if password recovery is supported.
      *
-     * @param array  $functionConfig Function configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig Function configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return array|false
+     * @return array
      */
-    protected function checkMethodresetPassword($functionConfig, $params)
+    protected function checkMethodresetPassword(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('resetPassword', [$params ?: []])) {
             return $functionConfig;
         }
-        return false;
+        return [];
     }
 
     /**
@@ -749,17 +735,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * @param array $functionConfig Function configuration
      * @param array $params         Patron data
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodgetMyTransactions($functionConfig, $params)
+    protected function checkMethodgetMyTransactions(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('getMyTransactions', [$params ?: []])) {
             return $functionConfig;
         }
-        return false;
+        return [];
     }
 
     /**
@@ -772,17 +757,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * @param array $functionConfig Function configuration
      * @param array $params         Patron data
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodgetMyTransactionHistory($functionConfig, $params)
+    protected function checkMethodgetMyTransactionHistory(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('getMyTransactionHistory', [$params ?: []])) {
             return $functionConfig;
         }
-        return false;
+        return [];
     }
 
     /**
@@ -795,17 +779,16 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * @param array $functionConfig Function configuration
      * @param array $params         Patron data
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodpurgeTransactionHistory($functionConfig, $params)
+    protected function checkMethodpurgeTransactionHistory(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('purgeTransactionHistory', [$params ?: []])) {
             return $functionConfig;
         }
-        return false;
+        return [];
     }
 
     /**
@@ -815,15 +798,14 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      * the driver configuration to determine if the system supports patron login.
      * It is currently assumed that all drivers do.
      *
-     * @param array  $functionConfig The patronLogin configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig The patronLogin configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with specific function keys
-     * and values for login; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodpatronLogin($functionConfig, $params)
+    protected function checkMethodpatronLogin(array $functionConfig, array $params): array
     {
         return $functionConfig;
     }
@@ -831,19 +813,19 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
     /**
      * Check if online payment is supported.
      *
-     * @param array  $functionConfig Function configuration values
-     * @param ?array $params         An array of function-specific params (or null)
+     * @param array $functionConfig Function configuration values
+     * @param array $params         An array of function-specific params (or null)
      *
-     * @return mixed On success, an associative array with the function name; on failure, false.
+     * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    protected function checkMethodregisterPayment($functionConfig, $params)
+    protected function checkMethodregisterPayment(array $functionConfig, array $params): array
     {
         if ($this->checkCapability('registerPayment', [$params ?: []])) {
             return ['function' => 'registerPayment'];
         }
-        return false;
+        return [];
     }
 
     /**
@@ -1129,15 +1111,15 @@ class Connection implements TranslatorAwareInterface, LoggerAwareInterface
      *
      * @param array $patron Patron data
      *
-     * @return bool|array Password policy array or false if unsupported
+     * @return array Password policy array (empty if unsupported)
      */
-    public function getPasswordPolicy($patron)
+    public function getPasswordPolicy(array $patron): array
     {
         return $this->checkCapability(
             'getConfig',
             ['changePassword', compact('patron')]
         ) ? $this->getDriver()->getConfig('changePassword', compact('patron'))
-            : false;
+            : [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Aleph.php
@@ -1559,16 +1559,16 @@ class Aleph extends AbstractBase implements
      * Public Function which retrieves historic loan, renew, hold and cancel
      * settings from the driver ini file.
      *
-     * @param string $func   The name of the feature to be checked
-     * @param array  $params Optional feature-specific parameters (array)
+     * @param string $function The name of the feature to be checked
+     * @param array  $params   Optional feature-specific parameters (array)
      *
      * @return array An array with key-value pairs.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($func, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        if ($func == 'Holds') {
+        if ($function == 'Holds') {
             $holdsConfig = $this->config['Holds'] ?? [];
             $defaults = [
                 'HMACKeys' => 'id:item_id',
@@ -1576,9 +1576,9 @@ class Aleph extends AbstractBase implements
                 'defaultRequiredDate' => '0:1:0',
             ];
             return $holdsConfig + $defaults;
-        } elseif ('getMyTransactionHistory' === $func) {
+        } elseif ('getMyTransactionHistory' === $function) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             return [
                 'max_results' => 10000,

--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1405,7 +1405,7 @@ class Alma extends AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ($function == 'patronLogin') {
             return [
@@ -1435,7 +1435,7 @@ class Alma extends AbstractBase implements
                 'default_sort' => 'due asc',
             ];
         } else {
-            $functionConfig = false;
+            $functionConfig = [];
         }
 
         return $functionConfig;

--- a/module/VuFind/src/VuFind/ILS/Driver/ComposedDriver.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/ComposedDriver.php
@@ -296,7 +296,7 @@ class ComposedDriver extends AbstractMultiDriver
      *
      * @return array An array with key-value pairs.
      */
-    public function getConfig($function, $params = null)
+    public function getConfig(string $function, array $params = []): array
     {
         return $this->defaultCall('getConfig', func_get_args());
     }

--- a/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/DAIA.php
@@ -233,9 +233,9 @@ class DAIA extends AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Demo.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Demo.php
@@ -2851,11 +2851,11 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
      * @param string $function The name of the feature to be checked
      * @param array  $params   Optional feature-specific parameters (array)
      *
-     * @return array|false An array with key-value pairs.
+     * @return array An array with key-value pairs.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         $this->checkIntermittentFailure();
         if ($function == 'Holds') {
@@ -2900,7 +2900,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         }
         if ($function == 'getMyTransactionHistory') {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             $config = [
                 'sort' => [
@@ -2943,7 +2943,7 @@ class Demo extends AbstractBase implements \VuFind\I18n\HasSorterInterface
         }
         if ('getPasswordRecoveryData' === $function || 'resetPassword' === $function) {
             $config = $this->config['PasswordRecovery'] ?? [];
-            return ($config['enabled'] ?? false) ? $config : false;
+            return ($config['enabled'] ?? false) ? $config : [];
         }
         if ($function == 'OnlinePayment') {
             return $this->config['OnlinePayment'] ?? [];

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -772,13 +772,13 @@ class Folio extends AbstractAPI implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         $key = match ($function) {
             'getMyTransactions' => 'Loans',
             default => $function
         };
-        return $this->config[$key] ?? false;
+        return $this->config[$key] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/GeniePlus.php
@@ -439,7 +439,7 @@ class GeniePlus extends AbstractAPI
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ('getMyTransactions' === $function) {
             return $this->config['Transactions'] ?? [
@@ -447,7 +447,7 @@ class GeniePlus extends AbstractAPI
             ];
         }
 
-        return false;
+        return [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/HorizonXMLAPI.php
@@ -121,10 +121,9 @@ class HorizonXMLAPI extends Horizon implements \VuFindHttp\HttpServiceAwareInter
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        $functionConfig = $this->config[$function] ?? false;
-        return $functionConfig;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Koha.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Koha.php
@@ -796,11 +796,11 @@ class Koha extends AbstractBase
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ('getMyTransactionHistory' === $function) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             return [
                 'max_results' => 100,
@@ -815,6 +815,6 @@ class Koha extends AbstractBase
                 'default_sort' => 'checkout desc',
             ];
         }
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 }

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaILSDI.php
@@ -541,11 +541,11 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ('getMyTransactionHistory' === $function) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             return [
                 'max_results' => 100,
@@ -560,7 +560,7 @@ class KohaILSDI extends AbstractBase implements HttpServiceAwareInterface, Logge
                 'default_sort' => 'checkout desc',
             ];
         }
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -1932,11 +1932,11 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ('getMyTransactionHistory' === $function) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             $limit = $this->config['TransactionHistory']['max_page_size'] ?? 100;
             return [
@@ -1981,10 +1981,10 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         }
         if ('getPasswordRecoveryData' === $function || 'resetPassword' === $function) {
             $config = $this->config['PasswordRecovery'] ?? [];
-            return ($config['enabled'] ?? false) ? $config : false;
+            return ($config['enabled'] ?? false) ? $config : [];
         }
 
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/MultiBackend.php
@@ -958,7 +958,7 @@ class MultiBackend extends AbstractMultiDriver
      *
      * @return array An array with key-value pairs.
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         $source = null;
         if (!empty($params)) {

--- a/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/NoILS.php
@@ -91,9 +91,9 @@ class NoILS extends AbstractBase implements TranslatorAwareInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Polaris.php
@@ -350,10 +350,9 @@ class Polaris extends AbstractBase implements \VuFindHttp\HttpServiceAwareInterf
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        $functionConfig = $this->config[$function] ?? false;
-        return $functionConfig;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/SierraRest.php
@@ -1982,7 +1982,7 @@ class SierraRest extends AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ('getMyTransactions' === $function) {
             return [
@@ -1991,7 +1991,7 @@ class SierraRest extends AbstractBase implements
         }
         if ('getMyTransactionHistory' === $function) {
             if (empty($this->config['TransactionHistory']['enabled'])) {
-                return false;
+                return [];
             }
             return [
                 'max_results' => 100,
@@ -2006,7 +2006,7 @@ class SierraRest extends AbstractBase implements
         }
         if ('getPasswordRecoveryData' === $function || 'resetPassword' === $function) {
             $config = $this->config['PasswordRecovery'] ?? [];
-            return ($config['enabled'] ?? false) ? $config : false;
+            return ($config['enabled'] ?? false) ? $config : [];
         }
         if ('OnlinePayment' === $function) {
             $result = $this->config['OnlinePayment'] ?? [];
@@ -2015,7 +2015,7 @@ class SierraRest extends AbstractBase implements
             return $result;
         }
 
-        return $this->config[$function] ?? false;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1493,10 +1493,9 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        $functionConfig = $this->config[$function] ?? false;
-        return $functionConfig;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Unicorn.php
@@ -148,10 +148,9 @@ class Unicorn extends AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        $functionConfig = $this->config[$function] ?? false;
-        return $functionConfig;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -315,11 +315,9 @@ class VoyagerRestful extends Voyager implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
-        $functionConfig = $this->config[$function] ?? false;
-
-        return $functionConfig;
+        return $this->config[$function] ?? [];
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/XCNCIP2.php
@@ -1569,11 +1569,11 @@ class XCNCIP2 extends AbstractBase implements
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = [])
+    public function getConfig(string $function, array $params = []): array
     {
         if ($function == 'Holds') {
             $holdsConfig = $this->config['Holds'] ?? [];
-            $extraHoldFields = empty($this->getPickUpLocations(null))
+            $extraHoldFields = empty($this->getPickUpLocations([]))
                 ? 'comments:requiredByDate'
                 : 'comments:pickUpLocation:requiredByDate';
             $defaults =  [
@@ -1586,7 +1586,7 @@ class XCNCIP2 extends AbstractBase implements
         }
         if ($function == 'StorageRetrievalRequests') {
             $config = $this->config['StorageRetrievalRequests'] ?? [];
-            $extraFields = empty($this->getPickUpLocations(null))
+            $extraFields = empty($this->getPickUpLocations([]))
                 ? 'comments:requiredByDate:item-issue'
                 : 'comments:pickUpLocation:requiredByDate:item-issue';
             $defaults =  [

--- a/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
+++ b/module/VuFind/src/VuFind/ILS/Logic/TitleHolds.php
@@ -220,7 +220,7 @@ class TitleHolds
             compact('id', 'patron')
         );
 
-        if ($checkHolds != false) {
+        if ($checkHolds) {
             if ($type == 'always') {
                 $addlink = true;
             } elseif ($type == 'availability') {

--- a/module/VuFind/src/VuFind/Navigation/AccountMenu.php
+++ b/module/VuFind/src/VuFind/Navigation/AccountMenu.php
@@ -171,83 +171,83 @@ class AccountMenu extends AbstractMenu
                   route: myresearch-favorites
                   icon: user-favorites
                   checkMethod: checkFavorites
-            
+
                 - name: checkedout
                   label: Checked Out Items
                   route: myresearch-checkedout
                   icon: user-checked-out
                   status: true
                   checkMethod: checkCheckedout
-            
+
                 - name: historicloans
                   label: Loan History
                   route: checkouts-history
                   icon: user-loan-history
                   checkMethod: checkHistoricloans
-            
+
                 - name: holds
                   label: Holds and Recalls
                   route: holds-list
                   icon: user-holds
                   status: true
                   checkMethod: checkHolds
-            
+
                 - name: storageRetrievalRequests
                   label: Storage Retrieval Requests
                   route: myresearch-storageretrievalrequests
                   icon: user-storage-retrievals
                   status: true
                   checkMethod: checkStorageRetrievalRequests
-            
+
                 - name: ILLRequests
                   label: Interlibrary Loan Requests
                   route: myresearch-illrequests
                   icon: user-ill-requests
                   status: true
                   checkMethod: checkILLRequests
-            
+
                 - name: fines
                   label: Fines
                   route: myresearch-fines
                   status: true
                   checkMethod: checkFines
                   iconMethod: finesIcon
-            
+
                 - name: profile
                   label: Profile
                   route: myresearch-profile
                   icon: profile
-            
+
                 - name: librarycards
                   label: Library Cards
                   route: librarycards-home
                   icon: barcode
                   checkMethod: checkLibraryCards
-            
+
                 - name: dgcontent
                   label: Overdrive Content
                   route: overdrive-mycontent
                   icon: overdrive
                   checkMethod: checkOverdrive
-            
+
                 - name: history
                   label: Search History
                   route: search-history
                   icon: search
                   checkMethod: checkHistory
-            
+
                 - name: usercontent
                   label: user_content
                   route: myresearch-usercontent
                   icon: user-content
                   checkMethod: checkUserContent
-            
+
                 - name: logout
                   label: Log Out
                   route: myresearch-logout
                   icon: sign-out
                   checkMethod: checkLogout
-            
+
             Lists:
               label: Your Lists
               id: acc-menu-lists-header
@@ -255,7 +255,7 @@ class AccountMenu extends AbstractMenu
               MenuItems:
                 - template: myresearch/menu-mylists.phtml
                   icon: user-list
-            
+
                 - name: newlist
                   label: Create a List
                   route: editList
@@ -429,7 +429,7 @@ class AccountMenu extends AbstractMenu
     protected function checkIlsFunction(string $function): bool
     {
         return $this->isIlsOnline()
-            && $this->ilsConnection->checkFunction($function, $this->getCapabilityParams());
+            && !empty($this->ilsConnection->checkFunction($function, $this->getCapabilityParams()));
     }
 
     /**

--- a/module/VuFind/src/VuFindTest/Unit/AbstractSectionTestCase.php
+++ b/module/VuFind/src/VuFindTest/Unit/AbstractSectionTestCase.php
@@ -254,12 +254,12 @@ abstract class AbstractSectionTestCase extends \PHPUnit\Framework\TestCase
                 };
             });
         $mockConnection->method('checkFunction')
-            ->willReturnCallback(function (string $function) use ($checkMethods) {
+            ->willReturnCallback(function (string $function) use ($checkMethods): array {
                 return match ($function) {
                     'getMyTransactionHistory' => $checkMethods['checkHistoricloans'] ?? true,
                     'StorageRetrievalRequests' => $checkMethods['checkStorageRetrievalRequests'] ?? true,
                     'ILLRequests' => $checkMethods['checkILLRequests'] ?? true,
-                };
+                } ? ['test' => true] : [];
             });
         $container->set(Connection::class, $mockConnection);
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/LoginHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/LoginHelperTest.php
@@ -492,7 +492,6 @@ class LoginHelperTest extends TestCase
      */
     public static function getILSLoginMethodProvider(): Generator
     {
-        yield 'defaults (null configuration)' => ['password', null, ''];
         yield 'defaults (empty array configuration)' => ['password', [], ''];
         yield 'non-default with empty target' => ['foo', ['loginMethod' => 'foo'], ''];
         yield 'non-default with non-empty target' => ['foo', ['loginMethod' => 'foo'], 'bar'];
@@ -502,13 +501,13 @@ class LoginHelperTest extends TestCase
      * Test getting the ILS login method.
      *
      * @param string $expectedMethod    Expected return value of getILSLoginMethod()
-     * @param ?array $patronLoginConfig Configuration for patronLogin method
+     * @param array  $patronLoginConfig Configuration for patronLogin method
      * @param string $target            Target to pass to getILSLoginMethod()
      *
      * @return void
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('getILSLoginMethodProvider')]
-    public function testGetILSLoginMethod(string $expectedMethod, ?array $patronLoginConfig, string $target): void
+    public function testGetILSLoginMethod(string $expectedMethod, array $patronLoginConfig, string $target): void
     {
         $ils = $this->getIls($patronLoginConfig, $target);
         $helper = $this->getAutowiredObject(ActionHelperLoginHelper::class, [Connection::class => $ils]);
@@ -518,12 +517,12 @@ class LoginHelperTest extends TestCase
     /**
      * Get mock ILS connection.
      *
-     * @param ?array $patronLoginConfig Configuration for patronLogin method
+     * @param array  $patronLoginConfig Configuration for patronLogin method
      * @param string $target            Target to pass to getILSLoginMethod()
      *
      * @return MockObject&Connection
      */
-    protected function getIls(?array $patronLoginConfig, string $target): Connection
+    protected function getIls(array $patronLoginConfig, string $target): Connection
     {
         $ils = $this->createMock(Connection::class);
         $ils->expects($this->once())

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Auth/MultiILSTest.php
@@ -259,7 +259,7 @@ class MultiILSTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $driver->method('getLoginDrivers')->willReturn(['ils1']);
         $driver->method('supportsMethod')->willReturn(true);
-        $driver->method('getConfig')->willReturn(new \VuFind\Config\Config([]));
+        $driver->method('getConfig')->willReturn([]);
 
         return $driver;
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiDriverTest/ILSMockTrait.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/MultiDriverTest/ILSMockTrait.php
@@ -206,7 +206,7 @@ trait ILSMockTrait
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function getConfig($function, $params = null)
+    public function getConfig(string $function, array $params = []): array
     {
         return [];
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/NoILSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/NoILSTest.php
@@ -138,6 +138,6 @@ class NoILSTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals([], $this->driver->getPurchaseHistory('foo'));
         $this->assertEquals(null, $this->driver->patronLogin('foo', 'bar'));
-        $this->assertFalse($this->driver->getConfig('Holds'));
+        $this->assertEmpty($this->driver->getConfig('Holds'));
     }
 }


### PR DESCRIPTION
This is part of https://openlibraryfoundation.atlassian.net/browse/VUFIND-1791

TODO
- [x] Update changelog when merging (Authentication modules have had explicit return types added to the supportsPasswordChange and supportsPasswordRecovery methods.
ILS drivers have had types added to the getConfig method signature, with false return values replaced by empty arrays.
Signature changes have been made to the getPasswordPolicy, checkFunction and checkMethod* methods of \VuFind\ILS\Connection.)