### PR TITLE
Avoid modifying original object in getUserContentRecordTitles.

### DIFF
--- a/module/VuFind/src/VuFind/ActionHelper/UserContentHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/UserContentHelper.php
@@ -89,6 +89,8 @@ class UserContentHelper implements HelperInterface
      */
     public function getUserContentRecordTitles(Paginator $contents): Paginator
     {
+        // Clone the object to avoid modifying the original data as a side-effect:
+        $contents = clone $contents;
         $ids = array_map(
             fn (array $content) => $content['source'] . '|' . $content['record_id'],
             iterator_to_array($contents)

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
@@ -168,7 +168,7 @@ class UserContentHelperTest extends TestCase
 
         $result = $this->getHelper($recordLoader)->getUserContentRecordTitles($contents);
 
-        $this->assertSame($contents, $result);
+        $this->assertNotSame($contents, $result);
 
         $titles = [];
         foreach ($result as $item) {

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
@@ -175,7 +175,7 @@ class UserContentHelperTest extends TestCase
 
         $result = $this->getHelper($recordLoader)->getUserContentRecordTitles($contents);
 
-        // Make sure the output is not a reference to the input:
+        // Make sure the output is not a reference to the input and that it contains expected values:
         $this->assertNotSame($contents, $result);
         $this->assertSame($expectedOutputArray, iterator_to_array($result));
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
@@ -151,15 +151,22 @@ class UserContentHelperTest extends TestCase
      */
     public function testGetUserContentRecordTitles(): void
     {
-        $contents = new Paginator(new ArrayAdapter([
+        $inputArray  = [
             ['source' => 'Solr', 'record_id' => 'record1'],
             ['source' => 'Summon', 'record_id' => 'record2'],
-        ]));
+        ];
+        $contents = new Paginator(new ArrayAdapter($inputArray));
 
+        // Set up expectation: the output will be like the input, but with titles added:
+        $expectedOutputArray = $inputArray;
+        $expectedOutputArray[0]['recordTitle'] = 'First title';
+        $expectedOutputArray[1]['recordTitle'] = 'Second title';
+
+        // Create fake record drivers using the expected titles set above:
         $driver1 = $this->createMock(RecordDriver::class);
-        $driver1->method('getTitle')->willReturn('First title');
+        $driver1->method('getTitle')->willReturn($expectedOutputArray[0]['recordTitle']);
         $driver2 = $this->createMock(RecordDriver::class);
-        $driver2->method('getTitle')->willReturn('Second title');
+        $driver2->method('getTitle')->willReturn($expectedOutputArray[1]['recordTitle']);
 
         $recordLoader = $this->createMock(RecordLoader::class);
         $recordLoader->expects($this->once())->method('loadBatch')
@@ -168,13 +175,9 @@ class UserContentHelperTest extends TestCase
 
         $result = $this->getHelper($recordLoader)->getUserContentRecordTitles($contents);
 
+        // Make sure the output is not a reference to the input:
         $this->assertNotSame($contents, $result);
-
-        $titles = [];
-        foreach ($result as $item) {
-            $titles[] = $item['recordTitle'] ?? null;
-        }
-        $this->assertSame(['First title', 'Second title'], $titles);
+        $this->assertSame($expectedOutputArray, iterator_to_array($result));
     }
 
     /**

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ActionHelper/UserContentHelperTest.php
@@ -151,7 +151,7 @@ class UserContentHelperTest extends TestCase
      */
     public function testGetUserContentRecordTitles(): void
     {
-        $inputArray  = [
+        $inputArray = [
             ['source' => 'Solr', 'record_id' => 'record1'],
             ['source' => 'Summon', 'record_id' => 'record2'],
         ];


### PR DESCRIPTION
As discussed in #5592. 