### PR TITLE
[A11y] Form system autocomplete attribute fixes

### DIFF
--- a/module/VuFind/src/VuFind/Form/Form.php
+++ b/module/VuFind/src/VuFind/Form/Form.php
@@ -649,6 +649,7 @@ class Form extends \Laminas\Form\Form implements
             'type' => 'email',
             'label' => $this->translate('feedback_email'),
             'group' => '__sender__',
+            'autocomplete' => 'email',
         ];
         if ($formConfig['senderInfoRequired'] ?? false) {
             $senderEmail['required'] = $senderName['required'] = true;
@@ -898,6 +899,7 @@ class Form extends \Laminas\Form\Form implements
             'required',
             'requireOne',
             'value',
+            'autocomplete',
         ];
     }
 
@@ -963,6 +965,10 @@ class Form extends \Laminas\Form\Form implements
         }
         if (!empty($el['settings'])) {
             $attributes += $el['settings'];
+        }
+        // Add autocomplete only for text and email fields
+        if (!empty($el['autocomplete']) && in_array($type, ['text', 'email'])) {
+            $attributes['autocomplete'] = $el['autocomplete'];
         }
         // Add aria-label only if not a hidden field and no aria-label specified:
         if (

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/FormTest.php
@@ -169,6 +169,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                 ],
                 [
                     'type' => 'submit',
@@ -216,6 +217,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                 'name' => 'email',
                 'group' => '__sender__',
                 'label' => 'feedback_email',
+                'autocomplete' => 'email',
             ],
         ];
         $postParams = [
@@ -295,6 +297,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                 ],
                 [
                     'type' => 'submit',
@@ -327,6 +330,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                     'settings' => [],
                 ],
                 [
@@ -377,6 +381,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                     'settings' => [
                         'aria-label' => 'Test label',
                     ],
@@ -903,6 +908,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                     'settings' => [],
                 ],
                 [
@@ -967,6 +973,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
                     'name' => 'email',
                     'group' => '__sender__',
                     'label' => 'feedback_email',
+                    'autocomplete' => 'email',
                     'settings' => [],
                 ],
                 [


### PR DESCRIPTION
In the feedback form, the email input lacks an autocomplete attribute
This PR : 
- Add the possibility to add an autocomplete attribute to the form inputs via FeedbackForms.yaml
- Add a default automplete to senderEmail