### PR TITLE
Fix ZoteroService.php cleanupRecords()

### DIFF
--- a/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
+++ b/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
@@ -333,7 +333,7 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
             foreach (array_keys(get_object_vars($record)) as $field) {
                 if ($field === 'creators') {
                     continue;
-                }                
+                }
                 if (!isset($itemSchema['fields'][$field])) {
                     // Check for field mapping:
                     if ($target = $itemSchema['mappedFields'][$field] ?? null) {

--- a/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
+++ b/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
@@ -331,6 +331,9 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
             $itemSchema = $this->getItemTypeSchema($fullSchema, $itemType);
             // Check fields:
             foreach (array_keys(get_object_vars($record)) as $field) {
+                if ($field === 'creators') {
+                    continue;
+                }                
                 if (!isset($itemSchema['fields'][$field])) {
                     // Check for field mapping:
                     if ($target = $itemSchema['mappedFields'][$field] ?? null) {
@@ -343,7 +346,7 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
             // Check authors:
             if (isset($record->creators)) {
                 foreach ($record->creators as &$creator) {
-                    if (!isset($itemSchema['creatorTypes'][$creator['creatorType']])) {
+                    if (!isset($itemSchema['creatorTypes'][$creator->creatorType])) {
                         $creator->creatorType = $itemSchema['primaryCreatorType'];
                     }
                 }

--- a/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
+++ b/module/VuFind/src/VuFind/Export/Zotero/ZoteroService.php
@@ -331,6 +331,7 @@ class ZoteroService implements LoggerAwareInterface, TranslatorAwareInterface
             $itemSchema = $this->getItemTypeSchema($fullSchema, $itemType);
             // Check fields:
             foreach (array_keys(get_object_vars($record)) as $field) {
+                // 'creators' is a valid field even though it is not included in the schema, so skip it here:
                 if ($field === 'creators') {
                     continue;
                 }


### PR DESCRIPTION
"creators" is not defined in the Zotero schema as a field, so the current code always removes it. I fix this by skipping that field.

Leaving "creators" in the object introduces a bug.
"$creator->creatorType" must be used instead of "$creator['creatorType']" since it is an object.