### PR TITLE
Use config array instead of object for record router

### DIFF
--- a/module/VuFind/config/module.config.php
+++ b/module/VuFind/config/module.config.php
@@ -291,7 +291,6 @@ $config = [
             \VuFind\Date\Converter::class => \VuFind\Service\DateConverterFactory::class,
             \VuFind\ILS\Logic\Holds::class => \VuFind\ILS\Logic\LogicFactory::class,
             \VuFind\ILS\Logic\TitleHolds::class => \VuFind\ILS\Logic\LogicFactory::class,
-            \VuFind\Record\Router::class => \VuFind\Service\ServiceWithConfigIniFactory::class,
             \VuFind\SMS\SMSInterface::class => \VuFind\SMS\Factory::class,
             \VuFind\UrlShortener\UrlShortenerInterface::class => \VuFind\UrlShortener\ServiceFactory::class,
             \VuFindHttp\HttpService::class => \VuFind\Service\HttpServiceFactory::class,

--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -97,8 +97,7 @@ class Router
         // to check if the driver is actually a collection; if so, we should switch
         // routes.
         if ($this->config['Collections']['collections'] ?? false) {
-            $routeConfig = isset($this->config['Collections']['route'])
-                ? $this->config['Collections']['route'] : [];
+            $routeConfig = $this->config['Collections']['route'] ?? [];
             $collectionRoutes
                 = array_merge(
                     ['record' => 'collection',

--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -29,6 +29,8 @@
 
 namespace VuFind\Record;
 
+use VuFind\ServiceManager\Factory\Autowire;
+
 use function count;
 use function is_object;
 
@@ -44,20 +46,14 @@ use function is_object;
 class Router
 {
     /**
-     * VuFind configuration.
-     *
-     * @var array
-     */
-    protected $config;
-
-    /**
      * Constructor.
      *
      * @param array $config VuFind configuration
      */
-    public function __construct(array $config)
-    {
-        $this->config = $config;
+    public function __construct(
+        #[Autowire(config: 'config')]
+        protected array $config
+    ) {
     }
 
     /**

--- a/module/VuFind/src/VuFind/Record/Router.php
+++ b/module/VuFind/src/VuFind/Record/Router.php
@@ -46,16 +46,16 @@ class Router
     /**
      * VuFind configuration.
      *
-     * @var \VuFind\Config\Config
+     * @var array
      */
     protected $config;
 
     /**
      * Constructor.
      *
-     * @param \VuFind\Config\Config $config VuFind configuration
+     * @param array $config VuFind configuration
      */
-    public function __construct(\VuFind\Config\Config $config)
+    public function __construct(array $config)
     {
         $this->config = $config;
     }
@@ -100,9 +100,9 @@ class Router
         // If collections are active and the record route was selected, we need
         // to check if the driver is actually a collection; if so, we should switch
         // routes.
-        if ($this->config->Collections->collections ?? false) {
-            $routeConfig = isset($this->config->Collections->route)
-                ? $this->config->Collections->route->toArray() : [];
+        if ($this->config['Collections']['collections'] ?? false) {
+            $routeConfig = isset($this->config['Collections']['route'])
+                ? $this->config['Collections']['route'] : [];
             $collectionRoutes
                 = array_merge(
                     ['record' => 'collection',

--- a/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
+++ b/module/VuFind/src/VuFind/Service/ServiceWithConfigIniFactory.php
@@ -38,11 +38,12 @@ use Psr\Container\ContainerInterface;
 /**
  * Generic factory to constructor-inject the config.ini settings.
  *
- * @category VuFind
- * @package  Service
- * @author   Demian Katz <demian.katz@villanova.edu>
- * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @category   VuFind
+ * @package    Service
+ * @author     Demian Katz <demian.katz@villanova.edu>
+ * @license    http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link       https://vufind.org/wiki/development Wiki
+ * @deprecated This class is deprecated and will be removed in release 13.
  */
 class ServiceWithConfigIniFactory implements FactoryInterface
 {
@@ -65,7 +66,7 @@ class ServiceWithConfigIniFactory implements FactoryInterface
         $requestedName,
         ?array $options = null
     ) {
-        $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigObject('config');
+        $config = $container->get(\VuFind\Config\ConfigManagerInterface::class)->getConfigArray('config');
         return new $requestedName($config, ...($options ?: []));
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
@@ -29,7 +29,6 @@
 
 namespace VuFindTest\Record;
 
-use VuFind\Config\Config;
 use VuFind\Record\Router;
 use VuFind\RecordDriver\AbstractBase as RecordDriver;
 

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/Record/RouterTest.php
@@ -258,6 +258,6 @@ class RouterTest extends \PHPUnit\Framework\TestCase
      */
     protected function getRouter($config = [])
     {
-        return new Router(new Config($config));
+        return new Router($config);
     }
 }

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkerTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordLinkerTest.php
@@ -30,7 +30,6 @@
 namespace VuFindTest\View\Helper\Root;
 
 use Laminas\View\Helper\EscapeHtml;
-use VuFind\Config\Config;
 use VuFind\Record\Router;
 use VuFind\Search\Base\Results;
 use VuFind\View\Helper\Root\RecordLinker;
@@ -230,7 +229,7 @@ class RecordLinkerTest extends \PHPUnit\Framework\TestCase
         $searchOptionManager = $this->createMock(\VuFind\Search\Options\PluginManager::class);
 
         $recordLinker = new RecordLinker(
-            new Router(new Config([])),
+            new Router([]),
             $memory,
             $url,
             $searchOptionManager,


### PR DESCRIPTION
Note for this PR: With the addition of autowiring to this file, the ServiceWithConfigIniFactory class is no longer being used. A `@deprecated` tag has been added into that file in _this_ PR.