### PR TITLE
Explicitly set VUFIND_HOME for JS check tasks.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -312,6 +312,7 @@
   <target name="checkSassBuild">
     <exec executable="npm" checkreturn="true" passthru="true">
       <arg line="run check:scss" />
+      <env key="VUFIND_HOME" value="${srcdir}" />
     </exec>
   </target>
 
@@ -319,6 +320,7 @@
   <target name="jsDependencyCheck">
     <exec executable="npm" checkreturn="true" passthru="true">
       <arg line="run check:dependencySync" />
+      <env key="VUFIND_HOME" value="${srcdir}" />
     </exec>
   </target>
 


### PR DESCRIPTION
With #4591 and #5455 the JS-based QA tasks now require VUFIND_HOME to be set. This alone is a nuisance for someone working with several branches side-by-side, but also can cause the checks to check the wrong VuFind instance.

This patch changes it so that running the `checkSassBuild` or `jsDependencyCheck` phing tasks (directly or via `composer qa`) will explicitly set VUFIND_HOME to srcdir to eliminate the possibility of VUFIND_HOME not being set or pointing to different instance.