### PR TITLE
Fix bug: PubDateVisAjax broken for Collections.

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/PubDateVisAjax.php
+++ b/module/VuFind/src/VuFind/Recommend/PubDateVisAjax.php
@@ -145,13 +145,14 @@ class PubDateVisAjax implements RecommendInterface
      */
     public function getVisFacets(): array
     {
+        $results = $this->getSearchResults();
         // Don't bother processing if the result set is empty:
-        if ($this->searchObject->getResultTotal() <= 0) {
+        if ($results->getResultTotal() <= 0) {
             return [];
         }
         return $this->processDateFacets(
-            $this->searchObject,
-            $this->searchObject->getParams()->getRawFilters(),
+            $results,
+            $results->getParams()->getRawFilters(),
             $this->dateFacets
         );
     }
@@ -194,7 +195,7 @@ class PubDateVisAjax implements RecommendInterface
     public function getSearchParams(): string
     {
         // Get search parameters and return them minus the leading ?:
-        return substr($this->searchObject->getUrlQuery()->getParams(false), 1);
+        return substr($this->getSearchResults()->getUrlQuery()->getParams(false), 1);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Recommend/PubDateVisAjax.php
+++ b/module/VuFind/src/VuFind/Recommend/PubDateVisAjax.php
@@ -196,4 +196,17 @@ class PubDateVisAjax implements RecommendInterface
         // Get search parameters and return them minus the leading ?:
         return substr($this->searchObject->getUrlQuery()->getParams(false), 1);
     }
+
+    /**
+     * Get search results object.
+     *
+     * @return \VuFind\Search\Base\Results
+     */
+    public function getSearchResults(): \VuFind\Search\Base\Results
+    {
+        if (!$this->searchObject) {
+            throw new \Exception('getSearchResults called before initialization.');
+        }
+        return $this->searchObject;
+    }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/CollectionsTest.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2017.
+ * Copyright (C) Villanova University 2017-2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -47,7 +47,7 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return Element
      */
-    protected function goToCollection()
+    protected function goToCollection(): Element
     {
         $session = $this->getMinkSession();
         $path = '/Collection/topcollection1';
@@ -60,7 +60,7 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return Element
      */
-    protected function goToCollectionHierarchy()
+    protected function goToCollectionHierarchy(): Element
     {
         $session = $this->getMinkSession();
         $path = '/Collection/subcollection1/HierarchyTree';
@@ -73,7 +73,7 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $this->changeConfigs(
             [
@@ -95,24 +95,51 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test that a collection can use the PubDateVisAjax recommendation module.
+     *
+     * @return void
+     */
+    public function testPubDateVisAjax(): void
+    {
+        $this->changeConfigs(
+            [
+                'config' => [
+                    'Collections' => [
+                        'collections' => true,
+                    ],
+                ],
+                'Collection' => [
+                    'Recommend' => ['top' => 'PubDateVisAjax:true:publishDate'],
+                ],
+            ]
+        );
+        $page = $this->goToCollection();
+        $this->waitForPageLoad($page);
+        $results = $page->findAll('css', '.result');
+        $this->assertCount(7, $results);
+        $this->assertEquals('1957', $this->findCssAndGetValue($page, '.datevis-input-from'));
+        $this->assertEquals('1985', $this->findCssAndGetValue($page, '.datevis-input-to'));
+    }
+
+    /**
      * Test that the keyword filter feature works correctly.
      *
      * @return void
      */
-    public function testKeywordFilter()
+    public function testKeywordFilter(): void
     {
         $this->changeConfigs(
             [
-            'config' => [
-                'Collections' => [
-                    'collections' => true,
+                'config' => [
+                    'Collections' => [
+                        'collections' => true,
+                    ],
                 ],
-            ],
-            'HierarchyDefault' => [
-                'Collections' => [
-                    'link_type' => 'Top',
+                'HierarchyDefault' => [
+                    'Collections' => [
+                        'link_type' => 'Top',
+                    ],
                 ],
-            ],
             ]
         );
         $page = $this->goToCollection();
@@ -128,24 +155,24 @@ class CollectionsTest extends \VuFindTest\Integration\MinkTestCase
      *
      * @return void
      */
-    public function testContextLinks()
+    public function testContextLinks(): void
     {
         // link_type => 'All'
         $this->changeConfigs(
             [
-            'config' => [
-                'Hierarchy' => [
-                    'showTree' => true,
+                'config' => [
+                    'Hierarchy' => [
+                        'showTree' => true,
+                    ],
+                    'Collections' => [
+                        'collections' => true,
+                    ],
                 ],
-                'Collections' => [
-                    'collections' => true,
+                'HierarchyDefault' => [
+                    'Collections' => [
+                        'link_type' => 'All',
+                    ],
                 ],
-            ],
-            'HierarchyDefault' => [
-                'Collections' => [
-                    'link_type' => 'All',
-                ],
-            ],
             ]
         );
         $page = $this->goToCollection();

--- a/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
+++ b/themes/bootstrap5/templates/Recommend/PubDateVisAjax.phtml
@@ -33,7 +33,7 @@
     ?>
     <div class="authorbox">
       <form<?=$this->htmlAttributes($formAttributes)?>>
-        <?=$this->results->getUrlQuery()->asHiddenFields(['page' => '/./', 'filter' => '/^' . preg_quote($facetField) . ':.*/'])?>
+        <?=$this->recommend->getSearchResults()->getUrlQuery()->asHiddenFields(['page' => '/./', 'filter' => '/^' . preg_quote($facetField) . ':.*/'])?>
         <input type="hidden" name="daterange[]" value="<?=$facetFieldEsc?>">
         <h3 class="datevis-label facet-title"><?=$this->transEsc($facetRange['label']) ?></h3>
         <div class="datevis-chart">


### PR DESCRIPTION
The PubDateVisAjax template made assumptions about a global `$this->results` variable that is not defined in all contexts. This caused a fatal error when including those recommendations in the Collections view. This PR revises the template to instead get the value from the recommendation object where it can be reliably and consistently found. It also adds a Mink test to catch regressions.