### PR TITLE
Use property instead of param annotations in component templates.

### DIFF
--- a/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
@@ -2,35 +2,35 @@
   /**
    * Confirm button component: display a button that drops down yes/no options to confirm an action.
    *
-   * @param ?string $align             Menu alignment (default = left)
-   * @param ?string $buttonClass       CSS class to apply to button element (if omitted, default is based on
+   * @property ?string $align             Menu alignment (default = left)
+   * @property ?string $buttonClass       CSS class to apply to button element (if omitted, default is based on
    *                                   $buttonLink)
-   * @param ?string $buttonId          ID to use for the button element (defaults to confirm_ concatenated with the
+   * @property ?string $buttonId          ID to use for the button element (defaults to confirm_ concatenated with the
    *                                   invocation counter)
-   * @param ?string $buttonIcon        Icon name to display with button text (optional; also requires $buttonLabel
+   * @property ?string $buttonIcon        Icon name to display with button text (optional; also requires $buttonLabel
    *                                   to be set)
-   * @param ?string $buttonLabel       Text to display on button
-   * @param ?string $buttonLabelHtml   HTML to display on button (ignored when $buttonIcon and $buttonLabel are
+   * @property ?string $buttonLabel       Text to display on button
+   * @property ?string $buttonLabelHtml   HTML to display on button (ignored when $buttonIcon and $buttonLabel are
    *                                   both set; overrides $buttonLabel otherwise)
-   * @param ?string $buttonLink        If set, the component will render as a link pointing to this URL; if unset, the
+   * @property ?string $buttonLink        If set, the component will render as a link pointing to this URL; if unset, the
    *                                   component will render as a submit button
-   * @param ?string $buttonName        Name attribute value for button (optional)
-   * @param ?string $cancelClass       CSS class(es) to use for cancel (no) option (optional)
-   * @param ?string $cancelId          ID to use for cancel (no) option (optional)
-   * @param ?string $cancelLabelHtml   HTML for cancel (no) option contents (default = translation of
+   * @property ?string $buttonName        Name attribute value for button (optional)
+   * @property ?string $cancelClass       CSS class(es) to use for cancel (no) option (optional)
+   * @property ?string $cancelId          ID to use for cancel (no) option (optional)
+   * @property ?string $cancelLabelHtml   HTML for cancel (no) option contents (default = translation of
    *                                   confirm_dialog_no)
-   * @param ?string $cancelTitle       Title attribute to use for cancel (no) option (optional) -- will be translated
-   * @param ?bool   $clearAccountCache Should we set the data-clear-account-cache attribute on the confirm (yes)
+   * @property ?string $cancelTitle       Title attribute to use for cancel (no) option (optional) -- will be translated
+   * @property ?bool   $clearAccountCache Should we set the data-clear-account-cache attribute on the confirm (yes)
    *                                   option? (default = false)
-   * @param ?string $confirmClass      CSS class(es) to use for confirm (yes) option (optional)
-   * @param ?string $confirmId         ID to use for confirm (yes) option (optional)
-   * @param ?string $confirmLabelHtml  HTML for confirm (yes) option contents (default = translation of
+   * @property ?string $confirmClass      CSS class(es) to use for confirm (yes) option (optional)
+   * @property ?string $confirmId         ID to use for confirm (yes) option (optional)
+   * @property ?string $confirmLabelHtml  HTML for confirm (yes) option contents (default = translation of
    *                                   confirm_dialog_yes)
-   * @param ?string $confirmLink       Href attribute to use for confirm (yes) option (optional)
-   * @param ?string $confirmTitle      Title attribute to use for confirm (yes) option (optional) -- will be translated
-   * @param ?string $header            Text to display at the header of the drop-down menu (optional; will be
+   * @property ?string $confirmLink       Href attribute to use for confirm (yes) option (optional)
+   * @property ?string $confirmTitle      Title attribute to use for confirm (yes) option (optional) -- will be translated
+   * @property ?string $header            Text to display at the header of the drop-down menu (optional; will be
    *                                   translated when provided)
-   * @param ?bool   $ignoreLightbox    Should we set data-lightbox-ignore attribute on all interactive elements?
+   * @property ?bool   $ignoreLightbox    Should we set data-lightbox-ignore attribute on all interactive elements?
    *                                   (default = false)
    */
   $buttonId = $this->buttonId ?? 'confirm_' . $this->_invocation;

