### PR TITLE
Update contentsecuritypolicy.ini rules for Google Tag Manager and Google Analytics

### DIFF
--- a/config/vufind/contentsecuritypolicy.ini
+++ b/config/vufind/contentsecuritypolicy.ini
@@ -26,34 +26,56 @@ use_nonce = true
 ; https://vufind.org/wiki/administration:security:content_security_policy
 [Directives]
 ; default of 'self' with 'none' on child, object, prefetch allows SVG requests.
+
 default-src[] = "'self'"
+
 child-src[] = "'none'"
+
 ; If you are using Cloudflare Turnstile protection, uncomment the line below.
 ;frame-src[] = 'https://challenges.cloudflare.com'
+
 object-src[] = "'none'"
 ; 'strict-dynamic' allows any trusted script to load other scripts with a hash.
 ;   Safari 15.3 and earlier does not support this feature. Since these browser
 ;   versions constitute a significant portion of users, especially mobile users,
 ;   'strict-dynamic' is disabled by default.
 ;   https://caniuse.com/mdn-http_headers_content-security-policy_strict-dynamic
+
 ;script-src[] = "'strict-dynamic'"
 ; backwards compatible to CSP 2
 script-src[] = "http:"
 script-src[] = "https:"
 ;script-src-elem[] = "'self'"
+
 connect-src[] = "'self'"
+; If you are using Google Tag Manager, uncomment the lines below
+;connect-src[] = "https://*.googletagmanager.com"
+;connect-src[] = "https://www.google.com/g/collect"
 ; If you are using Google Analytics, uncomment the line below
 ;connect-src[] = "https://*.google-analytics.com"
+;connect-src[] = "https://*.analytics.google.com"
 ; If you are using Matomo, fix the URL for your installation and uncomment the line below
 ;connect-src[] = "https://server.address/matomo/matomo.php"
 ; worker-src required for jsTree with browsers that don't support 'strict-dynamic' (e.g. Safari):
+
 worker-src[] = "blob:"
+
 style-src[] = "'self'"
 style-src[] = "'unsafe-inline'"
+
 img-src[] = "'self'"
 ; If you are using Google Books previews, uncomment the line below for
 ; https://www.google.com/intl/*/googlebooks/images/gbs_preview_button1.png
 ;img-src[] = "https://www.google.com/intl/"
+; If you are using Google Tag Manager, uncomment the line below
+;img-src[] = "https://www.googletagmanager.com"
+; If you are using Google Tag Manager's Preview Mode, uncomment the lines below
+;img-src[] = "https://googletagmanager.com"
+;img-src[] = "https://*.googletagmanager.com"
+;img-src[] = "https://ssl.gstatic.com"
+;img-src[] = "https://www.gstatic.com"
+; If you are using Google Analytics, uncomment the line below
+;img-src[] = "https://*.google-analytics.com"
 ; If you are using LibGuidesProfile recommendation module, uncomment the line below
 ;img-src[] = libapps.s3.amazonaws.com
 ; If you are using MapSelection recommendation module, uncomment a line below
@@ -71,7 +93,12 @@ img-src[] = "'self'"
 ;img-src[] = https://*.od-cdn.com
 ; For author images from Wikipedia Commons, uncomment the line below.
 ;img-src[] = https://upload.wikimedia.org/wikipedia/commons/
+
 font-src[] = "'self'"
+; If you are using Google Tag Manager's Preview Mode, uncomment the lines below
+;font-src[] = "https://fonts.gstatic.com"
+;font-src[] = "data:"
+
 base-uri[] = "'self'"
 
 ; Provide both report-uri and report-to headers to capture CSP violations.  Each is supported


### PR DESCRIPTION
Source: https://developers.google.com/tag-platform/security/guides/csp

Caveats:
- This ignores the script-src rules, as they are irrelevant for anyone using CSP v3 and `strict-dynamic`, which I hope/assume is anyone actually using CSP.
- This ignores the section on GA4 deployments using "Google Signals".