### PR TITLE
Fix pickup location text with no request group

### DIFF
--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -101,7 +101,7 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-select">
           <?php if ($selected === false): ?>
           <option value="" selected="selected">
-            <?php 
+            <?php
               $selectPickupLocationText = array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
                 ?? 'select_pickup_location';
             ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -89,8 +89,10 @@
         $selected = $this->homeLibrary ?? false;
       }
       $selectPickupLocationText =
-        array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
-        ?? 'select_pickup_location';
+        !$this->requestGroupNeeded ?
+          'select_pickup_location' :
+          array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
+            ?? 'select_pickup_location';
     ?>
     <?php if ($this->requestGroupNeeded): ?>
       <div class="form-group hold-pickup-location">

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -9,7 +9,7 @@
 
     $enumchronRaw = $this->gatheredDetails['requestedItem']['enumchron'] ?? '';
     $enumchron = $enumchronRaw !== '' ? " ($enumchronRaw)" : '';
-    $defaultRequestGroupLocationText = 'select_pickup_location';
+    $defaultRequestGroupLocationText = null;
 ?>
 <?=$this->component('page-title', ['title' => $this->translate('request_place_text'), 'headTitle' => $this->translate('request_place_text') . ': ' . $this->driver->getBreadcrumb()]);?>
 <?php if ($this->helpTextHtml): ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -9,7 +9,7 @@
 
     $enumchronRaw = $this->gatheredDetails['requestedItem']['enumchron'] ?? '';
     $enumchron = $enumchronRaw !== '' ? " ($enumchronRaw)" : '';
-    $selectPickupLocationText = 'select_pickup_location';
+    $defaultRequestGroupLocationText = 'select_pickup_location';
 ?>
 <?=$this->component('page-title', ['title' => $this->translate('request_place_text'), 'headTitle' => $this->translate('request_place_text') . ': ' . $this->driver->getBreadcrumb()]);?>
 <?php if ($this->helpTextHtml): ?>
@@ -64,13 +64,13 @@
             value="<?=$this->escapeHtmlAttr($group['id'])?>"
             data-locations-label="<?=$this->transEsc($group['locationsLabel'] ?? 'pick_up_location')?>"
             data-no-locations-label="<?=$this->transEsc($group['noLocationsLabel'] ?? 'No pickup locations available')?>"
-            data-select-location-text="<?=$this->transEsc($group['selectLocationText'] ?? $selectPickupLocationText)?>"
+            data-select-location-text="<?=$this->transEsc($group['selectLocationText'] ?? 'select_pickup_location')?>"
             <?=($selected == $group['id']) ? ' selected="selected"' : ''?>
           >
             <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
           </option>
           <?php if ($group['id'] === $this->defaultRequestGroup) {
-            $selectPickupLocationText = $group['selectLocationText'] ?? $selectPickupLocationText;
+            $defaultRequestGroupLocationText = $group['selectLocationText'] ?? 'select_pickup_location';
           } ?>
         <?php endforeach; ?>
       </select>
@@ -105,7 +105,7 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-select">
           <?php if ($selected === false): ?>
           <option value="" selected="selected">
-            <?=$this->transEsc($selectPickupLocationText)?>
+            <?=$this->transEsc($defaultRequestGroupLocationText ?? 'select_pickup_location')?>
           </option>
           <?php endif; ?>
         </select>
@@ -116,7 +116,7 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" class="form-select">
           <?php if ($selected === false && count($this->pickup) > 1): ?>
             <option value="" selected="selected">
-              <?=$this->transEsc($selectPickupLocationText)?>
+              <?=$this->transEsc('select_pickup_location')?>
             </option>
           <?php endif; ?>
           <?php foreach ($this->pickup as $lib): ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -9,6 +9,7 @@
 
     $enumchronRaw = $this->gatheredDetails['requestedItem']['enumchron'] ?? '';
     $enumchron = $enumchronRaw !== '' ? " ($enumchronRaw)" : '';
