### PR TITLE
KohaRest: Fix status message code check for NotForLoan or Lost status.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2475,9 +2475,10 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
         $statusKey = $code . ($data['status'] ?? '-');
         // Replace ':' in status key if used as status since ':' is
         // the namespace separator in translatable strings:
-        return $this->itemStatusMappings[$statusKey]
-            ?? $this->getPrefixedMessage($data['code'])
-            ?? $this->getPrefixedMessage(str_replace(':', '_', $statusKey));
+        if (null !== ($status = $this->itemStatusMappings[$statusKey] ?? null)) {
+            return $status;
+        }
+        return $this->getPrefixedMessage($data['code'] ?? str_replace(':', '_', $statusKey));
     }
 
     /**

--- a/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/KohaRest.php
@@ -2468,16 +2468,13 @@ class KohaRest extends \VuFind\ILS\Driver\AbstractBase implements
      */
     protected function getStatusCodeItemNotForLoanOrLost($code, $data, $item)
     {
-        // NotForLoan and Lost are special: status has a library-specific
-        // status number. Allow mapping of different status numbers
-        // separately (e.g. Item::NotForLoan with status number 4
-        // is mapped with key Item::NotForLoan4):
+        // NotForLoan and Lost are special: status has a library-specific status number. Allow mapping of different
+        // status numbers separately (e.g. Item::NotForLoan with status number 4 is mapped with key Item::NotForLoan4):
         $statusKey = $code . ($data['status'] ?? '-');
-        // Replace ':' in status key if used as status since ':' is
-        // the namespace separator in translatable strings:
         if (null !== ($status = $this->itemStatusMappings[$statusKey] ?? null)) {
             return $status;
         }
+        // Replace ':' in status key if used as status since ':' is the namespace separator in translatable strings:
         return $this->getPrefixedMessage($data['code'] ?? str_replace(':', '_', $statusKey));
     }
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/KohaRestTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/ILS/Driver/KohaRestTest.php
@@ -29,6 +29,7 @@
 
 namespace VuFindTest\ILS\Driver;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use VuFind\ILS\Driver\KohaRest;
 
 /**
@@ -43,6 +44,7 @@ use VuFind\ILS\Driver\KohaRest;
 class KohaRestTest extends \VuFindTest\Unit\ILSDriverTestCase
 {
     use \VuFindTest\Feature\FixtureTrait;
+    use \VuFindTest\Feature\ReflectionTrait;
 
     /**
      * Default test configuration.
@@ -216,5 +218,53 @@ class KohaRestTest extends \VuFindTest\Unit\ILSDriverTestCase
         $this->createConnector('purge-transaction-history');
         $this->expectExceptionMessage('Unsupported function');
         $this->driver->purgeTransactionHistory(['id' => 'bar'], [1, 2]);
+    }
+
+    /**
+     * Data provider for testGetStatusCodeItemNotForLoanOrLost.
+     *
+     * @return \Generator
+     */
+    public static function getStatusCodeItemNotForLoanOrLostProvider(): \Iterator
+    {
+        yield 'no data' => [
+            'Item::NotForLoan',
+            [],
+            'Item__NotForLoan-',
+        ];
+
+        yield 'status only' => [
+            'Item::NotForLoan',
+            [
+                'status' => '-',
+            ],
+            'Item__NotForLoan-',
+        ];
+
+        yield 'code only' => [
+            'Item::NotForLoan',
+            [
+                'code' => 'foo',
+            ],
+            'foo',
+        ];
+    }
+
+    /**
+     * Test getStatusCodeItemNotForLoanOrLost method.
+     *
+     * @param string $code     Status code
+     * @param array  $data     Status data
+     * @param string $expected Expected result
+     *
+     * @return void
+     */
+    #[DataProvider('getStatusCodeItemNotForLoanOrLostProvider')]
+    public function testGetStatusCodeItemNotForLoanOrLost(string $code, array $data, string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            $this->callMethod($this->driver, 'getStatusCodeItemNotForLoanOrLost', [$code, $data, []])
+        );
     }
 }


### PR DESCRIPTION
There was a mistake in #4787 that lost null coalescing of `$data['code']` that doesn't always exist.