### PR TITLE
Ensure that LoginHelper::catalogLogin returns null instead of false

### DIFF
--- a/module/VuFind/src/VuFind/ActionHelper/LoginHelper.php
+++ b/module/VuFind/src/VuFind/ActionHelper/LoginHelper.php
@@ -232,7 +232,7 @@ class LoginHelper implements HelperInterface
         }
 
         // Send either null or patron array back to caller:
-        return $patron ?? null;
+        return $patron ?: null;
     }
 
     /**


### PR DESCRIPTION
A failed catalog login would have lead to false being returned, which isn't an allowed return type.