### PR TITLE
Fix JS loading of results and result scroller for reduced result count

### DIFF
--- a/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
@@ -179,6 +179,17 @@ class GetSearchResults extends \VuFind\AjaxHandler\AbstractBase implements
         $paramsObj = $results->getParams();
         $paramsObj->getOptions()->spellcheckEnabled(false);
         $paramsObj->initFromRequest(new Parameters($searchParams));
+        $results->performAndProcessSearch();
+
+        // For a page parameter being out of the results list,
+        // we want load the last page available
+        $totalResults = $results->getResultTotal();
+        $limit = $paramsObj->getLimit();
+        $lastPage = $limit ? ceil($totalResults / $limit) : 1;
+        if ($totalResults > 0 && $paramsObj->getPage() > $lastPage) {
+            $paramsObj->setPage($lastPage);
+            $results->performAndProcessSearch();
+        }
 
         if ($this->getQueryParam($request, 'history')) {
             $this->saveSearchToHistory($results);

--- a/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetSearchResults.php
@@ -182,11 +182,9 @@ class GetSearchResults extends \VuFind\AjaxHandler\AbstractBase implements
         $results->performAndProcessSearch();
 
         // For a page parameter being out of the results list,
-        // we want load the last page available
-        $totalResults = $results->getResultTotal();
-        $limit = $paramsObj->getLimit();
-        $lastPage = $limit ? ceil($totalResults / $limit) : 1;
-        if ($totalResults > 0 && $paramsObj->getPage() > $lastPage) {
+        // we want to load the last page available
+        $lastPage = $results->getLastAvailablePage();
+        if ($results->getResultTotal() > 0 && $paramsObj->getPage() > $lastPage) {
             $paramsObj->setPage($lastPage);
             $results->performAndProcessSearch();
         }

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -391,7 +391,7 @@ class AbstractSearch extends AbstractBase
         }
         $view->params = $params = $results->getParams();
 
-        // For page parameter being out of results list, we want to redirect to correct page
+        // For a page parameter being out of the results list, we want to redirect to the correct page
         $page = $params->getPage();
         $totalResults = $results->getResultTotal();
         $limit = $params->getLimit();

--- a/module/VuFind/src/VuFind/Controller/AbstractSearch.php
+++ b/module/VuFind/src/VuFind/Controller/AbstractSearch.php
@@ -392,11 +392,8 @@ class AbstractSearch extends AbstractBase
         $view->params = $params = $results->getParams();
 
         // For a page parameter being out of the results list, we want to redirect to the correct page
-        $page = $params->getPage();
-        $totalResults = $results->getResultTotal();
-        $limit = $params->getLimit();
-        $lastPage = $limit ? ceil($totalResults / $limit) : 1;
-        if ($totalResults > 0 && $page > $lastPage) {
+        $lastPage = $results->getLastAvailablePage();
+        if ($results->getResultTotal() > 0 && $params->getPage() > $lastPage) {
             $queryParams = $request;
             $queryParams['page'] = $lastPage;
             return $this->redirect()->toRoute(

--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -372,6 +372,17 @@ abstract class Results
     }
 
     /**
+     * Get last available page.
+     *
+     * @return int
+     */
+    public function getLastAvailablePage(): int
+    {
+        $limit = $this->getParams()->getLimit();
+        return ($limit > 0) ? ceil($this->getResultTotal() / $limit) : 1;
+    }
+
+    /**
      * Manually override the start record number.
      *
      * @param ?int $rec Record number to use.

--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -145,10 +145,7 @@ class Results extends \VuFind\Search\Base\Results
 
             // For a page parameter being out of the results list, we do not want
             // to return any results from another page.
-            $page = $params->getPage();
-            $limit = $params->getLimit();
-            $lastPage = $limit ? ceil($this->resultTotal / $limit) : 1;
-            if ($this->resultTotal > 0 && $page > $lastPage) {
+            if ($this->getResultTotal() > 0 && $params->getPage() > $this->getLastAvailablePage()) {
                 $this->results = [];
             }
         }

--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -105,12 +105,13 @@ class Results extends \VuFind\Search\Base\Results
         $allTerms = trim($query->getAllTerms());
         $limit  = $this->getParams()->getLimit();
         $offset = $this->getStartRecord() - 1;
-        $params = $this->getParams()->getBackendParameters();
+        $params = $this->getParams();
+        $backendParams = $params->getBackendParameters();
         if ($allTerms === '') {
             if (!$this->config['General']['limiter_only'] ?? false) {
                 $this->storeErrorResponse('empty_search_disallowed');
                 return;
-            } elseif (!$this->paramsIncludeLimiter($params)) {
+            } elseif (!$this->paramsIncludeLimiter($backendParams)) {
                 $this->storeErrorResponse('empty_search_no_filters_disallowed');
                 return;
             }
@@ -121,7 +122,7 @@ class Results extends \VuFind\Search\Base\Results
             $query,
             $offset,
             $limit,
-            $params
+            $backendParams
         );
         $collection = $this->getSearchService()->invoke($command)
             ->getResult();
@@ -141,6 +142,15 @@ class Results extends \VuFind\Search\Base\Results
             // Construct record drivers for all the items in the response:
             $this->results = $collection->getRecords();
             $this->restrictedView = $collection->isRestrictedView();
+
+            // For a page parameter being out of the results list, we do not want
+            // to return any results from another page.
+            $page = $params->getPage();
+            $limit = $params->getLimit();
+            $lastPage = $limit ? ceil($this->resultTotal / $limit) : 1;
+            if ($this->resultTotal > 0 && $page > $lastPage) {
+                $this->results = [];
+            }
         }
     }
 

--- a/module/VuFind/src/VuFind/Search/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Search/ResultScroller.php
@@ -582,8 +582,7 @@ class ResultScroller
         // The results total of the initial search might have changed by the time we reach the end of the list.
         // Therefore, we should update it here to avoid confusion.
         if (!($retVal['nextRecord'] ?? null) && $currentPos = $retVal['currentPosition'] ?? null) {
-            $this->data->total = $currentPos;
-            $retVal['resultTotal'] = $this->data->total;
+            $retVal['resultTotal'] = $this->data->total = $currentPos;
             if ($this->data->firstlast) {
                 $this->data->lastId = end($this->data->currIds);
                 $retVal['lastRecord'] = $this->data->lastId;

--- a/module/VuFind/src/VuFind/Search/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Search/ResultScroller.php
@@ -554,43 +554,39 @@ class ResultScroller
             if ($pos > 0 && $pos < $count - 1) {
                 // the current record is somewhere in the middle of the current
                 // page, ie: not first or last
-                return $this->scrollOnCurrentPage($retVal, $pos);
+                $retVal = $this->scrollOnCurrentPage($retVal, $pos);
             } elseif ($pos == 0) {
                 // this record is first record on the current page
-                return $this
-                    ->fetchPreviousPage($retVal, $lastSearch, $pos, $count);
+                $retVal = $this->fetchPreviousPage($retVal, $lastSearch, $pos, $count);
             } elseif ($pos == $count - 1) {
                 // this record is last record on the current page
-                return $this->fetchNextPage($retVal, $lastSearch, $pos);
+                $retVal = $this->fetchNextPage($retVal, $lastSearch, $pos);
             }
         } else {
             // the current record is not on the current page
-            // if there is something on the previous page
-            if (!empty($this->data->prevIds)) {
-                // check if current record is on the previous page
-                $pos = is_array($this->data->prevIds)
-                    ? array_search($id, $this->data->prevIds) : false;
-                if ($pos !== false) {
-                    return $this
-                        ->scrollToPreviousPage($retVal, $lastSearch, $pos);
-                }
-            }
-            // if there is something on the next page
-            if (!empty($this->data->nextIds)) {
-                // check if current record is on the next page
-                $pos = is_array($this->data->nextIds)
-                    ? array_search($id, $this->data->nextIds) : false;
-                if ($pos !== false) {
-                    return $this->scrollToNextPage($retVal, $lastSearch, $pos);
-                }
-            }
-            if ($this->data->firstlast) {
+            if (($pos = array_search($id, $this->data->prevIds ?? [])) !== false) {
+                // if there is something on the previous page
+                $retVal = $this->scrollToPreviousPage($retVal, $lastSearch, $pos);
+            } elseif (($pos = array_search($id, $this->data->nextIds ?? [])) !== false) {
+                // if there is something on the next page
+                $retVal = $this->scrollToNextPage($retVal, $lastSearch, $pos);
+            } elseif ($this->data->firstlast) {
                 if ($id == $retVal['firstRecord']) {
-                    return $this->scrollToFirstRecord($retVal, $lastSearch);
+                    $retVal = $this->scrollToFirstRecord($retVal, $lastSearch);
+                } elseif ($id == $retVal['lastRecord']) {
+                    $retVal = $this->scrollToLastRecord($retVal, $lastSearch);
                 }
-                if ($id == $retVal['lastRecord']) {
-                    return $this->scrollToLastRecord($retVal, $lastSearch);
-                }
+            }
+        }
+
+        // The results total of the initial search might have changed until we reach the end of the list.
+        // Therefore, we should update it here to avoid confusion.
+        if (!($retVal['nextRecord'] ?? null) && $currentPos = $retVal['currentPosition'] ?? null) {
+            $this->data->total = $currentPos;
+            $retVal['resultTotal'] = $this->data->total;
+            if ($this->data->firstlast) {
+                $this->data->lastId = end($this->data->currIds);
+                $retVal['lastRecord'] = $this->data->lastId;
             }
         }
 

--- a/module/VuFind/src/VuFind/Search/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Search/ResultScroller.php
@@ -579,7 +579,7 @@ class ResultScroller
             }
         }
 
-        // The results total of the initial search might have changed until we reach the end of the list.
+        // The results total of the initial search might have changed by the time we reach the end of the list.
         // Therefore, we should update it here to avoid confusion.
         if (!($retVal['nextRecord'] ?? null) && $currentPos = $retVal['currentPosition'] ?? null) {
             $this->data->total = $currentPos;

--- a/module/VuFind/src/VuFind/Search/ResultScroller.php
+++ b/module/VuFind/src/VuFind/Search/ResultScroller.php
@@ -584,8 +584,7 @@ class ResultScroller
         if (!($retVal['nextRecord'] ?? null) && $currentPos = $retVal['currentPosition'] ?? null) {
             $retVal['resultTotal'] = $this->data->total = $currentPos;
             if ($this->data->firstlast) {
-                $this->data->lastId = end($this->data->currIds);
-                $retVal['lastRecord'] = $this->data->lastId;
+                $retVal['lastRecord'] = $this->data->lastId = end($this->data->currIds);
             }
         }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/BasicSearchTest.php
@@ -89,6 +89,41 @@ class BasicSearchTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that loading an out-of-bounds page with JS results in an in-bounds page.
+     *
+     * @return void
+     */
+    public function testOutOfBoundsPageWithJS()
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=Author&type=AllFields&limit=5');
+        $page = $session->getPage();
+        $this->assertStringStartsWith(
+            'Showing 1 - 5 results of 16',
+            trim($this->findCssAndGetText($page, '.search-stats'))
+        );
+        // Change searchspecs.yaml to reduce total results to 14.
+        $this->changeYamlConfigs(
+            [
+                'searchspecs' => [
+                    'AllFields' => [
+                        'DismaxFields' => [
+                            'author',
+                        ],
+                    ],
+                ],
+            ],
+            ['searchspecs']
+        );
+        $this->clickCss($page, '.pagination .page-last a');
+        $this->waitForPageLoad($page);
+        $this->assertStringContainsString(
+            'Showing 11 - 14 results of 14',
+            trim($this->findCssAndGetText($page, '.search-stats'))
+        );
+    }
+
+    /**
      * Data provider for testDefaultTopPagination.
      *
      * @return \Iterator

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NextPrevNavTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/NextPrevNavTest.php
@@ -101,4 +101,76 @@ class NextPrevNavTest extends \VuFindTest\Integration\MinkTestCase
 
         $this->findCss($page, 'nav .pager');
     }
+
+    /**
+     * If the total result count decreases during the next-prev navigation controls should update.
+     *
+     * @return void
+     */
+    public function testDecreasedResultCountChangesCauseNoProblems(): void
+    {
+        $this->changeConfigs(
+            ['config' => ['Record' => ['next_prev_navigation' => true, 'first_last_navigation' => true]]]
+        );
+
+        // when a search returns no results
+        // make sure no errors occur when visiting a collection record after
+        $session = $this->getMinkSession();
+        $page = $session->getPage();
+
+        $session->visit($this->getVuFindUrl() . '/Search/Results?lookfor=Author&type=AllFields&limit=2&page=6');
+        $this->waitForPageLoad($page);
+
+        $this->clickCss($page, '#result1 a.getFull');
+        $this->waitForPageLoad($page);
+
+        $pagerText = $this->findCssAndGetText($page, '.pager .pager-text');
+        $this->assertSame('#12 of 16 results', $pagerText);
+
+        // Change searchspecs.yaml to reduce total results to 14.
+        $this->changeYamlConfigs(
+            [
+                'searchspecs' => [
+                    'AllFields' => [
+                        'DismaxFields' => [
+                            'author',
+                        ],
+                    ],
+                ],
+            ],
+            ['searchspecs']
+        );
+
+        $this->clickCss($page, '.pager .page-next a');
+        $this->waitForPageLoad($page);
+
+        $pagerText = $this->findCssAndGetText($page, '.pager .pager-text');
+        $this->assertSame('#13 of 16 results', $pagerText);
+
+        // Test that reaching end of search results updates pager info
+        $this->clickCss($page, '.pager .page-next a');
+        $this->waitForPageLoad($page);
+
+        $pagerText = $this->findCssAndGetText($page, '.pager .pager-text');
+        $this->assertSame('#14 of 14 results', $pagerText);
+
+        $this->findCss($page, '.pager .page-next.disabled');
+        $this->findCss($page, '.pager .page-last.disabled');
+
+        $lastPageUrl = $session->getCurrentUrl();
+
+        // Test that updated info persists when going back
+        $this->clickCss($page, '.pager .page-prev a');
+        $this->waitForPageLoad($page);
+
+        $pagerText = $this->findCssAndGetText($page, '.pager .pager-text');
+        $this->assertSame('#13 of 14 results', $pagerText);
+
+        $this->unFindCss($page, '.pager .page-next.disabled');
+
+        // Test that link to last result is updated
+        $this->clickCss($page, '.pager .page-last a');
+        $this->waitForPageLoad($page);
+        $this->assertSame($lastPageUrl, $session->getCurrentUrl());
+    }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Search/ResultScrollerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Search/ResultScrollerTest.php
@@ -393,6 +393,100 @@ class ResultScrollerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test scrolling at end of middle page.
+     *
+     * @return void
+     */
+    public function testReducingTotalResults()
+    {
+        $results = $this->getMockResults(1, 2, 6);
+        $plugin = $this->getMockResultScroller($results);
+        $this->assertTrue($plugin->init($results));
+        $expected = [
+            'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|6',
+            'previousRecord' => 'Solr|1', 'nextRecord' => 'Solr|3',
+            'currentPosition' => 2, 'resultTotal' => 6,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('2'))
+        );
+
+        // Reduce search result count
+        $plugin->setResults($this->getMockResults(1, 2, 4));
+
+        // At the start of the next page, the values are not updated
+        // yet and show the old status.
+        $expected = [
+            'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|6',
+            'previousRecord' => 'Solr|2', 'nextRecord' => 'Solr|4',
+            'currentPosition' => 3, 'resultTotal' => 6,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('3'))
+        );
+
+        // Check that result total and last record are updated when reaching end of page
+        $expected = [
+            'firstRecord' => 'Solr|1', 'lastRecord' => 'Solr|4',
+            'previousRecord' => 'Solr|3', 'nextRecord' => null,
+            'currentPosition' => 4, 'resultTotal' => 4,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('4'))
+        );
+    }
+
+    /**
+     * Test scrolling at end of middle page.
+     *
+     * @return void
+     */
+    public function testReducingTotalResultsWithDisabledFirstLast()
+    {
+        $results = $this->getMockResults(1, 2, 6, false);
+        $plugin = $this->getMockResultScroller($results);
+        $this->assertTrue($plugin->init($results));
+        $expected = [
+            'firstRecord' => null, 'lastRecord' => null,
+            'previousRecord' => 'Solr|1', 'nextRecord' => 'Solr|3',
+            'currentPosition' => 2, 'resultTotal' => 6,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('2'))
+        );
+
+        // Reduce search result count
+        $plugin->setResults($this->getMockResults(1, 2, 4, false));
+
+        // At the start of the next page, the values are not updated
+        // yet and show the old status.
+        $expected = [
+            'firstRecord' => null, 'lastRecord' => null,
+            'previousRecord' => 'Solr|2', 'nextRecord' => 'Solr|4',
+            'currentPosition' => 3, 'resultTotal' => 6,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('3'))
+        );
+
+        // Check that result total is updated when reaching end of page
+        $expected = [
+            'firstRecord' => null, 'lastRecord' => null,
+            'previousRecord' => 'Solr|3', 'nextRecord' => null,
+            'currentPosition' => 4, 'resultTotal' => 4,
+        ];
+        $this->assertEquals(
+            $expected,
+            $plugin->getScrollData($results->getMockRecordDriver('4'))
+        );
+    }
+
+    /**
      * Get mock search results.
      *
      * @param int    $page      Current page number

--- a/themes/bootstrap5/templates/record/prev-next.phtml
+++ b/themes/bootstrap5/templates/record/prev-next.phtml
@@ -2,14 +2,14 @@
   <ul class="pager hidden-print">
     <?php if ($this->scrollData['previousRecord']): ?>
       <?php if ($this->scrollData['firstRecord']): ?>
-        <li role="none">
+        <li class="page-first" role="none">
           <a class="icon-link" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->scrollData['firstRecord']))?>" aria-label="<?=$this->transEscAttr('First Search Result')?>" rel="nofollow">
             <?=$this->icon('page-first', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('First')?></span>
           </a>
         </li>
       <?php endif; ?>
-      <li role="none">
+      <li class="page-prev" role="none">
         <a class="icon-link" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->scrollData['previousRecord']))?>" aria-label="<?=$this->transEscAttr('Previous Search Result')?>" rel="nofollow">
           <?=$this->icon('page-prev', 'icon-link__icon') ?>
           <span class="icon-link__label"><?=$this->transEsc('Prev')?></span>
@@ -17,14 +17,14 @@
       </li>
     <?php else: ?>
       <?php if ($this->scrollData['firstRecord']): ?>
-        <li class="disabled" aria-hidden="true" role="none">
+        <li class="page-first disabled" aria-hidden="true" role="none">
           <a class="icon-link">
             <?=$this->icon('page-first', 'icon-link__icon') ?>
             <span class="icon-link__label"><?=$this->transEsc('First')?>
           </a>
         </li>
       <?php endif; ?>
-      <li class="disabled" aria-hidden="true" role="none">
+      <li class="page-prev disabled" aria-hidden="true" role="none">
         <a class="icon-link">
           <?=$this->icon('page-prev', 'icon-link__icon') ?>
           <span class="icon-link__label"><?=$this->transEsc('Prev')?></span>
@@ -32,7 +32,7 @@
       </li>
     <?php endif; ?>
 
-    <li role="none">
+    <li class="pager-text" role="none">
       <?=$this->transEsc('of_num_results', [
         '%%position%%' => $this->localizedNumber($this->scrollData['currentPosition']),
         '%%total%%' => $this->localizedNumber($this->scrollData['resultTotal']),
@@ -40,14 +40,14 @@
     </li>
 
     <?php if ($this->scrollData['nextRecord']): ?>
-      <li role="none">
+      <li class="page-next" role="none">
         <a class="icon-link" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->scrollData['nextRecord']))?>" aria-label="<?=$this->transEscAttr('Next Search Result')?>" rel="nofollow">
           <span class="icon-link__label"><?=$this->transEsc('Next')?></span>
           <?=$this->icon('page-next', 'icon-link__icon') ?>
         </a>
       </li>
       <?php if ($this->scrollData['lastRecord']): ?>
-        <li role="none">
+        <li class="page-last" role="none">
           <a class="icon-link" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->scrollData['lastRecord']))?>" aria-label="<?=$this->transEscAttr('Last Search Result')?>" rel="nofollow">
             <span class="icon-link__label"><?=$this->transEsc('Last')?></span>
             <?=$this->icon('page-last', 'icon-link__icon') ?>
@@ -55,14 +55,14 @@
         </li>
       <?php endif; ?>
     <?php else: ?>
-      <li class="disabled" aria-hidden="true" role="none">
+      <li class="page-next disabled" aria-hidden="true" role="none">
         <a class="icon-link">
           <span class="icon-link__label"><?=$this->transEsc('Next')?></span>
           <?=$this->icon('page-next', 'icon-link__icon') ?>
         </a>
       </li>
       <?php if ($this->scrollData['lastRecord']): ?>
-        <li class="disabled" aria-hidden="true" role="none">
+        <li class="page-last disabled" aria-hidden="true" role="none">
           <a class="icon-link">
             <span class="icon-link__label"><?=$this->transEsc('Last')?></span>
             <?=$this->icon('page-last', 'icon-link__icon') ?>


### PR DESCRIPTION
This PR fixes two problems especially occurring with EDS's deduplication behavior, that lowers result counts on later pages. 

1. When performing a search in EDS and selecting the last page which is not available because of deduplication the last page available is loaded but the numbering of the results is not displayed correctly.

Example:

Initial search shows 83 total results
<img width="615" height="363" alt="image" src="https://github.com/user-attachments/assets/3396475a-f691-438c-a3af-a445fd249db8" />

After clicking on the fifth page the third page is being loaded with the updated total results of 51. However the search stats state "Showing 81 - 51" and the result numbering starts at 81.
<img width="615" height="363" alt="image" src="https://github.com/user-attachments/assets/f41f2e60-837e-4a2e-bf18-e419b98650b9" />

2. With the same search, selecting the second last actually available page, then clicking on the last record, using the next-prev-navigation to navigate to the last actually available record and the clicking on "next" will jump back to the start of the page.

Same example as in 1.:

Using the navigation and reaching the last record 51 looks like this
<img width="562" height="233" alt="image" src="https://github.com/user-attachments/assets/489c7cee-cc15-44d1-ab73-520c22fc0e6a" />

Clicking on next results in
<img width="562" height="233" alt="image" src="https://github.com/user-attachments/assets/96af71e1-7a9e-490a-9336-ad4643afbcc8" />

i.e. jumping back to the 41st result which is the first one on page 3.