### PR TITLE
Log unexpected ILS exceptions during authentication

### DIFF
--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -381,6 +381,8 @@ class ILS extends AbstractBase
                 // Pass Auth exceptions through
                 throw $e;
             } catch (\Exception $e) {
+                $context = [ 'type' => get_class($e), 'message' => $e->getMessage(), 'code' => $e->getCode() ];
+                $this->logError('The ILS driver signaled a technical error: {type} {message} {code}',  $context);
                 throw new AuthException('authentication_error_technical');
             }
         }

--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -382,7 +382,7 @@ class ILS extends AbstractBase
                 throw $e;
             } catch (\Exception $e) {
                 $context = [ 'type' => get_class($e), 'message' => $e->getMessage(), 'code' => $e->getCode() ];
-                $this->logError('The ILS driver signaled a technical error: {type} {message} {code}',  $context);
+                $this->logError('The ILS driver signaled a technical error: {type} {message} {code}', $context);
                 throw new AuthException('authentication_error_technical', 0, $e);
             }
         }

--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -383,7 +383,7 @@ class ILS extends AbstractBase
             } catch (\Exception $e) {
                 $context = [ 'type' => get_class($e), 'message' => $e->getMessage(), 'code' => $e->getCode() ];
                 $this->logError('The ILS driver signaled a technical error: {type} {message} {code}',  $context);
-                throw new AuthException('authentication_error_technical');
+                throw new AuthException('authentication_error_technical', 0, $e);
             }
         }
 

--- a/module/VuFind/src/VuFind/Auth/ILS.php
+++ b/module/VuFind/src/VuFind/Auth/ILS.php
@@ -381,7 +381,7 @@ class ILS extends AbstractBase
                 // Pass Auth exceptions through
                 throw $e;
             } catch (\Exception $e) {
-                $context = [ 'type' => get_class($e), 'message' => $e->getMessage(), 'code' => $e->getCode() ];
+                $context = [ 'type' => $e::class, 'message' => $e->getMessage(), 'code' => $e->getCode() ];
                 $this->logError('The ILS driver signaled a technical error: {type} {message} {code}', $context);
                 throw new AuthException('authentication_error_technical', 0, $e);
             }


### PR DESCRIPTION
This is a small quality of life improvement: Log information if the underlying ILS signaled a technical error. 