### PR TITLE
Add module permission for EDS and EPF.

### DIFF
--- a/config/vufind/permissionBehavior.ini
+++ b/config/vufind/permissionBehavior.ini
@@ -78,9 +78,19 @@ defaultDeniedTemplateBehavior = false
 ;controllerAccess[*] = access.VuFindInterface
 ;controllerAccess[VuFind\Controller\SearchController] = access.SearchResults
 
+; Configuration for EDS (needed to make it behave correctly in combined
+; searches):
+[access.EDSModule]
+deniedTemplateBehavior = showTemplate:error/loginForAccess
+
 ; Configuration for EIT (needed to make it behave correctly in combined
 ; searches):
 [access.EITModule]
+deniedTemplateBehavior = showTemplate:error/loginForAccess
+
+; Configuration for EPF (needed to make it behave correctly in combined
+; searches):
+[access.EPFModule]
 deniedTemplateBehavior = showTemplate:error/loginForAccess
 
 ; Configuration for developer settings

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -140,7 +140,7 @@ assertion[] = VerifiedEmail
 
 ; Default configuration for the EDS module (allow everyone by default).
 ; Do not disable or comment out this configuration if you want to use the EDS module!
-[default.EDSModule]
+[default.EDSModuleAccess]
 role[] = guest
 role[] = loggedin
 permission = access.EDSModule

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -152,8 +152,9 @@ permission = access.EDSModule
 ;ipRange[] = "192.168.11"
 ;permission = access.EDSExtendedResults
 
-; Default configuration for the EPF module (allow everyone by default).
-; Do not disable or comment out this configuration if you want to use the EPF module!
+; Default configuration for the EDS module (allow everyone by default).
+; If you comment out this section and do not provide a different section containing the access.EDSModule
+; permission, the below permissions will be automatically applied by DynamicRoleProviderFactory.
 [default.EPFModule]
 role[] = guest
 role[] = loggedin

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -139,7 +139,8 @@ assertion[] = VerifiedEmail
 ;permission = access.DebugMode
 
 ; Default configuration for the EDS module (allow everyone by default).
-; Do not disable or comment out this configuration if you want to use the EDS module!
+; If you comment out this section and do not provide a different section containing the access.EDSModule
+; permission, the below permissions will be automatically applied by DynamicRoleProviderFactory.
 [default.EDSModuleAccess]
 role[] = guest
 role[] = loggedin

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -152,7 +152,7 @@ permission = access.EDSModule
 ;ipRange[] = "192.168.11"
 ;permission = access.EDSExtendedResults
 
-; Default configuration for the EDS module (allow everyone by default).
+; Default configuration for the EPF module (allow everyone by default).
 ; If you comment out this section and do not provide a different section containing the access.EPFModule
 ; permission, the below permissions will be automatically applied by DynamicRoleProviderFactory.
 [default.EPFModule]

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -153,7 +153,7 @@ permission = access.EDSModule
 ;permission = access.EDSExtendedResults
 
 ; Default configuration for the EDS module (allow everyone by default).
-; If you comment out this section and do not provide a different section containing the access.EDSModule
+; If you comment out this section and do not provide a different section containing the access.EPFModule
 ; permission, the below permissions will be automatically applied by DynamicRoleProviderFactory.
 [default.EPFModule]
 role[] = guest

--- a/config/vufind/permissions.ini
+++ b/config/vufind/permissions.ini
@@ -92,7 +92,9 @@
 ; access.AdminModule - Controls access to the admin panel (if enabled in config.ini)
 ; access.DebugMode - Allows ?debug=true GET parameter to turn on debug mode
 ; access.EDSExtendedResults - Controls visibility of protected EDS results
+; access.EDSModule - Controls access to the EBSCO EDS module (if active)
 ; access.EITModule - Controls access to the EBSCO EIT module (if active)
+; access.EPFModule - Controls access to the EBSCO EPF module (if active)
 ; access.PrimoModule - Controls access to ALL Primo content
 ; access.StaffViewTab - Controls access to the staff view tab in record mode
 ; access.SummonExtendedResults - Controls visibility of protected Summon results
@@ -136,11 +138,25 @@ assertion[] = VerifiedEmail
 ;username[] = admin
 ;permission = access.DebugMode
 
-; Example for EDS
-;[default.EDSModule]
+; Default configuration for the EDS module (allow everyone by default).
+; Do not disable or comment out this configuration if you want to use the EDS module!
+[default.EDSModule]
+role[] = guest
+role[] = loggedin
+permission = access.EDSModule
+
+; Example for EDS extended results
+;[default.EDSExtendedResults]
 ;ipRange[] = "127.0.0.1"
 ;ipRange[] = "192.168.11"
 ;permission = access.EDSExtendedResults