+    $selectPickupLocationText = 'select_pickup_location';
 ?>
 <?=$this->component('page-title', ['title' => $this->translate('request_place_text'), 'headTitle' => $this->translate('request_place_text') . ': ' . $this->driver->getBreadcrumb()]);?>
 <?php if ($this->helpTextHtml): ?>
@@ -68,6 +69,9 @@
           >
             <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
           </option>
+          <?php if ($group['id'] === $this->defaultRequestGroup) {
+            $selectPickupLocationText = $group['selectLocationText'] ?? 'select_pickup_location';
+          } ?>
         <?php endforeach; ?>
       </select>
     </div>
@@ -101,10 +105,6 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-select">
           <?php if ($selected === false): ?>
           <option value="" selected="selected">
-            <?php
-              $selectPickupLocationText = array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
-                ?? 'select_pickup_location';
-            ?>
             <?=$this->transEsc($selectPickupLocationText)?>
           </option>
           <?php endif; ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -64,13 +64,13 @@
             value="<?=$this->escapeHtmlAttr($group['id'])?>"
             data-locations-label="<?=$this->transEsc($group['locationsLabel'] ?? 'pick_up_location')?>"
             data-no-locations-label="<?=$this->transEsc($group['noLocationsLabel'] ?? 'No pickup locations available')?>"
-            data-select-location-text="<?=$this->transEsc($group['selectLocationText'] ?? 'select_pickup_location')?>"
+            data-select-location-text="<?=$this->transEsc($group['selectLocationText'] ?? $selectPickupLocationText)?>"
             <?=($selected == $group['id']) ? ' selected="selected"' : ''?>
           >
             <?=$this->transEsc('request_group_' . $group['name'], null, $group['name'])?>
           </option>
           <?php if ($group['id'] === $this->defaultRequestGroup) {
-            $selectPickupLocationText = $group['selectLocationText'] ?? 'select_pickup_location';
+            $selectPickupLocationText = $group['selectLocationText'] ?? $selectPickupLocationText;
           } ?>
         <?php endforeach; ?>
       </select>
@@ -116,7 +116,7 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" class="form-select">
           <?php if ($selected === false && count($this->pickup) > 1): ?>
             <option value="" selected="selected">
-              <?=$this->transEsc('select_pickup_location')?>
+              <?=$this->transEsc($selectPickupLocationText)?>
             </option>
           <?php endif; ?>
           <?php foreach ($this->pickup as $lib): ?>

--- a/themes/bootstrap5/templates/record/hold.phtml
+++ b/themes/bootstrap5/templates/record/hold.phtml
@@ -88,11 +88,6 @@
         // default:
         $selected = $this->homeLibrary ?? false;
       }
-      $selectPickupLocationText =
-        !$this->requestGroupNeeded ?
-          'select_pickup_location' :
-          array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
-            ?? 'select_pickup_location';
     ?>
     <?php if ($this->requestGroupNeeded): ?>
       <div class="form-group hold-pickup-location">
@@ -106,6 +101,10 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" data-default="<?=$this->escapeHtmlAttr($selected)?>" class="form-select">
           <?php if ($selected === false): ?>
           <option value="" selected="selected">
+            <?php 
+              $selectPickupLocationText = array_filter($requestGroups, fn ($group) => $group['id'] == $defaultRequestGroup)[0]['selectLocationText']
+                ?? 'select_pickup_location';
+            ?>
             <?=$this->transEsc($selectPickupLocationText)?>
           </option>
           <?php endif; ?>
@@ -117,7 +116,7 @@
         <select id="pickUpLocation" name="gatheredDetails[pickUpLocation]" class="form-select">
           <?php if ($selected === false && count($this->pickup) > 1): ?>
             <option value="" selected="selected">
-              <?=$this->transEsc($selectPickupLocationText)?>
+              <?=$this->transEsc('select_pickup_location')?>
             </option>
           <?php endif; ?>
           <?php foreach ($this->pickup as $lib): ?>


### PR DESCRIPTION
#5337 introduced a bug looking for `$requestGroups` to be an array even when they are none.