### PR TITLE
Fix scroll to tab when tabs are in a positioned container.

### DIFF
--- a/themes/bootstrap5/js/record_tabs.js
+++ b/themes/bootstrap5/js/record_tabs.js
@@ -81,7 +81,7 @@ VuFind.register('recordTabs', function RecordTabs() {
     }
 
     if (scrollToTabs) {
-      window.scrollTo({top: tabElement.offsetTop, behavior: 'smooth'})
+      tabElement.scrollIntoView({behavior: 'smooth'});
     }
   }
 


### PR DESCRIPTION
If tabs happen to have a positioned parent, offsetTop returns a small value that doesn't directly work as scroll offset. This avoids any top position handling by requesting the element to scroll into view.