### PR TITLE
Drop support for PHP 8.2.

### DIFF
--- a/.github/workflows/ci-all.yaml
+++ b/.github/workflows/ci-all.yaml
@@ -30,12 +30,11 @@ on:
         default: 'default'
         type: choice
         options:
-          - '8.2'
           - '8.3'
           - '8.4'
           - '8.5'
           - 'default'
-          - '8.2, default (8.3), 8.4'
+          - 'default (8.3), 8.4'
           - 'all'
       debug_enabled:
         type: boolean
@@ -61,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ${{ (github.event_name == 'push') && fromJSON('["default"]') || (github.event.inputs.php-version == '8.2, default (8.3), 8.4') && fromJSON('["8.2", "8.4", "default"]') || (github.event.inputs.php-version == 'all') && fromJSON('["8.2", "8.3", "8.4", "8.5", "default"]') || fromJSON(format('["{0}"]', github.event.inputs.php-version)) }}
+        php-version: ${{ (github.event_name == 'push') && fromJSON('["default"]') || (github.event.inputs.php-version == 'default (8.3), 8.4') && fromJSON('["8.4", "default"]') || (github.event.inputs.php-version == 'all') && fromJSON('["8.3", "8.4", "8.5", "default"]') || fromJSON(format('["{0}"]', github.event.inputs.php-version)) }}
 
     steps:
       - name: Update old PHP xdebug

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,11 @@ jobs:
       VUFIND_LOCAL_DIR: ${{ github.workspace }}/local
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.3', '8.4', '8.5']
         # We run PHP-based tests on all platforms (qa-php), but we only include PHP AND
         # Javascript-related tests (qa-console) once. Since the JS results should be the
         # same on all platforms, we don't need to repeat them.
         include:
-          - php-version: 8.2
-            phing_tasks: "qa-php"
           - php-version: 8.3
             phing_tasks: "qa-console"
           - php-version: 8.4

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "GPL-2.0-only",
     "config": {
         "platform": {
-            "php": "8.2"
+            "php": "8.3"
         },
         "process-timeout": 0,
         "allow-plugins": {
@@ -44,7 +44,7 @@
         "ext-sodium": "*"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ahand/mobileesp": "dev-master",
         "browscap/browscap-php": "^7.2",
         "cap60552/php-sip2": "1.0.0",


### PR DESCRIPTION
TODO:
- [ ] Get Composer install to work (currently broken due to browscap-php/laminas-cache conflicts)
- [ ] Update changelog and requirements wiki page when merging
- [ ] Do not merge until close to 12.0 release date