### PR TITLE
Extra screen reader field-set announcement removed from Feedback form

### DIFF
--- a/themes/bootstrap5/templates/feedback/form.phtml
+++ b/themes/bootstrap5/templates/feedback/form.phtml
@@ -70,7 +70,7 @@
       <?php if (in_array($el['type'], ['checkbox', 'radio'])): ?>
         <div class="field-set" role="group"<?= !empty($el['label']) ? ' aria-labelledby="' . $this->escapeHtmlAttr($formElement->getAttribute('id')) . '"' : ''?>>
       <?php else: ?>
-        <div class="field-set"<?= !empty($elementHelpPre) ? ' role="contentinfo" aria-label="' . $this->escapeHtmlAttr($elementHelpPre) . '"' : ''?>>
+        <div class="field-set">
       <?php endif ?>
     <?php endif ?>
 


### PR DESCRIPTION
According to an accessibility review conducted by the Finnish Transport and Communications Agency:

> "In the source code of the page, the "Name" and "Address" input fields in the feedback form on the page, as well as the associated help text, have been assigned a page area whose type is programmatically defined as a footer by adding the attribute `role="contentinfo"` to the `<div>` tag for the content. The audit concluded that the content in question does not function as a footer on the page."

In practice, screen readers currently read the same information twice on the page: first the `aria-label` of the `field-set`, and then the corresponding heading. 