### PR TITLE
Add getHighlightedTitle to EDS record driver.

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -214,6 +214,24 @@ class EDS extends DefaultRecord
     }
 
     /**
+     * Get a highlighted title string, if available.
+     *
+     * @return string
+     */
+    public function getHighlightedTitle()
+    {
+        // If highlighting is available, it will be in the item data; the raw data will
+        // include <highlight> tags, but these get converted into spans by deeper layers
+        // of the record driver and should be further translated into highlight markers
+        // for appropriate processing by the highlight view helper.
+        return preg_replace(
+            '|<span class="highlight">([^<]*)</span>|',
+            '{{{{START_HILITE}}}}$1{{{{END_HILITE}}}}',
+            $this->getItemsTitle()
+        );
+    }
+
+    /**
      * Get the short (pre-subtitle) title of the record.
      *
      * @return string

--- a/module/VuFind/tests/fixtures/eds/eds-highlighting.json
+++ b/module/VuFind/tests/fixtures/eds/eds-highlighting.json
@@ -1,0 +1,10 @@
+{
+  "Items": [
+    {
+      "Name": "Title",
+      "Label": "Title",
+      "Group": "Ti",
+      "Data": "&lt;highlight&gt;highlighted part&lt;\/highlight&gt; of text. Also &lt;highlight&gt;more highlights&lt;\/highlight&gt;"
+    }
+  ]
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -1132,4 +1132,19 @@ class EDSTest extends \PHPUnit\Framework\TestCase
         $driver = $this->getDriver('valid-eds-record-2');
         $this->assertNull($driver->getScore());
     }
+
+    /**
+     * Test getHighlightedTitle().
+     *
+     * @return void
+     */
+    public function testGetHighlightedTitle(): void
+    {
+        $driver = $this->getDriver('eds-highlighting');
+        $this->assertEquals(
+            '{{{{START_HILITE}}}}highlighted part{{{{END_HILITE}}}} of text. '
+            . 'Also {{{{START_HILITE}}}}more highlights{{{{END_HILITE}}}}',
+            $driver->getHighlightedTitle()
+        );
+    }
 }


### PR DESCRIPTION
@sturkel89 noticed that the EDSResults recommendation module did not highlight search terms the way CatalogResults does. This is because the EDS record driver does not implement getHighlightedTitle. This PR adds the missing functionality, though I have some concerns that there may be edge cases where unwanted HTML might slip through into the recommendations. Testing assistance and feedback would be appreciated! (@cwolfebsco, do you have any thoughts on this?)

I suspect there may be room to make the record driver more efficient (I think getItems is doing some repeated work that we might optimize with caching). I also wonder if we might be able to better standardize the EDS-specific result-list.phtml template once this functionality is in place. Those are both projects for another day, though -- the goal here is simply to restore the missing highlighting functionality in the recommendation module (and anywhere else that it might be expected).

In any case, here's what things currently look like on the dev branch:

<img width="325" height="184" alt="image" src="https://github.com/user-attachments/assets/7d4ac9d5-86cc-4ee3-8dd4-cbaa3ba8d4c6" />

...and with this PR:

<img width="321" height="181" alt="image" src="https://github.com/user-attachments/assets/af6be5cc-ef91-4701-98d9-ab9e85d5abf3" />
