### PR TITLE
Fix links in facet list if opened in new window

### DIFF
--- a/themes/bootstrap5/templates/Recommend/SideFacets/single-facet.phtml
+++ b/themes/bootstrap5/templates/Recommend/SideFacets/single-facet.phtml
@@ -43,7 +43,7 @@
 ?>
 
 <span class="<?=implode(' ', $classList) ?>">
-  <a class="main-link<?=$hasCheckbox ? ' icon-link' : ''?>" href="<?=$toggleUrl ?>" data-lightbox-ignore data-title="<?=$this->escapeHtmlAttr($this->facet['displayText']) ?>" data-count="<?=$this->facet['count'] ?>"<?php if ($this->facet['isApplied']): ?> title="<?=$this->transEscAttr('applied_filter') ?>"<?php endif;?>>
+  <a class="main-link<?=$hasCheckbox ? ' icon-link' : ''?>" href="Results<?=$toggleUrl ?>" data-lightbox-ignore data-title="<?=$this->escapeHtmlAttr($this->facet['displayText']) ?>" data-count="<?=$this->facet['count'] ?>"<?php if ($this->facet['isApplied']): ?> title="<?=$this->transEscAttr('applied_filter') ?>"<?php endif;?>>
     <span class="text">
       <?=$displayText ?>
     </span>


### PR DESCRIPTION
Here is a way how a normal user could get to the error described in #5213:

1. go to for example https://vufind.org/demo/
2. click "Find"
3. in the facet "Format" click "more..."
4. open the link "see all..." in a new tab or window https://vufind.org/demo/Search/FacetList?type=AllFields&facet=format&facetop=AND&facetexclude=0
5. click on any entry, for example "Book" https://vufind.org/demo/Search/FacetList?type=AllFields&filter%5B%5D=format%3A%22Book%22 "An error has occurred"

The last link should instead be: https://vufind.org/demo/Search/Results?type=AllFields&filter[]=format%3A%22Book%22

This link consists of only parameters, so it stays on the same page. If you open the facet list from the results page in the lightbox, the links go correctly to the results page. If you open the facet list in a new tab/window instead, the links go falsely to the facet list.

Probably this is also the way how bots get to these wrong links and produce errors.

(MR)