### PR TITLE
Collapse elements in embedded result list views on first click

### DIFF
--- a/themes/bootstrap5/js/embedded_record.js
+++ b/themes/bootstrap5/js/embedded_record.js
@@ -130,8 +130,8 @@ VuFind.register('embedded', function embedded() {
     if (!link.classList.contains('js-setup')) {
       mediaBody.insertBefore(link, mediaBody.firstChild);
       result.classList.add('embedded');
-      shortNode.classList.add('collapse');
-      linksNode.classList.add('collapse');
+      shortNode.classList.add('collapse', 'show');
+      linksNode.classList.add('collapse', 'show');
       longNode = document.createElement('div');
       longNode.classList.add('long-view', 'collapse');
 


### PR DESCRIPTION
Hi,

I realized that collapse behavior was inconsistent when using AJAX tab view. The divs "result-body" and "result-links" were still displayed if you expanded the embedded record for the first time. On subsequent expansions they were hidden.

This PR adds the "show" class at the same time the "collapse" class is added. This results in the divs being hidden on first click, rendering the behavior more consistent.

I used AI to identify the problem and did not systematically check for a more elegant solution or unwanted side effects. (Just glad I can cross this off my list for now.) So this PR might also merely serve as a reminder for the inconsistent toggle behavior.