### PR TITLE
Allow extendclass generator to detect factories.

### DIFF
--- a/module/VuFind/src/VuFind/ServiceManager/AbstractPluginFactory.php
+++ b/module/VuFind/src/VuFind/ServiceManager/AbstractPluginFactory.php
@@ -31,9 +31,6 @@ namespace VuFind\ServiceManager;
 
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Psr\Container\ContainerInterface;
-use ReflectionClass;
-use VuFind\ServiceManager\Factory\AutowiringFactory;
-use VuFind\ServiceManager\Factory\DefaultFactory;
 
 /**
  * VuFind Abstract Plugin Factory.
@@ -46,8 +43,6 @@ use VuFind\ServiceManager\Factory\DefaultFactory;
  */
 class AbstractPluginFactory implements AbstractFactoryInterface
 {
-    use Factory\AutowireableTrait;
-
     /**
      * Default namespace for building class names (null to use class names as-is).
      *
@@ -77,6 +72,24 @@ class AbstractPluginFactory implements AbstractFactoryInterface
     protected ?string $defaultFactory = null;
 
     /**
+     * Factory detector.
+     *
+     * @var FactoryDetector
+     */
+    protected ?FactoryDetector $factoryDetector = null;
+
+    /**
+     * Get factory detector.
+     *
+     * @return FactoryDetector
+     */
+    protected function getFactoryDetector(): FactoryDetector
+    {
+        $this->factoryDetector ??= new FactoryDetector();
+        return $this->factoryDetector;
+    }
+
+    /**
      * Get the name of a class for a given plugin name.
      *
      * @param string $requestedName Name of service
@@ -98,62 +111,6 @@ class AbstractPluginFactory implements AbstractFactoryInterface
     }
 
     /**
-     * Given the name of a class, check if it has default factory behavior assigned; return an array
-     * of values from the DefaultFactory attribute.
-     *
-     * @param string $class Class name
-     *
-     * @return array{name: ?string, autodetect: bool}
-     */
-    protected function getDefaultFactorySettings(string $class): array
-    {
-        $reflectionClass = new ReflectionClass($class);
-        $matches = $reflectionClass->getAttributes(DefaultFactory::class);
-        if (!$matches) {
-            $matches = $reflectionClass->getConstructor()?->getAttributes(DefaultFactory::class);
-        }
-        return isset($matches[0]) ? $matches[0]->getArguments() : ['name' => null, 'autodetect' => true];
-    }
-
-    /**
-     * Given a class name, detect the best matching factory. Return null if none can be found.
-     * This is a support method for getFactoryForClass and should not be called directly; use
-     * getFactoryForClass to take advantage of internal caching.
-     *
-     * @param string $class Class name
-     *
-     * @return ?string
-     */
-    protected function detectFactoryForClass(string $class): ?string
-    {
-        $defaultFactorySettings = $this->getDefaultFactorySettings($class);
-        if ($defaultFactorySettings['name']) {
-            return $defaultFactorySettings['name'];
-        }
-        // If the class is autowireable, take advantage of that:
-        if ($this->isAutowireable($class)) {
-            return AutowiringFactory::class;
-        }
-        // Autodetect a factory if desired:
-        if ($defaultFactorySettings['autodetect']) {
-            // If the class has an explicit factory, use that:
-            if (class_exists($class . 'Factory')) {
-                return $class . 'Factory';
-            }
-            // Check if parent classes have factories:
-            $parentClass = get_parent_class($class);
-            while ($parentClass) {
-                if (class_exists($parentClass . 'Factory')) {
-                    return $parentClass . 'Factory';
-                }
-                $parentClass = get_parent_class($parentClass);
-            }
-        }
-        // If we got this far, we'll fall back on the default factory for lack of a better option:
-        return $this->defaultFactory;
-    }
-
-    /**
      * Given a class name, find the best matching factory. Return null if none can be found.
      *
      * @param string $class Class name
@@ -163,7 +120,8 @@ class AbstractPluginFactory implements AbstractFactoryInterface
     protected function getFactoryForClass(string $class): ?string
     {
         if (!isset($this->factoryForClass[$class])) {
-            $this->factoryForClass[$class] = $this->detectFactoryForClass($class);
+            $this->factoryForClass[$class] = $this->getFactoryDetector()->detectFactoryForClass($class)
+                ?? $this->defaultFactory;
         }
         return $this->factoryForClass[$class];
     }

--- a/module/VuFind/src/VuFind/ServiceManager/FactoryDetector.php
+++ b/module/VuFind/src/VuFind/ServiceManager/FactoryDetector.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Class to detect the best factory for another class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\ServiceManager;
+
+use ReflectionClass;
+use VuFind\ServiceManager\Factory\AutowiringFactory;
+use VuFind\ServiceManager\Factory\DefaultFactory;
+
+/**
+ * Class to detect the best factory for another class.
+ *
+ * @category VuFind
+ * @package  ServiceManager
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class FactoryDetector
+{
+    use Factory\AutowireableTrait;
+
+    /**
+     * Given the name of a class, check if it has default factory behavior assigned; return an array
+     * of values from the DefaultFactory attribute.
+     *
+     * @param string $class Class name
+     *
+     * @return array{name: ?string, autodetect: bool}
+     */
+    protected function getDefaultFactorySettings(string $class): array
+    {
+        $reflectionClass = new ReflectionClass($class);
+        $matches = $reflectionClass->getAttributes(DefaultFactory::class);
+        if (!$matches) {
+            $matches = $reflectionClass->getConstructor()?->getAttributes(DefaultFactory::class);
+        }
+        return isset($matches[0]) ? $matches[0]->getArguments() : ['name' => null, 'autodetect' => true];
+    }
+
+    /**
+     * Given a class name, detect the best matching factory. Return null if none can be found.
+     * This is a support method for getFactoryForClass and should not be called directly; use
+     * getFactoryForClass to take advantage of internal caching.
+     *
+     * @param string $class Class name
+     *
+     * @return ?string
+     */
+    public function detectFactoryForClass(string $class): ?string
+    {
+        $defaultFactorySettings = $this->getDefaultFactorySettings($class);
+        if ($defaultFactorySettings['name']) {
+            return $defaultFactorySettings['name'];
+        }
+        // If the class is autowireable, take advantage of that:
+        if ($this->isAutowireable($class)) {
+            return AutowiringFactory::class;
+        }
+        // Autodetect a factory if desired:
+        if ($defaultFactorySettings['autodetect']) {
+            // If the class has an explicit factory, use that:
+            if (class_exists($class . 'Factory')) {
+                return $class . 'Factory';
+            }
+            // Check if parent classes have factories:
+            $parentClass = get_parent_class($class);
+            while ($parentClass) {
+                if (class_exists($parentClass . 'Factory')) {
+                    return $parentClass . 'Factory';
+                }
+                $parentClass = get_parent_class($parentClass);
+            }
+        }
+        // If we got this far, we couldn't find a match.
+        return null;
+    }
+}

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorTools.php
@@ -34,6 +34,7 @@ use Laminas\Code\Generator\FileGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Reflection\ClassReflection;
 use Psr\Container\ContainerInterface;
