### PR TITLE
Handle when no facet is passed in to addFacet

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -50,6 +50,7 @@ use function intval;
 use function is_array;
 use function is_callable;
 use function is_object;
+use function strlen;
 
 /**
  * Abstract parameters search model.
@@ -1035,14 +1036,15 @@ class Params
      */
     public function addFacet($newField, $newAlias = null, $ored = false)
     {
-        if (!empty($newField)) {
-            if ($newAlias == null) {
-                $newAlias = $newField;
-            }
-            $this->facetConfig[$newField] = $newAlias;
-            if ($ored) {
-                $this->orFacets[] = $newField;
-            }
+        if (strlen($newField) == 0) {
+            throw new \Exception('Can not add facet when no field provided');
+        }
+        if ($newAlias == null) {
+            $newAlias = $newField;
+        }
+        $this->facetConfig[$newField] = $newAlias;
+        if ($ored) {
+            $this->orFacets[] = $newField;
         }
     }
 

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1037,7 +1037,7 @@ class Params
     public function addFacet($newField, $newAlias = null, $ored = false)
     {
         if (strlen($newField) == 0) {
-            throw new \Exception('Can not add facet when no field provided');
+            throw new \VuFind\Exception\BadRequest('Can not add facet when no field provided');
         }
         if ($newAlias == null) {
             $newAlias = $newField;

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1035,7 +1035,7 @@ class Params
      */
     public function addFacet($newField, $newAlias = null, $ored = false)
     {
-        if (!empty($newField) {
+        if (!empty($newField)) {
             if ($newAlias == null) {
                 $newAlias = $newField;
             }

--- a/module/VuFind/src/VuFind/Search/Base/Params.php
+++ b/module/VuFind/src/VuFind/Search/Base/Params.php
@@ -1035,12 +1035,14 @@ class Params
      */
     public function addFacet($newField, $newAlias = null, $ored = false)
     {
-        if ($newAlias == null) {
-            $newAlias = $newField;
-        }
-        $this->facetConfig[$newField] = $newAlias;
-        if ($ored) {
-            $this->orFacets[] = $newField;
+        if (!empty($newField) {
+            if ($newAlias == null) {
+                $newAlias = $newField;
+            }
+            $this->facetConfig[$newField] = $newAlias;
+            if ($ored) {
+                $this->orFacets[] = $newField;
+            }
         }
     }
 


### PR DESCRIPTION
We ran into this scenario where no `facet` parameter is passed when [facetListAction](https://github.com/vufind-org/vufind/blob/8b6deabf552e1d72a3b28d97266f21782940926d/module/VuFind/src/VuFind/Controller/AbstractSearch.php#L889) is called which results in `facet.field=` being passed to Solr, and will return a 400 Bad Request error. We suspect this is bots since I can't see how a normal user would do that through the interface, but even still it seems like it is safer to handle it in the function to not add a facet that is empty.