### PR TITLE
Add shared test coverage for AbstractSearchObject recommend modules

### DIFF
--- a/module/VuFind/src/VuFind/Recommend/AbstractSearchObject.php
+++ b/module/VuFind/src/VuFind/Recommend/AbstractSearchObject.php
@@ -30,6 +30,7 @@
 
 namespace VuFind\Recommend;
 
+use VuFind\Search\Base\Results;
 use VuFind\Search\SearchRunner;
 
 use function intval;
@@ -200,10 +201,15 @@ abstract class AbstractSearchObject implements RecommendInterface
     /**
      * Get search results.
      *
-     * @return \VuFind\Search\Base\Results
+     * @return Results
+     *
+     * @throws \Exception
      */
-    public function getResults()
+    public function getResults(): Results
     {
+        if (null === $this->results) {
+            throw new \Exception(static::class . '::getResults() called before init().');
+        }
         return $this->results;
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
@@ -49,7 +49,6 @@ use VuFind\Search\SearchRunner;
  */
 abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
 {
-    use \VuFindTest\Feature\SearchObjectsTrait;
     use \VuFindTest\Feature\WithConsecutiveTrait;
 
     /**
@@ -185,14 +184,37 @@ abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test process() does not touch the results.
+     * Test that process() does not replace the results already set by init().
      *
      * @return void
      */
     public function testProcessDoesNotAlterResults(): void
     {
-        $recommend = $this->getRecommend();
+        $mockResults = $this->createMock(Results::class);
+        $runner = $this->createStub(SearchRunner::class);
+        $runner->method('run')->willReturn($mockResults);
+
+        $recommend = $this->getRecommend($runner);
+        $recommend->setConfig('');
+        $recommend->init(
+            $this->createStub(Params::class),
+            new Parameters(['lookfor' => 'test query'])
+        );
+
         $recommend->process($this->createMock(Results::class));
-        $this->assertNull($recommend->getResults());
+
+        $this->assertSame($mockResults, $recommend->getResults());
+    }
+
+    /**
+     * Test that getResults() throws an exception if called before init().
+     *
+     * @return void
+     */
+    public function testGetResultsWithoutInitialization(): void
+    {
+        $recommend = $this->getRecommend();
+        $this->expectException(\Exception::class);
+        $recommend->getResults();
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
@@ -87,8 +87,8 @@ abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
     ): AbstractSearchObject {
         $class = $this->getTestClass();
         return new $class(
-            $runner ?? $this->createMock(SearchRunner::class),
-            $configManager ?? $this->createMock(ConfigManagerInterface::class)
+            $runner ?? $this->createStub(SearchRunner::class),
+            $configManager ?? $this->createStub(ConfigManagerInterface::class)
         );
     }
 
@@ -127,7 +127,7 @@ abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
         $mockResults = $this->createMock(Results::class);
         $runner = $this->createMock(SearchRunner::class);
         $runner->expects($this->once())->method('run')
-            ->with([], $this->getExpectedSearchClassId(), $this->isType('callable'))
+            ->with([], $this->getExpectedSearchClassId(), $this->isCallable())
             ->willReturn($mockResults);
 
         $recommend = $this->getRecommend($runner);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * AbstractSearchObject Test Class.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Villanova University 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace VuFindTest\Recommend;
+
+use Laminas\Stdlib\Parameters;
+use PHPUnit\Framework\MockObject\MockObject;
+use VuFind\Config\ConfigManagerInterface;
+use VuFind\Recommend\AbstractSearchObject;
+use VuFind\Search\Base\Options;
+use VuFind\Search\Base\Params;
+use VuFind\Search\Base\Results;
+use VuFind\Search\SearchRunner;
+
+/**
+ * AbstractSearchObject Test Class.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\SearchObjectsTrait;
+    use \VuFindTest\Feature\WithConsecutiveTrait;
+
+    /**
+     * Get the class name of the module.
+     *
+     * @return string
+     */
+    abstract protected function getTestClass(): string;
+
+    /**
+     * Get search class id for the module
+     *
+     * @return string
+     */
+    abstract protected function getExpectedSearchClassId(): string;
+
+    /**
+     * Get the default heading for the module
+     *
+     * @return string
+     */
+    abstract protected function getExpectedDefaultHeading(): string;
+
+    /**
+     * Create an instance of the module.
+     *
+     * @param ?SearchRunner           $runner        Search runner (null for mock)
+     * @param ?ConfigManagerInterface $configManager Config manager (null for mock)
+     *
+     * @return AbstractSearchObject
+     */
+    protected function getRecommend(
+        ?SearchRunner $runner = null,
+        ?ConfigManagerInterface $configManager = null
+    ): AbstractSearchObject {
+        $class = $this->getTestClass();
+        return new $class(
+            $runner ?? $this->createMock(SearchRunner::class),
+            $configManager ?? $this->createMock(ConfigManagerInterface::class)
+        );
+    }
+
+    /**
+     * Test that an empty recommend configuration string returns the module's default heading.
+     *
+     * @return void
+     */
+    public function testDefaultHeading(): void
+    {
+        $recommend = $this->getRecommend();
+        $recommend->setConfig('');
+        $this->assertEquals($this->getExpectedDefaultHeading(), $recommend->getHeading());
+    }
+
+    /**
+     * Test that a configured heading overrides the default.
+     *
+     * @return void
+     */
+    public function testCustomHeadingFromConfig(): void
+    {
+        $recommend = $this->getRecommend();
+        $recommend->setConfig('lookfor:10:Custom Heading Text');
+        $this->assertEquals('Custom Heading Text', $recommend->getHeading());
+    }
+
+    /**
+     * Test that init() runs a search using the module's expected search class
+     * ID, and that getResults() exposes whatever the runner returns.
+     *
+     * @return void
+     */
+    public function testInitRunsSearchWithExpectedClassId(): void
+    {
+        $mockResults = $this->createMock(Results::class);
+        $runner = $this->createMock(SearchRunner::class);
+        $runner->expects($this->once())->method('run')
+            ->with([], $this->getExpectedSearchClassId(), $this->isType('callable'))
+            ->willReturn($mockResults);
+
+        $recommend = $this->getRecommend($runner);
+        $recommend->setConfig('');
+
+        $params = $this->createMock(Params::class);
+        $request = new Parameters(['lookfor' => 'test query']);
+        $recommend->init($params, $request);
+
+        $this->assertSame($mockResults, $recommend->getResults());
+    }
+
+    /**
+     * Test that filters are applied to the search parameters when the search callback runs.
+     *
+     * @return void
+     */
+    public function testInitAppliesConfiguredFilters(): void
+    {
+        $configManager = $this->createMock(ConfigManagerInterface::class);
+        $configManager->expects($this->once())->method('getConfigArray')
+            ->with('searches')
+            ->willReturn(['MyFilterSection' => ['building:main', 'format:Book']]);
+
+        $capturedCallback = null;
+        $runner = $this->createMock(SearchRunner::class);
+        $runner->method('run')->willReturnCallback(
+            function ($request, $classId, $callback) use (&$capturedCallback): MockObject {
+                $capturedCallback = $callback;
+                return $this->createMock(Results::class);
+            }
+        );
+
+        $recommend = $this->getRecommend($runner, $configManager);
+        $recommend->setConfig('lookfor:5:Heading:MyFilterSection');
+
+        $outerParams = $this->createMock(Params::class);
+        $request = new Parameters(['lookfor' => 'test query']);
+        $recommend->init($outerParams, $request);
+        $this->assertIsCallable($capturedCallback);
+
+        $innerOptions = $this->createMock(Options::class);
+        $innerOptions->method('getSearchIni')->willReturn('searches');
+        $innerOptions->method('getHandlerForLabel')->willReturn('AllFields');
+        $innerParams = $this->createMock(Params::class);
+        $innerParams->method('getOptions')->willReturn($innerOptions);
+        $innerParams->expects($this->once())->method('setLimit')->with(5);
+        $this->expectConsecutiveCalls(
+            $innerParams,
+            'addFilter',
+            [['building:main'], ['format:Book']]
+        );
+
+        ($capturedCallback)($runner, $innerParams);
+    }
+
+    /**
+     * Test process() does not touch the results.
+     *
+     * @return void
+     */
+    public function testProcessDoesNotAlterResults(): void
+    {
+        $recommend = $this->getRecommend();
+        $recommend->process($this->createMock(Results::class));
+        $this->assertNull($recommend->getResults());
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
@@ -215,6 +215,7 @@ abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
     {
         $recommend = $this->getRecommend();
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($this->getTestClass() . '::getResults() called before init().');
         $recommend->getResults();
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/AbstractSearchObjectTestCase.php
@@ -60,14 +60,14 @@ abstract class AbstractSearchObjectTestCase extends \PHPUnit\Framework\TestCase
     abstract protected function getTestClass(): string;
 
     /**
-     * Get search class id for the module
+     * Get search class id for the module.
      *
      * @return string
      */
     abstract protected function getExpectedSearchClassId(): string;
 
     /**
-     * Get the default heading for the module
+     * Get the default heading for the module.
      *
      * @return string
      */

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CatalogResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/CatalogResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * CatalogResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\CatalogResults;
 
 /**
- * SummonResults Test Class.
+ * CatalogResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class CatalogResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return CatalogResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'Solr';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'Catalog Results';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EDSResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EDSResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * EDSResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\EDSResults;
 
 /**
- * SummonResults Test Class.
+ * EDSResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class EDSResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return EDSResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'EDS';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'EDS Results';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EPFResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/EPFResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * EPFResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\EPFResults;
 
 /**
- * SummonResults Test Class.
+ * EPFResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class EPFResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return EPFResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'EPF';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'epf_recommendations';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesAZResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesAZResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * LibGuidesAZResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\LibGuidesAZResults;
 
 /**
- * SummonResults Test Class.
+ * LibGuidesAZResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class LibGuidesAZResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return LibGuidesAZResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'LibGuidesAZ';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'libguidesaz_recommendations';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/LibGuidesResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * LibGuidesResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\LibGuidesResults;
 
 /**
- * SummonResults Test Class.
+ * LibGuidesResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class LibGuidesResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return LibGuidesResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'LibGuides';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'libguides_recommendations';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ProQuestFSGResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/ProQuestFSGResultsTest.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * SummonResults Test Class.
+ * ProQuestFSGResults Test Class.
  *
  * PHP version 8
  *
- * Copyright (C) Villanova University 2022.
+ * Copyright (C) Villanova University 2026.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -22,7 +22,6 @@
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
@@ -30,19 +29,18 @@
 
 namespace VuFindTest\Recommend;
 
-use VuFind\Recommend\SummonResults;
+use VuFind\Recommend\ProQuestFSGResults;
 
 /**
- * SummonResults Test Class.
+ * ProQuestFSGResults Test Class.
  *
  * @category VuFind
  * @package  Tests
- * @author   Sudharma Kellampalli <skellamp@villanova.edu>
  * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class SummonResultsTest extends AbstractSearchObjectTestCase
+class ProQuestFSGResultsTest extends AbstractSearchObjectTestCase
 {
     /**
      * Get the class name of the module.
@@ -51,7 +49,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getTestClass(): string
     {
-        return SummonResults::class;
+        return ProQuestFSGResults::class;
     }
 
     /**
@@ -61,7 +59,7 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedSearchClassId(): string
     {
-        return 'Summon';
+        return 'ProQuestFSG';
     }
 
     /**
@@ -71,6 +69,6 @@ class SummonResultsTest extends AbstractSearchObjectTestCase
      */
     protected function getExpectedDefaultHeading(): string
     {
-        return 'Summon Results';
+        return 'proquestfsg_recommendations';
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/WebResultsTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Recommend/WebResultsTest.php
@@ -23,6 +23,7 @@
  * @category VuFind
  * @package  Tests
  * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
@@ -30,7 +31,6 @@
 namespace VuFindTest\Recommend;
 
 use VuFind\Recommend\WebResults;
-use VuFindTest\Feature\ConfigRelatedServicesTrait;
 
 /**
  * WebResults Test Class.
@@ -38,25 +38,39 @@ use VuFindTest\Feature\ConfigRelatedServicesTrait;
  * @category VuFind
  * @package  Tests
  * @author   Sudharma Kellampalli <skellamp@villanova.edu>
+ * @author   Emmanuel Afuadajo <afuadajoe@gmail.com>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
  * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
  */
-class WebResultsTest extends \PHPUnit\Framework\TestCase
+class WebResultsTest extends AbstractSearchObjectTestCase
 {
-    use ConfigRelatedServicesTrait;
+    /**
+     * Get the class name of the module.
+     *
+     * @return string
+     */
+    protected function getTestClass(): string
+    {
+        return WebResults::class;
+    }
 
     /**
-     * Test getting search class id.
+     * Get search class id for the module.
      *
-     * @return void
+     * @return string
      */
-    public function testGetSearchClassId(): void
+    protected function getExpectedSearchClassId(): string
     {
-        $class = new \ReflectionClass(WebResults::class);
-        $method = $class->getMethod('getSearchClassId');
-        $runner = $this->createMock(\VuFind\Search\SearchRunner::class);
-        $obj = new WebResults($runner, $this->getMockConfigManager());
+        return 'SolrWeb';
+    }
 
-        $this->assertSame('SolrWeb', $method->invoke($obj));
+    /**
+     * Get the default heading for the module.
+     *
+     * @return string
+     */
+    protected function getExpectedDefaultHeading(): string
+    {
+        return 'Library Web Search';
     }
 }


### PR DESCRIPTION
Add AbstractSearchObjectTestCase, an abstract PHPUnit base holding the actual test logic, extended by 8 thin per-class test files that each supply the class name, expected search class ID, and expected default heading.