### PR TITLE
Improve EDS AccessLevel handling

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -271,7 +271,7 @@ class EDS extends DefaultRecord
     }
 
     /**
-     * Check whether access to the record is restricted
+     * Check whether access to the record is restricted.
      *
      * @return bool
      */
@@ -282,7 +282,7 @@ class EDS extends DefaultRecord
     }
 
     /**
-     * Check whether the record is a placeholder
+     * Check whether the record is a placeholder.
      *
      * @return bool
      */

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -271,6 +271,27 @@ class EDS extends DefaultRecord
     }
 
     /**
+     * Check whether access to the record is restricted
+     *
+     * @return bool
+     */
+    public function isRestrictedView(): bool
+    {
+        $accessLevel = $this->getAccessLevel();
+        return !empty($accessLevel) && $accessLevel !== '3';
+    }
+
+    /**
+     * Check whether the record is a placeholder
+     *
+     * @return bool
+     */
+    public function isPlaceholder(): bool
+    {
+        return $this->getAccessLevel() === '1';
+    }
+
+    /**
      * Get the authors of the record.
      *
      * @return string

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -249,7 +249,7 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     public function testIsRestrictedView(): void
     {
         $driver = $this->getDriver('valid-eds-record');
-        $this->assertEquals(false, $driver->isRestrictedView());
+        $this->assertFalse($driver->isRestrictedView());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -242,6 +242,17 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test isRestrictedView for a record.
+     *
+     * @return void
+     */
+    public function testIsRestrictedView(): void
+    {
+        $driver = $this->getDriver('valid-eds-record');
+        $this->assertEquals(false, $driver->isRestrictedView());
+    }
+
+    /**
      * Test getItemsAuthors for a record.
      *
      * @return void

--- a/themes/bootstrap5/templates/RecordDriver/EDS/core-fields.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/core-fields.phtml
@@ -2,8 +2,7 @@
   $formatter = $this->recordDataFormatter($this->driver);
   $coreFields = $formatter->getData($formatter->getDefaults($this->defaults ?? 'core'));
   $dbLabel = $this->driver->getDbLabel();
-  $accessLevel = $this->driver->getAccessLevel();
-  $restrictedView = empty($accessLevel) ? false : true;
+  $restrictedView = $this->driver->isRestrictedView();
   $searchOptions = $this->searchOptions($this->driver->getSourceIdentifier());
 ?>
 <?php if ($searchOptions->showRestrictedViewWarning() && $restrictedView): ?>

--- a/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
@@ -1,7 +1,5 @@
 <?php
   $this->assetManager()->appendStyleLink('EDS.css');
-  $accessLevel = $this->driver->getAccessLevel();
-  $restrictedView = empty($accessLevel) ? false : true;
   $recordLinker = $this->recordLinker($this->results);
   $largeImage = $this->record($this->driver)->getThumbnail('large');
   $linkAttributes = $largeImage ? ['href' => $largeImage, 'data-lightbox-image' => 'true'] : [];
@@ -39,6 +37,15 @@
         $formatter = $this->recordDataFormatter($this->driver);
         $items = $formatter->getData($formatter->getDefaults('result-list'));
       ?>
+      <?php if ($this->driver->isPlaceholder()): ?>
+        <div class="resultItemLine1">
+          <p>
+            <?=$this->transEsc('This result is not displayed to guests')?>
+            <br>
+            <?=$this->render('error/loginForAccess.phtml')?>
+          </p>
+        </div>
+      <?php endif; ?>
       <?php if (!empty($items)): ?>
         <?php foreach ($items as $item): ?>
           <div class="resultItemLine1">
@@ -55,14 +62,6 @@
             <?php endif;?>
           </div>
         <?php endforeach; ?>
-      <?php elseif ($restrictedView): ?>
-        <div class="resultItemLine1">
-          <p>
-            <?=$this->transEsc('This result is not displayed to guests')?>
-            <br>
-            <?=$this->render('error/loginForAccess.phtml')?>
-          </p>
-        </div>
       <?php endif; ?>
 
       <div class="resultItemLine4 custom-links">
@@ -161,7 +160,7 @@
         <?php endforeach; ?>
       <?php endif; ?>
 
-      <?=(!$restrictedView && $this->driver->supportsCoinsOpenUrl()) ? '<span class="Z3988" aria-hidden="true" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
+      <?=(!$this->driver->isRestrictedView() && $this->driver->supportsCoinsOpenUrl()) ? '<span class="Z3988" aria-hidden="true" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>' : ''?>
     </div>
   </div>
   <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>

--- a/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EDS/result-list.phtml
@@ -46,23 +46,21 @@
           </p>
         </div>
       <?php endif; ?>
-      <?php if (!empty($items)): ?>
-        <?php foreach ($items as $item): ?>
-          <div class="resultItemLine1">
-            <?php if ('Title' == $item['label']): ?>
-              <h2>
-                <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver))?>" class="title getFull _record_link"  data-view="<?=$this->escapeHtmlAttr($this->params->getOptions()->getListViewOption())?>">
-                <?=$item['value']?> </a>
-              </h2>
-            <?php else:?>
-              <p>
-                <b><?=$this->transEsc($item['label'])?>:</b>
-                <?=$item['value']?>
-              </p>
-            <?php endif;?>
-          </div>
-        <?php endforeach; ?>
-      <?php endif; ?>
+      <?php foreach ($items as $item): ?>
+        <div class="resultItemLine1">
+          <?php if ('Title' == $item['label']): ?>
+            <h2>
+              <a href="<?=$this->escapeHtmlAttr($recordLinker->getUrl($this->driver))?>" class="title getFull _record_link"  data-view="<?=$this->escapeHtmlAttr($this->params->getOptions()->getListViewOption())?>">
+              <?=$item['value']?> </a>
+            </h2>
+          <?php else:?>
+            <p>
+              <b><?=$this->transEsc($item['label'])?>:</b>
+              <?=$item['value']?>
+            </p>
+          <?php endif;?>
+        </div>
+      <?php endforeach; ?>
 
       <div class="resultItemLine4 custom-links">
         <?php $customLinks = array_merge($this->driver->getFTCustomLinks(), $this->driver->getCustomLinks());

--- a/themes/bootstrap5/templates/RecordDriver/EPF/core-fields.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/EPF/core-fields.phtml
@@ -1,11 +1,9 @@
 <?php
   $formatter = $this->recordDataFormatter($this->driver);
   $coreFields = $formatter->getData($formatter->getDefaults($this->defaults ?? 'core'));
-  $accessLevel = $this->driver->getAccessLevel();
-  $restrictedView = empty($accessLevel) ? false : true;
   $searchOptions = $this->searchOptions($this->driver->getSourceIdentifier());
 ?>
-<?php if ($searchOptions->showRestrictedViewWarning() && $restrictedView): ?>
+<?php if ($searchOptions->showRestrictedViewWarning() && $this->driver->isRestrictedView()): ?>
   <?=$this->render('error/restrictedViewWarning.phtml')?>
 <?php endif; ?>
 <?php if (!empty($coreFields)): ?>


### PR DESCRIPTION
This PR improves the handling of EDS AccessLevels 1 (placeholder record) and 3 (full access to record).

For placeholder records the "This result is not displayed to guests" message and the login link is always displayed, before any item information that might be present. This covers the case that the database name, which is always available, is displayed in the result list (currently only the database name would be displayed). A placeholder record has no title, therefore the message and login link are displayed first.

For records with full access the restricted view warning is removed.

I would suggest to address other issues like changes to the EDS records for the unit tests or changing the handling of the show_restricted_view_warning option in separate PRs.