### PR TITLE
OpenIDConnect: Default to signature key if use is not specified.

### DIFF
--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -602,7 +602,7 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
             $jwks = json_decode($response->getBody(), true);
             foreach ($jwks['keys'] as $i => $jwk) {
                 // Filter for signature keys only.
-                if (($jwk['use'] ?? '') === 'sig') {
+                if (($jwk['use'] ?? 'sig') === 'sig') {
                     $this->jwks[$jwk['kid'] ?? $i] = $jwk;
                 }
             }


### PR DESCRIPTION
The [discovery spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) states that jwks_uri response "contains the signing key(s) the RP uses to validate signatures from the OP. The JWK Set MAY also contain the Server's encryption key(s), which are used by RPs to encrypt requests to the Server. When both signing and encryption keys are made available, a use (public key use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate each key's intended usage." This implies that when the use parameter is not present, only signing keys are included, and filtering should default to that.