### PR TITLE
Fix broken asset loading causing HTML validation errors in tests.

### DIFF
--- a/module/VuFind/src/VuFind/Action/Combined/ResultAction.php
+++ b/module/VuFind/src/VuFind/Action/Combined/ResultAction.php
@@ -103,6 +103,7 @@ class ResultAction extends AbstractCombinedSearchAndResultsAction implements
             $html = '';
         } else {
             $templateParams = [
+                'ajax' => true,
                 'searchClassId' => $searchClassId,
                 'currentSearch' => $currentSearch,
                 'domId' => 'combined_' . str_replace(':', '____', $sectionId),

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -1,6 +1,4 @@
 <?php
-  // Initialize theme resources:
-  $this->setupThemeResources();
   $templateParams = $this->currentSearch['templateParams'];
   $results = $templateParams['results'];
   $params = $results->getParams();
@@ -77,9 +75,8 @@
       }
       JS;
 ?>
-<?=$this->headLink()?>
 <?=$this->assetManager()->outputInlineScriptString($countsJs)?>
-
+<?php ob_start(); // buffer output so we can collect header resources before main content is rendered ?>
 <?php if ($this->currentSearch['more_link'] ?? false): ?>
   <div class="float-end">
     <a href="<?=$moreUrl?>" class="btn btn-link icon-link">
@@ -195,3 +192,9 @@
     </p>
   <?php endif; ?>
 <?php endif; ?>
+<?php
+  $content = ob_get_contents();
+  ob_end_clean();
+  // If we're in AJAX mode, output header assets now; otherwise, they will be rendered as part of the main page header.
+  echo $this->ajax ? $this->assetManager()->outputHeaderAssets() : false;
+  echo $content;

--- a/themes/bootstrap5/templates/combined/results-list.phtml
+++ b/themes/bootstrap5/templates/combined/results-list.phtml
@@ -196,5 +196,5 @@
   $content = ob_get_contents();
   ob_end_clean();
   // If we're in AJAX mode, output header assets now; otherwise, they will be rendered as part of the main page header.
-  echo $this->ajax ? $this->assetManager()->outputHeaderAssets() : false;
+  echo $this->ajax ? $this->assetManager()->outputHeaderAssets() : '';
   echo $content;


### PR DESCRIPTION
The Jenkins build is currently failing because favicon `<link>` tags are being output in inappropriate places, and the meta tags created by the `SetupThemeResources` view helper are being doubled up. Both of these problems appear to be caused by header-oriented helpers being called from the template used to render individual sections of the combined search screen.

I have removed these calls, and tests are now passing with valid HTML output... but I can't help suspecting that these were here for some kind of reason. Is there some edge case I have broken by fixing these problems?

TODO
- [x] Run full test suite