### PR TITLE
EDS: Get the item's page count

### DIFF
--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1063,7 +1063,7 @@ class EDS extends DefaultRecord
     }
 
     /**
-     * Get year of containing record.
+     * Get the start page of the item that contains this record.
      *
      * @return string
      */
@@ -1095,6 +1095,22 @@ class EDS extends DefaultRecord
                     }
                 }
             }
+        }
+        return '';
+    }
+
+    /**
+     * Get the page count.
+     *
+     * @return string
+     */
+    public function getPageCount() {
+        if ($pageCount = $this->extractEbscoDataFromRecordInfo(
+                'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount')[0] ?? null) {
+            return $pageCount;
+        }
+        elseif ($pageCount = $this->getItem('Name', 'Pages')) {
+            return $pageCount;
         }
         return '';
     }

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1109,10 +1109,10 @@ class EDS extends DefaultRecord
         if (
             $pageCount = $this->extractEbscoDataFromRecordInfo(
                 'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount'
-            )[0] ?? null
+            )[0] ?? ''
         ) {
             return $pageCount;
-        } elseif ($pageCount = $this->getItem('Name', 'Pages')) {
+        } elseif ($pageCount = $this->getItem('Name', 'Pages')[0]['Data'] ?? '') {
             return $pageCount;
         }
         return '';

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1106,9 +1106,11 @@ class EDS extends DefaultRecord
      */
     public function getPageCount()
     {
-        if ($pageCount = $this->extractEbscoDataFromRecordInfo(
-            'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount'
-        )[0] ?? null) {
+        if (
+            $pageCount = $this->extractEbscoDataFromRecordInfo(
+                'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount'
+            )[0] ?? null
+        ) {
             return $pageCount;
         } elseif ($pageCount = $this->getItem('Name', 'Pages')) {
             return $pageCount;

--- a/module/VuFind/src/VuFind/RecordDriver/EDS.php
+++ b/module/VuFind/src/VuFind/RecordDriver/EDS.php
@@ -1104,12 +1104,13 @@ class EDS extends DefaultRecord
      *
      * @return string
      */
-    public function getPageCount() {
+    public function getPageCount()
+    {
         if ($pageCount = $this->extractEbscoDataFromRecordInfo(
-                'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount')[0] ?? null) {
+            'BibRecord/BibEntity/PhysicalDescription/Pagination/PageCount'
+        )[0] ?? null) {
             return $pageCount;
-        }
-        elseif ($pageCount = $this->getItem('Name', 'Pages')) {
+        } elseif ($pageCount = $this->getItem('Name', 'Pages')) {
             return $pageCount;
         }
         return '';

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -910,8 +910,26 @@ class EDSTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetPageCount(): void
     {
+        // Find page count in PhysicalDescription
         $driver = $this->getDriver('valid-eds-record');
         $this->assertEquals('217', $driver->getPageCount());
+
+        // Fail to find it
+        $json = $this->getJsonFixture('eds/valid-eds-record.json');
+        unset($json['RecordInfo']['BibRecord']['BibEntity']['PhysicalDescription']['Pagination']);
+        $driver->setRawData($json);
+        $this->assertEquals('', $driver->getPageCount());
+
+        // Find it in Items
+        $json['Items'][] =
+        [
+            'Name' => 'Pages',
+            'Label' => 'Page Count',
+            'Group' => 'Src',
+            'Data' => '42',
+        ];
+        $driver->setRawData($json);
+        $this->assertEquals('42', $driver->getPageCount());
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/RecordDriver/EDSTest.php
@@ -904,6 +904,17 @@ class EDSTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getPageCount for a record.
+     *
+     * @return void
+     */
+    public function testGetPageCount(): void
+    {
+        $driver = $this->getDriver('valid-eds-record');
+        $this->assertEquals('217', $driver->getPageCount());
+    }
+
+    /**
      * Test getFormats for an ebook record.
      *
      * @return void


### PR DESCRIPTION
The page count is sometimes part of the `src` item data, i.e. the last element of 

> Source: Marvels & Tales; 2026, Vol. 40 Issue 1, p47-64, 18p

But in some dense contexts like the combined search, you may just want to display the page count.