### PR TITLE
Add Mink integration test for Channels record tab.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/ChannelsTest.php
@@ -455,4 +455,26 @@ class ChannelsTest extends \VuFindTest\Integration\MinkTestCase
         $this->assertCount(54, $allItems);
         $this->assertCount(54, $allIds);
     }
+
+    /**
+     * Test loading channels in the Similar Items tab.
+     *
+     * @return void
+     */
+    public function testSimilarItemsTab(): void
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Record/geo20001');
+        $page = $session->getPage();
+        // No channel entries before opening tab:
+        $this->assertCount(0, $page->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
+        // Switch to tab:
+        $this->clickCss($page, '.record-tab.channels a');
+        $this->waitForPageLoad($page);
+        // There should be one row of results:
+        $this->assertCount(6, $page->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
+        // Add more results and confirm they loaded:
+        $this->clickCss($page, '.channel-load-more-btn');
+        $this->assertCount(12, $page->findAll('css', 'li.channel-item:not(.hidden-batch-item)'));
+    }
 }


### PR DESCRIPTION
We received a report that the "more results" button was not working correctly in the Channels tab. This PR adds a Mink test to cover the functionality. However, the test is passing, so I have been unable to find a problem.

I created this test against the release-11.0 branch in case we found a bug that would justify an 11.0.4 release; however, since we have not yet discovered such a problem, I'm leaving this pointed at the dev branch and release 11.1 for now. It can be easily retargeted if we determine that there is a need.