### PR TITLE
Fix GoogleAnalytics gtag() config command

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -2481,8 +2481,8 @@ validateHierarchySequences = true
 ; Uncomment this section and provide your API key to enable Google Analytics.
 ;[GoogleAnalytics]
 ;apiKey = "mykey"
-; Options to pass to the ga() function's create call; if omitted, defaults to
-; 'auto'. The example below can be uncommented to work around a common problem
+; Options to pass to the gtag() function's config command; if omitted, defaults to
+; '{}'. The example below can be uncommented to work around a common problem
 ; with browsers complaining about problems with the samesite attribute. Note
 ; that the value of this setting must be valid Javascript code, so be careful
 ; about quoting and escaping.

--- a/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/GoogleAnalytics.php
@@ -50,7 +50,7 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
     protected $key;
 
     /**
-     * Options to pass to the ga() create command.
+     * Options to pass to the gtag() config command.
      *
      * @var string
      */
@@ -74,7 +74,7 @@ class GoogleAnalytics extends \Laminas\View\Helper\AbstractHelper
             $options = [];
         }
         $this->key = $key;
-        $this->createOptions = $options['create_options_js'] ?? "'auto'";
+        $this->createOptions = $options['create_options_js'] ?? '{}';
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/GoogleAnalyticsTest.php
@@ -59,7 +59,7 @@ class GoogleAnalyticsTest extends \PHPUnit\Framework\TestCase
                 window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', 'myfakekey', 'auto');
+            gtag('config', 'myfakekey', {});
                 //-->
             </script>
             JS;


### PR DESCRIPTION
The current GoogleAnalytics JS code doesn't work. The script is loaded, but there is no tracking.
Problem is you can't pass "auto" to the gtag() function. It only worked with the old ga().
The 3rd parameter must be an object.
https://developers.google.com/tag-platform/gtagjs/reference#config

I've fixed it in the GoogleAnalytics class, updated the test and config.ini, too.

The cookie_flags example is still valid: https://developers.google.com/analytics/devguides/collection/ga4/reference/config#cookie_flags

Currently, the problem can be fixed by using this setting in config.ini:
create_options_js = "{}"
(or any valid object, of course)