### PR TITLE
Remove unused, non-working checkLessToSass task.

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v4

--- a/build.xml
+++ b/build.xml
@@ -317,16 +317,6 @@
     </exec>
   </target>
 
-  <!-- Run LessToSass, error if there are uncommitted changes (used by continuous integration) -->
-  <target name="checkLessToSass">
-    <exec executable="npm" checkreturn="true" passthru="true">
-      <arg line="run lessToSass" />
-    </exec>
-    <exec executable="git" checkreturn="true" passthru="true">
-      <arg line="diff --exit-code *.scss" />
-    </exec>
-  </target>
-
   <!-- PHP API Documentation -->
   <target name="phpdoc">
     <!-- Skip the whole phpdoc task when disabled -->


### PR DESCRIPTION
We no longer support LESS, and this Phing task no longer works. It should be removed to prevent confusion. I'm extracting this from #4591 to get the cleanup merged sooner.

TODO:
- [x] Merge #5301 first to separate GitHub Actions fix.