### PR TITLE
Centralize validation of EDS credentials.

### DIFF
--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -523,6 +523,22 @@ class Backend extends AbstractBackend
     }
 
     /**
+     * Are the provided credentials valid for use with the API?
+     *
+     * @param string $username Username to check
+     * @param string $password Password to check
+     *
+     * @return bool
+     */
+    protected function credentialsAreValid(string $username, string $password): bool
+    {
+        if ($username === 'USERNAME' && $password === 'PASSWORD') {
+            throw new \Exception('Default EDS credentials detected; service not configured correctly.');
+        }
+        return !empty($username) && !empty($password);
+    }
+
+    /**
      * Obtain the authentication to use with the EDS API from cache if it exists. If
      * not, then generate a new one.
      *
@@ -559,7 +575,7 @@ class Backend extends AbstractBackend
         $username = $this->userName;
         $password = $this->password;
         $orgId = $this->orgId;
-        if (!empty($username) && !empty($password)) {
+        if ($this->credentialsAreValid($username, $password)) {
             $this->debug(
                 'Calling Authenticate with username: '
                 . "$username, password: XXXXXXXX, orgid: $orgId "
@@ -606,7 +622,7 @@ class Backend extends AbstractBackend
 
         $username = $this->userName;
         $password = $this->password;
-        if (!empty($username) && !empty($password)) {
+        if ($this->credentialsAreValid($username, $password)) {
             $results = $this->client
                 ->authenticate($username, $password, $this->orgId, ['autocomplete']);
             $autoresult = $results['Autocomplete'] ?? [];

--- a/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
+++ b/module/VuFindSearch/src/VuFindSearch/Backend/EDS/Backend.php
@@ -532,7 +532,7 @@ class Backend extends AbstractBackend
      */
     protected function credentialsAreValid(string $username, string $password): bool
     {
-        if ($username === 'USERNAME' && $password === 'PASSWORD') {
+        if ($username === 'USERNAME' || $password === 'PASSWORD') {
             throw new \Exception('Default EDS credentials detected; service not configured correctly.');
         }
         return !empty($username) && !empty($password);


### PR DESCRIPTION
It occurred to me that malicious requests to an improperly secured SystemStatus endpoint could direct random traffic to EDS servers once #5384 is merged. This PR adds an extra check so that if EDS.ini has not been filled in with real credentials, the system will not attempt to make a call to the authentication endpoint, and further EDS API activity should be blocked.