### PR TITLE
Create ID mapping methods and add optional ID prefix in Folio driver

### DIFF
--- a/config/vufind/Folio.ini
+++ b/config/vufind/Folio.ini
@@ -37,6 +37,9 @@ global_token_cache = true
 ; - instance (FOLIO instance ID -- the default)
 ; - hrid (FOLIO human-readable ID)
 type = instance
+; If VuFind has a prefix on IDs compared to the FOLIO ID you can specify it here to
+; so the IDs are correctly mapped (default is "").
+;prefix = ""
 
 ; This section controls how we authenticate FOLIO users. There are two possible
 ; ways of authenticating users: logging them in to Okapi, or looking them up in

--- a/module/VuFind/src/VuFind/ILS/Driver/Folio.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Folio.php
@@ -49,6 +49,7 @@ use function is_int;
 use function is_object;
 use function is_string;
 use function sprintf;
+use function strlen;
 
 /**
  * FOLIO REST API driver.
@@ -221,6 +222,43 @@ class Folio extends AbstractAPI implements
     {
         // Normalize string to tolerate minor variations in config file:
         return trim(strtolower($this->config['IDs']['type'] ?? 'instance'));
+    }
+
+    /**
+     * Get the prefix of VuFind's bib IDs compared to the FOLIO ID.
+     *
+     * @return string
+     */
+    protected function getBibIdPrefix(): string
+    {
+        return $this->config['IDs']['prefix'] ?? '';
+    }
+
+    /**
+     * Map the FOLIO ID in to VuFind's bibliographic ID.
+     *
+     * @param string $folioId FOLIO ID
+     *
+     * @return string
+     */
+    protected function folioIdToBibId(string $folioId): string
+    {
+        return $this->getBibIdPrefix() . $folioId;
+    }
+
+    /**
+     * Map VuFind's bibliographic ID to the FOLIO ID.
+     *
+     * @param string $bibId Bib ID
+     *
+     * @return string
+     */
+    protected function bibIdToFolioId(string $bibId): string
+    {
+        if ($idPrefix = $this->getBibIdPrefix()) {
+            return substr($bibId, strlen($idPrefix));
+        }
+        return $bibId;
     }
 
     /**
@@ -502,7 +540,7 @@ class Folio extends AbstractAPI implements
         // Special case: if we're using instance IDs and we already have one,
         // short-circuit the lookup process:
         if ($idType === 'instance' && is_string($instanceOrInstanceId)) {
-            return $instanceOrInstanceId;
+            return $this->folioIdToBibId($instanceOrInstanceId);
         }
 
         $instance = is_object($instanceOrInstanceId)
@@ -511,9 +549,9 @@ class Folio extends AbstractAPI implements
 
         switch ($idType) {
             case 'hrid':
-                return $instance->hrid;
+                return $this->folioIdToBibId($instance->hrid);
             case 'instance':
-                return $instance->id;
+                return $this->folioIdToBibId($instance->id);
         }
 
         throw new \Exception('Unsupported ID type: ' . $idType);
@@ -721,10 +759,11 @@ class Folio extends AbstractAPI implements
         // directly:
         $idType = $this->getBibIdType();
         $idField = $idType === 'instance' ? 'id' : $idType;
+        $folioIds = array_map([$this, 'bibIdToFolioId'], $bibIds);
         $instances = [];
         foreach (
             $this->getByBatch(
-                $bibIds,
+                $folioIds,
                 $idField,
                 'instances',
                 '/instance-storage/instances'
@@ -1377,13 +1416,13 @@ class Folio extends AbstractAPI implements
             // Do not retrieve the instances if we already have their ids
             $instanceIds = $bibIds;
             foreach ($bibIds as $bibId) {
-                $bibIdToInstanceId[$bibId] = $bibId;
+                $bibIdToInstanceId[$bibId] = $this->bibIdToFolioId($bibId);
             }
         } else {
             $instances = $this->getInstancesByBibIds($bibIds);
             $instanceIds = array_map(fn ($instance) => $instance->id, $instances);
             foreach ($instances as $instance) {
-                $bibIdToInstanceId[$instance->$idType] = $instance->id;
+                $bibIdToInstanceId[$this->getBibId($instance)] = $instance->id;
             }
         }
         $holdings = $this->getHoldingsByInstanceIds($instanceIds);
@@ -3006,6 +3045,7 @@ class Folio extends AbstractAPI implements
                 ? 'instanceHrid' : 'instanceId';
             $bibId = $item->copiedItem->$idProperty ?? null;
             if ($bibId !== null) {
+                $bibId = $this->folioIdToBibId($bibId);
                 $courseData = $this->getCourseDetails(
                     $item->courseListingId ?? null
                 );

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/FolioTest.php
@@ -1026,6 +1026,23 @@ class FolioTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getHolding with HRID-based lookup and ID prefix.
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\Depends('testGetHoldingWithHridLookup')]
+    public function testGetHoldingWithHridLookupAndIdPrefix(): void
+    {
+        $driverConfig = $this->defaultDriverConfig;
+        $driverConfig['IDs']['type'] = 'hrid';
+        $driverConfig['IDs']['prefix'] = 'testPrefix-';
+        $this->createConnector('get-holding', $driverConfig);
+        $expectedResult = $this->getExpectedGetHoldingResult();
+        $expectedResult['holdings']['0']['id'] = 'testPrefix-foo';
+        $this->assertEquals($expectedResult, $this->driver->getHolding('testPrefix-foo'));
+    }
+
+    /**
      * Get expected result of getHoldings(), used by testGetHoldingsWithMultipleIds().
      *
      * @return array


### PR DESCRIPTION
The IDs of the records in our index have a prefix that does not exist in the Folio we use. This PR adds the option to specify that prefix.

It does this in the new methods `folioIdToBibId` and `bibIdToFolioId` which makes it even easier to customize, if you require a more complex mapping.