### PR TITLE
ArchivesSpace XSLT: prevent illegal date range syntax.

### DIFF
--- a/import/xsl/archivesspace.xsl
+++ b/import/xsl/archivesspace.xsl
@@ -147,7 +147,7 @@
                         <xsl:value-of select="php:function('VuFind::extractBestDateOrRange', dc:date)"/>
                     </field>
                     <field name="publishDateRange">
-                        <xsl:value-of select="php:function('VuFind::extractBestDateOrRange', dc:date)"/>
+                        <xsl:value-of select="php:function('VuFind::extractBestDateOrRange', dc:date, boolean('true'))"/>
                     </field>
                     <field name="publishDateSort">
                         <xsl:value-of select="php:function('VuFind::extractEarliestYear', dc:date)"/>

--- a/module/VuFind/src/VuFind/XSLT/Import/VuFind.php
+++ b/module/VuFind/src/VuFind/XSLT/Import/VuFind.php
@@ -615,18 +615,30 @@ class VuFind
      * Best is defined as the first value to consist of only YYYY or YYYY-ZZZZ,
      * with no other text. If no "best" match is found, the first value is used.
      *
-     * @param array $input DOM elements to search.
+     * @param array $input  DOM elements to search.
+     * @param bool  $strict Only return valid Solr date range values.
      *
      * @return string
      */
-    public static function extractBestDateOrRange($input)
+    public static function extractBestDateOrRange($input, $strict = false)
     {
+        $fallback = null;
         foreach ($input as $current) {
             if (preg_match('/^\d{4}(-\d{4})?$/', $current->textContent)) {
-                return $current->textContent;
+                return ($strict && str_contains($current->textContent, '-'))
+                    ? '[' . str_replace('-', ' TO ', $current->textContent) . ']'
+                    : $current->textContent;
+            } elseif (null === $fallback) {
+                if ($strict) {
+                    if (preg_match('/\d{4}/', $current->textContent, $matches)) {
+                        $fallback = $matches[0];
+                    }
+                } else {
+                    $fallback = $current->textContent;
+                }
             }
         }
-        return reset($input)->textContent;
+        return $fallback ?? '';
     }
 
     /**


### PR DESCRIPTION
Solr date range fields only accept limited syntax, but the extractBestDateOrRange XSLT method potentially sends unstructured strings. This PR adds a strict mode which can be used to avoid illegal values.

It seems likely that some of the other XSLT examples would benefit from the introduction of extractBestDateOrRange to prevent similar problems, but I don't want to change anything without a use case, so I'm keeping this initial PR focused on the specific problem that impacted my local environment.