### PR TITLE
Replace SearchSpecsReader with ConfigManager

### DIFF
--- a/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
+++ b/module/VuFind/src/VuFind/Config/SearchSpecsReader.php
@@ -37,6 +37,8 @@ namespace VuFind\Config;
  * @author   Demian Katz <demian.katz@villanova.edu>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
+ *
+ * @deprecated Use \VuFind\Config\ConfigManager instead
  */
 class SearchSpecsReader extends YamlReader
 {

--- a/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/AbstractSolrBackendFactory.php
@@ -110,11 +110,11 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
     protected string $facetConfig;
 
     /**
-     * YAML searchspecs filename.
+     * Search specs config name.
      *
      * @var string
      */
-    protected string $searchYaml;
+    protected string $searchSpecsConfig;
 
     /**
      * VuFind configuration reader.
@@ -623,7 +623,7 @@ abstract class AbstractSolrBackendFactory extends AbstractBackendFactory
      */
     protected function loadSpecs(): array
     {
-        return $this->getService(\VuFind\Config\SearchSpecsReader::class)->get($this->searchYaml);
+        return $this->getService(\VuFind\Config\ConfigManager::class)->getConfigArray($this->searchSpecsConfig);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Factory/Search2BackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/Search2BackendFactory.php
@@ -47,7 +47,7 @@ class Search2BackendFactory extends SolrDefaultBackendFactory
     {
         parent::__construct();
         $this->mainConfig = $this->searchConfig = $this->facetConfig = 'Search2';
-        $this->searchYaml = 'searchspecs2.yaml';
+        $this->searchSpecsConfig = 'searchspecs2';
     }
 
     /**

--- a/module/VuFind/src/VuFind/Search/Factory/SolrAuthBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrAuthBackendFactory.php
@@ -46,7 +46,7 @@ class SolrAuthBackendFactory extends AbstractSolrBackendFactory
     public function __construct()
     {
         $this->searchConfig = 'authority';
-        $this->searchYaml = 'authsearchspecs.yaml';
+        $this->searchSpecsConfig = 'authsearchspecs';
         $this->facetConfig = 'authority';
         $this->indexNameSetting = 'default_authority_core';
         $this->defaultIndexName = 'authority';

--- a/module/VuFind/src/VuFind/Search/Factory/SolrDefaultBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrDefaultBackendFactory.php
@@ -46,7 +46,7 @@ class SolrDefaultBackendFactory extends AbstractSolrBackendFactory
     public function __construct()
     {
         $this->searchConfig = 'searches';
-        $this->searchYaml = 'searchspecs.yaml';
+        $this->searchSpecsConfig = 'searchspecs';
         $this->facetConfig = 'facets';
         $this->defaultIndexName = 'biblio';
         $this->allowFallbackForIndexName = true;

--- a/module/VuFind/src/VuFind/Search/Factory/SolrReservesBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrReservesBackendFactory.php
@@ -47,7 +47,7 @@ class SolrReservesBackendFactory extends AbstractSolrBackendFactory
     {
         $this->defaultIndexName = 'reserves';
         $this->searchConfig = 'reserves';
-        $this->searchYaml = 'reservessearchspecs.yaml';
+        $this->searchSpecsConfig = 'reservessearchspecs';
         $this->facetConfig = 'reserves';
     }
 

--- a/module/VuFind/src/VuFind/Search/Factory/SolrWebBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SolrWebBackendFactory.php
@@ -46,7 +46,7 @@ class SolrWebBackendFactory extends AbstractSolrBackendFactory
     public function __construct()
     {
         $this->searchConfig = 'website';
-        $this->searchYaml = 'websearchspecs.yaml';
+        $this->searchSpecsConfig = 'websearchspecs';
         $this->facetConfig = 'website';
         $this->defaultIndexName = 'website';
     }


### PR DESCRIPTION
TODO:
- [x] Update changelog when merging (\VuFind\Search\Factory\AbstractSolrBackendFactory's searchYaml property has been replaced with searchSpecsConfig. VuFind\Config\SearchSpecsReader has been deprecated.)