### PR TITLE
Strip punctuation from topics in topic browse.

### DIFF
--- a/import/marc.properties
+++ b/import/marc.properties
@@ -93,7 +93,7 @@ callnumber-sort = custom, getLCSortable(099ab:090ab:050ab)
 callnumber-raw = 099ab:090ab:050ab
 
 topic = custom, getAllAlphaSubfields(600:610:611:630:650:653:656, " ")
-topic_browse = custom, getAllAlphaSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002"), filter("[,.: ]+$=>")
+topic_browse = custom, getAllAlphaSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002"), filter("[,.:\\s]+$=>")
 genre = custom, getAllAlphaSubfields(655, " ")
 geographic = custom, getAllAlphaSubfields(651, " ")
 era = custom, getAllAlphaSubfields(648, " ")

--- a/import/marc.properties
+++ b/import/marc.properties
@@ -93,7 +93,7 @@ callnumber-sort = custom, getLCSortable(099ab:090ab:050ab)
 callnumber-raw = 099ab:090ab:050ab
 
 topic = custom, getAllAlphaSubfields(600:610:611:630:650:653:656, " ")
-topic_browse = custom, getAllAlphaSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002")
+topic_browse = custom, getAllAlphaSubfieldsUTF8Delimited(600:610:611:630:650:653:656, "\u2002"), filter("[,.: ]+$=>")
 genre = custom, getAllAlphaSubfields(655, " ")
 geographic = custom, getAllAlphaSubfields(651, " ")
 era = custom, getAllAlphaSubfields(648, " ")


### PR DESCRIPTION
At Villanova, we have noticed that inconsistent cataloging results in redundant headings in topic browse, where some instances have trailing punctuation and others do not. This PR strips all punctuation to better normalize headings. It might have undesired side effects in some edge cases (e.g. name headings ending in "Mrs.") but this seems a reasonable price to pay for improved browsing.

We could have even better matching if we switched to case-insensitive matching, but that would be more work -- I'll leave that open to discussion as a possible follow-up revision.

I'm interested to hear people's thoughts on this!

TODO
- [x] Run full test suite to be sure there are no side effects in existing tests
- [x] Confirm that user input is trimmed in a way that aligns with the data trimming for consistency