--- a/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/confirm-button.phtml
@@ -4,34 +4,34 @@
    *
    * @property ?string $align             Menu alignment (default = left)
    * @property ?string $buttonClass       CSS class to apply to button element (if omitted, default is based on
-   *                                   $buttonLink)
+   *                                      $buttonLink)
    * @property ?string $buttonId          ID to use for the button element (defaults to confirm_ concatenated with the
-   *                                   invocation counter)
+   *                                      invocation counter)
    * @property ?string $buttonIcon        Icon name to display with button text (optional; also requires $buttonLabel
-   *                                   to be set)
+   *                                      to be set)
    * @property ?string $buttonLabel       Text to display on button
    * @property ?string $buttonLabelHtml   HTML to display on button (ignored when $buttonIcon and $buttonLabel are
-   *                                   both set; overrides $buttonLabel otherwise)
+   *                                      both set; overrides $buttonLabel otherwise)
    * @property ?string $buttonLink        If set, the component will render as a link pointing to this URL; if unset, the
-   *                                   component will render as a submit button
+   *                                      component will render as a submit button
    * @property ?string $buttonName        Name attribute value for button (optional)
    * @property ?string $cancelClass       CSS class(es) to use for cancel (no) option (optional)
    * @property ?string $cancelId          ID to use for cancel (no) option (optional)
    * @property ?string $cancelLabelHtml   HTML for cancel (no) option contents (default = translation of
-   *                                   confirm_dialog_no)
+   *                                      confirm_dialog_no)
    * @property ?string $cancelTitle       Title attribute to use for cancel (no) option (optional) -- will be translated
    * @property ?bool   $clearAccountCache Should we set the data-clear-account-cache attribute on the confirm (yes)
-   *                                   option? (default = false)
+   *                                      option? (default = false)
    * @property ?string $confirmClass      CSS class(es) to use for confirm (yes) option (optional)
    * @property ?string $confirmId         ID to use for confirm (yes) option (optional)
    * @property ?string $confirmLabelHtml  HTML for confirm (yes) option contents (default = translation of
-   *                                   confirm_dialog_yes)
+   *                                      confirm_dialog_yes)
    * @property ?string $confirmLink       Href attribute to use for confirm (yes) option (optional)
    * @property ?string $confirmTitle      Title attribute to use for confirm (yes) option (optional) -- will be translated
    * @property ?string $header            Text to display at the header of the drop-down menu (optional; will be
-   *                                   translated when provided)
+   *                                      translated when provided)
    * @property ?bool   $ignoreLightbox    Should we set data-lightbox-ignore attribute on all interactive elements?
-   *                                   (default = false)
+   *                                      (default = false)
    */
   $buttonId = $this->buttonId ?? 'confirm_' . $this->_invocation;
   if (null === ($buttonClass = $this->buttonClass)) {

--- a/themes/bootstrap5/templates/_ui/components/date-range-slider.phtml
+++ b/themes/bootstrap5/templates/_ui/components/date-range-slider.phtml
@@ -8,7 +8,7 @@
    * @property ?int   $rangeMax   The maximum allowed year (default = next year)
    * @property string $sliderId   The ID for the slider element
    * @property ?array $values     An array of [minimum, maximum] values representing the current selection (defaults to
-   *                           [$rangeMin, $rangeMax])
+   *                              [$rangeMin, $rangeMax])
    */
   $this->assetManager()->appendScriptLink('vendor/nouislider.min.js');
   $this->assetManager()->appendStyleLink('vendor/nouislider.min.css');