+
+; Default configuration for the EPF module (allow everyone by default).
+; Do not disable or comment out this configuration if you want to use the EPF module!
+[default.EPFModule]
+role[] = guest
+role[] = loggedin
+permission = access.EPFModule
 
 ; Examples for Shibboleth
 ;

--- a/module/VuFind/src/VuFind/Controller/EPFController.php
+++ b/module/VuFind/src/VuFind/Controller/EPFController.php
@@ -52,6 +52,7 @@ class EPFController extends AbstractSearch
     public function __construct(ServiceLocatorInterface $sm)
     {
         $this->searchClassId = 'EPF';
+        $this->accessPermission = 'access.EPFModule';
         parent::__construct($sm);
     }
 

--- a/module/VuFind/src/VuFind/Controller/EPFrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/EPFrecordController.php
@@ -52,6 +52,7 @@ class EPFrecordController extends AbstractRecord
     public function __construct(ServiceLocatorInterface $sm)
     {
         $this->sourceId = 'EPF';
+        $this->accessPermission = 'access.EPFModule';
         parent::__construct($sm);
     }
 }

--- a/module/VuFind/src/VuFind/Controller/EdsController.php
+++ b/module/VuFind/src/VuFind/Controller/EdsController.php
@@ -54,6 +54,7 @@ class EdsController extends AbstractSearch
     public function __construct(ServiceLocatorInterface $sm)
     {
         $this->searchClassId = 'EDS';
+        $this->accessPermission = 'access.EDSModule';
         parent::__construct($sm);
     }
 

--- a/module/VuFind/src/VuFind/Controller/EdsrecordController.php
+++ b/module/VuFind/src/VuFind/Controller/EdsrecordController.php
@@ -54,6 +54,7 @@ class EdsrecordController extends AbstractRecord
     public function __construct(ServiceLocatorInterface $sm)
     {
         // Override some defaults:
+        $this->accessPermission = 'access.EDSModule';
         $this->sourceId = 'EDS';
         $this->fallbackDefaultTab = 'Description';
 

--- a/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
+++ b/module/VuFind/src/VuFind/Role/DynamicRoleProviderFactory.php
@@ -135,12 +135,14 @@ class DynamicRoleProviderFactory implements FactoryInterface
                 = 'access.StaffViewTab';
         }
 
-        // Add EIT settings if they are absent:
-        if (!$this->permissionDefined($permissions, 'access.EITModule')) {
-            $permissions['legacy.EITModule'] = [
-                'role' => 'loggedin',
-                'permission' => 'access.EITModule',
-            ];
+        // Add EDS, EIT and EPF settings if they are absent:
+        foreach (['EDSModule', 'EITModule', 'EPFModule'] as $module) {
+            if (!$this->permissionDefined($permissions, 'access.' . $module)) {
+                $permissions['legacy.' . $module] = [
+                    'role' => $module === 'EITModule' ? 'loggedin' : ['guest', 'loggedin'],
+                    'permission' => 'access.' . $module,
+                ];
+            }
         }
 
         // Add Summon settings if they are absent:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -327,7 +327,7 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
         $eitConfig = ['role' => ['guest', 'loggedin'], 'permission' => 'access.EDSModule'];
         $this->assertEquals(
             $eitConfig,
-            $results['permissions']['default.EDSModule']
+            $results['permissions']['default.EDSModuleAccess']
         );
 
         // EIT assertions:

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -323,11 +323,25 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
             $results['permissions']['access.SummonExtendedResults']
         );
 
+        // EDS assertions:
+        $eitConfig = ['role' => ['guest', 'loggedin'], 'permission' => 'access.EDSModule'];
+        $this->assertEquals(
+            $eitConfig,
+            $results['permissions']['default.EDSModule']
+        );
+
         // EIT assertions:
         $eitConfig = ['role' => 'loggedin', 'permission' => 'access.EITModule'];
         $this->assertEquals(
             $eitConfig,
             $results['permissions']['default.EITModule']
+        );
+
+        // EPF assertions:
+        $eitConfig = ['role' => ['guest', 'loggedin'], 'permission' => 'access.EPFModule'];
+        $this->assertEquals(
+            $eitConfig,
+            $results['permissions']['default.EPFModule']
         );
 
         // Primo assertions:


### PR DESCRIPTION
Follows the existing setup for EIT and Primo to make it possible to restrict access e.g. to logged-in users.

TODO:

- [x] Add to changelog the new permissions and change from `[default.EDSModule]` to `[default.EDSExtendedResults]` for the EDS extended results permission configuration.