### PR TITLE
Set `email_verified` for OpenID Connect users

### DIFF
--- a/config/vufind/OpenIDConnectClient.ini
+++ b/config/vufind/OpenIDConnectClient.ini
@@ -29,3 +29,7 @@ username_prefix = ""
 ;userinfo_endpoint = "https://openidconnect.provider.url/oauth/userinfo"
 ;issuer = "https://openidconnect.provider.url"
 ;jwks_uri = "https://openidconnect.provider.url/oauth/jwks"
+
+; Treat all emails from this IdP as verified, even if email_verified claim
+; is missing or false (useful when IdP is a Shibboleth proxy).
+treat_email_as_verified = true

--- a/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
+++ b/module/VuFind/src/VuFind/Auth/OpenIDConnect.php
@@ -32,6 +32,7 @@
 
 namespace VuFind\Auth;
 
+use DateTime;
 use DomainException;
 use Firebase\JWT\BeforeValidException;
 use Firebase\JWT\ExpiredException;
@@ -317,6 +318,14 @@ class OpenIDConnect extends AbstractBase implements \VuFindHttp\HttpServiceAware
             if (!empty($attrValue)) {
                 if ($userAttr === 'email') {
                     $userService->updateUserEmail($user, $attrValue);
+                    $treatAsVerified = $this->getConfig('treat_email_as_verified');
+                    if ($treatAsVerified) {
+                        $user->setEmailVerified(new \DateTime());
+                    } elseif (isset($userInfo->email_verified)) {
+                        $user->setEmailVerified(
+                            $userInfo->email_verified ? new DateTime() : null
+                        );
+                    }
                     continue;
                 }
                 if ($userAttr === 'cat_password') {


### PR DESCRIPTION
Previously, `email_verified` was always set to null for OpenID Connect users. Now, the `email_verified` claim from the userinfo endpoint is used when provided by the IdP.

A new configuration setting allows treating all email addresses from an OpenID Connect provider as verified, which is useful when the IdP is a Shibboleth proxy that does not propagate email verification status.

Assisted-by: Claude Sonnet 4.6 (Anthropic)