+use VuFind\ServiceManager\FactoryDetector;
 
 use function count;
 use function in_array;
@@ -56,20 +57,13 @@ class GeneratorTools
     use \VuFindConsole\ConsoleOutputTrait;
 
     /**
-     * Laminas configuration.
-     *
-     * @var array
-     */
-    protected $config;
-
-    /**
      * Constructor.
      *
-     * @param array $config Laminas configuration
+     * @param array           $config          Laminas configuration
+     * @param FactoryDetector $factoryDetector Factory detector
      */
-    public function __construct(array $config)
+    public function __construct(protected array $config, protected FactoryDetector $factoryDetector)
     {
-        $this->config = $config;
     }
 
     /**
@@ -402,7 +396,11 @@ class GeneratorTools
             $delegators = $this->getDelegatorsFromContainer($pm, $class);
         }
 
-        // No factory found? Throw an error!
+        // No factory found? Try to detect one!
+        if (empty($factory)) {
+            $factory = $this->factoryDetector->detectFactoryForClass($class);
+        }
+        // Still no factory found? Throw an error!
         if (empty($factory)) {
             throw new \Exception('Could not find factory for ' . $class);
         }
@@ -458,9 +456,9 @@ class GeneratorTools
      * @param ContainerInterface $container Container to inspect
      * @param string             $class     Class whose factory we want
      *
-     * @return string
+     * @return ?string
      */
-    protected function getFactoryFromContainer(ContainerInterface $container, $class)
+    protected function getFactoryFromContainer(ContainerInterface $container, string $class): ?string
     {
         $factories = $this->getAllFactoriesFromContainer($container);
         return $factories[$class] ?? null;

--- a/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
+++ b/module/VuFindConsole/src/VuFindConsole/Generator/GeneratorToolsFactory.php
@@ -34,6 +34,7 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
+use VuFind\ServiceManager\FactoryDetector;
 
 /**
  * Generator tools factory.
@@ -68,6 +69,6 @@ class GeneratorToolsFactory implements FactoryInterface
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        return new $requestedName($container->get('config'));
+        return new $requestedName($container->get('config'), new FactoryDetector());
     }
 }


### PR DESCRIPTION
Recent work to eliminate explicit factory configuration broke some of the code generation tools. This PR begins to address the problem by refactoring factory detection logic to a reusable class.

TODO
- [ ] Run full test suite
- [ ] Test generators thoroughly