### PR TITLE
Remove broken loadInitialTabWithAjax and add noscript message

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -141,9 +141,6 @@ defaultRecordTab = Holdings
 ; Hide the holdings tab if no holdings are available from the ILS; note that this
 ; feature requires your ILS driver to support the hasHoldings() method.
 hideHoldingsTabWhenEmpty = false
-; Whether to load the default tab through AJAX (which brings some performance
-; gain but breaks compatibility with non-Javascript-enabled browsers; off by default)
-;loadInitialTabWithAjax = true
 ; The holdingsTemplate to use to display the ILS holdings (defaults to standard).
 ; See the templates/RecordTab/holdingsils subdirectory of your theme for options.
 ;holdingsTemplate = extended

--- a/module/VuFind/src/VuFind/Action/Record/AbstractRecordAction.php
+++ b/module/VuFind/src/VuFind/Action/Record/AbstractRecordAction.php
@@ -293,7 +293,6 @@ abstract class AbstractRecordAction extends AbstractTemplateRenderingAction
             'defaultTab' => strtolower($this->getDefaultTab()),
             'backgroundTabs' => $this->getBackgroundTabs(),
             'tabsExtraScripts' => $this->getTabsExtraScripts($tabs),
-            'loadInitialTabWithAjax' => (bool)($this->config['Site']['loadInitialTabWithAjax'] ?? false),
         ]);
 
         // Set up next/previous record links (if appropriate)

--- a/module/VuFind/src/VuFind/Config/Upgrade.php
+++ b/module/VuFind/src/VuFind/Config/Upgrade.php
@@ -571,7 +571,7 @@ class Upgrade implements LoggerAwareInterface
                 = ['link' => $newConfig['Content']['GoogleOptions']];
         }
 
-        // Disable unused, obsolete settings:
+        // Remove unused, obsolete settings:
         unset($newConfig['Index']['local']);
         if (isset($newConfig['Cache']['umask'])) {
             unset($newConfig['Cache']['umask']);
@@ -580,6 +580,7 @@ class Upgrade implements LoggerAwareInterface
                 . 'if you need a custom umask, please configure it at the operating system level.'
             );
         }
+        unset($newConfig['Site']['loadInitialTabWithAjax']);
 
         // Warn the user if they are using an unsupported theme:
         $this->checkTheme('theme', 'sandal5');

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordTabs.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordTabs.php
@@ -79,7 +79,6 @@ class RecordTabs
         string $activeTab
     ): array {
         $ajaxTabUrl = $this->recordLinker->getTabUrl($driver, 'AjaxTab');
-        $loadInitialTabWithAjax = (bool)($this->config['Site']['loadInitialTabWithAjax'] ?? false);
         $backgroundTabs = $this->tabManager->getBackgroundTabNames($driver);
         $tabArray = [];
         foreach ($tabs as $tab => $obj) {
@@ -90,7 +89,7 @@ class RecordTabs
             $tabItem['buttonAttributes'] = [
                 'class' => 'record-tab-button',
             ];
-            $loadContent = (($activeTab === $tab) && !$loadInitialTabWithAjax) || !$obj->supportsAjax();
+            $loadContent = !$obj->supportsAjax();
             $tabItem['content'] = $loadContent ? ($this->recordHelper)($driver)->getTab($obj) : '';
             $tabItem['paneAttributes'] = [
                 'class' => 'record-tab-pane',

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
@@ -225,10 +225,7 @@ class LinkResolverTest extends \VuFindTest\Integration\MinkTestCase
     public function testLinkOnRecordPageWithLinkInHoldingsAndAjaxTabLoading()
     {
         // By default, no OpenURL on record page:
-        $page = $this->setupRecordPage(
-            ['show_in_holdings' => true],
-            ['Site' => ['loadInitialTabWithAjax' => true]]
-        );
+        $page = $this->setupRecordPage(['show_in_holdings' => true]);
         $this->assertOpenUrl($page);
     }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/LinkResolverTest.php
@@ -216,16 +216,4 @@ class LinkResolverTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->setupRecordPage(['show_in_holdings' => true]);
         $this->assertOpenUrl($page);
     }
-
-    /**
-     * Test a link on the record page (in holdings tab w/ AJAX loading).
-     *
-     * @return void
-     */
-    public function testLinkOnRecordPageWithLinkInHoldingsAndAjaxTabLoading()
-    {
-        // By default, no OpenURL on record page:
-        $page = $this->setupRecordPage(['show_in_holdings' => true]);
-        $this->assertOpenUrl($page);
-    }
 }

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
@@ -141,17 +141,6 @@ class RecordTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Test that tabs work correctly.
-     *
-     * @return void
-     */
-    public function testLoadInitialTab(): void
-    {
-        $this->tryRecordTabsOnId('testsample1');
-        $this->tryLoadingTabHashAndReturningToDefault('testsample2');
-    }
-
-    /**
      * Data provider for testPermalink().
      *
      * @return \Iterator

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordTest.php
@@ -141,15 +141,12 @@ class RecordTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
-     * Test that tabs work correctly with loadInitialTabWithAjax turned on.
+     * Test that tabs work correctly.
      *
      * @return void
      */
-    public function testLoadInitialTabWithAjax(): void
+    public function testLoadInitialTab(): void
     {
-        $this->changeConfigs(
-            ['config' => ['Site' => ['loadInitialTabWithAjax' => 1]]]
-        );
         $this->tryRecordTabsOnId('testsample1');
         $this->tryLoadingTabHashAndReturningToDefault('testsample2');
     }

--- a/themes/bootstrap5/templates/_ui/components/tabs.phtml
+++ b/themes/bootstrap5/templates/_ui/components/tabs.phtml
@@ -55,6 +55,11 @@
 </ul>
 
 <div class="<?=implode(' ', $tabContentClasses)?>">
+  <noscript>
+    <div class="alert alert-danger">
+      <?=$this->transEsc('Please enable JavaScript.')?>
+    </div>
+  </noscript>
   <?php foreach ($this->tabs as $tabName => $tab): ?>
     <?php
       $tabPaneAttributes = $this->htmlAttributes([


### PR DESCRIPTION
Since the tab refactoring the tabs haven't worked without JS, and the loadInitialTabWithAjax setting was also broken due to case-sensitive comparison. The setting has been removed since it no longer serves a purpose, and a message is displayed below the tab bar if JS is disabled.

TODO
- [x] Update changelog when merging (note removal of non-JS tab support)