### PR TITLE
Simplify Bootstrap5 installation/build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ module/VuFind/tests/.phpunit*
 node_modules
 public/swagger-ui
 tests/phpcs.cache.json
-themes/bootstrap5/scss/vendor/bootstrap
 local/DirLocations.ini
 local/config/vufind.bak
 local/config/vufind/*

--- a/themes/bootstrap5/package.json
+++ b/themes/bootstrap5/package.json
@@ -3,7 +3,7 @@
   "description": "Dependencies for the bootstrap5 theme",
   "scripts": {
     "check:jsTranslations": "node tools/jsTranslationsCheck.js",
-    "installBuildDeps": "npm install --ignore-scripts --no-audit && node tools/copyDependencies.mjs --only-build-deps",
+    "installBuildDeps": "npm install --ignore-scripts --no-audit",
     "updateDeps": "npm update --ignore-scripts && node tools/copyDependencies.mjs"
   },
   "dependencies": {

--- a/themes/bootstrap5/tools/copyDependencies.mjs
+++ b/themes/bootstrap5/tools/copyDependencies.mjs
@@ -1,22 +1,7 @@
 import { cp } from 'node:fs/promises';
 import { copyFile } from 'node:fs/promises';
 
-let buildDepsOnly = false;
-process.argv.forEach(arg => {
-    if (arg === '--only-build-deps') {
-        buildDepsOnly = true;
-    }
-});
-
 console.log('Copying dependencies...');
-
-// Bootstrap 5
-await cp('node_modules/bootstrap/scss/.', 'scss/vendor/bootstrap/', { recursive: true });
-
-if (buildDepsOnly) {
-    console.log('Done copying build dependencies.');
-    process.exit();
-}
 
 // Font Awesome
 await cp('node_modules/@fortawesome/fontawesome-free/webfonts/.', 'css/vendor/font-awesome/webfonts/', { recursive: true });


### PR DESCRIPTION
The SCSS compiler is capable of finding Bootstrap 5 in the node_modules directory, so there is no reason to copy it into the vendor directory of the theme. This PR eliminates unnecessary steps, configuration and tooling to simplify the CSS compilation process.