### PR TITLE
Update config cache only when config is actually loaded from disk.

### DIFF
--- a/module/VuFind/src/VuFind/Config/ConfigManager.php
+++ b/module/VuFind/src/VuFind/Config/ConfigManager.php
@@ -191,11 +191,12 @@ class ConfigManager implements ConfigManagerInterface
         // load configuration if it was not cached yet.
         if ($config === null) {
             $config = $this->configLoader->loadConfigFromLocation($configLocation, $handleParentConfig, $forceReload);
+
+            if ($useAdvancedCache) {
+                $advancedCache->setItem($cacheKey, $config);
+            }
         }
 
-        if ($useAdvancedCache) {
-            $advancedCache->setItem($cacheKey, $config);
-        }
         return $config;
     }
 


### PR DESCRIPTION
Updating a disk cache item is expensive, and it clears the stat cache every time, so we should avoid it when not necessary. I profiled the rendering of a record page, and this change dropped the average execution time from ~200ms to ~120ms, which is quite significant. This was with a standalone VuFind integration test environment, so in real production environment the effect could be different.