### PR TITLE
[VUFIND-1791] Use empty arrays instead of false as default in recommendation settings

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Options.php
+++ b/module/VuFind/src/VuFind/Search/Base/Options.php
@@ -1308,7 +1308,7 @@ abstract class Options implements TranslatorAwareInterface
         ) {
             $recommend['top'] = $searchSettings['TopRecommendations'][$handler];
         } else {
-            $recommend['top'] = $searchSettings['General']['default_top_recommend'] ?? false;
+            $recommend['top'] = $searchSettings['General']['default_top_recommend'] ?? [];
         }
         if (
             null !== $handler
@@ -1316,7 +1316,7 @@ abstract class Options implements TranslatorAwareInterface
         ) {
             $recommend['side'] = $searchSettings['SideRecommendations'][$handler];
         } else {
-            $recommend['side'] = $searchSettings['General']['default_side_recommend'] ?? false;
+            $recommend['side'] = $searchSettings['General']['default_side_recommend'] ?? [];
         }
         if (
             null !== $handler
@@ -1324,7 +1324,7 @@ abstract class Options implements TranslatorAwareInterface
         ) {
             $recommend['noresults'] = $searchSettings['NoResultsRecommendations'][$handler];
         } else {
-            $recommend['noresults'] = $searchSettings['General']['default_noresults_recommend'] ?? false;
+            $recommend['noresults'] = $searchSettings['General']['default_noresults_recommend'] ?? [];
         }
 
         return $recommend;


### PR DESCRIPTION
This changes the original reason for https://openlibraryfoundation.atlassian.net/browse/VUFIND-1791. I did not find any more cases.

- [x] Resolve [VUFIND-1791](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1791) when merging
