### PR TITLE
Accessibility: Add aria-current flag to currently selected language

### DIFF
--- a/themes/bootstrap5/templates/_ui/components/menu-button.phtml
+++ b/themes/bootstrap5/templates/_ui/components/menu-button.phtml
@@ -71,6 +71,7 @@
           <?php if ($current['external'] ?? false): ?> target="_blank"<?php endif; ?>
           <?php if ($current['lightbox'] ?? false): ?> data-lightbox="true"<?php endif; ?>
           <?php if ($setParams = $current['setQueryParams'] ?? null): ?> data-click-set-query-params="<?=$this->escapeHtmlAttr(http_build_query($setParams))?>"<?php endif; ?>
+          <?php if ($current['selected'] ?? false): ?> aria-current="true"<?php endif; ?>
           rel="nofollow"
         >
           <span><?=$this->transEsc($current['label']) ?></span>


### PR DESCRIPTION
Our accessibility testers bemoaned that the currently selected language in to header nav is not sufficiently marked semantically. To make the selected language reliably recognizable, they suggested that the selected href should get the additional flag @aria-current="true"@

