### PR TITLE
Fix jsTranslationsCheck on Node v25.

### DIFF
--- a/themes/bootstrap5/tools/jsTranslationsCheck.js
+++ b/themes/bootstrap5/tools/jsTranslationsCheck.js
@@ -121,7 +121,7 @@ try {
       continue;
     }
 
-    const entryPath = path.join(entry.path, entry.name);
+    const entryPath = path.join(entry.parentPath || entry.path, entry.name);
     const templateContents = fs.readFileSync(entryPath, "utf8");
 
     const phpStrings = getPhpTranslations(templateContents);


### PR DESCRIPTION
Dirent.path no longer exists (it was already deprecated before).