### PR TITLE
Adapt extended holdings template for use with GetThis

### DIFF
--- a/themes/bootstrap5/templates/RecordTab/holdingsils/extended.phtml
+++ b/themes/bootstrap5/templates/RecordTab/holdingsils/extended.phtml
@@ -5,9 +5,9 @@
     $checkILLRequest = $holding['checkILLRequest'] ?? false;
     $availabilityStatus = $holding['availability'];
     $getThisLoader = $tab->getGetThisLoader();
-    if ($getThisEnabled = $getThisLoader?->areItemsSupported([$holding])) {
+    if ($getThisLoader?->areItemsSupported([$holding])) {
         $getThisLoader->setItems([$holding]);
-        $getThisLoader->setRecordDriver($this->record($this->driver));
+        $getThisLoader->setRecordDriver($this->driver);
         $isOnlineResource = $getThisLoader->isOnlineResource($holding['item_id'] ?? null);
         $getThisURL = $isOnlineResource ? null : $this->url(
             'record-getthis',


### PR DESCRIPTION
I noticed that the extended holdings ILS template broke when `getThisEnabled = true`. I copied the parts from standard.phtml which seems to work fine.