### PR TITLE
FOLIO: Respect the user's FOLIO fulfillment preference

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2150,7 +2150,7 @@ class Folio extends AbstractAPI implements
      */
     protected function getRequestPreference(string $userId): array
     {
-        if ($requestPreference = ($this->requestPreferenceCache[$userId] ?? false)) {
+        if ($requestPreference = ($this->requestPreferenceCache[$userId] ?? null)) {
             return $requestPreference;
         }
 

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2150,7 +2150,8 @@ class Folio extends AbstractAPI implements
      */
     protected function getRequestPreference(string $userId): array
     {
-        if ($requestPreference = ($this->requestPreferenceCache[$userId] ?? null)) {
+        $requestPreference = $this->requestPreferenceCache[$userId] ?? null;
+        if ($requestPreference !== null) {
             return $requestPreference;
         }
 
@@ -2160,7 +2161,7 @@ class Folio extends AbstractAPI implements
             '/request-preference-storage/request-preference?query=userId==' . $userId
         );
         $requestPreferencesResponse = json_decode($response->getBody(), true);
-        $requestPreference = $requestPreferencesResponse['requestPreferences'][0] ?? null;
+        $requestPreference = $requestPreferencesResponse['requestPreferences'][0] ?? [];
 
         $this->requestPreferenceCache[$userId] = $requestPreference;
         return $requestPreference;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2133,7 +2133,7 @@ class Folio extends AbstractAPI implements
      * placeHold, minus the patron data. May be used to limit the request group
      * options or may be ignored.
      *
-     * @return string A location ID
+     * @return string A fulfillment preference
      */
     public function getDefaultRequestGroup($patron = false, $holdDetails = null)
     {
@@ -2144,7 +2144,7 @@ class Folio extends AbstractAPI implements
         );
         $requestPreferencesResponse = json_decode($response->getBody());
         $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
-        return $requestPreferences->fulfillment ?? 'Hold Shelf';
+        return $requestPreferences?->fulfillment ?? 'Hold Shelf';
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -145,6 +145,13 @@ class Folio extends AbstractAPI implements
     protected $courseCache = null;
 
     /**
+     * Cache for request preference data (null if not yet populated).
+     *
+     * @var ?object
+     */
+    protected $requestPreferenceCache = null;
+
+    /**
      * Constructor.
      *
      * @param \VuFind\Date\Converter $dateConverter  Date converter object
@@ -2094,15 +2101,9 @@ class Folio extends AbstractAPI implements
         $patron = null,
         $holdDetails = null
     ) {
-        // circulation-storage.request-preferences.collection.get
-        $response = $this->makeRequest(
-            'GET',
-            '/request-preference-storage/request-preference?query=userId==' . $patron['id']
-        );
-        $requestPreferencesResponse = json_decode($response->getBody());
-        $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
-        $allowHoldShelf = $requestPreferences->holdShelf ?? true;
-        $allowDelivery = ($requestPreferences->delivery ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
+        $requestPreference = $this->getRequestPreference($patron['id']);
+        $allowHoldShelf = $requestPreference->holdShelf ?? true;
+        $allowDelivery = ($requestPreference->delivery ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
         $locationsLabels = $this->config['Holds']['locationsLabelByRequestGroup'] ?? [];
         if ($allowHoldShelf && $allowDelivery) {
             return [
@@ -2137,14 +2138,33 @@ class Folio extends AbstractAPI implements
      */
     public function getDefaultRequestGroup($patron = false, $holdDetails = null)
     {
+        $requestPreference = $this->getRequestPreference($patron['id']);
+        return $requestPreference?->fulfillment ?? 'Hold Shelf';
+    }
+
+    /**
+     * Retrieve and cache the request preference.
+     *
+     * @param string $userId The user's UUID
+     *
+     * @return string A request fulfillment preference
+     */
+    protected function getRequestPreference(string $userId)
+    {
+        if ($this->requestPreferenceCache) {
+            return $this->requestPreferenceCache;
+        }
+
         // circulation-storage.request-preferences.collection.get
         $response = $this->makeRequest(
             'GET',
-            '/request-preference-storage/request-preference?query=userId==' . $patron['id']
+            '/request-preference-storage/request-preference?query=userId==' . $userId
         );
         $requestPreferencesResponse = json_decode($response->getBody());
-        $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
-        return $requestPreferences?->fulfillment ?? 'Hold Shelf';
+        $requestPreference = $requestPreferencesResponse->requestPreferences[0] ?? null;
+
+        $this->requestPreferenceCache = $requestPreference;
+        return $requestPreference;
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2122,6 +2122,32 @@ class Folio extends AbstractAPI implements
     }
 
     /**
+     * Get Default Request Group.
+     *
+     * In FOLIO, this is equivalent to the fulfillment preference.
+     *
+     * @param array $patron      Patron information returned by the patronLogin
+     * method.
+     * @param array $holdDetails Optional array, only passed in when getting a list
+     * in the context of placing a hold; contains most of the same values passed to
+     * placeHold, minus the patron data. May be used to limit the request group
+     * options or may be ignored.
+     *
+     * @return string A location ID
+     */
+    public function getDefaultRequestGroup($patron = false, $holdDetails = null)
+    {
+        // circulation-storage.request-preferences.collection.get
+        $response = $this->makeRequest(
+            'GET',
+            '/request-preference-storage/request-preference?query=userId==' . $patron['id']
+        );
+        $requestPreferencesResponse = json_decode($response->getBody());
+        $requestPreferences = $requestPreferencesResponse->requestPreferences[0] ?? null;
+        return $requestPreferences->fulfillment ?? 'Hold Shelf';
+    }
+
+    /**
      * Get list of address types from FOLIO.  Cache as needed.
      *
      * @return array An array mapping an address type id to its name.

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -147,7 +147,7 @@ class Folio extends AbstractAPI implements
     /**
      * Cache for request preference data (null if not yet populated).
      *
-     * @var ?object
+     * @var ?array
      */
     protected $requestPreferenceCache = null;
 
@@ -2102,8 +2102,8 @@ class Folio extends AbstractAPI implements
         $holdDetails = null
     ) {
         $requestPreference = $this->getRequestPreference($patron['id']);
-        $allowHoldShelf = $requestPreference->holdShelf ?? true;
-        $allowDelivery = ($requestPreference->delivery ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
+        $allowHoldShelf = $requestPreference['holdShelf'] ?? true;
+        $allowDelivery = ($requestPreference['delivery'] ?? false) && ($this->config['Holds']['allowDelivery'] ?? true);
         $locationsLabels = $this->config['Holds']['locationsLabelByRequestGroup'] ?? [];
         if ($allowHoldShelf && $allowDelivery) {
             return [
@@ -2138,7 +2138,7 @@ class Folio extends AbstractAPI implements
     public function getDefaultRequestGroup($patron, $holdDetails = null)
     {
         $requestPreference = $this->getRequestPreference($patron['id']);
-        return $requestPreference?->fulfillment ?? 'Hold Shelf';
+        return $requestPreference['fulfillment'] ?? 'Hold Shelf';
     }
 
     /**
@@ -2146,9 +2146,9 @@ class Folio extends AbstractAPI implements
      *
      * @param string $userId The user's UUID
      *
-     * @return string A request fulfillment preference
+     * @return array An array containing several aspects of request preference
      */
-    protected function getRequestPreference(string $userId)
+    protected function getRequestPreference(string $userId): array
     {
         if ($this->requestPreferenceCache) {
             return $this->requestPreferenceCache;
@@ -2159,8 +2159,8 @@ class Folio extends AbstractAPI implements
             'GET',
             '/request-preference-storage/request-preference?query=userId==' . $userId
         );
-        $requestPreferencesResponse = json_decode($response->getBody());
-        $requestPreference = $requestPreferencesResponse->requestPreferences[0] ?? null;
+        $requestPreferencesResponse = json_decode($response->getBody(), true);
+        $requestPreference = $requestPreferencesResponse['requestPreferences'][0] ?? null;
 
         $this->requestPreferenceCache = $requestPreference;
         return $requestPreference;

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -2127,16 +2127,15 @@ class Folio extends AbstractAPI implements
      *
      * In FOLIO, this is equivalent to the fulfillment preference.
      *
-     * @param array $patron      Patron information returned by the patronLogin
-     * method.
-     * @param array $holdDetails Optional array, only passed in when getting a list
+     * @param array  $patron      Patron information returned by the patronLogin method.
+     * @param ?array $holdDetails Optional array, only passed in when getting a list
      * in the context of placing a hold; contains most of the same values passed to
      * placeHold, minus the patron data. May be used to limit the request group
      * options or may be ignored.
      *
-     * @return string A fulfillment preference
+     * @return false|string       The default request group for the patron.
      */
-    public function getDefaultRequestGroup($patron = false, $holdDetails = null)
+    public function getDefaultRequestGroup($patron, $holdDetails = null)
     {
         $requestPreference = $this->getRequestPreference($patron['id']);
         return $requestPreference?->fulfillment ?? 'Hold Shelf';

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -145,11 +145,11 @@ class Folio extends AbstractAPI implements
     protected $courseCache = null;
 
     /**
-     * Cache for request preference data (null if not yet populated).
+     * Cache for request preference data.
      *
-     * @var ?array
+     * @var array
      */
-    protected $requestPreferenceCache = null;
+    protected array $requestPreferenceCache = [];
 
     /**
      * Constructor.
@@ -2150,8 +2150,8 @@ class Folio extends AbstractAPI implements
      */
     protected function getRequestPreference(string $userId): array
     {
-        if ($this->requestPreferenceCache) {
-            return $this->requestPreferenceCache;
+        if ($requestPreference = ($this->requestPreferenceCache[$userId] ?? false)) {
+            return $requestPreference;
         }
 
         // circulation-storage.request-preferences.collection.get
@@ -2162,7 +2162,7 @@ class Folio extends AbstractAPI implements
         $requestPreferencesResponse = json_decode($response->getBody(), true);
         $requestPreference = $requestPreferencesResponse['requestPreferences'][0] ?? null;
 
-        $this->requestPreferenceCache = $requestPreference;
+        $this->requestPreferenceCache[$userId] = $requestPreference;
         return $requestPreference;
     }
 

--- a/module/VuFind/tests/fixtures/folio/responses/get-request-preference.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-request-preference.json
@@ -1,0 +1,28 @@
+[
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/request-preference-storage\/request-preference?query=userId==whatever",
+        "expectedParams": {
+        },
+        "bodyType": "json",
+        "body": {
+            "requestPreferences": [
+                {
+                    "id": "668b8f1b-6cd6-48e5-be2b-48b9f39da4ce",
+                    "userId": "ba2e7a40-f845-4fe0-84c4-26b283bdc5d3",
+                    "holdShelf": true,
+                    "delivery": true,
+                    "defaultDeliveryAddressTypeId": "49d8f402-1ec9-4418-b6aa-e8a88f7b0ac6",
+                    "fulfillment": "Delivery",
+                    "metadata": {
+                        "createdDate": "2022-09-15T13:17:16.334+00:00",
+                        "createdByUserId": "cfcd85b2-9e7d-4b98-bb95-f1c25025899b",
+                        "updatedDate": "2026-05-18T21:14:44.795+00:00",
+                        "updatedByUserId": "1591c58f-e8a3-4255-be54-2b2af5de3d23"
+                    }
+                }
+            ]
+        },
+        "totalRecords": 1
+    }
+]

--- a/module/VuFind/tests/fixtures/folio/responses/get-request-preference.json
+++ b/module/VuFind/tests/fixtures/folio/responses/get-request-preference.json
@@ -24,5 +24,31 @@
             ]
         },
         "totalRecords": 1
+    },
+    {
+        "expectedMethod": "GET",
+        "expectedPath": "\/request-preference-storage\/request-preference?query=userId==user2",
+        "expectedParams": {
+        },
+        "bodyType": "json",
+        "body": {
+            "requestPreferences": [
+                {
+                    "id": "668b8f1b-6cd6-48e5-be2b-48b9f39da4ce",
+                    "userId": "ba2e7a40-f845-4fe0-84c4-26b283bdc5d3",
+                    "holdShelf": true,
+                    "delivery": true,
+                    "defaultDeliveryAddressTypeId": "49d8f402-1ec9-4418-b6aa-e8a88f7b0ac6",
+                    "fulfillment": "Hold Shelf",
+                    "metadata": {
+                        "createdDate": "2022-09-15T13:17:16.334+00:00",
+                        "createdByUserId": "cfcd85b2-9e7d-4b98-bb95-f1c25025899b",
+                        "updatedDate": "2026-05-18T21:14:44.795+00:00",
+                        "updatedByUserId": "1591c58f-e8a3-4255-be54-2b2af5de3d23"
+                    }
+                }
+            ]
+        },
+        "totalRecords": 1
     }
 ]

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -1518,6 +1518,14 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     {
         $driverConfig = $this->defaultDriverConfig;
         $this->createConnector('get-request-preference', $driverConfig);
-        $this->assertEquals('Delivery', $this->driver->getDefaultRequestGroup(['id' => 'whatever']));
+
+        // Confirm the FOLIO call is made only once per user, due to caching
+        $this->driver->expects($this->exactly(2))->method('makeRequest');
+        $requestGroup = $this->driver->getDefaultRequestGroup(['id' => 'whatever']);
+        $this->assertEquals('Delivery', $requestGroup);
+        for ($i=0; $i<2; $i++) {
+            $requestGroup = $this->driver->getDefaultRequestGroup(['id' => 'user2']);
+        }
+        $this->assertEquals('Hold Shelf', $requestGroup);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -1523,7 +1523,7 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         $this->driver->expects($this->exactly(2))->method('makeRequest');
         $requestGroup = $this->driver->getDefaultRequestGroup(['id' => 'whatever']);
         $this->assertEquals('Delivery', $requestGroup);
-        for ($i=0; $i<2; $i++) {
+        for ($i = 0; $i < 2; $i++) {
             $requestGroup = $this->driver->getDefaultRequestGroup(['id' => 'user2']);
         }
         $this->assertEquals('Hold Shelf', $requestGroup);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -1507,4 +1507,17 @@ class FolioTest extends \PHPUnit\Framework\TestCase
         ];
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test getDefaultRequestGroup with a user UUID-based lookup.
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\Depends('testTokens')]
+    public function testGetDefaultRequestGroup(): void
+    {
+        $driverConfig = $this->defaultDriverConfig;
+        $this->createConnector('get-request-preference', $driverConfig);
+        $this->assertEquals('Delivery', $this->driver->getDefaultRequestGroup(['id' => 'whatever']));
+    }
 }


### PR DESCRIPTION
If a FOLIO user account has both Hold Shelf and Delivery enabled, then they also have a "Fulfillment preference" field set to one of those two options.  VuFind's hold form uses the `requestGroup` field to display those two options.  We should respect that FOLIO preference in VuFind by defaulting to the user's preferred option, instead of displaying the `select_request_group` dummy option.  

Of course the user can always select the other option.