### PR TITLE
Fix arbitrary attributes flag in script rendering

### DIFF
--- a/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
+++ b/module/VuFindTheme/src/VuFindTheme/View/Helper/AssetManager.php
@@ -400,7 +400,7 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setScript($script, $type, $attrs);
-        $result = ($inlineScript)();
+        $result = (string)($inlineScript)();
         if ($resetArbitraryAttributes !== null) {
             $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }
@@ -432,7 +432,7 @@ class AssetManager extends \Laminas\View\Helper\AbstractHelper
         $type = $attrs['type'] ?? 'text/javascript';
         unset($attrs['type']);
         $inlineScript->setFile($src, $type, $attrs);
-        $result = ($inlineScript)();
+        $result = (string)($inlineScript)();
         if ($resetArbitraryAttributes !== null) {
             $inlineScript->setAllowArbitraryAttributes($resetArbitraryAttributes);
         }

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
@@ -64,6 +64,33 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Mock the Laminas InlineScript helper.
+     *
+     * @return InlineScript&\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function getMockInlineScriptHelper(): InlineScript
+    {
+        $inlineScriptHelper = $this->createMock(InlineScript::class);
+        $currentlyAllowed = false;
+        $inlineScriptHelper->method('arbitraryAttributesAllowed')
+            ->willReturnCallback(function () use (&$currentlyAllowed) {
+                return $currentlyAllowed;
+            });
+        $inlineScriptHelper->method('setAllowArbitraryAttributes')
+            ->willReturnCallback(function ($flag) use (&$currentlyAllowed) {
+                $currentlyAllowed = $flag;
+            });
+        // Note that the invoke method returns the helper itself -- not a string.
+        // This matches the actual helper's behavior.
+        $inlineScriptHelper->method('__invoke')->willReturnSelf();
+        $inlineScriptHelper->method('__toString')
+            ->willReturnCallback(function () use (&$currentlyAllowed) {
+                return 'output:' . ($currentlyAllowed ? '1' : '0');
+            });
+        return $inlineScriptHelper;
+    }
+
+    /**
      * Test that outputInlineScriptLink() behaves as expected.
      *
      * @param array  $attrs        Attributes array
@@ -76,8 +103,7 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
     public function testOutputInlineScriptLink(array $attrs, bool $arbitrary, string $expectedType): void
     {
         $script = 'foo.js';
-        $inlineScriptHelper = $this->createMock(InlineScript::class);
-        $inlineScriptHelper->method('arbitraryAttributesAllowed')->willReturn(false);
+        $inlineScriptHelper = $this->getMockInlineScriptHelper();
         $inlineScriptHelper
             ->expects($arbitrary ? $this->exactly(2) : $this->never())
             ->method('setAllowArbitraryAttributes');
@@ -86,11 +112,11 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('__call')
             ->with('setFile', [$script, $expectedType, $expectedAttrs]);
-        $inlineScriptHelper->method('__invoke')->willReturn('output');
         $view = $this->getPhpRenderer(['inlineScript' => $inlineScriptHelper]);
         $assetManager = $view->plugin('assetManager');
         $options = ['allow_arbitrary_attributes' => $arbitrary];
-        $this->assertEquals('output', $assetManager->outputInlineScriptLink($script, $attrs, $options));
+        $expected = 'output:' . ($arbitrary ? '1' : '0');
+        $this->assertEquals($expected, $assetManager->outputInlineScriptLink($script, $attrs, $options));
     }
 
     /**
@@ -106,8 +132,7 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
     public function testOutputInlineScriptString(array $attrs, bool $arbitrary, string $expectedType): void
     {
         $script = 'foo';
-        $inlineScriptHelper = $this->createMock(InlineScript::class);
-        $inlineScriptHelper->method('arbitraryAttributesAllowed')->willReturn(false);
+        $inlineScriptHelper = $this->getMockInlineScriptHelper();
         $inlineScriptHelper
             ->expects($arbitrary ? $this->exactly(2) : $this->never())
             ->method('setAllowArbitraryAttributes');
@@ -116,11 +141,11 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('__call')
             ->with('setScript', [$script, $expectedType, $expectedAttrs]);
-        $inlineScriptHelper->method('__invoke')->willReturn('output');
         $view = $this->getPhpRenderer(['inlineScript' => $inlineScriptHelper]);
         $assetManager = $view->plugin('assetManager');
         $options = ['allow_arbitrary_attributes' => $arbitrary];
-        $this->assertEquals('output', $assetManager->outputInlineScriptString($script, $attrs, $options));
+        $expected = 'output:' . ($arbitrary ? '1' : '0');
+        $this->assertEquals($expected, $assetManager->outputInlineScriptString($script, $attrs, $options));
     }
 
     /**

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
@@ -31,6 +31,7 @@ namespace VuFindTest\View\Helper;
 
 use Exception;
 use Laminas\View\Helper\InlineScript;
+use PHPUnit\Framework\MockObject\MockObject;
 use VuFindTest\Feature\ViewTrait;
 use VuFindTheme\AssetPipeline;
 use VuFindTheme\ThemeInfo;

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
@@ -64,7 +64,8 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Mock the Laminas InlineScript helper.
+     * Mock the Laminas InlineScript helper with functional "allow arbitrary attribute" support to
+     * test behavior that could lead to subtle bugs.
      *
      * @return InlineScript&\PHPUnit\Framework\MockObject\MockObject
      */

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
@@ -77,7 +77,7 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
                 return $currentlyAllowed;
             });
         $inlineScriptHelper->method('setAllowArbitraryAttributes')
-            ->willReturnCallback(function ($flag) use (&$currentlyAllowed) {
+            ->willReturnCallback(function ($flag) use (&$currentlyAllowed): void {
                 $currentlyAllowed = $flag;
             });
         // Note that the invoke method returns the helper itself -- not a string.

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/View/Helper/AssetManagerTest.php
@@ -68,9 +68,9 @@ class AssetManagerTest extends \PHPUnit\Framework\TestCase
      * Mock the Laminas InlineScript helper with functional "allow arbitrary attribute" support to
      * test behavior that could lead to subtle bugs.
      *
-     * @return InlineScript&\PHPUnit\Framework\MockObject\MockObject
+     * @return InlineScript&MockObject
      */
-    public function getMockInlineScriptHelper(): InlineScript
+    public function getMockInlineScriptHelper(): InlineScript&MockObject
     {
         $inlineScriptHelper = $this->createMock(InlineScript::class);
         $currentlyAllowed = false;


### PR DESCRIPTION
When AssetManager renders an inline script, sets and then resets a Laminas InlineScript helper property to allow (or not) arbitrary attributes on the script.  However it resets that value before actually generating the script output, which happens implicitly at the end of the function via an implied cast.  The code as-is assumes that invoking the helper itself would return a string, but it doesn't.  This forces the string cast sooner so it respects the arbitrary attributes setting.

Claude caught this as part of a PR I'm developing separately, and it seemed worth a bugfix.  However there is risk involved since theoretically a whole set of attributes may have been striped (or not stripped) before this fix.  For example, Claude flags that `data-lightbox-run="always"` in lightbox.phtml may have never fired. I have not confirmed this myself as it's just one of a theoretical class of issues this fix may spawn, so it's a larger question of what branch to do it on -- release-11.1 or dev.

Assisted-by: Sonnet 5 (Anthropic)