### PR TITLE
Treat BadRequest exceptions as debug rather than critical.

### DIFF
--- a/module/VuFind/src/VuFind/Exception/BadRequest.php
+++ b/module/VuFind/src/VuFind/Exception/BadRequest.php
@@ -57,6 +57,9 @@ class BadRequest extends \Exception implements HttpStatusInterface, SeverityLeve
      */
     public function getSeverityLevel()
     {
+        // A BadRequest exception means that we caught malformed user input; this reflects bad external
+        // behavior but does not generally indicate a critical flaw in the system. Reducing the severity
+        // level of these exceptions prevents distracting noise in critical system logs.
         return \Psr\Log\LogLevel::DEBUG;
     }
 }

--- a/module/VuFind/src/VuFind/Exception/BadRequest.php
+++ b/module/VuFind/src/VuFind/Exception/BadRequest.php
@@ -38,7 +38,7 @@ namespace VuFind\Exception;
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development Wiki
  */
-class BadRequest extends \Exception implements HttpStatusInterface
+class BadRequest extends \Exception implements HttpStatusInterface, SeverityLevelInterface
 {
     /**
      * Get HTTP status associated with this exception.
@@ -48,5 +48,15 @@ class BadRequest extends \Exception implements HttpStatusInterface
     public function getHttpStatus()
     {
         return 400;
+    }
+
+    /**
+     * Get the logging severity level for this exception.
+     *
+     * @return int
+     */
+    public function getSeverityLevel()
+    {
+        return \Psr\Log\LogLevel::DEBUG;
     }
 }


### PR DESCRIPTION
Vulnerability scans sometimes flood my logs with "critical" error messages which actually just reflect VuFind appropriately rejecting malformed requests. I think we should reduce the log level of BadRequest exceptions to debug to prevent this distracting noise. Happy to discuss other options, though!