### PR TITLE
Optimize 302 redirects to avoid rendering full layout template.

### DIFF
--- a/module/VuFind/src/VuFind/Bootstrapper.php
+++ b/module/VuFind/src/VuFind/Bootstrapper.php
@@ -29,6 +29,8 @@
 
 namespace VuFind;
 
+use Laminas\Http\Header\Location;
+use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\Http\RouteMatch;
 use Psr\Container\ContainerInterface;
@@ -363,6 +365,29 @@ class Bootstrapper
             $viewModel->renderingError = true;
         };
         $this->events->attach('render.error', $callback, 10000);
+    }
+
+    /**
+     * Set up handling for rendering redirects.
+     *
+     * @return void
+     */
+    protected function initRenderRedirects(): void
+    {
+        // When a render is triggered, check the response status code and switch to a simple redirect template for
+        // 302 redirects.
+        $callback = function ($event): void {
+            $response = $event->getResponse();
+            if ($response instanceof Response && $response->getStatusCode() === 302) {
+                $viewModel = $this->container->get('ViewManager')->getViewModel();
+                if ($viewModel->getTemplate() === 'layout/layout') {
+                    $viewModel->setTemplate('layout/redirect');
+                    $location = $response->getHeaders()->get('Location');
+                    $viewModel->setVariable('redirectUrl', $location instanceof Location ? $location->getUri() : null);
+                }
+            }
+        };
+        $this->events->attach('render', $callback, 10000);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Controller/AbstractBase.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractBase.php
@@ -138,6 +138,7 @@ class AbstractBase extends AbstractActionController implements AccessPermissionI
                 ->check($this->accessPermission, $this->accessDeniedBehavior);
             if (is_object($response)) {
                 $e->setResponse($response);
+                $e->stopPropagation(true);
             }
         }
     }

--- a/themes/bootstrap5/templates/layout/redirect.phtml
+++ b/themes/bootstrap5/templates/layout/redirect.phtml
@@ -1,0 +1,20 @@
+<?php
+  // Note: this page is only displayed for 302 redirects and normally not displayed to the user, so translation is not
+  // necessary.
+
+  if (($children = $this->layout()->getChildren()) && $children[0]?->getTemplate() === 'laminas_whoops/simple_error') {
+    // Whoops error is a complete page, so just output it and nothing else:
+    echo $this->layout()->content;
+    return;
+  }
+  echo $this->doctype();
+?>
+
+<html>
+  <head>
+    <title>Redirect</title>
+  </head>
+  <body>
+    302 Redirect to <?=$this->escapeHtml($this->redirectUrl ?? '[unavailable]')?>
+  </body>
+</html>


### PR DESCRIPTION
We can save a few cycles and some bandwidth by not rendering the layout on redirects.