### PR TITLE
Fix default Blender configuration Solr sort settings.

### DIFF
--- a/config/vufind/Blender.ini
+++ b/config/vufind/Blender.ini
@@ -39,7 +39,7 @@ next_prev_navigation = false
 
 [General]
 default_handler = AllFields
-default_sort = "relevance,id asc"
+default_sort = "relevance"
 default_view = list
 default_limit = 20
 ;limit_options        = 10,20,40,60,80,100

--- a/config/vufind/BlenderMappings.yaml
+++ b/config/vufind/BlenderMappings.yaml
@@ -322,7 +322,7 @@ Sorting:
       Mappings:
         EDS: relevance
         Primo: relevance
-        Solr: relevance
+        Solr: relevance,id asc
     title:
       Mappings:
         Primo: title


### PR DESCRIPTION
We just went live with Blender and noticed a bug in the default Blender configuration: using out-of-the-box defaults results in the default sort showing as "Other" instead of "Relevance." This PR should fix the problem.