### PR TITLE
BibTeX: add comma after URL fields to improve validation

### DIFF
--- a/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
+++ b/themes/root/templates/RecordDriver/AbstractBase/export-bibtex.phtml
@@ -134,7 +134,7 @@ if (is_array($notes)) {
 }
 
 foreach ($this->record($this->driver)->getUrlList() as $url) {
-    echo "url = {{$url}}\n";
+    echo "url = {{$url}},\n";
 }
 
 // Record separator:


### PR DESCRIPTION
…e bibtex file

A comma after each line, even the last one is syntactically ok, but not having a comma if the field isn't the last one, invalidates the record.