### PR TITLE
User content: update obsolete sr-only CSS class

### DIFF
--- a/themes/bootstrap5/templates/comments/userlist.phtml
+++ b/themes/bootstrap5/templates/comments/userlist.phtml
@@ -79,7 +79,7 @@
                 <div class="checkbox-container result">
                   <div class="checkbox">
                     <label>
-                      <span class="sr-only"><?=$this->transEsc('Select');?></span>
+                      <span class="visually-hidden"><?=$this->transEsc('Select');?></span>
                       <input class="checkbox-select-item" type="checkbox" name="deleteSelectedcomment[]" value="<?=$this->escapeHtmlAttr(($comment['id']))?>" id="checkbox_comment_<?=$comment['id']?>">
                     </label>
                   </div>

--- a/themes/bootstrap5/templates/ratings/userlist.phtml
+++ b/themes/bootstrap5/templates/ratings/userlist.phtml
@@ -75,7 +75,7 @@
                   <div class="checkbox-container result">
                     <div class="checkbox">
                       <label>
-                        <span class="sr-only"><?=$this->transEsc('Select');?></span>
+                        <span class="visually-hidden"><?=$this->transEsc('Select');?></span>
                         <input class="checkbox-select-item" type="checkbox" name="deleteSelectedrating[]" value="<?=$this->escapeHtmlAttr(($rating['id']))?>" id="checkbox_rating_<?=$rating['id']?>">
                       </label>
                     </div>

--- a/themes/bootstrap5/templates/tag/userlist.phtml
+++ b/themes/bootstrap5/templates/tag/userlist.phtml
@@ -79,7 +79,7 @@
                 <div class="checkbox-container result">
                   <div class="checkbox">
                     <label>
-                      <span class="sr-only"><?=$this->transEsc('Select');?></span>
+                      <span class="visually-hidden"><?=$this->transEsc('Select');?></span>
                       <input class="checkbox-select-item" type="checkbox" name="deleteSelectedtag[]" value="<?=$this->escapeHtmlAttr(($tag['id']))?>" id="checkbox_tag_<?=$tag['id']?>">
                     </label>
                   </div>


### PR DESCRIPTION
Bootstrap 5 uses `visually-hidden` instead of `sr-only` but a few instances of the old class were missed in conversion.