### PR TITLE
Apply eslint to utility code

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -293,17 +293,17 @@
   <!-- ESLint -->
   <target name="eslint">
     <exec executable="npx" escape="false" checkreturn="true" passthru="true">
-      <arg line="eslint ${srcdir}/themes/**/*.js" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js" />
     </exec>
   </target>
   <target name="eslint-fix">
     <exec executable="npx" escape="false" passthru="true">
-      <arg line="eslint ${srcdir}/themes/**/*.js --fix" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --fix" />
     </exec>
   </target>
   <target name="eslint-report">
     <exec executable="npx" escape="false">
-      <arg line="eslint ${srcdir}/themes/**/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml" />
     </exec>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -293,17 +293,17 @@
   <!-- ESLint -->
   <target name="eslint">
     <exec executable="npx" escape="false" checkreturn="true" passthru="true">
-      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --no-error-on-unmatched-pattern" />
     </exec>
   </target>
   <target name="eslint-fix">
     <exec executable="npx" escape="false" passthru="true">
-      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --fix" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --fix --no-error-on-unmatched-pattern" />
     </exec>
   </target>
   <target name="eslint-report">
     <exec executable="npx" escape="false">
-      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml" />
+      <arg line="eslint ${srcdir}/themes/**/*.js ${srcdir}/util/*.js ${srcdir}/util/**/*.js --format checkstyle -o ${builddir}/reports/eslint-checkstyle.xml --no-error-on-unmatched-pattern" />
     </exec>
   </target>
 

--- a/util/i18n/create_language_translations.js
+++ b/util/i18n/create_language_translations.js
@@ -18,47 +18,41 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, see
  * <https://www.gnu.org/licenses/>.
- *
- * @category VuFind
- * @package  Utilities
- * @author   Demian Katz <demian.katz@villanova.edu>
- * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/automation Wiki
  */
-
+/* global process, require */
 const childProcess = require("child_process");
 const codes = require("all-iso-language-codes");
 const fs = require("fs");
 
 const args = process.argv.slice(2);
 if (args.length < 1) {
-    console.info("Usage: node create_language_translations.js [language code]");
-    return;
+  console.error("Usage: node create_language_translations.js [language code]");
+  process.exit(1);
 }
 
 const home = process.env.VUFIND_HOME;
 
 args.forEach(lang => {
-    const langNative = codes.getNativeName(lang);
+  const langNative = codes.getNativeName(lang);
 
-    let lines = "";
-    codes.getAll639_3().forEach((code) => {
-        const translation = codes.getName(code, lang);
-        const engTranslation = codes.getName(code, "en");
-        const nativeTranslation = codes.getNativeName(code);
-        if (translation != null
+  let lines = "";
+  codes.getAll639_3().forEach((code) => {
+    const translation = codes.getName(code, lang);
+    const engTranslation = codes.getName(code, "en");
+    const nativeTranslation = codes.getNativeName(code);
+    if (translation !== null
             // Filter out English translations unless we're generating the English file:
-            && (lang == "en" || translation != engTranslation)
+            && (lang === "en" || translation !== engTranslation)
             // Filter out native translations unless it's the native translation of the language we're working on:
-            && (translation == langNative || translation != nativeTranslation)
-        ) {
-            lines += `${code} = "${translation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"\n`;
-        }
-    });
+            && (translation === langNative || translation !== nativeTranslation)
+    ) {
+      lines += `${code} = "${translation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"\n`;
+    }
+  });
 
-    const outfile = `${home}/languages/ISO639-3/${lang}.ini`;
-    const existing = fs.existsSync(outfile) ? fs.readFileSync(outfile) : "";
-    fs.writeFileSync(outfile, lines + "\n" + existing);
+  const outfile = `${home}/languages/ISO639-3/${lang}.ini`;
+  const existing = fs.existsSync(outfile) ? fs.readFileSync(outfile) : "";
+  fs.writeFileSync(outfile, lines + "\n" + existing);
 });
 
 childProcess.execSync(`php ${home}/public/index.php language normalize ${home}/languages`);

--- a/util/i18n/create_language_translations.js
+++ b/util/i18n/create_language_translations.js
@@ -41,10 +41,10 @@ args.forEach(lang => {
     const engTranslation = codes.getName(code, "en");
     const nativeTranslation = codes.getNativeName(code);
     if (translation !== null
-            // Filter out English translations unless we're generating the English file:
-            && (lang === "en" || translation !== engTranslation)
-            // Filter out native translations unless it's the native translation of the language we're working on:
-            && (translation === langNative || translation !== nativeTranslation)
+      // Filter out English translations unless we're generating the English file:
+      && (lang === "en" || translation !== engTranslation)
+      // Filter out native translations unless it's the native translation of the language we're working on:
+      && (translation === langNative || translation !== nativeTranslation)
     ) {
       lines += `${code} = "${translation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"\n`;
     }


### PR DESCRIPTION
The eslint utility was not being applied to Javascript in our util directory. This PR adds the missing check and fixes some issues raised by the tool.