### PR TITLE
Fix change_tracker problems when resetting test environment.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1197,6 +1197,8 @@ ${git_status}
 
     <phingcall target="configure_install" />
     <phingcall target="setup_database" />
+    <phingcall target="importrec"><property name="filename" value="tests/data/author_relator_preload.mrc" /></phingcall>
+    <phingcall target="importrec"><property name="filename" value="tests/data/author_relators.mrc" /></phingcall>
     <phingcall target="delete_fake_records" />
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1197,6 +1197,7 @@ ${git_status}
 
     <phingcall target="configure_install" />
     <phingcall target="setup_database" />
+    <!-- We need to reload these two MARC files to repopulate the change_tracker database table -->
     <phingcall target="importrec"><property name="filename" value="tests/data/author_relator_preload.mrc" /></phingcall>
     <phingcall target="importrec"><property name="filename" value="tests/data/author_relators.mrc" /></phingcall>
     <phingcall target="delete_fake_records" />

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IdentifierLinkerTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/IdentifierLinkerTest.php
@@ -58,7 +58,10 @@ class IdentifierLinkerTest extends \VuFindTest\Integration\MinkTestCase
             ],
         );
         $session = $this->getMinkSession();
-        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=id:(0000183626-1 OR testsample1)&limit=1');
+        // Sort is important here to ensure predictable order of records; we want the identifier on page 2:
+        $session->visit(
+            $this->getVuFindUrl() . '/Search/Results?lookfor=id:(0000183626-1 OR testsample1)&limit=1&sort=author'
+        );
         $page = $session->getPage();
         $this->waitForPageLoad($page);
         $this->unfindCss($page, '.identifierLink a');


### PR DESCRIPTION
The test introduced in #5211 breaks after running the Phing `reset_setup` task due to the loss of change_tracker data. This PR adjusts the task to regenerate the necessary change tracker data as part of the reset process. It also adjusts a test that would previously fail after the reset due to a change in default record order in the Solr index.