### PR TITLE
Improve config/upgrade console tool error handling.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -270,6 +270,9 @@ class Upgrade implements LoggerAwareInterface
             $this->pathResolver->getBaseConfigDirPath()
         );
         $localConfigDir = $this->pathResolver->getLocalConfigDirPath();
+        if (null === $localConfigDir) {
+            throw new \Exception('Cannot find local configuration directory; is VUFIND_LOCAL_DIR unset?');
+        }
         foreach ($baseConfigLocations as $configLocation) {
             $configName = $configLocation->getConfigName();
             if ($configLocation instanceof ConfigDirectory) {


### PR DESCRIPTION
While upgrading the public demo instance for the 11.1 release, I discovered that the config/upgrade console tool fails in an ungraceful way if the local config directory cannot be found due to missing environment variables:

```
PHP Fatal error:  Uncaught TypeError: VuFind\Config\PathResolver::getMatchingConfigLocation(): Argument #1 ($path) must be of type string, null given, called in /usr/local/vufind/module/VuFind/src/VuFind/Config/Upgrade.php on line 288 and defined in /usr/local/vufind/module/VuFind/src/VuFind/Config/PathResolver.php:325
```

This PR adds a check to avoid the type error and replaces it with a more helpful message:

```
Exception: Cannot find local configuration directory; is VUFIND_LOCAL_DIR unset? in /usr/local/vufind/module/VuFind/src/VuFind/Config/Upgrade.php:274
```