### PR TITLE
Make result backendId nullable

### DIFF
--- a/module/VuFind/src/VuFind/Search/Base/Results.php
+++ b/module/VuFind/src/VuFind/Search/Base/Results.php
@@ -74,9 +74,9 @@ abstract class Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = '';
+    protected ?string $backendId = null;
 
     /**
      * Override (only for use in very rare cases).
@@ -464,9 +464,9 @@ abstract class Results
     /**
      * Basic 'getter' of search backend identifier.
      *
-     * @return string
+     * @return ?string
      */
-    public function getBackendId(): string
+    public function getBackendId(): ?string
     {
         return $this->backendId;
     }

--- a/module/VuFind/src/VuFind/Search/Blender/Results.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Results.php
@@ -43,9 +43,9 @@ class Results extends \VuFind\Search\Solr\Results
     /**
      * Search backend identifiers.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Blender';
+    protected ?string $backendId = 'Blender';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/Blender2/Results.php
+++ b/module/VuFind/src/VuFind/Search/Blender2/Results.php
@@ -43,7 +43,7 @@ class Results extends \VuFind\Search\Blender\Results
     /**
      * Search backend identifiers.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Blender2';
+    protected ?string $backendId = 'Blender2';
 }

--- a/module/VuFind/src/VuFind/Search/BrowZine/Results.php
+++ b/module/VuFind/src/VuFind/Search/BrowZine/Results.php
@@ -45,9 +45,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'BrowZine';
+    protected ?string $backendId = 'BrowZine';
 
     /**
      * Returns the stored list of facets for the last search.

--- a/module/VuFind/src/VuFind/Search/EDS/Results.php
+++ b/module/VuFind/src/VuFind/Search/EDS/Results.php
@@ -51,9 +51,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'EDS';
+    protected ?string $backendId = 'EDS';
 
     /**
      * Facet list.

--- a/module/VuFind/src/VuFind/Search/EIT/Results.php
+++ b/module/VuFind/src/VuFind/Search/EIT/Results.php
@@ -49,9 +49,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'EIT';
+    protected ?string $backendId = 'EIT';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/EPF/Results.php
+++ b/module/VuFind/src/VuFind/Search/EPF/Results.php
@@ -50,9 +50,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'EPF';
+    protected ?string $backendId = 'EPF';
 
     /**
      * Facet list.

--- a/module/VuFind/src/VuFind/Search/LibGuides/Results.php
+++ b/module/VuFind/src/VuFind/Search/LibGuides/Results.php
@@ -45,9 +45,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'LibGuides';
+    protected ?string $backendId = 'LibGuides';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/LibGuidesAZ/Results.php
+++ b/module/VuFind/src/VuFind/Search/LibGuidesAZ/Results.php
@@ -45,7 +45,7 @@ class Results extends \VuFind\Search\LibGuides\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'LibGuidesAZ';
+    protected ?string $backendId = 'LibGuidesAZ';
 }

--- a/module/VuFind/src/VuFind/Search/Pazpar2/Results.php
+++ b/module/VuFind/src/VuFind/Search/Pazpar2/Results.php
@@ -45,9 +45,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Pazpar2';
+    protected ?string $backendId = 'Pazpar2';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/Primo/Results.php
+++ b/module/VuFind/src/VuFind/Search/Primo/Results.php
@@ -52,9 +52,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Primo';
+    protected ?string $backendId = 'Primo';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/ProQuestFSG/Results.php
+++ b/module/VuFind/src/VuFind/Search/ProQuestFSG/Results.php
@@ -45,9 +45,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'ProQuestFSG';
+    protected ?string $backendId = 'ProQuestFSG';
 
     /**
      * Facets returned in search response.

--- a/module/VuFind/src/VuFind/Search/Search2/Results.php
+++ b/module/VuFind/src/VuFind/Search/Search2/Results.php
@@ -41,9 +41,9 @@ namespace VuFind\Search\Search2;
 class Results extends \VuFind\Search\Solr\Results
 {
     /**
-     * Backend ID.
+     * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Search2';
+    protected ?string $backendId = 'Search2';
 }

--- a/module/VuFind/src/VuFind/Search/Search2Collection/Results.php
+++ b/module/VuFind/src/VuFind/Search/Search2Collection/Results.php
@@ -41,9 +41,9 @@ namespace VuFind\Search\Search2Collection;
 class Results extends \VuFind\Search\SolrCollection\Results
 {
     /**
-     * Search backend identifiers.
+     * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Search2Collection';
+    protected ?string $backendId = 'Search2Collection';
 }

--- a/module/VuFind/src/VuFind/Search/Solr/Results.php
+++ b/module/VuFind/src/VuFind/Search/Solr/Results.php
@@ -78,9 +78,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Solr';
+    protected ?string $backendId = 'Solr';
 
     /**
      * Currently used spelling query, if any.

--- a/module/VuFind/src/VuFind/Search/SolrAuth/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrAuth/Results.php
@@ -43,7 +43,7 @@ class Results extends \VuFind\Search\Solr\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'SolrAuth';
+    protected ?string $backendId = 'SolrAuth';
 }

--- a/module/VuFind/src/VuFind/Search/SolrReserves/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrReserves/Results.php
@@ -45,7 +45,7 @@ class Results extends \VuFind\Search\Solr\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'SolrReserves';
+    protected ?string $backendId = 'SolrReserves';
 }

--- a/module/VuFind/src/VuFind/Search/SolrWeb/Results.php
+++ b/module/VuFind/src/VuFind/Search/SolrWeb/Results.php
@@ -43,7 +43,7 @@ class Results extends \VuFind\Search\Solr\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'SolrWeb';
+    protected ?string $backendId = 'SolrWeb';
 }

--- a/module/VuFind/src/VuFind/Search/Summon/Results.php
+++ b/module/VuFind/src/VuFind/Search/Summon/Results.php
@@ -76,9 +76,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'Summon';
+    protected ?string $backendId = 'Summon';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/WorldCat/Results.php
+++ b/module/VuFind/src/VuFind/Search/WorldCat/Results.php
@@ -45,9 +45,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'WorldCat';
+    protected ?string $backendId = 'WorldCat';
 
     /**
      * Support method for performAndProcessSearch -- perform a search based on the

--- a/module/VuFind/src/VuFind/Search/WorldCat2/Results.php
+++ b/module/VuFind/src/VuFind/Search/WorldCat2/Results.php
@@ -47,9 +47,9 @@ class Results extends \VuFind\Search\Base\Results
     /**
      * Search backend identifier.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $backendId = 'WorldCat2';
+    protected ?string $backendId = 'WorldCat2';
 
     /**
      * Facet list.

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -297,7 +297,10 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
         if (!$searchObject->getOptions()->supportsScheduledSearch()) {
             $backendId = $searchObject->getBackendId();
             $searchId = $searchObject->getSearchId();
-            $this->err('Unsupported search backend ' . ($backendId ?? '<unknown>') . ' for search ' . ($searchId ?? '<unknown>'));
+            $this->err(
+                'Unsupported search backend ' . ($backendId ?? '<unknown>')
+                . ' for search ' . ($searchId ?? '<unknown>')
+            );
             return false;
         }
         return $searchObject;

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -295,14 +295,9 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
         }
         $searchObject = $minSO->deminify($this->resultsManager);
         if (!$searchObject->getOptions()->supportsScheduledSearch()) {
-            if (($backendId = $searchObject->getBackendId()) && ($searchId = $searchObject->getSearchId())) {
-                $this->err('Unsupported search backend ' . $backendId . ' for search ' . $searchId);
-            } else {
-                $errorMessage = $backendId
-                    ? "Cannot get search ID from $backendId"
-                    : 'Cannot get backend ID from ' . $searchObject::class;
-                $this->err($errorMessage);
-            }
+            $backendId = $searchObject->getBackendId();
+            $searchId = $searchObject->getSearchId();
+            $this->err('Unsupported search backend ' . ($backendId ?? '<unknown>') . ' for search ' . ($searchId ?? '<unknown>'));
             return false;
         }
         return $searchObject;

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -295,10 +295,11 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
         }
         $searchObject = $minSO->deminify($this->resultsManager);
         if (!$searchObject->getOptions()->supportsScheduledSearch()) {
-            $this->err(
-                'Unsupported search backend ' . $searchObject->getBackendId()
-                . ' for search ' . $searchObject->getSearchId()
-            );
+            if (($backendId = $searchObject->getBackendId()) && ($searchId = $searchObject->getSearchId())) {
+                $this->err('Unsupported search backend ' . $backendId . ' for search ' . $searchId);
+            } else {
+                $this->err('Unsupported search object');
+            }
             return false;
         }
         return $searchObject;

--- a/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/VuFindConsole/src/VuFindConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -298,7 +298,10 @@ class NotifyCommand extends Command implements TranslatorAwareInterface
             if (($backendId = $searchObject->getBackendId()) && ($searchId = $searchObject->getSearchId())) {
                 $this->err('Unsupported search backend ' . $backendId . ' for search ' . $searchId);
             } else {
-                $this->err('Unsupported search object');
+                $errorMessage = $backendId
+                    ? "Cannot get search ID from $backendId"
+                    : 'Cannot get backend ID from ' . $searchObject::class;
+                $this->err($errorMessage);
             }
             return false;
         }


### PR DESCRIPTION
EDIT: This is a followup to #5612. The `backendId` in results becomes nullable.

Original:
While working on making the backend id nullable as discussed in #5612, I noticed that the tag search is being saved but not retrieved correctly by `getLastSearchUrl`. The params `getSearchClassId` method is being used for saving instead of the results `getBackendId` method. That's why I decided to change that instead.

`getBackendId` is then only used in `NotifyCommand` for an error log message. So this is also changed to use the params `getSearchClassId` method instead and we can deprecate `getBackendId`.