### PR TITLE
SummonBackendFactory: fix type error.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -119,6 +119,9 @@ class SummonBackendFactory extends AbstractBackendFactory
         // Load credentials:
         $id = $this->config->Summon->apiId ?? null;
         $key = $this->config->Summon->apiKey ?? null;
+        if (null === $id || null === $key) {
+            throw new \Exception('Credentials missing from [Summon] section of config.ini.');
+        }
 
         // Create connector:
         $options = ['authedUser' => $this->isAuthed()];

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -117,8 +117,8 @@ class SummonBackendFactory extends AbstractBackendFactory
     protected function createConnector()
     {
         // Load credentials:
-        $id = $this->config->Summon->apiId ?? '';
-        $key = $this->config->Summon->apiKey ?? '';
+        $id = $this->config->Summon->apiId ?? null;
+        $key = $this->config->Summon->apiKey ?? null;
 
         // Create connector:
         $options = ['authedUser' => $this->isAuthed()];

--- a/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
+++ b/module/VuFind/src/VuFind/Search/Factory/SummonBackendFactory.php
@@ -117,8 +117,8 @@ class SummonBackendFactory extends AbstractBackendFactory
     protected function createConnector()
     {
         // Load credentials:
-        $id = $this->config->Summon->apiId ?? null;
-        $key = $this->config->Summon->apiKey ?? null;
+        $id = $this->config->Summon->apiId ?? '';
+        $key = $this->config->Summon->apiKey ?? '';
 
         // Create connector:
         $options = ['authedUser' => $this->isAuthed()];


### PR DESCRIPTION
The SummonBackendFactory defaults credentials to null when missing from configuration, but the Connector class requires strings. We don't want to fail with a type error -- let's use empty strings instead so we can fail with a more helpful error.