### PR TITLE
Fix last search links

### DIFF
--- a/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/SearchMemory.php
@@ -89,8 +89,8 @@ class SearchMemory extends AbstractHelper
     public function getLastSearchUrl(): ?string
     {
         if ($lastSearch = $this->getLastSearch()) {
-            $searchClassId = $lastSearch->getBackendId();
             $params = $lastSearch->getParams();
+            $searchClassId = $params->getSearchClassId();
             // Use last settings for params that are not stored in the search:
             foreach (['limit', 'view', 'sort'] as $setting) {
                 $value = $this->memory->retrieveLastSetting($searchClassId, $setting);

--- a/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
+++ b/module/VuFind/tests/integration-tests/src/VuFindTest/Mink/RecordActionsTest.php
@@ -317,6 +317,26 @@ final class RecordActionsTest extends \VuFindTest\Integration\MinkTestCase
     }
 
     /**
+     * Test sorting persists in last search link.
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\Depends('testTagSearchSort')]
+    public function testTagSearchSortPersistsInLastSearchLink(): void
+    {
+        $page = $this->performSearch('five', 'tag');
+        $this->clickCss($page, $this->sortControlSelector . ' option', null, 1);
+        $this->waitForPageLoad($page);
+        $this->assertSelectedSort($page, 'author');
+        $page->clickLink('Dewey browse test');
+        $this->assertSame('Dewey browse test', $this->findCssAndGetText($page, 'h1'));
+        // Click on search results in breadcrumb to go back to search and check that
+        // author sort is still selected
+        $page->clickLink('Search Results');
+        $this->assertSelectedSort($page, 'author');
+    }
+
+    /**
      * Test that default autocomplete behavior is correct on a non-default search handler.
      *
      * @return void


### PR DESCRIPTION
The params `getSearchClassId` method is being used for saving searches. But the results `getBackendId` method is currently used for retrieving saved searches in `getLastSearchUrl` in the search memory.

Because of this the breadcrumb links back to the search result for tag searches did not save the params properly.

This PR fixes that by using the params `getSearchClassId` method in the search memories `getLastSearchUrl` as well.