### PR TITLE
Fix ajax tab error on SVG links

### DIFF
--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -241,7 +241,7 @@ function handleAjaxTabLinkClick(event){
 function handleAjaxTabLinks() {
   document.querySelectorAll('a').forEach((a) => {
     const href = a.href;
-    if (typeof href == 'string' && href.match(/\/AjaxTab[/?]/)) {
+    if (typeof href === 'string' && href.match(/\/AjaxTab[/?]/)) {
       a.addEventListener('click', handleAjaxTabLinkClick);
     }
   });

--- a/themes/bootstrap5/js/record.js
+++ b/themes/bootstrap5/js/record.js
@@ -241,7 +241,7 @@ function handleAjaxTabLinkClick(event){
 function handleAjaxTabLinks() {
   document.querySelectorAll('a').forEach((a) => {
     const href = a.href;
-    if (typeof href !== 'undefined' && href.match(/\/AjaxTab[/?]/)) {
+    if (typeof href == 'string' && href.match(/\/AjaxTab[/?]/)) {
       a.addEventListener('click', handleAjaxTabLinkClick);
     }
   });


### PR DESCRIPTION
`querySelectorAll('a')` will return any SVG links that happen to be on the page (i.e. in local templates) in addition to normal HTML links.  These also have `href` attributes, but they are not of type 'string', and do not have a `match` function.

https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/href

This line then throws a JS error, and if that link is on the page ahead of the actual record tab links, it prevents them from being setup properly.