### PR TITLE
Add Javascript dependency synchronization check.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -173,6 +173,7 @@
   <target name="qa-js-and-scss" description="quality assurance js and scss tasks">
     <phingcall target="eslint"/>
     <phingcall target="checkSassBuild"/>
+    <phingcall target="jsDependencyCheck" />
     <phingcall target="jsTranslationsCheck" />
   </target>
 
@@ -311,6 +312,13 @@
   <target name="checkSassBuild">
     <exec executable="npm" checkreturn="true" passthru="true">
       <arg line="run check:scss" />
+    </exec>
+  </target>
+
+  <!-- Check for Node.js dependency synchronization errors -->
+  <target name="jsDependencyCheck">
+    <exec executable="npm" checkreturn="true" passthru="true">
+      <arg line="run check:dependencySync" />
     </exec>
   </target>
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:scss": "npm run installBuildDeps && node util/build-css.js --check-only",
     "watch:scss": "npm run installBuildDeps && nodemon --watch util/ --watch themes/ --ext scss,js --exec \"node util/build-css.js\"",
 
+    "check:dependencySync": "npm run check:dependencySync --workspaces --if-present --ignore-scripts",
     "check:jsTranslations": "npm run check:jsTranslations --workspaces --if-present --ignore-scripts"
   },
   "workspaces": [

--- a/themes/bootstrap5/package.json
+++ b/themes/bootstrap5/package.json
@@ -2,6 +2,7 @@
   "name": "vufind-bootstrap5",
   "description": "Dependencies for the bootstrap5 theme",
   "scripts": {
+    "check:dependencySync": "node tools/copyDependencies.js && git diff --quiet HEAD",
     "check:jsTranslations": "node tools/jsTranslationsCheck.js",
     "installBuildDeps": "npm install --ignore-scripts --no-audit",
     "updateDeps": "npm update --ignore-scripts && node tools/copyDependencies.js"

--- a/themes/bootstrap5/package.json
+++ b/themes/bootstrap5/package.json
@@ -2,7 +2,7 @@
   "name": "vufind-bootstrap5",
   "description": "Dependencies for the bootstrap5 theme",
   "scripts": {
-    "check:dependencySync": "node tools/copyDependencies.js && git diff --quiet HEAD",
+    "check:dependencySync": "node tools/copyDependencies.js && git diff --quiet HEAD || (echo Changed dependencies must be committed && false)",
     "check:jsTranslations": "node tools/jsTranslationsCheck.js",
     "installBuildDeps": "npm install --ignore-scripts --no-audit",
     "updateDeps": "npm update --ignore-scripts && node tools/copyDependencies.js"


### PR DESCRIPTION
This adds a new QA check to ensure that we have not updated Node.js dependencies without remembering to copy them into the appropriate place in the theme. This will help ensure that we don't accidentally merge Dependabot PRs without properly installing files and testing code.