### PR TITLE
Always initialize Results backend identifier.

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -76,7 +76,7 @@ abstract class Results
      *
      * @var string
      */
-    protected string $backendId;
+    protected string $backendId = '';
 
     /**
      * Override (only for use in very rare cases).

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -281,6 +281,9 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
         $page = $this->performSearch('five', 'tag');
         $this->assertResultTitles($page, 3, 'Dewey browse test', '<HTML> The Basics');
         $this->assertSelectedSort($page, 'title');
+        // Click on a record to be sure that the results lead to the right place:
+        $page->clickLink('Dewey browse test');
+        $this->assertSame('Dewey browse test', $this->findCssAndGetText($page, 'h1'));
     }
 
     /**


### PR DESCRIPTION
This avoids error `Typed property VuFind\Search\Base\Results::$backendId must not be accessed before initialization` when handling a Results object that does not have its own backend (such as Tags) in SearchMemory::getLastSearchUrl.

We used to get away with the variable being uninitialized because it didn't have a type until #4944.