### PR TITLE
Don't update browser url when navigating tabs in search results

### DIFF
--- a/themes/bootstrap5/js/record_tabs.js
+++ b/themes/bootstrap5/js/record_tabs.js
@@ -43,7 +43,7 @@ VuFind.register('recordTabs', function RecordTabs() {
           let tabPane = document.querySelector(tabButton.dataset.bsTarget);
           if (!tabPane) return;
           let tabUrl = tabPane.dataset.tabUrl;
-          if (window.history.replaceState && tabUrl) {
+          if (window.history.replaceState && tabUrl && !tabPane.closest('.result')) {
             window.history.replaceState({}, document.title, tabUrl);
           }
           _ajaxLoadTab(tabPane);

--- a/themes/bootstrap5/js/record_tabs.js
+++ b/themes/bootstrap5/js/record_tabs.js
@@ -43,6 +43,8 @@ VuFind.register('recordTabs', function RecordTabs() {
           let tabPane = document.querySelector(tabButton.dataset.bsTarget);
           if (!tabPane) return;
           let tabUrl = tabPane.dataset.tabUrl;
+          // We only want to replace the browser URL when clicking a tab on a record page;
+          // embedded search results should not change browser history to prevent confusion.
           if (window.history.replaceState && tabUrl && !tabPane.closest('.result')) {
             window.history.replaceState({}, document.title, tabUrl);
           }

--- a/themes/bootstrap5/js/record_tabs.js
+++ b/themes/bootstrap5/js/record_tabs.js
@@ -45,7 +45,7 @@ VuFind.register('recordTabs', function RecordTabs() {
           let tabUrl = tabPane.dataset.tabUrl;
           // We only want to replace the browser URL when clicking a tab on a record page;
           // embedded search results should not change browser history to prevent confusion.
-          if (window.history.replaceState && tabUrl && !tabPane.closest('.result')) {
+          if (window.history.replaceState && tabUrl && !tabPane.closest('.result .long-view')) {
             window.history.replaceState({}, document.title, tabUrl);
           }
           _ajaxLoadTab(tabPane);


### PR DESCRIPTION
Hi, another small fix regarding tabbed and accordion view in result lists.

Previously, if you clicked on e.g. the holdings tab, VuFind would update the URL in the browser's address bar. If you then refreshed the page or applied a facet, it was not the result list being loaded but the full view, leading to unexpected behavior.

I used AI to find and fix this (minimax-m2.7). Quick tests seem good, but of course I'm open for better solutions if available.

TODO
- [ ] Merge #5602 after this is merged