### PR TITLE
PHPUnit: fail on warnings

### DIFF
--- a/module/VuFind/tests/phpunit.xml
+++ b/module/VuFind/tests/phpunit.xml
@@ -7,6 +7,7 @@
   displayDetailsOnTestsThatTriggerWarnings="true"
   displayDetailsOnTestsThatTriggerDeprecations="true"
   displayDetailsOnPhpunitDeprecations="true"
+  failOnWarning="true"
   cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="AllUnitTests">


### PR DESCRIPTION
Our PHPUnit test suite should not issue any warnings -- if something regresses, we should be alerted.