### PR TITLE
YamlReader: respect disabled cache settings.

### DIFF
--- a/module/VuFind/src/VuFind/Config/YamlReader.php
+++ b/module/VuFind/src/VuFind/Config/YamlReader.php
@@ -129,6 +129,9 @@ class YamlReader
             $cacheConfig['CacheConfigName_' . $this->cacheName] ?? [],
         );
         $reloadOnFileChange = $cacheOptions['reloadOnFileChange'] ?? true;
+        if ($cacheOptions['disabled'] ?? false) {
+            $cache = false;
+        }
 
         // Generate cache key:
         $cacheKey = $defaultFile .


### PR DESCRIPTION
This fix was required to get tests passing in #4359. It has been extracted here so it can be merged separately.