### PR TITLE
Fix bug: case sensitive tags displayed incorrectly in UserList.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/TagController.php
+++ b/module/VuFind/src/VuFind/Controller/TagController.php
@@ -31,6 +31,7 @@ namespace VuFind\Controller;
 
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFind\Exception\Forbidden as ForbiddenException;
+use VuFind\Tags\TagsService;
 use VuFind\Validator\CsrfInterface;
 
 /**
@@ -105,6 +106,7 @@ class TagController extends AbstractSearch
                 $paging['sort'],
                 $paging['page'],
                 $paging['limit'],
+                $this->getService(TagsService::class)->hasCaseSensitiveTags()
             )
         );
         return $this->createViewModel(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -384,8 +384,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
      */
     public static function tagManagementTagDisplayProvider(): Generator
     {
-        yield 'case sensitive' => [true, ['ONE', 'new tag', 'THREE 4', 'one', 'three 4', 'five']];
-        yield 'case insensitive' => [false, ['one', 'new tag', 'three 4', 'one', 'three 4', 'five']];
+        yield 'case sensitive' => [true, ['ONE', 'THREE 4', 'five', 'five', 'five', 'new tag', 'one', 'three 4']];
+        yield 'case insensitive' => [false, ['five', 'five', 'five', 'new tag', 'one', 'one', 'three 4', 'three 4']];
     }
 
     /**
@@ -415,6 +415,8 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->fillInLoginForm($page, 'username2', 'test', false);
         $this->submitLoginForm($page, false);
         $tags = array_map(fn ($tag) => $tag->getText(), $page->findAll('css', 'td.user-tag div'));
+        // Sort tags to account for database platform and timing differences:
+        sort($tags);
         $this->assertEquals($expected, $tags);
     }
 

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -31,6 +31,7 @@
 namespace VuFindTest\Mink;
 
 use Behat\Mink\Element\Element;
+use Generator;
 
 use function count;
 use function intval;
@@ -374,6 +375,47 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $this->waitForPageLoad($page);
         $tags = $page->findAll('css', '.tagList .tag');
         $this->assertCount(6, $tags);
+    }
+
+    /**
+     * Data provider for testTagManagementTagDisplay.
+     *
+     * @return Generator<string, array>
+     */
+    public static function tagManagementTagDisplayProvider(): Generator
+    {
+        yield 'case sensitive' => [true, ['ONE', 'new tag', 'THREE 4', 'one', 'three 4', 'five']];
+        yield 'case insensitive' => [false, ['one', 'new tag', 'three 4', 'one', 'three 4', 'five']];
+    }
+
+    /**
+     * Test display of tags in user content management area.
+     *
+     * @param bool     $caseSensitive Use case sensitive tags?
+     * @param string[] $expected      Expected tag text
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('tagManagementTagDisplayProvider')]
+    #[\PHPUnit\Framework\Attributes\Depends('testAddSensitiveTag')]
+    public function testTagManagementTagDisplay(bool $caseSensitive, array $expected): void
+    {
+        if ($caseSensitive) {
+            $this->changeConfigs(
+                [
+                    'config' => [
+                        'Social' => ['case_sensitive_tags' => 'true'],
+                    ],
+                ]
+            );
+        }
+        $session = $this->getMinkSession();
+        $session->visit($this->getVuFindUrl('/Tag/UserList'));
+        $page = $session->getPage();
+        $this->fillInLoginForm($page, 'username2', 'test', false);
+        $this->submitLoginForm($page, false);
+        $tags = array_map(fn ($tag) => $tag->getText(), $page->findAll('css', 'td.user-tag div'));
+        $this->assertEquals($expected, $tags);
     }
 
     /**


### PR DESCRIPTION
Case sensitive tags were not displayed correctly in the user content management area because we were failing to pass the config setting down from the controller. This PR fixes the problem and adds a Mink test to prevent regressions.

TODO
- [x] Run full test suite with MySQL
- [x] Run full test suite with PostgreSQL