### PR TITLE
Fix self-copy error in Ini::writeConfig() when base and destination config match.

### DIFF
--- a/module/VuFind/src/VuFind/Config/Handler/Ini.php
+++ b/module/VuFind/src/VuFind/Config/Handler/Ini.php
@@ -206,7 +206,7 @@ class Ini extends AbstractBase
         $outfile = $destinationLocation->getPath();
         $this->backupFile($outfile);
 
-        if ($baseLocation !== null && file_exists($baseLocation->getPath())) {
+        if ($baseLocation !== null && file_exists($baseLocation->getPath()) && $baseLocation->getPath() !== $outfile) {
             // Copy from base to provide structure
             if (!copy($baseLocation->getPath(), $outfile)) {
                 throw new FileAccessException(

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigWritingTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Config/ConfigWritingTest.php
@@ -163,6 +163,31 @@ class ConfigWritingTest extends ConfigTestCase
     }
 
     /**
+     * Test writing when the base and destination locations are identical.
+     *
+     * @return void
+     */
+    public function testWritingWithIdenticalBaseAndDestination(): void
+    {
+        $this->setUpLocalConfigDir('write/ini');
+        $container = $this->getContainerWithConfigRelatedServices(
+            baseDir: $this->getFixtureDir() . 'configs/write/ini',
+            baseSubDir: ''
+        );
+        $pathResolver = $container->get(PathResolver::class);
+        $configManager = $container->get(ConfigManagerInterface::class);
+
+        $configLocation = $pathResolver->getForcedLocalConfigLocation('config');
+        $config = $configManager->loadConfigFromLocation($configLocation);
+        $config['Section1']['key1'] = 'newval';
+
+        $configManager->writeConfig($configLocation, $config, $configLocation);
+
+        $result = $this->readConfig('config');
+        $this->assertSame('newval', $result['Section1']['key1']);
+    }
+
+    /**
      * Assert that two configuration dirs are equal.
      *
      * @param string $expected Expected directory


### PR DESCRIPTION
During installation, the Basic config "Fix" action first creates `local/config/vufind/config.ini` and then, in the same request, calls `changeConfig()` to update values such as the site URL.
Because the local config now exists, `changeConfig()` treats it as the base config as well as the destination. `Ini::writeConfig()` then attempts to do `copy($path, $path)`
PHP returns `false` for this self-copy, which triggers the `FileAccessException`. The installer then catches it and displays a generic permissions error, even though the file permissions are correct.

Fix: skip the copy step when the base and destination paths are the same file.