### PR TITLE
Enable displaying of lower level hierarchy items of current path

### DIFF
--- a/themes/bootstrap5/js/hierarchy_tree.js
+++ b/themes/bootstrap5/js/hierarchy_tree.js
@@ -197,6 +197,14 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
   }
 
   /**
+   * Display full hierarchy of current path.
+   * @param {HTMLElement} treeEl The hierarchy tree element. 
+   */
+  function showCurrentPathFullHierarchy(treeEl) {
+    treeEl.querySelectorAll('li').forEach(el => el.classList.remove('hidden'));
+  }
+
+  /**
    * Scroll the tree to the selected record.
    * @param {HTMLElement} treeEl The hierarchy tree element.
    */
@@ -243,6 +251,15 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
             }
             scrollToSelected(treeEl);
           });
+          const selectedElement = containerEl.querySelector('li.hierarchy-tree__selected');
+          const selectedElementToggle = selectedElement.querySelector('button.js-toggle-expanded');
+          if (selectedElementToggle) {
+            selectedElementToggle.addEventListener('click', () => {
+              if (!showEl.checked) {
+                showCurrentPathFullHierarchy(selectedElement);
+              }
+            });
+          }
         }
       }
     }

--- a/themes/bootstrap5/js/hierarchy_tree.js
+++ b/themes/bootstrap5/js/hierarchy_tree.js
@@ -252,13 +252,15 @@ VuFind.register('hierarchyTree', function HierarchyTree() {
             scrollToSelected(treeEl);
           });
           const selectedElement = containerEl.querySelector('li.hierarchy-tree__selected');
-          const selectedElementToggle = selectedElement.querySelector('button.js-toggle-expanded');
-          if (selectedElementToggle) {
-            selectedElementToggle.addEventListener('click', () => {
-              if (!showEl.checked) {
-                showCurrentPathFullHierarchy(selectedElement);
-              }
-            });
+          if (selectedElement) {
+            const selectedElementToggle = selectedElement.querySelector('button.js-toggle-expanded');
+            if (selectedElementToggle) {
+              selectedElementToggle.addEventListener('click', () => {
+                if (!showEl.checked) {
+                  showCurrentPathFullHierarchy(selectedElement);
+                }
+              });
+            }
           }
         }
       }


### PR DESCRIPTION
When only the current hierarchy path (fullHierarchyRecordView = false) is used as a setting, it has caused some confusion as the button is still visible for the selected record, yet doesn’t do anything but give the impression that there is nothing within the item.

It was suggested if it could still show the rest of the hierarchy after the selected item, while initially only showing the path to the selected item.

(Other suggestion was that clicking it would enable the “Show Full Hierarchy” checkbox and show the whole tree.)