### PR TITLE
Strengthened types in signature of TagsService::parse()

### DIFF
--- a/module/VuFind/src/VuFind/Controller/MyResearchController.php
+++ b/module/VuFind/src/VuFind/Controller/MyResearchController.php
@@ -966,7 +966,7 @@ class MyResearchController extends AbstractBase
         $favorites = $this->getService(\VuFind\Favorites\FavoritesService::class);
         $didSomething = false;
         foreach ($lists as $list) {
-            $tags = $this->params()->fromPost('tags' . $list);
+            $tags = $this->params()->fromPost('tags' . $list) ?? '';
             $favorites->save(
                 [
                     'list'  => $list,

--- a/module/VuFind/src/VuFind/Tags/TagsService.php
+++ b/module/VuFind/src/VuFind/Tags/TagsService.php
@@ -81,7 +81,7 @@ class TagsService
      *
      * @return array
      */
-    public function parse($tags)
+    public function parse(string $tags): array
     {
         preg_match_all('/"[^"]*"|[^ ]+/', trim($tags), $words);
         $result = [];


### PR DESCRIPTION
Same PR like #5221 , but with added signature change for 12.0 release to prevent null tags in parse()