### PR TITLE
Fix null string error with deactivated user tags when adding a title from one favorite list to another

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -959,7 +959,7 @@ class MyResearchController extends AbstractBase
         $favorites = $this->getService(\VuFind\Favorites\FavoritesService::class);
         $didSomething = false;
         foreach ($lists as $list) {
-            $tags = $this->params()->fromPost('tags' . $list) ?? '';
+            $tags = $this->params()->fromPost('tags' . $list, '');
             $favorites->save(
                 [
                     'list'  => $list,

--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -959,7 +959,7 @@ class MyResearchController extends AbstractBase
         $favorites = $this->getService(\VuFind\Favorites\FavoritesService::class);
         $didSomething = false;
         foreach ($lists as $list) {
-            $tags = $this->params()->fromPost('tags' . $list);
+            $tags = $this->params()->fromPost('tags' . $list) ?? '';
             $favorites->save(
                 [
                     'list'  => $list,


### PR DESCRIPTION
When navigating to MyResearch/Edit?id=<id>&source=<source>&list_id=<listId> to add a saved record to another list, clicking "Save" throws:

Whoops\Exception\ErrorException: trim(): Passing null to parameter #1 ($string) of type string is deprecated

at TagsService.php:86 via MyResearchController::processEditSubmit().

Root Cause:
trim(null) is deprecated in PHP 8.1+.

When Social.tags = disabled is set in config.ini, the edit template (myresearch/edit.phtml) does not render the <input name="tags{listId}"> field (guarded by usertags()->getMode() !== 'disabled'). However, the corresponding <input type="hidden" name="lists[]"> is rendered unconditionally. On form submission, processEditSubmit() iterates over the posted lists[] values and calls:

$tags = $this->params()->fromPost('tags' . $list);  // returns null — field not in POST
$tagsService->parse($tags);                          // calls trim(null) → deprecation error