### PR TITLE
Update instructions for date and time formats in config.ini

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -115,7 +115,7 @@ locale          = en_US
 ;   http://www.php.net/manual/en/timezones.php
 timezone        = "America/New_York"
 ; These two settings control how dates and times are formatted in the user interface, using PHP date formatting syntax.
-; The default for displayDateFormat is m-d-Y (MM-DD-YYYY 01-01-2027)
+; The default for displayDateFormat is "m-d-Y" (MM-DD-YYYY, e.g. 01-01-2027)
 ; The default for displayTimeFormat is "H:i" (HH:MM, e.g. 23:01)
 ;   If you prefer formatting for a 12-hour clock (e.g., 11:01 PM) you can use "g:i A"
 ; Find details on how to build valid date/time format strings here:

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -115,10 +115,12 @@ locale          = en_US
 ;   http://www.php.net/manual/en/timezones.php
 timezone        = "America/New_York"
 ; A string used to format user interface date strings using the PHP date() function
-; default is m-d-Y (MM-DD-YYYY 01-01-2010)
+; default is m-d-Y (MM-DD-YYYY 01-01-2027)
 displayDateFormat = "m-d-Y"
 ; A string used to format user interface time strings using the PHP date() function
 ; default is H:i (HH:MM 23:01)
+; Find valid time values here:
+;   https://www.php.net/manual/en/datetime.format.php
 displayTimeFormat = "H:i"
 ; The base VuFind URL will load this controller unless the user is logged in:
 defaultModule   = Search

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -114,7 +114,7 @@ locale          = en_US
 ; Find valid timezone values here:
 ;   http://www.php.net/manual/en/timezones.php
 timezone        = "America/New_York"
-; These two settings control how dates and times are formatted using the PHP date() function.
+; These two settings control how dates and times are formatted in the user interface, using PHP date formatting syntax.
 ; The default for displayDateFormat is m-d-Y (MM-DD-YYYY 01-01-2027)
 ; The default for displayTimeFormat is H:i (HH:MM 23:01); the display for a 12-hour clock (e.g., 11:01 PM) would use g:i A
 ; Find details on how to build valid date/time format strings here:

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -116,7 +116,8 @@ locale          = en_US
 timezone        = "America/New_York"
 ; These two settings control how dates and times are formatted in the user interface, using PHP date formatting syntax.
 ; The default for displayDateFormat is m-d-Y (MM-DD-YYYY 01-01-2027)
-; The default for displayTimeFormat is H:i (HH:MM 23:01); the display for a 12-hour clock (e.g., 11:01 PM) would use g:i A
+; The default for displayTimeFormat is "H:i" (HH:MM, e.g. 23:01)
+;   If you prefer formatting for a 12-hour clock (e.g., 11:01 PM) you can use "g:i A"
 ; Find details on how to build valid date/time format strings here:
 ;   https://www.php.net/manual/en/datetime.format.php
 displayDateFormat = "m-d-Y"

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -119,7 +119,7 @@ timezone        = "America/New_York"
 displayDateFormat = "m-d-Y"
 ; A string used to format user interface time strings using the PHP date() function
 ; default is H:i (HH:MM 23:01)
-; Find valid time values here:
+; Find details on how to build valid date/time format strings here:
 ;   https://www.php.net/manual/en/datetime.format.php
 displayTimeFormat = "H:i"
 ; The base VuFind URL will load this controller unless the user is logged in:

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -114,13 +114,12 @@ locale          = en_US
 ; Find valid timezone values here:
 ;   http://www.php.net/manual/en/timezones.php
 timezone        = "America/New_York"
-; A string used to format user interface date strings using the PHP date() function
-; default is m-d-Y (MM-DD-YYYY 01-01-2027)
-displayDateFormat = "m-d-Y"
-; A string used to format user interface time strings using the PHP date() function
-; default is H:i (HH:MM 23:01)
+; These two settings control how dates and times are formatted using the PHP date() function.
+; The default for displayDateFormat is m-d-Y (MM-DD-YYYY 01-01-2027)
+; The default for displayTimeFormat is H:i (HH:MM 23:01); the display for a 12-hour clock (e.g., 11:01 PM) would use g:i A
 ; Find details on how to build valid date/time format strings here:
 ;   https://www.php.net/manual/en/datetime.format.php
+displayDateFormat = "m-d-Y"
 displayTimeFormat = "H:i"
 ; The base VuFind URL will load this controller unless the user is logged in:
 defaultModule   = Search


### PR DESCRIPTION
This PR updates the example date format to show 2027 rather than 2010.

It also provides a link to documentation for updating the time display. The default value is a 24-hour clock without instructions for using a different display.