--- a/themes/bootstrap5/templates/_ui/components/date-range-slider.phtml
+++ b/themes/bootstrap5/templates/_ui/components/date-range-slider.phtml
@@ -2,12 +2,12 @@
   /**
    * Date range slider component
    *
-   * @param string $inputMaxId The ID of the input element for maximum range value
-   * @param string $inputMinId The ID of the input element for minimum range value
-   * @param ?int   $rangeMin   The minimum allowed year (default = 1400)
-   * @param ?int   $rangeMax   The maximum allowed year (default = next year)
-   * @param string $sliderId   The ID for the slider element
-   * @param ?array $values     An array of [minimum, maximum] values representing the current selection (defaults to
+   * @property string $inputMaxId The ID of the input element for maximum range value
+   * @property string $inputMinId The ID of the input element for minimum range value
+   * @property ?int   $rangeMin   The minimum allowed year (default = 1400)
+   * @property ?int   $rangeMax   The maximum allowed year (default = next year)
+   * @property string $sliderId   The ID for the slider element
+   * @property ?array $values     An array of [minimum, maximum] values representing the current selection (defaults to
    *                           [$rangeMin, $rangeMax])
    */
   $this->assetManager()->appendScriptLink('vendor/nouislider.min.js');

--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -2,8 +2,8 @@
   /**
    * Component to display a button that drops down a menu of options.
    *
-   * @param ?string $href         URL to link the menu button to, as a non-Javascript fallback (optional)
-   * @param array   $menuItems    Array of arrays representing menu items; each element can/should contain these keys:
+   * @property ?string $href         URL to link the menu button to, as a non-Javascript fallback (optional)
+   * @property array   $menuItems    Array of arrays representing menu items; each element can/should contain these keys:
    *                              - external (bool): if true, apply a target of _blank to the link (default = false)
    *                              - label (string): text of menu option link (required, will be translated)
    *                              - description (string): description displayed below the label (optional, will be translated)
@@ -12,11 +12,11 @@
    *                              - url (string): target link for menu option (required)
    *                              - setQueryParams (array): An array of query parameters to set when the menu item is
    *                                clicked instead of following the url (optional)
-   * @param ?array  $toggleAttrs  Additional attributes to apply to the toggle button
-   * @param string  $toggleLabel  The label for the toggle button (will be translated)
-   * @param ?string $wrapperTag   Tag to use as a wrapper around the control (default = div)
-   * @param ?string $wrapperClass Extra CSS class(es) to apply to the wrapper tag
-   * @param ?string $menuAlign    Alignment of the drop-down. Default is alignment with the start side of its parent.
+   * @property ?array  $toggleAttrs  Additional attributes to apply to the toggle button
+   * @property string  $toggleLabel  The label for the toggle button (will be translated)
+   * @property ?string $wrapperTag   Tag to use as a wrapper around the control (default = div)
+   * @property ?string $wrapperClass Extra CSS class(es) to apply to the wrapper tag
+   * @property ?string $menuAlign    Alignment of the drop-down. Default is alignment with the start side of its parent.
    *                              'end' aligns with the end side of its parent.
    */
   $wrapperTag = $this->wrapperTag ?? 'div';

--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -4,20 +4,20 @@
    *
    * @property ?string $href         URL to link the menu button to, as a non-Javascript fallback (optional)
    * @property array   $menuItems    Array of arrays representing menu items; each element can/should contain these keys:
