### PR TITLE
Raise requirement to Node 22; enforce it.

### DIFF
--- a/.github/workflows/ci-all.yaml
+++ b/.github/workflows/ci-all.yaml
@@ -112,7 +112,7 @@ jobs:
         if: ${{ inputs.phing_task_qa_console }}
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Debug list all package.json
         run: find $GITHUB_WORKSPACE -name package.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ matrix.phing_tasks == 'qa-console' }}
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "eslint-plugin-jsdoc": "^62.0.0",
         "eslint-plugin-no-jquery": "^3.0.0",
         "globals": "^16.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "workspaces": [
     "themes/bootstrap5"
   ],
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "dependencies": {
     "clean-css": "^5.3.3",
     "commander": "^14.0.0",


### PR DESCRIPTION
Our project policy has been to offer compatibility with the oldest actively supported versions of languages required by the project. Node.js 20 has passed end of life, so this PR raises the minimum requirement to 22 and explicitly specifies it in package.json, which we had not previously done. I chose 22.13.0 instead of 22.0.0 because several of our current dependencies require that minimum version (likely because of CVE fixes applied at that point in time).

Now that we are using Dependabot to update dependencies, we also need to be sure that we do not install package versions that require Node.js versions higher than our supported minimum. I have adjusted our GitHub Actions to use the new minimum version, and I have added an .npmrc to enforce strict engine requirements, so the build will fail if incompatible versions are proposed.

TODO
- [x] Document raised requirement in wiki when merging.