### PR TITLE
Upgrade PhpDocumentor to 3.10.0 and fix errors/warnings

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,7 +65,7 @@
   <property name="solr_version" value="9.8.1" />
   <property name="solr_port" value="8983" />
   <property name="skip_phpdoc" value="false" />
-  <property name="phpdoc_version" value="3.3.1" />
+  <property name="phpdoc_version" value="3.10.0" />
   <property name="html_validator" value="" /><!-- set to base address of NU Validator (e.g. http://localhost:8888/) for HTML validation during Mink tests -->
   <property name="html_validator_fail_tests" value="1" /><!-- set to 0 to just log HTML validation errors without causing tests to fail -->
   <property name="html_validator_log_file" value="" /><!-- set to a file name to log HTML validation messages to -->

--- a/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
+++ b/module/VuFind/src/VuFind/Auth/ILSAuthenticator.php
@@ -127,7 +127,7 @@ class ILSAuthenticator implements DbServiceAwareInterface
      *
      * @param ?string $text The text to decrypt (null values will be returned as null)
      *
-     * @return ?string|bool The decrypted string (null if empty or false if invalid)
+     * @return null|string|bool The decrypted string (null if empty or false if invalid)
      * @throws \VuFind\Exception\PasswordSecurity
      */
     public function decrypt(?string $text)
@@ -140,7 +140,7 @@ class ILSAuthenticator implements DbServiceAwareInterface
      *
      * @param ?string $text The text to encrypt (null values will be returned as null)
      *
-     * @return ?string|bool The encrypted string (null if empty or false if invalid)
+     * @return null|string|bool The encrypted string (null if empty or false if invalid)
      * @throws \VuFind\Exception\PasswordSecurity
      */
     public function encrypt(?string $text)
@@ -168,7 +168,7 @@ class ILSAuthenticator implements DbServiceAwareInterface
      * @param bool    $encrypt True if we wish to encrypt text, False if we wish to
      * decrypt text.
      *
-     * @return ?string|bool    The encrypted/decrypted string (null = empty input; false = error)
+     * @return null|string|bool The encrypted/decrypted string (null = empty input; false = error)
      * @throws \VuFind\Exception\PasswordSecurity
      */
     protected function encryptOrDecrypt(?string $text, bool $encrypt = true)

--- a/module/VuFind/src/VuFind/Db/Entity/Ratings.php
+++ b/module/VuFind/src/VuFind/Db/Entity/Ratings.php
@@ -122,7 +122,7 @@ class Ratings implements RatingsEntityInterface
     /**
      * Get user.
      *
-     * @return ?UserEntityInterface;
+     * @return ?UserEntityInterface
      */
     public function getUser(): ?UserEntityInterface
     {

--- a/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
+++ b/module/VuFind/src/VuFind/Db/Service/AuditEventService.php
@@ -330,7 +330,7 @@ class AuditEventService extends AbstractDbService implements
      *
      * @param array $details Details
      *
-     * @return @rray
+     * @return array
      */
     protected function scrubSecrets(array $details): array
     {

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Files/BadStringsTest.php
@@ -26,7 +26,7 @@
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  *
- * @VuFind.SkipBadStringCheck
+ * @VuFindSkipBadStringCheck
  */
 
 namespace VuFindTest\Files;
@@ -70,7 +70,10 @@ class BadStringsTest extends \PHPUnit\Framework\TestCase
         foreach ($filesToCheck as $fileToCheck) {
             $fileContents = file_get_contents($fileToCheck);
             // Use annotation to skip files:
-            if (str_contains($fileContents, '* @VuFind.SkipBadStringTest')) {
+            if (
+                str_contains($fileContents, '* @VuFind.SkipBadStringTest')
+                || str_contains($fileContents, '* @VuFindSkipBadStringTest')
+            ) {
                 continue;
             }
             $reasons = [];

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/GetThisLoaderTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/GetThisLoaderTest.php
@@ -438,7 +438,7 @@ class GetThisLoaderTest extends TestCase
     /**
      * Data provider.
      *
-     * @return Iterator<(int | string), mixed>
+     * @return Iterator<(int | string), array>
      */
     public static function provideSubTemplateParamsData(): Iterator
     {
@@ -675,7 +675,7 @@ class GetThisLoaderTest extends TestCase
     /**
      * Data provider for testShowCopyNumber().
      *
-     * @return Iterator<?bool, array, bool>
+     * @return Iterator<(int | string), array>
      */
     public static function provideShowCopyNumberData(): Iterator
     {

--- a/module/VuFindApi/src/VuFindApi/Controller/ApiTrait.php
+++ b/module/VuFindApi/src/VuFindApi/Controller/ApiTrait.php
@@ -223,7 +223,7 @@ trait ApiTrait
      *
      * @param array $settings API key settings from config.ini
      *
-     * @return void;
+     * @return void
      */
     protected function initApiKeySettings(array $settings): void
     {


### PR DESCRIPTION
This PR upgrades our configuration to use the latest PhpDocumentor release and fixes a few minor issues that were causing errors and warnings.

One slightly significant change: PhpDocumentor does not allow `.` characters in tags, so `VuFind.SkipBadStringTest` has been changed to `VuFindSkipBadStringTest`. The legacy value is still supported for back-compatibility.