### PR TITLE
Fix Other Versions tab link.

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
@@ -6,7 +6,7 @@
   if (isset($this->tabs['Versions'])) {
     $url = !empty($this->full)
       ? ($this->recordLinker()->getTabUrl($this->driver, 'Versions', [], ['query' => ['sid' => $this->searchId]]) . '#tabnav')
-      : '#versions';
+      : '#tab-button-versions';
     $translationKey = 'other_versions_link';
   } else {
     $url = $this->recordLinker()->getVersionsSearchUrl($this->driver);


### PR DESCRIPTION
Record tabs refactoring changed the tab id, so the change needs to be reflected in the link as well.