### PR TITLE
Normalize styles for autowire attribute.

### DIFF
--- a/module/VuFind/src/VuFind/Action/ActionDispatchListener.php
+++ b/module/VuFind/src/VuFind/Action/ActionDispatchListener.php
@@ -58,7 +58,7 @@ class ActionDispatchListener
      * @param PluginManager $actionPluginManager Action plugin manager
      * @param RouteHelper   $routeHelper         Route helper
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected PluginManager $actionPluginManager,
         protected RouteHelper $routeHelper,

--- a/module/VuFind/src/VuFind/Action/Ajax/AbstractAjaxAction.php
+++ b/module/VuFind/src/VuFind/Action/Ajax/AbstractAjaxAction.php
@@ -56,7 +56,7 @@ abstract class AbstractAjaxAction extends AbstractAction implements TranslatorAw
      *
      * @param AjaxPluginManager $ajaxManager AJAX Handler Plugin Manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         AjaxPluginManager $ajaxManager
     ) {

--- a/module/VuFind/src/VuFind/Action/Alphabrowse/HomeAction.php
+++ b/module/VuFind/src/VuFind/Action/Alphabrowse/HomeAction.php
@@ -95,7 +95,6 @@ class HomeAction extends AbstractTemplateRenderingAction
      * @param SearchService $searchService Search service
      * @param array         $config        VuFind configuration
      */
-    #[Autowire()]
     public function __construct(
         protected SearchService $searchService,
         #[Autowire(config: 'config')] protected array $config,

--- a/module/VuFind/src/VuFind/Action/Cart/AbstractCartAction.php
+++ b/module/VuFind/src/VuFind/Action/Cart/AbstractCartAction.php
@@ -56,7 +56,7 @@ abstract class AbstractCartAction extends AbstractTemplateRenderingAction
      * @param Cart           $cart           Cart handler
      * @param FollowupHelper $followupHelper Followup helper
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected Export $export,
         protected Cart $cart,

--- a/module/VuFind/src/VuFind/Action/Channels/AbstractChannelsAction.php
+++ b/module/VuFind/src/VuFind/Action/Channels/AbstractChannelsAction.php
@@ -49,7 +49,7 @@ abstract class AbstractChannelsAction extends AbstractTemplateRenderingAction
      *
      * @param ChannelLoader $channelLoader Channel loader
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected ChannelLoader $channelLoader,
     ) {

--- a/module/VuFind/src/VuFind/Action/Content/ContentAction.php
+++ b/module/VuFind/src/VuFind/Action/Content/ContentAction.php
@@ -57,7 +57,7 @@ class ContentAction extends AbstractTemplateRenderingAction
      *
      * @param PageLocator $pageLocator Page locator
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected PageLocator $pageLocator,
     ) {

--- a/module/VuFind/src/VuFind/Action/DeveloperSettings/AbstractDeveloperSettingsAction.php
+++ b/module/VuFind/src/VuFind/Action/DeveloperSettings/AbstractDeveloperSettingsAction.php
@@ -54,7 +54,7 @@ abstract class AbstractDeveloperSettingsAction extends AbstractTemplateRendering
      * @param DeveloperSettingsService $developerSettingsService Developer settings service
      * @param AuthManager              $authManager              Authentication manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected DeveloperSettingsService $developerSettingsService,
         protected AuthManager $authManager,

--- a/module/VuFind/src/VuFind/Action/MyResearch/CatalogLoginAction.php
+++ b/module/VuFind/src/VuFind/Action/MyResearch/CatalogLoginAction.php
@@ -55,7 +55,7 @@ class CatalogLoginAction extends AbstractTemplateRenderingAction
      *
      * @param AuthManager $authManager Authentication manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected AuthManager $authManager,
     ) {

--- a/module/VuFind/src/VuFind/Action/MyResearch/LoginAction.php
+++ b/module/VuFind/src/VuFind/Action/MyResearch/LoginAction.php
@@ -56,7 +56,7 @@ class LoginAction extends AbstractTemplateRenderingAction
      *
      * @param AuthManager $authManager Authentication manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected AuthManager $authManager,
     ) {

--- a/module/VuFind/src/VuFind/ActionHelper/FlashMessagesHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/FlashMessagesHelper.php
@@ -48,7 +48,7 @@ class FlashMessagesHelper implements HelperInterface
      *
      * @param FlashMessenger $flashMessenger Flash messenger
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected FlashMessenger $flashMessenger,
     ) {

--- a/module/VuFind/src/VuFind/ActionHelper/FormHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/FormHelper.php
@@ -56,7 +56,7 @@ class FormHelper implements HelperInterface
      *
      * @param CaptchaService $captchaService Captcha service
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected CaptchaService $captchaService,
     ) {

--- a/module/VuFind/src/VuFind/ActionHelper/ForwardHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/ForwardHelper.php
@@ -50,7 +50,7 @@ class ForwardHelper implements HelperInterface
      *
      * @param ActionPluginManager $actionPluginManager Action plugin manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected ActionPluginManager $actionPluginManager,
     ) {

--- a/module/VuFind/src/VuFind/ActionHelper/LoginHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/LoginHelper.php
@@ -76,7 +76,6 @@ class LoginHelper implements HelperInterface
      * @param ServerUrlHelper                 $serverUrlHelper    Server URL helper
      * @param UrlHelper                       $urlHelper          URL helper
      */
-    #[Autowire()]
     public function __construct(
         protected RouteHelper $routeHelper,
         protected FollowupHelper $followupHelper,

--- a/module/VuFind/src/VuFind/ActionHelper/RedirectHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/RedirectHelper.php
@@ -49,7 +49,7 @@ class RedirectHelper implements HelperInterface
      *
      * @param RouteHelper $routeHelper Route helper
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected RouteHelper $routeHelper,
     ) {

--- a/module/VuFind/src/VuFind/ActionHelper/UrlHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/UrlHelper.php
@@ -64,7 +64,7 @@ class UrlHelper implements HelperInterface
      * @param RouteHelper     $routeHelper     Route helper
      * @param ServerUrlHelper $serverUrlHelper Server URL helper
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected RouteHelper $routeHelper,
         protected ServerUrlHelper $serverUrlHelper,

--- a/module/VuFind/src/VuFind/ActionHelper/UserContentHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/UserContentHelper.php
@@ -52,7 +52,7 @@ class UserContentHelper implements HelperInterface
      * @param RecordLoader        $recordLoader        Record loader
      * @param AccountCapabilities $accountCapabilities Account capabilities helper
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected RecordLoader $recordLoader,
         protected AccountCapabilities $accountCapabilities,

--- a/module/VuFind/src/VuFind/AjaxHandler/GetCookieConsent.php
+++ b/module/VuFind/src/VuFind/AjaxHandler/GetCookieConsent.php
@@ -51,7 +51,7 @@ class GetCookieConsent extends AbstractBase
      *
      * @param TemplateRendererInterface $renderer Template renderer
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected TemplateRendererInterface $renderer
     ) {

--- a/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
+++ b/module/VuFind/src/VuFind/Autocomplete/SolrPrefix.php
@@ -100,7 +100,7 @@ class SolrPrefix implements AutocompleteInterface
      *
      * @param \VuFind\Search\Results\PluginManager $results Results plugin manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(\VuFind\Search\Results\PluginManager $results)
     {
         $this->resultsManager = $results;

--- a/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilities.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AccountCapabilities.php
@@ -48,8 +48,8 @@ class AccountCapabilities
      *
      * @param Helper $helper Capabilities helper
      */
+    #[Autowire]
     public function __construct(
-        #[Autowire]
         protected Helper $helper
     ) {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/AvailabilityStatus.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/AvailabilityStatus.php
@@ -112,7 +112,7 @@ class AvailabilityStatus
      *
      * @param RendererInterface $view View renderer
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(protected RendererInterface $view)
     {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/BulkAction.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/BulkAction.php
@@ -62,7 +62,7 @@ class BulkAction
      * @param ConfigManagerInterface $configManager Configuration manager
      * @param RendererInterface      $view          View renderer
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(
         protected Export $export,
         protected ConfigManagerInterface $configManager,

--- a/module/VuFind/src/VuFind/View/Helper/Root/Cart.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Cart.php
@@ -47,7 +47,7 @@ class Cart
      *
      * @param \VuFind\Cart $cart Cart model
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(protected \VuFind\Cart $cart)
     {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/DateTime.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/DateTime.php
@@ -50,7 +50,6 @@ class DateTime
      * @param \VuFind\Date\Converter $converter Date converter
      * @param Translate              $translate Translate view helper
      */
-    #[Autowire]
     public function __construct(
         protected \VuFind\Date\Converter $converter,
         #[Autowire(container: 'ViewHelperManager')]

--- a/module/VuFind/src/VuFind/View/Helper/Root/Export.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Export.php
@@ -50,7 +50,6 @@ class Export
     #[Autowire]
     public function __construct(protected \VuFind\Export $export)
     {
-        $this->export = $export;
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/Ratings.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Ratings.php
@@ -48,7 +48,7 @@ class Ratings
      *
      * @param RatingsService $service Ratings service
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(protected RatingsService $service)
     {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchOptions.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchOptions.php
@@ -48,7 +48,7 @@ class SearchOptions
      *
      * @param PluginManager $manager Search manager
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(protected PluginManager $manager)
     {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchParams.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchParams.php
@@ -48,8 +48,8 @@ class SearchParams
      *
      * @param PluginManager $manager Search manager
      */
+    #[Autowire]
     public function __construct(
-        #[Autowire]
         protected PluginManager $manager
     ) {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/Section.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/Section.php
@@ -96,7 +96,6 @@ class Section
      * @param RendererInterface       $viewRenderer   View renderer
      * @param ResolverInterface       $viewResolver   View resolver
      */
-    #[Autowire()]
     public function __construct(
         protected SectionServiceInterface $sectionService,
         #[Autowire(container: 'ViewHelperManager')]

--- a/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrl.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ShortenUrl.php
@@ -48,8 +48,8 @@ class ShortenUrl
      *
      * @param UrlShortenerInterface $shortener URL shortener
      */
+    #[Autowire]
     public function __construct(
-        #[Autowire()]
         protected UrlShortenerInterface $shortener
     ) {
     }

--- a/module/VuFind/src/VuFind/View/Helper/Root/ThemeConfig.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/ThemeConfig.php
@@ -48,10 +48,9 @@ class ThemeConfig
      *
      * @param ThemeInfo $themeInfo ThemeInfo
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(protected ThemeInfo $themeInfo)
     {
-        $this->themeInfo = $themeInfo;
     }
 
     /**

--- a/module/VuFind/src/VuFind/View/Helper/Root/UserTags.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/UserTags.php
@@ -62,7 +62,7 @@ class UserTags
      *
      * @param AccountCapabilities $capabilities Account capabilities service
      */
-    #[Autowire()]
+    #[Autowire]
     public function __construct(AccountCapabilities $capabilities)
     {
         $this->mode = $capabilities->getTagSetting();

--- a/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
+++ b/module/VuFind/src/VuFind/View/Renderer/LaminasTemplateRenderer.php
@@ -65,7 +65,6 @@ class LaminasTemplateRenderer implements TemplateRendererInterface
      * @param string                 $notFoundTemplate       Template for 404 errors
      * @param string                 $errorTemplate          Template for errors
      */
-    #[Autowire()]
     public function __construct(
         protected ServerUrlHelper $serverUrlHelper,
         #[Autowire(service: 'ViewRenderer')]

--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/ImageLink.php
@@ -52,7 +52,6 @@ class ImageLink
      * @param Url                    $urlHelper Url view helper
      */
     public function __construct(
-        #[Autowire]
         protected \VuFindTheme\ThemeInfo $themeInfo,
         #[Autowire(container: 'ViewHelperManager')]
         protected Url $urlHelper

--- a/tests/vufind.php-cs-fixer.php
+++ b/tests/vufind.php-cs-fixer.php
@@ -11,6 +11,7 @@ $rules = [
     '@PHPUnit10x0Migration:risky' => true,
     '@PSR12' => true,
     'align_multiline_comment' => true,
+    'attribute_empty_parentheses' => ['use_parentheses' => false],
     'binary_operator_spaces' => [
         'default' => 'single_space',
         'operators' => ['=' => null, '=>' => null],


### PR DESCRIPTION
As discussed on #5497, this PR normalizes the way we use the Autowire attribute:

1.) It adds a php-cs-fixer rule to remove extraneous parentheses
2.) It removes top-level attributes when parameter-level attributes are also present to reduce redundancy
3.) When the only parameter-level attribute has no arguments, it moves it to the top of the constructor (since it is not parameter-specific)

I am certainly open to discussing and revising any of these practices, but this aligns most closely with what I have already been doing so far.

TODO
- [x] Run full test suite