### PR TITLE
Change the roles of links in Rating.phtml files to buttons to meet accessibility requirements

### DIFF
--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/rating.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/rating.phtml
@@ -19,7 +19,7 @@
     <?php endif; ?>
     <?=$this->component('star-rating', ['readonly' => true, 'ratingData' => $ratingData, 'labelAttrs' => ['data-click-callback="addRecordRating"']]);?>
     <span class="rating-summary">
-      <a href="<?=$addUrlEsc?>" data-lightbox title="<?=$this->transEscAttr('rating_add_or_update')?>">
+      <a href="<?=$addUrlEsc?>" data-lightbox title="<?=$this->transEscAttr('rating_add_or_update')?>" role="button">
         <?=$this->transEsc($countKeys[$ratingData['count']] ?? 'rating_summary', $translationParams)?>
       </a>
     </span>

--- a/themes/bootstrap5/templates/record/rating.phtml
+++ b/themes/bootstrap5/templates/record/rating.phtml
@@ -68,7 +68,7 @@
   <?php endif; ?>
 <?php else: ?>
   <?php $singleSignOn = $this->auth()->hasSessionInitiator(); ?>
-  <a href="<?=$this->url('myresearch-userlogin') ?>" class="btn btn-primary"<?php if (!$singleSignOn): ?> data-lightbox<?php endif; ?> title="<?=$this->transEscAttr('Login')?>">
+  <a href="<?=$this->url('myresearch-userlogin') ?>" class="btn btn-primary"<?php if (!$singleSignOn): ?> data-lightbox<?php endif; ?> title="<?=$this->transEscAttr('Login')?>" role="button">
     <?=$this->icon('sign-in') ?>
     <?=$this->transEsc('You must be logged in first') ?>
   </a>


### PR DESCRIPTION
Currently link that leads to a modal where user can view and add star ratings is not defined for the screen readers as a button, which is mandatory if the link opens a modal. Also the modal that opens has a button which is defined as a link and not a button. Both of these are fixed with this PR. 