### PR TITLE
Update component annotations for release 12

### DIFF
--- a/themes/bootstrap5/templates/_ui/components/catalog-login-form.phtml
+++ b/themes/bootstrap5/templates/_ui/components/catalog-login-form.phtml
@@ -2,7 +2,7 @@
   /**
    * Component to display the catalog login form.
    *
-   * @param bool $showMenu Should we render the AccountMenu section in a sidebar (default = false)?
+   * @property bool $showMenu Should we render the AccountMenu section in a sidebar (default = false)?
    */
 
   // Convenience variable:

--- a/themes/bootstrap5/templates/_ui/components/radio-fieldset.phtml
+++ b/themes/bootstrap5/templates/_ui/components/radio-fieldset.phtml
@@ -2,10 +2,10 @@
   /**
    * Radio form element inside a fieldset for accessibility standards.
    *
-   * @param string  $groupName    Name of the radio group
-   * @param ?string $displayName  Name to be displayed (default = $groupName)
-   * @param array   $values       Array of values
-   * @param ?string $checkedValue Checked value (default is first value)
+   * @property string  $groupName    Name of the radio group
+   * @property ?string $displayName  Name to be displayed (default = $groupName)
+   * @property array   $values       Array of values
+   * @property ?string $checkedValue Checked value (default is first value)
    */
   $escGroupNameAttr = $this->escapeHtmlAttr($this->groupName);
   if (!in_array($this->checkedValue, $this->values)) {

--- a/themes/bootstrap5/templates/_ui/components/tabs.phtml
+++ b/themes/bootstrap5/templates/_ui/components/tabs.phtml
@@ -2,12 +2,12 @@
   /**
    * Tabs component.
    *
-   * @param array  $tabs              Tabs
-   * @param string $activeTab         Active tab
-   * @param string $idSuffix          Id suffix (optional)
-   * @param array  $tabNavClasses     Extra classes for the tab bar (optional)
-   * @param array  $tabContentClasses Extra classes for the tab content container (optional)
-   * @param array  $tabPaneClasses    Extra classes for the tab pane (optional)
+   * @property array   $tabs              Tabs
+   * @property string  $activeTab         Active tab
+   * @property ?string $idSuffix          Id suffix (optional)
+   * @property ?array  $tabNavClasses     Extra classes for the tab bar (optional)
+   * @property ?array  $tabContentClasses Extra classes for the tab content container (optional)
+   * @property ?array  $tabPaneClasses    Extra classes for the tab pane (optional)
    */
 
   $tabNavClasses = array_merge(['nav', 'nav-tabs'], $this->tabNavClasses ?? []);
@@ -37,7 +37,7 @@
         'data-bs-toggle' => 'tab',
         'data-bs-target' => '#' . $paneId,
       ]);
-      if ($activeTab == $tabName) {
+      if ($this->activeTab == $tabName) {
         $buttonAttributes->add('class', 'active');
         $buttonAttributes->add('aria-selected', 'true');
       } else {
@@ -64,7 +64,7 @@
         'aria-labelledby' => $getButtonId($tabName),
         'data-tab-name' => $tabName,
       ]);
-      if ($activeTab == $tabName) {
+      if ($this->activeTab == $tabName) {
           $tabPaneAttributes->add('class', 'active');
       }
       $tabPaneAttributes->merge($tab['paneAttributes'] ?? []);


### PR DESCRIPTION
This follow-up to #5349 adjusts templates added in the dev-12.0 branch. The changes to tabs.phtml go beyond simply changing `@param` to `@property` since static analysis revealed some minor issues (nullable types had to be added to some properties, and we were using `$this->` inconsistently).