### PR TITLE
Refactor Mailer to use template renderer in sendLink method.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CartController.php
+++ b/module/VuFind/src/VuFind/Controller/CartController.php
@@ -306,7 +306,6 @@ class CartController extends AbstractBase
                     $view->from,
                     $view->message,
                     $url,
-                    $this->getViewRenderer(),
                     $view->subject,
                     $cc
                 );

--- a/module/VuFind/src/VuFind/Controller/SearchController.php
+++ b/module/VuFind/src/VuFind/Controller/SearchController.php
@@ -180,7 +180,6 @@ class SearchController extends AbstractSolrSearch
                     $view->from,
                     $view->message,
                     $view->url,
-                    $this->getViewRenderer(),
                     $view->subject,
                     $cc
                 );

--- a/module/VuFind/src/VuFind/Mailer/Mailer.php
+++ b/module/VuFind/src/VuFind/Mailer/Mailer.php
@@ -39,6 +39,7 @@ use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Mime\Part\DataPart;
 use VuFind\Exception\Mail as MailException;
 use VuFind\RecordDriver\AbstractBase;
+use VuFind\View\Renderer\TemplateRendererInterface;
 
 use function count;
 use function is_array;
@@ -91,11 +92,15 @@ class Mailer implements
     /**
      * Constructor.
      *
-     * @param MailerInterface $transport Mail transport
-     * @param array           $options   Message log options
+     * @param MailerInterface           $transport        Mail transport
+     * @param TemplateRendererInterface $templateRenderer Template renderer
+     * @param array                     $options          Message log options
      */