-   *                              - external (bool): if true, apply a target of _blank to the link (default = false)
-   *                              - label (string): text of menu option link (required, will be translated)
-   *                              - description (string): description displayed below the label (optional, will be translated)
-   *                              - lightbox (bool): if true, open the link in a lightbox (default = false)
-   *                              - selected (bool): is this the active menu item? (default = false)
-   *                              - url (string): target link for menu option (required)
-   *                              - setQueryParams (array): An array of query parameters to set when the menu item is
-   *                                clicked instead of following the url (optional)
+   *                                 - external (bool): if true, apply a target of _blank to the link (default = false)
+   *                                 - label (string): text of menu option link (required, will be translated)
+   *                                 - description (string): description displayed below the label (optional, will be translated)
+   *                                 - lightbox (bool): if true, open the link in a lightbox (default = false)
+   *                                 - selected (bool): is this the active menu item? (default = false)
+   *                                 - url (string): target link for menu option (required)
+   *                                 - setQueryParams (array): An array of query parameters to set when the menu item is
+   *                                   clicked instead of following the url (optional)
    * @property ?array  $toggleAttrs  Additional attributes to apply to the toggle button
    * @property string  $toggleLabel  The label for the toggle button (will be translated)
    * @property ?string $wrapperTag   Tag to use as a wrapper around the control (default = div)
    * @property ?string $wrapperClass Extra CSS class(es) to apply to the wrapper tag
    * @property ?string $menuAlign    Alignment of the drop-down. Default is alignment with the start side of its parent.
-   *                              'end' aligns with the end side of its parent.
+   *                                 'end' aligns with the end side of its parent.
    */
   $wrapperTag = $this->wrapperTag ?? 'div';
   $wrapperClass = 'dropdown'; // Bootstrap class

--- a/themes/bootstrap5/templates/_ui/components/page-title.phtml
+++ b/themes/bootstrap5/templates/_ui/components/page-title.phtml
@@ -4,12 +4,12 @@
    *
    * @property string       title         Translated title to be used as the header element value
    * @property string|false headTitle     Translated head title to be set for the page. Default is same as the title.
-   *                                   Set to false to disable.
+   *                                      Set to false to disable.
    * @property int          level         Header level. Default is 2. Level 1 in lightbox context will be changed to 2
-   *                                   if lightboxLevel is unset.
+   *                                      if lightboxLevel is unset.
    * @property int          lightboxLevel Header level in lightbox context. Allows level 1 header to be set.
    * @property string       class         Same as header element class attribute.
-   *                                   Appended values are 'vc-page-title' and in lightbox 'vc-page-title lightbox-title'.
+   *                                      Appended values are 'vc-page-title' and in lightbox 'vc-page-title lightbox-title'.
    * @property ?bool        escape        Whether or not to escape heading contents (by default, title is escaped).
    */
   $title = $this->title ?? 'title_missing';

