### PR TITLE
Fix download for Hathi Trust book preview

### DIFF
--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -135,8 +135,13 @@ function getHTPreviews(keys) {
     if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
       let url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
         + batch.join('|');
-      $.getJSON(url)
-        .done(processHTBookInfo);
+      fetch(url, {
+        headers: {
+          'Accept': 'application/json'
+        }
+      }).then(response => response.json())
+        .then(response => processHTBookInfo(response));
+
       batch = [];
     }
   }

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -124,12 +124,12 @@ function processHTBookInfo(booksInfo) {
  * @param {string} keys A space-separated string of bibkeys.
  */
 function getHTPreviews(keys) {
-  var skeys = keys.replace(/(ISBN|LCCN|OCLC)/gi, '$1:').toLowerCase();
-  var bibkeys = skeys.split(/\s+/);
+  let skeys = keys.replace(/(ISBN|LCCN|OCLC)/gi, '$1:').toLowerCase();
+  let bibkeys = skeys.split(/\s+/);
   // fetch 20 books at time if there are more than 20
   // since hathitrust only allows 20 at a time
   // as per https://vufind.org/jira/browse/VUFIND-317
-  var batch = [];
+  let batch = [];
   for (var i = 0; i < bibkeys.length; i++) {
     batch.push(bibkeys[i]);
     if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -120,6 +120,25 @@ function processHTBookInfo(booksInfo) {
 }
 
 /**
+ * Fetch a single HathiTrust batch and pass the JSON response to the preview processor.
+ * Extracted from the loop in getHTPreviews() to avoid creating a callback inside the
+ * loop body, which triggers a JSHint warning.
+ *
+ * @param {Array} batch An array of HathiTrust bibkeys to request.
+ * @returns {Promise} A promise resolving when the batch has been processed.
+ */
+function fetchHTPreviewBatch(batch) {
+  const url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
+    + batch.join('|');
+  return fetch(url, {
+    headers: {
+      'Accept': 'application/json'
+    }
+  }).then(response => response.json())
+    .then(processHTBookInfo);
+}
+
+/**
  * Fetch HathiTrust books in batches from the API.
  * @param {string} keys A space-separated string of bibkeys.
  */
@@ -133,15 +152,7 @@ function getHTPreviews(keys) {
   for (let i = 0; i < bibkeys.length; i++) {
     batch.push(bibkeys[i]);
     if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
-      const url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
-        + batch.join('|');
-      fetch(url, {
-        headers: {
-          'Accept': 'application/json'
-        }
-      }).then(response => response.json())
-        .then(response => processHTBookInfo(response));
-
+      fetchHTPreviewBatch(batch);
       batch = [];
     }
   }

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -31,28 +31,6 @@ function getOLOptions() {
 }
 
 /**
- * Fetch HathiTrust books in batches from the API.
- * @param {string} keys A space-separated string of bibkeys.
- */
-function getHTPreviews(keys) {
-  var skeys = keys.replace(/(ISBN|LCCN|OCLC)/gi, '$1:').toLowerCase();
-  var bibkeys = skeys.split(/\s+/);
-  // fetch 20 books at time if there are more than 20
-  // since hathitrust only allows 20 at a time
-  // as per https://vufind.org/jira/browse/VUFIND-317
-  var batch = [];
-  for (var i = 0; i < bibkeys.length; i++) {
-    batch.push(bibkeys[i]);
-    if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
-      let url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
-        + batch.join('|');
-      $.getJSON(url)
-        .done(processHTBookInfo);
-      batch = [];
-    }
-  }
-}
-/**
  * Update a preview link and its corresponding record thumbnail with a new URL.
  * @param {jQuery} $link The preview button element.
  * @param {string} url   The preview URL.
@@ -137,6 +115,29 @@ function processHTBookInfo(booksInfo) {
           applyPreviewUrl($link, items[i].itemURL);
         }
       }
+    }
+  }
+}
+
+/**
+ * Fetch HathiTrust books in batches from the API.
+ * @param {string} keys A space-separated string of bibkeys.
+ */
+function getHTPreviews(keys) {
+  var skeys = keys.replace(/(ISBN|LCCN|OCLC)/gi, '$1:').toLowerCase();
+  var bibkeys = skeys.split(/\s+/);
+  // fetch 20 books at time if there are more than 20
+  // since hathitrust only allows 20 at a time
+  // as per https://vufind.org/jira/browse/VUFIND-317
+  var batch = [];
+  for (var i = 0; i < bibkeys.length; i++) {
+    batch.push(bibkeys[i]);
+    if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
+      let url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
+        + batch.join('|');
+      $.getJSON(url)
+        .done(processHTBookInfo);
+      batch = [];
     }
   }
 }

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -123,7 +123,6 @@ function processHTBookInfo(booksInfo) {
  * Fetch a single HathiTrust batch and pass the JSON response to the preview processor.
  * Extracted from the loop in getHTPreviews() to avoid creating a callback inside the
  * loop body, which triggers a JSHint warning.
- *
  * @param {Array} batch An array of HathiTrust bibkeys to request.
  * @returns {Promise} A promise resolving when the batch has been processed.
  */

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -44,9 +44,10 @@ function getHTPreviews(keys) {
   for (var i = 0; i < bibkeys.length; i++) {
     batch.push(bibkeys[i]);
     if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
-      var script = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
-                + batch.join('|') + '&callback=processHTBookInfo';
-      $.getScript(script);
+      let url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
+        + batch.join('|');
+      $.getJSON(url)
+        .done(processHTBookInfo);
       batch = [];
     }
   }

--- a/themes/bootstrap5/js/preview.js
+++ b/themes/bootstrap5/js/preview.js
@@ -130,10 +130,10 @@ function getHTPreviews(keys) {
   // since hathitrust only allows 20 at a time
   // as per https://vufind.org/jira/browse/VUFIND-317
   let batch = [];
-  for (var i = 0; i < bibkeys.length; i++) {
+  for (let i = 0; i < bibkeys.length; i++) {
     batch.push(bibkeys[i]);
     if ((i > 0 && i % 20 === 0) || i === bibkeys.length - 1) {
-      let url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
+      const url = 'https://catalog.hathitrust.org/api/volumes/brief/json/'
         + batch.join('|');
       fetch(url, {
         headers: {


### PR DESCRIPTION
The HathiTrust endpoint is being served as application/json, not executable JavaScript/JSONP.

Modern browsers block that as a script load.