### PR TITLE
Use configuration defaultRecordTab for record details

### DIFF
--- a/config/vufind/RecordTabs.ini
+++ b/config/vufind/RecordTabs.ini
@@ -15,6 +15,15 @@
 ; backgroundLoadedTabs[] -- This repeatable setting can be used to identify tabs
 ;                that should be asynchronously loaded in the background to improve
 ;                performance. Use the "X" value from the tabs setting as the id.
+; defaultEmbeddedTab -- This controls which tab is active by default in the
+;                embedded (search result) view. It may reference a regular tab
+;                (an "X" value from tabs) or a special embedded tab: Information,
+;                Tools, or Related. If empty, falls back to defaultTab.
+; embeddedTabs -- A comma-delimited list of tab names controlling which tabs
+;                appear in the embedded (search result) view and their order.
+;                May include special embedded tabs (Information, Tools, Related)
+;                and regular tab names (matching "X" values from tabs). If
+;                empty, all available tabs are shown in their default order.
 [VuFind\RecordDriver\EDS]
 tabs[Description] = Description
 tabs[TOC] = TOC

--- a/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetails.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetRecordDetails.php
@@ -51,13 +51,11 @@ class GetRecordDetails extends AbstractBase
     /**
      * Constructor.
      *
-     * @param array                     $config       Framework configuration
      * @param Loader                    $recordLoader Record loader
      * @param TabManager                $tabManager   Record Tab manager
      * @param TemplateRendererInterface $renderer     Template renderer
      */
     public function __construct(
-        protected array $config,
         protected Loader $recordLoader,
         protected TabManager $tabManager,
         protected TemplateRendererInterface $renderer,
@@ -86,8 +84,7 @@ class GetRecordDetails extends AbstractBase
 
         $details = $this->tabManager->getTabDetailsForRecord(
             $driver,
-            Psr7ServerRequest::toLaminas($request),
-            'Information'
+            Psr7ServerRequest::toLaminas($request)
         );
 
         $html = $this->renderer->renderTemplateAsString(
@@ -95,6 +92,9 @@ class GetRecordDetails extends AbstractBase
             'record/ajaxview-' . $viewtype . '.phtml',
             [
                 'defaultTab' => $details['default'],
+                'defaultEmbeddedTab' => $this->tabManager
+                    ->getDefaultEmbeddedTabForRecord($driver),
+                'embeddedTabs' => $this->tabManager->getEmbeddedTabs($driver),
                 'driver' => $driver,
                 'tabs' => $details['tabs'],
                 'backgroundTabs' => $this->tabManager

--- a/module/VuFind/src/VuFind/RecordTab/TabManager.php
+++ b/module/VuFind/src/VuFind/RecordTab/TabManager.php
@@ -201,6 +201,43 @@ class TabManager
     }
 
     /**
+     * Get the default tab for embedded (search result) view by looking up the
+     * provided record driver in the tab configuration array.
+     *
+     * @param AbstractRecordDriver $driver   Record driver
+     * @param ?string              $fallback Fallback to use if no tab configured.
+     *
+     * @return ?string
+     */
+    public function getDefaultEmbeddedTabForRecord(
+        AbstractRecordDriver $driver,
+        ?string $fallback = null
+    ): ?string {
+        $default = $this->getConfigByClass($driver, 'defaultEmbeddedTab', null);
+        if (!$default) {
+            $default = $this->getConfigByClass($driver, 'defaultTab', null);
+        }
+        return $default ?: $fallback;
+    }
+
+    /**
+     * Get the configured tab order for embedded (search result) view.
+     * Returns null if no custom order is configured.
+     *
+     * @param AbstractRecordDriver $driver Record driver
+     *
+     * @return ?array
+     */
+    public function getEmbeddedTabs(AbstractRecordDriver $driver): ?array
+    {
+        $config = $this->getConfigByClass($driver, 'embeddedTabs', null);
+        if (empty($config)) {
+            return null;
+        }
+        return array_values(array_filter(array_map('trim', explode(',', $config))));
+    }
+
+    /**
      * Get an array of extra JS scripts by looking up the provided record driver in
      * the provided tab configuration array.
      *

--- a/themes/bootstrap5/templates/record/ajaxview-accordion.phtml
+++ b/themes/bootstrap5/templates/record/ajaxview-accordion.phtml
@@ -4,88 +4,105 @@
   $this->defaultTab = strtolower($this->defaultTab);
   $idSuffixEsc = $this->escapeHtmlAttr(md5($this->driver->getUniqueId() . '|' . $this->driver->getSourceIdentifier()));
   $parentIdEsc = 'accordion_' . $idSuffixEsc;
+  $activeTab = $this->defaultEmbeddedTab
+    ? strtolower($this->defaultEmbeddedTab)
+    : $this->defaultTab;
+
+  $sections = [];
+
+  $coreMetadata = trim($this->record($this->driver)->getCoreMetadata());
+  if (!empty($coreMetadata)) {
+    $sections['information'] = [
+      'title' => $this->translate('ajaxview_label_information'),
+      'innerContent' => '<div class="list-tab-content record panel-body">'
+        . '<input type="hidden" value="' . $this->escapeHtmlAttr($this->driver->getUniqueId()) . '" class="hiddenId" id="record_id_' . $idSuffixEsc . '">'
+        . '<input type="hidden" value="' . $this->escapeHtmlAttr($this->driver->getSourceIdentifier()) . '" class="hiddenSource">'
+        . $coreMetadata . '</div>',
+      'panelClasses' => '',
+      'headingExtra' => ' loaded',
+      'linkExtra' => '',
+      'collapseClass' => 'panel-collapse collapse',
+    ];
+  }
+
+  $toolbar = trim($this->record($this->driver)->getToolbar());
+  if (!empty($toolbar)) {
+    $sections['tools'] = [
+      'title' => $this->translate('ajaxview_label_tools'),
+      'innerContent' => '<div class="list-tab-content panel-body">' . $toolbar . '</div>',
+      'panelClasses' => '',
+      'headingExtra' => ' loaded',
+      'linkExtra' => '',
+      'collapseClass' => 'panel-collapse collapse',
+    ];
+  }
+
+  $relatedList = $this->related()->getList($this->driver);
+  if ($relatedList != null) {
+    $relatedContent = '';
+    foreach ($relatedList as $current) {
+      $relatedContent .= $this->related()->render($current);
+    }
+    $sections['related'] = [
+      'title' => $this->transEsc('Related Items'),
+      'innerContent' => '<div class="list-tab-content panel-body">' . $relatedContent . '</div>',
+      'panelClasses' => '',
+      'headingExtra' => ' loaded',
+      'linkExtra' => '',
+      'collapseClass' => 'panel-collapse collapse',
+    ];
+  }
+
+  $filteredTabs = array_filter($this->tabs, fn ($obj) => $obj->supportsSearchResultEmbedding());
+  foreach ($filteredTabs as $tab => $obj) {
+    $tabLower = strtolower($tab);
+    $panelClasses = [];
+    if (!$obj->isVisible()) {
+      $panelClasses[] = 'hidden';
+    }
+    if (!$obj->supportsAjax()) {
+      $panelClasses[] = 'noajax';
+    }
+    if ($activeTab === $tabLower) {
+      $panelClasses[] = 'default';
+    }
+    $headingExtra = ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs))
+      ? ' data-background'
+      : '';
+    $sections[$tabLower] = [
+      'title' => $this->transEsc($obj->getDescription()),
+      'innerContent' => '',
+      'panelClasses' => implode(' ', $panelClasses),
+      'headingExtra' => $headingExtra,
+      'linkExtra' => ' data-href="' . $this->escapeHtmlAttr($this->recordLinker()->getTabUrl($this->driver, $tab)) . '#tabnav"',
+      'collapseClass' => 'list-tab-content panel-collapse collapse',
+    ];
+  }
+
+  if (!empty($this->embeddedTabs)) {
+    $ordered = [];
+    foreach ($this->embeddedTabs as $tabName) {
+      $key = strtolower($tabName);
+      if (isset($sections[$key])) {
+        $ordered[$key] = $sections[$key];
+      }
+    }
+    $sections = $ordered;
+  }
 ?>
 
 <div class="list-tabs panel-group" id="<?=$parentIdEsc?>" role="tablist">
-  <?php $coreMetadata = $this->record($this->driver)->getCoreMetadata(); ?>
-  <?php if (!empty($coreMetadata)): ?>
-    <div class="panel panel-default">
-      <div id="information_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#information_<?=$idSuffixEsc?>-content" role="tab">
+  <?php foreach ($sections as $key => $section): ?>
+    <?php $linkExtra = $section['linkExtra']; ?>
+    <div class="panel panel-default<?= $section['panelClasses'] ? ' ' . $section['panelClasses'] : '' ?>">
+      <div id="<?=$key?>_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading<?=$section['headingExtra'] ?>" data-bs-toggle="collapse" data-bs-target="#<?=$key?>_<?=$idSuffixEsc?>-content" role="tab">
         <h4 class="panel-title">
-          <a class="accordion-toggle">
-            <?=$this->translate('ajaxview_label_information') ?>
-          </a>
+          <a class="accordion-toggle"<?=$linkExtra ?>><?=$section['title']?></a>
         </h4>
       </div>
-      <div id="information_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'information'): ?> show<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
-        <div class="list-tab-content record panel-body">
-          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" class="hiddenId" id="record_id_<?=$idSuffixEsc?>">
-          <input type="hidden" value="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier()) ?>" class="hiddenSource">
-          <?=$coreMetadata ?>
-        </div>
+      <div id="<?=$key?>_<?=$idSuffixEsc?>-content" class="<?=$section['collapseClass']?><?= $activeTab === $key ? ' show' : '' ?>" data-bs-parent="#<?=$parentIdEsc?>">
+        <?=$section['innerContent'] ?>
       </div>
-    </div>
-  <?php endif; ?>
-
-  <?php $toolbar = $this->record($this->driver)->getToolbar(); ?>
-  <?php if (!empty($toolbar)): ?>
-    <div class="panel panel-default">
-      <div id="tools_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#tools_<?=$idSuffixEsc?>-content" role="tab">
-        <h4 class="panel-title">
-          <a class="accordion-toggle">
-            <?=$this->translate('ajaxview_label_tools') ?>
-          </a>
-        </h4>
-      </div>
-      <div id="tools_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'tools'): ?> show<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
-        <div class="list-tab-content panel-body">
-          <?=$toolbar ?>
-        </div>
-      </div>
-    </div>
-  <?php endif; ?>
-
-  <?php $relatedList = $this->related()->getList($this->driver); ?>
-  <?php if ($relatedList != null): ?>
-    <div class="panel panel-default">
-      <div id="related_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading loaded" data-bs-toggle="collapse" data-bs-target="#related_<?=$idSuffixEsc?>-content" role="tab">
-        <h4 class="panel-title">
-          <a class="accordion-toggle">
-            <?=$this->transEsc('Related Items')?>
-          </a>
-        </h4>
-      </div>
-      <div id="related_<?=$idSuffixEsc?>-content" class="panel-collapse collapse<?php if ($this->defaultTab === 'related'): ?> show<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>">
-        <div class="list-tab-content panel-body">
-          <?php foreach ($relatedList as $current): ?>
-            <?=$this->related()->render($current)?>
-          <?php endforeach; ?>
-        </div>
-      </div>
-    </div>
-  <?php endif; ?>
-  <?php $filteredTabs = array_filter($this->tabs, fn ($obj) => $obj->supportsSearchResultEmbedding()); ?>
-  <?php foreach ($filteredTabs as $tab => $obj): ?>
-    <?php // add current tab to breadcrumbs if applicable:
-      $desc = $obj->getDescription();
-      $tab_classes = [];
-      if (!$obj->isVisible()) {
-        $tab_classes[] = 'hidden';
-      }
-      if (!$obj->supportsAjax()) {
-        $tab_classes[] = 'noajax';
-      }
-      if ($this->defaultTab === strtolower($tab)) {
-        $tab_classes[] = 'default';
-      }
-    ?>
-    <div class="panel panel-default <?=implode(' ', $tab_classes) ?>">
-      <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>" class="list-tab-toggle panel-heading" data-bs-toggle="collapse" data-bs-target="#<?=strtolower($tab)?>_<?=$idSuffixEsc?>-content"<?php if ($obj->supportsAjax() && in_array($tab, $this->backgroundTabs)):?> data-background<?php endif ?> role="tab">
-        <h4 class="panel-title">
-          <a class="accordion-toggle" data-href="<?=$this->escapeHtmlAttr($this->recordLinker()->getTabUrl($this->driver, $tab))?>#tabnav"><?=$this->transEsc($desc) ?></a>
-        </h4>
-      </div>
-      <div id="<?=$this->escapeHtmlAttr(strtolower($tab))?>_<?=$idSuffixEsc?>-content" class="list-tab-content panel-collapse collapse<?php if ($this->defaultTab === strtolower($tab)): ?> show<?php endif; ?>" data-bs-parent="#<?=$parentIdEsc?>"></div>
     </div>
   <?php endforeach; ?>
 </div>

--- a/themes/bootstrap5/templates/record/ajaxview-tabs.phtml
+++ b/themes/bootstrap5/templates/record/ajaxview-tabs.phtml
@@ -46,6 +46,25 @@
   }
   $filteredTabs = array_filter($this->tabs, fn ($obj) => $obj->supportsSearchResultEmbedding());
   $tabs = array_merge($tabs, $this->recordTabs()->getTabs($this->driver, $filteredTabs, $this->defaultTab));
+
+  // Apply embeddedTabs order if configured:
+  if (!empty($this->embeddedTabs)) {
+    $ordered = [];
+    foreach ($this->embeddedTabs as $tabName) {
+      $key = strtolower($tabName);
+      if (isset($tabs[$key])) {
+        $ordered[$key] = $tabs[$key];
+      }
+    }
+    $tabs = $ordered;
+  }
+
+  $activeTab = $this->defaultEmbeddedTab
+    ? strtolower($this->defaultEmbeddedTab)
+    : $this->defaultTab;
+  if (!isset($tabs[$activeTab]) && !empty($tabs)) {
+    $activeTab = array_key_first($tabs);
+  }
 ?>
 <?=$this->component(
     'tabs',


### PR DESCRIPTION
This allows setting of `defaultRecordTab` for `lists_view=tabs` to a tab value other than the default 'Holdings'.

Assisted-by: minimax-m2.7 (MiniMax)