--- a/themes/bootstrap5/templates/_ui/components/page-title.phtml
+++ b/themes/bootstrap5/templates/_ui/components/page-title.phtml
@@ -2,15 +2,15 @@
   /**
    * Page title component, which checks if the current template is rendered in lightbox or not. Use only once for each page.
    *
-   * @param string       title         Translated title to be used as the header element value
-   * @param string|false headTitle     Translated head title to be set for the page. Default is same as the title.
+   * @property string       title         Translated title to be used as the header element value
+   * @property string|false headTitle     Translated head title to be set for the page. Default is same as the title.
    *                                   Set to false to disable.
-   * @param int          level         Header level. Default is 2. Level 1 in lightbox context will be changed to 2
+   * @property int          level         Header level. Default is 2. Level 1 in lightbox context will be changed to 2
    *                                   if lightboxLevel is unset.
-   * @param int          lightboxLevel Header level in lightbox context. Allows level 1 header to be set.
-   * @param string       class         Same as header element class attribute.
+   * @property int          lightboxLevel Header level in lightbox context. Allows level 1 header to be set.
+   * @property string       class         Same as header element class attribute.
    *                                   Appended values are 'vc-page-title' and in lightbox 'vc-page-title lightbox-title'.
-   * @param ?bool        escape        Whether or not to escape heading contents (by default, title is escaped).
+   * @property ?bool        escape        Whether or not to escape heading contents (by default, title is escaped).
    */
   $title = $this->title ?? 'title_missing';
   $headerAttrs = [

--- a/themes/bootstrap5/templates/_ui/components/show-account-menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/show-account-menu-button.phtml
@@ -2,9 +2,9 @@
   /**
    * Wrapper around show-sidebar-button component designed specifically for the account menu sidebar.
    *
-   * @param ?string $title    Title for link (will be translated; defaults to sidebar_expand)
-   * @param string  $targetId HTML element ID to link to (default = 'myresearch-sidebar')
-   * @param string  $linkText Text to display within link (default = 'Your Account')
+   * @property ?string $title    Title for link (will be translated; defaults to sidebar_expand)
+   * @property string  $targetId HTML element ID to link to (default = 'myresearch-sidebar')
+   * @property string  $linkText Text to display within link (default = 'Your Account')
    */
 ?>
 <?=$this->component('show-sidebar-button', $this->vars()->getArrayCopy() + ['targetId' => 'myresearch-sidebar', 'linkText' => 'Your Account']);

--- a/themes/bootstrap5/templates/_ui/components/show-search-sidebar-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/show-search-sidebar-button.phtml
@@ -2,9 +2,9 @@
   /**
    * Wrapper around show-sidebar-button component designed specifically for the search sidebar.
    *
-   * @param ?string $title    Title for link (will be translated; defaults to sidebar_expand)
-   * @param string  $targetId HTML element ID to link to (default = 'search-sidebar')
-   * @param string  $linkText Text to display within link (default = 'Refine Results')
+   * @property ?string $title    Title for link (will be translated; defaults to sidebar_expand)
+   * @property string  $targetId HTML element ID to link to (default = 'search-sidebar')
+   * @property string  $linkText Text to display within link (default = 'Refine Results')
    */
 ?>
 <?=$this->component('show-sidebar-button', $this->vars()->getArrayCopy() + ['targetId' => 'search-sidebar', 'linkText' => 'Refine Results']);

--- a/themes/bootstrap5/templates/_ui/components/show-sidebar-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/show-sidebar-button.phtml
@@ -2,9 +2,9 @@
     /**
      * Component to display a link to navigate to a sidebar (used in responsive mobile modes)
      *
-     * @param ?string $title    Title for link (will be translated; defaults to sidebar_expand)
-     * @param string  $targetId HTML element ID to link to
-     * @param string  $linkText Text to display within link
+     * @property ?string $title    Title for link (will be translated; defaults to sidebar_expand)
+     * @property string  $targetId HTML element ID to link to
+     * @property string  $linkText Text to display within link
      */
     $side = $this->config()->offcanvasSide();
     $aAttrs = [

--- a/themes/bootstrap5/templates/_ui/components/star-rating.phtml
+++ b/themes/bootstrap5/templates/_ui/components/star-rating.phtml
@@ -2,11 +2,11 @@
   /**
    * Component to display a star rating.
    *
-   * @param ?bool  $allowClear Should the control include a clear button? (default = false)
-   * @param ?array $labelAttrs Array of HTML attributes to apply to the label (optional)
-   * @param ?array $inputAttrs Array of HTML attributes to apply to the input (optional)
-   * @param array  $ratingData Rating data (array containing 'count' and 'rating' values)
-   * @param ?bool  $readonly   Should the control be read-only? (default = false)
+   * @property ?bool  $allowClear Should the control include a clear button? (default = false)
+   * @property ?array $labelAttrs Array of HTML attributes to apply to the label (optional)
+   * @property ?array $inputAttrs Array of HTML attributes to apply to the input (optional)
+   * @property array  $ratingData Rating data (array containing 'count' and 'rating' values)
+   * @property ?bool  $readonly   Should the control be read-only? (default = false)
    */
   $id = $this->escapeHtmlAttr(uniqid());
   $labelAttrs = !empty($this->labelAttrs) ? (' ' . implode(' ', $this->labelAttrs)) : '';


### PR DESCRIPTION
As @rominail pointed out in #5338, templates receive inputs as properties, not parameters. This PR adjusts our component annotations to reflect this.

TODO
- [x] Apply equivalent changes in dev-12.0 after merging