### PR TITLE
Tweak HoldsTest to avoid a race condition with lightbox instances.

### DIFF
--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/HoldsTest.php
@@ -192,6 +192,8 @@ final class HoldsTest extends \VuFindTest\Integration\MinkTestCase
             $this->findCssAndSetValue($page, $selector, $value);
         }
         $this->clickCss($page, '.modal-body .btn.btn-primary');
+        // Ensure that the page has loaded and the "place hold" dialog is no longer present:
+        $this->waitForPageLoad($page);
     }
 
     /**


### PR DESCRIPTION
In some tests placing a hold is immediately followed by closing the lightbox. If we don't wait for page load after the hold is placed, the closeLightbox method may try to close the "place hold" dialog that's already being replaced by the result dialog. While the retry logic in closeLightbox will handle the case properly, it causes a lengthy wait when the first close attempt fails.