### PR TITLE
Fix null coalescing precedence

### DIFF
--- a/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
+++ b/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php
@@ -337,7 +337,7 @@ class RateLimiterManager implements LoggerAwareInterface, TranslatorAwareInterfa
                     default => $req->getPost()->toArray() + $req->getQuery()->toArray(),
                 };
                 foreach ($value as $key => $val) {
-                    if ($val !== $allParams[$key] ?? null) {
+                    if ($val !== ($allParams[$key] ?? null)) {
                         return false;
                     }
                 }


### PR DESCRIPTION
Minor bug fix to correct the operator precedence for the null coalesce vs the `!==` operator in the `RateLimiterManger.php`.

Sample config scenario that may trigger it (taken from `RateLimiter.yaml`):

```yaml
Policies:
  search:
    filters:
      - controller: AJAX
        action: JSON
        params:
          method: getSearchResults
```

Error in Apache logs this resolves:

```
 PHP Warning:  Undefined array key "method" in /usr/local/vufind/module/VuFind/src/VuFind/RateLimiter/RateLimiterManager.php on line 340
```