### PR TITLE
Fix stale refreshOnClose when lightbox is closed

### DIFF
--- a/themes/bootstrap5/js/lightbox.js
+++ b/themes/bootstrap5/js/lightbox.js
@@ -576,6 +576,7 @@ VuFind.register('lightbox', function Lightbox() {
     _currentUrl = false;
     _lbReferrerUrl = false;
     _lightboxTitle = false;
+    VuFind.lightbox.refreshOnClose = false;
     _modalParams = {};
   }
 


### PR DESCRIPTION
`refreshOnClose` is never reset after it's enabled for one lightbox; it will still be on for others.

Claude caught this as part of a larger feature PR; I'm extracting it into a bug fix.

Assisted-by: Sonnet 5 (Anthropic)