### PR TITLE
Use config array instead of object for Email Handler

### DIFF
--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -66,7 +66,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
      * Constructor.
      *
      * @param RendererInterface $viewRenderer View renderer
-     * @param array            $config       Main config
+     * @param array             $config       Main config
      * @param Mailer            $mailer       Mailer
      */
     public function __construct(

--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -56,17 +56,10 @@ class Email implements HandlerInterface, LoggerAwareInterface
     use LoggerAwareTrait;
 
     /**
-     * Main config.
-     *
-     * @var array
-     */
-    protected $mainConfig;
-
-    /**
      * Constructor.
      *
      * @param RendererInterface $viewRenderer View renderer
-     * @param array             $config       Main config
+     * @param array             $mainConfig       Main config
      * @param Mailer            $mailer       Mailer
      */
     public function __construct(
@@ -74,7 +67,6 @@ class Email implements HandlerInterface, LoggerAwareInterface
         protected array $mainConfig,
         protected Mailer $mailer
     ) {
-        $this->mainConfig = $config;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -74,9 +74,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
         array $config,
         protected Mailer $mailer
     ) {
-        $this->viewRenderer = $viewRenderer;
         $this->mainConfig = $config;
-        $this->mailer = $mailer;
     }
 
     /**

--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -59,7 +59,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
      * Constructor.
      *
      * @param RendererInterface $viewRenderer View renderer
-     * @param array             $mainConfig       Main config
+     * @param array             $mainConfig   Main config
      * @param Mailer            $mailer       Mailer
      */
     public function __construct(

--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -71,7 +71,7 @@ class Email implements HandlerInterface, LoggerAwareInterface
      */
     public function __construct(
         protected RendererInterface $viewRenderer,
-        array $config,
+        protected array $mainConfig,
         protected Mailer $mailer
     ) {
         $this->mainConfig = $config;

--- a/module/VuFind/src/VuFind/Form/Handler/Email.php
+++ b/module/VuFind/src/VuFind/Form/Handler/Email.php
@@ -56,37 +56,23 @@ class Email implements HandlerInterface, LoggerAwareInterface
     use LoggerAwareTrait;
 
     /**
-     * View renderer.
-     *
-     * @var RendererInterface
-     */
-    protected $viewRenderer;
-
-    /**
      * Main config.
      *
-     * @var Config
+     * @var array
      */
     protected $mainConfig;
-
-    /**
-     * Mailer.
-     *
-     * @var Mailer
-     */
-    protected $mailer;
 
     /**
      * Constructor.
      *
      * @param RendererInterface $viewRenderer View renderer
-     * @param Config            $config       Main config
+     * @param array            $config       Main config
      * @param Mailer            $mailer       Mailer
      */
     public function __construct(
-        RendererInterface $viewRenderer,
-        Config $config,
-        Mailer $mailer
+        protected RendererInterface $viewRenderer,
+        array $config,
+        protected Mailer $mailer
     ) {
         $this->viewRenderer = $viewRenderer;
         $this->mainConfig = $config;
@@ -155,9 +141,9 @@ class Email implements HandlerInterface, LoggerAwareInterface
     {
         $config = $this->mainConfig;
         $email = $form->getEmailFromAddress()
-            ?: $config->Feedback->sender_email ?? 'noreply@vufind.org';
+            ?: $config['Feedback']['sender_email'] ?? 'noreply@vufind.org';
         $name = $form->getEmailFromName()
-            ?: $config->Feedback->sender_name ?? 'VuFind Feedback';
+            ?: $config['Feedback']['sender_name'] ?? 'VuFind Feedback';
 
         return [$name, $email];
     }

--- a/module/VuFind/src/VuFind/Form/Handler/EmailFactory.php
+++ b/module/VuFind/src/VuFind/Form/Handler/EmailFactory.php
@@ -73,7 +73,7 @@ class EmailFactory implements FactoryInterface
 
         return new $requestedName(
             $container->get('ViewRenderer'),
-            $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config'),
+            $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigArray('config'),
             $container->get(\VuFind\Mailer\Mailer::class)
         );
     }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Form/Handler/EmailTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Form/Handler/EmailTest.php
@@ -195,7 +195,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
 
         return new Email(
             $renderer,
-            new \VuFind\Config\Config($config),
+            $config,
             $mailer
         );
     }


### PR DESCRIPTION
mainConfig vs. config in the __construct method: does $config get protected there or no, becuase the protected variable is the mainConfig (which is later assigned to = config)