-    public function __construct(MailerInterface $transport, protected array $options = [])
-    {
+    public function __construct(
+        MailerInterface $transport,
+        protected TemplateRendererInterface $templateRenderer,
+        protected array $options = []
+    ) {
         $this->setTransport($transport);
     }
 
@@ -336,7 +341,6 @@ class Mailer implements
      * @param string|Address                         $from    Sender name and email address
      * @param string                                 $msg     User notes to include in message
      * @param string                                 $url     URL to share
-     * @param PhpRenderer                            $view    View object (used to render email templates)
      * @param ?string                                $subject Subject for email (optional)
      * @param string|string[]|Address|Address[]|null $cc      CC recipient(s) (null for none)
      * @param string|string[]|Address|Address[]|null $replyTo Reply-To address(es) (or delimited list, null for none)
@@ -349,7 +353,6 @@ class Mailer implements
         string|Address $from,
         string $msg,
         string $url,
-        PhpRenderer $view,
         ?string $subject = null,
         string|Address|array|null $cc = null,
         string|Address|array|null $replyTo = null
@@ -357,9 +360,9 @@ class Mailer implements
         if (null === $subject) {
             $subject = $this->getDefaultLinkSubject();
         }
-        $body = $view->partial(
-            'Email/share-link.phtml',
-            [
+        $body = $this->templateRenderer->renderTemplateAsString(
+            template: 'Email/share-link.phtml',
+            params: [
                 'msgUrl' => $url, 'to' => $to, 'from' => $from, 'message' => $msg,
             ]
         );

--- a/module/VuFind/src/VuFind/Mailer/MailerFactory.php
+++ b/module/VuFind/src/VuFind/Mailer/MailerFactory.php
@@ -37,6 +37,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 use VuFind\Config\Feature\SecretTrait;
+use VuFind\View\Renderer\TemplateRendererInterface;
 
 /**
  * Factory for instantiating Mailer objects.
@@ -131,6 +132,7 @@ class MailerFactory implements FactoryInterface
             new \Symfony\Component\Mailer\Mailer(
                 \Symfony\Component\Mailer\Transport::fromDsn($this->getDSN($config))
             ),
+            $container->get(TemplateRendererInterface::class),
             [
                 'message_log' => $config['Mail']['message_log'] ?? null,
                 'message_log_format' => $config['Mail']['message_log_format'] ?? null,

--- a/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
+++ b/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
@@ -181,6 +181,9 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
         }
 
         // Prepare layout and render:
+        if (null === $request) {
+            throw new InvalidArgumentException('Request is required for rendering with layout');
+        }
         $layout = $this->getLayout($request);
 
         $templateParts = explode('/', $viewModel->getTemplate());

--- a/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
+++ b/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
@@ -189,10 +189,7 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
         $templateParts = explode('/', $viewModel->getTemplate());
         $layout->setVariable('templateDir', $templateParts[0]);
         $layout->setVariable('templateName', $templateParts[1] ?? null);
-
-        if ($this->inLightbox($request)) {
-            $this->setupRenderingInLightbox($request, $layout);
-        }
+        $this->setupRenderingInLightbox($request, $layout);
 
         // Clear any previous children (e.g. when rendering an error):
         if ($layout instanceof ViewModel) {
@@ -306,7 +303,7 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
     }
 
     /**
-     * Setup layout for rendering lightbox content.
+     * Setup layout with lightbox-related variables, and template when a lightbox is requested.
      *
      * @param ServerRequestInterface $request Request
      * @param ViewModel              $layout  Layout
@@ -315,7 +312,9 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
      */
     protected function setupRenderingInLightbox(ServerRequestInterface $request, ViewModel $layout): void
     {
-        $layout->setTemplate('layout/lightbox');
+        if ($this->inLightbox($request)) {
+            $layout->setTemplate('layout/lightbox');
+        }
         $lightboxParentUrl = new Http($this->serverUrlHelper->getCurrentUrl());
         $query = $lightboxParentUrl->getQueryAsArray();
         unset($query['lightboxChild']);

--- a/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
+++ b/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
@@ -191,15 +191,7 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
         $layout->setVariable('templateName', $templateParts[1] ?? null);
 
         if ($this->inLightbox($request)) {
-            $layout->setTemplate('layout/lightbox');
-        }
-        $lightboxParentUrl = new Http($this->serverUrlHelper->getCurrentUrl());
-        $query = $lightboxParentUrl->getQueryAsArray();
-        unset($query['lightboxChild']);
-        $lightboxParentUrl->setQuery($query);
-        $layout->lightboxParent = $lightboxParentUrl->toString();
-        if ($lightboxChild = $request->getQueryParams()['lightboxChild'] ?? null) {
-            $layout->lightboxChild = $lightboxChild;
+            $this->setupRenderingInLightbox($request, $layout);
         }
 
         // Clear any previous children (e.g. when rendering an error):
@@ -311,5 +303,26 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
             }
         }
         return strtolower($name);
+    }
+
+    /**
+     * Setup layout for rendering lightbox content.
+     *
+     * @param ServerRequestInterface $request Request
+     * @param ViewModel              $layout  Layout
+     *
+     * @return void
+     */
+    protected function setupRenderingInLightbox(ServerRequestInterface $request, ViewModel $layout): void
+    {
+        $layout->setTemplate('layout/lightbox');
+        $lightboxParentUrl = new Http($this->serverUrlHelper->getCurrentUrl());
+        $query = $lightboxParentUrl->getQueryAsArray();
+        unset($query['lightboxChild']);
+        $lightboxParentUrl->setQuery($query);
+        $layout->setVariable('lightboxParent', $lightboxParentUrl->toString());
+        if ($lightboxChild = $request->getQueryParams()['lightboxChild'] ?? null) {
+            $layout->setVariable('lightboxChild', $lightboxChild);
+        }
     }
 }

