### PR TITLE
Do not fail dependency sync check for unrelated changes.

### DIFF
--- a/themes/bootstrap5/package.json
+++ b/themes/bootstrap5/package.json
@@ -2,7 +2,7 @@
   "name": "vufind-bootstrap5",
   "description": "Dependencies for the bootstrap5 theme",
   "scripts": {
-    "check:dependencySync": "npm run copyUpdatedDeps && git diff --quiet HEAD || (echo Changed dependencies must be committed && false)",
+    "check:dependencySync": "npm run copyUpdatedDeps && git diff --quiet HEAD $VUFIND_HOME/themes/**/**/vendor || (echo Changed dependencies must be committed && false)",
     "check:jsTranslations": "node tools/jsTranslationsCheck.js",
     "installBuildDeps": "npm install --ignore-scripts --no-audit",
     "copyUpdatedDeps": "node tools/copyDependencies.js",


### PR DESCRIPTION
Any uncommitted changes would cause the dependency sync check to fail. This PR changes the git diff to specifically look for modified vendor files inside the themes, preventing unrelated changes from blocking the `composer qa` command. Thanks to @aleksip for reporting the problem!