### PR TITLE
Improve types in SMSInterface and implementations.

### DIFF
--- a/module/VuFind/src/VuFind/SMS/AbstractBase.php
+++ b/module/VuFind/src/VuFind/SMS/AbstractBase.php
@@ -64,7 +64,7 @@ abstract class AbstractBase implements SMSInterface
      *
      * @return string
      */
-    protected function filterPhoneNumber($num)
+    protected function filterPhoneNumber(string $num): string
     {
         $filter = $this->smsConfig->General->filter ?? '-.() ';
         return str_replace(str_split($filter), '', $num);
@@ -75,7 +75,7 @@ abstract class AbstractBase implements SMSInterface
      *
      * @return string
      */
-    public function getValidationType()
+    public function getValidationType(): string
     {
         // Load setting from config; at present, only US is implemented in templates
         return $this->smsConfig->General->validation ?? 'US';

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -67,15 +67,15 @@ class Clickatell extends AbstractBase
     /**
      * Send a text message to the specified provider.
      *
-     * @param string $provider The provider ID to send to
-     * @param string $to       The phone number at the provider
-     * @param string $from     The email address to use as sender
-     * @param string $message  The message to send
+     * @param string  $provider The provider ID to send to
+     * @param string  $to       The phone number at the provider
+     * @param ?string $from     The email address to use as sender (null for default)
+     * @param string  $message  The message to send
      *
      * @throws \VuFind\Exception\Mail
      * @return void
      */
-    public function text($provider, $to, $from, $message)
+    public function text(string $provider, string $to, ?string $from, string $message): void
     {
         $url = $this->getApiUrl($to, $message);
         try {
@@ -90,7 +90,6 @@ class Clickatell extends AbstractBase
         if (!str_starts_with($response, 'ID:')) {
             throw new SMSException($response, SMSException::ERROR_UNKNOWN);
         }
-        return true;
     }
 
     /**
@@ -100,7 +99,7 @@ class Clickatell extends AbstractBase
      *
      * @return array
      */
-    public function getCarriers()
+    public function getCarriers(): array
     {
         return [
             'Clickatell' => ['name' => 'Clickatell', 'domain' => null],
@@ -112,9 +111,9 @@ class Clickatell extends AbstractBase
      *
      * @return string
      */
-    protected function getApiUsername()
+    protected function getApiUsername(): string
     {
-        return $this->smsConfig->Clickatell->user ?? null;
+        return $this->smsConfig->Clickatell->user ?? '';
     }
 
     /**
@@ -122,9 +121,9 @@ class Clickatell extends AbstractBase
      *
      * @return string
      */
-    protected function getApiPassword()
+    protected function getApiPassword(): string
     {
-        return $this->smsConfig->Clickatell->password ?? null;
+        return $this->smsConfig->Clickatell->password ?? '';
     }
 
     /**
@@ -132,9 +131,9 @@ class Clickatell extends AbstractBase
      *
      * @return string
      */
-    protected function getApiId()
+    protected function getApiId(): string
     {
-        return $this->smsConfig->Clickatell->api_id ?? null;
+        return $this->smsConfig->Clickatell->api_id ?? '';
     }
 
     /**
@@ -145,7 +144,7 @@ class Clickatell extends AbstractBase
      *
      * @return string
      */
-    protected function getApiUrl($to, $message)
+    protected function getApiUrl(string $to, string $message): string
     {
         // Get base URL:
         $url = isset($this->smsConfig->Clickatell->url)
@@ -169,7 +168,7 @@ class Clickatell extends AbstractBase
      *
      * @return string
      */
-    protected function formatMessage($message)
+    protected function formatMessage(string $message): string
     {
         // Clickatell expects UCS-2 encoding:
         if (!function_exists('iconv')) {

--- a/module/VuFind/src/VuFind/SMS/Clickatell.php
+++ b/module/VuFind/src/VuFind/SMS/Clickatell.php
@@ -49,16 +49,15 @@ class Clickatell extends AbstractBase
      *
      * @var \Laminas\Http\Client
      */
-    protected $client;
+    protected \Laminas\Http\Client $client;
 
     /**
      * Constructor.
      *
      * @param \VuFind\Config\Config $config  SMS configuration
-     * @param array                 $options Additional options (client may be an
-     *                                       HTTP client object)
+     * @param array                 $options Additional options (client may be an HTTP client object)
      */
-    public function __construct(\VuFind\Config\Config $config, $options = [])
+    public function __construct(\VuFind\Config\Config $config, array $options = [])
     {
         parent::__construct($config);
         $this->client = $options['client'] ?? new \Laminas\Http\Client();

--- a/module/VuFind/src/VuFind/SMS/Mailer.php
+++ b/module/VuFind/src/VuFind/SMS/Mailer.php
@@ -116,7 +116,7 @@ class Mailer extends AbstractBase
      *
      * @return array
      */
-    public function getCarriers()
+    public function getCarriers(): array
     {
         return $this->carriers;
     }
@@ -124,15 +124,15 @@ class Mailer extends AbstractBase
     /**
      * Send a text message to the specified provider.
      *
-     * @param string $provider The provider ID to send to
-     * @param string $to       The phone number at the provider
-     * @param string $from     The email address to use as sender
-     * @param string $message  The message to send
+     * @param string  $provider The provider ID to send to
+     * @param string  $to       The phone number at the provider
+     * @param ?string $from     The email address to use as sender (null for default)
+     * @param string  $message  The message to send
      *
      * @throws \VuFind\Exception\SMS
      * @return void
      */
-    public function text($provider, $to, $from, $message)
+    public function text(string $provider, string $to, ?string $from, string $message): void
     {
         $knownCarriers = array_keys($this->carriers);
         if (empty($provider) || !in_array($provider, $knownCarriers)) {
@@ -146,6 +146,6 @@ class Mailer extends AbstractBase
             . '@' . $this->carriers[$provider]['domain'];
         $from = empty($from) ? $this->defaultFrom : $from;
         $subject = '';
-        return $this->mailer->send($to, $from, $subject, $message);
+        $this->mailer->send($to, $from, $subject, $message);
     }
 }

--- a/module/VuFind/src/VuFind/SMS/Mailer.php
+++ b/module/VuFind/src/VuFind/SMS/Mailer.php
@@ -50,7 +50,7 @@ class Mailer extends AbstractBase
      *
      * @var array
      */
-    protected $carriers = [
+    protected array $carriers = [
         'virgin' => ['name' => 'Virgin Mobile', 'domain' => 'vmobl.com'],
         'verizon' => ['name' => 'Verizon', 'domain' => 'vtext.com'],
         'tmobile' => ['name' => 'T Mobile', 'domain' => 'tmomail.net'],
@@ -62,14 +62,14 @@ class Mailer extends AbstractBase
      *
      * @var string
      */
-    protected $defaultFrom;
+    protected string $defaultFrom;
 
     /**
      * VuFind Mailer object.
      *
      * @var \VuFind\Mailer\Mailer
      */
-    protected $mailer;
+    protected \VuFind\Mailer\Mailer $mailer;
 
     /**
      * Constructor.
@@ -94,8 +94,7 @@ class Mailer extends AbstractBase
         }
 
         // Load default "from" address:
-        $this->defaultFrom
-            = $options['defaultFrom'] ?? '';
+        $this->defaultFrom = $options['defaultFrom'] ?? '';
 
         // Make sure mailer dependency has been injected:
         if (

--- a/module/VuFind/src/VuFind/SMS/SMSInterface.php
+++ b/module/VuFind/src/VuFind/SMS/SMSInterface.php
@@ -45,7 +45,7 @@ interface SMSInterface
      *
      * @return string
      */
-    public function getValidationType();
+    public function getValidationType(): string;
 
     /**
      * Get a list of carriers supported by the module. Returned as an array of
@@ -54,18 +54,18 @@ interface SMSInterface
      *
      * @return array
      */
-    public function getCarriers();
+    public function getCarriers(): array;
 
     /**
      * Send a text message to the specified provider.
      *
-     * @param string $provider The provider ID to send to
-     * @param string $to       The phone number at the provider
-     * @param string $from     The email address to use as sender
-     * @param string $message  The message to send
+     * @param string  $provider The provider ID to send to
+     * @param string  $to       The phone number at the provider
+     * @param ?string $from     The email address to use as sender (null for default)
+     * @param string  $message  The message to send
      *
      * @throws \VuFind\Exception\Mail
      * @return void
      */
-    public function text($provider, $to, $from, $message);
+    public function text(string $provider, string $to, ?string $from, string $message): void;
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -29,6 +29,8 @@
 
 namespace VuFindTest\SMS;
 
+use Laminas\Http\Client;
+use PHPUnit\Framework\MockObject\MockObject;
 use VuFind\SMS\Clickatell;
 
 use function function_exists;
@@ -49,7 +51,8 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @var string
      */
-    protected $expectedBaseUri = 'https://api.clickatell.com/http/sendmsg?api_id=api_id&user=user&password=password';
+    protected string $expectedBaseUri
+        = 'https://api.clickatell.com/http/sendmsg?api_id=api_id&user=user&password=password';
 
     /**
      * Setup method.
@@ -69,7 +72,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testCarriers()
+    public function testCarriers(): void
     {
         $expected = [
             'Clickatell' => ['name' => 'Clickatell', 'domain' => null],
@@ -83,7 +86,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUnknownException()
+    public function testUnknownException(): void
     {
         // Behavior of getDisplayMessage() in VuFind\Exception\Mail depends on
         // environment
@@ -121,7 +124,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testSuccessResponse()
+    public function testSuccessResponse(): void
     {
         $client = $this->getMockClient();
         $expectedUri = $this->expectedBaseUri . '&to=1234567890&text=hello';
@@ -138,9 +141,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
             ->willReturn($client);
         $client->expects($this->once())->method('send')->willReturn($response);
         $obj = $this->getClickatell($client);
-        $this->assertTrue(
-            $obj->text('Clickatell', '1234567890', 'test@example.com', 'hello')
-        );
+        $obj->text('Clickatell', '1234567890', 'test@example.com', 'hello');
     }
 
     /**
@@ -148,7 +149,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testUnexpectedResponse()
+    public function testUnexpectedResponse(): void
     {
         $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('badbadbad');
@@ -178,7 +179,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testFailureResponse()
+    public function testFailureResponse(): void
     {
         $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('Problem sending text.');
@@ -207,7 +208,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testClientException()
+    public function testClientException(): void
     {
         $this->expectException(\VuFind\Exception\SMS::class);
         $this->expectExceptionMessage('Foo');
@@ -232,12 +233,12 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
     /**
      * Build a test object.
      *
-     * @param \Laminas\Http\Client $client HTTP client (null for default)
-     * @param array                $config Configuration (null for default)
+     * @param ?Client $client HTTP client (null for default)
+     * @param ?array  $config Configuration (null for default)
      *
      * @return Clickatell
      */
-    protected function getClickatell($client = null, $config = null)
+    protected function getClickatell(?Client $client = null, ?array $config = null): Clickatell
     {
         if (null === $config) {
             $config = $this->getDefaultConfig();
@@ -256,7 +257,7 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    protected function getDefaultConfig()
+    protected function getDefaultConfig(): array
     {
         return [
             'Clickatell' => [
@@ -270,9 +271,9 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a mock HTTP client.
      *
-     * @return \Laminas\Http\Client
+     * @return \Laminas\Http\Client&MockObject
      */
-    protected function getMockClient()
+    protected function getMockClient(): \Laminas\Http\Client&MockObject
     {
         return $this->createMock(\Laminas\Http\Client::class);
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/SMS/ClickatellTest.php
@@ -271,10 +271,10 @@ class ClickatellTest extends \PHPUnit\Framework\TestCase
     /**
      * Get a mock HTTP client.
      *
-     * @return \Laminas\Http\Client&MockObject
+     * @return Client&MockObject
      */
-    protected function getMockClient(): \Laminas\Http\Client&MockObject
+    protected function getMockClient(): Client&MockObject
     {
-        return $this->createMock(\Laminas\Http\Client::class);
+        return $this->createMock(Client::class);
     }
 }


### PR DESCRIPTION
While reviewing #5520, I noticed that there were some type errors in the PHPDoc of the SMS classes. This PR makes types explicit and fixes the errors and inconsistencies.

TODO
- [x] Run full test suite
- [x] Update changelog when merging