### PR TITLE
Misc Alma improvements [Draft]

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Alma.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Alma.php
@@ -1833,6 +1833,7 @@ class Alma extends AbstractBase implements
                     if ($note = $marc->getSubfield($field, 'n')) {
                         $item['item_notes'] = [$note];
                     }
+                    $item['locationhref'] = $marc->getSubfield($field, 'u');
                     $status[] = $item;
                 }
                 // Digital


### PR DESCRIPTION
I'm currently looking at some parts of VuFind's Alma integration. I will collect possible minor improvements here. It may merely serve as a reminder for future discussion. Current changes:

## Add direct link for Alma electronic resources in holdings list
Adds direct access to the resource in the holding entry via the URL provided in AVE $u:
<img width="1920" height="206" alt="image" src="https://github.com/user-attachments/assets/b8982ef8-2c16-46aa-adae-ef6a471196f5" />

For the subfield u to be populated the Alma setting General > Other Settings > publishing_base_url is [required](https://developers.exlibrisgroup.com/alma/apis/docs/bibs/R0VUIC9hbG1hd3MvdjEvYmlicy97bW1zX2lkfQ==/) to be set. However, I'm not sure whether it should be as described in the [developer documentation](https://developers.exlibrisgroup.com/alma/integrations/discovery/openurl_resolving/) (https://<Alma_domain>/openurl/<Alma_institution_code>/<view_code>?) or like I've read somewhere else (https://[ALMA_URL]/view/uresolver/[INST_CODE]/openurl).

### Side note regarding link resolver URLs
Both URLs work for the aforementioned linking, but for sake of consistency one might want to choose the one happens to be using als the value for "url" in config.ini [OpenURL], where they actually behave differently: The former breaks embedding while it works for the latter. Is there a good spot for documenting this, either in the config file or the documentation?