### PR TITLE
Web crawl command: improve exception; do not fail on empty <loc> in sitemap

### DIFF
--- a/import/xsl/sitemap.xsl
+++ b/import/xsl/sitemap.xsl
@@ -9,7 +9,7 @@
         <add>
             <xsl:for-each select="//sitemap:url">
                 <!-- We can't index without a loc element containing a URI! -->
-                <xsl:if test="sitemap:loc">
+                <xsl:if test="string-length(sitemap:loc) > 0">
                     <doc>
                         <!-- Pass the URI to PHP, which will use full-text
                              extraction and generate pre-built XML output;

--- a/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/Import/WebCrawlCommand.php
@@ -364,7 +364,7 @@ class WebCrawlCommand extends Command
                     }
                 } catch (\Exception $e) {
                     if ($verbose) {
-                        $output->writeln($e::class . ': ' . $e->getMessage());
+                        $output->writeln((string)$e);
                     }
                     $retVal = false;
                 }


### PR DESCRIPTION
I ran into a problem where a malformed sitemap containing `<loc></loc>` would trigger a fatal error and break web crawling entirely. This PR improves the verbose exception display in the web crawl command to help with troubleshooting and fixes the XSLT to ignore empty locations.