### PR TITLE
Restore missing record numbers.

### DIFF
--- a/themes/bootstrap5/templates/search/list-list.phtml
+++ b/themes/bootstrap5/templates/search/list-list.phtml
@@ -13,6 +13,10 @@
     <li<?php if (empty($this->excludeResultIds)): ?> id="result<?=$i?>"<?php endif; ?> class="result<?=$current->supportsAjaxStatus() ? ' ajaxItem' : ''?>" data-record-number="<?=$this->escapeHtmlAttr($recordNumber)?>">
       <?php if ($showCheckboxes): ?>
         <?=$this->record($current)->getCheckbox('', 'search-cart-form', $recordNumber)?>
+      <?php else: ?>
+        <div class="record-number">
+          <?=$recordNumber ?>
+        </div>
       <?php endif; ?>
       <?=$this->record($current)->getSearchResult('list', $this->results)?>
     </li>


### PR DESCRIPTION
#4677 caused record numbering to be removed for scenarios where checkboxes are not visible; this PR restores the missing numbers.