--- a/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
+++ b/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
@@ -153,17 +153,17 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
     /**
      * Render a template and return the result as a string.
      *
-     * @param ServerRequestInterface $request        Request
-     * @param ?string                $template       Template name, or null to use default for the action
-     * @param array                  $params         Template parameters
-     * @param array[]                $childTemplates Any child templates; an array of associative array with keys
-     * 'template' and 'params'
-     * @param bool                   $useLayout      Render full page with the layout?
+     * @param ?ServerRequestInterface $request        Request (must be set if $template is null or $useLayout is true)
+     * @param ?string                 $template       Template name, or null to use default for the action
+     * @param array                   $params         Template parameters
+     * @param array[]                 $childTemplates Any child templates; an array of associative array with keys
+     *                                                'template' and 'params'
+     * @param bool                    $useLayout      Render full page with the layout?
      *
      * @return string
      */
     public function renderTemplateAsString(
-        ServerRequestInterface $request,
+        ?ServerRequestInterface $request = null,
         ?string $template = null,
         array $params = [],
         array $childTemplates = [],
@@ -174,20 +174,39 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
         foreach ($childTemplates as $current) {
             $viewModel->addChild($this->createViewModel($request, $current['params'] ?? [], $current['template']));
         }
-        if ($useLayout) {
-            $layout = $this->getLayout($request);
-            // Clear any previous children (e.g. when rendering an error):
-            if ($layout instanceof ViewModel) {
-                $layout->clearChildren();
-            }
-            $layout->addChild($viewModel);
+        if (!$useLayout) {
             // Force renderer to return the result:
-            $layout->setOption('has_parent', true);
-            return $view->render($layout);
+            $viewModel->setOption('has_parent', true);
+            return $view->render($viewModel);
         }
+
+        // Prepare layout and render:
+        $layout = $this->getLayout($request);
+
+        $templateParts = explode('/', $viewModel->getTemplate());
+        $layout->setVariable('templateDir', $templateParts[0]);
+        $layout->setVariable('templateName', $templateParts[1] ?? null);
+
+        if ($this->inLightbox($request)) {
+            $layout->setTemplate('layout/lightbox');
+        }
+        $lightboxParentUrl = new Http($this->serverUrlHelper->getCurrentUrl());
+        $query = $lightboxParentUrl->getQueryAsArray();
+        unset($query['lightboxChild']);
+        $lightboxParentUrl->setQuery($query);
+        $layout->lightboxParent = $lightboxParentUrl->toString();
+        if ($lightboxChild = $request->getQueryParams()['lightboxChild'] ?? null) {
+            $layout->lightboxChild = $lightboxChild;
+        }
+
+        // Clear any previous children (e.g. when rendering an error):
+        if ($layout instanceof ViewModel) {
+            $layout->clearChildren();
+        }
+        $layout->addChild($viewModel);
         // Force renderer to return the result:
-        $viewModel->setOption('has_parent', true);
-        return $view->render($viewModel);
+        $layout->setOption('has_parent', true);
+        return $view->render($layout);
     }
 
     /**
@@ -205,34 +224,21 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
     /**
      * Create a new ViewModel.
      *
-     * @param ServerRequestInterface $request  Request
-     * @param array                  $params   Parameters to pass to ViewModel constructor
-     * @param ?string                $template Template name, or null to use default for the action
+     * @param ?ServerRequestInterface $request  Request
+     * @param array                   $params   Parameters to pass to ViewModel constructor
+     * @param ?string                 $template Template name, or null to use default for the action
      *
      * @return ViewModel
      */
     public function createViewModel(
-        ServerRequestInterface $request,
+        ?ServerRequestInterface $request,
         array $params,
         ?string $template = null
     ): ViewModel {
         $template ??= $this->getDefaultTemplateName($request);
-        $layout = $this->getLayout($request);
-        if ($this->inLightbox($request)) {
-            $layout->setTemplate('layout/lightbox');
+        if ($request && $this->inLightbox($request)) {
             $params['inLightbox'] = true;
         }
-        $lightboxParentUrl = new Http($this->serverUrlHelper->getCurrentUrl());
-        $query = $lightboxParentUrl->getQueryAsArray();
-        unset($query['lightboxChild']);
-        $lightboxParentUrl->setQuery($query);
-        $layout->lightboxParent = $lightboxParentUrl->toString();
-        if ($lightboxChild = $request->getQueryParams()['lightboxChild'] ?? null) {
-            $layout->lightboxChild = $lightboxChild;
-        }
-        $templateParts = explode('/', $template);
-        $layout->setVariable('templateDir', $templateParts[0]);
-        $layout->setVariable('templateName', $templateParts[1] ?? null);
         $viewModel = new ViewModel($params);
         $viewModel->setTemplate($template);
         return $viewModel;
@@ -249,10 +255,11 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
      */
     public function getLayout(ServerRequestInterface $request): ModelInterface
     {
-        if (!($result = $request->getAttribute('view-model'))) {
+        if (!($layout = $request->getAttribute('view-model'))) {
             throw new InvalidArgumentException("Request must include the 'view-model' attribute");
         }
-        return $result;
+
+        return $layout;
     }
 
     /**
@@ -271,13 +278,13 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
     /**
      * Get default template name for the action.
      *
-     * @param ServerRequestInterface $request Request
+     * @param ?ServerRequestInterface $request Request
      *
      * @return string
      */
-    protected function getDefaultTemplateName(ServerRequestInterface $request): string
+    protected function getDefaultTemplateName(?ServerRequestInterface $request): string
     {
-        if (!($action = $request->getAttribute('action-id'))) {
+        if (!($action = $request?->getAttribute('action-id'))) {
             throw new \InvalidArgumentException("Request must include the 'action-id' attribute");
         }
         $parts = explode('/', $action);

--- a/module/VuFind/src/VuFind/View/Renderer/TemplateRendererInterface.php
+++ b/module/VuFind/src/VuFind/View/Renderer/TemplateRendererInterface.php
@@ -96,17 +96,17 @@ interface TemplateRendererInterface
     /**
      * Render a template and return the result as a string.
      *
-     * @param ServerRequestInterface $request        Request
-     * @param ?string                $template       Template name, or null to use default for the action
-     * @param array                  $params         Template parameters
-     * @param array[]                $childTemplates Any child templates; an array of associative array with keys
-     * 'template' and 'params'
-     * @param bool                   $useLayout      Render full page with the layout?
+     * @param ?ServerRequestInterface $request        Request (must be set if $template is null or $useLayout is true)
+     * @param ?string                 $template       Template name, or null to use default for the action
+     * @param array                   $params         Template parameters
+     * @param array[]                 $childTemplates Any child templates; an array of associative array with keys
+     *                                                'template' and 'params'
+     * @param bool                    $useLayout      Render full page with the layout?
      *
      * @return string
      */
     public function renderTemplateAsString(
-        ServerRequestInterface $request,
+        ?ServerRequestInterface $request = null,
         ?string $template = null,
         array $params = [],
         array $childTemplates = [],

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Mailer/MailerTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use VuFind\Mailer\Mailer;
 use VuFind\Mailer\MailerFactory;
+use VuFind\View\Renderer\TemplateRendererInterface;
 use VuFindTest\Container\MockContainer;
 
 use function count;
@@ -375,7 +376,7 @@ class MailerTest extends \PHPUnit\Framework\TestCase
 
         $transport = $this->createMock(MailerInterface::class);
         $transport->expects($this->once())->method('send')->willThrowException(new \Exception('Boom'));
-        $mailer = new Mailer($transport);
+        $mailer = new Mailer($transport, $this->createMock(TemplateRendererInterface::class));
         $mailer->send('to@example.com', 'from@example.com', 'subject', 'body');
     }
 
@@ -412,19 +413,16 @@ class MailerTest extends \PHPUnit\Framework\TestCase
      */
     public function testSendLink()
     {
-        $view = $this->createMock(\Laminas\View\Renderer\PhpRenderer::class);
-        $view->method('__call')
+        $renderer = $this->createMock(TemplateRendererInterface::class);
+        $renderer->method('renderTemplateAsString')
             ->willReturnCallback(
-                function ($method, $args) {
-                    if ($method === 'partial') {
-                        $this->assertSame('Email/share-link.phtml', $args[0]);
-                        $this->assertSame('http://foo', $args[1]['msgUrl']);
-                        $this->assertSame('to@example.com;to2@example.com', $args[1]['to']);
-                        $this->assertSame('from@example.com', $args[1]['from']);
-                        $this->assertSame('message', $args[1]['message']);
-                        return 'body';
-                    }
-                    return null;
+                function (?\Psr\Http\Message\ServerRequestInterface $request, ?string $template, array $params) {
+                    $this->assertSame('Email/share-link.phtml', $template);
+                    $this->assertSame('http://foo', $params['msgUrl']);
+                    $this->assertSame('to@example.com;to2@example.com', $params['to']);
+                    $this->assertSame('from@example.com', $params['from']);
+                    $this->assertSame('message', $params['message']);
+                    return 'body';
                 }
             );
 
@@ -438,14 +436,13 @@ class MailerTest extends \PHPUnit\Framework\TestCase
                 && 'body' == $message->getBody()->getBody()
                 && 'Library Catalog Search Result' == $message->getSubject();
         };
-        $mailer = $this->getMailer($callback);
+        $mailer = $this->getMailer($callback, $renderer);
         $mailer->setMaxRecipients(2);
         $mailer->sendLink(
             'to@example.com;to2@example.com',
             'from@example.com',
             'message',
             'http://foo',
-            $view,
             null,
             'cc@example.com'
         );
@@ -515,16 +512,17 @@ class MailerTest extends \PHPUnit\Framework\TestCase
     /**
      * Create mailer with a mock transport.
      *
-     * @param ?callable $callback Mock send method result callback
+     * @param ?callable                  $callback Mock send method result callback
+     * @param ?TemplateRendererInterface $renderer Template renderer
      *
      * @return Mailer
      */
-    protected function getMailer($callback = null)
+    protected function getMailer($callback = null, ?TemplateRendererInterface $renderer = null)
     {
         $transport = $this->createMock(MailerInterface::class);
         if ($callback) {
             $transport->expects($this->once())->method('send')->with($this->callback($callback));
         }
-        return new Mailer($transport);
+        return new Mailer($transport, $renderer ?? $this->createMock(TemplateRendererInterface::class));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Renderer/LaminasTemplateRendererTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Renderer/LaminasTemplateRendererTest.php
@@ -179,10 +179,28 @@ class LaminasTemplateRendererTest extends TestCase
      */
     public function testRenderTemplateAsString(): void
     {
-        $renderer = $this->getRenderer(null, 'Foo!');
+        $renderer = $this->getRenderer(null, true);
 
         $result = $renderer->renderTemplateAsString(template: 'error/index', params: ['message' => 'Foo']);
-        $this->assertSame('Foo!', $result);
+        $this->assertJsonStringEqualsJsonString(
+            '{"template": "error\/index", "params": {"message": "Foo"}}',
+            $result
+        );
+    }
+
+    /**
+     * Test missing request with layout in renderTemplateAsString.
+     *
+     * @return void
+     */
+    public function testMissingRequest(): void
+    {
+        $layout = $this->createMock(ViewModel::class);
+        $renderer = $this->getRenderer($layout, null);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Request is required for rendering with layout');
+        $renderer->renderTemplateAsString(template: 'foo', useLayout: true);
     }
 
     /**
@@ -218,11 +236,12 @@ class LaminasTemplateRendererTest extends TestCase
      * Get LaminasTemplateRenderer.
      *
      * @param ?ViewModel $layout  Layout
-     * @param ?string    $content Page content, or null to not expect a call to render() method
+     * @param ?string    $content Page content, null to not expect a call to render() method or true to return rendering
+     * context
      *
      * @return LaminasTemplateRenderer
      */
-    protected function getRenderer(?ViewModel $layout, ?string $content): LaminasTemplateRenderer
+    protected function getRenderer(?ViewModel $layout, string|true|null $content): LaminasTemplateRenderer
     {
         $view = $this->createMock(View::class);
         $render = $view->expects(null !== $content ? $this->once() : $this->never())
@@ -230,7 +249,16 @@ class LaminasTemplateRendererTest extends TestCase
         if ($layout) {
             $render = $render->with($layout);
         }
-        $render->willReturn($content);
+        if (true === $content) {
+            $render->willReturnCallback(
+                fn (ViewModel $viewModel) => json_encode([
+                    'template' => $viewModel->getTemplate(),
+                    'params' => $viewModel->getVariables(),
+                ])
+            );
+        } else {
+            $render->willReturn($content);
+        }
 
         $viewManager = $this->createMock(ViewManager::class);
         $viewManager->method('getView')

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Renderer/LaminasTemplateRendererTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Renderer/LaminasTemplateRendererTest.php
@@ -173,6 +173,19 @@ class LaminasTemplateRendererTest extends TestCase
     }
 
     /**
+     * Test renderTemplateAsString.
+     *
+     * @return void
+     */
+    public function testRenderTemplateAsString(): void
+    {
+        $renderer = $this->getRenderer(null, 'Foo!');
+
+        $result = $renderer->renderTemplateAsString(template: 'error/index', params: ['message' => 'Foo']);
+        $this->assertSame('Foo!', $result);
+    }
+
+    /**
      * Get mock layout ViewModel.
      *
      * @param bool   $inLightbox       Are we in lightbox?
@@ -204,18 +217,20 @@ class LaminasTemplateRendererTest extends TestCase
     /**
      * Get LaminasTemplateRenderer.
      *
-     * @param ViewModel $layout  Layout
-     * @param ?string   $content Page content, or null to not expect a call to render() method
+     * @param ?ViewModel $layout  Layout
+     * @param ?string    $content Page content, or null to not expect a call to render() method
      *
      * @return LaminasTemplateRenderer
      */
-    protected function getRenderer(ViewModel $layout, ?string $content): LaminasTemplateRenderer
+    protected function getRenderer(?ViewModel $layout, ?string $content): LaminasTemplateRenderer
     {
         $view = $this->createMock(View::class);
-        $view->expects(null !== $content ? $this->once() : $this->never())
-            ->method('render')
-            ->with($layout)
-            ->willReturn($content);
+        $render = $view->expects(null !== $content ? $this->once() : $this->never())
+            ->method('render');
+        if ($layout) {
+            $render = $render->with($layout);
+        }
+        $render->willReturn($content);
 
         $viewManager = $this->createMock(ViewManager::class);
         $viewManager->method('getView')


### PR DESCRIPTION
Includes changes to TemplateRendererInterface and LaminasTemplateRenderer to allow rendering of a template to a string without having to pass a request to the renderer.

Extracted from #5347.

TODO
- [ ] Update changelog when merging