### PR TITLE
Fix asset loading in combined search AJAX columns.

### DIFF
--- a/module/VuFind/src/VuFind/Controller/CombinedController.php
+++ b/module/VuFind/src/VuFind/Controller/CombinedController.php
@@ -129,15 +129,13 @@ class CombinedController extends AbstractSearch implements \Psr\Log\LoggerAwareI
             if (!empty($settings['view']->extraErrors)) {
                 $viewParams['extraErrors'] = $settings['view']->extraErrors;
             }
-            // Initialize theme resources:
-            ($this->getViewRenderer()->plugin('setupThemeResources'))(true);
             // Render content:
             $html = $this->getViewRenderer()->render(
                 'combined/results-list.phtml',
                 $viewParams
             );
             // Prepend CSS in case of custom files added by templates:
-            $html = ($this->getViewRenderer()->plugin('headLink'))() . $html;
+            $html = ($this->getViewRenderer()->plugin('assetManager'))->outputHeaderAssets() . $html;
         }
         return $this->getAjaxResponse('text/html', $html);
     }


### PR DESCRIPTION
This backports bug fixes from #5500 to the release-11.1 branch.

Note that I'm removing the setupThemeResources call because I believe it to be redundant and unnecessary; however, if there is any concern that it might break something, I can put it back for now -- the duplicate asset loading is wasteful but doesn't break functionality.