### PR TITLE
[VUFIND-1828] Deprecate Piwik functionality in favor of Matomo

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2483,8 +2483,6 @@ validateHierarchySequences = true
 ; about quoting and escaping.
 ;create_options_js = "{cookie_flags: 'max-age=7200;secure;samesite=none'}"
 
-; Matomo analytics version 4 and later (for version 3 and earlier, use Piwik section
-; below):
 ; Uncomment this section and provide your Matomo server address and site id to enable
 ; Matomo analytics. Note: The Matomo URL should also be provided in the related
 ; connect-src setting of contentsecuritypolicy.ini.
@@ -2527,10 +2525,10 @@ validateHierarchySequences = true
 ; see https://matomo.org/faq/general/faq_157/ for more information.
 ;disableCookies = true
 
-; Piwik and Matomo 3.x (for Matomo version 4 and later, use Matomo section above):
-; The Piwik product has been renamed to Matomo, but for backward compatibility,
-; the terminology has not yet been changed in VuFind. Uncomment this section and
-; provide your Matomo or Piwik server address and site id to enable Matomo/Piwik
+; The Piwik product has been renamed to Matomo, and this section has been deprecated.
+; It will be retained until release 12.0 for backward compatibility, but users should
+; switch to use the [Matomo] section above instead. Uncomment this section and provide
+; your Matomo or Piwik server address and site id to enable legacy Matomo/Piwik
 ; analytics. Note: VuFind's Matomo/Piwik integration uses several custom variables;
 ; to take advantage of them, you must reconfigure Matomo/Piwik by switching
 ; to its root directory and running this command to raise a default limit:

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -541,6 +541,12 @@ class Upgrade implements LoggerAwareInterface
             );
         }
 
+        // Warn the user about the deprecated Piwik analytics section:
+        if (!empty($newConfig['Piwik'] ?? [])) {
+            $this->addWarning(
+                'You are using the deprecated [Piwik] section for analytics. Please switch to [Matomo] instead.'
+            );
+        }
         // Upgrade Google Options:
         if (
             isset($newConfig['Content']['GoogleOptions'])

--- a/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Piwik.php
@@ -40,6 +40,8 @@ use function strlen;
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org Main Site
+ *
+ * @deprecated Use Matomo
  */
 class Piwik extends \Laminas\View\Helper\AbstractHelper
 {

--- a/module/VuFind/tests/fixtures/configs/piwik/config.ini
+++ b/module/VuFind/tests/fixtures/configs/piwik/config.ini
@@ -1,0 +1,3 @@
+[Piwik]
+url = foo
+site_id = 1

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Config/UpgradeTest.php
@@ -382,6 +382,21 @@ class UpgradeTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test [Piwik] section handling.
+     *
+     * @return void
+     */
+    public function testPiwikHandling(): void
+    {
+        $upgrader = $this->runAndGetConfigUpgrader('piwik');
+        $warnings = $upgrader->getWarnings();
+        $this->assertContains(
+            'You are using the deprecated [Piwik] section for analytics. Please switch to [Matomo] instead.',
+            $warnings
+        );
+    }
+
+    /**
      * Test Google-related warnings.
      *
      * @return void


### PR DESCRIPTION
TODO
- [x] Update changelog when merging
- [x] Resolve [VUFIND-1828](https://openlibraryfoundation.atlassian.net/browse/VUFIND-1828) when merging
- [x] Open follow-up to remove deprecated code (and make Matomo back-compatible with `[Piwik]` settings) in dev-12.0 after merging