### PR TITLE
Add FormatBased cover provider

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1097,9 +1097,13 @@ verify_server_certificate = false
 
 ; You can select Syndetics, LibraryThing, Summon, OpenLibrary,
 ; Contentcafe, Buchhandel, Google, BrowZine, ObalkyKnih, Orb, Koha, Demo,
-; and/or LocalFile. Service-specific notes:
+; FormatBased, and/or LocalFile. Service-specific notes:
 ;   - BrowZine requires you to have BrowZine.ini configured appropriately.
 ;   - Buchhandel requires a valid token in the [Buchhandel] section.
+;   - FormatBased provides a cover image depending on the format of the
+;       record (Solr field "format") if none of the other providers found
+;       one. It is meant to be used as the last entry of the list. See the
+;       [FormatBasedCovers] section for configuration options.
 ;   - Google Books caching behavior can be customized in the [Cache_GoogleCover]
 ;       section.
 ;   - Koha requires the koha_cover_url setting below. Additionally, for
@@ -1136,7 +1140,7 @@ verify_server_certificate = false
 ;   - Orb requires that you complete the [Orb] section. Cache settings can be
 ;       adjusted in the [Cache_OrbCover] section.
 ;   - Summon service takes a Serials Solutions client key, NOT Summon API key!
-;coverimages     = Syndetics:MySyndeticsId,LibraryThing:MyLibraryThingId,Google,ObalkyKnih,OpenLibrary,Summon:MySerialsSolutionsClientKey,Buchhandel,Contentcafe:MyContentCafeID,BrowZine,LocalFile:PathToFile,Koha,Orb
+;coverimages     = Syndetics:MySyndeticsId,LibraryThing:MyLibraryThingId,Google,ObalkyKnih,OpenLibrary,Summon:MySerialsSolutionsClientKey,Buchhandel,Contentcafe:MyContentCafeID,BrowZine,LocalFile:PathToFile,Koha,Orb,FormatBased
 
 ; When using the Koha cover provider, you should fill in this setting:
 ;koha_cover_url = "https://localhost/cgi-bin/koha/opac-image.pl"
@@ -1273,6 +1277,30 @@ authors         = disabled
 ; Geographic Display
 ; These configuration settings have been superseded by the geofeatures.ini file.
 ; See the [MapTab] section of the geofeatures.ini file for more information.
+
+[FormatBasedCovers]
+; Settings for the FormatBased cover loader (see the coverimages setting above).
+; It provides a cover image depending on the format of the record (Solr field
+; "format") if none of the other cover providers found one. It is meant to be
+; used as the last entry of coverimages.
+;
+; image_dir: directory containing one image file per format, named after the
+;            format value, e.g. "Book.svg" for format "Book"
+;            (png, jpg, jpeg, gif, webp or svg).
+;            If not set, the default directory
+;            <VUFIND_HOME>/themes/bootstrap5/images/format-covers is used,
+;            which contains a set of simple default images.
+; default:   image used for all formats without a dedicated image; may also be
+;            omitted, in which case a file named "default.*" in image_dir is
+;            used if present.
+; Any other key is an explicit mapping of a format value to an image file path
+; (takes precedence over image_dir). Paths may be absolute filesystem paths or
+; file:// or http(s):// URLs.
+;
+; Examples:
+;image_dir = "/path/to/image/directory"
+;default   = "/path/to/default.png"
+;e-Book    = "/path/to/ebook.png"
 
 ; This section controls the behavior of the cover generator when makeDynamicCovers
 ; above is non-false.

