### PR TITLE
[A11y] Fix anchor mismatch

### DIFF
--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -448,7 +448,12 @@ function applyRecordTabHash(scrollToTabs) {
   const activeLi = recordTabs.querySelector('li.active');
   const activeTab = activeLi ? activeLi.dataset.tab : undefined;
   const initiallyActiveTab = recordTabs.querySelector('li.initiallyActive a');
-  const newTab = typeof window.location.hash !== 'undefined' ? window.location.hash.toLowerCase().substring(1) : '';
+  let newTab = typeof window.location.hash !== 'undefined' ? window.location.hash.toLowerCase().substring(1) : '';
+  const prefix = 'record-tab-';
+
+  if (newTab.startsWith(prefix)) {
+    newTab = newTab.replace(prefix, '');
+  }
 
   // Open tab in url hash
   if (initiallyActiveTab && (newTab === '' || newTab === 'tabnav')) {

--- a/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
+++ b/themes/bootstrap5/templates/RecordDriver/DefaultRecord/versions-link.phtml
@@ -6,7 +6,7 @@
   if (isset($this->tabs['Versions'])) {
     $url = !empty($this->full)
       ? ($this->recordLinker()->getTabUrl($this->driver, 'Versions', [], ['query' => ['sid' => $this->searchId]]) . '#tabnav')
-      : '#versions';
+      : '#record-tab-versions';
     $translationKey = 'other_versions_link';
   } else {
     $url = $this->recordLinker()->getVersionsSearchUrl($this->driver);


### PR DESCRIPTION
Currently the link anchor points to an unexisting id `versions`
I adapted the JS and link anchor to point to an existing id `record-tab-versions`
This PR fix the feature to make it accessible