### PR TITLE
ExternalSearch recommendations: allow non-default query param name.

### DIFF
--- a/config/vufind/searches.ini
+++ b/config/vufind/searches.ini
@@ -237,9 +237,9 @@ callnumber-sort = sort_callnumber
 author = sort_author
 title = sort_title
 
-; This section allows you to override existing special sort type aliases like 
-; "year", "author", "title", etc. or to define your own. It is necessary 
-; to specify xxx[field] - option either with index field name or user sort function. 
+; This section allows you to override existing special sort type aliases like
+; "year", "author", "title", etc. or to define your own. It is necessary
+; to specify xxx[field] - option either with index field name or user sort function.
 ; Default sort direction is 'desc', but it could be overridden by xxx[order].
 [LocalSortDefinitions]
 ;title[field] = title_sort
@@ -527,12 +527,13 @@ pattern[sort_first_indexed_desc] = "^first_indexed desc$"
 ;       to true if you want a search query that consists only of a DOI to redirect
 ;       automatically to the DOI resolver, or set it to false to only display a
 ;       message with a link. (Default is "true").
-; ExternalSearch:[link label]:[url template]
+; ExternalSearch:[link label]:[url template]:[search query parameter]
 ;       Display a link to an external search system. The contents of the <a> tag
 ;       will be [link label] (which will be run through the translator -- use a
 ;       translation string if you need to display a string containing a colon).
 ;       The href will be [url template] with %%lookfor%% replaced with the current
-;       search's lookfor parameter. If you omit the %%lookfor%% placeholder, the
+;       search's lookfor parameter (or the specified named [search query parameter],
+;       if you do not omit that value). If you omit the %%lookfor%% placeholder, the
 ;       search terms will simply be appended to the end of the URL template.
 ; Libraryh3lp:[type]:[id]:[skin]
 ;       Display a chat box for the Libraryh3lp service. [type] indicates the type

--- a/module/VuFind/src/VuFind/Recommend/ExternalSearch.php
+++ b/module/VuFind/src/VuFind/Recommend/ExternalSearch.php
@@ -62,6 +62,13 @@ class ExternalSearch implements RecommendInterface
     protected $lookfor;
 
     /**
+     * Name of query parameter containing search query.
+     *
+     * @var string
+     */
+    protected string $lookforParam = 'lookfor';
+
+    /**
      * Store the configuration of the recommendation module.
      *
      * @param string $settingsStr Settings from searches.ini.
@@ -71,9 +78,16 @@ class ExternalSearch implements RecommendInterface
     public function setConfig($settingsStr)
     {
         // Parse the settings:
-        $settings = explode(':', $settingsStr, 2);
-        $this->linkText = $settings[0] ?? null;
-        $this->template = $settings[1] ?? null;
+        $settings = explode(':', $settingsStr);
+        $this->linkText = array_shift($settings) ?? '';
+        $this->template = array_shift($settings) ?? '';
+        // Since URL template likely includes a colon because of ://, we need to reassemble accordingly:
+        $next = array_shift($settings);
+        if (str_starts_with($next ?? '', '//')) {
+            $this->template .= ':' . $next;
+            $next = array_shift($settings);
+        }
+        $this->lookforParam = $next ?? $this->lookforParam;
     }
 
     /**
@@ -91,7 +105,7 @@ class ExternalSearch implements RecommendInterface
      */
     public function init($params, $request)
     {
-        $this->lookfor = $request->get('lookfor');
+        $this->lookfor = $request->get($this->lookforParam);
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ExternalSearchTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ExternalSearchTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\Recommend;
 
+use Generator;
 use VuFind\Recommend\ExternalSearch;
 
 /**
@@ -43,21 +44,56 @@ use VuFind\Recommend\ExternalSearch;
 class ExternalSearchTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Data provider for.
+     *
+     * @return Generator
+     */
+    public static function dataProvider(): Generator
+    {
+        yield 'default concatenation' => [
+            'my label',
+            'http://foo?q=',
+            'beep',
+            'http://foo?q=beep',
+        ];
+        yield 'template behavior' => [
+            'my label',
+            'http://foo?q=%%lookfor%%&z=xyzzy',
+            'beep',
+            'http://foo?q=beep&z=xyzzy',
+        ];
+        yield 'non-default query parameter' => [
+            'my label',
+            'http://foo?q=%%lookfor%%&z=xyzzy',
+            'beep',
+            'http://foo?q=beep&z=xyzzy',
+            'foo',
+        ];
+    }
+
+    /**
      * Run a test scenario.
      *
-     * @param string $label       Link text
-     * @param string $template    Link template
-     * @param string $lookfor     Search query
-     * @param string $expectedUrl Expected URL
+     * @param string  $label        Link text
+     * @param string  $template     Link template
+     * @param string  $lookfor      Search query
+     * @param string  $expectedUrl  Expected URL
+     * @param ?string $lookforParam Name of query parameter holding $lookfor value (null for default)
      *
      * @return void
      */
-    protected function runProcedure($label, $template, $lookfor, $expectedUrl)
-    {
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
+    public function testRecommend(
+        string $label,
+        string $template,
+        string $lookfor,
+        string $expectedUrl,
+        ?string $lookforParam = null
+    ): void {
         $rec = new ExternalSearch();
-        $rec->setConfig($label . ':' . $template);
+        $rec->setConfig($label . ':' . $template . ($lookforParam ? ":$lookforParam" : ''));
         $params = new \Laminas\Stdlib\Parameters();
-        $params->set('lookfor', $lookfor);
+        $params->set($lookforParam ?? 'lookfor', $lookfor);
         $rec->init(
             $this->createMock(\VuFind\Search\Solr\Params::class),
             $params
@@ -67,35 +103,5 @@ class ExternalSearchTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertEquals($label, $rec->getLinkText());
         $this->assertEquals($expectedUrl, $rec->getUrl());
-    }
-
-    /**
-     * Test concatenation behavior.
-     *
-     * @return void
-     */
-    public function testDefaultConcatenation()
-    {
-        $this->runProcedure(
-            'my label',
-            'http://foo?q=',
-            'beep',
-            'http://foo?q=beep'
-        );
-    }
-
-    /**
-     * Test template insertion behavior.
-     *
-     * @return void
-     */
-    public function testTemplateBehavior()
-    {
-        $this->runProcedure(
-            'my label',
-            'http://foo?q=%%lookfor%%&z=xyzzy',
-            'beep',
-            'http://foo?q=beep&z=xyzzy'
-        );
     }
 }


### PR DESCRIPTION
The ExternalSearch recommendation module currently does not work correctly if embedded in the Author module, because it is hard-coded to expect a `lookfor` parameter. This PR makes it possible to configure it to use a different parameter like `author` when needed.