--- a/module/VuFind/src/VuFind/Content/Covers/FormatBased.php
+++ b/module/VuFind/src/VuFind/Content/Covers/FormatBased.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * FormatBased cover content loader.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Universitätsbibliothek Mannheim 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace VuFind\Content\Covers;
+
+use VuFind\Record\Loader as RecordLoader;
+
+use function in_array;
+
+/**
+ * FormatBased cover content loader.
+ *
+ * Returns a cover image depending on the format of the record. This is meant
+ * to be used as the last entry of the coverimages list in the [Content]
+ * section of config.ini: it only produces a result if none of the other
+ * providers did, and maps the record format (Solr field "format") to a
+ * locally stored image file.
+ *
+ * Configuration is read from the [FormatBasedCovers] section of config.ini:
+ * - image_dir: directory containing one image file per format, named after
+ *   the format value (e.g. "book.png" for format "book"); if not set, the
+ *   default directory <VUFIND_HOME>/themes/bootstrap5/images/format-covers
+ *   (which contains a set of simple default images) is used;
+ * - default: image file used for all formats without a dedicated image;
+ * - any other key is treated as an explicit mapping of a format value to an
+ *   image file path (takes precedence over image_dir).
+ *
+ * Image paths may be absolute filesystem paths or file:// or http(s):// URLs.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class FormatBased extends \VuFind\Content\AbstractCover
+{
+    /**
+     * Image file extensions to look for in image_dir, in order of preference.
+     *
+     * @var array
+     */
+    protected $extensions = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'];
+
+    /**
+     * Constructor.
+     *
+     * @param RecordLoader $recordLoader Record loader
+     * @param string       $imageDir     Directory containing per-format images
+     * @param array        $mapping      Explicit format => image path mapping
+     * @param string       $default      Image path used for unknown formats
+     */
+    public function __construct(
+        protected RecordLoader $recordLoader,
+        protected string $imageDir = '',
+        protected array $mapping = [],
+        protected string $default = ''
+    ) {
+        $this->cacheAllowed = true;
+        $this->supportsRecordid = true;
+    }
+
+    /**
+     * Get image URL for a particular recordId (or false if not found).
+     *
+     * @param string $key  API key, unused
+     * @param string $size Size of image to load (small/medium/large), unused
+     * @param array  $ids  Associative array of identifiers
+     *
+     * @return string|bool URL of the image, or false if no valid image is found
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function getUrl($key, $size, $ids)
+    {
+        $recordId = $ids['recordid'];
+        $source = $ids['source'] ?? DEFAULT_SEARCH_BACKEND;
+        $driver = $this->recordLoader->load($recordId, $source);
+        $formats = method_exists($driver, 'getFormats') ? $driver->getFormats() : [];
+        $format = $formats[0] ?? '';
+        $file = $this->findFile($format);
+        return $file ? $this->toUrl($file) : false;
+    }
+
+    /**
+     * Find the image file for the given format.
+     *
+     * @param string $format Record format value
+     *
+     * @return string|bool Path or URL of the image, or false if none found
+     */
+    protected function findFile(string $format)
+    {
+        if ($format !== '') {
+            // Explicit mapping takes precedence:
+            if (isset($this->mapping[$format])) {
+                return $this->mapping[$format];
+            }
+            if ($this->imageDir !== '') {
+                $file = $this->findImageInDir($this->imageDir, $format);
+                if ($file !== false) {
+                    return $file;
+                }
+            }
+        }
+        // Fall back to the default image:
+        if ($this->default !== '') {
+            return $this->default;
+        }
+        if ($this->imageDir !== '') {
+            return $this->findImageInDir($this->imageDir, 'default');
+        }
+        return false;
+    }
+
+    /**
+     * Look for an image file with the given name in a directory.
+     *
+     * @param string $dir  Directory to search
+     * @param string $name Base file name (sanitized here, as it may come
+     *                     from the index)
+     *
+     * @return string|bool Path of the image, or false if not found
+     */
+    protected function findImageInDir(string $dir, string $name)
+    {
+        $safe = preg_replace('/[^A-Za-z0-9._-]/', '', $name);
+        if (in_array($safe, ['', '.', '..'], true)) {
+            return false;
+        }
+        foreach ($this->extensions as $ext) {
+            $file = rtrim($dir, '/') . '/' . $safe . '.' . $ext;
+            if (is_readable($file)) {
+                return $file;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Convert a filesystem path to a URL understood by the image loader.
+     *
+     * @param string $file File path or URL
+     *
+     * @return string URL
+     */
+    protected function toUrl(string $file)
+    {
+        if (preg_match('#^(file|https?)://#', $file)) {
+            return $file;
+        }
+        return 'file://' . $file;
+    }
+}

--- a/module/VuFind/src/VuFind/Content/Covers/FormatBasedFactory.php
+++ b/module/VuFind/src/VuFind/Content/Covers/FormatBasedFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * FormatBased cover loader factory.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Universitätsbibliothek Mannheim 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:cover_loaders Wiki
+ */
+
+namespace VuFind\Content\Covers;
+
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerInterface;
+use VuFind\Config\ConfigManagerInterface;
+use VuFind\Record\Loader as RecordLoader;
+
+use function defined;
+use function in_array;
+use function is_string;
+
+/**
+ * FormatBased cover loader factory.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:cover_loaders Wiki
+ */
+class FormatBasedFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+{
+    /**
+     * Create an object.
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException&\Throwable if any other error occurs
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options passed to factory.');
+        }
+        $config = $container->get(ConfigManagerInterface::class)->getConfigArray('config');
+        $section = $config['FormatBasedCovers'] ?? [];
+        $imageDir = isset($section['image_dir']) ? trim((string)$section['image_dir']) : '';
+        if ($imageDir === '' && defined('APPLICATION_PATH')) {
+            // Use the default set of format images shipped with the bootstrap5 theme:
+            $imageDir = APPLICATION_PATH . '/themes/bootstrap5/images/format-covers';
+        }
+        $default = isset($section['default']) ? trim((string)$section['default']) : '';
+        $mapping = [];
+        foreach ($section as $name => $value) {
+            if (in_array($name, ['image_dir', 'default'], true) || !is_string($value)) {
+                continue;
+            }
+            $value = trim($value);
+            if ($value !== '') {
+                $mapping[$name] = $value;
+            }
+        }
+        $recordLoader = $container->get(RecordLoader::class);
+        return new $requestedName($recordLoader, $imageDir, $mapping, $default);
+    }
+}

--- a/module/VuFind/src/VuFind/Content/Covers/PluginManager.php
+++ b/module/VuFind/src/VuFind/Content/Covers/PluginManager.php
@@ -58,6 +58,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
         'browzine' => BrowZine::class,
         'contentcafe' => ContentCafe::class,
         'demo' => Demo::class,
+        'formatbased' => FormatBased::class,
         'google' => Google::class,
         'koha' => Koha::class,
         'librarything' => LibraryThing::class,
@@ -75,6 +76,7 @@ class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
      * @var array
      */
     protected $factories = [
+        FormatBased::class => FormatBasedFactory::class,
         ObalkyKnih::class => ObalkyKnihContentFactory::class,
     ];
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/FormatBasedFactoryTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/FormatBasedFactoryTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * FormatBased cover loader factory unit tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Universitätsbibliothek Mannheim 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFindTest\Content\Covers;
+
+use VuFind\Config\ConfigManagerInterface;
+use VuFind\Content\Covers\FormatBased;
+use VuFind\Content\Covers\FormatBasedFactory;
+use VuFind\Record\Loader as RecordLoader;
+
+use function defined;
+
+/**
+ * Unit tests for FormatBased cover loader factory.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class FormatBasedFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Read a protected property of the created service.
+     *
+     * @param FormatBased $service Service to inspect
+     * @param string      $name    Property name
+     *
+     * @return mixed
+     */
+    protected function getProperty(FormatBased $service, string $name)
+    {
+        $property = new \ReflectionProperty(FormatBased::class, $name);
+        return $property->getValue($service);
+    }
+
+    /**
+     * Create the service using the given config array.
+     *
+     * @param array $config Config array as returned by ConfigManagerInterface
+     *
+     * @return FormatBased
+     */
+    protected function createService(array $config): FormatBased
+    {
+        $configManager = $this->createMock(ConfigManagerInterface::class);
+        $configManager->method('getConfigArray')->with('config')->willReturn($config);
+        $recordLoader = $this->createMock(RecordLoader::class);
+        $container = $this->createMock(\Psr\Container\ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            static function (string $id) use ($configManager, $recordLoader) {
+                return $id === ConfigManagerInterface::class
+                    ? $configManager
+                    : $recordLoader;
+            }
+        );
+        $factory = new FormatBasedFactory();
+        return $factory($container, FormatBased::class);
+    }
+
+    /**
+     * Test that image_dir defaults to the bootstrap5 theme directory.
+     *
+     * @return void
+     */
+    public function testDefaultImageDir(): void
+    {
+        $service = $this->createService([]);
+        $expected = defined('APPLICATION_PATH')
+            ? APPLICATION_PATH . '/themes/bootstrap5/images/format-covers'
+            : '';
+        $this->assertSame($expected, $this->getProperty($service, 'imageDir'));
+    }
+
+    /**
+     * Test that an explicit image_dir setting is used.
+     *
+     * @return void
+     */
+    public function testExplicitImageDir(): void
+    {
+        $service = $this->createService(
+            ['FormatBasedCovers' => ['image_dir' => ' /tmp/images ']]
+        );
+        $this->assertSame('/tmp/images', $this->getProperty($service, 'imageDir'));
+    }
+
+    /**
+     * Test that an explicit empty image_dir falls back to the default.
+     *
+     * @return void
+     */
+    public function testEmptyImageDirFallsBackToDefault(): void
+    {
+        $service = $this->createService(
+            ['FormatBasedCovers' => ['image_dir' => '  ']]
+        );
+        $expected = defined('APPLICATION_PATH')
+            ? APPLICATION_PATH . '/themes/bootstrap5/images/format-covers'
+            : '';
+        $this->assertSame($expected, $this->getProperty($service, 'imageDir'));
+    }
+
+    /**
+     * Test that the default setting and format mappings are parsed.
+     *
+     * @return void
+     */
+    public function testDefaultAndMappings(): void
+    {
+        $service = $this->createService(
+            [
+                'FormatBasedCovers' => [
+                    'default' => '/tmp/default.png',
+                    'e-Book' => '/tmp/ebook.png',
+                    'Journal' => '/tmp/journal.png',
+                ],
+            ]
+        );
+        $this->assertSame('/tmp/default.png', $this->getProperty($service, 'default'));
+        $this->assertSame(
+            ['e-Book' => '/tmp/ebook.png', 'Journal' => '/tmp/journal.png'],
+            $this->getProperty($service, 'mapping')
+        );
+    }
+}

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/FormatBasedTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Content/Covers/FormatBasedTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * FormatBased cover loader unit tests.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Universitätsbibliothek Mannheim 2026.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+
+namespace VuFindTest\Content\Covers;
+
+use VuFind\Content\Covers\FormatBased;
+use VuFind\Record\Loader as RecordLoader;
+
+use function dirname;
+
+/**
+ * Unit tests for FormatBased cover loader.
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Stefan Weil <sw@weilnetz.de>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class FormatBasedTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Directory holding test images.
+     *
+     * @var string
+     */
+    protected $imageDir;
+
+    /**
+     * Standard setup method.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->imageDir = sys_get_temp_dir() . '/vufind_formatbased_test_' . uniqid();
+        mkdir($this->imageDir, 0o777, true);
+        foreach (['book.png', 'journal.jpg', 'default.png'] as $file) {
+            file_put_contents($this->imageDir . '/' . $file, 'fake image data');
+        }
+    }
+
+    /**
+     * Standard teardown method.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        foreach (glob($this->imageDir . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->imageDir);
+        parent::tearDown();
+    }
+
+    /**
+     * Create a cover loader with a mocked record loader returning the
+     * given formats.
+     *
+     * @param array $formats Formats reported by the record driver
+     * @param array $args    Constructor arguments after the record loader
+     *
+     * @return FormatBased
+     */
+    protected function createLoader(array $formats, array $args = []): FormatBased
+    {
+        $driver = new class ($formats) {
+            /**
+             * Constructor.
+             *
+             * @param array $formats Formats reported by the record driver
+             *
+             * @return void
+             */
+            public function __construct(protected array $formats)
+            {
+            }
+
+            /**
+             * Get the formats reported by the record driver.
+             *
+             * @return array
+             */
+            public function getFormats(): array
+            {
+                return $this->formats;
+            }
+        };
+        $recordLoader = $this->createMock(RecordLoader::class);
+        $recordLoader
+            ->method('load')
+            ->willReturn($driver);
+        return new FormatBased($recordLoader, ...$args);
+    }
+
+    /**
+     * Test that the loader only supports requests with a recordid.
+     *
+     * @return void
+     */
+    public function testSupports(): void
+    {
+        $loader = $this->createLoader([], [$this->imageDir]);
+        $this->assertTrue($loader->supports(['recordid' => '1']));
+        $this->assertFalse($loader->supports(['isbn' => new \VuFindCode\ISBN('123')]));
+        $this->assertFalse($loader->supports([]));
+    }
+
+    /**
+     * Test that the loader allows caching.
+     *
+     * @return void
+     */
+    public function testCacheAllowed(): void
+    {
+        $loader = $this->createLoader([], [$this->imageDir]);
+        $this->assertTrue($loader->isCacheAllowed());
+    }
+
+    /**
+     * Test that an image from image_dir is returned for a known format.
+     *
+     * @return void
+     */
+    public function testImageDirLookup(): void
+    {
+        $loader = $this->createLoader(['book'], [$this->imageDir]);
+        $this->assertSame(
+            'file://' . $this->imageDir . '/book.png',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that jpg files in image_dir are found, too.
+     *
+     * @return void
+     */
+    public function testImageDirLookupJpg(): void
+    {
+        $loader = $this->createLoader(['journal'], [$this->imageDir]);
+        $this->assertSame(
+            'file://' . $this->imageDir . '/journal.jpg',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that an explicit mapping takes precedence over image_dir.
+     *
+     * @return void
+     */
+    public function testMappingPrecedence(): void
+    {
+        $other = $this->imageDir . '/book.png';
+        $loader = $this->createLoader(['book'], [$this->imageDir, ['book' => $other . '.copy']]);
+        file_put_contents($other . '.copy', 'fake image data');
+        $this->assertSame(
+            'file://' . $other . '.copy',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that http(s) URLs are passed through unchanged.
+     *
+     * @return void
+     */
+    public function testHttpUrlPassthrough(): void
+    {
+        $loader = $this->createLoader(
+            ['book'],
+            ['', ['book' => 'https://example.com/book.png']]
+        );
+        $this->assertSame(
+            'https://example.com/book.png',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that unknown formats fall back to the default image.
+     *
+     * @return void
+     */
+    public function testDefaultImage(): void
+    {
+        $loader = $this->createLoader(['Map'], [$this->imageDir]);
+        $this->assertSame(
+            'file://' . $this->imageDir . '/default.png',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that an explicit default setting is used.
+     *
+     * @return void
+     */
+    public function testExplicitDefault(): void
+    {
+        $other = $this->imageDir . '/default.png';
+        $loader = $this->createLoader(['Map'], ['', [], $other]);
+        $this->assertSame(
+            'file://' . $other,
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+
+    /**
+     * Test that false is returned when no image is configured.
+     *
+     * @return void
+     */
+    public function testNoConfiguredImage(): void
+    {
+        $loader = $this->createLoader(['Map']);
+        $this->assertFalse($loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr']));
+    }
+
+    /**
+     * Test that format values containing path separators cannot escape
+     * the image directory.
+     *
+     * @return void
+     */
+    public function testPathTraversalSanitization(): void
+    {
+        // If sanitization were broken, "../evil" would resolve to
+        // <imageDir>/../evil.png:
+        file_put_contents(dirname($this->imageDir) . '/evil.png', 'sentinel');
+        $loader = $this->createLoader(['../evil'], [$this->imageDir]);
+        $this->assertSame(
+            'file://' . $this->imageDir . '/default.png',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+        unlink(dirname($this->imageDir) . '/evil.png');
+    }
+
+    /**
+     * Test that records without a format fall back to the default image.
+     *
+     * @return void
+     */
+    public function testEmptyFormat(): void
+    {
+        $loader = $this->createLoader([], [$this->imageDir]);
+        $this->assertSame(
+            'file://' . $this->imageDir . '/default.png',
+            $loader->getUrl(null, 'small', ['recordid' => '1', 'source' => 'Solr'])
+        );
+    }
+}

--- a/themes/bootstrap5/images/format-covers/Article.svg
+++ b/themes/bootstrap5/images/format-covers/Article.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#2e7d32"/>
+  <rect x="50" y="60" width="100" height="180" rx="4" fill="#ffffff"/>
+  <rect x="62" y="76" width="76" height="14" rx="3" fill="#2e7d32"/>
+  <line x1="62" y1="108" x2="104" y2="108" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="130" x2="138" y2="130" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="150" x2="138" y2="150" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="170" x2="138" y2="170" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="190" x2="138" y2="190" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="210" x2="138" y2="210" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+  <line x1="62" y1="228" x2="112" y2="228" stroke="#2e7d32" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Book.svg
+++ b/themes/bootstrap5/images/format-covers/Book.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#1e88e5"/>
+  <rect x="55" y="65" width="90" height="170" rx="8" fill="#ffffff"/>
+  <line x1="74" y1="65" x2="74" y2="235" stroke="#1e88e5" stroke-width="6"/>
+  <line x1="92" y1="112" x2="130" y2="112" stroke="#1e88e5" stroke-width="9" stroke-linecap="round"/>
+  <line x1="92" y1="136" x2="122" y2="136" stroke="#1e88e5" stroke-width="9" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/BookChapter.svg
+++ b/themes/bootstrap5/images/format-covers/BookChapter.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#c0ca33"/>
+  <rect x="55" y="62" width="90" height="176" rx="6" fill="#ffffff"/>
+  <line x1="74" y1="62" x2="74" y2="238" stroke="#c0ca33" stroke-width="6"/>
+  <rect x="116" y="62" width="18" height="66" fill="#c0ca33"/>
+  <line x1="86" y1="156" x2="134" y2="156" stroke="#c0ca33" stroke-width="8" stroke-linecap="round"/>
+  <line x1="86" y1="178" x2="126" y2="178" stroke="#c0ca33" stroke-width="8" stroke-linecap="round"/>
+  <line x1="86" y1="200" x2="134" y2="200" stroke="#c0ca33" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Braille.svg
+++ b/themes/bootstrap5/images/format-covers/Braille.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#00796b"/>
+  <circle cx="80" cy="105" r="11" fill="#ffffff"/>
+  <circle cx="80" cy="150" r="11" fill="#ffffff"/>
+  <circle cx="120" cy="105" r="11" fill="#ffffff" opacity="0.35"/>
+  <circle cx="120" cy="150" r="11" fill="#ffffff" opacity="0.35"/>
+  <circle cx="80" cy="195" r="11" fill="#ffffff" opacity="0.35"/>
+  <circle cx="120" cy="195" r="11" fill="#ffffff" opacity="0.35"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/ConferenceProceeding.svg
+++ b/themes/bootstrap5/images/format-covers/ConferenceProceeding.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#d81b60"/>
+  <rect x="84" y="66" width="32" height="50" rx="16" fill="#ffffff"/>
+  <line x1="88" y1="82" x2="112" y2="82" stroke="#d81b60" stroke-width="3"/>
+  <line x1="88" y1="94" x2="112" y2="94" stroke="#d81b60" stroke-width="3"/>
+  <line x1="100" y1="116" x2="100" y2="180" stroke="#ffffff" stroke-width="8"/>
+  <path d="M66 180 L134 180 L144 202 L56 202 Z" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Database.svg
+++ b/themes/bootstrap5/images/format-covers/Database.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#4527a0"/>
+  <rect x="48" y="90" width="104" height="120" fill="#ffffff"/>
+  <ellipse cx="100" cy="90" rx="52" ry="20" fill="#ffffff"/>
+  <ellipse cx="100" cy="210" rx="52" ry="20" fill="#ffffff"/>
+  <path d="M48 122 A52 20 0 0 0 152 122" fill="none" stroke="#4527a0" stroke-width="5"/>
+  <path d="M48 165 A52 20 0 0 0 152 165" fill="none" stroke="#4527a0" stroke-width="5"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Dissertation.svg
+++ b/themes/bootstrap5/images/format-covers/Dissertation.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#5c6bc0"/>
+  <rect x="60" y="92" width="80" height="116" fill="#ffffff"/>
+  <rect x="52" y="78" width="96" height="24" rx="12" fill="#ffffff"/>
+  <rect x="52" y="208" width="96" height="24" rx="12" fill="#ffffff"/>
+  <line x1="76" y1="122" x2="124" y2="122" stroke="#5c6bc0" stroke-width="6" stroke-linecap="round"/>
+  <line x1="76" y1="142" x2="124" y2="142" stroke="#5c6bc0" stroke-width="6" stroke-linecap="round"/>
+  <line x1="76" y1="162" x2="124" y2="162" stroke="#5c6bc0" stroke-width="6" stroke-linecap="round"/>
+  <line x1="76" y1="182" x2="108" y2="182" stroke="#5c6bc0" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Electronic.svg
+++ b/themes/bootstrap5/images/format-covers/Electronic.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#00838f"/>
+  <rect x="42" y="72" width="116" height="86" rx="6" fill="#ffffff"/>
+  <rect x="52" y="82" width="96" height="66" rx="3" fill="#00838f"/>
+  <line x1="64" y1="100" x2="112" y2="100" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <line x1="64" y1="120" x2="136" y2="120" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <line x1="64" y1="140" x2="124" y2="140" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <rect x="92" y="158" width="16" height="22" fill="#ffffff"/>
+  <rect x="66" y="180" width="68" height="10" rx="5" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Globe.svg
+++ b/themes/bootstrap5/images/format-covers/Globe.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#0288d1"/>
+  <circle cx="100" cy="150" r="70" fill="#ffffff"/>
+  <ellipse cx="100" cy="150" rx="30" ry="70" fill="none" stroke="#0288d1" stroke-width="5"/>
+  <line x1="30" y1="150" x2="170" y2="150" stroke="#0288d1" stroke-width="5"/>
+  <line x1="37" y1="120" x2="163" y2="120" stroke="#0288d1" stroke-width="5"/>
+  <line x1="37" y1="180" x2="163" y2="180" stroke="#0288d1" stroke-width="5"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/GovernmentDocument.svg
+++ b/themes/bootstrap5/images/format-covers/GovernmentDocument.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#5d4037"/>
+  <rect x="54" y="60" width="92" height="178" rx="4" fill="#ffffff"/>
+  <path d="M146 60 L146 92 L114 60 Z" fill="#5d4037"/>
+  <line x1="68" y1="86" x2="120" y2="86" stroke="#5d4037" stroke-width="6" stroke-linecap="round"/>
+  <line x1="68" y1="106" x2="132" y2="106" stroke="#5d4037" stroke-width="6" stroke-linecap="round"/>
+  <line x1="68" y1="126" x2="132" y2="126" stroke="#5d4037" stroke-width="6" stroke-linecap="round"/>
+  <line x1="68" y1="146" x2="112" y2="146" stroke="#5d4037" stroke-width="6" stroke-linecap="round"/>
+  <path d="M92 200 L85 230 L100 214 L115 230 L108 200 Z" fill="#5d4037"/>
+  <circle cx="100" cy="186" r="20" fill="#5d4037"/>
+  <circle cx="100" cy="186" r="7" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Journal.svg
+++ b/themes/bootstrap5/images/format-covers/Journal.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#fb8c00"/>
+  <rect x="45" y="60" width="110" height="180" rx="4" fill="#ffffff"/>
+  <rect x="57" y="74" width="86" height="30" rx="2" fill="#fb8c00"/>
+  <line x1="57" y1="124" x2="143" y2="124" stroke="#fb8c00" stroke-width="7" stroke-linecap="round"/>
+  <line x1="57" y1="146" x2="143" y2="146" stroke="#fb8c00" stroke-width="7" stroke-linecap="round"/>
+  <line x1="57" y1="168" x2="120" y2="168" stroke="#fb8c00" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Kit.svg
+++ b/themes/bootstrap5/images/format-covers/Kit.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#f4511e"/>
+  <rect x="50" y="96" width="100" height="104" rx="6" fill="#ffffff"/>
+  <line x1="50" y1="126" x2="150" y2="126" stroke="#f4511e" stroke-width="6"/>
+  <rect x="86" y="108" width="28" height="10" rx="5" fill="#f4511e"/>
+  <rect x="76" y="150" width="48" height="34" rx="3" fill="#f4511e"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Map.svg
+++ b/themes/bootstrap5/images/format-covers/Map.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#43a047"/>
+  <path d="M40 100 L80 85 L80 205 L40 220 Z" fill="#ffffff" opacity="0.8"/>
+  <path d="M80 85 L120 100 L120 220 L80 205 Z" fill="#ffffff"/>
+  <path d="M120 100 L160 85 L160 205 L120 220 Z" fill="#ffffff" opacity="0.8"/>
+  <path d="M55 195 C 80 140, 118 172, 148 112" fill="none" stroke="#43a047" stroke-width="5" stroke-dasharray="11 9" stroke-linecap="round"/>
+  <circle cx="148" cy="112" r="7" fill="#43a047"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Microfilm.svg
+++ b/themes/bootstrap5/images/format-covers/Microfilm.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#8d6e63"/>
+  <circle cx="100" cy="150" r="66" fill="#ffffff"/>
+  <circle cx="100" cy="150" r="57" fill="#8d6e63"/>
+  <circle cx="100" cy="118" r="13" fill="#ffffff"/>
+  <circle cx="69.6" cy="140" r="13" fill="#ffffff"/>
+  <circle cx="80.8" cy="175.9" r="13" fill="#ffffff"/>
+  <circle cx="119.2" cy="175.9" r="13" fill="#ffffff"/>
+  <circle cx="130.4" cy="140" r="13" fill="#ffffff"/>
+  <circle cx="100" cy="150" r="12" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/MusicalScore.svg
+++ b/themes/bootstrap5/images/format-covers/MusicalScore.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#ab47bc"/>
+  <line x1="40" y1="112" x2="160" y2="112" stroke="#ffffff" stroke-width="4"/>
+  <line x1="40" y1="130" x2="160" y2="130" stroke="#ffffff" stroke-width="4"/>
+  <line x1="40" y1="148" x2="160" y2="148" stroke="#ffffff" stroke-width="4"/>
+  <line x1="40" y1="166" x2="160" y2="166" stroke="#ffffff" stroke-width="4"/>
+  <line x1="40" y1="184" x2="160" y2="184" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="78" cy="166" r="13" fill="#ffffff"/>
+  <line x1="89" y1="166" x2="89" y2="100" stroke="#ffffff" stroke-width="8"/>
+  <path d="M89 100 C 106 104, 112 116, 104 130 C 108 118, 102 112, 89 112 Z" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Newspaper.svg
+++ b/themes/bootstrap5/images/format-covers/Newspaper.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#546e7a"/>
+  <rect x="45" y="62" width="110" height="176" rx="3" fill="#ffffff"/>
+  <rect x="45" y="62" width="110" height="36" fill="#546e7a"/>
+  <line x1="55" y1="120" x2="93" y2="120" stroke="#546e7a" stroke-width="6" stroke-linecap="round"/>
+  <line x1="55" y1="138" x2="93" y2="138" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="55" y1="156" x2="93" y2="156" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="55" y1="174" x2="93" y2="174" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="107" y1="120" x2="145" y2="120" stroke="#546e7a" stroke-width="6" stroke-linecap="round"/>
+  <line x1="107" y1="138" x2="145" y2="138" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="107" y1="156" x2="145" y2="156" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="107" y1="174" x2="145" y2="174" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="55" y1="196" x2="145" y2="196" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+  <line x1="55" y1="214" x2="125" y2="214" stroke="#546e7a" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Photo.svg
+++ b/themes/bootstrap5/images/format-covers/Photo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#00acc1"/>
+  <rect x="45" y="80" width="110" height="140" rx="8" fill="#ffffff"/>
+  <circle cx="74" cy="114" r="11" fill="#00acc1"/>
+  <path d="M53 212 L88 156 L112 190 L128 168 L147 212 Z" fill="#00acc1"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/PhysicalObject.svg
+++ b/themes/bootstrap5/images/format-covers/PhysicalObject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#7cb342"/>
+  <path d="M100 82 L150 110 L100 138 L50 110 Z" fill="#ffffff"/>
+  <path d="M50 110 L100 138 L100 218 L50 190 Z" fill="#ffffff" opacity="0.8"/>
+  <path d="M150 110 L100 138 L100 218 L150 190 Z" fill="#ffffff" opacity="0.6"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Serial.svg
+++ b/themes/bootstrap5/images/format-covers/Serial.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#f9a825"/>
+  <rect x="45" y="60" width="110" height="180" rx="4" fill="#ffffff"/>
+  <rect x="57" y="74" width="86" height="30" rx="2" fill="#f9a825"/>
+  <line x1="57" y1="124" x2="143" y2="124" stroke="#f9a825" stroke-width="7" stroke-linecap="round"/>
+  <line x1="57" y1="146" x2="143" y2="146" stroke="#f9a825" stroke-width="7" stroke-linecap="round"/>
+  <line x1="57" y1="168" x2="120" y2="168" stroke="#f9a825" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="152" cy="92" r="26" fill="#f9a825" stroke="#ffffff" stroke-width="5"/>
+  <path d="M143 92 L150 99 L162 84" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Software.svg
+++ b/themes/bootstrap5/images/format-covers/Software.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#455a64"/>
+  <path d="M72 112 L44 150 L72 188" fill="none" stroke="#ffffff" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M128 112 L156 150 L128 188" fill="none" stroke="#ffffff" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="110" y1="104" x2="90" y2="196" stroke="#ffffff" stroke-width="11" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/SoundRecording.svg
+++ b/themes/bootstrap5/images/format-covers/SoundRecording.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#8e24aa"/>
+  <circle cx="75" cy="185" r="15" fill="#ffffff"/>
+  <circle cx="135" cy="170" r="15" fill="#ffffff"/>
+  <line x1="87" y1="185" x2="87" y2="108" stroke="#ffffff" stroke-width="8"/>
+  <line x1="147" y1="170" x2="147" y2="93" stroke="#ffffff" stroke-width="8"/>
+  <path d="M83 108 L151 93 L151 116 L83 131 Z" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Text.svg
+++ b/themes/bootstrap5/images/format-covers/Text.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#607d8b"/>
+  <rect x="52" y="58" width="96" height="184" rx="4" fill="#ffffff"/>
+  <line x1="68" y1="84" x2="120" y2="84" stroke="#607d8b" stroke-width="9" stroke-linecap="round"/>
+  <line x1="68" y1="110" x2="132" y2="110" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+  <line x1="68" y1="130" x2="132" y2="130" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+  <line x1="68" y1="150" x2="132" y2="150" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+  <line x1="68" y1="170" x2="132" y2="170" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+  <line x1="68" y1="190" x2="132" y2="190" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+  <line x1="68" y1="210" x2="104" y2="210" stroke="#607d8b" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Thesis.svg
+++ b/themes/bootstrap5/images/format-covers/Thesis.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#3949ab"/>
+  <path d="M74 150 L126 150 L132 194 L68 194 Z" fill="#ffffff"/>
+  <path d="M100 90 L168 122 L100 154 L32 122 Z" fill="#ffffff"/>
+  <circle cx="100" cy="90" r="5" fill="#ffffff"/>
+  <line x1="168" y1="122" x2="168" y2="168" stroke="#ffffff" stroke-width="5"/>
+  <circle cx="168" cy="172" r="6" fill="#ffffff"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/Video.svg
+++ b/themes/bootstrap5/images/format-covers/Video.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#e53935"/>
+  <rect x="40" y="70" width="120" height="160" rx="10" fill="#ffffff"/>
+  <rect x="48" y="84" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="48" y="116" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="48" y="148" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="48" y="180" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="142" y="84" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="142" y="116" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="142" y="148" width="10" height="14" rx="2" fill="#e53935"/>
+  <rect x="142" y="180" width="10" height="14" rx="2" fill="#e53935"/>
+  <path d="M88 122 L88 182 L136 152 Z" fill="#e53935"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/default.svg
+++ b/themes/bootstrap5/images/format-covers/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#4553a4"/>
+  <path d="M100 118 C 82 104, 56 99, 32 103 L32 196 C 56 192, 82 197, 100 211 C 118 197, 144 192, 168 196 L168 103 C 144 99, 118 104, 100 118 Z" fill="#ffffff"/>
+  <line x1="100" y1="118" x2="100" y2="211" stroke="#4553a4" stroke-width="4"/>
+</svg>

--- a/themes/bootstrap5/images/format-covers/eBook.svg
+++ b/themes/bootstrap5/images/format-covers/eBook.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#00897b"/>
+  <rect x="48" y="52" width="104" height="196" rx="14" fill="#ffffff"/>
+  <path d="M100 128 C 88 118, 70 114, 54 117 L54 181 C 70 178, 88 182, 100 192 C 112 182, 130 178, 146 181 L146 117 C 130 114, 112 118, 100 128 Z" fill="#00897b"/>
+  <line x1="100" y1="128" x2="100" y2="192" stroke="#ffffff" stroke-width="3"/>
+  <line x1="100" y1="216" x2="100" y2="216" stroke="#00897b" stroke-width="8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Add a cover content loader that provides a cover image depending on the format of a record (Solr field "format") if none of the other cover providers found one. It is meant to be used as the last entry of the coverimages list in the [Content] section of config.ini.

Images are looked up in a configurable directory (image_dir in the new [FormatBasedCovers] section, defaulting to
themes/bootstrap5/images/format-covers, which ships a set of simple SVG cover images for the following record formats:

  Article, Book, Book Chapter, Braille, Conference Proceeding,
  Database, Dissertation, Electronic, eBook, Globe, Government
  Document, Journal, Kit, Map, Microfilm, Musical Score, Newspaper,
  Photo, Physical Object, Serial, Software, Sound Recording, Text,
  Thesis and Video.

Records with any other format (or no format at all) fall back to a generic default image. Explicit per-format mappings and the default image can be configured as well; image paths may be filesystem paths or file:// or http(s) URLs.

Assisted-by: OpenCode / qwen3.8-27b-thinking (Alibaba Cloud)